### PR TITLE
chore: use common test image

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -35,9 +35,6 @@ class AdmissionControllerTest extends BaseSpecification {
     static final private String TEST_NAMESPACE = "qa-admission-controller-test"
 
     static final private String NGINX                = "qanginx"
-    static final private String NGINX_IMAGE          = "quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1"
-    static final private String NGINX_IMAGE_WITH_SHA = "quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1"+
-                                    "@sha256:6bf47794f923462389f5a2cda49cf5777f736db8563edc3ff78fb9d87e6e22ec"
     static final private String NGINX_CVE            = "CVE-2017-16932"
 
     static final private String BUSYBOX_NO_BYPASS        = "busybox-no-bypass"
@@ -53,7 +50,7 @@ class AdmissionControllerTest extends BaseSpecification {
     static final private Deployment NGINX_DEPLOYMENT = new Deployment()
             .setName(NGINX)
             .setNamespace(TEST_NAMESPACE)
-            .setImage(NGINX_IMAGE)
+            .setImage(TEST_IMAGE)
             .addLabel("app", "test")
 
     static final private Deployment BUSYBOX_NO_BYPASS_DEPLOYMENT = new Deployment()
@@ -99,7 +96,7 @@ class AdmissionControllerTest extends BaseSpecification {
         sleep(10000 * (ClusterService.isOpenShift4() ? 4 : 1))
 
         // Pre run scan to avoid timeouts with inline scans in the tests below
-        ImageService.scanImage(NGINX_IMAGE)
+        ImageService.scanImage(TEST_IMAGE)
 
         orchestrator.ensureNamespaceExists(TEST_NAMESPACE)
     }
@@ -301,8 +298,8 @@ class AdmissionControllerTest extends BaseSpecification {
         "Data inputs are: "
 
         image | _
-        NGINX_IMAGE_WITH_SHA | _
-        NGINX_IMAGE | _
+        TEST_IMAGE | _
+        TEST_IMAGE.split("@").first() | _
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -29,8 +29,8 @@ class AttemptedAlertsTest extends BaseSpecification {
             (DEP_NAMES[1]): createDeployment(DEP_NAMES[1], "quay.io/rhacs-eng/qa-multi-arch-nginx:latest"),
             (DEP_NAMES[2]): createDeployment(DEP_NAMES[2], "quay.io/rhacs-eng/qa-multi-arch-nginx:latest"),
             (DEP_NAMES[3]): createDeployment(DEP_NAMES[3], "quay.io/rhacs-eng/qa-multi-arch-nginx:latest"),
-            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
-            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
+            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], TEST_IMAGE),
+            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], TEST_IMAGE),
     ]
 
     static final private String LATEST_TAG_POLICY_NAME = "Latest tag"

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -21,8 +21,6 @@ import spock.lang.Unroll
 @Tag("PZ")
 class CSVTest extends BaseSpecification {
 
-    private static final IMAGE_SHA = "sha256:6bf47794f923462389f5a2cda49cf5777f736db8563edc3ff78fb9d87e6e22ec"
-
     private static final CVE_FIELDS_FRAGEMENT = """
     fragment cveFields on EmbeddedVulnerability {
       id: cve
@@ -151,7 +149,7 @@ class CSVTest extends BaseSpecification {
 
     private static final Deployment CVE_DEPLOYMENT = new Deployment()
             .setName("nginx-deployment")
-            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
+            .setImage(TEST_IMAGE)
             .addLabel("app", "test")
 
     def setupSpec() {

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -725,7 +725,7 @@ class ComplianceTest extends BaseSpecification {
         "create Deployment that forces checks to fail"
         Deployment deployment = new Deployment()
                 .setName("compliance-deployment")
-                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
+                .setImage(TEST_IMAGE)
                 .addPort(80, "UDP")
                 .setCommand(["/bin/sh", "-c",])
                 .setArgs(["dd if=/dev/zero of=/dev/null & yes"])

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -232,15 +232,12 @@ class ImageManagementTest extends BaseSpecification {
     def "Verify risk is properly being attributed to scanned images"() {
         when:
         "Scan an image and then grab the image data"
-        ImageService.scanImage(
-            "quay.io/rhacs-eng/qa-multi-arch-nginx@" +
-            "sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
+        ImageService.scanImage(TEST_IMAGE)
 
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
-            def image = ImageService.getImage(
-                    "sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
+            def image = ImageService.getImage(IMAGE_SHA)
             assert image != null && image.riskScore != 0
         }
     }
@@ -254,8 +251,7 @@ class ImageManagementTest extends BaseSpecification {
                 .setName("risk-image")
                 .setNamespace(TEST_NAMESPACE)
                 .setReplicas(1)
-                .setImage("quay.io/rhacs-eng/qa-multi-arch-nginx" +
-                    "@sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
+                .setImage(TEST_IMAGE)
                 .setCommand(["sleep", "60000"])
                 .setSkipReplicaWait(false)
 
@@ -264,8 +260,7 @@ class ImageManagementTest extends BaseSpecification {
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
-            def image = ImageService.getImage(
-                    "sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
+            def image = ImageService.getImage(IMAGE_SHA)
             assert image != null && image.riskScore != 0
         }
 

--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -20,7 +20,7 @@ class K8sEventDetectionTest extends BaseSpecification {
     static private registerDeployment(String name, boolean privileged) {
         DEPLOYMENTS.add(
             new Deployment().setName(name)
-                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine").addLabel("app", name).
+                .setImage(TEST_IMAGE).addLabel("app", name).
                 setPrivilegedFlag(privileged)
         )
         return name

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -27,7 +27,7 @@ class ProcessVisualizationTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                 .setName (NGINXDEPLOYMENT)
-                .setImage ("quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine")
+                .setImage (TEST_IMAGE)
                 .addLabel ( "app", "test" ),
             new Deployment()
                 .setName (STRUTSDEPLOYMENT)


### PR DESCRIPTION
## Description

We have a common test image to use in tests. Let's use it where possible to minimize issues with downloading new images.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
