### PR TITLE
fix(CI): batch load test metrics

### DIFF
--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -3,11 +3,6 @@ on:
   workflow_dispatch:
   schedule:
   - cron: 23 * * * *
-  pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
 
 # Ensure that only a single batch loader is running
 concurrency: Batch load test metrics

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -1,0 +1,22 @@
+name: Batch load test metrics
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: 23 * * * *
+jobs:
+  batch-load-test-metrics:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Report
+      env:
+        GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      shell: bash
+      run: |
+        source scripts/ci/lib.sh
+
+        setup_gcp
+        batch_load_test_metrics

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
   - cron: 23 * * * *
+
+# Ensure that only a single batch loader is running
+concurrency: Batch load test metrics
+
 jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   schedule:
   - cron: 23 * * * *
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 
 # Ensure that only a single batch loader is running
 concurrency: Batch load test metrics

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Report
+    - name: Load
       env:
         GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       shell: bash

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1217,11 +1217,7 @@ post_process_test_results() {
             -slack-output "${slack_attachments_file}" \
             "${extra_args[@]}"
 
-        info "Creating Big Query test records from ${csv_output}"
-        bq load \
-            --skip_leading_rows=1 \
-            --allow_quoted_newlines \
-            ci_metrics.stackrox_tests "${csv_output}"
+        save_test_metrics "${csv_output}"
     } || true
     set -u
 }

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -233,13 +233,13 @@ save_test_metrics() {
 }
 
 batch_load_test_metrics() {
-    while _batch_load_test_metrics; do
+    while _load_one_batch; do
         echo "batch loaded"
     done
     echo "done"
 }
 
-_batch_load_test_metrics() {
+_load_one_batch() {
     info "Gathering a batch of test metrics to load"
     local files=()
     for metrics_file in $(gsutil ls "${_BATCH_STORAGE_UPLOAD}"); do
@@ -251,7 +251,7 @@ _batch_load_test_metrics() {
         return 1
     fi
 
-    info "Found ${#files[@]} metrics for this batch load"
+    info "Found ${#files[@]} metric(s) for this batch load"
 
     # Move the batch to a new location for processing to guard against reprocess
     local process_location

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -223,9 +223,9 @@ save_test_metrics() {
     gsutil cp "${csv}" "${to}"
 }
 
-batch_load_test_metrics() {
-            # bq load \
-            # --skip_leading_rows=1 \
-            # --allow_quoted_newlines \
-            # ci_metrics.stackrox_tests "${csv_output}"
-}
+# batch_load_test_metrics() {
+#             # bq load \
+#             # --skip_leading_rows=1 \
+#             # --allow_quoted_newlines \
+#             # ci_metrics.stackrox_tests "${csv_output}"
+# }

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -209,3 +209,23 @@ LIMIT
     echo "Posting data to slack"
     jq -n --arg data "$data" "$body" | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
+
+save_test_metrics() {
+    if [[ "$#" -ne 1 ]]; then
+        die "missing arg. usage: save_test_metrics <CSV file>"
+    fi
+
+    local csv="$1"
+    local to="gs://stackrox-ci-artifacts/test-metrics/"
+
+    info "Saving Big Query test records from ${csv} to ${to}"
+
+    gsutil cp "${csv}" "${to}"
+}
+
+batch_load_test_metrics() {
+            # bq load \
+            # --skip_leading_rows=1 \
+            # --allow_quoted_newlines \
+            # ci_metrics.stackrox_tests "${csv_output}"
+}

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -267,6 +267,7 @@ _load_one_batch() {
         --allow_quoted_newlines \
         "${_TESTS_TABLE_NAME}" "${process_location}/*"
 
+    info "Moving the processed batch to ${_BATCH_STORAGE_DONE}"
     gsutil -m mv "${process_location}" "${_BATCH_STORAGE_DONE}/"
 
     return 0

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -258,7 +258,7 @@ _load_one_batch() {
     local process_location
     process_location="${_BATCH_STORAGE_PROCESSING}/$(date +%Y-%m-%d-%H-%M-%S.%N)"
     info "Moving the batch to ${process_location}"
-    gsutil -m mv ${files[*]} "${process_location}/"
+    gsutil -m mv "${files[@]}" "${process_location}/"
     gsutil ls -l "${process_location}"
 
     info "Loading into BQ"

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -234,9 +234,9 @@ save_test_metrics() {
 
 batch_load_test_metrics() {
     while _load_one_batch; do
-        echo "batch loaded"
+        info "one batch loaded"
     done
-    echo "done"
+    info "done loading"
 }
 
 _load_one_batch() {

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -217,6 +217,7 @@ LIMIT
 _TESTS_TABLE_NAME="acs-san-stackroxci:ci_metrics.stackrox_tests"
 _BATCH_STORAGE_UPLOAD="gs://stackrox-ci-artifacts/test-metrics/upload"
 _BATCH_STORAGE_PROCESSING="gs://stackrox-ci-artifacts/test-metrics/processing"
+_BATCH_STORAGE_DONE="gs://stackrox-ci-artifacts/test-metrics/done"
 _BATCH_SIZE=20
 
 save_test_metrics() {
@@ -229,7 +230,7 @@ save_test_metrics() {
 
     info "Saving Big Query test records from ${csv} to ${to}"
 
-    gsutil cp "${csv}" "${to}"
+    gsutil cp "${csv}" "${to}/"
 }
 
 batch_load_test_metrics() {
@@ -257,7 +258,7 @@ _load_one_batch() {
     local process_location
     process_location="${_BATCH_STORAGE_PROCESSING}/$(date +%Y-%m-%d-%H-%M-%S.%N)"
     info "Moving the batch to ${process_location}"
-    gsutil -m mv ${files[*]} "${process_location}"
+    gsutil -m mv ${files[*]} "${process_location}/"
     gsutil ls -l "${process_location}"
 
     info "Loading into BQ"
@@ -265,6 +266,8 @@ _load_one_batch() {
         --skip_leading_rows=1 \
         --allow_quoted_newlines \
         "${_TESTS_TABLE_NAME}" "${process_location}/*"
+
+    gsutil -m mv "${process_location}" "${_BATCH_STORAGE_DONE}/"
 
     return 0
 }


### PR DESCRIPTION
## Description

Test metrics were not always saved to BigQuery due to quota limits [e.g.](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1763256628238356480). These limits cannot be raised. The remedy is to batch load.  https://cloud.google.com/bigquery/docs/troubleshoot-quotas#ts-table-import-quota

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] manually processed the results from this PR
- [x] ran on PR as workflow.  [1 CSV](https://github.com/stackrox/stackrox/actions/runs/8166070680/attempts/1?pr=10242)
- [x] ran on PR as workflow. [0 CSV](https://github.com/stackrox/stackrox/actions/runs/8166070680/attempts/3?pr=10242)
- [x] ran on PR as workflow. > [20 CSV](https://github.com/stackrox/stackrox/actions/runs/8179144588/job/22364577652?pr=10242).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
