### PR TITLE
chore: Move operator lower bound OCP version 4.11 -> 4.12

### DIFF
--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -16,9 +16,17 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Labels for operator certification https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
-# Note: vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
-LABEL com.redhat.openshift.versions="v4.11"
 LABEL com.redhat.delivery.operator.bundle=true
+
+# This sets the earliest version of OCP where our operator build would show up in the official Red Hat operator catalog.
+# vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+#
+# The version here should stay the lowest not yet EOL so that downstream CVP tests don't fail.
+# See EOL schedule: https://docs.engineering.redhat.com/display/SP/Shipping+Operators+to+EOL+OCP+versions
+#
+# See https://docs.engineering.redhat.com/display/StackRox/Add+support+for+new+OpenShift+version#AddsupportfornewOpenShiftversion-RemovesupportforOpenShiftversionwentEOL
+# for info when to adjust this version.
+LABEL com.redhat.openshift.versions="v4.12"
 
 # Use post-processed files (instead of the original ones).
 COPY build/bundle/manifests /manifests/

--- a/operator/bundle.Dockerfile.extra
+++ b/operator/bundle.Dockerfile.extra
@@ -1,7 +1,15 @@
 # Labels for operator certification https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
-# Note: vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
-LABEL com.redhat.openshift.versions="v4.11"
 LABEL com.redhat.delivery.operator.bundle=true
+
+# This sets the earliest version of OCP where our operator build would show up in the official Red Hat operator catalog.
+# vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+#
+# The version here should stay the lowest not yet EOL so that downstream CVP tests don't fail.
+# See EOL schedule: https://docs.engineering.redhat.com/display/SP/Shipping+Operators+to+EOL+OCP+versions
+#
+# See https://docs.engineering.redhat.com/display/StackRox/Add+support+for+new+OpenShift+version#AddsupportfornewOpenShiftversion-RemovesupportforOpenShiftversionwentEOL
+# for info when to adjust this version.
+LABEL com.redhat.openshift.versions="v4.12"
 
 # Use post-processed files (instead of the original ones).
 COPY build/bundle/manifests /manifests/


### PR DESCRIPTION
## Description

This repeats the exercise of https://github.com/stackrox/stackrox/pull/8531, now moving to 4.12 as 4.11 went EOL on Feb 24th.

This is done as part of our [procedure](https://docs.engineering.redhat.com/display/StackRox/Add+support+for+new+OpenShift+version#AddsupportfornewOpenShiftversion-RemovesupportforOpenShiftversionwentEOL).

## Checklist
- [x] Investigated and inspected CI test results

None of these are needed and so won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I will not test this in any particular way besides looking at CI. It should just work like https://github.com/stackrox/stackrox/pull/8531 did.

Note that `ocp-4-11-operator-e2e-tests` passed because the label, to my best belief, only influences where (in which indexes) the image gets released by the downstream tools. It apparently does not prevent the operator from being installed on a lower version (as we decided in OCP compat meeting, we don't want to add hard protection from installing on old versions).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
