### PR TITLE
fix(declarative-config): validate notifiers before upserting

### DIFF
--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -74,7 +74,7 @@ func (u *notifierUpdater) Upsert(ctx context.Context, m protocompat.Message) err
 		return errox.InvalidArgs.CausedBy(err)
 	}
 	if _, err := u.notifierDS.UpsertNotifier(ctx, notifierProto); err != nil {
-		return errox.InvalidArgs.CausedBy(err)
+		return errors.Wrap(err, "storing notifier")
 	}
 	notifier, err := notifiers.CreateNotifier(notifierProto)
 	if err != nil {

--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -10,6 +10,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/policycleaner"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
+	"github.com/stackrox/rox/central/notifiers/validation"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
@@ -69,9 +70,11 @@ func (u *notifierUpdater) Upsert(ctx context.Context, m protocompat.Message) err
 			return errors.Errorf("Error securing declarative config notifier %s, notifications to this notifier will fail", notifierProto.GetName())
 		}
 	}
-	_, err := u.notifierDS.UpsertNotifier(ctx, notifierProto)
-	if err != nil {
-		return err
+	if err := validation.ValidateNotifierConfig(notifierProto, true); err != nil {
+		return errox.InvalidArgs.CausedBy(err)
+	}
+	if _, err := u.notifierDS.UpsertNotifier(ctx, notifierProto); err != nil {
+		return errox.InvalidArgs.CausedBy(err)
 	}
 	notifier, err := notifiers.CreateNotifier(notifierProto)
 	if err != nil {

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stackrox/rox/central/notifier/datastore/internal/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
-	"github.com/stackrox/rox/pkg/endpoints"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -30,10 +28,6 @@ type datastoreImpl struct {
 func (b *datastoreImpl) UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error) {
 	if err := sac.VerifyAuthzOK(integrationSAC.WriteAllowed(ctx)); err != nil {
 		return "", err
-	}
-
-	if err := validateNotifier(notifier); err != nil {
-		return "", errox.InvalidArgs.CausedBy(err)
 	}
 
 	b.lock.Lock()
@@ -73,9 +67,6 @@ func (b *datastoreImpl) UpsertManyNotifiers(ctx context.Context, notifiers []*st
 		}
 		if err = verifyNotifierOrigin(ctx, notifier); err != nil {
 			return errors.Wrap(err, "origin didn't match for new notifier")
-		}
-		if err := validateNotifier(notifier); err != nil {
-			return errox.InvalidArgs.CausedBy(err)
 		}
 	}
 	return b.storage.UpsertMany(ctx, notifiers)
@@ -180,9 +171,6 @@ func (b *datastoreImpl) AddNotifier(ctx context.Context, notifier *storage.Notif
 	} else if !ok {
 		return "", sac.ErrResourceAccessDenied
 	}
-	if err := validateNotifier(notifier); err != nil {
-		return "", errox.InvalidArgs.CausedBy(err)
-	}
 
 	notifier.Id = uuid.NewV4().String()
 
@@ -224,9 +212,6 @@ func (b *datastoreImpl) UpdateNotifier(ctx context.Context, notifier *storage.No
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-	if err := validateNotifier(notifier); err != nil {
-		return errox.InvalidArgs.CausedBy(err)
-	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -260,25 +245,4 @@ func (b *datastoreImpl) RemoveNotifier(ctx context.Context, id string) error {
 		return errors.Wrap(err, "origin didn't match for existing notifier")
 	}
 	return b.storage.Delete(ctx, id)
-}
-
-func validateNotifier(notifier *storage.Notifier) error {
-	if notifier == nil {
-		return errors.New("empty notifier")
-	}
-	errorList := errorhelpers.NewErrorList("Validation")
-	if notifier.GetName() == "" {
-		errorList.AddString("notifier name must be defined")
-	}
-	if notifier.GetType() == "" {
-		errorList.AddString("notifier type must be defined")
-	}
-	if notifier.GetUiEndpoint() == "" {
-		errorList.AddString("notifier UI endpoint must be defined")
-	}
-	if err := endpoints.ValidateEndpoints(notifier.Config); err != nil {
-		errorList.AddWrap(err, "invalid endpoint")
-	}
-	// We skip validating the notifier config for each type and push the responsibility to the clients.
-	return errorList.ToError()
 }

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -279,5 +279,6 @@ func validateNotifier(notifier *storage.Notifier) error {
 	if err := endpoints.ValidateEndpoints(notifier.Config); err != nil {
 		errorList.AddWrap(err, "invalid endpoint")
 	}
+	// We skip validating the notifier config for each type and push the responsibility to the clients.
 	return errorList.ToError()
 }

--- a/central/notifier/datastore/datastsore_test.go
+++ b/central/notifier/datastore/datastsore_test.go
@@ -162,14 +162,24 @@ func (s *notifierDataStoreTestSuite) TestAllowsAdd() {
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{})
+	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
+	})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *notifierDataStoreTestSuite) TestErrorOnAdd() {
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
 
-	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{})
+	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
+	})
 	s.Error(err)
 }
 
@@ -187,14 +197,24 @@ func (s *notifierDataStoreTestSuite) TestAllowsUpdate() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, true, nil).Times(1)
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{Id: "id"})
+	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
+	})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *notifierDataStoreTestSuite) TestErrorOnUpdate() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, false, nil).Times(1)
 
-	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{Id: "id"})
+	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
+	})
 	s.Error(err)
 }
 
@@ -218,16 +238,20 @@ func (s *notifierDataStoreTestSuite) TestAllowsRemove() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateMutableToImmutable() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE,
 		},
 	}, true, nil).Times(1)
 
 	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:   "id",
