### PR TITLE
ROX-22760: fix SARIF printer for empty results

### DIFF
--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/gjson"
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version"
 )
@@ -197,7 +198,9 @@ func sarifEntriesFromJSONObject(jsonObject interface{}, pathExpressions map[stri
 
 	numberOfValues := len(data[SarifRuleJSONPathExpressionKey])
 	for key, values := range data {
-		if len(values) != numberOfValues {
+		// "-" is used as an empty replacement value in case values are missing in an array for GJSON. Hence, ignore
+		// all values which may not match the number of expected values iff the array contains the replacement value.
+		if len(values) != numberOfValues && !sliceutils.Equal(values, []string{"-"}) {
 			return nil, errox.InvalidArgs.Newf("the amount of values retrieved from JSON path expressions "+
 				"should be %d, but got %d for key %s", numberOfValues, len(values), key)
 		}

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -81,3 +81,26 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	output := exp.ReplaceAllString(out.String(), `"version": ""`)
 	assert.Equal(t, string(expectedOutput), output)
 }
+
+func TestSarifPrinter_Print_EmptyViolations(t *testing.T) {
+	obj := &testObject{Violations: []violation{}}
+	expressions := map[string]string{
+		SarifRuleJSONPathExpressionKey:     "violations.#.id",
+		SarifHelpJSONPathExpressionKey:     "violations.#.reason",
+		SarifSeverityJSONPathExpressionKey: "violations.#.severity",
+	}
+
+	out := strings.Builder{}
+	expectedOutput, err := os.ReadFile(path.Join("testdata", "empty_sarif_report.json"))
+	require.NoError(t, err)
+
+	printer := NewSarifPrinter(expressions, "docker.io/nginx:1.19", SarifPolicyReport)
+	err = printer.Print(obj, &out)
+	require.NoError(t, err)
+
+	// Since the report contains the version, replace it specifically here.
+	exp, err := regexp.Compile(fmt.Sprintf(`"version": "%s"`, version.GetMainVersion()))
+	require.NoError(t, err)
+	output := exp.ReplaceAllString(out.String(), `"version": ""`)
+	assert.Equal(t, string(expectedOutput), output)
+}

--- a/pkg/printers/testdata/empty_sarif_report.json
+++ b/pkg/printers/testdata/empty_sarif_report.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "fullName": "roxctl command line utility",
+          "informationUri": "https://github.com/stackrox/stackrox",
+          "name": "roxctl",
+          "rules": [],
+          "version": ""
+        }
+      },
+      "results": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description

We've received an issue where the SARIF report couldn't be generated in case no violations have been found during image / deployment check.

The reason is that the JSON path expressions we use with GJSON, particularily the `help` one, is returning a `-` as value. This is our "empty value" replacement string, which is needed to be returned for array values.

We didn't handle this properly during evaluating the JSON path expressions, so this is now being handled correctly.

_Note: this should be merged after #10148 since it also fixes the version replacement_

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Manual test:
Run roxctl for a deployment which doesn't have violations and expect no errors being returned, just an empty SARIF report:
```bash
roxctl image check --image=quay.io/jetstack/cert-manager-webhook:v1.14.3 --output sarif
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
