### PR TITLE
fix(scanner): Fix vuln naming per updater + better NVD matching

### DIFF
--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -32,10 +32,24 @@ var (
 		claircore.High:       v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
 		claircore.Critical:   v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
 	}
-	// vulnNamePatterns is a prioritized list of regexes to match against
-	// vulnerability information to extract their ID.
+
+	// Updater patterns are used to determine the security updater the
+	// vulnerability was detected.
+
+	osvUpdaterPattern  = regexp.MustCompile(`^osv/.*`)
+	rhelUpdaterPattern = regexp.MustCompile(`^RHEL\d+-`)
+	awsUpdaterPattern  = regexp.MustCompile(`^aws-`)
+
+	// Name patterns are regexes to match against vulnerability fields to
+	// extract their name according to their updater.
+
+	awsVulnNamePattern  = regexp.MustCompile(`ALAS\d*-\d{4}-\d+`)
+	rhelVulnNamePattern = regexp.MustCompile(`(RHSA|RHBA|RHEA)-\d{4}:\d+`)
+
+	// vulnNamePatterns is a default prioritized list of regexes to match
+	// vulnerability names.
 	vulnNamePatterns = []*regexp.Regexp{
-		regexp.MustCompile(`((RHSA|RHBA|RHEA)-\d{4}:\d+)|(ALAS\d*-\d{4}-\d+)`),
+		// A CVE.
 		regexp.MustCompile(`CVE-\d{4}-\d+`),
 		// GHSA, see: https://github.com/github/advisory-database#ghsa-ids
 		regexp.MustCompile(`GHSA(-[2-9cfghjmpqrvwx]{4}){3}`),
@@ -279,11 +293,7 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 	return pkgVulns
 }
 
-func toProtoV4VulnerabilitiesMap(
-	ctx context.Context,
-	vulns map[string]*claircore.Vulnerability,
-	nvdVulns map[string]*nvdschema.CVEAPIJSON20CVEItem,
-) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
+func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircore.Vulnerability, nvdVulns map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
 	if vulns == nil {
 		return nil, nil
 	}
@@ -309,7 +319,22 @@ func toProtoV4VulnerabilitiesMap(
 			repoID = v.Repo.ID
 		}
 		normalizedSeverity := toProtoV4VulnerabilitySeverity(ctx, v.NormalizedSeverity)
