### PR TITLE
ROX-22790: (WIP) Generate NetworkPolices based on the baseline

### DIFF
--- a/central/networkpolicies/generator/generator_impl.go
+++ b/central/networkpolicies/generator/generator_impl.go
@@ -139,8 +139,7 @@ func (g *generator) generateGraph(ctx context.Context, clusterID string, query *
 	var graph []*node
 	for _, deployment := range relevantDeployments {
 		// check if the baseline was cut
-		deploymentNode, err := g.generateNodeFromBaselineForDeployment(ctx, deployment, includePorts)
-		deploymentNode.selected = true
+		deploymentNode, err := g.generateNodeFromBaselineForDeployment(ctx, deployment, includePorts, true)
 		if err != nil {
 			log.Error(err)
 			continue
@@ -319,7 +318,7 @@ func (g *generator) GenerateFromBaselineForDeployment(
 		return nil, nil, errors.New("deployment not found")
 	}
 
-	node, err := g.generateNodeFromBaselineForDeployment(ctx, deployment, req.GetIncludePorts())
+	node, err := g.generateNodeFromBaselineForDeployment(ctx, deployment, req.GetIncludePorts(), false)
 	if err != nil {
 		return nil, nil, err
 	} else if node == nil {

--- a/central/networkpolicies/generator/generator_impl.go
+++ b/central/networkpolicies/generator/generator_impl.go
@@ -298,10 +298,8 @@ func (g *generator) generatePolicies(graph []*node, namespacesByName map[string]
 			continue
 		}
 
-		log.Debugf("generate policy for node %v", node)
 		policy := generatePolicy(node, namespacesByName, ingressPolicies, egressPolicies)
 		if policy != nil {
-			log.Debugf("generated policy for node %v", node)
 			generatedPolicies = append(generatedPolicies, policy)
 		}
 	}

--- a/central/networkpolicies/generator/generator_impl_test.go
+++ b/central/networkpolicies/generator/generator_impl_test.go
@@ -28,6 +28,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const (
+	clusterID = "mycluster"
+)
+
 type generatorTestSuite struct {
 	suite.Suite
 	generator *generator
@@ -49,60 +53,153 @@ func TestGenerator(t *testing.T) {
 	suite.Run(t, new(generatorTestSuite))
 }
 
-var testNetworkPolicies = []*storage.NetworkPolicy{
-	{
-		Id:        "policy1",
-		Name:      "policy1",
+var (
+	deploymentA = &storage.Deployment{
+		Id:        "depA",
+		Name:      "depA",
 		Namespace: "ns1",
-	},
-	{
-		Id:        "policy2",
-		Name:      "policy2",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "A"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "A"},
+		},
+	}
+	deploymentB = &storage.Deployment{
+		Id:        "depB",
+		Name:      "depB",
 		Namespace: "ns1",
-		Labels: map[string]string{
-			generatedNetworkPolicyLabel: "true",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "B"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "B"},
 		},
-	},
-	{
-		Id:        "policy3",
-		Name:      "policy3",
+	}
+	deploymentC = &storage.Deployment{
+		Id:        "depC",
+		Name:      "depC",
+		Namespace: "ns1",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "C"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "C"},
+		},
+	}
+	deploymentD = &storage.Deployment{
+		Id:        "depD",
+		Name:      "depD",
 		Namespace: "ns2",
-	},
-	{
-		Id:        "policy4",
-		Name:      "policy4",
-		Namespace: "ns2",
-		Labels: map[string]string{
-			generatedNetworkPolicyLabel: "true",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "D"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "D"},
 		},
-	},
-	{
-		Id:        "policy5",
-		Name:      "policy5",
-		Namespace: "kube-system",
-	},
-	{
-		Id:        "policy6",
-		Name:      "policy6",
-		Namespace: "kube-system",
-		Labels: map[string]string{
-			generatedNetworkPolicyLabel: "true",
+	}
+	deploymentE = &storage.Deployment{
+		Id:        "depE",
+		Name:      "depE",
+		Namespace: "baz",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "E"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "E"},
 		},
-	},
-	{
-		Id:        "policy7",
-		Name:      "policy7",
-		Namespace: "stackrox",
-	},
-	{
-		Id:        "policy8",
-		Name:      "policy8",
-		Namespace: "stackrox",
-		Labels: map[string]string{
-			generatedNetworkPolicyLabel: "true",
+	}
+	deploymentF = &storage.Deployment{
+		Id:        "depF",
+		Name:      "depF",
+		Namespace: "qux",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "F"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "F"},
 		},
