### PR TITLE
ROX-21016: Remove RPM binary from main image

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -60,8 +60,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
-    # TODO(ROX-13934): Potentially add *RPM* to this list again
-    rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory


### PR DESCRIPTION
## Description
This PR removes the RPM binary from our main image.
RPM was originally introduced in the context of Node Scanning, as that code requires RPM to work.
We ended up moving the Node Scanning code to its own container, eliminating the need for RPM in the main image.

Our Downstream images already contain this change ([see here](https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/blob/rhacs-4.3-rhel-8/distgit/containers/rhacs-main/Dockerfile.in?ref_type=heads#L79)).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manual test by running any recent main version manually and running `rpm --version`.
This fails with `rpm: command not found` in the main image created by this PR.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
