### PR TITLE
ROX-22693: remove isOpenShift3()

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
@@ -123,10 +123,6 @@ class ClusterService extends BaseService {
         isAKS
     }
 
-    static Boolean isOpenShift3() {
-        return getCluster().getType() == ClusterOuterClass.ClusterType.OPENSHIFT_CLUSTER
-    }
-
     static Boolean isOpenShift4() {
         return getCluster().getType() == ClusterOuterClass.ClusterType.OPENSHIFT4_CLUSTER
     }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -115,7 +115,6 @@ class BaseSpecification extends Specification {
                 LOG.info metadata.toString()
                 LOG.info "isGKE: ${orchestrator.isGKE()}"
                 LOG.info "isEKS: ${ClusterService.isEKS()}"
-                LOG.info "isOpenShift3: ${ClusterService.isOpenShift3()}"
                 LOG.info "isOpenShift4: ${ClusterService.isOpenShift4()}"
             }
             catch (Exception ex) {
@@ -125,7 +124,7 @@ class BaseSpecification extends Specification {
             }
         }
 
-        if (ClusterService.isOpenShift3() || ClusterService.isOpenShift4()) {
+        if (ClusterService.isOpenShift4()) {
             assert Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT,
                     "Set CLUSTER=OPENSHIFT when testing OpenShift"
         }

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -12,7 +12,6 @@ import io.stackrox.proto.storage.ClusterOuterClass
 import objects.ConfigMap
 import objects.Deployment
 import objects.Secret
-import services.ClusterService
 import util.ApplicationHealth
 import util.Timer
 

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -73,12 +73,6 @@ class TLSChallengeTest extends BaseSpecification {
         orchestrator.scaleDeployment("stackrox", "sensor", 1)
         ApplicationHealth ah = new ApplicationHealth(orchestrator, 600)
         ah.waitForSensorHealthiness()
-        if (ClusterService.isOpenShift3()) {
-            // OpenShift 3.11 networking needs a kick to ensure sensor is reachable (ROX-7869)
-            sleep(5000)
-            orchestrator.addOrUpdateServiceLabel("sensor", "stackrox", "kick",
-                    System.currentTimeSeconds().toString())
-        }
 
         orchestrator.deleteAllPodsAndWait("stackrox", [app: "collector"])
         ah.waitForCollectorHealthiness()


### PR DESCRIPTION
## Description

OCP 3.x is no longer supported in QA e2e tests. Nor are there any jobs running that [_think_](https://search.dptools.openshift.org/?search=.*isOpenShift3.+true.*&maxAge=336h&context=1&type=build-log&name=.*stackrox.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) they are openshift 3.x. This API call can be flaky, so lets remove it where it is not needed. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
