### PR TITLE
fix: quay test panic

### DIFF
--- a/pkg/registries/quay/quay.go
+++ b/pkg/registries/quay/quay.go
@@ -150,9 +150,9 @@ func (q *Quay) Test() error {
 	if err != nil {
 		log.Errorf("Quay error response: %s", err)
 		if resp == nil {
-			return errors.New("Received error from Quay. Check Central logs for the full error.")
+			return errors.New("received error from Quay; check Central logs for the full error")
 		}
-		return errors.Errorf("Received http status code %d from Quay. Check Central logs for the full error.", resp.StatusCode)
+		return errors.Errorf("received http status code %d from Quay; check Central logs for the full error", resp.StatusCode)
 	}
 
 	defer utils.IgnoreError(resp.Body.Close)
@@ -162,7 +162,7 @@ func (q *Quay) Test() error {
 			return errors.Errorf("error reaching quay.io with HTTP code %d", resp.StatusCode)
 		}
 		log.Errorf("Quay error response: %d %s", resp.StatusCode, string(body))
-		return errors.Errorf("Received http status code %d from Quay. Check Central logs for the full error.", resp.StatusCode)
+		return errors.Errorf("received http status code %d from Quay; check Central logs for the full error", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/registries/quay/quay.go
+++ b/pkg/registries/quay/quay.go
@@ -148,8 +148,11 @@ func (q *Quay) Test() error {
 	}
 	resp, err := client.Get(discoveryURL)
 	if err != nil {
-		log.Errorf("Quay error response: %d", resp.StatusCode)
-		return errors.Errorf("received http status code %d from Quay. Check Central logs for full error.", resp.StatusCode)
+		log.Errorf("Quay error response: %s", err)
+		if resp == nil {
+			return errors.Errorf("Received error from Quay. Check Central logs for the full error.")
+		}
+		return errors.Errorf("Received http status code %d from Quay. Check Central logs for the full error.", resp.StatusCode)
 	}
 
 	defer utils.IgnoreError(resp.Body.Close)
@@ -159,7 +162,7 @@ func (q *Quay) Test() error {
 			return errors.Errorf("error reaching quay.io with HTTP code %d", resp.StatusCode)
 		}
 		log.Errorf("Quay error response: %d %s", resp.StatusCode, string(body))
-		return errors.Errorf("received http status code %d from Quay. Check Central logs for full error.", resp.StatusCode)
+		return errors.Errorf("Received http status code %d from Quay. Check Central logs for the full error.", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/registries/quay/quay.go
+++ b/pkg/registries/quay/quay.go
@@ -150,7 +150,7 @@ func (q *Quay) Test() error {
 	if err != nil {
 		log.Errorf("Quay error response: %s", err)
 		if resp == nil {
-			return errors.Errorf("Received error from Quay. Check Central logs for the full error.")
+			return errors.New("Received error from Quay. Check Central logs for the full error.")
 		}
 		return errors.Errorf("Received http status code %d from Quay. Check Central logs for the full error.", resp.StatusCode)
 	}


### PR DESCRIPTION
## Description

A 4 year old nil panic. If `err == nil`, we cannot assume that `resp != nil`. See https://redhat-internal.slack.com/archives/CELUQKESC/p1709683503070829.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
