### PR TITLE
ROX-22613: Duplicated hint with default value for boolean flags

### DIFF
--- a/roxctl/patch_flag_usage.go
+++ b/roxctl/patch_flag_usage.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -9,7 +9,10 @@ import (
 
 func processFlag(flag *pflag.Flag) {
 	if flag.Value.Type() == "bool" && flag.DefValue == "false" && flag.Name != "help" {
-		flag.Usage = fmt.Sprintf("%s (default %s)", flag.Usage, flag.DefValue)
+		const defaultFalseSuffix = " (default false)"
+		if !strings.HasSuffix(flag.Usage, defaultFalseSuffix) {
+			flag.Usage += defaultFalseSuffix
+		}
 	}
 }
 

--- a/roxctl/patch_flag_usage.go
+++ b/roxctl/patch_flag_usage.go
@@ -14,6 +14,8 @@ func processFlag(flag *pflag.Flag) {
 }
 
 func processCommandFlags(command *cobra.Command) {
+	// LocalFlags() calls mergePersistentFlags() so PersistentFlags are merged.
+	_ = command.LocalFlags()
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		processFlag(flag)
 	})

--- a/roxctl/patch_flag_usage.go
+++ b/roxctl/patch_flag_usage.go
@@ -17,9 +17,6 @@ func processCommandFlags(command *cobra.Command) {
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		processFlag(flag)
 	})
-	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-		processFlag(flag)
-	})
 }
 
 // AddMissingDefaultsToFlagUsage processes the tree of commands starting at the provided command

--- a/roxctl/patch_flag_usage.go
+++ b/roxctl/patch_flag_usage.go
@@ -1,25 +1,21 @@
 package main
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func processFlag(flag *pflag.Flag) {
 	if flag.Value.Type() == "bool" && flag.DefValue == "false" && flag.Name != "help" {
-		const defaultFalseSuffix = " (default false)"
-		if !strings.HasSuffix(flag.Usage, defaultFalseSuffix) {
-			flag.Usage += defaultFalseSuffix
-		}
+		flag.Usage += " (default false)"
 	}
 }
 
 func processCommandFlags(command *cobra.Command) {
-	// LocalFlags() calls mergePersistentFlags() so PersistentFlags are merged.
-	_ = command.LocalFlags()
-	command.Flags().VisitAll(func(flag *pflag.Flag) {
+	// LocalFlags() calls mergePersistentFlags() so PersistentFlags are merged
+	// to Flags(), but returns only local flags, so PersistentFlags are not
+	// revisited on every command.
+	command.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		processFlag(flag)
 	})
 }

--- a/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
+++ b/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
@@ -22,15 +22,15 @@ teardown() {
 
 @test "roxctl-release roxctl help should have no duplicated (default false) " {
   run roxctl-release --help
-  assert_line --regexp "^[[:space:]]+--insecure .* to true (default false)$"
+  assert_line --regexp "--insecure .* to true (default false)$"
 }
 
 @test "roxctl-release roxctl central whoami help should have no duplicated (default false) " {
   run roxctl-release central whoami --help
-  assert_line --regexp "^[[:space:]]+--plaintext .* to true (default false)$"
+  assert_line --regexp "--plaintext .* to true (default false)$"
 }
 
 @test "roxctl-release roxctl declarative-config create notifier generic help shouldn have no duplicated (default false) " {
   run roxctl-release declarative-config create notifier generic --help
-  assert_line --regexp "^[[:space:]]+--webhook-skip-tls-verify .* verification (default false)$"
+  assert_line --regexp "--webhook-skip-tls-verify .* verification (default false)$"
 }

--- a/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
+++ b/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+out_dir=""
+
+setup_file() {
+  # remove binaries from the previous runs
+  delete-outdated-binaries "$(roxctl-release version)"
+
+  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
+  command -v yq > /dev/null || skip "Tests in this file require yq"
+}
+
+setup() {
+  export out_dir="$(mktemp -d -u)"
+}
+
+teardown() {
+  rm -rf "$out_dir"
+}
+
+@test "roxctl-release roxctl help should have no duplicated (default false) " {
+  run roxctl-release --help
+  assert_line --regexp "^      --insecure .* to true (default false)$"
+}
+
+@test "roxctl-release roxctl central whoami help should have no duplicated (default false) " {
+  run roxctl-release central whoami --help
+  assert_line --regexp "^      --plaintext .* to true (default false)$"
+}
+
+@test "roxctl-release roxctl declarative-config create notifier generic help shouldn have no duplicated (default false) " {
+  run roxctl-release declarative-config create notifier generic --help
+  assert_line --regexp "^      --webhook-skip-tls-verify .* verification (default false)$"
+}

--- a/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
+++ b/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
@@ -22,15 +22,15 @@ teardown() {
 
 @test "roxctl-release roxctl help should have no duplicated (default false) " {
   run roxctl-release --help
-  assert_line --regexp "^      --insecure .* to true (default false)$"
+  assert_line --regexp "^[[:space:]]+--insecure .* to true (default false)$"
 }
 
 @test "roxctl-release roxctl central whoami help should have no duplicated (default false) " {
   run roxctl-release central whoami --help
-  assert_line --regexp "^      --plaintext .* to true (default false)$"
+  assert_line --regexp "^[[:space:]]+--plaintext .* to true (default false)$"
 }
 
 @test "roxctl-release roxctl declarative-config create notifier generic help shouldn have no duplicated (default false) " {
   run roxctl-release declarative-config create notifier generic --help
-  assert_line --regexp "^      --webhook-skip-tls-verify .* verification (default false)$"
+  assert_line --regexp "^[[:space:]]+--webhook-skip-tls-verify .* verification (default false)$"
 }

--- a/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
+++ b/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
@@ -23,15 +23,15 @@ teardown() {
 
 @test "roxctl-release roxctl help should have no duplicated (default false) " {
   run roxctl-release --help
-  assert_line --regexp "--insecure .* to true (default false)$"
+  assert_line --regexp '^[[:space:]]+--insecure .* to true \(default false\)$'
 }
 
 @test "roxctl-release roxctl central whoami help should have no duplicated (default false) " {
   run roxctl-release central whoami --help
-  assert_line --regexp "--plaintext .* to true (default false)$"
+  assert_line --regexp '^[[:space:]]+--plaintext .* to true \(default false\)$'
 }
 
 @test "roxctl-release roxctl declarative-config create notifier generic help shouldn have no duplicated (default false) " {
   run roxctl-release declarative-config create notifier generic --help
-  assert_line --regexp "--webhook-skip-tls-verify .* verification (default false)$"
+  assert_line --regexp '^[[:space:]]+--webhook-skip-tls-verify .* verification \(default false\)$'
 }

--- a/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
+++ b/tests/roxctl/bats-tests/local/central-boolean-defaults.bats
@@ -13,7 +13,8 @@ setup_file() {
 }
 
 setup() {
-  export out_dir="$(mktemp -d -u)"
+  out_dir="$(mktemp -d -u)"
+  export out_dir
 }
 
 teardown() {


### PR DESCRIPTION
## Description

Notice the default value hints in the end of the help message:

```console
michael@work$ roxctl
...
--plaintext                  Use a plaintext (unencrypted) connection; only works in conjunction with --insecure. Alternatively can be enabled by setting the ROX_PLAINTEXT environment variable to true (default false) (default false)
...
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

After the change:

```console
$ roxctl
...
--plaintext                  Use a plaintext (unencrypted) connection; only works in conjunction with --insecure. Alternatively can be enabled by setting the ROX_PLAINTEXT environment variable to true (default false)
...
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