-	},
-}
+	}
+	deploymentG = &storage.Deployment{
+		Id:        "depG",
+		Name:      "depG",
+		Namespace: "qux",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "G"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "G"},
+		},
+	}
+	deploymentH = &storage.Deployment{
+		Id:        "depH",
+		Name:      "depH",
+		Namespace: "baz",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "H"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "H"},
+		},
+	}
+	deploymentX = &storage.Deployment{
+		Id:        "depX",
+		Name:      "depX",
+		Namespace: "baz",
+		ClusterId: clusterID,
+		PodLabels: map[string]string{"depID": "X"},
+		LabelSelector: &storage.LabelSelector{
+			MatchLabels: map[string]string{"depID": "X"},
+		},
+	}
+
+	testNetworkPolicies = []*storage.NetworkPolicy{
+		{
+			Id:        "policy1",
+			Name:      "policy1",
+			Namespace: "ns1",
+		},
+		{
+			Id:        "policy2",
+			Name:      "policy2",
+			Namespace: "ns1",
+			Labels: map[string]string{
+				generatedNetworkPolicyLabel: "true",
+			},
+		},
+		{
+			Id:        "policy3",
+			Name:      "policy3",
+			Namespace: "ns2",
+		},
+		{
+			Id:        "policy4",
+			Name:      "policy4",
+			Namespace: "ns2",
+			Labels: map[string]string{
+				generatedNetworkPolicyLabel: "true",
+			},
+		},
+		{
+			Id:        "policy5",
+			Name:      "policy5",
+			Namespace: "kube-system",
+		},
+		{
+			Id:        "policy6",
+			Name:      "policy6",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				generatedNetworkPolicyLabel: "true",
+			},
+		},
+		{
+			Id:        "policy7",
+			Name:      "policy7",
+			Namespace: "stackrox",
+		},
+		{
+			Id:        "policy8",
+			Name:      "policy8",
+			Namespace: "stackrox",
+			Labels: map[string]string{
+				generatedNetworkPolicyLabel: "true",
+			},
+		},
+	}
+)
 
 func (s *generatorTestSuite) SetupTest() {
 	s.hasNoneCtx = sac.WithGlobalAccessScopeChecker(context.Background(), sac.DenyAllAccessScopeChecker())
@@ -215,201 +312,136 @@ func sortPolicies(policies []*storage.NetworkPolicy) {
 	})
 }
 
