### PR TITLE
ROX-22848: increase cloud source wait time

### DIFF
--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -29,7 +29,7 @@ class CloudSourcesTest extends BaseSpecification {
         "verify we have discovered clusters"
         // The initial sync may take a bit since we are connecting to the "Red Hat1" OCM organization which hosts
         // a lot of clusters.
-        withRetry(10, 30) {
+        withRetry(30, 10) {
             def count = DiscoveredClustersService.countDiscoveredClusters()
             assert count > 0
         }

--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -29,7 +29,7 @@ class CloudSourcesTest extends BaseSpecification {
         "verify we have discovered clusters"
         // The initial sync may take a bit since we are connecting to the "Red Hat1" OCM organization which hosts
         // a lot of clusters.
-        withRetry(10, 10) {
+        withRetry(10, 30) {
             def count = DiscoveredClustersService.countDiscoveredClusters()
             assert count > 0
         }


### PR DESCRIPTION
## Description

In https://issues.redhat.com/browse/ROX-22848 we observed a case where 10 * 10s retries were not sufficient to populate the discovered clusters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
