### PR TITLE
fix(CI): provide password for docker login retries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,11 +372,8 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          _login() {
-            docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
-          }
-          scripts/lib.sh retry 5 true _login
-        shell: bash
+          source ./scripts/ci/lib.sh
+          registry_ro_login "quay.io/rhacs-eng"
 
       - name: Push images
         # Skip for external contributions.
@@ -540,11 +537,8 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          _login() {
-            docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
-          }
-          scripts/lib.sh retry 5 true _login
-        shell: bash
+          source ./scripts/ci/lib.sh
+          registry_rw_login "quay.io/rhacs-eng"
 
       - name: Build Operator Bundle image
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,7 +372,7 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          _login() {
+          function _login() {
             docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
           }
           scripts/lib.sh retry 5 true _login
@@ -539,7 +539,7 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          _login() {
+          function _login() {
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
           }
           scripts/lib.sh retry 5 true _login

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,8 +372,7 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          source ./scripts/ci/lib.sh
-          registry_ro_login "quay.io/rhacs-eng"
+          ./scripts/ci/lib.sh registry_ro_login "quay.io/rhacs-eng"
 
       - name: Push images
         # Skip for external contributions.
@@ -537,8 +536,7 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          source ./scripts/ci/lib.sh
-          registry_rw_login "quay.io/rhacs-eng"
+          ./scripts/ci/lib.sh registry_rw_login "quay.io/rhacs-eng"
 
       - name: Build Operator Bundle image
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,7 +372,10 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          scripts/lib.sh retry 5 true docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
+          _login() {
+            docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
+          }
+          scripts/lib.sh retry 5 true _login
 
       - name: Push images
         # Skip for external contributions.
@@ -536,7 +539,10 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          scripts/lib.sh retry 5 true docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
+          _login() {
+            docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
+          }
+          scripts/lib.sh retry 5 true _login
 
       - name: Build Operator Bundle image
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,10 +372,11 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          function _login() {
+          _login() {
             docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
           }
           scripts/lib.sh retry 5 true _login
+        shell: bash
 
       - name: Push images
         # Skip for external contributions.
@@ -539,10 +540,11 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
-          function _login() {
+          _login() {
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
           }
           scripts/lib.sh retry 5 true _login
+        shell: bash
 
       - name: Build Operator Bundle image
         run: |

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -365,12 +365,16 @@ registry_rw_login() {
 
     case "$registry" in
         quay.io/rhacs-eng)
-            retry 5 true \
-              docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
+            _login() {
+                docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
+            }
+            retry 5 true _login
             ;;
         quay.io/stackrox-io)
-            retry 5 true \
-              docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+            _login() {
+                docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+            }
+            retry 5 true _login
             ;;
         *)
             die "Unsupported registry login: $registry"
@@ -386,8 +390,10 @@ registry_ro_login() {
 
     case "$registry" in
         quay.io/rhacs-eng)
-            retry 5 true \
-              docker login -u "$QUAY_RHACS_ENG_RO_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RO_PASSWORD" quay.io
+            _login() {
+                docker login -u "$QUAY_RHACS_ENG_RO_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RO_PASSWORD" quay.io
+            }
+            retry 5 true _login
             ;;
         *)
             die "Unsupported registry login: $registry"


### PR DESCRIPTION
## Description

The use of herestrings for logins with the `retry()` wrapper is problematic because <<< only provides the password for the first attemps. [e.g.](https://github.com/stackrox/stackrox/actions/runs/8070705260/job/22049086776) - the first failure is a timeout, subsequent attempts fail as the login gets no password.

## Checklist
- [x] Investigated and inspected CI test results - scanner v4 tests are pretty flaky

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
