### PR TITLE
ROX-20038: migrate GCR qa test images

### DIFF
--- a/qa-tests-backend/README.md
+++ b/qa-tests-backend/README.md
@@ -40,7 +40,7 @@ are inferred from the `deploy/{k8s,openshift}/central-deploy` directory.
 
 ### Tests dependent on integration credentials
 - If your tests depend on an integration password or token in an environment variable such as:
-  `GOOGLE_CREDENTIALS_GCR_SCANNER`, `EMAIL_NOTIFIER_PASSWORD`,
+  `GOOGLE_CREDENTIALS_GCR_SCANNER_V2`, `EMAIL_NOTIFIER_PASSWORD`,
   `MAILGUN_PASSWORD`, `JIRA_TOKEN`, `DTR_REGISTRY_PASSWORD`, `QUAY_PASSWORD`
   - Create a `qa-tests-backend/qa-test-settings.properties` file that contains environment variable assignments.
   - Copy environment variable settings from the [StackRox 1Password Vault](https://stackrox.1password.com)

--- a/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
@@ -304,10 +304,10 @@ class GCRImageIntegration implements ImageIntegration {
     static ImageIntegrationOuterClass.ImageIntegration.Builder getCustomBuilder(Map customArgs = [:]) {
         Map defaultArgs = [
                 name: "gcr",
-                project: "stackrox-ci",
+                project: "acs-san-stackroxci",
                 endpoint: "us.gcr.io",
                 includeScanner: true,
-                serviceAccount: Env.mustGet("GOOGLE_CREDENTIALS_GCR_SCANNER"),
+                serviceAccount: Env.mustGetGCRServiceAccount(),
                 wifEnabled: false,
                 skipTestIntegration: false,
         ]

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -267,6 +267,14 @@ class Env {
         return mustGet("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT_V2")
     }
 
+    static String mustGetGCRServiceAccount() {
+        return mustGet("GOOGLE_CREDENTIALS_GCR_SCANNER_V2")
+    }
+
+    static String mustGetGCRNoAccessServiceAccount() {
+        return mustGet("GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY_V2")
+    }
+
     static String mustGetPagerdutyToken() {
         return mustGet("PAGERDUTY_TOKEN")
     }

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerNoImageScanTest.groovy
@@ -34,7 +34,7 @@ OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
     private final static String IMAGE_SIGNATURE = "Image Signature Test"
 
     private final static String NON_EXISTENT_IMAGE = "non-existent:image"
-    private final static String IMAGE_WITH_SCANS = "us.gcr.io/stackrox-ci/nginx:1.12"
+    private final static String IMAGE_WITH_SCANS = "us.gcr.io/acs-san-stackroxci/nginx:1.12"
 
     def setupSpec() {
         noImageScansEnforcements = Services.updatePolicyEnforcement(

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -383,9 +383,9 @@ class BaseSpecification extends Specification {
     }
 
     static addGCRImagePullSecret(ns = Constants.ORCHESTRATOR_NAMESPACE) {
-        if (!Env.IN_CI && Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER", null) == null) {
+        if (!Env.IN_CI && Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER_V2", null) == null) {
             // Arguably this should be fatal but for tests that don't pull from us.gcr.io it is not strictly necessary
-            LOG.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER env var is missing. "+
+            LOG.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER_V2 env var is missing. "+
                     "(this is ok if your test does not use images on us.gcr.io)"
             return
         }
@@ -399,7 +399,7 @@ class BaseSpecification extends Specification {
                 name: "gcr-image-pull-secret",
                 server: "https://us.gcr.io",
                 username: "_json_key",
-                password: Env.mustGetInCI("GOOGLE_CREDENTIALS_GCR_SCANNER", "{}"),
+                password: Env.mustGetInCI("GOOGLE_CREDENTIALS_GCR_SCANNER_V2", "{}"),
                 namespace: ns
         ))
 

--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -24,10 +24,10 @@ class BuiltinPoliciesTest extends BaseSpecification {
 
     // Arch specific test images
     static final private String TRIGGER_MOST_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
-        "us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19":
+        "us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.19":
         "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most-v1")
     static final private String TRIGGER_ALPINE_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
-        "us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6":
+        "us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/alpine:0.6":
         "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-alpine")
 
     static final private List<Deployment> DEPLOYMENTS = [

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -113,7 +113,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             .addLabel("app", "test"),
         new Deployment()
             .setName(GCR_NGINX)
-            .setImage("us.gcr.io/stackrox-ci/qa-multi-arch:nginx-1.12")
+            .setImage("us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12")
             .addLabel ( "app", "test" )
             .setCommand(["sleep", "600"]),
     ]

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -43,7 +43,7 @@ class ImageScanningTest extends BaseSpecification {
     static final private String UBI8_0_IMAGE = "registry.access.redhat.com/ubi8:8.0-208"
     static final private String RHEL7_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:rhel7-minimal-7.5-422"
     static final private String QUAY_IMAGE_WITH_CLAIR_SCAN_DATA = "quay.io/rhacs-eng/qa:nginx-unprivileged"
-    static final private String GCR_IMAGE   = "us.gcr.io/stackrox-ci/qa-multi-arch/registry-image:0.2"
+    static final private String GCR_IMAGE   = "us.gcr.io/acs-san-stackroxci/qa-multi-arch/registry-image:0.2"
     static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-12-1"
     static final private String OCI_IMAGE   = "quay.io/rhacs-eng/qa:oci-manifest"
     static final private String LIST_IMAGE_OCI_MANIFEST = "quay.io/rhacs-eng/qa:list-image-oci-manifest"
@@ -70,7 +70,7 @@ class ImageScanningTest extends BaseSpecification {
             "quay": new Deployment()
                     .setName("quay-image-scanning-test")
                     .setNamespace(TEST_NAMESPACE)
-                    // same image as us.gcr.io/stackrox-ci/qa/registry-image:0.3 but just retagged
+                    // same image as us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3 but just retagged
                     // Alternatively can use quay.io/rhacs-eng/qa:struts-app but that doesn't have as many
                     // dockerfile violations
                     .setImage("quay.io/rhacs-eng/qa:registry-image-0-3")
@@ -79,7 +79,7 @@ class ImageScanningTest extends BaseSpecification {
             "gcr": new Deployment()
                     .setName("gcr-image-scanning-test")
                     .setNamespace(TEST_NAMESPACE)
-                    .setImage("us.gcr.io/stackrox-ci/qa/registry-image:0.3")
+                    .setImage("us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3")
                     .addLabel("app", "gcr-image-scanning-test")
                     .addImagePullSecret("gcr-image-scanning-test"),
             "ecr": new Deployment()
@@ -108,7 +108,7 @@ class ImageScanningTest extends BaseSpecification {
                     name: "gcr-image-scanning-test",
                     namespace: TEST_NAMESPACE,
                     username: "_json_key",
-                    password: Env.mustGet("GOOGLE_CREDENTIALS_GCR_SCANNER"),
+                    password: Env.mustGetGCRServiceAccount(),
                     server: "https://us.gcr.io"),
             "ecr": new Secret(
                     name: "ecr-image-registry-test",
@@ -378,7 +378,7 @@ class ImageScanningTest extends BaseSpecification {
                  {
             GCRImageIntegration.createCustomIntegration(
                              name: "gcr-no-access",
-                             serviceAccount: Env.mustGet("GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY"),
+                             serviceAccount: Env.mustGetGCRNoAccessServiceAccount(),
                              skipTestIntegration: true,
                      ) },]                                                                                          |
                 41  | 170 | 28

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -775,7 +775,7 @@ class IntegrationsTest extends BaseSpecification {
         }       | StatusRuntimeException |
         /invalid endpoint: endpoint cannot reference localhost/ |
         "invalid endpoint"
-        new GCRImageIntegration() | { [serviceAccount: Env.mustGet("GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY"),]
+        new GCRImageIntegration() | { [serviceAccount: Env.mustGetGCRNoAccessServiceAccount(),]
         }       | StatusRuntimeException | /PermissionDenied/ | "account without access"
         new GCRImageIntegration() | { [project: "not-a-project",]
         }       | StatusRuntimeException | /PermissionDenied/ | "incorrect project"

--- a/qa-tests-backend/src/test/groovy/LocalQaPropsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/LocalQaPropsTest.groovy
@@ -15,13 +15,13 @@ import spock.lang.Specification
 @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
 class LocalQaPropsTest extends Specification {
 
-    def "CheckPropertyFileInputValue > GOOGLE_CREDENTIALS_GCR_SCANNER"() {
-        // When using GOOGLE_CREDENTIALS_GCR_SCANNER in qa-test-settings.properties
+    def "CheckPropertyFileInputValue > GOOGLE_CREDENTIALS_GCR_SCANNER_V2"() {
+        // When using GOOGLE_CREDENTIALS_GCR_SCANNER_V2 in qa-test-settings.properties
         // this test can be used to validate the reconstituted json credentials key.
         // No claims are made regarding key validity or authorizations. Only the
         // validity of the json data and exact content match via sha256 is performed.
         when:
-        def originalString = Env.mustGet('GOOGLE_CREDENTIALS_GCR_SCANNER')
+        def originalString = Env.mustGetGCRServiceAccount()
         def slurper = new JsonSlurper()
         def rawData = slurper.parseText(originalString)
         def canonicalJson = JsonOutput.toJson(rawData)
@@ -30,9 +30,9 @@ class LocalQaPropsTest extends Specification {
         canonicalJsonSha256 == 'f75d8cf9ea0c7886293f689478daafe75126c719313b4366c02bd41d69bb05e5'
     }
 
-    def "CheckPropertyFileInputValue > GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY"() {
+    def "CheckPropertyFileInputValue > GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY_V2"() {
         when:
-        def originalString = Env.mustGet('GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY')
+        def originalString = Env.mustGetGCRNoAccessServiceAccount()
         def slurper = new JsonSlurper()
         def rawData = slurper.parseText(originalString)
         def canonicalJson = JsonOutput.toJson(rawData)

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -41,7 +41,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_A =
             createAndRegisterDeployment()
                     .setName("deployment-a")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:0.3")
+                    .setImage("us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:0.3")
                     .setCapabilities(["NET_ADMIN", "SYSLOG"], ["IPC_LOCK", "WAKE_ALARM"])
                     .addLimits("cpu", "0.5")
                     .addRequest("cpu", "0.25")
@@ -111,7 +111,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_B =
             createAndRegisterDeployment()
                     .setName("deployment-b")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19")
+                    .setImage("us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.19")
                     .setCapabilities(["NET_ADMIN"], ["IPC_LOCK"])
                     .addLimits("cpu", "1")
                     .addRequest("cpu", "0.5")
@@ -183,7 +183,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_C =
             createAndRegisterDeployment()
                     .setName("deployment-c")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6")
+                    .setImage("us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/alpine:0.6")
                     .addAnnotation("im-a-key", "with a different value")
                     .addAnnotation("another-key", "and a value")
                     .addLabel("im-a-key", "with_a_different_value")
@@ -550,7 +550,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private NO_IMAGE_REMOTE = setPolicyFieldANDValues(
             BASE_POLICY.clone().setName("AAA_NO_IMAGE_REMOTE"),
             "Image Remote",
-            ["stackrox-ci/qa/trigger-policy-violations/more"]
+            ["acs-san-stackroxci/qa/trigger-policy-violations/more"]
     )
 
     // "Image Tag"

--- a/qa-tests-backend/test-images/fail-compliance/ssh/Makefile
+++ b/qa-tests-backend/test-images/fail-compliance/ssh/Makefile
@@ -5,5 +5,5 @@ VERSION=0.1
 .PHONY: image
 image:
 	docker build -t fail-compliance/ssh:${VERSION} .
-	docker tag fail-compliance/ssh:${VERSION} us.gcr.io/stackrox-ci/qa/fail-compliance/ssh:${VERSION}
-	docker push us.gcr.io/stackrox-ci/qa/fail-compliance/ssh:${VERSION}
+	docker tag fail-compliance/ssh:${VERSION} us.gcr.io/acs-san-stackroxci/qa/fail-compliance/ssh:${VERSION}
+	docker push us.gcr.io/acs-san-stackroxci/qa/fail-compliance/ssh:${VERSION}

--- a/qa-tests-backend/test-images/trigger-policy-violations/alpine/Makefile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/alpine/Makefile
@@ -5,5 +5,5 @@ VERSION=0.6
 .PHONY: image
 image:
 	docker build -t trigger-policy-violations/alpine:${VERSION} .
-	docker tag trigger-policy-violations/alpine:${VERSION} us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:${VERSION}
-	docker push us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:${VERSION}
+	docker tag trigger-policy-violations/alpine:${VERSION} us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/alpine:${VERSION}
+	docker push us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/alpine:${VERSION}

--- a/qa-tests-backend/test-images/trigger-policy-violations/more/Makefile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/more/Makefile
@@ -5,5 +5,5 @@ VERSION=0.3
 .PHONY: image
 image:
 	docker build -t trigger-policy-violations/more:${VERSION} .
-	docker tag trigger-policy-violations/more:${VERSION} us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:${VERSION}
-	docker push us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:${VERSION}
+	docker tag trigger-policy-violations/more:${VERSION} us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:${VERSION}
+	docker push us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:${VERSION}

--- a/qa-tests-backend/test-images/trigger-policy-violations/most/Makefile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/most/Makefile
@@ -5,5 +5,5 @@ VERSION=0.19
 .PHONY: image
 image:
 	docker build -t trigger-policy-violations/most:${VERSION} .
-	docker tag trigger-policy-violations/most:${VERSION} us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:${VERSION}
-	docker push us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:${VERSION}
+	docker tag trigger-policy-violations/most:${VERSION} us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:${VERSION}
+	docker push us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:${VERSION}

--- a/scripts/ci/clair/clair-kubernetes.yaml
+++ b/scripts/ci/clair/clair-kubernetes.yaml
@@ -38,7 +38,7 @@ spec:
           secretName: clairsecret
       containers:
       - name: clair
-        image: us.gcr.io/stackrox-ci/clair:v2.1.4
+        image: us.gcr.io/acs-san-stackroxci/clair:v2.1.4
         args:
           - "-config"
           - "/config/config.yaml"
@@ -66,7 +66,7 @@ spec:
         app: postgres
     spec:
       containers:
-      - image: us.gcr.io/stackrox-ci/postgres:9.6.18
+      - image: us.gcr.io/acs-san-stackroxci/postgres:9.6.18
         name: postgres
         env:
         - name: POSTGRES_PASSWORD

--- a/scripts/ci/clairv4/Dockerfile
+++ b/scripts/ci/clairv4/Dockerfile
@@ -1,3 +1,3 @@
-FROM us.gcr.io/stackrox-ci/postgres:12.13
+FROM us.gcr.io/acs-san-stackroxci/postgres:12.13
 
 COPY dump/tmp/dump.sql.gz /docker-entrypoint-initdb.d/dump.sql.gz

--- a/scripts/ci/clairv4/clairv4-kubernetes.yaml
+++ b/scripts/ci/clairv4/clairv4-kubernetes.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
       - name: postgres
         # Generic PostgreSQL 12 image used for online-mode.
-        # image: us.gcr.io/stackrox-ci/postgres:12.13
+        # image: us.gcr.io/acs-san-stackroxci/postgres:12.13
         image: quay.io/rhacs-eng/qa:clairv4-postgres-12.13
         env:
         - name: POSTGRES_USER

--- a/scripts/ci/openshift-gcr-secrets.sh
+++ b/scripts/ci/openshift-gcr-secrets.sh
@@ -2,5 +2,5 @@
 
 oc create namespace qa
 oc project qa
-oc create secret docker-registry --docker-username=_json_key --docker-password="$GOOGLE_CREDENTIALS_GCR_SCANNER" --docker-server https://us.gcr.io --docker-email stackrox@stackrox.com gcr
+oc create secret docker-registry --docker-username=_json_key --docker-password="$GOOGLE_CREDENTIALS_GCR_SCANNER_V2" --docker-server https://us.gcr.io --docker-email stackrox@stackrox.com gcr
 oc secrets link serviceaccount/default secrets/gcr --for=pull


### PR DESCRIPTION
## Description

Migrate the GCR test images from `stackrox-ci` to `acs-san-stackroxci`. Needs additional container analysis roles from https://github.com/stackrox/automation-iac/pull/73.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

QA tests are passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
