### PR TITLE
ROX-22699: Increase the wait time for deployments

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -41,11 +41,6 @@ class Constants {
     static final INTERNAL_ENTITIES_SOURCE_ID = "ada12424-bde3-4313-b810-bb463cbe8f90" // pkg/networkgraph/constants.go
     static final STACKROX_ANNOTATION_TRUNCATION_LENGTH = 254
     static final CORE_IMAGE_INTEGRATION_NAME = "core quay"
-    // Padding required for test feature timeouts. This is used to configure the
-    // globalTimeout for long running tests. The value takes into consideration
-    // common functionality that occurs for all tests such as debug gathering when
-    // tests fail.
-    static final TEST_FEATURE_TIMEOUT_PAD = 360
     static final String SPLUNK_TEST_NAMESPACE = "qa-splunk"
 
     /*

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -196,9 +196,13 @@ class BaseSpecification extends Specification {
         globalSetupDone = true
     }
 
+    // `globalTimeout` serves to stop stuck tests hogging clusters. A side
+    // effect is that it can abort tests legitimately taking longer. Reaching
+    // `globalTimeout` is to be avoided because it upsets Spock and generates
+    // confusing junit reports.
     @Rule
     Timeout globalTimeout = new Timeout(
-            isRaceBuild() ? 2500 : 800,
+            isRaceBuild() ? 6000 : 2000,
             TimeUnit.SECONDS
     )
     @Rule

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -28,8 +28,6 @@ import services.DeclarativeConfigHealthService
 import services.NotifierService
 import services.RoleService
 
-import org.junit.Rule
-import org.junit.rules.Timeout
 import spock.lang.Tag
 
 @Tag("Parallel")

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -227,11 +227,6 @@ splunk:
                     .putAllSourceTypes(["audit": "stackrox-audit-message", "alert": "stackrox-alert"])
             ).build()
 
-    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1200, TimeUnit.SECONDS)
-
     private ScheduledFuture<?> annotateTaskHandle
 
     def setup() {

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -120,14 +120,6 @@ class DefaultPoliciesTest extends BaseSpecification {
 
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 300
 
-    // Override the global JUnit test timeout to cover a test instance waiting
-    // WAIT_FOR_VIOLATION_TIMEOUT over three test tries and the appprox. 6
-    // minutes it can take to gather debug when the first test run fails plus
-    // some padding.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(3*WAIT_FOR_VIOLATION_TIMEOUT + 300 + 120, TimeUnit.SECONDS)
-
     @Shared
     private String gcrId
     @Shared

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -1,7 +1,6 @@
 import static Services.getPolicies
 import static Services.waitForViolation
 
-import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
 import io.grpc.StatusRuntimeException
@@ -39,8 +38,6 @@ import util.Helpers
 import util.SlackUtil
 
 import org.junit.Assume
-import org.junit.Rule
-import org.junit.rules.Timeout
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -30,10 +30,6 @@ import spock.lang.Tag
 // ROX-14228 skipping tests for 1st release on power & z
 @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
 class IntegrationsSplunkViolationsTest extends BaseSpecification {
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1000 + Constants.TEST_FEATURE_TIMEOUT_PAD, TimeUnit.SECONDS)
-
     private static final String ASSETS_DIR = Paths.get(
             System.getProperty("user.dir"), "artifacts", "splunk-violations-test")
     private static final String PATH_TO_SPLUNK_TA_SPL = Paths.get(ASSETS_DIR,

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -21,8 +21,6 @@ import util.SplunkUtil
 import util.SplunkUtil.SplunkDeployment
 import util.Timer
 
-import org.junit.Rule
-import org.junit.rules.Timeout
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Tag

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -58,10 +58,6 @@ class IntegrationsTest extends BaseSpecification {
 
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 30
 
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1000, TimeUnit.SECONDS)
-
     def setupSpec() {
         orchestrator.batchCreateDeployments(DEPLOYMENTS)
         DEPLOYMENTS.each { Services.waitForDeployment(it) }

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -1,7 +1,5 @@
 import static util.Helpers.withRetry
 
-import java.util.concurrent.TimeUnit
-
 import io.grpc.StatusRuntimeException
 
 import io.stackrox.proto.storage.ClusterOuterClass
@@ -37,8 +35,6 @@ import util.SplunkUtil
 import util.SyslogServer
 
 import org.junit.Assume
-import org.junit.Rule
-import org.junit.rules.Timeout
 import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -172,11 +172,6 @@ class NetworkBaselineTest extends BaseSpecification {
         }
     }
 
-    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(1600, TimeUnit.SECONDS)
-
     @Tag("NetworkBaseline")
     def "Verify network baseline functionality"() {
         when:

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -1,7 +1,5 @@
 import static util.Helpers.evaluateWithRetry
 
-import java.util.concurrent.TimeUnit
-
 import com.google.protobuf.Timestamp
 
 import io.stackrox.proto.storage.NetworkBaselineOuterClass
@@ -12,9 +10,7 @@ import services.NetworkBaselineService
 import util.NetworkGraphUtil
 import util.Timer
 
-import org.junit.Rule
 import spock.lang.Tag
-import spock.lang.Timeout
 
 @Tag("PZ")
 class NetworkBaselineTest extends BaseSpecification {

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -103,11 +103,6 @@ class NetworkFlowTest extends BaseSpecification {
         ]
     }
 
-    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(1600, TimeUnit.SECONDS)
-
     // Source deployments
     @Shared
     private List<Deployment> sourceDeployments

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -1,8 +1,6 @@
 import static io.restassured.RestAssured.given
 import static util.Helpers.withRetry
 
-import java.util.concurrent.TimeUnit
-
 import io.grpc.StatusRuntimeException
 import io.restassured.response.Response
 import orchestratormanager.OrchestratorTypes
@@ -34,15 +32,12 @@ import util.NetworkGraphUtil
 import util.Timer
 
 import org.junit.Assume
-import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Tag
 import spock.lang.Unroll
-
-import spock.lang.Timeout
 
 // TODO(ROX-13739): Re-enable these tests in compatibility-test step
 @Stepwise

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -3,12 +3,8 @@ import static Services.waitForViolation
 import static util.Helpers.evaluateWithRetry
 import static util.Helpers.trueWithin
 
-import java.util.concurrent.TimeUnit
-
 import com.google.protobuf.util.Timestamps
 import org.apache.commons.lang3.StringUtils
-import org.junit.Rule
-import org.junit.rules.Timeout
 
 import io.stackrox.proto.api.v1.AlertServiceOuterClass
 import io.stackrox.proto.storage.AlertOuterClass

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -44,6 +44,8 @@ class ProcessBaselinesTest extends BaseSpecification {
     static final private String DEPLOYMENTNGINX_POST_DELETE_API = "pb-deploymentnginx-post-delete-api"
     static final private String DEPLOYMENTNGINX_REMOVEPROCESS = "pb-deploymentnginx-removeprocess"
 
+    static final private Integer RISK_WAIT_TIME = 240
+
     static final private List<Deployment> DEPLOYMENTS =
         [
              new Deployment()
@@ -111,17 +113,6 @@ class ProcessBaselinesTest extends BaseSpecification {
                      .setEnv(["CLUSTER_NAME": "main"])
                      .addLabel("app", "test"),
             ]
-
-    static final private Integer BASELINE_WAIT_TIME = 100
-    static final private Integer RISK_WAIT_TIME = 240
-
-    // Override the global JUnit test timeout to cover a test instance taking
-    // LONGEST_TEST over three test tries and the appprox. 6
-    // minutes it can take to gather debug when the first test run fails plus
-    // some padding.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(4*(BASELINE_WAIT_TIME + RISK_WAIT_TIME) + 300 + 120, TimeUnit.SECONDS)
 
     @Shared
     private Policy unauthorizedProcessExecution

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -420,7 +420,7 @@ class Services extends BaseService {
         return disappearedFromStackRox
     }
 
-    static waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 2) {
+    static waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 5) {
         if (deployment.deploymentUid == null) {
             LOG.info "deploymentID for [${deployment.name}] is null, checking orchestrator directly for deployment ID"
             deployment.deploymentUid = OrchestratorType.orchestrator.getDeploymentId(deployment)

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -420,6 +420,9 @@ class Services extends BaseService {
         return disappearedFromStackRox
     }
 
+    // When changing the timeout here, remember there might be other enclosing
+    // timeout that should be in sync. For example,`globalTimeout` which aborts
+    // tests but should be generally avoided.
     static waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 5) {
         if (deployment.deploymentUid == null) {
             LOG.info "deploymentID for [${deployment.name}] is null, checking orchestrator directly for deployment ID"


### PR DESCRIPTION
## Description

I've seen an image taking 4m to download on one node and 7s on another. This PR drastically increases the overall wait timeout for deployments to come online.

As per @gavin-stackrox 's suggestion, it also bumps `globalTimeout` proportionally and removes all overrides for it to consolidate and simplify.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI run

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
