### PR TITLE
chore(signatures): minor improvements to signatures

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stackrox/rox/pkg/scanners/types"
 	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stackrox/rox/pkg/signatures"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/sync"
 	scannerV1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	"golang.org/x/time/rate"
@@ -806,7 +805,7 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 }
 
 func uniqueImageSignatures(sigs []*storage.Signature) []*storage.Signature {
-	uniqueSigs := sliceutils.ShallowClone(sigs)
+	uniqueSigs := make([]*storage.Signature, 0, len(sigs))
 	for _, sig := range sigs {
 		if !protoutils.SliceContains(sig, uniqueSigs) {
 			uniqueSigs = append(uniqueSigs, sig)


### PR DESCRIPTION
## Description

This PR brings two improvements to the signature things:
- we streamlined the verified signature references now to not have the special case of `len(verifiedReferences==0)` and defaulting to the image name, but instead do it within the `getVerifiedImageReferences`.
- we also make sure to not have duplicated signatures being added to the image, this has been seen on one occurrence where an image has more than one signature with the same payload assigned.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
