### PR TITLE
chore(tests): poll for more images before operator e2e

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -476,7 +476,9 @@ poll_for_system_test_images() {
     # Require images based on the job
     case "$CI_JOB_NAME" in
         *-operator-e2e-tests)
-            reqd_images=("stackrox-operator" "stackrox-operator-bundle" "stackrox-operator-index" "main")
+            reqd_images=("stackrox-operator" "stackrox-operator-bundle" "stackrox-operator-index"
+                         "main" "central-db" "collector" "collector-slim"
+                         "scanner" "scanner-db" "scanner-v4" "scanner-v4-db")
             ;;
         *-race-condition-qa-e2e-tests)
             reqd_images=("main-rcd" "roxctl")


### PR DESCRIPTION
## Description

For example if scanner-db image build fails (like it's [happening to be](https://github.com/stackrox/stackrox/pull/10254) right now) then the test starts and then fails mid-way, and it takes a bit of digging to find the cause.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is enough.

Works as intended:

```
[...]
INFO: Wed Mar  6 09:34:20 UTC 2024: Checking for scanner-v4 using https://quay.io/api/v1/repository/rhacs-eng/scanner-v4/tag?specificTag=4.4.x-64-g9c19e44585
{"tags": [], "page": 1, "has_additional": false}
INFO: Wed Mar  6 09:34:20 UTC 2024: scanner-v4 does not exist
ERROR: Timed out waiting for images after 3600 seconds
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
