### PR TITLE
fix(ui): Fix pagination offset for administration events table

### DIFF
--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -153,7 +153,8 @@ export function getListAdministrationEventsArg({
     sortOption,
 }: GetAdministrationEventResponseArg): ListAdministrationEventsRequest {
     const filter = getAdministrationEventsFilter(searchFilter);
-    const pagination: Pagination = { limit: perPage, offset: page - 1, sortOption };
+    const offset = (page - 1) * perPage;
+    const pagination: Pagination = { limit: perPage, offset, sortOption };
     return { filter, pagination };
 }
 


### PR DESCRIPTION
## Description

Fix administration events same as discovered clusters in https://github.com/stackrox/stackrox/pull/10090/files

My bad to make the original mistake, and then duplicate it!

Thanks to Stephan for seeing it and to Linda for fixing it.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn start` in ui

### Manual testing

1. Visit /main/administration-events on stagingdb

    * See initial request with `pagination.limit=10&pagination.offset=0` in query string.
        ![staging_offset_0](https://github.com/stackrox/stackrox/assets/11862657/9191da98-d9a8-4b96-96ae-4f2fcb179475)

    * Click right arrow and see request with `pagination.limit=10&pagination.offset=1` in query string (inconsistent and incorrect) for page address with `?page=2` in query string.
        ![staging_offset_1](https://github.com/stackrox/stackrox/assets/11862657/a5ab28c1-e4bc-4f50-aed8-fed42f715544)

2. Visit /main/administration-events?page=2&perPage=1 in local deployment with code change.
    * See the second event. Although impossible to set `perPage=1` through UI, this is page address query string consistent with `pagination.limit=1&pagination.offset=1` in request query string.
        ![local_offset_1_perPage=1](https://github.com/stackrox/stackrox/assets/11862657/8379bdc4-a2e1-4137-9789-9f15de2f0bae)

3. Visit /main/administration-events?page=2 with default 10 per page and temporary replacement of `itemCount={count}` with `itemCount={10 * count}` prop in `Pagination` element to test with only 2 events.
    * See correct `pagination.limit=10&pagination.offset=10` in request query string but no events as expected.
        ![local_offset_1_perPage=1](https://github.com/stackrox/stackrox/assets/11862657/dd4e7de3-1b5b-4d56-8af9-f7cda79d38dd)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administration/events/eventsTable.test.js
