### PR TITLE
fix(scanner): include dev in offline mode

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -527,7 +527,8 @@ func (h *httpHandler) openMostRecentV4OfflineFile(ctx context.Context, t updater
 		}
 		defer utils.IgnoreError(mf.Close)
 
-		if offlineV != minorVersionPattern.FindString(updaterKey) {
+		if (updaterKey != "dev" && offlineV != minorVersionPattern.FindString(updaterKey)) ||
+			(updaterKey == "dev" && offlineV != "dev") {
 			msg := fmt.Sprintf("failed to get offline vuln file, uploaded file is version: %s and requested file version is: %s", offlineV, updaterKey)
 			log.Errorf(msg)
 			return nil, errors.New(msg)


### PR DESCRIPTION
## Description
If the matcher is requesting "dev" vuln file, Central should make sure the offline vuln is also "dev"
Note the "dev" offline bundle needs to be created manually at this moment

## Checklist
- [x] Investigated and inspected CI test results

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
