### PR TITLE
ROX-22411: Apply exception updates to original req on approval

### DIFF
--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -137,11 +137,7 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 
 		// If the update was approved, apply the update to original request and wipe out the update field.
 		if status == storage.RequestStatus_APPROVED {
-			switch r := req.GetUpdatedReq().(type) {
-			case *storage.VulnerabilityRequest_UpdatedDeferralReq:
-				req.Req = &storage.VulnerabilityRequest_DeferralReq{DeferralReq: r.UpdatedDeferralReq}
-				// Currently, only deferral requests can be updated
-			}
+			applyUpdateRequest(req)
 		}
 
 		// Wipe out the update field whether the update was approved or denied.
@@ -159,6 +155,36 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 		return nil, err
 	}
 	return req, nil
+}
+
+func applyUpdateRequest(req *storage.VulnerabilityRequest) {
+	if !features.UnifiedCVEDeferral.Enabled() {
+		switch r := req.GetUpdatedReq().(type) {
+		case *storage.VulnerabilityRequest_UpdatedDeferralReq:
+			req.Req = &storage.VulnerabilityRequest_DeferralReq{DeferralReq: r.UpdatedDeferralReq}
+			// Only deferral requests can be updated for VM 1.0 exceptions
+		}
+		return
+	}
+	switch r := req.GetUpdatedReq().(type) {
+	case *storage.VulnerabilityRequest_DeferralUpdate:
+		req.Req = &storage.VulnerabilityRequest_DeferralReq{
+			DeferralReq: &storage.DeferralRequest{
+				Expiry: r.DeferralUpdate.GetExpiry(),
+			},
+		}
+		req.Entities = &storage.VulnerabilityRequest_Cves{
+			Cves: &storage.VulnerabilityRequest_CVEs{
+				Cves: r.DeferralUpdate.GetCVEs(),
+			},
+		}
+	case *storage.VulnerabilityRequest_FalsePositiveUpdate:
+		req.Entities = &storage.VulnerabilityRequest_Cves{
+			Cves: &storage.VulnerabilityRequest_CVEs{
+				Cves: r.FalsePositiveUpdate.GetCVEs(),
+			},
+		}
+	}
 }
 
 func (ds *datastoreImpl) UpdateRequestExpiry(ctx context.Context, id, message string, updatedExpiry *storage.RequestExpiry) (*storage.VulnerabilityRequest, error) {

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -286,7 +286,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus_UnifiedCVEDeferral() {
 	defUpdate := &storage.VulnerabilityRequest_DeferralUpdate{
 		DeferralUpdate: &storage.DeferralUpdate{
 			Expiry: &storage.RequestExpiry{
-				Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: types.TimestampNow()},
+				Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: protocompat.TimestampNow()},
 			},
 			CVEs: []string{"cve-1"},
 		},

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -175,6 +175,9 @@ func (s *VulnRequestDataStoreTestSuite) TestOnlyApproversWithWriteCanUpdateStatu
 }
 
 func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus() {
+	if features.UnifiedCVEDeferral.Enabled() {
+		s.T().SkipNow()
+	}
 	pendingReq := &storage.VulnerabilityRequest{Requestor: &storage.SlimUser{Id: fakeUserID}, Expired: false}
 	pendingUpdateReq := &storage.VulnerabilityRequest{
 		Status:    storage.RequestStatus_APPROVED_PENDING_UPDATE,
@@ -188,56 +191,48 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus() {
 		}},
 	}
 	cases := []struct {
-		name                            string
-		existingReq                     *storage.VulnerabilityRequest
-		status                          storage.RequestStatus
-		expectedStatus                  storage.RequestStatus
-		expectedReqObj                  interface{}
-		expectedUpdatedObj              interface{}
-		skipIfUnifiedCVEDeferralEnabled bool
+		name               string
+		existingReq        *storage.VulnerabilityRequest
+		status             storage.RequestStatus
+		expectedStatus     storage.RequestStatus
+		expectedReqObj     interface{}
+		expectedUpdatedObj interface{}
 	}{
 		{
-			name:                            "Pending request should be approved",
-			existingReq:                     pendingReq.Clone(),
-			status:                          storage.RequestStatus_APPROVED,
-			expectedStatus:                  storage.RequestStatus_APPROVED,
-			expectedReqObj:                  pendingReq.GetReq(),
-			expectedUpdatedObj:              nil,
-			skipIfUnifiedCVEDeferralEnabled: false,
+			name:               "Pending request should be approved",
+			existingReq:        pendingReq.Clone(),
+			status:             storage.RequestStatus_APPROVED,
+			expectedStatus:     storage.RequestStatus_APPROVED,
+			expectedReqObj:     pendingReq.GetReq(),
+			expectedUpdatedObj: nil,
 		},
 		{
-			name:                            "Pending request should be denied",
-			existingReq:                     pendingReq.Clone(),
-			status:                          storage.RequestStatus_DENIED,
-			expectedStatus:                  storage.RequestStatus_DENIED,
-			expectedReqObj:                  pendingReq.GetReq(),
-			expectedUpdatedObj:              nil,
-			skipIfUnifiedCVEDeferralEnabled: false,
+			name:               "Pending request should be denied",
+			existingReq:        pendingReq.Clone(),
+			status:             storage.RequestStatus_DENIED,
+			expectedStatus:     storage.RequestStatus_DENIED,
+			expectedReqObj:     pendingReq.GetReq(),
+			expectedUpdatedObj: nil,
 		},
 		{
-			name:                            "Request pending update that was denied should go back to old approved state",
-			existingReq:                     pendingUpdateReq.Clone(),
-			status:                          storage.RequestStatus_DENIED,
-			expectedStatus:                  storage.RequestStatus_APPROVED,
-			expectedReqObj:                  pendingUpdateReq.GetReq(),
-			expectedUpdatedObj:              nil,
-			skipIfUnifiedCVEDeferralEnabled: false,
+			name:               "Request pending update that was denied should go back to old approved state",
+			existingReq:        pendingUpdateReq.Clone(),
+			status:             storage.RequestStatus_DENIED,
+			expectedStatus:     storage.RequestStatus_APPROVED,
+			expectedReqObj:     pendingUpdateReq.GetReq(),
+			expectedUpdatedObj: nil,
 		},
 		{
-			name:                            "Deferral request pending update that was approved should have req updated",
-			existingReq:                     pendingUpdateReq.Clone(),
-			status:                          storage.RequestStatus_APPROVED,
-			expectedStatus:                  storage.RequestStatus_APPROVED,
-			expectedReqObj:                  &storage.VulnerabilityRequest_DeferralReq{DeferralReq: pendingUpdateReq.GetUpdatedDeferralReq()},
-			expectedUpdatedObj:              nil,
-			skipIfUnifiedCVEDeferralEnabled: true,
+			name:               "Deferral request pending update that was approved should have req updated",
+			existingReq:        pendingUpdateReq.Clone(),
+			status:             storage.RequestStatus_APPROVED,
+			expectedStatus:     storage.RequestStatus_APPROVED,
+			expectedReqObj:     &storage.VulnerabilityRequest_DeferralReq{DeferralReq: pendingUpdateReq.GetUpdatedDeferralReq()},
+			expectedUpdatedObj: nil,
 		},
 	}
 	for _, c := range cases {
 		s.T().Run(c.name, func(t *testing.T) {
-			if c.skipIfUnifiedCVEDeferralEnabled && features.UnifiedCVEDeferral.Enabled() {
-				t.SkipNow()
-			}
 			s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(c.existingReq, true, nil)
 			s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -283,13 +278,12 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatusRequiresComment() {
 	s.EqualError(err, "comment is required when approving/denying a vulnerability request")
 }
 
-func (s *VulnRequestDataStoreTestSuite) TestUpdateStatusAppliesRequestedUpdates() {
+func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus_UnifiedCVEDeferral() {
 	if !features.UnifiedCVEDeferral.Enabled() {
 		s.T().SkipNow()
 	}
-	// Case: Approving deferral updates applies the new CVE list and expiry to the original req
-	req := fixtures.GetGlobalDeferralRequestV2("cve-1", "cve-2")
-	deferralUpdateReq := &storage.VulnerabilityRequest_DeferralUpdate{
+	pendingDefReq := fixtures.GetGlobalDeferralRequestV2("cve-1", "cve-2")
+	defUpdate := &storage.VulnerabilityRequest_DeferralUpdate{
 		DeferralUpdate: &storage.DeferralUpdate{
 			Expiry: &storage.RequestExpiry{
 				Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: types.TimestampNow()},
@@ -297,37 +291,90 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatusAppliesRequestedUpdates(
 			CVEs: []string{"cve-1"},
 		},
 	}
-	req.UpdatedReq = deferralUpdateReq
-	req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+	pendingDefUpdateReq := pendingDefReq.Clone()
+	pendingDefUpdateReq.UpdatedReq = defUpdate
+	pendingDefUpdateReq.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
 
-	s.mockStore.EXPECT().Get(gomock.Any(), req.GetId()).Return(req, true, nil).Times(1)
-	s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	resp, err := s.datastore.UpdateRequestStatus(selfApproverAllSac, req.GetId(), "approve deferral update", storage.RequestStatus_APPROVED)
-	s.NoError(err)
-
-	s.Equal(deferralUpdateReq.DeferralUpdate.GetExpiry(), resp.GetDeferralReq().GetExpiry())
-	s.ElementsMatch(deferralUpdateReq.DeferralUpdate.GetCVEs(), resp.GetCves().GetCves())
-	s.Equal(storage.RequestStatus_APPROVED, resp.GetStatus())
-	s.Nil(resp.GetUpdatedReq())
-
-	// Case: Approving false positive updates applies the new CVE list to the original req
-	req = fixtures.GetGlobalFPRequestV2("cve-1", "cve-2")
-	fpUpdateReq := &storage.VulnerabilityRequest_FalsePositiveUpdate{
+	pendingFpReq := fixtures.GetGlobalFPRequestV2("cve-1", "cve-2")
+	fpUpdate := &storage.VulnerabilityRequest_FalsePositiveUpdate{
 		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
 			CVEs: []string{"cve-1"},
 		},
 	}
-	req.UpdatedReq = fpUpdateReq
-	req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+	pendingFpUpdateReq := pendingFpReq.Clone()
+	pendingFpUpdateReq.UpdatedReq = fpUpdate
+	pendingFpUpdateReq.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
 
-	s.mockStore.EXPECT().Get(gomock.Any(), req.GetId()).Return(req, true, nil).Times(1)
-	s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	resp, err = s.datastore.UpdateRequestStatus(selfApproverAllSac, req.GetId(), "approve deferral update", storage.RequestStatus_APPROVED)
-	s.NoError(err)
+	cases := []struct {
+		name              string
+		existingReq       *storage.VulnerabilityRequest
+		status            storage.RequestStatus
+		expectedStatus    storage.RequestStatus
+		expectedReqObj    interface{}
+		expectedCVEs      []string
+		expectedUpdateReq interface{}
+	}{
+		{
+			name:              "Pending request should be approved",
+			existingReq:       pendingDefReq.Clone(),
+			status:            storage.RequestStatus_APPROVED,
+			expectedStatus:    storage.RequestStatus_APPROVED,
+			expectedReqObj:    pendingDefReq.Clone().GetReq(),
+			expectedCVEs:      pendingDefReq.Clone().GetCves().GetCves(),
+			expectedUpdateReq: nil,
+		},
+		{
+			name:              "Pending request should be denied",
+			existingReq:       pendingDefReq.Clone(),
+			status:            storage.RequestStatus_DENIED,
+			expectedStatus:    storage.RequestStatus_DENIED,
+			expectedReqObj:    pendingDefReq.Clone().GetReq(),
+			expectedCVEs:      pendingDefReq.Clone().GetCves().GetCves(),
+			expectedUpdateReq: nil,
+		},
+		{
+			name:              "Request pending update that was denied should go back to old approved state",
+			existingReq:       pendingDefUpdateReq.Clone(),
+			status:            storage.RequestStatus_DENIED,
+			expectedStatus:    storage.RequestStatus_APPROVED,
+			expectedReqObj:    pendingDefUpdateReq.Clone().GetReq(),
+			expectedCVEs:      pendingDefUpdateReq.Clone().GetCves().GetCves(),
+			expectedUpdateReq: nil,
+		},
+		{
+			name:              "Deferral request pending update that was approved should have req and entities updated",
+			existingReq:       pendingDefUpdateReq.Clone(),
+			status:            storage.RequestStatus_APPROVED,
+			expectedStatus:    storage.RequestStatus_APPROVED,
+			expectedReqObj:    &storage.VulnerabilityRequest_DeferralReq{DeferralReq: &storage.DeferralRequest{Expiry: defUpdate.DeferralUpdate.GetExpiry()}},
+			expectedCVEs:      defUpdate.DeferralUpdate.GetCVEs(),
+			expectedUpdateReq: nil,
+		},
+		{
+			name:              "False positive request pending update that was approved should have req and entities updated",
+			existingReq:       pendingFpUpdateReq,
+			status:            storage.RequestStatus_APPROVED,
+			expectedStatus:    storage.RequestStatus_APPROVED,
+			expectedReqObj:    &storage.VulnerabilityRequest_FpRequest{FpRequest: &storage.FalsePositiveRequest{}},
+			expectedCVEs:      fpUpdate.FalsePositiveUpdate.GetCVEs(),
+			expectedUpdateReq: nil,
+		},
+	}
 
-	s.ElementsMatch(fpUpdateReq.FalsePositiveUpdate.GetCVEs(), resp.GetCves().GetCves())
-	s.Equal(storage.RequestStatus_APPROVED, resp.GetStatus())
-	s.Nil(resp.GetUpdatedReq())
+	for _, c := range cases {
+		s.T().Run(c.name, func(t *testing.T) {
+			s.mockStore.EXPECT().Get(gomock.Any(), c.existingReq.GetId()).Return(c.existingReq, true, nil)
+			s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
+
+			resp, err := s.datastore.UpdateRequestStatus(selfApproverAllSac, c.existingReq.GetId(), "status changed", c.status)
+			s.NoError(err)
+			s.Len(resp.Comments, 2)
+			s.Equal("status changed", resp.Comments[1].Message)
+			s.Equal(c.expectedStatus, resp.Status)
+			s.Equal(c.expectedReqObj, resp.Req)
+			s.Equal(c.expectedCVEs, resp.GetCves().GetCves())
+		})
+	}
 }
 
 func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestExpiryRequiresWriteOnAny() {

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -188,48 +188,56 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus() {
 		}},
 	}
 	cases := []struct {
-		name               string
-		existingReq        *storage.VulnerabilityRequest
-		status             storage.RequestStatus
-		expectedStatus     storage.RequestStatus
-		expectedReqObj     interface{}
-		expectedUpdatedObj interface{}
+		name                            string
+		existingReq                     *storage.VulnerabilityRequest
+		status                          storage.RequestStatus
+		expectedStatus                  storage.RequestStatus
+		expectedReqObj                  interface{}
+		expectedUpdatedObj              interface{}
+		skipIfUnifiedCVEDeferralEnabled bool
 	}{
 		{
-			name:               "Pending request should be approved",
-			existingReq:        pendingReq.Clone(),
-			status:             storage.RequestStatus_APPROVED,
-			expectedStatus:     storage.RequestStatus_APPROVED,
-			expectedReqObj:     pendingReq.GetReq(),
-			expectedUpdatedObj: nil,
+			name:                            "Pending request should be approved",
+			existingReq:                     pendingReq.Clone(),
+			status:                          storage.RequestStatus_APPROVED,
+			expectedStatus:                  storage.RequestStatus_APPROVED,
+			expectedReqObj:                  pendingReq.GetReq(),
+			expectedUpdatedObj:              nil,
+			skipIfUnifiedCVEDeferralEnabled: false,
 		},
 		{
-			name:               "Pending request should be denied",
-			existingReq:        pendingReq.Clone(),
-			status:             storage.RequestStatus_DENIED,
-			expectedStatus:     storage.RequestStatus_DENIED,
-			expectedReqObj:     pendingReq.GetReq(),
-			expectedUpdatedObj: nil,
+			name:                            "Pending request should be denied",
+			existingReq:                     pendingReq.Clone(),
+			status:                          storage.RequestStatus_DENIED,
+			expectedStatus:                  storage.RequestStatus_DENIED,
+			expectedReqObj:                  pendingReq.GetReq(),
+			expectedUpdatedObj:              nil,
+			skipIfUnifiedCVEDeferralEnabled: false,
 		},
 		{
-			name:               "Request pending update that was denied should go back to old approved state",
-			existingReq:        pendingUpdateReq.Clone(),
-			status:             storage.RequestStatus_DENIED,
-			expectedStatus:     storage.RequestStatus_APPROVED,
-			expectedReqObj:     pendingUpdateReq.GetReq(),
-			expectedUpdatedObj: nil,
+			name:                            "Request pending update that was denied should go back to old approved state",
+			existingReq:                     pendingUpdateReq.Clone(),
+			status:                          storage.RequestStatus_DENIED,
+			expectedStatus:                  storage.RequestStatus_APPROVED,
+			expectedReqObj:                  pendingUpdateReq.GetReq(),
+			expectedUpdatedObj:              nil,
+			skipIfUnifiedCVEDeferralEnabled: false,
 		},
 		{
-			name:               "Deferral request pending update that was approved should have req updated",
-			existingReq:        pendingUpdateReq.Clone(),
-			status:             storage.RequestStatus_APPROVED,
-			expectedStatus:     storage.RequestStatus_APPROVED,
-			expectedReqObj:     &storage.VulnerabilityRequest_DeferralReq{DeferralReq: pendingUpdateReq.GetUpdatedDeferralReq()},
-			expectedUpdatedObj: nil,
+			name:                            "Deferral request pending update that was approved should have req updated",
+			existingReq:                     pendingUpdateReq.Clone(),
+			status:                          storage.RequestStatus_APPROVED,
+			expectedStatus:                  storage.RequestStatus_APPROVED,
+			expectedReqObj:                  &storage.VulnerabilityRequest_DeferralReq{DeferralReq: pendingUpdateReq.GetUpdatedDeferralReq()},
+			expectedUpdatedObj:              nil,
+			skipIfUnifiedCVEDeferralEnabled: true,
 		},
 	}
 	for _, c := range cases {
 		s.T().Run(c.name, func(t *testing.T) {
+			if c.skipIfUnifiedCVEDeferralEnabled && features.UnifiedCVEDeferral.Enabled() {
+				t.SkipNow()
+			}
 			s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(c.existingReq, true, nil)
 			s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -273,6 +281,53 @@ func (s *VulnRequestDataStoreTestSuite) TestCannotUpdateStatusToApprovedPendingU
 func (s *VulnRequestDataStoreTestSuite) TestUpdateStatusRequiresComment() {
 	_, err := s.datastore.UpdateRequestStatus(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), "id", "", storage.RequestStatus_APPROVED)
 	s.EqualError(err, "comment is required when approving/denying a vulnerability request")
+}
+
+func (s *VulnRequestDataStoreTestSuite) TestUpdateStatusAppliesRequestedUpdates() {
+	if !features.UnifiedCVEDeferral.Enabled() {
+		s.T().SkipNow()
+	}
+	// Case: Approving deferral updates applies the new CVE list and expiry to the original req
+	req := fixtures.GetGlobalDeferralRequestV2("cve-1", "cve-2")
+	deferralUpdateReq := &storage.VulnerabilityRequest_DeferralUpdate{
+		DeferralUpdate: &storage.DeferralUpdate{
+			Expiry: &storage.RequestExpiry{
+				Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: types.TimestampNow()},
+			},
+			CVEs: []string{"cve-1"},
+		},
+	}
+	req.UpdatedReq = deferralUpdateReq
+	req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+
+	s.mockStore.EXPECT().Get(gomock.Any(), req.GetId()).Return(req, true, nil).Times(1)
+	s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	resp, err := s.datastore.UpdateRequestStatus(selfApproverAllSac, req.GetId(), "approve deferral update", storage.RequestStatus_APPROVED)
+	s.NoError(err)
+
+	s.Equal(deferralUpdateReq.DeferralUpdate.GetExpiry(), resp.GetDeferralReq().GetExpiry())
+	s.ElementsMatch(deferralUpdateReq.DeferralUpdate.GetCVEs(), resp.GetCves().GetCves())
+	s.Equal(storage.RequestStatus_APPROVED, resp.GetStatus())
+	s.Nil(resp.GetUpdatedReq())
+
+	// Case: Approving false positive updates applies the new CVE list to the original req
+	req = fixtures.GetGlobalFPRequestV2("cve-1", "cve-2")
+	fpUpdateReq := &storage.VulnerabilityRequest_FalsePositiveUpdate{
+		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+			CVEs: []string{"cve-1"},
+		},
+	}
+	req.UpdatedReq = fpUpdateReq
+	req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+
+	s.mockStore.EXPECT().Get(gomock.Any(), req.GetId()).Return(req, true, nil).Times(1)
+	s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	resp, err = s.datastore.UpdateRequestStatus(selfApproverAllSac, req.GetId(), "approve deferral update", storage.RequestStatus_APPROVED)
+	s.NoError(err)
+
+	s.ElementsMatch(fpUpdateReq.FalsePositiveUpdate.GetCVEs(), resp.GetCves().GetCves())
+	s.Equal(storage.RequestStatus_APPROVED, resp.GetStatus())
+	s.Nil(resp.GetUpdatedReq())
 }
 
 func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestExpiryRequiresWriteOnAny() {


### PR DESCRIPTION
## Description

When an update requests to a VM 2.0 exception request is approved, the desired updates must be applied to the original request.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

#### Added Unit tests

#### Manual test by updating an approved pending vuln request

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
