### PR TITLE
fix(CI): retry retag operation

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -422,7 +422,8 @@ push_matching_collector_scanner_images() {
         if is_OPENSHIFT_CI; then
             oc_image_mirror "$1" "$2"
         else
-            "$SCRIPTS_ROOT/scripts/ci/pull-retag-push.sh" "$1" "$2"
+            retry 5 true \
+                "$SCRIPTS_ROOT/scripts/ci/pull-retag-push.sh" "$1" "$2"
         fi
     }
 


### PR DESCRIPTION
## Description

Adds a retry for the retag operation for scanner and collector images. This operation (retag) was missed in earlier PRs to retry quay.io actions e.g. #8844. (`hack [c]` from build failures [analysis](https://docs.google.com/spreadsheets/d/13gSYdmxLyUHl0CZgrN5ux-H7R3bgVCd9jT2C6-dbQqE/edit#gid=0))

## Checklist
- [x] Investigated and inspected CI test results - failures are known flakes :(

## Testing Performed

### Here I tell how I validated my change

CI is sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
