### PR TITLE
ROX-22144: Disallow creating a scan if SSB has same profile

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/singleton.go
+++ b/central/complianceoperator/v2/compliancemanager/singleton.go
@@ -5,6 +5,7 @@ import (
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
+	ssbDatastore "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -17,7 +18,7 @@ var (
 // Singleton returns the compliance operator manager
 func Singleton() Manager {
 	once.Do(func() {
-		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton())
+		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton(), ssbDatastore.Singleton())
 	})
 	return manager
 }

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -298,8 +298,8 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 		},
 	}
 
-	_, err = service.CreateComplianceScanConfiguration(ctx, duplicateSSBProfileReq)
-	assert.Contains(t, err.Error(), "already exists for profile")
+	_, err = scanConfigService.CreateComplianceScanConfiguration(ctx, duplicateSSBProfileReq)
+	assert.Contains(t, err.Error(), "is already used in scan setting binding")
 
 	err = client.Delete(context.TODO(), duplicatedScanSettingBinding)
 	require.NoError(t, err, "failed to delete ScanSettingBinding %s", duplicatedScanSettingBinding.Name)


### PR DESCRIPTION
## Description

The Compliance Operator will only run check for one time if a profile is executed under multiple scan setting bindings. So to ensure that the user retrieves results as expected then we should alert the user if the scan configuration being created in ACS clashes with an existing SSB in compliance operator.  If such a clash exists we should return an error notifying the user of this during the creation of the scan configuration.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* Added Unit-test to ComplianceManager.
* Added e2e test to test creating scan with a duplicated profile ScanSettingBinding.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