-func (s *generatorTestSuite) TestGenerate() {
-	now := time.Now().UTC()
-	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
-	req := &v1.GenerateNetworkPoliciesRequest{
-		ClusterId:        "mycluster",
-		DeleteExisting:   v1.GenerateNetworkPoliciesRequest_NONE,
-		NetworkDataSince: ts,
-	}
-
-	ctxHasDeploymentsAccessMatcher := sacTestutils.ContextWithAccess(sac.ScopeSuffix{
-		sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
-		sac.ResourceScopeKey(resources.Deployment.Resource),
-		sac.ClusterScopeKey("mycluster"),
-	})
-
-	s.mockDeployments.EXPECT().SearchRawDeployments(ctxHasDeploymentsAccessMatcher, gomock.Any()).Return(
-		[]*storage.Deployment{
+func generateExternalNetworkPeer(ingress bool, port uint32, protocol storage.L4Protocol) *storage.NetworkBaselinePeer {
+	return &storage.NetworkBaselinePeer{
+		Properties: []*storage.NetworkBaselineConnectionProperties{
 			{
-				Id:        "depA",
-				Name:      "depA",
-				Namespace: "ns1",
-				PodLabels: map[string]string{"depID": "A"},
-				LabelSelector: &storage.LabelSelector{
+				Ingress:  ingress,
+				Port:     port,
+				Protocol: protocol,
+			},
+		},
+		Entity: &storage.NetworkEntity{
+			Info: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+				Id:   "id",
+				Desc: &storage.NetworkEntityInfo_ExternalSource_{
+					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+						Name: "external",
+						Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
+							Cidr: "192.0.2.0/24",
+						},
+						Default: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateDeploymentNetworkPeer(dstID string, dstName string, dstNamespace string, clusterID string, ingress bool, port uint32, protocol storage.L4Protocol) *storage.NetworkBaselinePeer {
+	return &storage.NetworkBaselinePeer{
+		Properties: []*storage.NetworkBaselineConnectionProperties{
+			{
+				Ingress:  ingress,
+				Port:     port,
+				Protocol: protocol,
+			},
+		},
+		Entity: &storage.NetworkEntity{
+			Scope: &storage.NetworkEntity_Scope{
+				ClusterId: clusterID,
+			},
+			Info: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_DEPLOYMENT,
+				Id:   dstID,
+				Desc: &storage.NetworkEntityInfo_Deployment_{
+					Deployment: &storage.NetworkEntityInfo_Deployment{
+						Name:      dstName,
+						Namespace: dstNamespace,
+						Cluster:   clusterID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func deploymentsToMap(deployments ...*storage.Deployment) map[string]*storage.Deployment {
+	ret := make(map[string]*storage.Deployment)
+	for _, d := range deployments {
+		ret[d.GetId()] = d
+	}
+	return ret
+}
+
+func deploymentsToSlice(deployments ...*storage.Deployment) []*storage.Deployment {
+	ret := append([]*storage.Deployment{}, deployments...)
+	return ret
+}
+
+func generateBaselineMapFromDeployments(deployments ...*storage.Deployment) map[string]*storage.NetworkBaseline {
+	ret := make(map[string]*storage.NetworkBaseline)
+	for _, d := range deployments {
+		ret[d.GetId()] = &storage.NetworkBaseline{
+			DeploymentId:   d.GetId(),
+			DeploymentName: d.GetName(),
+			ClusterId:      d.GetClusterId(),
+			Namespace:      d.GetNamespace(),
+			Peers:          []*storage.NetworkBaselinePeer{},
+			ForbiddenPeers: []*storage.NetworkBaselinePeer{},
+		}
+	}
+	return ret
+}
+
+var (
+	namespaceMetadata = []*storage.NamespaceMetadata{
+		{
+			Id:   "1",
+			Name: "ns1",
+			Labels: map[string]string{
+				namespaces.NamespaceNameLabel: "ns1",
+			},
+		},
+		{
+			Id:   "2",
+			Name: "ns2",
+			Labels: map[string]string{
+				namespaces.NamespaceNameLabel: "ns2",
+			},
+		},
+	}
+	existingNetworkPolicies = []*storage.NetworkPolicy{
+		{
+			Id:        "np1",
+			ClusterId: clusterID,
+			Namespace: "ns1",
+			Spec: &storage.NetworkPolicySpec{
+				PodSelector: &storage.LabelSelector{
 					MatchLabels: map[string]string{"depID": "A"},
 				},
+				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 			},
-			{
-				Id:        "depB",
-				Name:      "depB",
-				Namespace: "ns1",
-				PodLabels: map[string]string{"depID": "B"},
-				LabelSelector: &storage.LabelSelector{
+		},
+		{
+			Id:        "np2",
+			ClusterId: clusterID,
+			Namespace: "ns1",
+			Spec: &storage.NetworkPolicySpec{
+				PodSelector: &storage.LabelSelector{
 					MatchLabels: map[string]string{"depID": "B"},
 				},
+				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE},
 			},
-			{
-				Id:        "depC",
-				Name:      "depC",
-				Namespace: "ns1",
-				PodLabels: map[string]string{"depID": "C"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "C"},
-				},
-			},
-			{
-				Id:        "depD",
-				Name:      "depD",
-				Namespace: "ns2",
-				PodLabels: map[string]string{"depID": "D"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "D"},
-				},
-			},
-		}, nil)
-
-	s.mockNamespaceStore.EXPECT().SearchNamespaces(gomock.Any(), gomock.Any()).Return(
-		[]*storage.NamespaceMetadata{
-			{
-				Id:   "1",
-				Name: "ns1",
-				Labels: map[string]string{
-					namespaces.NamespaceNameLabel: "ns1",
-				},
-			},
-			{
-				Id:   "2",
-				Name: "ns2",
-				Labels: map[string]string{
-					namespaces.NamespaceNameLabel: "ns2",
-				},
-			},
-		}, nil)
-
-	clusterIDMatcher := testutils.PredMatcher("check cluster ID", func(clusterID string) bool { return clusterID == "mycluster" })
-	s.mocksNetworkPolicies.EXPECT().GetNetworkPolicies(s.hasReadCtx, clusterIDMatcher, "").Return(
-		[]*storage.NetworkPolicy{
-			{
-				Id:        "np1",
-				ClusterId: "mycluster",
-				Namespace: "ns1",
-				Spec: &storage.NetworkPolicySpec{
-					PodSelector: &storage.LabelSelector{
-						MatchLabels: map[string]string{"depID": "A"},
-					},
-					PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
-				},
-			},
-			{
-				Id:        "np2",
-				ClusterId: "mycluster",
-				Namespace: "ns1",
-				Spec: &storage.NetworkPolicySpec{
-					PodSelector: &storage.LabelSelector{
-						MatchLabels: map[string]string{"depID": "B"},
-					},
-					PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE},
-				},
-			},
-		}, nil)
-
-	mockFlowStore := nfDSMocks.NewMockFlowDataStore(s.mockCtrl)
-
-	ctxHasNetworkFlowAccessMatcher := sacTestutils.ContextWithAccess(
-		sac.ScopeSuffix{
-			sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKey(resources.NetworkGraph.Resource),
-			sac.ClusterScopeKey("mycluster"),
-		})
-
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).Return(
-		[]*storage.NetworkFlow{
-			{
-				Props: &storage.NetworkFlowProperties{
-					SrcEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depA",
-					},
-					DstEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depB",
-					},
-				},
-			},
-			{
-				Props: &storage.NetworkFlowProperties{
-					SrcEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depA",
-					},
-					DstEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depC",
-					},
-				},
-			},
-			{
-				Props: &storage.NetworkFlowProperties{
-					SrcEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depC",
-					},
-					DstEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depB",
-					},
-				},
-			},
-			{
-				Props: &storage.NetworkFlowProperties{
-					SrcEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depD",
-					},
-					DstEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depB",
-					},
-				},
-			},
-			{
-				Props: &storage.NetworkFlowProperties{
-					SrcEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_INTERNET,
-					},
-					DstEntity: &storage.NetworkEntityInfo{
-						Type: storage.NetworkEntityInfo_DEPLOYMENT,
-						Id:   "depC",
-					},
-				},
-			},
-		}, &now, nil)
-
-	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
-	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)
-	s.mockGlobalFlowDataStore.EXPECT().GetFlowStore(gomock.Any(), gomock.Eq("mycluster")).Return(mockFlowStore, nil)
-
-	generatedPolicies, toDelete, err := s.generator.Generate(s.hasReadCtx, req)
-	s.NoError(err)
-	s.Empty(toDelete)
-
-	// canonicalize policies, strip out uninteresting fields
-	for _, policy := range generatedPolicies {
-		s.Equal("true", policy.GetLabels()[generatedNetworkPolicyLabel])
-		policy.Labels = nil
-		s.Equal(networkPolicyAPIVersion, policy.GetApiVersion())
-		policy.ApiVersion = ""
+		},
 	}
