### PR TITLE
chore: cleanup qa protos migration script

### DIFF
--- a/qa-tests-backend/scripts/migrate_protos.sh
+++ b/qa-tests-backend/scripts/migrate_protos.sh
@@ -8,6 +8,5 @@ cp -r ../proto/* ${JAVA_PATH}
 
 # Migrate v1 API protos from the Scanner repo
 SCANNER_DIR=$(go list -f '{{.Dir}}' -m github.com/stackrox/scanner)
-SCANNER_PROTO_BASE_PATH=$SCANNER_DIR/proto/
 # files from gomod cache have no write permission causing problems for gradle
-cp -r --no-preserve=mode ${SCANNER_PROTO_BASE_PATH}/* ${JAVA_PATH}
+cp -r --no-preserve=mode ${SCANNER_DIR}/proto/* ${JAVA_PATH}

--- a/qa-tests-backend/scripts/migrate_protos.sh
+++ b/qa-tests-backend/scripts/migrate_protos.sh
@@ -3,36 +3,11 @@
 JAVA_PATH=src/main/proto/
 
 # Migrate protos from the stackrox repo.
-
-for file in $(find ../proto/*); do
-    if [[ -d $file ]]; then
-        dir=${file#"../proto/"}
-        mkdir -p "${JAVA_PATH}${dir}"
-        echo "${JAVA_PATH}${dir}"
-    fi
-done
-
-for file in $(find ../proto/* -name '*.proto'); do
-    if [[ -f $file ]]; then
-        java_file=${file#"../proto/"}
-        sed -e ':a' -e 'N' -e '$!ba' -e 's/\[\([^]]*\)\]//g' "$file" | sed '/gogo/d' > "${JAVA_PATH}${java_file}"
-    fi
-done
+mkdir -p ${JAVA_PATH}
+cp -r ../proto/* ${JAVA_PATH}
 
 # Migrate v1 API protos from the Scanner repo
-
 SCANNER_DIR=$(go list -f '{{.Dir}}' -m github.com/stackrox/scanner)
-SCANNER_PROTO_BASE_PATH=$SCANNER_DIR/proto
-
-mkdir -p "${JAVA_PATH}scanner/api/v1"
-echo "${JAVA_PATH}scanner/api/v1"
-
-for file in $(find "$SCANNER_PROTO_BASE_PATH" -name '*.proto'); do
-    if [[ -f $file ]]; then
-        # Get relative path. Should be along the lines of scanner/api/v1/*.proto
-        rel_file=${file/"$SCANNER_PROTO_BASE_PATH"/""}
-        rel_file="${rel_file:1}"
-        sed -e ':a' -e 'N' -e '$!ba' -e 's/\[\([^]]*\)\]//g' "$file" | sed '/gogo/d' > "${JAVA_PATH}${rel_file}"
-    fi
-done
-
+SCANNER_PROTO_BASE_PATH=$SCANNER_DIR/proto/
+# files from gomod cache have no write permission causing problems for gradle
+cp -r --no-preserve=mode ${SCANNER_PROTO_BASE_PATH}/* ${JAVA_PATH}


### PR DESCRIPTION
## Description

As we removed gogoproto from proto files we don't need to remove gogo references in qa proto migration step.
This PR simplifies migration code by just copying protos. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

`make style` is enough as for qa it generates java classes from protos.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
