### PR TITLE
fix(ui): Make helm install in UI consistent with docs

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -16,7 +16,8 @@ import useMetadata from 'hooks/useMetadata';
 import { getVersionedDocs } from 'utils/versioning';
 
 const codeBlock = [
-    'helm install stackrox-secured-cluster-services rhacs/secured-cluster-services -n stackrox \\',
+    'helm install -n stackrox --create-namespace \\',
+    'stackrox-secured-cluster-services rhacs/secured-cluster-services \\',
     '-f <path/to/Helm-values-cluster-init-bundle.yaml> \\',
     '--set clusterName=<name_of_the_secured_cluster> \\',
     '--set centralEndpoint=<endpoint_of_central_service> \\',


### PR DESCRIPTION
## Description

Thank you Kerry for identifying this inconsistency:
1. Docs (as source of truth) has `stackrox-secured-cluster-services` with `--create-namespace`
    * https://docs.openshift.com/acs/4.3/installing/installing_other/install-secured-cluster-other.html
    * https://docs.openshift.com/acs/4.3/installing/installing_ocp/install-secured-cluster-ocp.html#installing-secured-cluster-services-quickly_install-secured-cluster-ocp
2. Platform UI has `stackrox-secured-cluster-services` without `--create-namespace`
3. RedHatInsights UI (as indirect source, but with unknown provenance) has `rhacs-secured-cluster-services` without `--create-namespace`
    https://github.com/RedHatInsights/acs-ui/blob/main/src/routes/GettingStartedPage/Wizard/InstallWithHelm.js#L50

### Analysis

Because successful installation during team test worked around some problems, it seems plausible that the namespace had been created by some other step along the way.

### Solution

Replace first line of code block in Platform UI with first two lines from docs.

### Residue

Fix RedHatInsights UI for 4.4 upgrade to cloud service.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui