### PR TITLE
fix: Unify RELATED_IMAGE_SCANNER_V4_* to just RELATED_IMAGE_SCANNER_V4

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1349,8 +1349,7 @@ spec:
                 - name: RELATED_IMAGE_ROXCTL
                 - name: RELATED_IMAGE_CENTRAL_DB
                 - name: RELATED_IMAGE_SCANNER_V4_DB
-                - name: RELATED_IMAGE_SCANNER_V4_INDEXER
-                - name: RELATED_IMAGE_SCANNER_V4_MATCHER
+                - name: RELATED_IMAGE_SCANNER_V4
                 - name: MEMORY_LIMIT_BYTES
                   valueFrom:
                     resourceFieldRef:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -46,8 +46,7 @@ spec:
         - name: RELATED_IMAGE_ROXCTL
         - name: RELATED_IMAGE_CENTRAL_DB
         - name: RELATED_IMAGE_SCANNER_V4_DB
-        - name: RELATED_IMAGE_SCANNER_V4_INDEXER
-        - name: RELATED_IMAGE_SCANNER_V4_MATCHER
+        - name: RELATED_IMAGE_SCANNER_V4
         - name: MEMORY_LIMIT_BYTES
           valueFrom:
             resourceFieldRef:

--- a/operator/pkg/images/env.go
+++ b/operator/pkg/images/env.go
@@ -13,6 +13,6 @@ var (
 	CollectorSlim    = env.RegisterSetting("RELATED_IMAGE_COLLECTOR_SLIM")
 	CollectorFull    = env.RegisterSetting("RELATED_IMAGE_COLLECTOR_FULL")
 	ScannerV4DB      = env.RegisterSetting("RELATED_IMAGE_SCANNER_V4_DB")
-	ScannerV4Indexer = env.RegisterSetting("RELATED_IMAGE_SCANNER_V4_INDEXER")
-	ScannerV4Matcher = env.RegisterSetting("RELATED_IMAGE_SCANNER_V4_MATCHER")
+	ScannerV4Indexer = env.RegisterSetting("RELATED_IMAGE_SCANNER_V4")
+	ScannerV4Matcher = env.RegisterSetting("RELATED_IMAGE_SCANNER_V4")
 )


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/stackrox/pull/10128 in attempt to get successful downstream build with V4.

`RELATED_IMAGE_*` populated values are needed for users to be able to mirror containers for air-gapped/disconnected usage. They also provide means to override operand images used by the operator.

The way they are populated downstream is a bit convoluted and for the most part outside of our control. Here's what I can remember about it.

