### PR TITLE
fix(ci): Use Operator in the OSD jobs

### DIFF
--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -8,6 +8,7 @@ from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import AutomationFlavorsCluster
 
 # set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 

--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -10,7 +10,6 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
-os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -8,6 +8,7 @@ from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import AutomationFlavorsCluster
 
 # set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -10,7 +10,6 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
-os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -322,8 +322,6 @@ deploy_sensor() {
         # et al.
         kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
     fi
-    # Bump Sensor's memory to match operator installs.
-    kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'memory=4Gi' --limits 'memory=8Gi'
 }
 
 # shellcheck disable=SC2120

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -322,11 +322,8 @@ deploy_sensor() {
         # et al.
         kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
     fi
-    # Bump Sensor's memory to avoid OOMing.
-    # See:
-    # https://issues.redhat.com/browse/ROX-22587
-    # This should be removed once we implement mechanisms to retrieve information before OOMing.
-    kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'memory=2Gi' --limits 'memory=4Gi'
+    # Bump Sensor's memory to match operator installs.
+    kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'memory=4Gi' --limits 'memory=8Gi'
 }
 
 # shellcheck disable=SC2120

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -322,6 +322,11 @@ deploy_sensor() {
         # et al.
         kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
     fi
+    # Bump Sensor's memory to avoid OOMing.
+    # See:
+    # https://issues.redhat.com/browse/ROX-22587
+    # This should be removed once we implement mechanisms to retrieve information before OOMing.
+    kubectl -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'memory=2Gi' --limits 'memory=4Gi'
 }
 
 # shellcheck disable=SC2120


### PR DESCRIPTION
## Description

~Currently sensor's memory limit is 500Mi when we deploy with the deploy scripts. This is causing sensor to OOM in some instances. Until we have a better way to debug these OOMs, let's bump sensor's memory limits to match operator installs (4Gi/8Gi).~

~Additionally,~ the OSD jobs were not being deployed via operator.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Check in the artifacts that sensor's memory limit are set to the new value.
- [x] Check the OSD jobs and make sure they're deployed via operator.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
