### PR TITLE
fix(qa): Skip known failures on PZ 

### DIFF
--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -18,7 +18,8 @@ import spock.lang.Unroll
 
 @Unroll
 @Tag("BAT")
-@Tag("PZ")
+//ROX-20525 Disable test for ppc64le and s390x until Fix is availble
+//@Tag("PZ")
 class CSVTest extends BaseSpecification {
 
     private static final IMAGE_SHA = "sha256:6bf47794f923462389f5a2cda49cf5777f736db8563edc3ff78fb9d87e6e22ec"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -727,6 +727,8 @@ class NetworkFlowTest extends BaseSpecification {
     }
 
     @Tag("BAT")
+    //ROX-21491 skipping test case for p/z
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify generated network policies"() {
         // TODO(RS-178): EKS cannot NetworkPolicy
         Assume.assumeFalse(ClusterService.isEKS())


### PR DESCRIPTION
## Description
Skipping known failed tests for CSVTest and NetworkFlowTest. Will be reenanble once test case error is resolved
ROX-21491
ROX-16337

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
relying on CI