-
-	sortPolicies(generatedPolicies)
-
-	expectedPolicies := []*storage.NetworkPolicy{
+	expectedPolicies = []*storage.NetworkPolicy{
 		// No policy for depA as there already is an existing policy
 		{
 			Name:      "stackrox-generated-depB",
 			Namespace: "ns1",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -444,6 +476,7 @@ func (s *generatorTestSuite) TestGenerate() {
 		{
 			Name:      "stackrox-generated-depC",
 			Namespace: "ns1",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -457,6 +490,7 @@ func (s *generatorTestSuite) TestGenerate() {
 		{
 			Name:      "stackrox-generated-depD",
 			Namespace: "ns2",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -465,25 +499,176 @@ func (s *generatorTestSuite) TestGenerate() {
 			},
 		},
 	}
+)
 
+func (s *generatorTestSuite) TestGenerateWithBaselines() {
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
+	req := &v1.GenerateNetworkPoliciesRequest{
+		ClusterId:        clusterID,
+		DeleteExisting:   v1.GenerateNetworkPoliciesRequest_NONE,
+		NetworkDataSince: ts,
+	}
+
+	ctxHasDeploymentsAccessMatcher := sacTestutils.ContextWithAccess(sac.ScopeSuffix{
+		sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
+		sac.ResourceScopeKey(resources.Deployment.Resource),
+		sac.ClusterScopeKey(clusterID),
+	})
+
+	deployments := deploymentsToSlice(deploymentA, deploymentB, deploymentC, deploymentD)
+	deploymentsMap := deploymentsToMap(deployments...)
+	baselines := generateBaselineMapFromDeployments(deployments...)
+	// egress flows are not taken into consideration, we add them in the test to illustrative purposes
+	baselines[deploymentA.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depB", "depB", "ns1", clusterID, false, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depC", "depC", "ns1", clusterID, false, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[deploymentB.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depA", "depA", "ns1", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depC", "depC", "ns1", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depD", "depD", "ns2", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[deploymentC.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depB", "depB", "ns1", clusterID, false, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depA", "depA", "ns1", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateExternalNetworkPeer(true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[deploymentD.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depB", "depB", "ns1", clusterID, false, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	s.mockDeployments.EXPECT().SearchRawDeployments(ctxHasDeploymentsAccessMatcher, gomock.Any()).Return(deployments, nil)
+
+	s.mockNetworkBaselineStore.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).
+		Times(len(deployments)).
+		DoAndReturn(func(_ any, deploymentID string) (*storage.NetworkBaseline, bool, error) {
+			baseline, ok := baselines[deploymentID]
+			s.Require().True(ok)
+			return baseline, true, nil
+		})
+	s.mockDeployments.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ any, deploymentID string) (*storage.Deployment, bool, error) {
+			deployment, ok := deploymentsMap[deploymentID]
+			s.Require().True(ok)
+			return deployment, true, nil
+		})
+
+	s.mockNamespaceStore.EXPECT().SearchNamespaces(gomock.Any(), gomock.Any()).Return(namespaceMetadata, nil)
+
+	clusterIDMatcher := testutils.PredMatcher("check cluster ID", func(id string) bool { return id == clusterID })
+	s.mocksNetworkPolicies.EXPECT().GetNetworkPolicies(s.hasReadCtx, clusterIDMatcher, "").Return(existingNetworkPolicies, nil)
+
+	generatedPolicies, toDelete, err := s.generator.Generate(s.hasReadCtx, req)
+	s.NoError(err)
+	s.Empty(toDelete)
+
+	// canonicalize policies, strip out uninteresting fields
+	for _, policy := range generatedPolicies {
+		s.Equal("true", policy.GetLabels()[generatedNetworkPolicyLabel])
+		policy.Labels = nil
+		s.Equal(networkPolicyAPIVersion, policy.GetApiVersion())
+		policy.ApiVersion = ""
+	}
+
+	sortPolicies(generatedPolicies)
 	sortPolicies(expectedPolicies)
 
 	s.Equal(expectedPolicies, generatedPolicies)
 }
 
-func depFlow(fromID, toID string) *storage.NetworkFlow {
+func depFlow(toID, fromID string) *storage.NetworkFlow {
 	return &storage.NetworkFlow{
 		Props: &storage.NetworkFlowProperties{
 			SrcEntity: &storage.NetworkEntityInfo{
 				Type: storage.NetworkEntityInfo_DEPLOYMENT,
-				Id:   toID,
+				Id:   fromID,
 			},
 			DstEntity: &storage.NetworkEntityInfo{
 				Type: storage.NetworkEntityInfo_DEPLOYMENT,
-				Id:   fromID,
+				Id:   toID,
 			},
 		},
 	}
+}
+
+func (s *generatorTestSuite) TestGenerateWithMissingBaselines() {
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
+	req := &v1.GenerateNetworkPoliciesRequest{
+		ClusterId:        clusterID,
+		DeleteExisting:   v1.GenerateNetworkPoliciesRequest_NONE,
+		NetworkDataSince: ts,
+	}
+
+	ctxHasDeploymentsAccessMatcher := sacTestutils.ContextWithAccess(sac.ScopeSuffix{
+		sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
+		sac.ResourceScopeKey(resources.Deployment.Resource),
+		sac.ClusterScopeKey(clusterID),
+	})
+
+	deployments := deploymentsToSlice(deploymentA, deploymentB, deploymentC, deploymentD)
+	s.mockDeployments.EXPECT().SearchRawDeployments(ctxHasDeploymentsAccessMatcher, gomock.Any()).Return(deployments, nil)
+
+	s.mockNetworkBaselineStore.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).
+		Times(len(deployments)).
+		DoAndReturn(func(_ any, _ string) (*storage.NetworkBaseline, bool, error) {
+			return nil, false, nil
+		})
+
+	s.mockNamespaceStore.EXPECT().SearchNamespaces(gomock.Any(), gomock.Any()).Return(namespaceMetadata, nil)
+
+	mockFlowStore := nfDSMocks.NewMockFlowDataStore(s.mockCtrl)
+
+	ctxHasNetworkFlowAccessMatcher := sacTestutils.ContextWithAccess(
+		sac.ScopeSuffix{
+			sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKey(resources.NetworkGraph.Resource),
+			sac.ClusterScopeKey(clusterID),
+		})
+
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).Return(
+		[]*storage.NetworkFlow{
+			depFlow(deploymentB.GetId(), deploymentA.GetId()),
+			depFlow(deploymentC.GetId(), deploymentA.GetId()),
+			depFlow(deploymentB.GetId(), deploymentC.GetId()),
+			depFlow(deploymentB.GetId(), deploymentD.GetId()),
+			{
+				Props: &storage.NetworkFlowProperties{
+					SrcEntity: &storage.NetworkEntityInfo{
+						Type: storage.NetworkEntityInfo_INTERNET,
+					},
+					DstEntity: &storage.NetworkEntityInfo{
+						Type: storage.NetworkEntityInfo_DEPLOYMENT,
+						Id:   "depC",
+					},
+				},
+			},
+		}, &now, nil)
+
+	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)
+	s.mockGlobalFlowDataStore.EXPECT().GetFlowStore(gomock.Any(), gomock.Eq(clusterID)).Return(mockFlowStore, nil)
+
+	clusterIDMatcher := testutils.PredMatcher("check cluster ID", func(id string) bool { return id == clusterID })
+	s.mocksNetworkPolicies.EXPECT().GetNetworkPolicies(s.hasReadCtx, clusterIDMatcher, "").Return(existingNetworkPolicies, nil)
+
+	generatedPolicies, toDelete, err := s.generator.Generate(s.hasReadCtx, req)
+	s.NoError(err)
+	s.Empty(toDelete)
+
+	// canonicalize policies, strip out uninteresting fields
+	for _, policy := range generatedPolicies {
+		s.Equal("true", policy.GetLabels()[generatedNetworkPolicyLabel])
+		policy.Labels = nil
+		s.Equal(networkPolicyAPIVersion, policy.GetApiVersion())
+		policy.ApiVersion = ""
+	}
+
+	sortPolicies(generatedPolicies)
+	sortPolicies(expectedPolicies)
+
+	s.Equal(expectedPolicies, generatedPolicies)
 }
 
 func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
@@ -499,6 +684,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 	// - depD has incoming flows from depA
 	// Namespace baz:
 	// - depE has incoming flows from depB
+	// - depH has incoming flows from depA and a deployment without access, depX. Its baseline is missing
 	// Namespace qux:
 	// - depF has incoming flows from depC, depD and depG
 	// - depG has no flows
@@ -516,17 +702,17 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 				storage.Access_READ_ACCESS: {
 					resources.Deployment.Resource: &sac.TestResourceScope{
 						Clusters: map[string]*sac.TestClusterScope{
-							"mycluster": {Namespaces: []string{"foo", "bar", "baz", "qux"}},
+							clusterID: {Namespaces: []string{"foo", "bar", "baz", "qux"}},
 						},
 					},
 					resources.NetworkGraph.Resource: &sac.TestResourceScope{
 						Clusters: map[string]*sac.TestClusterScope{
-							"mycluster": {Namespaces: []string{"foo", "baz", "qux"}},
+							clusterID: {Namespaces: []string{"foo", "baz", "qux"}},
 						},
 					},
 					resources.Namespace.Resource: &sac.TestResourceScope{
 						Clusters: map[string]*sac.TestClusterScope{
-							"mycluster": {Namespaces: []string{"foo", "bar", "baz"}},
+							clusterID: {Namespaces: []string{"foo", "bar", "baz"}},
 						},
 					},
 				},
@@ -535,7 +721,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 	now := time.Now().UTC()
 	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.GenerateNetworkPoliciesRequest{
-		ClusterId:        "mycluster",
+		ClusterId:        clusterID,
 		Query:            "Namespace: foo,bar,qux",
 		DeleteExisting:   v1.GenerateNetworkPoliciesRequest_NONE,
 		NetworkDataSince: ts,
@@ -544,71 +730,67 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 	ctxHasAllDeploymentsAccessMatcher := sacTestutils.ContextWithAccess(sac.ScopeSuffix{
 		sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
 		sac.ResourceScopeKey(resources.Deployment.Resource),
-		sac.ClusterScopeKey("mycluster"),
+		sac.ClusterScopeKey(clusterID),
 	})
-
-	s.mockDeployments.EXPECT().SearchRawDeployments(gomock.Not(ctxHasAllDeploymentsAccessMatcher), gomock.Any()).Return(
-		[]*storage.Deployment{
-			{
-				Id:        "depA",
-				Name:      "depA",
-				Namespace: "foo",
-				PodLabels: map[string]string{"depID": "A"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "A"},
-				},
-			},
-			{
-				Id:        "depB",
-				Name:      "depB",
-				Namespace: "foo",
-				PodLabels: map[string]string{"depID": "B"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "B"},
-				},
-			},
-			{
-				Id:        "depC",
-				Name:      "depC",
-				Namespace: "foo",
-				PodLabels: map[string]string{"depID": "C"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "C"},
-				},
-			},
-			{
-				Id:        "depD",
-				Name:      "depD",
-				Namespace: "bar",
-				PodLabels: map[string]string{"depID": "D"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "D"},
-				},
-			},
-			{
-				Id:        "depF",
-				Name:      "depF",
-				Namespace: "qux",
-				PodLabels: map[string]string{"depID": "F"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "F"},
-				},
-			},
-			{
-				Id:        "depG",
-				Name:      "depG",
-				Namespace: "qux",
-				PodLabels: map[string]string{"depID": "G"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "G"},
-				},
-			},
-		}, nil)
+	// Cloning the deployments A, B, C, and D as we are changing the namespaces for this test
+	depA := deploymentA.Clone()
+	depA.Namespace = "foo"
+	depB := deploymentB.Clone()
+	depB.Namespace = "foo"
+	depC := deploymentC.Clone()
+	depC.Namespace = "foo"
+	depD := deploymentD.Clone()
+	depD.Namespace = "bar"
+	deployments := deploymentsToSlice(depA, depB, depC, depD, deploymentH, deploymentF, deploymentG)
+	deploymentsMap := deploymentsToMap(depA, depB, depC, depD, deploymentF, deploymentG, deploymentE)
+	baselines := generateBaselineMapFromDeployments(depA, depB, depC, depD, deploymentF, deploymentG)
+	baselines[depA.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depB", "depB", "foo", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depE", "depE", "baz", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depD", "depD", "bar", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		// Deployment Y was deleted
+		generateDeploymentNetworkPeer("depY", "depY", "deleted", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[depB.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depA", "depA", "foo", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depX", "depX", "baz", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[depC.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depF", "depF", "qux", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depA", "depA", "foo", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	baselines[deploymentF.GetId()].Peers = []*storage.NetworkBaselinePeer{
+		generateDeploymentNetworkPeer("depC", "depC", "foo", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depG", "depG", "qux", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+		generateDeploymentNetworkPeer("depD", "depD", "bar", clusterID, true, 80, storage.L4Protocol_L4_PROTOCOL_TCP),
+	}
+	s.mockDeployments.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(ctx context.Context, deploymentID string) (*storage.Deployment, bool, error) {
+			val, ok := ctx.Value(sac.GetGlobalAccessScopeContextKey(s.T())).(sac.ScopeCheckerCore)
+			if !ok {
+				return nil, false, nil
+			}
+			// If the call is made with not enough privileges
+			if !val.Allowed() {
+				deployment, ok := deploymentsMap[deploymentID]
+				if !ok {
+					return nil, false, nil
+				}
+				return deployment, true, nil
+			}
+			// Privileged request returns the deployment X
+			if deploymentID == deploymentX.GetId() {
+				return deploymentX, true, nil
+			}
+			return nil, false, nil
+		})
+	s.mockDeployments.EXPECT().SearchRawDeployments(gomock.Not(ctxHasAllDeploymentsAccessMatcher), gomock.Any()).Return(deployments, nil)
 
 	ctxHasAllNamespaceAccessMatcher := sacTestutils.ContextWithAccess(sac.ScopeSuffix{
 		sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
 		sac.ResourceScopeKey(resources.Namespace.Resource),
-		sac.ClusterScopeKey("mycluster"),
+		sac.ClusterScopeKey(clusterID),
 	})
 
 	s.mockNamespaceStore.EXPECT().SearchNamespaces(gomock.Not(ctxHasAllNamespaceAccessMatcher), gomock.Any()).Return(
@@ -636,77 +818,57 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 			},
 		}, nil,
 	)
-
-	// Assume no existing network policies.
-	s.mocksNetworkPolicies.EXPECT().GetNetworkPolicies(gomock.Any(), "mycluster", "").Return(nil, nil)
-
 	mockFlowStore := nfDSMocks.NewMockFlowDataStore(s.mockCtrl)
 
 	ctxHasClusterWideNetworkFlowAccessMatcher := sacTestutils.ContextWithAccess(
 		sac.ScopeSuffix{
 			sac.AccessModeScopeKey(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKey(resources.NetworkGraph.Resource),
-			sac.ClusterScopeKey("mycluster"),
+			sac.ClusterScopeKey(clusterID),
 		})
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).Return(
 		[]*storage.NetworkFlow{
-			depFlow("depA", "depB"),
-			depFlow("depA", "depD"),
-			depFlow("depA", "depE"),
-			depFlow("depA", "depY"),
-			depFlow("depB", "depA"),
-			depFlow("depB", "depX"),
-			depFlow("depC", "depA"),
-			depFlow("depC", "depF"),
-			depFlow("depD", "depA"),
-			// depE flows not relevant
-			depFlow("depF", "depC"),
-			depFlow("depF", "depD"),
-			depFlow("depF", "depG"),
+			depFlow(deploymentH.GetId(), depA.GetId()),
+			depFlow(deploymentH.GetId(), deploymentX.GetId()),
 		}, &now, nil)
 
 	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)
-	s.mockGlobalFlowDataStore.EXPECT().GetFlowStore(gomock.Any(), gomock.Eq("mycluster")).Return(mockFlowStore, nil)
+	s.mockGlobalFlowDataStore.EXPECT().GetFlowStore(gomock.Any(), gomock.Eq(clusterID)).Return(mockFlowStore, nil)
 
 	// Expect a query for looking up deployments that were not selected as part of the initial query
 	// (visible or invisible).
 	s.mockDeployments.EXPECT().GetDeployments(
 		gomock.Not(ctxHasAllDeploymentsAccessMatcher),
-		// depD is part of the query since it was eliminated as irrelevant before.
-		testutils.AssertionMatcher(assert.ElementsMatch, []string{"depD", "depE", "depX", "depY"})).Return(
-		[]*storage.Deployment{
-			{
-				Id:        "depD",
-				Name:      "depD",
-				Namespace: "bar",
-				PodLabels: map[string]string{"depID": "D"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "D"},
-				},
-			},
-			{
-				Id:        "depE",
-				Name:      "depE",
-				Namespace: "baz",
-				PodLabels: map[string]string{"depID": "E"},
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{"depID": "E"},
-				},
-			},
-		}, nil,
+		// depX is part of the query since it was eliminated as irrelevant before.
+		testutils.AssertionMatcher(assert.ElementsMatch, []string{depA.GetId(), deploymentX.GetId()})).Return(
+		[]*storage.Deployment{depA}, nil,
 	)
