### PR TITLE
ROX-21948: Fix sorting Discovered Time on Observed CVEs table

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -16,7 +16,7 @@ type ObservedCVEsProps = {
     showComponentDetails: (components: EmbeddedImageScanComponent[], cveName: string) => void;
 };
 
-const sortFields = ['Severity', 'CVSS', 'Discovered'];
+const sortFields = ['Severity', 'CVSS', 'CVE Created Time'];
 const defaultSortOption: SortOption = {
     field: 'Severity',
     direction: 'desc',

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -200,7 +200,7 @@ function ObservedCVEsTable({
                         <Th sort={getSortParams('Severity')}>Severity</Th>
                         <Th sort={getSortParams('CVSS')}>CVSS score</Th>
                         <Th>Affected components</Th>
-                        <Th sort={getSortParams('Discovered')}>Discovered</Th>
+                        <Th sort={getSortParams('CVE Created Time')}>Discovered</Th>
                     </Tr>
                 </Thead>
                 <Tbody>


### PR DESCRIPTION
## Description

In VM 1.0, at some point, we specified the wrong API sort field name for the column labeled "Discovered" in the Observed CVEs table of Image Findings. (In main CVE tables, it uses the "CVE Created Time" sort field for the Discovered column.)

This small change causes clicking on the table header to use the correct API sort field name.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

I verified that, after this change, the correct sort field was being passed in the API call, and the correctly sorted data was now coming back.

Before
![Screenshot 2024-03-04 at 5 04 18 PM](https://github.com/stackrox/stackrox/assets/715729/f2bcc15c-2505-44b8-8371-4112fa37acf0)


After
![Screenshot 2024-03-04 at 5 01 58 PM](https://github.com/stackrox/stackrox/assets/715729/1c22a687-3dad-40f8-8d5d-0e8e2a44a5a4)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
