### PR TITLE
fix(scanv4): indexer/matcher config map pretty display

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -16,9 +16,15 @@ indexer:
       sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
       user=postgres
       sslmode=verify-full
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.statementTimeoutMs) -}} statement_timeout={{._rox.scannerV4.db.source.statementTimeoutMs}} {{- end }}
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.minConns) -}} pool_min_conns={{._rox.scannerV4.db.source.minConns}} {{- end }}
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.statementTimeoutMs) }}
+      statement_timeout={{._rox.scannerV4.db.source.statementTimeoutMs}}
+{{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.minConns) }}
+      pool_min_conns={{._rox.scannerV4.db.source.minConns}}
+{{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) }}
+      pool_max_conns={{._rox.scannerV4.db.source.maxConns}}
+{{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   get_layer_timeout: 1m

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -18,9 +18,15 @@ matcher:
       sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
       user=postgres
       sslmode=verify-full
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.statementTimeoutMs) -}} statement_timeout={{._rox.scannerV4.db.source.statementTimeoutMs}} {{- end }}
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.minConns) -}} pool_min_conns={{._rox.scannerV4.db.source.minConns}} {{- end }}
-      {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.statementTimeoutMs) }}
+      statement_timeout={{._rox.scannerV4.db.source.statementTimeoutMs}}
+{{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.minConns) }}
+      pool_min_conns={{._rox.scannerV4.db.source.minConns}}
+{{- end }}
+{{- if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) }}
+      pool_max_conns={{._rox.scannerV4.db.source.maxConns}}
+{{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION


### PR DESCRIPTION
## Description

Having trailing whitespace or lines consisting only of whitespace in a `ConfigMap` data results in the data being shown as a difficult to read string, when retrieving it using `kubectl`, e.g.:
```yaml
data:
  config.yaml: "# Configuration file for Scanner v4 Matcher.\nstackrox_services: true\nindexer:\n  enable: false\nmatcher:\n  enable: true\n  database:\n    conn_string: >\n      host=scanner-v4-db.stackrox.svc\n      port=5432\n      sslrootcert=/run/secrets/stackrox.io/certs/ca.pem\n      user=postgres\n      sslmode=verify-full\n      \n      \n      \n      client_encoding=UTF8\n    password_file: /run/secrets/stackrox.io/secrets/password\n  indexer_addr: scanner-v4-indexer.stackrox.svc:8443\nlog_level: info\ngrpc_listen_addr: 0.0.0.0:8443\nhttp_listen_addr: 0.0.0.0:9443\nproxy:\n  config_dir: /run/secrets/stackrox.io/proxy-config\n  config_file: config.yaml\n"
```

This is due to this Kubernetes [issue](https://github.com/kubernetes/kubernetes/issues/36222).

This PR makes sure that Helm doesn't output lines that contain whitespace.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```bash
make deploy-via-olm

# install Central with Scanner-V4 enabled

kubectl -n stackrox get cm/scanner-v4-indexer-config -o yaml
kubectl -n stackrox get cm/scanner-v4-matcher-config -o yaml

# verify output
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