-
 	// Expect a query with elevated privileges for looking up deployments that we are still missing info about
 	// (either deleted or invisible to the user).
 	s.mockDeployments.EXPECT().Search(ctxHasAllDeploymentsAccessMatcher, gomock.Any()).Return(
 		[]search.Result{
 			{
-				ID: "depX",
+				ID: deploymentX.GetId(),
 			},
 			// depY was deleted!
 		}, nil)
+	// Assume no existing network policies.
+	s.mocksNetworkPolicies.EXPECT().GetNetworkPolicies(gomock.Any(), clusterID, "").Return(nil, nil)
+
+	s.mockNetworkBaselineStore.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ any, deploymentID string) (*storage.NetworkBaseline, bool, error) {
+			s.T().Log("Baseline for deployment ", deploymentID)
+			baseline, ok := baselines[deploymentID]
+			if !ok {
+				s.T().Log("Baseline for deployment ", deploymentID, " not found")
+				return nil, false, nil
+			}
+			s.T().Log("Baseline for deployment ", deploymentID, " found")
+			return baseline, true, nil
+		})
 
 	generatedPolicies, toDelete, err := s.generator.Generate(ctx, req)
 	s.NoError(err)
@@ -729,11 +891,12 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 	// - NO netpol for depD (no netflow access)
 	// - NO netpol for depE (not selected)
 	// - netpol for qux (don't need NS metadata for netpol generation, only for peers in other namespaces)
