### PR TITLE
ROX-18561: fix flake during version replacement

### DIFF
--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -1,6 +1,7 @@
 package printers
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"regexp"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +76,7 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// Since the report contains the version, replace it specifically here.
-	exp, err := regexp.Compile(`"version": "[34].*"`)
+	exp, err := regexp.Compile(fmt.Sprintf(`"version": "%s"`, version.GetMainVersion()))
 	require.NoError(t, err)
 	output := exp.ReplaceAllString(out.String(), `"version": ""`)
 	assert.Equal(t, string(expectedOutput), output)


### PR DESCRIPTION
## Description

The SARIF test currently asserts on the output without the taking into account of the version.

Currently, the version is being replaced by a regex and expects it to start with either 3.X or 4.X. While this is expected, we do have some people running the release pipeline with different tags and it's easier to just replace with `version.GetMainVersion()` to make things more robust.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
