### PR TITLE
feat: Add RELATED_IMAGE_ environment variables for Scanner V4 images

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1348,6 +1348,9 @@ spec:
                 - name: RELATED_IMAGE_COLLECTOR_FULL
                 - name: RELATED_IMAGE_ROXCTL
                 - name: RELATED_IMAGE_CENTRAL_DB
+                - name: RELATED_IMAGE_SCANNER_V4_DB
+                - name: RELATED_IMAGE_SCANNER_V4_INDEXER
+                - name: RELATED_IMAGE_SCANNER_V4_MATCHER
                 - name: MEMORY_LIMIT_BYTES
                   valueFrom:
                     resourceFieldRef:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -45,6 +45,9 @@ spec:
         - name: RELATED_IMAGE_COLLECTOR_FULL
         - name: RELATED_IMAGE_ROXCTL
         - name: RELATED_IMAGE_CENTRAL_DB
+        - name: RELATED_IMAGE_SCANNER_V4_DB
+        - name: RELATED_IMAGE_SCANNER_V4_INDEXER
+        - name: RELATED_IMAGE_SCANNER_V4_MATCHER
         - name: MEMORY_LIMIT_BYTES
           valueFrom:
             resourceFieldRef:


### PR DESCRIPTION
## Description

This enables Scanner V4 images get cached for disconnected installs and also be overridden.

Found these are missing through this thread <https://redhat-external.slack.com/archives/C04UNQPLNAC/p1708979138937469>. Did a similar thing for central-db before - <https://github.com/stackrox/stackrox/pull/3643>. How do we not forget doing that in the future?

## Checklist
- [x] Investigated and inspected CI test results

These aren't needed and won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

This one is possible to test manually, but tedious. I will rely on the fact that env variables seem to be plugged in the operator code and that this may soon be tested by IBM colleagues in <https://redhat-external.slack.com/archives/C04UNQPLNAC/p1708979138937469>.

I will check that the downstrteam build injects the default image reference in these new variables, although this is only doable after this is merged.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