-	expectedPolicies := []*storage.NetworkPolicy{
-		// No policy for depA as there already is an existing policy
+	// - netpol for depH allowing all cluster traffic
+	expectedNetworkPolicies := []*storage.NetworkPolicy{
 		{
 			Name:      "stackrox-generated-depA",
 			Namespace: "foo",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -771,6 +934,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 		{
 			Name:      "stackrox-generated-depB",
 			Namespace: "foo",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -784,6 +948,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 		{
 			Name:      "stackrox-generated-depC",
 			Namespace: "foo",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -815,6 +980,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 		{
 			Name:      "stackrox-generated-depF",
 			Namespace: "qux",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -862,6 +1028,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 		{
 			Name:      "stackrox-generated-depG",
 			Namespace: "qux",
+			ClusterId: clusterID,
 			Spec: &storage.NetworkPolicySpec{
 				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
 				PodSelector: &storage.LabelSelector{
@@ -870,10 +1037,24 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 				Ingress: nil,
 			},
 		},
+		{
+			Name:      "stackrox-generated-depH",
+			Namespace: "baz",
+			ClusterId: clusterID,
+			Spec: &storage.NetworkPolicySpec{
+				PolicyTypes: []storage.NetworkPolicyType{storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE},
+				PodSelector: &storage.LabelSelector{
+					MatchLabels: map[string]string{"depID": "H"},
+				},
+				Ingress: []*storage.NetworkPolicyIngressRule{
+					allowAllPodsAllNS,
+				},
+			},
+		},
 	}
 
-	sortPolicies(expectedPolicies)
-	s.Equal(expectedPolicies, generatedPolicies)
+	sortPolicies(expectedNetworkPolicies)
+	s.Equal(expectedNetworkPolicies, generatedPolicies)
 }
 
 func (s *generatorTestSuite) TestGenerateFromBaselineForDeployment() {

--- a/central/networkpolicies/generator/graph.go
+++ b/central/networkpolicies/generator/graph.go
@@ -306,14 +306,20 @@ func (g *generator) generateNodeFromBaselineForDeployment(
 	// Temporarily elevate permissions to obtain all deployments in cluster.
 	elevatedCtx := sac.WithAllAccess(ctx)
 	// Since we only generate ingress flows, we only look at ingress peers for policy generation
+	log.Debugf("Baseline for deployment %s - %s in namespace %s. (locked: %t) (observation period: %v)",
+		deployment.GetId(), deployment.GetName(), deployment.GetNamespace(),
+		baseline.GetLocked(), baseline.GetObservationPeriodEnd())
 	for _, peer := range baseline.GetPeers() {
+		log.Debugf("Baseline Peer for deployment %s - %s in namespace %s: %+v", deployment.GetId(), deployment.GetName(), deployment.GetNamespace(), peer)
 		peerNode := g.populateNode(elevatedCtx, peer.GetEntity().GetInfo().GetId(), peer.GetEntity().GetInfo().GetType())
 		if peerNode == nil {
 			// Peer deployment probably has been deleted.
 			continue
 		}
 		for _, props := range peer.GetProperties() {
+			log.Debugf("Properties from peer node %+v --> %+v", peer.GetEntity().GetInfo(), props)
 			if !props.GetIngress() {
+				log.Debugf("Not ingress")
 				continue
 			}
 			var port portDesc

--- a/central/networkpolicies/generator/graph.go
+++ b/central/networkpolicies/generator/graph.go
@@ -307,20 +307,14 @@ func (g *generator) generateNodeFromBaselineForDeployment(
 	deploymentNode.selected = setSelected
 
 	// Since we only generate ingress flows, we only look at ingress peers for policy generation
-	log.Debugf("Baseline for deployment %s - %s in namespace %s. (locked: %t) (observation period: %v)",
-		deployment.GetId(), deployment.GetName(), deployment.GetNamespace(),
-		baseline.GetLocked(), baseline.GetObservationPeriodEnd())
 	for _, peer := range baseline.GetPeers() {
-		log.Debugf("Baseline Peer for deployment %s - %s in namespace %s: %+v", deployment.GetId(), deployment.GetName(), deployment.GetNamespace(), peer)
 		peerNode := g.populateNode(ctx, peer.GetEntity().GetInfo().GetId(), peer.GetEntity().GetInfo().GetType())
 		if peerNode == nil {
 			// Peer deployment probably has been deleted.
 			continue
 		}
 		for _, props := range peer.GetProperties() {
-			log.Debugf("Properties from peer node %+v --> %+v", peer.GetEntity().GetInfo(), props)
 			if !props.GetIngress() {
-				log.Debugf("Not ingress")
 				continue
 			}
 			var port portDesc

--- a/central/networkpolicies/generator/graph.go
+++ b/central/networkpolicies/generator/graph.go
@@ -287,6 +287,7 @@ func (g *generator) generateNodeFromBaselineForDeployment(
 	ctx context.Context,
 	deployment *storage.Deployment,
 	includePorts bool,
+	setSelected bool,
 ) (*node, error) {
 	if isProtectedDeployment(deployment) {
 		return nil, errors.New("cannot generate policy for a protected deployment")
@@ -302,6 +303,7 @@ func (g *generator) generateNodeFromBaselineForDeployment(
 
 	deploymentNode := createNode(networkgraph.Entity{Type: storage.NetworkEntityInfo_DEPLOYMENT, ID: deployment.GetId()})
 	deploymentNode.deployment = deployment
+	deploymentNode.selected = setSelected
 
 	// Temporarily elevate permissions to obtain all deployments in cluster.
 	elevatedCtx := sac.WithAllAccess(ctx)

--- a/pkg/sac/context.go
+++ b/pkg/sac/context.go
@@ -2,6 +2,7 @@ package sac
 
 import (
 	"context"
+	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/utils"
@@ -36,4 +37,9 @@ func WithAllAccess(ctx context.Context) context.Context {
 // scope checks.
 func WithNoAccess(ctx context.Context) context.Context {
 	return WithGlobalAccessScopeChecker(ctx, denyAllScopeCheckerCore)
+}
+
+// GetGlobalAccessScopeContextKey this is for testing purposes only
+func GetGlobalAccessScopeContextKey(_ *testing.T) globalAccessScopeContextKey {
+	return globalAccessScopeContextKey{}
 }


### PR DESCRIPTION
## Description

Currently we have two ways to generate network policies from the UI. One takes into consideration the baseline and the other one doesn’t. This led to different results for the same deployments depending on which way was used. To fix this I propose we generate network policies always considering the baseline and, only if the baseline is missing, fallback to checking the network flows.
Additionally the network policy generation based on the baseline was always generating them with elevated privileges. This led to network policies revealing masked deployments that should not be seen by the user. I propose to fix this by allowing all ingress traffic if a deployment has flows from a masked deployment (this was the old behavior for the generation based on network flows).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
