### PR TITLE
ROX-22724: Bump registry HTTP timeout to 90s

### DIFF
--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -22,7 +22,17 @@ import (
 )
 
 const (
-	registryTimeout  = 5 * time.Second
+	// This timeout is used as http.Client.Timeout for the registry's HTTP
+	// client and hence includes everything from connection to reading the
+	// response body. The timeout has been chosen rather arbitrarily, it is
+	// probably less harm in waiting a bit longer than in aborting early a
+	// request that is about to succeed.
+	//
+	// TODO(alexr): Consider setting ResponseHeaderTimeout for registry's
+	//   transport to make timeout errors more specific and hence facilitate
+	//   retries and troubleshooting.
+	registryClientTimeout = 90 * time.Second
+
 	repoListInterval = 10 * time.Minute
 )
 
@@ -79,7 +89,7 @@ func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegrat
 		return nil, err
 	}
 
-	client.Client.Timeout = registryTimeout
+	client.Client.Timeout = registryClientTimeout
 
 	var repoSet set.Set[string]
 	var ticker *time.Ticker

--- a/pkg/registries/ibm/ibm.go
+++ b/pkg/registries/ibm/ibm.go
@@ -2,7 +2,6 @@ package ibm
 
 import (
 	"errors"
-	"time"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -12,8 +11,6 @@ import (
 
 const (
 	username = "iamapikey"
-
-	registryTimeout = 10 * time.Second
 )
 
 // Creator provides the type and registries.Creator to add to the registries Registry.
@@ -63,7 +60,5 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 	if err != nil {
 		return nil, err
 	}
-	// IBM needs a custom timeout because it's pretty slow
-	registry.Client.Client.Timeout = registryTimeout
 	return registry, nil
 }


### PR DESCRIPTION
## Description

Registry timeouts are a source of CI flakes and maybe also affect our users.

This PR makes an assumption that waiting longer for registry operations is not a big deal while aborting early a request that is about to succeed is very unfortunate, especially given we do not retry transient timeouts in reprocessor: HTTP client timeout in docker registry client is increased from 5s to 90s.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is probably sufficient. The biggest risk here is unknown to author effects of changing the timeout, which is best addressed by CIs and reviews.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
