### PR TITLE
ROX-22914: gcp workload identities=false for Interop(AWS)

### DIFF
--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -10,7 +10,7 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
-// Workload identities are only set up for `openshift-4` infra clusters.
+# Workload identities are only set up for `openshift-4` infra clusters.
 if 'openshift-4' in os.environ.get('CLUSTER_FLAVOR_VARIANT', ''):
     os.environ["SETUP_WORKLOAD_IDENTITIES"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"


### PR DESCRIPTION
Turn off workload setup for interop ocp testing because it fails with errors like:
```
ERROR: Policy modification failed. For a binding with condition, run "gcloud alpha iam policies lint-condition" to identify issues in condition.
```
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-stackrox-stackrox-master-ocp-4-16-lp-interop-acs-tests-aws/1765010476296572928#1:build-log.txt%3A422

Successful test run with this change for ocp4.15 interop testing: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/49523/rehearse-49523-periodic-ci-stackrox-stackrox-test-fix-ocp-interop-workloadidentities-ocp-4-15-lp-interop-acs-tests-aws/1769825316458467328