### PR TITLE
fix(CI): properly recognize the no results case

### DIFF
--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -177,7 +177,7 @@ LIMIT
     }
 
     local body
-    if [[ -s "${data_file}" ]]; then
+    if [[ $(cat "${data_file}") != "[]" ]]; then
         jq < "${data_file}"
         # shellcheck disable=SC2016
         body='{"blocks":[


### PR DESCRIPTION
## Description

This is a followup to #9828 where I insufficiently tested the happy case (I had only looked at UI output which was empty, but in fact the raw JSON is an _empty list_).

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
$ bq --project_id acs-san-stackroxci --quiet --format=json query --use_legacy_sql=false "select 1 from ci_metrics.stackrox_tests__extended_view where false" > a
$ if [[ $(cat a) = "[]" ]]; then echo yes;else echo nope;fi
yes
$
```

Also ran the workflow manually and checked the result [here](https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1710148369326869).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
