### PR TITLE
fix(build): drop broken s390x scanner builds for now

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -30,7 +30,7 @@ jobs:
         source './scripts/ci/lib.sh'
 
         # If goarch is updated, be sure to update architectures in push-manifests below.
-        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le", "s390x"] }, "push_manifests": { "name":["default"] } }'
+        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le"] }, "push_manifests": { "name":["default"] } }'
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
         if ! is_tagged; then
@@ -147,7 +147,7 @@ jobs:
         source ./scripts/ci/lib.sh
 
         # If this is updated, be sure to update goarch in define-scanner-job-matrix above.
-        architectures="amd64,arm64,ppc64le,s390x"
+        architectures="amd64,arm64,ppc64le"
 
         push_scanner_image_manifest_lists "$architectures"
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -30,6 +30,7 @@ jobs:
         source './scripts/ci/lib.sh'
 
         # If goarch is updated, be sure to update architectures in push-manifests below.
+        # TODO(ROX-22927): re-add s390x here
         matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le"] }, "push_manifests": { "name":["default"] } }'
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
@@ -147,6 +148,7 @@ jobs:
         source ./scripts/ci/lib.sh
 
         # If this is updated, be sure to update goarch in define-scanner-job-matrix above.
+        # TODO(ROX-22927): re-add s390x here
         architectures="amd64,arm64,ppc64le"
 
         push_scanner_image_manifest_lists "$architectures"


### PR DESCRIPTION
## Description

S390x scanner-db builds (They are built differently from the other architectures) are broken:

```
#12 88.14 Error: Unable to find a match: postgresql postgresql-private-libs postgresql-server postgresql-contrib
```

This prevents the image manifest push from running, in turn breaking many e2e tests for *all* architectures.

Let's drop this build until it is fixed by its maintainers, in order to allow all other architectures to build and e2e-test successfully. cc @RTann @kcrane 

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
