### PR TITLE
chore(ui): Compliance v2 UX improvements

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Button,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
@@ -12,7 +13,6 @@ import {
     ListItem,
     Modal,
     ModalVariant,
-    Text,
     Title,
     ToggleGroup,
     ToggleGroupItem,
@@ -47,7 +47,6 @@ function CheckStatusModal({ checkResult, isOpen, status, handleClose }: CheckSta
                     </Label>
                 </LabelGroup>
             )}
-            <Text>{rationale}</Text>
             <ToggleGroup aria-label="Toggle for check details modal view">
                 <ToggleGroupItem
                     text="Check details"
@@ -73,8 +72,19 @@ function CheckStatusModal({ checkResult, isOpen, status, handleClose }: CheckSta
                 tabIndex={0}
                 header={header}
                 aria-label="Check status details modal"
+                actions={[
+                    <Button key="cancel" variant="primary" onClick={handleClose}>
+                        Close
+                    </Button>,
+                ]}
             >
                 <DescriptionList>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Rationale</DescriptionListTerm>
+                        <DescriptionListDescription className="formatted-text">
+                            {rationale}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>Description</DescriptionListTerm>
                         <DescriptionListDescription className="formatted-text">
@@ -82,7 +92,7 @@ function CheckStatusModal({ checkResult, isOpen, status, handleClose }: CheckSta
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
-                        <DescriptionListTerm>Instruction</DescriptionListTerm>
+                        <DescriptionListTerm>Instructions</DescriptionListTerm>
                         <DescriptionListDescription className="formatted-text">
                             {instructions}
                         </DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
@@ -13,7 +13,7 @@ import {
     Spinner,
     Title,
 } from '@patternfly/react-core';
-import { Caption, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
@@ -170,10 +170,6 @@ function ClusterSelection({
                     />
                 )}
                 <TableComposable>
-                    <Caption>
-                        <span className="pf-u-danger-color-100">* </span>
-                        At least one cluster is required
-                    </Caption>
                     <Thead noWrap>
                         <Tr>
                             <Th

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
@@ -13,7 +13,6 @@ import {
     Title,
 } from '@patternfly/react-core';
 import {
-    Caption,
     ExpandableRowContent,
     TableComposable,
     Tbody,
@@ -204,10 +203,6 @@ function ProfileSelection({
                     />
                 )}
                 <TableComposable>
-                    <Caption>
-                        <span className="pf-u-danger-color-100">* </span>
-                        At least one profile is required
-                    </Caption>
                     <Thead noWrap>
                         <Tr>
                             <Th

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ComplianceClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ComplianceClusterStatus.tsx
@@ -36,7 +36,7 @@ function ComplianceClusterStatus({ errors }: ComplianceClusterStatusProps) {
             headerContent={<div>{errors.length === 1 ? 'Error' : 'Errors'}</div>}
             bodyContent={<div>{errors.join(', ')}</div>}
         >
-            <Button variant="link">
+            <Button variant="link" className="pf-u-p-0">
                 <IconText icon={statusObj.icon} text={statusObj.statusText} />
             </Button>
         </Popover>

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -236,14 +236,11 @@ export function complianceResultsOverview(
  * due to the absence of a dedicated single-cluster endpoint
  */
 export function getAllClustersCombinedStats(
+    sortOption: ApiSortOption,
     page?: number,
     pageSize?: number
 ): Promise<ComplianceClusterOverallStats[]> {
     const searchFilter = {};
-    const sortOption = {
-        field: 'Cluster',
-        reversed: false,
-    };
     const params = getListQueryParams(searchFilter, sortOption, page, pageSize);
 
     return axios
@@ -252,6 +249,16 @@ export function getAllClustersCombinedStats(
         }>(`${complianceResultsServiceUrl}/stats/overall/cluster?${params}`)
         .then((response) => {
             return response?.data?.scanStats ?? [];
+        });
+}
+
+export function getAllClustersCombinedStatsCount(): Promise<number> {
+    return axios
+        .get<{
+            count: number;
+        }>(`${complianceResultsServiceUrl}/stats/overall/cluster/count`)
+        .then((response) => {
+            return response?.data?.count ?? 0;
         });
 }
 


### PR DESCRIPTION
## Description

These are all improvements made thanks to the bug bash:

- Clusters coverage table:
  - Can sort by cluster name 
  - Correctly display the total count of clusters
- Check status modal:
  - Add a "Close" button at the bottom of the modal
  - Move the rationale to the description list below the header
- Cluster status
  - Remove the padding from the button when the status is unhealthy to keep consistent with the healthy status indicator
- Cluster and Profile selection for scan config:
  - Remove "at least one * is required" caption because it is redundant with the alert

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
### Check modal
#### Before
![Screenshot 2024-02-28 at 1 17 02 PM](https://github.com/stackrox/stackrox/assets/61400697/bc9c102a-52d5-4393-9131-0da307f795af)

#### After
![Screenshot 2024-02-28 at 1 15 27 PM](https://github.com/stackrox/stackrox/assets/61400697/e1a5743c-5150-431d-960f-49e8f418fa38)

---

### Cluster/profile selection (+ cluster status change)
#### Before
![Screenshot 2024-02-28 at 1 16 48 PM](https://github.com/stackrox/stackrox/assets/61400697/304d6012-88d5-4e86-802c-edc36b7c8f74)

#### After
![Screenshot 2024-02-28 at 1 16 08 PM](https://github.com/stackrox/stackrox/assets/61400697/773079ae-7c0d-4554-ab3e-b93c83e07416)
