### PR TITLE
ROX-22847: use V2 bucket in golang backup test

### DIFF
--- a/tests/external_backup_test.go
+++ b/tests/external_backup_test.go
@@ -20,9 +20,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-const (
-	testGCSBucket = "stackrox-ci-gcs-db-upload-test"
-)
+var testGCSBucket = os.Getenv("GCP_GCS_BACKUP_TEST_BUCKET_NAME_V2")
 
 func countNumBackups(t *testing.T, client *googleStorage.Client, prefix string) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -46,7 +44,7 @@ func verifyNumBackups(t *testing.T, numBackups int, numExpected int) {
 }
 
 func TestGCSExternalBackup(t *testing.T) {
-	serviceAccount := os.Getenv("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT")
+	serviceAccount := os.Getenv("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT_V2")
 	require.NotEmpty(t, serviceAccount)
 
 	prefix := os.Getenv("BUILD_ID")
@@ -70,7 +68,7 @@ func TestGCSExternalBackup(t *testing.T) {
 		Config: &storage.ExternalBackup_Gcs{
 			Gcs: &storage.GCSConfig{
 				Bucket:         testGCSBucket,
-				ServiceAccount: os.Getenv("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT"),
+				ServiceAccount: serviceAccount,
 				ObjectPrefix:   prefix,
 			},
 		},


### PR DESCRIPTION
## Description

Move the golang backup test to the new `acs-san-stackroxci` project as part of the `stackrox.com -> redhat.com` GCP migration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
