### PR TITLE
ROX-20125: new base snapshot

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1068,6 +1068,17 @@ restore_56_1_backup() {
         central db restore --timeout 2m stackrox_56_1_fixed_upgrade.zip
 }
 
+restore_4_1_postgres_backup() {
+    info "Restoring a 4.1 postgres backup"
+
+    require_environment "API_ENDPOINT"
+    require_environment "ROX_PASSWORD"
+
+    gsutil cp gs://stackrox-ci-upgrade-test-fixtures/upgrade-test-dbs/postgres_db_4_1.sql.zip .
+    roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" \
+        central db restore --timeout 5m postgres_db_4_1.sql.zip
+}
+
 update_public_config() {
     info "Updating public config to ensure that it is overridden by restore"
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1057,6 +1057,7 @@ _record_build_info() {
     update_job_record "build" "${build_info}"
 }
 
+# TODO(ROX-22872): remove
 restore_56_1_backup() {
     info "Restoring a 56.1 backup"
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -77,7 +77,7 @@ test_e2e() {
 
     # Give some time for previous tests to finish up
     wait_for_api
-    restore_56_1_backup
+    restore_4_1_postgres_backup
     wait_for_api
 
     info "E2E external backup tests"

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -61,6 +61,7 @@ test_upgrade() {
     fi
 
     preamble
+    preamble_postgres
     setup_deployment_env false false
     setup_podsecuritypolicies_config
     remove_existing_stackrox_resources

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1091
 
+# TODO(ROX-22872): Remove this test
 set -euo pipefail
 
 # Tests upgrade to Postgres.

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -131,6 +131,7 @@ deploy_earlier_postgres_central() {
     helm install -n stackrox --create-namespace stackrox-central-services /tmp/early-stackrox-central-services-chart \
          --set central.adminPassword.value="${ROX_PASSWORD}" \
          --set central.db.enabled=true \
+         --set central.persistence.none=true \
          --set central.exposure.loadBalancer.enabled=true \
          --set system.enablePodSecurityPolicies=false \
          --set central.image.tag="${EARLIER_TAG}" \

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -68,6 +68,10 @@ validate_upgrade() {
     rm -f FAIL
     remove_qa_test_results
 
+    # temp, grab a backup so I can use it as a new start
+    info "Grabbing a backup to use it later"
+    "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" central backup --output qa-tests-backend/build/test-results/
+
     info "Validating the upgrade with upgrade tests: $stage_description"
 
     CLUSTER="$CLUSTER_TYPE_FOR_TEST" \

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -482,18 +482,6 @@ preamble() {
         (cd "$(dirname "$REPO_FOR_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_TIME_TRAVEL")")
     fi
 
-    if [[ -z "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
-    info "Will clone or update a clean copy of the rox repo for Postgres DB test at $REPO_FOR_POSTGRES_TIME_TRAVEL"
-        if [[ -d "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
-            if is_CI; then
-              info "Repo for time travel already exists! Will use it."
-            fi
-            (cd "$REPO_FOR_POSTGRES_TIME_TRAVEL" && git checkout master && git reset --hard && git pull)
-        else
-            (cd "$(dirname "$REPO_FOR_POSTGRES_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_POSTGRES_TIME_TRAVEL")")
-        fi
-    fi
-
     if is_CI; then
         if ! command -v yq >/dev/null 2>&1; then
             sudo wget https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -O /usr/bin/yq
@@ -501,5 +489,20 @@ preamble() {
         fi
     else
         require_executable yq
+    fi
+}
+
+# TODO(ROX-22872):  remove
+preamble_postgres() {
+    info "Starting test preamble postgres"
+
+    info "Will clone or update a clean copy of the rox repo for Postgres DB test at $REPO_FOR_POSTGRES_TIME_TRAVEL"
+    if [[ -d "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
+        if is_CI; then
+          info "Repo for time travel already exists! Will use it."
+        fi
+        (cd "$REPO_FOR_POSTGRES_TIME_TRAVEL" && git checkout master && git reset --hard && git pull)
+    else
+        (cd "$(dirname "$REPO_FOR_POSTGRES_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_POSTGRES_TIME_TRAVEL")")
     fi
 }

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -70,6 +70,7 @@ validate_upgrade() {
 
     # temp, grab a backup so I can use it as a new start
     info "Grabbing a backup to use it later"
+    mkdir -p qa-tests-backend/build/test-results
     "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" -p "$ROX_PASSWORD" central backup --output qa-tests-backend/build/test-results/
 
     info "Validating the upgrade with upgrade tests: $stage_description"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -70,7 +70,7 @@ validate_upgrade() {
 
     # temp, grab a backup so I can use it as a new start
     info "Grabbing a backup to use it later"
-    "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" central backup --output qa-tests-backend/build/test-results/
+    "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" -p "$ROX_PASSWORD" central backup --output qa-tests-backend/build/test-results/
 
     info "Validating the upgrade with upgrade tests: $stage_description"
 

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -126,6 +126,12 @@ restore_backup_test() {
     restore_56_1_backup
 }
 
+restore_4_1_backup() {
+    info "Restoring a 4.1 backup into a newer central"
+
+    restore_4_1_postgres_backup
+}
+
 force_rollback() {
     info "Forcing a rollback to $FORCE_ROLLBACK_VERSION"
 

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -89,7 +89,7 @@ function roxcurl() {
   curl -u "admin:${ROX_PASSWORD}" -k "https://${API_ENDPOINT}${url}" "$@"
 }
 
-# TODO(ROX-22125): remove
+# TODO(ROX-22872): remove
 deploy_earlier_central() {
     info "Deploying: $EARLIER_TAG..."
 

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -68,11 +68,6 @@ validate_upgrade() {
     rm -f FAIL
     remove_qa_test_results
 
-    # temp, grab a backup so I can use it as a new start
-    info "Grabbing a backup to use it later"
-    mkdir -p qa-tests-backend/build/test-results
-    "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" -p "$ROX_PASSWORD" central backup --output qa-tests-backend/build/test-results/
-
     info "Validating the upgrade with upgrade tests: $stage_description"
 
     CLUSTER="$CLUSTER_TYPE_FOR_TEST" \
@@ -152,6 +147,7 @@ deploy_earlier_postgres_central() {
     ci_export "ROX_PASSWORD" "$ROX_PASSWORD"
 }
 
+# TODO(ROX-22872): remove
 restore_backup_test() {
     info "Restoring a 56.1 backup into a newer central"
 
@@ -486,7 +482,7 @@ preamble() {
         (cd "$(dirname "$REPO_FOR_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_TIME_TRAVEL")")
     fi
 
-    if [[ -n "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
+    if [[ -z "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
     info "Will clone or update a clean copy of the rox repo for Postgres DB test at $REPO_FOR_POSTGRES_TIME_TRAVEL"
         if [[ -d "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
             if is_CI; then

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -89,7 +89,39 @@ function roxcurl() {
   curl -u "admin:${ROX_PASSWORD}" -k "https://${API_ENDPOINT}${url}" "$@"
 }
 
+# TODO(ROX-22125): remove
 deploy_earlier_central() {
+    info "Deploying: $EARLIER_TAG..."
+
+    make cli
+
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" command -v roxctl
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl version
+
+    # Let's try helm
+    ROX_PASSWORD="$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c12 || true)"
+    PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl helm output central-services --image-defaults opensource --output-dir /tmp/early-stackrox-central-services-chart
+
+    helm install -n stackrox --create-namespace stackrox-central-services /tmp/early-stackrox-central-services-chart \
+         --set central.adminPassword.value="${ROX_PASSWORD}" \
+         --set central.db.enabled=false \
+         --set central.exposure.loadBalancer.enabled=true \
+         --set system.enablePodSecurityPolicies=false \
+         --set central.image.tag="${EARLIER_TAG}" \
+         --set central.db.image.tag="${EARLIER_TAG}" \
+         --set scanner.image.tag="$(cat SCANNER_VERSION)" \
+         --set scanner.dbImage.tag="$(cat SCANNER_VERSION)"
+
+    # Installing this way returns faster than the scripts but everything isn't running when it finishes like with
+    # the scripts.  So we will give it a minute for things to get started before we proceed
+    sleep 60
+
+    ROX_USERNAME="admin"
+    ci_export "ROX_USERNAME" "$ROX_USERNAME"
+    ci_export "ROX_PASSWORD" "$ROX_PASSWORD"
+}
+
+deploy_earlier_postgres_central() {
     info "Deploying: $EARLIER_TAG..."
 
     make cli

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -103,7 +103,7 @@ deploy_earlier_central() {
 
     helm install -n stackrox --create-namespace stackrox-central-services /tmp/early-stackrox-central-services-chart \
          --set central.adminPassword.value="${ROX_PASSWORD}" \
-         --set central.db.enabled=false \
+         --set central.db.enabled=true \
          --set central.exposure.loadBalancer.enabled=true \
          --set system.enablePodSecurityPolicies=false \
          --set central.image.tag="${EARLIER_TAG}" \

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -486,6 +486,7 @@ preamble() {
         (cd "$(dirname "$REPO_FOR_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_TIME_TRAVEL")")
     fi
 
+    if [[ -n "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
     info "Will clone or update a clean copy of the rox repo for Postgres DB test at $REPO_FOR_POSTGRES_TIME_TRAVEL"
         if [[ -d "$REPO_FOR_POSTGRES_TIME_TRAVEL" ]]; then
             if is_CI; then
@@ -495,6 +496,7 @@ preamble() {
         else
             (cd "$(dirname "$REPO_FOR_POSTGRES_TIME_TRAVEL")" && git clone https://github.com/stackrox/stackrox.git "$(basename "$REPO_FOR_POSTGRES_TIME_TRAVEL")")
         fi
+    fi
 
     if is_CI; then
         if ! command -v yq >/dev/null 2>&1; then

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 
+EARLIER_TAG="4.1.3"
+EARLIER_SHA="8a4677e3d45ebc4f065ec052d1d66d6ead2084bb"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
@@ -74,8 +76,6 @@ test_upgrade_paths() {
 
     local log_output_dir="$1"
 
-    EARLIER_TAG="4.1.3"
-    EARLIER_SHA="8a4677e3d45ebc4f065ec052d1d66d6ead2084bb"
     # To test we remain backwards compatible rollback to 4.1.x
     FORCE_ROLLBACK_VERSION="4.1.3"
 
@@ -282,7 +282,7 @@ deploy_scaled_workload() {
         -f /tmp/cluster-init-bundle.yaml \
         --set system.enablePodSecurityPolicies=false \
         --set clusterName=scale-remote \
-        --set image.main.tag="${INITIAL_POSTGRES_TAG}" \
+        --set image.main.tag="${EARLIER_TAG}" \
         --set image.collector.tag="$(make collector-tag)" \
         --set centralEndpoint="$API_ENDPOINT"
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -31,7 +31,7 @@ test_upgrade() {
 
     # Need to push the flag to ci so that is where it needs to be for the part
     # of the test.  We start this test with RocksDB
-    ci_export ROX_POSTGRES_DATASTORE "false"
+    ci_export ROX_POSTGRES_DATASTORE "true"
 
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade <log-output-dir>"


### PR DESCRIPTION
## Description

Update the database snapshot used for most tests to be based off 4.1.  4.1 was chosen because the upgrade test goes through a backward compatibility test and 4.1 is where we introduced that requirement for the data.  

There remains a specific test test `legacy_to_postgres` that still uses the 3.56 snapshot.  This is because the purpose of that test is solely to test going from RocksDB to Postgres.  That test will be removed with ROX-22872 as will the rest of the references to the 3.56 snapshot.  Once that is complete we should be able to begin the rest of the RocksDB removal beginning with the migrations. 

Note:  I could have probably made some of these changes more elegant but it didn't seem worth it since some of these things are going to be removed entirely anyway.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The changes are purely to tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
