### PR TITLE
ROX-22852: validate provider in datastore

### DIFF
--- a/central/authprovider/datastore/datastore_impl.go
+++ b/central/authprovider/datastore/datastore_impl.go
@@ -2,8 +2,9 @@ package datastore
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
+	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/central/authprovider/datastore/internal/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
@@ -50,7 +51,7 @@ func (b *datastoreImpl) GetAuthProvidersFiltered(ctx context.Context,
 	// store.Walk.
 	authProviders, err := b.storage.GetAll(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving auth providers")
+		return nil, pkgErrors.Wrap(err, "retrieving auth providers")
 	}
 	filteredAuthProviders := make([]*storage.AuthProvider, 0, len(authProviders))
 	for _, authProvider := range authProviders {
@@ -67,7 +68,10 @@ func (b *datastoreImpl) AddAuthProvider(ctx context.Context, authProvider *stora
 		return err
 	}
 	if err := verifyAuthProviderOrigin(ctx, authProvider); err != nil {
-		return errors.Wrap(err, "origin didn't match for new auth provider")
+		return pkgErrors.Wrap(err, "origin didn't match for new auth provider")
+	}
+	if err := validateAuthProvider(authProvider); err != nil {
+		return err
 	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -86,6 +90,9 @@ func (b *datastoreImpl) UpdateAuthProvider(ctx context.Context, authProvider *st
 	if err := sac.VerifyAuthzOK(accessSAC.WriteAllowed(ctx)); err != nil {
 		return err
 	}
+	if err := validateAuthProvider(authProvider); err != nil {
+		return err
+	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -96,10 +103,10 @@ func (b *datastoreImpl) UpdateAuthProvider(ctx context.Context, authProvider *st
 		return err
 	}
 	if err = verifyAuthProviderOrigin(ctx, existingProvider); err != nil {
-		return errors.Wrap(err, "origin didn't match for existing auth provider")
+		return pkgErrors.Wrap(err, "origin didn't match for existing auth provider")
 	}
 	if err = verifyAuthProviderOrigin(ctx, authProvider); err != nil {
-		return errors.Wrap(err, "origin didn't match for new auth provider")
+		return pkgErrors.Wrap(err, "origin didn't match for new auth provider")
 	}
 	return b.storage.Upsert(ctx, authProvider)
 }
@@ -122,7 +129,7 @@ func (b *datastoreImpl) RemoveAuthProvider(ctx context.Context, id string, force
 
 func verifyAuthProviderOrigin(ctx context.Context, ap *storage.AuthProvider) error {
 	if !declarativeconfig.CanModifyResource(ctx, ap) {
-		return errors.Wrapf(errox.NotAuthorized, "auth provider %q's origin is %s, cannot be modified or deleted with the current permission",
+		return pkgErrors.Wrapf(errox.NotAuthorized, "auth provider %q's origin is %s, cannot be modified or deleted with the current permission",
 			ap.GetName(), ap.GetTraits().GetOrigin())
 	}
 	return nil
@@ -147,8 +154,22 @@ func (b *datastoreImpl) verifyExistsAndMutable(ctx context.Context, id string, f
 		return nil, errox.InvalidArgs.Newf("auth provider %q is immutable and can only be removed"+
 			" via API and specifying the force flag", id)
 	default:
-		utils.Should(errors.Wrapf(errox.InvalidArgs, "unknown mutability mode given: %q",
+		utils.Should(pkgErrors.Wrapf(errox.InvalidArgs, "unknown mutability mode given: %q",
 			provider.GetTraits().GetMutabilityMode()))
 	}
 	return nil, errox.InvalidArgs.Newf("auth provider %q is immutable", id)
+}
+
+func validateAuthProvider(ap *storage.AuthProvider) error {
+	var validationErrs error
+	if ap.GetId() == "" {
+		return errox.InvalidArgs.CausedBy("auth provider ID is empty")
+	}
+	if ap.GetName() == "" {
+		validationErrs = errors.Join(validationErrs, errox.InvalidArgs.CausedBy("auth provider name is empty"))
+	}
+	if ap.GetLoginUrl() == "" {
+		validationErrs = errors.Join(validationErrs, errox.InvalidArgs.CausedBy("auth provider login URL is empty"))
+	}
+	return pkgErrors.Wrap(validationErrs, "validating auth provider")
 }

--- a/central/authprovider/datastore/datastore_impl.go
+++ b/central/authprovider/datastore/datastore_impl.go
@@ -163,7 +163,7 @@ func (b *datastoreImpl) verifyExistsAndMutable(ctx context.Context, id string, f
 func validateAuthProvider(ap *storage.AuthProvider) error {
 	var validationErrs error
 	if ap.GetId() == "" {
-		return errox.InvalidArgs.CausedBy("auth provider ID is empty")
+		validationErrs = errors.Join(validationErrs, errox.InvalidArgs.CausedBy("auth provider ID is empty"))
 	}
 	if ap.GetName() == "" {
 		validationErrs = errors.Join(validationErrs, errox.InvalidArgs.CausedBy("auth provider name is empty"))

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -376,3 +376,49 @@ func (s *authProviderDataStoreTestSuite) TestAddImperativeDeclaratively() {
 	err := s.dataStore.AddAuthProvider(s.hasWriteDeclarativeCtx, ap)
 	s.ErrorIs(err, errox.NotAuthorized)
 }
+
+func (s *authProviderDataStoreTestSuite) TestValidateAuthProvider() {
+	cases := map[string]struct {
+		ap  *storage.AuthProvider
+		err error
+	}{
+		"empty auth provider should return error": {
+			ap:  &storage.AuthProvider{},
+			err: errox.InvalidArgs,
+		},
+		"empty ID should return an error": {
+			ap: &storage.AuthProvider{
+				Name:     "test",
+				LoginUrl: "test",
+			},
+			err: errox.InvalidArgs,
+		},
+		"empty name should return an error": {
+			ap: &storage.AuthProvider{
+				Id:       "test-id",
+				LoginUrl: "test",
+			},
+			err: errox.InvalidArgs,
+		},
+		"empty login URL should return an error": {
+			ap: &storage.AuthProvider{
+				Id:   "test-id",
+				Name: "test",
+			},
+			err: errox.InvalidArgs,
+		},
+		"all required fields set should not return an error": {
+			ap: &storage.AuthProvider{
+				Id:       "test-id",
+				Name:     "test",
+				LoginUrl: "test",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			s.ErrorIs(validateAuthProvider(tc.ap), tc.err)
+		})
+	}
+}

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -144,14 +144,22 @@ func (s *authProviderDataStoreTestSuite) TestAllowsAdd() {
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 
-	err := s.dataStore.AddAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.AddAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "test",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *authProviderDataStoreTestSuite) TestErrorOnAdd() {
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
 
-	err := s.dataStore.AddAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.AddAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "test",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.Error(err)
 }
 
@@ -180,14 +188,22 @@ func (s *authProviderDataStoreTestSuite) TestAllowsUpdate() {
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{}, true, nil).Times(1)
 
-	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "test",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *authProviderDataStoreTestSuite) TestErrorOnUpdate() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, false, nil).Times(1)
 
-	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "test",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.Error(err)
 }
 
@@ -201,35 +217,46 @@ func (s *authProviderDataStoreTestSuite) TestAllowsRemove() {
 
 func (s *authProviderDataStoreTestSuite) TestUpdateMutableToImmutable() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE,
 		},
 	}, true, nil).Times(1)
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "id",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.NoError(err)
 }
 
 func (s *authProviderDataStoreTestSuite) TestUpdateImmutableNoForce() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
 	}, true, nil).Times(1)
 
-	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{})
+	err := s.dataStore.UpdateAuthProvider(s.hasWriteCtx, &storage.AuthProvider{
+		Id:       "id",
+		Name:     "test",
+		LoginUrl: "test",
+	})
 	s.ErrorIs(err, errox.InvalidArgs)
 }
 
 func (s *authProviderDataStoreTestSuite) TestDeleteImmutableNoForce() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
@@ -241,8 +268,9 @@ func (s *authProviderDataStoreTestSuite) TestDeleteImmutableNoForce() {
 
 func (s *authProviderDataStoreTestSuite) TestDeleteImmutableForce() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE,
 		},
@@ -255,8 +283,9 @@ func (s *authProviderDataStoreTestSuite) TestDeleteImmutableForce() {
 
 func (s *authProviderDataStoreTestSuite) TestDeleteDeclarativeViaAPI() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -268,8 +297,9 @@ func (s *authProviderDataStoreTestSuite) TestDeleteDeclarativeViaAPI() {
 
 func (s *authProviderDataStoreTestSuite) TestDeleteDeclarativeSuccess() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -282,8 +312,9 @@ func (s *authProviderDataStoreTestSuite) TestDeleteDeclarativeSuccess() {
 
 func (s *authProviderDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -296,8 +327,9 @@ func (s *authProviderDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 
 func (s *authProviderDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -311,8 +343,9 @@ func (s *authProviderDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 
 func (s *authProviderDataStoreTestSuite) TestDeleteImperativeDeclaratively() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -324,8 +357,9 @@ func (s *authProviderDataStoreTestSuite) TestDeleteImperativeDeclaratively() {
 
 func (s *authProviderDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -338,8 +372,9 @@ func (s *authProviderDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 
 func (s *authProviderDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -351,8 +386,9 @@ func (s *authProviderDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 
 func (s *authProviderDataStoreTestSuite) TestAddDeclarativeSuccess() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -366,8 +402,9 @@ func (s *authProviderDataStoreTestSuite) TestAddDeclarativeSuccess() {
 
 func (s *authProviderDataStoreTestSuite) TestAddImperativeDeclaratively() {
 	ap := &storage.AuthProvider{
-		Id:   "id",
-		Name: "name",
+		Id:       "id",
+		Name:     "name",
+		LoginUrl: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},


### PR DESCRIPTION
## Description

This PR adds validation of the authprovider to add / update within the datastore.

Previously this kind of validation was only done within the service layer. However, when using the datastore through different clients such as the declarative config approach, the validation was skipped before upserting and it was possible to add invalid auth providers to the database, rendering Central effectively unable to start up.

This change adds the basic validation to the datastore ensuring that no invalid entries may be added before upserting.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