1. In the downstream build, all operands and operator are built before operator bundle.
2. Operator bundle build is triggered after that, and information about all containers built by the pipeline before that is passed in environment variables like `RHACS_SCANNER_V4_RHEL8_CONTAINER_BUILD_INFO_JSON`.
This goes by _container image_ actually built. Therefore, if we build `scanner_v4` container we get one variable `RHACS_SCANNER_V4_RHEL8_CONTAINER_BUILD_INFO_JSON`. If we would build two separate `scanner_v4_indexer` and `scanner_v4_matcher` containers, we'd automatically receive two variables: `RHACS_SCANNER_V4_INDEXER_RHEL8_CONTAINER_BUILD_INFO_JSON` and `RHACS_SCANNER_V4_MATCHER_RHEL8_CONTAINER_BUILD_INFO_JSON` but we don't.
3. We have a pair of scripts where [one](https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/blob/rhacs-1.0-rhel-8/distgit/containers/rhacs-operator-bundle/collect-related-images.py?ref_type=heads) converts `RHACS_*_RHEL8_CONTAINER_BUILD_INFO_JSON` to `RELATED_IMAGE_*`, [another](https://github.com/stackrox/stackrox/blob/67730496e0f6356dfe459d6381f2b924a76844ab/operator/bundle_helpers/patch-csv.py#L26-L38) injects values of `RELATED_IMAGE_*` environment variables into Operator CSV.
4. The previous step injects images with floating tags and in internal registry, e.g. `RELATED_IMAGE_SCANNER_V4=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-v4-rhel8:1.0.0-21`. There is a step in OSBS (the thing which builds containers downstream) called [pinning](https://osbs.readthedocs.io/en/latest/users.html?highlight=pinning#pinning-pullspecs-for-related-images). It replaces floating tag with digest and updates registry from internal to `registry.redhat.io` with our project's location appended - `registry.redhat.io/advanced-cluster-security/`. It also populates `spec.relatedImages`.

<details>
<summary>The end result looks like this (for 4.3.4)</summary>

```yaml
[...]
              containers:
              - [...]
                env:
                - name: RELATED_IMAGE_MAIN
                  value: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:04820b12f8d78d1da4c6fa055f8284be0c0b6e3541969257c87fb950adfa044c
                - name: RELATED_IMAGE_SCANNER
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8@sha256:4bb16bf9a0162dc80fce2ae7ba941540ea03c7c1cc929a2af27c9acb51030806
                - name: RELATED_IMAGE_SCANNER_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8@sha256:c773398e7278d7ec19c802786f0db169bcaba24449d906ed2c3327d91203b94d
                - name: RELATED_IMAGE_SCANNER_DB
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:359d14444d599da13706737560f5f3f344e47ab15aaed806164a450414f599df
                - name: RELATED_IMAGE_SCANNER_DB_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8@sha256:1ac1d4f3c9fee60d4927e7e1df38867b5b5cae738f2e036ae365695e3cecf6d2
                - name: RELATED_IMAGE_COLLECTOR_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8@sha256:55695b0f92544108645c2bd2128f0bae1f2b7f87fb774fd8345ce71c9319c11e
                - name: RELATED_IMAGE_COLLECTOR_FULL
                  value: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8@sha256:718dafd75b2f37904acae157de11be8827c0adc523f870c3bc8cc89f3987d8a2
                - name: RELATED_IMAGE_ROXCTL
                  value: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:31fda70497c8d178257a58830ff64adc2e452e4ef946293b62d6cb2974bd52ed
                - name: RELATED_IMAGE_CENTRAL_DB
                  value: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:ade3c0b4cfb4b40b107c05dd4e384a3d255852bbfc99cc45b53472180f4aad73
[...]
  relatedImages:
  - name: rhacs-rhel8-operator-2667b40a5a90d15eaa696453dd39146c2072f9630aa14deac1a0d38bddc2aee9-annotation
    image: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:2667b40a5a90d15eaa696453dd39146c2072f9630aa14deac1a0d38bddc2aee9
  - name: manager
    image: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:2667b40a5a90d15eaa696453dd39146c2072f9630aa14deac1a0d38bddc2aee9
  - name: kube-rbac-proxy
    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:a8ad0e76ce4cae9f9b36aecf125c4ed56fc2d776fe3df113d41bfc1c2f8b3602
  - name: main
    image: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:04820b12f8d78d1da4c6fa055f8284be0c0b6e3541969257c87fb950adfa044c
  - name: scanner
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8@sha256:4bb16bf9a0162dc80fce2ae7ba941540ea03c7c1cc929a2af27c9acb51030806
  - name: scanner_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8@sha256:c773398e7278d7ec19c802786f0db169bcaba24449d906ed2c3327d91203b94d
  - name: scanner_db
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:359d14444d599da13706737560f5f3f344e47ab15aaed806164a450414f599df
  - name: scanner_db_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8@sha256:1ac1d4f3c9fee60d4927e7e1df38867b5b5cae738f2e036ae365695e3cecf6d2
  - name: collector_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8@sha256:55695b0f92544108645c2bd2128f0bae1f2b7f87fb774fd8345ce71c9319c11e
  - name: collector_full
    image: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8@sha256:718dafd75b2f37904acae157de11be8827c0adc523f870c3bc8cc89f3987d8a2
  - name: roxctl
    image: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:31fda70497c8d178257a58830ff64adc2e452e4ef946293b62d6cb2974bd52ed
  - name: central_db
    image: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:ade3c0b4cfb4b40b107c05dd4e384a3d255852bbfc99cc45b53472180f4aad73
```

</details>

The current attempt to use `RELATED_IMAGE_SCANNER_V4_INDEXER` and `RELATED_IMAGE_SCANNER_V4_MATCHER` when only `RELATED_IMAGE_SCANNER_V4` is provided leads to operator bundle build error downstream. [Here](https://jenkins-cpaas-rhacs.apps.cpaas-poc.r6c9.p1.openshiftapps.com/job/release-1.0/job/rhacs/job/rhacs-operator-bundle/job/rhel8-operator-container/3/consoleFull), search for "Traceback", note that logs last until we redeploy CPaaS.

<details>
<summary>Relevant part of the output</summary>

```
 ++ ./collect-related-images.py
 + export RELATED_IMAGE_COLLECTOR_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-collector-slim-rhel8:1.0.0-102 export RELATED_IMAGE_SCANNER_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-slim-rhel8:1.0.0-528 export RELATED_IMAGE_MAIN=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-main-rhel8:1.0.0-599 export RELATED_IMAGE_CENTRAL_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-central-db-rhel8:1.0.0-219 export RELATED_IMAGE_SCANNER_V4=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-v4-rhel8:1.0.0-21 export RELATED_IMAGE_SCANNER=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-rhel8:1.0.0-606 export RELATED_IMAGE_COLLECTOR_FULL=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-collector-rhel8:1.0.0-393 export RELATED_IMAGE_SCANNER_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-db-rhel8:1.0.0-630 export RELATED_IMAGE_ROXCTL=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-roxctl-rhel8:1.0.0-290 export RELATED_IMAGE_OPERATOR=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-rhel8-operator:1.0.0-310 export RELATED_IMAGE_SCANNER_V4_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-v4-db-rhel8:1.0.0-21 export RELATED_IMAGE_SCANNER_DB_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-db-slim-rhel8:1.0.0-96
 + RELATED_IMAGE_COLLECTOR_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-collector-slim-rhel8:1.0.0-102
 + RELATED_IMAGE_SCANNER_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-slim-rhel8:1.0.0-528
 + RELATED_IMAGE_MAIN=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-main-rhel8:1.0.0-599
 + RELATED_IMAGE_CENTRAL_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-central-db-rhel8:1.0.0-219
 + RELATED_IMAGE_SCANNER_V4=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-v4-rhel8:1.0.0-21
 + RELATED_IMAGE_SCANNER=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-rhel8:1.0.0-606
 + RELATED_IMAGE_COLLECTOR_FULL=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-collector-rhel8:1.0.0-393
 + RELATED_IMAGE_SCANNER_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-db-rhel8:1.0.0-630
 + RELATED_IMAGE_ROXCTL=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-roxctl-rhel8:1.0.0-290
 + RELATED_IMAGE_OPERATOR=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-rhel8-operator:1.0.0-310
 + RELATED_IMAGE_SCANNER_V4_DB=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-v4-db-rhel8:1.0.0-21
 + RELATED_IMAGE_SCANNER_DB_SLIM=registry-proxy.engineering.redhat.com/rh-osbs/rhacs-scanner-db-slim-rhel8:1.0.0-96
 + upstream-sources/operator/bundle_helpers/patch-csv.py --use-version 1.0.0 --first-version 4.0.0 --operator-image registry-proxy.engineering.redhat.com/rh-osbs/rhacs-rhel8-operator:1.0.0-310 --add-supported-arch amd64 --add-supported-arch ppc64le --add-supported-arch s390x
 2024-02-28 00:52:17,930 patch-csv.py: Replaced: quay.io/stackrox-io/stackrox-operator:0.0.1 with registry-proxy.engineering.redhat.com/rh-osbs/rhacs-rhel8-operator:1.0.0-310
 2024-02-28 00:52:17,930 patch-csv.py: Replaced: quay.io/stackrox-io/stackrox-operator:0.0.1 with registry-proxy.engineering.redhat.com/rh-osbs/rhacs-rhel8-operator:1.0.0-310
 Traceback (most recent call last):
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/patch-csv.py", line 177, in <module>
     main()
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/patch-csv.py", line 167, in main
     patch_csv(doc,
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/patch-csv.py", line 64, in patch_csv
     rewrite(csv_doc, related_image_passthrough)
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   [Previous line repeated 1 more time]
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 17, in rewrite
     res = rewrite(elem, rewriter)
           ^^^^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   [Previous line repeated 1 more time]
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 17, in rewrite
     res = rewrite(elem, rewriter)
           ^^^^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 24, in rewrite
     res = rewrite(v, rewriter)
           ^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 17, in rewrite
     res = rewrite(elem, rewriter)
           ^^^^^^^^^^^^^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/rewrite.py", line 12, in rewrite
     res = rewriter(d)
           ^^^^^^^^^^^
   File "/workDir/workspace/release-1.0/rhacs/rhacs-operator-bundle/rhel8-operator-container/rhacs-operator-bundle/upstream-sources/operator/bundle_helpers/patch-csv.py", line 38, in related_image_passthrough
     val["value"] = os.environ[name]
                    ~~~~~~~~~~^^^^^^
   File "<frozen os>", line 685, in __getitem__
 KeyError: 'RELATED_IMAGE_SCANNER_V4_INDEXER'
```

</details>

Since we don't have separate V4 matcher and indexer images, we either have to reduce our `RELATED_IMAGE_*` environment variables (this PR) or adjust the step (3) to populate both `RELATED_IMAGE_SCANNER_V4_INDEXER` and `RELATED_IMAGE_SCANNER_V4_MATCHER` with the same data and hope that step (4) and further machinery remains happy with that (or address issues that occur there).

This PR suggests to use only one variable `RELATED_IMAGE_SCANNER_V4` following the fact that we don't have separate images for matcher and indexer today. Whether we plan having them in the future is hopefully going to be clarified in [this Slack thread](https://redhat-internal.slack.com/archives/C033Z8KMZAM/p1709119914557639).

This PR (obviously) does not touch `RELATED_IMAGE_SCANNER_V4_DB` because there is a separate image for it.

## Checklist
- [x] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

This isn't very testable upstream. The plan would be to merge this (once CI is green enough), run the build downstream and examine the output.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
