### PR TITLE
ROX-21656: roxctl deployment check E2E tests

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -113,3 +113,8 @@ pz-test: compile
 pz-test-debug: compile
 	@echo "+ $@"
 	$(GRADLE) testPZDebug $(GRADLE_TEST_ARGS)
+
+.PHONY: deployment-check-test
+deployment-check-test: compile
+	@echo "+ $@"
+	$(GRADLE) testDeploymentCheck $(GRADLE_TEST_ARGS)

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -251,7 +251,6 @@ task runSampleScript(dependsOn: 'classes', type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
     }
 }
-
 task testPZ(type: Test) {
     useJUnitPlatform {
         includeTags "PZ"
@@ -260,6 +259,11 @@ task testPZ(type: Test) {
 task testPZDebug(type: Test) {
     useJUnitPlatform {
         includeTags "PZDebug"
+    }
+}
+task testDeploymentCheck(type: Test) {
+    useJUnitPlatform {
+        includeTags "DeploymentCheck"
     }
 }
 test {

--- a/qa-tests-backend/src/main/groovy/services/DetectionService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/DetectionService.groovy
@@ -1,15 +1,16 @@
-package services;
+package services
 
 import io.stackrox.proto.api.v1.DetectionServiceGrpc
 import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployDetectionResponse
-import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployYAMLDetectionRequest;
+import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployYAMLDetectionRequest
 
-class DetectionService extends BaseService{
+class DetectionService extends BaseService {
     static getDetectionClient() {
         return DetectionServiceGrpc.newBlockingStub(getChannel())
     }
 
-    static DeployDetectionResponse getDetectDeploytimeFromYAML(DeployYAMLDetectionRequest request = DeployYAMLDetectionRequest.newBuilder().build()){
+    static DeployDetectionResponse getDetectDeploytimeFromYAML(
+            DeployYAMLDetectionRequest request = DeployYAMLDetectionRequest.newBuilder().build()) {
         return getDetectionClient().detectDeployTimeFromYAML(request)
     }
 

--- a/qa-tests-backend/src/main/groovy/services/DetectionService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/DetectionService.groovy
@@ -1,0 +1,16 @@
+package services;
+
+import io.stackrox.proto.api.v1.DetectionServiceGrpc
+import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployDetectionResponse
+import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployYAMLDetectionRequest;
+
+class DetectionService extends BaseService{
+    static getDetectionClient() {
+        return DetectionServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    static DeployDetectionResponse getDetectDeploytimeFromYAML(DeployYAMLDetectionRequest request = DeployYAMLDetectionRequest.newBuilder().build()){
+        return getDetectionClient().detectDeployTimeFromYAML(request)
+    }
+
+}

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -209,7 +209,3 @@ spec:
         """.formatted(deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName)
     }
 }
-
-
-
-

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -1,9 +1,6 @@
 import static util.Helpers.withRetry
 
-import io.fabric8.openshift.api.model.ClusterRoleBinding
-
 import io.stackrox.proto.api.v1.DetectionServiceOuterClass
-import io.stackrox.proto.api.v1.DetectionServiceOuterClass.DeployDetectionRemark
 import io.stackrox.proto.storage.Rbac
 
 import objects.K8sRole
@@ -81,7 +78,7 @@ class DeploymentCheck extends BaseSpecification {
     @Tag("BAT")
     @Tag("Integration")
     @Tag("DeploymentCheck")
-    def "Test Deployment Check - Multiple Deployments"() {
+    def "Test Deployment Check - Single Deployment"() {
         given:
         "builder is prepared"
         def builder = DetectionServiceOuterClass.DeployYAMLDetectionRequest.newBuilder()
@@ -125,8 +122,8 @@ class DeploymentCheck extends BaseSpecification {
         then:
         assert res
         assert res.getRemarksList().size() == 2
-        assert !res.getRemarksList().findAll {it.getName() == DEPLOYMENT_CHECK}.isEmpty()
-        assert !res.getRemarksList().findAll {it.getName() == "de2"}.isEmpty()
+        assert !res.getRemarksList().findAll { it.getName() == DEPLOYMENT_CHECK }.isEmpty()
+        assert !res.getRemarksList().findAll { it.getName() == "de2" }.isEmpty()
     }
 
     static String createDeploymentYaml(String deploymentName) {
@@ -206,6 +203,7 @@ spec:
         image: ubuntu:latest
         ports:
         - containerPort: 80
-        """.formatted(deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName)
+        """.formatted(deploymentName, deploymentName, deploymentName, deploymentName, deploymentName, deploymentName,
+                deploymentName, deploymentName, deploymentName)
     }
 }

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -1,0 +1,71 @@
+import javax.security.auth.Subject
+
+import io.fabric8.kubernetes.api.model.ServiceAccount
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding
+import io.kubernetes.client.proto.V1
+
+import io.stackrox.proto.api.v1.DetectionServiceGrpc
+import io.stackrox.proto.storage.ServiceAccountOuterClass
+
+import objects.Deployment
+import objects.NetworkPolicy
+import objects.NetworkPolicyTypes
+import services.DetectionService
+
+import spock.lang.Tag
+
+class DeploymentCheck extends BaseSpecification {
+    // Test labels - each test has its own unique label space. This is also used to name
+    // each tests policy and deployment.
+    private final static String DEPLOYMENT_CHECK = "check-deployments"
+
+//    private final static Map<String, NetworkPolicy> POLICIES = [
+//            (DEPLOYMENT_CHECK):
+//            new NetworkPolicy("multi-port-egress")
+//                    .setNamespace("qa")
+//                    .addPodSelector("app":DEPLOYMENT_CHECK)
+//                    .addPolicyType(NetworkPolicyTypes.INGRESS)
+//
+//    ]
+//
+//    private final static Map<String, ServiceAccount> SERVICE_ACCOUNTS = [
+//            (DEPLOYMENT_CHECK): new ServiceAccount()
+//
+//    ]
+//
+//    private final static Map<String, ClusterRoleBinding> CLUSTER_ROLE_BINDING = [
+//            (DEPLOYMENT_CHECK): new ClusterRoleBinding().setSubjects()
+//    ]
+
+    private final static Map<String, Deployment> DEPLOYMENTS = [
+            (DEPLOYMENT_CHECK):
+                new Deployment()
+                        .setName(DEPLOYMENT_CHECK)
+                        .setNamespace("qa")
+                        .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine")
+                        .addPort(80)
+                        .setSkipReplicaWait(true)
+                        .addLabel("app", DEPLOYMENT_CHECK)
+                        .setServiceAccountName(""),
+    ]
+
+
+
+    def setupSpec(){}
+
+    def cleanupSpec(){}
+
+    /*
+    1. Create policies, deployments, network policies and RBACs in the test setup
+    2. Call a central API (deployment check)
+    3. Assert that the violation slice has (or doesn't) certain violations
+    * */
+
+    @Tag("BAT")
+    @Tag("Integration")
+    @Tag("DeploymentCheck")
+    def "Test Deployment Check"(){
+        DetectionService.getDetectDeploytimeFromYAML()
+
+    }
+}

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -103,6 +103,9 @@ class DeploymentCheck extends BaseSpecification {
         assert res.getRemarks(0).getAppliedNetworkPolicies(0) == DEPLOYMENT_CHECK
     }
 
+    @Tag("BAT")
+    @Tag("Integration")
+    @Tag("DeploymentCheck")
     def "Test Deployment Check - Multiple Deployments"() {
         given:
         "builder is prepared"

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -40,20 +40,32 @@ class DeploymentCheck extends BaseSpecification {
     private final static Map<String, Deployment> DEPLOYMENTS = [
             (DEPLOYMENT_CHECK):
                 new Deployment()
-                        .setName(DEPLOYMENT_CHECK)
-                        .setNamespace("qa")
-                        .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine")
-                        .addPort(80)
-                        .setSkipReplicaWait(true)
-                        .addLabel("app", DEPLOYMENT_CHECK)
-                        .setServiceAccountName(""),
+                    .setImage("ghcr.io/linuxserver/nginx:1.24.0-r7-ls261")
+                    .setCommand(["sh", "-c", "while true; do sleep 5; apt-get -y update; done"]),
+
+//                new Deployment()
+//                        .setName(DEPLOYMENT_CHECK)
+//                        .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine")
+//                        .setNamespace("qa")
+//                        .addPort(80)
+//                        .setSkipReplicaWait(true)
+//                        .addLabel("app", DEPLOYMENT_CHECK)
+//                        .setServiceAccountName(""),
     ]
 
 
 
-    def setupSpec(){}
+    def setupSpec(){
+        orchestrator.batchCreateDeployments(DEPLOYMENTS.collect {
+            String label, Deployment d -> d.setName(label).addLabel("app", label)
+        })
+    }
 
-    def cleanupSpec(){}
+    def cleanupSpec(){
+        DEPLOYMENTS.each {
+            label, d -> orchestrator.deleteDeployment(d)
+        }
+    }
 
     /*
     1. Create policies, deployments, network policies and RBACs in the test setup
@@ -65,7 +77,13 @@ class DeploymentCheck extends BaseSpecification {
     @Tag("Integration")
     @Tag("DeploymentCheck")
     def "Test Deployment Check"(){
-        DetectionService.getDetectDeploytimeFromYAML()
+        //DetectionService.getDetectDeploytimeFromYAML()
+        given:
+        "deployment already fabricated"
+        Deployment d = DEPLOYMENTS[DEPLOYMENT_CHECK]
 
+        expect:
+        log.info "Checked given"
+        assert true
     }
 }

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -111,7 +111,7 @@ class DeploymentCheck extends BaseSpecification {
         "builder is prepared"
         def secondDeployment = "de2"
         def builder = DetectionServiceOuterClass.DeployYAMLDetectionRequest.newBuilder()
-        def multiDeployments = createDeploymentYaml(DEPLOYMENT_CHECK, DEPLOYMENT_CHECK) +
+        def multiDeployments = createDeploymentYaml(DEPLOYMENT_CHECK, DEPLOYMENT_CHECK) + "\n---\n" +
                 createDeploymentYaml(secondDeployment, DEPLOYMENT_CHECK)
         builder.setYaml(multiDeployments)
         builder.setNamespace(DEPLOYMENT_CHECK)

--- a/tools/generate-helpers/bootstrap-migration/migration.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration.go.tpl
@@ -22,4 +22,3 @@ var (
 func init() {
 	migrations.MustRegisterMigration(migration)
 }
-

--- a/tools/generate-helpers/bootstrap-migration/migration.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration.go.tpl
@@ -22,3 +22,4 @@ var (
 func init() {
 	migrations.MustRegisterMigration(migration)
 }
+


### PR DESCRIPTION
## Description
Add E2E groovy tests for the new features in `roxctl deployment check` that were introduced in [ROX-20907](https://issues.redhat.com/browse/ROX-20907).
Namely, the tests assert on the addition of correct remarks. 
Remarks consist of the following information per deployment:
- Permission level
- Applied Network Policies

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Running groovy tests on CI and manually against OS4 cluster

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
