### PR TITLE
ROX-22846: Disable failing e2e tests for power and z architectures

### DIFF
--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Tag
 import spock.lang.Unroll
 import util.Env
 
-@Tag("PZ")
+// @Tag("PZ") // ROX-22846: uncomment when resolved.
 class BuiltinPoliciesTest extends BaseSpecification {
     static final private String TRIGGER_MOST = "trigger-most"
     static final private String TRIGGER_ALPINE = "trigger-alpine"

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 import util.Env
 
 @Tag("Parallel")
-@Tag("PZ")
+// @Tag("PZ") // ROX-22846: uncomment when resolved.
 class ImageManagementTest extends BaseSpecification {
 
     private static final String TEST_NAMESPACE = "qa-image-management"

--- a/qa-tests-backend/src/test/groovy/PaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PaginationTest.groovy
@@ -10,7 +10,7 @@ import services.SecretService
 
 import spock.lang.Tag
 
-@Tag("PZ")
+// @Tag("PZ") // ROX-22846: uncomment when resolved.
 class PaginationTest extends BaseSpecification {
     static final private Map<String, String> SECRETS = [
             "pagination-secret-1" : null,


### PR DESCRIPTION
## Description

All e2e tests that rely on the "No CPU request or memory limit specified" policy fail today. Disable until resolved.

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

No need

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