-		sev, err := severityAndScores(ctx, v, nvdVulns)
+		name := vulnerabilityName(v)
+		// Find the related NVD vuln for this vulnerability name, let it be empty if no
+		// NVD vuln for that name was found.
+		var nvdVuln nvdschema.CVEAPIJSON20CVEItem
+		if nvdCVEs, ok := nvdVulns[v.ID]; ok {
+			if v, ok := nvdCVEs[name]; ok {
+				nvdVuln = *v
+			} else {
+				// Pick the first one as a fallback.
+				for _, v := range nvdCVEs {
+					nvdVuln = *v
+					break
+				}
+			}
+		}
+		sev, err := severityAndScores(ctx, v, &nvdVuln)
 		if err != nil {
 			zlog.Warn(ctx).
 				Err(err).
@@ -341,10 +366,8 @@ func toProtoV4VulnerabilitiesMap(
 		description := v.Description
 		if description == "" {
 			// No description provided, so fall back to NVD.
-			if v, ok := nvdVulns[v.ID]; ok {
-				if len(v.Descriptions) > 0 {
-					description = v.Descriptions[0].Value
-				}
+			if len(nvdVuln.Descriptions) > 0 {
+				description = nvdVuln.Descriptions[0].Value
 			}
 		}
 		if vulnerabilities == nil {
@@ -352,7 +375,7 @@ func toProtoV4VulnerabilitiesMap(
 		}
 		vulnerabilities[k] = &v4.VulnerabilityReport_Vulnerability{
 			Id:                 v.ID,
-			Name:               vulnerabilityName(v),
+			Name:               name,
 			Description:        description,
 			Issued:             issued,
 			Link:               v.Links,
@@ -531,7 +554,7 @@ func fixedInVersion(v *claircore.Vulnerability) string {
 
 // nvdVulnerabilities look for NVD CVSS in the vulnerability report enrichments and
 // returns a map of CVEs.
-func nvdVulnerabilities(enrichments map[string][]json.RawMessage) (map[string]*nvdschema.CVEAPIJSON20CVEItem, error) {
+func nvdVulnerabilities(enrichments map[string][]json.RawMessage) (map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem, error) {
 	enrichmentsList := enrichments[nvd.Type]
 	if len(enrichmentsList) == 0 {
 		return nil, nil
@@ -545,12 +568,19 @@ func nvdVulnerabilities(enrichments map[string][]json.RawMessage) (map[string]*n
 	if len(items) == 0 {
 		return nil, nil
 	}
-	ret := make(map[string]*nvdschema.CVEAPIJSON20CVEItem)
-	for id, list := range items {
-		// There is no criteria for selecting more than one enrichment record, assume the
-		// first is the right one.
-		i := list[0]
-		ret[id] = &i
+	// Returns a map of maps keyed by CVE ID due to enrichment matching on multiple
+	// vulnerability fields, potentially including unrelated records--we assume the
+	// caller will know how to filter what is relevant.
+	ret := make(map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem)
+	for ccVulnID, list := range items {
+		if len(list) > 0 {
+			m := make(map[string]*nvdschema.CVEAPIJSON20CVEItem)
+			for idx := range list {
+				vulnData := list[idx]
+				m[vulnData.ID] = &vulnData
+			}
+			ret[ccVulnID] = m
+		}
 	}
 	return ret, nil
 }
@@ -582,15 +612,10 @@ type severityValues struct {
 	v3Score  float32
 }
 
-var (
-	osvUpdaterPattern  = regexp.MustCompile(`^osv/.*`)
-	rhelUpdaterPattern = regexp.MustCompile(`^RHEL\d+-`)
-)
-
 // severityAndScores returns the severity and scores information out of a
 // ClairCore vulnerability. The returned information is dependent on the
 // underlying updater.
-func severityAndScores(ctx context.Context, vuln *claircore.Vulnerability, nvdVulns map[string]*nvdschema.CVEAPIJSON20CVEItem) (severityValues, error) {
+func severityAndScores(ctx context.Context, vuln *claircore.Vulnerability, nvdVuln *nvdschema.CVEAPIJSON20CVEItem) (severityValues, error) {
 	ctx = zlog.ContextWithValues(ctx,
 		"component", "mappers/severityAndScores",
 		"updater", vuln.Updater,
@@ -614,7 +639,7 @@ func severityAndScores(ctx context.Context, vuln *claircore.Vulnerability, nvdVu
 	}
 
 	// Default/fallback is NVD.
-	return nvdSeverityAndScores(vuln, nvdVulns)
+	return nvdSeverityAndScores(vuln, nvdVuln)
 }
 
 func rhelSeverityAndScores(vuln *claircore.Vulnerability) (severityValues, error) {
@@ -693,14 +718,9 @@ func cvssVector(cvssVector string) (severityValues, error) {
 	return values, nil
 }
 
-func nvdSeverityAndScores(vuln *claircore.Vulnerability, nvdVulns map[string]*nvdschema.CVEAPIJSON20CVEItem) (severityValues, error) {
+func nvdSeverityAndScores(vuln *claircore.Vulnerability, v *nvdschema.CVEAPIJSON20CVEItem) (severityValues, error) {
 	values := severityValues{
 		severity: vuln.Severity,
-	}
-
-	v, ok := nvdVulns[vuln.ID]
-	if !ok {
-		return values, errors.New("cannot find NVD data")
 	}
 
 	// Sanity check the NVD data.
@@ -735,15 +755,36 @@ func nvdSeverityAndScores(vuln *claircore.Vulnerability, nvdVulns map[string]*nv
 // in the vulnerability details. It works by matching data against well-known
 // name patterns, and defaults to the original name if nothing is found.
 func vulnerabilityName(vuln *claircore.Vulnerability) string {
-	for _, p := range vulnNamePatterns {
-		v := p.FindString(vuln.Name)
-		if v != "" {
+	// Attempt per-updater patterns.
+	switch {
+	case rhelUpdaterPattern.MatchString(vuln.Updater):
+		if v, ok := findName(vuln, rhelVulnNamePattern); ok {
 			return v
 		}
-		v = p.FindString(vuln.Links)
-		if v != "" {
+	case awsUpdaterPattern.MatchString(vuln.Updater):
+		if v, ok := findName(vuln, awsVulnNamePattern); ok {
+			return v
+		}
+	}
+	// Default patterns.
+	for _, p := range vulnNamePatterns {
+		if v, ok := findName(vuln, p); ok {
 			return v
 		}
 	}
 	return vuln.Name
+}
+
+// findName searches for a vulnerability name using the specified regex in
+// pre-determined fields of the vulnerability, returning the name if found.
+func findName(vuln *claircore.Vulnerability, p *regexp.Regexp) (string, bool) {
+	v := p.FindString(vuln.Name)
+	if v != "" {
+		return v, true
+	}
+	v = p.FindString(vuln.Links)
+	if v != "" {
+		return v, true
+	}
+	return "", false
 }

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -610,7 +610,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 	assert.NoError(t, err)
 	tests := map[string]struct {
 		ccVulnerabilities map[string]*claircore.Vulnerability
-		nvdVulns          map[string]*nvdschema.CVEAPIJSON20CVEItem
+		nvdVulns          map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem
 		want              map[string]*v4.VulnerabilityReport_Vulnerability
 	}{
 		"when nil then nil": {},
@@ -823,19 +823,25 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					ID:      "foo",
+					Name:    "Name contains CVE-1234-567",
 					Issued:  now,
 					Updater: "unknown updater",
 				},
 			},
-			nvdVulns: map[string]*nvdschema.CVEAPIJSON20CVEItem{
+			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
 				"foo": {
-					ID: "CVE-1234-567",
-					Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
-						CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
-							{
-								CvssData: &nvdschema.CVSSV31{
-									Version:      "3.1",
-									VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					"CVE-9999-999": {
+						ID: "CVE-9999-999",
+					},
+					"CVE-1234-567": {
+						ID: "CVE-1234-567",
+						Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
+							CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
+								{
+									CvssData: &nvdschema.CVSSV31{
+										Version:      "3.1",
+										VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+									},
 								},
 							},
 						},
@@ -846,6 +852,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				"foo": {
 					Id:     "foo",
 					Issued: protoNow,
+					Name:   "CVE-1234-567",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
 							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
@@ -858,19 +865,25 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					ID:      "foo",
+					Name:    "Name contains CVE-1234-567",
 					Issued:  now,
 					Updater: "osv/sample-updater",
 				},
 			},
-			nvdVulns: map[string]*nvdschema.CVEAPIJSON20CVEItem{
+			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
 				"foo": {
-					ID: "CVE-1234-567",
-					Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
-						CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
-							{
-								CvssData: &nvdschema.CVSSV31{
-									Version:      "3.1",
-									VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					"CVE-9999-999": {
+						ID: "CVE-9999-999",
+					},
+					"CVE-1234-567": {
+						ID: "CVE-1234-567",
+						Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
+							CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
+								{
+									CvssData: &nvdschema.CVSSV31{
+										Version:      "3.1",
+										VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+									},
 								},
 							},
 						},
@@ -880,6 +893,46 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Id:     "foo",
+					Issued: protoNow,
+					Name:   "CVE-1234-567",
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+						},
+					},
+				},
+			},
+		},
+		"when using NVD and vuln name is not CVE then return first NVD scores": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:      "foo",
+					Name:    "NOT-A-CVE",
+					Issued:  now,
+					Updater: "unknown updater",
+				},
+			},
+			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
+				"foo": {
+					"CVE-1234-567": {
+						ID: "CVE-1234-567",
+						Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
+							CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
+								{
+									CvssData: &nvdschema.CVSSV31{
+										Version:      "3.1",
+										VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Name:   "NOT-A-CVE",
 					Issued: protoNow,
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
@@ -923,6 +976,7 @@ func Test_vulnerabilityName(t *testing.T) {
 		name     string
 		links    string
 		expected string
+		updater  string
 	}{
 		"Alpine": {
 			name:     "CVE-2018-16840",
@@ -957,22 +1011,41 @@ func Test_vulnerabilityName(t *testing.T) {
 			links:    "https://nvd.nist.gov/vuln/detail/CVE-2023-47248",
 			expected: "CVE-2023-47248",
 		},
-		"RHEL over CVE": {
+		"when rhel updater then RHEL over CVE": {
 			links:    "https://access.redhat.com/security/cve/CVE-2023-25761 https://access.redhat.com/errata/RHSA-2023:1866 https://access.redhat.com/security/cve/CVE-2023-25762",
 			expected: "RHSA-2023:1866",
+			updater:  "RHEL9-FOOBAR",
+		},
+		"when not rhel updater then CVE over RHEL": {
+			links:    "https://access.redhat.com/security/cve/CVE-2023-25761 https://access.redhat.com/errata/RHSA-2023:1866 https://access.redhat.com/security/cve/CVE-2023-25762",
+			expected: "CVE-2023-25761",
+			updater:  "not-rhel",
 		},
 		"ALAS over CVE": {
 			links:    "https://alas.aws.amazon.com/AL2023/ALAS-2023-356.html https://alas.aws.amazon.com/cve/html/CVE-2023-39189.html",
 			expected: "ALAS-2023-356",
+			updater:  "aws-foobar-",
 		},
 	}
 	for name, testcase := range testcases {
 		t.Run(name, func(t *testing.T) {
-			v := &claircore.Vulnerability{Name: testcase.name, Links: testcase.links}
+			v := &claircore.Vulnerability{
+				Name:    testcase.name,
+				Links:   testcase.links,
+				Updater: testcase.updater,
+			}
 			assert.Equal(t, testcase.expected, vulnerabilityName(v))
 		})
 	}
-
+	t.Run("when updater is osv/go then prefer GO over RHSA", func(t *testing.T) {
+		v := &claircore.Vulnerability{
+			Updater:     "osv/go",
+			Name:        "GO-2021-0072",
+			Description: "Uncontrolled resource allocation in github.com/docker/distribution",
+			Links:       "https://github.com/distribution/distribution/pull/2340 https://github.com/distribution/distribution/commit/91c507a39abfce14b5c8541cf284330e22208c0f https://access.redhat.com/errata/RHSA-2017:2603 http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00047.html",
+		}
+		assert.Equal(t, "GO-2021-0072", vulnerabilityName(v))
+	})
 }
 
 func Test_versionID(t *testing.T) {


### PR DESCRIPTION
## Description

1. Create a map of NVD vulns keyed by CVE name and map V4 report vulnerabilities to NVD vulnerabilities by name.
2. Apply different vulnerability name patterns based on the vuln updater name. In particular, if RHEL or AMZN are applied, they are only applied if such updates are found. Otherwise, the previous matching patterns are used.

Why: To fix the NVD enricher, which matches [in multiple fields in the vulnerability](https://github.com/stackrox/stackrox/blob/master/scanner/enricher/nvd/nvd.go#L398-L406), and the enrichment map may contain unrelated NVD vulns. Right now, we pick the first NVD vuln in the results. And we might pick the wrong vuln. Example:

Example of a description that would cause this:

```
    end_pattern (called from internal_fnmatch) in the GNU C Library (aka glibcor libc6) before 2.22 might allow context-dependent attackers to cause adenial of service (application crash), as demonstrated by use of thefnmatch library function with the **(!() pattern. NOTE: this is not thesame as CVE-2015-8984; also, some Linux distributions have fixedCVE-2015-8984 but have not fixed this additional fnmatch issue.
```

CVE-2015-8984 could be included in the enrichment map because it's found in the description.

This also fixes issues when the vulnerability from an unrelated updater contains vulnerability name patterns that are irrelevant, [example](https://pkg.go.dev/vuln/GO-2021-0072) found in [registry.redhat.io/redhat/redhat-operator-index:v4.14](https://staging.demo.stackrox.com/main/vulnerability-management/images?workflowState[0][t]=IMAGE&workflowState[0][i]=sha256%3A05294b938b942e35ccc673df7917a99f2de072522322c65883dc6286fa8016e7&s[Image]=%25operator).
 
## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
⮩  make build
⮩  make certs
⮩  cp config.yaml.sample config.yaml
⮩  # Optionally config.yaml
⮩  ./bin/scanner --conf config.yaml &
⮩  make e2e-run
⮩  ROX_SCANNERCTL_BASIC_AUTH="$SCANNER_E2E_REDHAT_USERNAME:$SCANNER_E2E_REDHAT_PASSWORD" ./bin/scannerctl scan --insecure-skip-tls-verify --matcher-address=:8443 'https://registry.redhat.io/redhat/redhat-operator-index:v4.14' | tee /tmp/r.json
⮩  cat /tmp/r.json | jq '.vulnerabilities[] | select(.name == "GO-2021-0072")'
{
  "id": "10524357",
  "name": "GO-2021-0072",
  "description": "Uncontrolled resource allocation in github.com/docker/distribution",
  "issued": {
    "seconds": 1618430692
  },
  "link": "https://github.com/distribution/distribution/pull/2340 https://github.com/distribution/distribution/commit/91c507a39abfce14b5c8541cf284330e22208c0f https://access.redhat.com/errata/RHSA-2017:2603 http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00047.html",
  "fixed_in_version": "2.7.0-rc.0+incompatible"
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
