### PR TITLE
fix(ui): Update debug log for component tests

### DIFF
--- a/ui/apps/platform/scripts/cypress-component.sh
+++ b/ui/apps/platform/scripts/cypress-component.sh
@@ -4,4 +4,4 @@ export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
 
 mkdir -p "$artifacts_dir" && touch "${artifacts_dir:-/tmp}/cypress-err.txt"
-DEBUG="*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"
+CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT=180000 DEBUG="cypress:*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"

--- a/ui/apps/platform/scripts/cypress-component.sh
+++ b/ui/apps/platform/scripts/cypress-component.sh
@@ -4,4 +4,4 @@ export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
 
 mkdir -p "$artifacts_dir" && touch "${artifacts_dir:-/tmp}/cypress-err.txt"
-CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT=180000 DEBUG="cypress:*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"
+CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT=180000 DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -37,5 +37,5 @@ if [ $2 == "--spec" ]; then
     fi
     cypress run --spec "cypress/integration/$3"
 else
-    DEBUG="*" NO_COLOR=1 cypress "$@" 2> /dev/null
+    DEBUG="cypress:*" NO_COLOR=1 cypress "$@" 2> /dev/null
 fi

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -37,5 +37,5 @@ if [ $2 == "--spec" ]; then
     fi
     cypress run --spec "cypress/integration/$3"
 else
-    DEBUG="cypress:*" NO_COLOR=1 cypress "$@" 2> /dev/null
+    DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> /dev/null
 fi


### PR DESCRIPTION
## Description

Two changes in component tests to help get these more stable/diagnose why they are failing ~20% of the time:

1. Changes `DEBUG=*` to `DEBUG=cypress:`. The former was logging all debug output from webpack, babel, etc. and creating an unusable amount of noise in the log file. Scoping to just cypress logs brings the file size from ~1GB to ~500**KB**
2. Adds a parameter to increase the timeout when a browser reconnect occurs, based on https://www.github.com/cypress-io/cypress/issues/27623. I'm not sure this is the issue, but I do get similar error messages to our CI failures when I set the timeout to a very low number and I can see ` Timed out waiting for the browser to connect. Retrying again... ` in the CI logs. If this has no impact, or a negative impact, we can revert later.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

`yarn test-component`

CI