### PR TITLE
test(scanv4): Make renderer tests Scanner V4 aware

### DIFF
--- a/pkg/renderer/images_test.go
+++ b/pkg/renderer/images_test.go
@@ -164,17 +164,21 @@ func TestComputeOverrides(t *testing.T) {
 func TestConfigureImageOverrides(t *testing.T) {
 	testFlavor := flavorUtils.MakeImageFlavorForTest(t)
 	cases := map[string]struct {
-		configValues               CommonConfig
-		expectedMainRegistry       string
-		expectedMainOverrides      map[string]string
-		expectedScannerOverrides   map[string]string
-		expectedScannerDBOverrides map[string]string
+		configValues                 CommonConfig
+		expectedMainRegistry         string
+		expectedMainOverrides        map[string]string
+		expectedScannerOverrides     map[string]string
+		expectedScannerDBOverrides   map[string]string
+		expectedScannerV4Overrides   map[string]string
+		expectedScannerV4DBOverrides map[string]string
 	}{
 		"Override Main Registry": {
 			configValues: CommonConfig{
-				MainImage:      "quay.io/rhacs/main",
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        "quay.io/rhacs/main",
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 			expectedMainRegistry: "quay.io/rhacs",
 			expectedMainOverrides: map[string]string{
@@ -186,19 +190,29 @@ func TestConfigureImageOverrides(t *testing.T) {
 			expectedScannerDBOverrides: map[string]string{
 				"Registry": "test.registry",
 			},
+			expectedScannerV4Overrides: map[string]string{
+				"Registry": "test.registry",
+			},
+			expectedScannerV4DBOverrides: map[string]string{
+				"Registry": "test.registry",
+			},
 		},
 		"Don't override main registry": {
 			configValues: CommonConfig{
-				MainImage:      testFlavor.MainImage(),
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        testFlavor.MainImage(),
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 		},
 		"Override Main sub-repo": {
 			configValues: CommonConfig{
-				MainImage:      "test.registry/sub-repo/main",
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        "test.registry/sub-repo/main",
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 			expectedMainRegistry: "test.registry/sub-repo",
 			expectedMainOverrides: map[string]string{
@@ -210,12 +224,20 @@ func TestConfigureImageOverrides(t *testing.T) {
 			expectedScannerDBOverrides: map[string]string{
 				"Registry": "test.registry",
 			},
+			expectedScannerV4Overrides: map[string]string{
+				"Registry": "test.registry",
+			},
+			expectedScannerV4DBOverrides: map[string]string{
+				"Registry": "test.registry",
+			},
 		},
 		"Override Main sub-repo and name": {
 			configValues: CommonConfig{
-				MainImage:      "test.registry/sub-repo/my-main",
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        "test.registry/sub-repo/my-main",
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 			expectedMainOverrides: map[string]string{
 				"Name": "sub-repo/my-main",
@@ -225,11 +247,17 @@ func TestConfigureImageOverrides(t *testing.T) {
 		// Scanner
 		"Override Scanner registry": {
 			configValues: CommonConfig{
-				MainImage:      testFlavor.MainImage(),
-				ScannerImage:   "quay.io/rhacs/scanner",
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        testFlavor.MainImage(),
+				ScannerImage:     "quay.io/rhacs/scanner",
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   "quay.io/rhacs/scanner-v4",
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 			expectedScannerOverrides: map[string]string{
+				"Registry": "quay.io/rhacs",
+				"Tag":      "latest",
+			},
+			expectedScannerV4Overrides: map[string]string{
 				"Registry": "quay.io/rhacs",
 				"Tag":      "latest",
 			},
@@ -237,21 +265,28 @@ func TestConfigureImageOverrides(t *testing.T) {
 		// ScannerDB
 		"Override ScannerDB registry": {
 			configValues: CommonConfig{
-				MainImage:      testFlavor.MainImage(),
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: "quay.io/rhacs/scanner-db",
+				MainImage:        testFlavor.MainImage(),
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   "quay.io/rhacs/scanner-db",
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: "quay.io/rhacs/scanner-v4-db",
 			},
 			expectedScannerDBOverrides: map[string]string{
 				"Registry": "quay.io/rhacs",
 				"Tag":      "latest",
 			},
-		},
+			expectedScannerV4DBOverrides: map[string]string{
+				"Registry": "quay.io/rhacs",
+				"Tag":      "latest",
+			}},
 		// Registries combinations
 		"Override Main and Scanner registries": {
 			configValues: CommonConfig{
-				MainImage:      "quay.io/rhacs/main",
-				ScannerImage:   "stackrox.io/scanner",
-				ScannerDBImage: testFlavor.ScannerDBImage(),
+				MainImage:        "quay.io/rhacs/main",
+				ScannerImage:     "stackrox.io/scanner",
+				ScannerDBImage:   testFlavor.ScannerDBImage(),
+				ScannerV4Image:   "stackrox.io/scanner-v4",
+				ScannerV4DBImage: testFlavor.ScannerV4DBImage(),
 			},
 			expectedMainRegistry: "quay.io/rhacs",
 			expectedMainOverrides: map[string]string{
@@ -264,12 +299,21 @@ func TestConfigureImageOverrides(t *testing.T) {
 			expectedScannerDBOverrides: map[string]string{
 				"Registry": "test.registry",
 			},
+			expectedScannerV4Overrides: map[string]string{
+				"Registry": "stackrox.io",
+				"Tag":      "latest",
+			},
+			expectedScannerV4DBOverrides: map[string]string{
+				"Registry": "test.registry",
+			},
 		},
 		"Override Main and ScannerDB registries": {
 			configValues: CommonConfig{
-				MainImage:      "quay.io/rhacs/main",
-				ScannerImage:   testFlavor.ScannerImage(),
-				ScannerDBImage: "stackrox.io/scanner-db",
+				MainImage:        "quay.io/rhacs/main",
+				ScannerImage:     testFlavor.ScannerImage(),
+				ScannerDBImage:   "stackrox.io/scanner-db",
+				ScannerV4Image:   testFlavor.ScannerV4Image(),
+				ScannerV4DBImage: "stackrox.io/scanner-v4-db",
 			},
 			expectedMainRegistry: "quay.io/rhacs",
 			expectedMainOverrides: map[string]string{
@@ -279,15 +323,24 @@ func TestConfigureImageOverrides(t *testing.T) {
 				"Registry": "test.registry",
 			},
 			expectedScannerDBOverrides: map[string]string{
+				"Registry": "stackrox.io",
+				"Tag":      "latest",
+			},
+			expectedScannerV4Overrides: map[string]string{
+				"Registry": "test.registry",
+			},
+			expectedScannerV4DBOverrides: map[string]string{
 				"Registry": "stackrox.io",
 				"Tag":      "latest",
 			},
 		},
 		"Override Main, Scanner and ScannerDB with the same registries": {
 			configValues: CommonConfig{
-				MainImage:      "quay.io/rhacs/main",
-				ScannerImage:   "quay.io/rhacs/scanner",
-				ScannerDBImage: "quay.io/rhacs/scanner-db",
+				MainImage:        "quay.io/rhacs/main",
+				ScannerImage:     "quay.io/rhacs/scanner",
+				ScannerDBImage:   "quay.io/rhacs/scanner-db",
+				ScannerV4Image:   "quay.io/rhacs/scanner-v4",
+				ScannerV4DBImage: "quay.io/rhacs/scanner-v4-db",
 			},
 			expectedMainRegistry: "quay.io/rhacs",
 			expectedMainOverrides: map[string]string{
@@ -297,6 +350,12 @@ func TestConfigureImageOverrides(t *testing.T) {
 				"Tag": "latest",
 			},
 			expectedScannerDBOverrides: map[string]string{
+				"Tag": "latest",
+			},
+			expectedScannerV4Overrides: map[string]string{
+				"Tag": "latest",
+			},
+			expectedScannerV4DBOverrides: map[string]string{
 				"Tag": "latest",
 			},
 		},
@@ -333,6 +392,16 @@ func TestConfigureImageOverrides(t *testing.T) {
 				assert.Equal(t, c.expectedScannerDBOverrides, config.K8sConfig.ImageOverrides["ScannerDB"].(map[string]string))
 			} else {
 				assert.Len(t, config.K8sConfig.ImageOverrides["ScannerDB"], 0, "should have no keys in ScannerDB map")
+			}
+			if c.expectedScannerV4Overrides != nil {
+				assert.Equal(t, c.expectedScannerV4Overrides, config.K8sConfig.ImageOverrides["ScannerV4"].(map[string]string))
+			} else {
+				assert.Len(t, config.K8sConfig.ImageOverrides["ScannerV4"], 0, "should have no keys in ScannerV4 map")
+			}
+			if c.expectedScannerV4DBOverrides != nil {
+				assert.Equal(t, c.expectedScannerV4DBOverrides, config.K8sConfig.ImageOverrides["ScannerV4DB"].(map[string]string))
+			} else {
+				assert.Len(t, config.K8sConfig.ImageOverrides["ScannerV4DB"], 0, "should have no keys in ScannerV4DB map")
 			}
 		})
 	}

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -56,6 +56,7 @@ func getDefaultMetaValues(t *testing.T) *charts.MetaValues {
 
 		ScannerSlimImageRemote: "scanner",
 		ScannerImageTag:        "3.0.11-slim",
+		ScannerV4ImageTag:      "4.4.0.x-92-g9e8a347ffe",
 
 		CollectionMethod: "CORE_BPF",
 

--- a/pkg/renderer/kubernetes_test.go
+++ b/pkg/renderer/kubernetes_test.go
@@ -19,8 +19,9 @@ func getBaseConfig() Config {
 		ClusterType: storage.ClusterType_KUBERNETES_CLUSTER,
 		K8sConfig: &K8sConfig{
 			CommonConfig: CommonConfig{
-				MainImage:    "stackrox/main:2.2.11.0-57-g392c0f5bed-dirty",
-				ScannerImage: "stackrox.io/scanner:0.4.2",
+				MainImage:      "stackrox/main:2.2.11.0-57-g392c0f5bed-dirty",
+				ScannerImage:   "stackrox.io/scanner:0.4.2",
+				ScannerV4Image: "stackrox.io/scanner-v4:0.5.0",
 			},
 		},
 	}
@@ -118,6 +119,13 @@ func (suite *renderSuite) TestRenderMultiple() {
 func (suite *renderSuite) TestRenderWithBadImage() {
 	conf := getBaseConfig()
 	conf.K8sConfig.ScannerImage = "invalid-image#!@$"
+	_, err := Render(conf, suite.testFlavor)
+	suite.Error(err)
+}
+
+func (suite *renderSuite) TestRenderWithBadV4Image() {
+	conf := getBaseConfig()
+	conf.K8sConfig.ScannerV4Image = "invalid-image#!@$"
 	_, err := Render(conf, suite.testFlavor)
 	suite.Error(err)
 }

--- a/pkg/renderer/render_test.go
+++ b/pkg/renderer/render_test.go
@@ -85,9 +85,11 @@ func TestRenderScannerOnly(t *testing.T) {
 		},
 		K8sConfig: &K8sConfig{
 			CommonConfig: CommonConfig{
-				MainImage:      flavor.MainImage(),
-				ScannerImage:   flavor.ScannerImage(),
-				ScannerDBImage: flavor.ScannerDBImage(),
+				MainImage:        flavor.MainImage(),
+				ScannerImage:     flavor.ScannerImage(),
+				ScannerDBImage:   flavor.ScannerDBImage(),
+				ScannerV4Image:   flavor.ScannerV4Image(),
+				ScannerV4DBImage: flavor.ScannerV4DBImage(),
 			},
 			DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 		},
@@ -125,9 +127,11 @@ func TestRenderWithDeclarativeConfig(t *testing.T) {
 		},
 		K8sConfig: &K8sConfig{
 			CommonConfig: CommonConfig{
-				MainImage:      flavor.MainImage(),
-				ScannerImage:   flavor.ScannerImage(),
-				ScannerDBImage: flavor.ScannerDBImage(),
+				MainImage:        flavor.MainImage(),
+				ScannerImage:     flavor.ScannerImage(),
+				ScannerDBImage:   flavor.ScannerDBImage(),
+				ScannerV4Image:   flavor.ScannerV4Image(),
+				ScannerV4DBImage: flavor.ScannerV4DBImage(),
 			},
 			DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 			DeclarativeConfigMounts: DeclarativeConfigMounts{
@@ -201,9 +205,11 @@ func TestRenderDeclarativeConfigEmpty(t *testing.T) {
 			},
 			K8sConfig: &K8sConfig{
 				CommonConfig: CommonConfig{
-					MainImage:      flavor.MainImage(),
-					ScannerImage:   flavor.ScannerImage(),
-					ScannerDBImage: flavor.ScannerDBImage(),
+					MainImage:        flavor.MainImage(),
+					ScannerImage:     flavor.ScannerImage(),
+					ScannerDBImage:   flavor.ScannerDBImage(),
+					ScannerV4Image:   flavor.ScannerV4Image(),
+					ScannerV4DBImage: flavor.ScannerV4DBImage(),
 				},
 				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 			},
@@ -230,9 +236,11 @@ func TestRenderDeclarativeConfigEmpty(t *testing.T) {
 			},
 			K8sConfig: &K8sConfig{
 				CommonConfig: CommonConfig{
-					MainImage:      flavor.MainImage(),
-					ScannerImage:   flavor.ScannerImage(),
-					ScannerDBImage: flavor.ScannerDBImage(),
+					MainImage:        flavor.MainImage(),
+					ScannerImage:     flavor.ScannerImage(),
+					ScannerDBImage:   flavor.ScannerDBImage(),
+					ScannerV4Image:   flavor.ScannerV4Image(),
+					ScannerV4DBImage: flavor.ScannerV4DBImage(),
 				},
 				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 			},
@@ -259,9 +267,11 @@ func TestRenderDeclarativeConfigEmpty(t *testing.T) {
 			},
 			K8sConfig: &K8sConfig{
 				CommonConfig: CommonConfig{
-					MainImage:      flavor.MainImage(),
-					ScannerImage:   flavor.ScannerImage(),
-					ScannerDBImage: flavor.ScannerDBImage(),
+					MainImage:        flavor.MainImage(),
+					ScannerImage:     flavor.ScannerImage(),
+					ScannerDBImage:   flavor.ScannerDBImage(),
+					ScannerV4Image:   flavor.ScannerV4Image(),
+					ScannerV4DBImage: flavor.ScannerV4DBImage(),
 				},
 				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 				DeclarativeConfigMounts: DeclarativeConfigMounts{
@@ -326,9 +336,11 @@ func TestDeclarativeConfigDuplicateValues(t *testing.T) {
 		},
 		K8sConfig: &K8sConfig{
 			CommonConfig: CommonConfig{
-				MainImage:      flavor.MainImage(),
-				ScannerImage:   flavor.ScannerImage(),
-				ScannerDBImage: flavor.ScannerDBImage(),
+				MainImage:        flavor.MainImage(),
+				ScannerImage:     flavor.ScannerImage(),
+				ScannerDBImage:   flavor.ScannerDBImage(),
+				ScannerV4Image:   flavor.ScannerV4Image(),
+				ScannerV4DBImage: flavor.ScannerV4DBImage(),
 			},
 			DeploymentFormat: v1.DeploymentFormat_KUBECTL,
 			DeclarativeConfigMounts: DeclarativeConfigMounts{


### PR DESCRIPTION
## Description

The pkg/renderer tests had not been Scanner V4 aware. So this is including Scanner V4 and Scanner V4 DB images into those tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Running automated tests.