-		Name: "new name",
+		Id:         "id",
+		Name:       "new name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
@@ -237,8 +261,10 @@ func (s *notifierDataStoreTestSuite) TestUpdateMutableToImmutable() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeViaAPI() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -250,8 +276,10 @@ func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeSuccess() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -264,8 +292,10 @@ func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -278,8 +308,10 @@ func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -293,8 +325,10 @@ func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveImperativeDeclaratively() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -306,8 +340,10 @@ func (s *notifierDataStoreTestSuite) TestRemoveImperativeDeclaratively() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -320,8 +356,10 @@ func (s *notifierDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 
 func (s *notifierDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -333,8 +371,10 @@ func (s *notifierDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestAddDeclarativeSuccess() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -348,8 +388,10 @@ func (s *notifierDataStoreTestSuite) TestAddDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestAddImperativeDeclaratively() {
 	ap := &storage.Notifier{
-		Id:   "id",
-		Name: "name",
+		Id:         "id",
+		Name:       "name",
+		Type:       "notifier",
+		UiEndpoint: "test",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},

--- a/central/notifiers/validation/validate.go
+++ b/central/notifiers/validation/validate.go
@@ -10,40 +10,65 @@ import (
 	"github.com/stackrox/rox/central/notifiers/pagerduty"
 	"github.com/stackrox/rox/central/notifiers/splunk"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/endpoints"
+	"github.com/stackrox/rox/pkg/errorhelpers"
 	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 )
 
 // ValidateNotifierConfig validates notifier configuration based on the given notifier's type
 func ValidateNotifierConfig(notifier *storage.Notifier, validateSecret bool) error {
+	if notifier == nil {
+		return errors.New("empty notifier")
+	}
+	errorList := errorhelpers.NewErrorList("Validation")
+	if notifier.GetName() == "" {
+		errorList.AddString("notifier name must be defined")
+	}
+	if notifier.GetType() == "" {
+		errorList.AddString("notifier type must be defined")
+	}
+	if notifier.GetUiEndpoint() == "" {
+		errorList.AddString("notifier UI endpoint must be defined")
+	}
+	if err := endpoints.ValidateEndpoints(notifier.Config); err != nil {
+		errorList.AddWrap(err, "invalid endpoint")
+	}
 	switch notifier.GetType() {
 	case pkgNotifiers.AWSSecurityHubType:
 		if err := awssh.Validate(notifier.GetAwsSecurityHub(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate AWS SecurityHub config")
+			errorList.AddWrap(err, "failed to validate AWS SecurityHub config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.CSCCType:
 		if err := cscc.Validate(notifier.GetCscc(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate CSCC config")
+			errorList.AddWrap(err, "failed to validate CSCC config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.JiraType:
 		if err := jira.Validate(notifier.GetJira(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate Jira config")
+			errorList.AddWrap(err, "failed to validate Jira config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.EmailType:
 		if err := email.Validate(notifier.GetEmail(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate Email config")
+			errorList.AddWrap(err, "failed to validate Email config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.GenericType:
 		if err := generic.Validate(notifier.GetGeneric(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate Generic config")
+			errorList.AddWrap(err, "failed to validate Generic config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.PagerDutyType:
 		if err := pagerduty.Validate(notifier.GetPagerduty(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate PagerDuty config")
+			errorList.AddWrap(err, "failed to validate PagerDuty config")
+			return errorList.ToError()
 		}
 	case pkgNotifiers.SplunkType:
 		if err := splunk.Validate(notifier.GetSplunk(), validateSecret); err != nil {
-			return errors.Wrap(err, "failed to validate Splunk config")
+			errorList.AddWrap(err, "failed to validate Splunk config")
+			return errorList.ToError()
 		}
 	}
-	return nil
+	return errorList.ToError()
 }

--- a/central/reports/config/datastore/datastore_impl_v2_test.go
+++ b/central/reports/config/datastore/datastore_impl_v2_test.go
@@ -168,7 +168,7 @@ func (s *ReportConfigurationDatastoreV2Tests) TestSortReportConfigByCompletionTi
 func (s *ReportConfigurationDatastoreV2Tests) storeNotifier(name string) *storage.NotifierConfiguration_Id {
 	allCtx := sac.WithAllAccess(context.Background())
 
-	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name})
+	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name, Type: "email", UiEndpoint: "http://localhost"})
 	s.Require().NoError(err)
 	return &storage.NotifierConfiguration_Id{Id: id}
 }

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -56,7 +56,7 @@ func (s *ServiceLevelConfigSeparationSuite) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier", Type: "generic", UiEndpoint: "http://localhost"})
 	s.Require().NoError(err)
 
 	// Add collection

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -77,7 +77,7 @@ func (s *ServiceLevelConfigSeparationSuiteV2) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier", Type: "generic", UiEndpoint: "http://localhost"})
 	s.Require().NoError(err)
 
 	// Add collection

--- a/central/reports/snapshot/datastore/datastore_impl_test.go
+++ b/central/reports/snapshot/datastore/datastore_impl_test.go
@@ -164,7 +164,7 @@ func (s *ReportSnapshotDatastoreTestSuite) TestReportMetadataWorkflows() {
 func (s *ReportSnapshotDatastoreTestSuite) storeNotifier(name string) *storage.NotifierConfiguration_Id {
 	allCtx := sac.WithAllAccess(context.Background())
 
-	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name})
+	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name, Type: "generic", UiEndpoint: "http://localhost"})
 	s.Require().NoError(err)
 	return &storage.NotifierConfiguration_Id{Id: id}
 }


### PR DESCRIPTION
## Description

The validation of different notifier types is encoded within the creator function of each notifier type, not within the notifiers datastore.

Hence, we should attempt to create the notifier beforehand (note that this does not persist the notifier in any form) before upserting the notifier within the datastore as well as within the processor.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
