### PR TITLE
fix(ci): scanner build fail fast

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -50,6 +50,7 @@ jobs:
     needs: define-scanner-job-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       # Supports two go binary builds:
       # default    - built with environment defaults (see handle-tagged-build & env.mk)
       # prerelease - built with GOTAGS=release
@@ -108,10 +109,10 @@ jobs:
     - build-and-push-scanner
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       # Supports two image builds:
       # default
       # prerelease
-      fail-fast: false
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_manifests }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61


### PR DESCRIPTION
## Description

At the moment, s390x builds are failing. This should not block x86_64 builds from proceeding, so fail fast.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
