### PR TITLE
chore(ui): Remove compliance scan config profile's select all option

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
@@ -64,11 +64,7 @@ function ProfileSelection({
         [formikValues.profiles]
     );
 
-    const { allRowsSelected, selected, onSelect, onSelectAll } = useTableSelection(
-        profiles,
-        profileIsPreSelected,
-        'name'
-    );
+    const { selected, onSelect } = useTableSelection(profiles, profileIsPreSelected, 'name');
 
     const handleSelect = (
         event: React.FormEvent<HTMLInputElement>,
@@ -82,15 +78,6 @@ function ProfileSelection({
                 return index === rowId ? isSelected : selected[index];
             })
             .map((profile) => profile.name);
-
-        setTouched({ ...formikTouched, profiles: true });
-        setFieldValue('profiles', newSelectedProfileNames);
-    };
-
-    const handleSelectAll = (event: React.FormEvent<HTMLInputElement>, isSelected: boolean) => {
-        onSelectAll(event, isSelected);
-
-        const newSelectedProfileNames = isSelected ? profiles.map((profile) => profile.name) : [];
 
         setTouched({ ...formikTouched, profiles: true });
         setFieldValue('profiles', newSelectedProfileNames);
@@ -205,12 +192,7 @@ function ProfileSelection({
                 <TableComposable>
                     <Thead noWrap>
                         <Tr>
-                            <Th
-                                select={{
-                                    onSelect: handleSelectAll,
-                                    isSelected: allRowsSelected,
-                                }}
-                            />
+                            <Th />
                             <Th />
                             <Th>Profile</Th>
                             <Th>Rule set</Th>


### PR DESCRIPTION
## Description

Selecting all profiles will likely always results in a configuration error, so removing that feature would be wise.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2024-03-08 at 10 07 50 AM](https://github.com/stackrox/stackrox/assets/61400697/bd403164-2309-4348-857f-7045de5f9365)



