### PR TITLE
ROX-18444:  add openshift-compliance to gather

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -167,6 +167,7 @@ class PostClusterTest(StoreArtifacts):
             "openshift-authentication",
             "openshift-etcd",
             "openshift-controller-manager",
+            "openshift-compliance",
         ]
         self.collect_central_artifacts = collect_central_artifacts
 


### PR DESCRIPTION
## Description

For the compliance tests it will be helpful to gather the `openshift-compliance` namespace in order to see if there are. issues with the compliance operator when the tests are executed.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Snippet of files that were collected with the gather now that the `openshift-compliance` namespace was included.
```
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/events.yaml
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/events.txt
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/ITEM_COUNT.txt
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-worker-a-qzpnw_object.json
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-2.c.acs-san-stackroxci.internal_object.json
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-worker-a-qzpnw_describe.log
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-worker-b-cdswm_describe.log
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-0.c.acs-san-stackroxci.internal_object.json
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-1.c.acs-san-stackroxci.internal_object.json
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-0.c.acs-san-stackroxci.internal_describe.log
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-2.c.acs-san-stackroxci.internal_describe.log
./1764714308874276864-pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/k8s-service-logs/openshift-compliance/nodes/rox-ci-74276864-khp4x-master-1.c.acs-san-stackroxci.internal_describe.log
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
