### PR TITLE
fix(Scanner): validate updates bundle version in v4 mode

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -592,14 +592,12 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	cleanup := func() {
 		_ = os.RemoveAll(tmpDir)
 	}
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "removing temporary file")
-	}
 
 	// Extract the file and copy contents to the temporary file, notice we
 	// intentionally don't Sync(), to benefit from filesystem caching.
 	_, err = io.Copy(tmpFile, fileReader)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		return nil, nil, errors.Wrap(err, "writing to temporary file")
 	}
 

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -687,5 +687,5 @@ func validateV4DefsVersion(zipPath string) error {
 			}
 		}
 	}
-
+	return nil
 }

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -604,6 +604,7 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	// Reset for caller's convenience.
 	_, err = tmpFile.Seek(0, io.SeekStart)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		return nil, nil, errors.Wrap(err, "writing to temporary file")
 	}
 	return tmpFile, cleanup, nil

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -493,7 +493,7 @@ func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, u
 
 	offlineFile, err := h.openMostRecentV4OfflineFile(ctx, t, updaterKey, fileName)
 	if err != nil {
-		log.Errorf("failed to access offline file: %v, ignore the message if offline mode is not activated", err)
+		log.Debugf("failed to access offline file: %v, ignore the message if no offline bundle has been uploaded", err)
 	}
 	defer toClose(offlineFile)
 

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -272,7 +272,16 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	// Try download offline zip, only abort test when download fails
+	// No mapping json file
+	req = s.getRequestWithJSONFile(t, "name2repos")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// No mapping json file
+	req = s.getRequestWithJSONFile(t, "repo2cpe")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
 	tempDir := t.TempDir()
 	filePath := tempDir + "/test.zip"
 
@@ -301,6 +310,16 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
+
+	req = s.getRequestWithJSONFile(t, "repo2cpe")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	req = s.getRequestWithJSONFile(t, "name2repos")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 }
 
 func (s *handlerTestSuite) mockHandleDefsFile(zipF *zip.File, blobName string) error {

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -311,14 +311,14 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
 
+	w = mock.NewResponseWriter()
 	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	w.Data.Reset()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
+	w = mock.NewResponseWriter()
 	req = s.getRequestWithJSONFile(t, "name2repos")
-	w.Data.Reset()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -312,11 +312,13 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
 
 	req = s.getRequestWithJSONFile(t, "repo2cpe")
+	w.Data.Reset()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
 	req = s.getRequestWithJSONFile(t, "name2repos")
+	w.Data.Reset()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))


### PR DESCRIPTION
## Description
Validate offline bundle version in v4 mode
Add tests for mapping json download

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed
1. Deploy
```
export OFFLINE_MODE=true
export ROX_SCANNER_V4=true
KUBECONFIG=/path/to/artifacts/kubeconfig deploy/k8s/deploy-local.sh
```

2. Check vuln data
```
unzip -l scanner-vuln-updates.zip
Archive:  scanner-vuln-updates.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
140154404  02-14-2024 11:41   scanner-defs.zip
   248088  02-14-2024 11:41   k8s-istio.zip
144211510  02-14-2024 11:41   scanner-v4-defs-4.3.zip
---------                     -------
284614002                     3 files
```
3. Upload
`curl --insecure -u admin:[PWD] -F "file=@scanner-vuln-updates.zip" https://localhost:8000/api/extensions/scannerdefinitions -v`

4. Successful results
```
* * We are completely uploaded and fine
< HTTP/2 200 
< vary: Accept-Encoding
< content-type: text/plain; charset=utf-8
< content-length: 57
< date: Tue, 27 Feb 2024 23:35:09 GMT
< 
* Connection #0 to host localhost left intact
Successfully stored the offline vulnerability definitions
```

```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?file=repo2cpe > repo2cpe.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2041k  100 2041k    0     0  1040k      0  0:00:01  0:00:01 --:--:-- 1040k
ls -lh repo2cpe.json 
-rw-r--r-- 1 yili staff 2.0M Feb 27 17:54 repo2cpe.json
```

Failure:
```
unzip -l scanner-vulns-4.2.zip
Archive:  scanner-vulns-4.2.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
140524129  02-21-2024 19:41   scanner-defs.zip
   248088  02-21-2024 19:41   k8s-istio.zip
   112200  02-21-2024 19:41   scanner-v4-defs-4.2.zip
---------                     -------
140884417                     3 files
```

`curl --insecure -u admin:[pwd] -F "file=@scanner-vulns-4.2.zip" https://localhost:8000/api/extensions/scannerdefinitions -v`

```
> Content-Length: 140885152
> Content-Type: multipart/form-data; boundary=------------------------hJtnza1jCwuGMNr6NqswqY
> 
* We are completely uploaded and fine
< HTTP/2 400 
< vary: Accept-Encoding
< content-type: text/plain; charset=utf-8
< content-length: 233
< date: Tue, 27 Feb 2024 23:49:40 GMT
< 
* Connection #0 to host localhost left intact
{"code":3,"message":"failed to upload offline file bundle, uploaded file is version: 4.2 and system version is: 4.3.x-1348-gd88b87b02b; please upload an offline bundle version: 4.3, consider using command roxctl scanner download-db"}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
