### PR TITLE
chore(vulncheck): ignore vulns until we can bump Go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -572,7 +572,7 @@ jobs:
           make -C operator/ docker-push-index | cat
 
   scan-go-binaries:
-    #if: github.event_name == 'push'
+    if: github.event_name == 'push'
     env:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -572,7 +572,7 @@ jobs:
           make -C operator/ docker-push-index | cat
 
   scan-go-binaries:
-    if: github.event_name == 'push'
+    #if: github.event_name == 'push'
     env:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest

--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -9,7 +9,27 @@
     },
     "GO-2023-2382": {
       "reason": "Requires version bump",
-      "until": "2024-03-22T00:00:00Z"
+      "until": "2024-04-07T00:00:00Z"
+    },
+    "GO-2024-2598": {
+      "reason": "Requires version bump",
+      "until": "2024-04-07T00:00:00Z"
+    },
+    "GO-2024-2599": {
+      "reason": "Requires version bump",
+      "until": "2024-04-07T00:00:00Z"
+    },
+    "GO-2024-2600": {
+      "reason": "Requires version bump",
+      "until": "2024-04-07T00:00:00Z"
+    },
+    "GO-2024-2609": {
+      "reason": "Requires version bump",
+      "until": "2024-04-07T00:00:00Z"
+    },
+    "GO-2024-2610": {
+      "reason": "Requires version bump",
+      "until": "2024-04-07T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Description

Ignore vulns which can only be fixed via a minor version bump. We will do that at a later time.

These vulns were all evaluated to only be at a Medium/Moderate severity, so we are ok with waiting.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

I didn't

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
