### PR TITLE
ROX-18969: add label selector to operator cache

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stackrox/rox/pkg/version"
 	rawZap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -51,7 +52,6 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	coreV1 "k8s.io/api/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"

--- a/operator/main.go
+++ b/operator/main.go
@@ -51,7 +51,6 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-
 	coreV1 "k8s.io/api/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/operator/main.go
+++ b/operator/main.go
@@ -45,7 +45,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -167,7 +167,7 @@ func run() error {
 			// Limit caching of Secret and ConfigMaps to labeled
 			// resources because those are usually the objects
 			// with highest impact on memory consumption
-			ByObject: map[client.Object]cache.ByObject{
+			ByObject: map[ctrlClient.Object]cache.ByObject{
 				&coreV1.Secret{}: {
 					Label: cacheLabelSelector,
 				},

--- a/operator/pkg/central/extensions/common.go
+++ b/operator/pkg/central/extensions/common.go
@@ -18,7 +18,7 @@ var (
 	errUnexpectedGVK = errors.New("invoked reconciliation extension for object with unexpected GVK")
 )
 
-func wrapExtension(runFn func(ctx context.Context, central *platform.Central, client ctrlClient.Client, statusUpdater func(statusFunc updateStatusFunc), log logr.Logger) error, client ctrlClient.Client) extensions.ReconcileExtension {
+func wrapExtension(runFn func(ctx context.Context, central *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, statusUpdater func(statusFunc updateStatusFunc), log logr.Logger) error, client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
 	return func(ctx context.Context, u *unstructured.Unstructured, statusUpdater func(extensions.UpdateStatusFunc), log logr.Logger) error {
 		if u.GroupVersionKind() != platform.CentralGVK {
 			log.Error(errUnexpectedGVK, "unable to reconcile central", "expectedGVK", platform.CentralGVK, "actualGVK", u.GroupVersionKind())
@@ -43,6 +43,6 @@ func wrapExtension(runFn func(ctx context.Context, central *platform.Central, cl
 				return true
 			})
 		}
-		return runFn(ctx, &c, client, wrappedStatusUpdater, log)
+		return runFn(ctx, &c, client, apiReader, wrappedStatusUpdater, log)
 	}
 }

--- a/operator/pkg/central/extensions/common_test.go
+++ b/operator/pkg/central/extensions/common_test.go
@@ -61,7 +61,7 @@ func basicSpecWithScanner(scannerEnabled bool, scannerV4Enabled bool) platform.C
 }
 
 // TODO(ROX-9453): Refactor this to be used also by Secured Cluster reconciler extensions.
-func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, central *platform.Central, client ctrlClient.Client, statusUpdater func(updateStatusFunc), log logr.Logger) error, c secretReconciliationTestCase) {
+func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, central *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, statusUpdater func(updateStatusFunc), log logr.Logger) error, c secretReconciliationTestCase) {
 	central := &platform.Central{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "platform.stackrox.io/v1alpha1",
@@ -110,7 +110,7 @@ func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, cent
 
 	// Verify that an initial invocation does not touch any of the existing unmanaged secrets, and creates
 	// the expected managed ones.
-	err := runFn(context.Background(), central.DeepCopy(), client, statusUpdater, logr.Discard())
+	err := runFn(context.Background(), central.DeepCopy(), client, client, statusUpdater, logr.Discard())
 	if c.ExpectedError == "" {
 		require.NoError(t, err)
 	} else {
@@ -165,7 +165,7 @@ func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, cent
 	assert.Empty(t, secretsByName, "one or more unexpected secrets exist")
 
 	// Verify that a second invocation does not further change the cluster state
-	err = runFn(context.Background(), central.DeepCopy(), client, statusUpdater, logr.Discard())
+	err = runFn(context.Background(), central.DeepCopy(), client, client, statusUpdater, logr.Discard())
 	assert.NoError(t, err, "second invocation of reconciliation function failed")
 
 	if c.VerifyStatus != nil {
@@ -182,7 +182,7 @@ func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, cent
 	central.DeletionTimestamp = new(metav1.Time)
 	*central.DeletionTimestamp = metav1.Now()
 
-	err = runFn(context.Background(), central.DeepCopy(), client, statusUpdater, logr.Discard())
+	err = runFn(context.Background(), central.DeepCopy(), client, client, statusUpdater, logr.Discard())
 	assert.NoError(t, err, "deletion of CR resulted in error")
 
 	secretsList3 := &v1.SecretList{}

--- a/operator/pkg/central/extensions/reconcile_admin_password.go
+++ b/operator/pkg/central/extensions/reconcile_admin_password.go
@@ -63,7 +63,7 @@ func (r *reconcileAdminPasswordExtensionRun) readPasswordFromReferencedSecret(ct
 	passwordSecret := &coreV1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: r.centralObj.GetNamespace(), Name: r.passwordSecretName}
 	// using APIReader for uncached access because the operator might not own this secret
-	// thus we can't guarantee that labels are set propperly for it to be in the cache
+	// thus we can't guarantee that labels are set properly for it to be in the cache
 	if err := r.APIReader().Get(ctx, key, passwordSecret); err != nil {
 		return errors.Wrapf(err, "failed to retrieve admin password secret %q", r.passwordSecretName)
 	}

--- a/operator/pkg/central/extensions/reconcile_admin_password.go
+++ b/operator/pkg/central/extensions/reconcile_admin_password.go
@@ -12,10 +12,10 @@ import (
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	commonExtensions "github.com/stackrox/rox/operator/pkg/common/extensions"
 	"github.com/stackrox/rox/operator/pkg/types"
+	"github.com/stackrox/rox/operator/pkg/utils"
 	"github.com/stackrox/rox/pkg/auth/htpasswd"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
 	"github.com/stackrox/rox/pkg/renderer"
-	coreV1 "k8s.io/api/core/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,9 +60,10 @@ func (r *reconcileAdminPasswordExtensionRun) readPasswordFromReferencedSecret(ct
 
 	r.passwordSecretName = r.centralObj.Spec.Central.AdminPasswordSecret.Name
 
-	passwordSecret := &coreV1.Secret{}
-	key := ctrlClient.ObjectKey{Namespace: r.centralObj.GetNamespace(), Name: r.passwordSecretName}
-	if err := r.Client().Get(ctx, key, passwordSecret); err != nil {
+	// using unstructured client to call API server instead of cache, because we can't
+	// ensure that a user provided secret matches the selectors configured for the cache
+	passwordSecret, err := utils.GetSecretWithUnstrucuteredObj(ctx, r.passwordSecretName, r.centralObj.GetNamespace(), r.Client())
+	if err != nil {
 		return errors.Wrapf(err, "failed to retrieve admin password secret %q", r.passwordSecretName)
 	}
 

--- a/operator/pkg/central/extensions/reconcile_central_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_central_db_password.go
@@ -53,7 +53,7 @@ func (r *reconcileCentralDBPasswordExtensionRun) readAndSetPasswordFromReference
 	passwordSecret := &coreV1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: r.centralObj.GetNamespace(), Name: passwordSecretName}
 	// using APIReader for uncached access because the operator might not own this secret
-	// thus we can't guarantee that labels are set propperly for it to be in the cache
+	// thus we can't guarantee that labels are set properly for it to be in the cache
 	if err := r.APIReader().Get(ctx, key, passwordSecret); err != nil {
 		return errors.Wrapf(err, "failed to retrieve central db password secret %q", passwordSecretName)
 	}

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -99,12 +99,12 @@ func getPersistenceByTarget(central *platform.Central, target PVCTarget) *platfo
 // ReconcilePVCExtension reconciles PVCs created by the operator. The PVC is not managed by a Helm chart
 // because if a user uninstalls StackRox, it should keep the data, preventing to unintentionally erasing data.
 // On uninstall the owner reference is removed from the PVC objects.
-func ReconcilePVCExtension(client ctrlClient.Client, target PVCTarget, defaultClaimName string) extensions.ReconcileExtension {
-	fn := func(ctx context.Context, central *platform.Central, client ctrlClient.Client, _ func(statusFunc updateStatusFunc), log logr.Logger) error {
+func ReconcilePVCExtension(client ctrlClient.Client, apiReader ctrlClient.Reader, target PVCTarget, defaultClaimName string) extensions.ReconcileExtension {
+	fn := func(ctx context.Context, central *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(statusFunc updateStatusFunc), log logr.Logger) error {
 		persistence := getPersistenceByTarget(central, target)
 		return reconcilePVC(ctx, central, persistence, target, defaultClaimName, client, log)
 	}
-	return wrapExtension(fn, client)
+	return wrapExtension(fn, client, apiReader)
 }
 
 func reconcilePVC(ctx context.Context, central *platform.Central, persistence *platform.Persistence, target PVCTarget, defaultClaimName string, client ctrlClient.Client, log logr.Logger) error {

--- a/operator/pkg/central/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_scanner_db_password.go
@@ -20,10 +20,10 @@ const (
 
 // ReconcileScannerDBPasswordExtension returns an extension that takes care of creating the scanner-db-password
 // secret ahead of time.
-func ReconcileScannerDBPasswordExtension(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(reconcileScannerDBPassword, client)
+func ReconcileScannerDBPasswordExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(reconcileScannerDBPassword, client, apiReader)
 }
 
-func reconcileScannerDBPassword(ctx context.Context, c *platform.Central, client ctrlClient.Client, _ func(updateStatusFunc), _ logr.Logger) error {
-	return commonExtensions.ReconcileScannerDBPassword(ctx, c, client)
+func reconcileScannerDBPassword(ctx context.Context, c *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(updateStatusFunc), _ logr.Logger) error {
+	return commonExtensions.ReconcileScannerDBPassword(ctx, c, client, apiReader)
 }

--- a/operator/pkg/central/extensions/reconcile_scanner_v4_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_scanner_v4_db_password.go
@@ -16,10 +16,10 @@ var (
 
 // ReconcileScannerV4DBPasswordExtension returns an extension that takes care of creating the scanner-v4-db-password
 // secret ahead of time.
-func ReconcileScannerV4DBPasswordExtension(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(reconcileScannerV4DBPassword, client)
+func ReconcileScannerV4DBPasswordExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(reconcileScannerV4DBPassword, client, apiReader)
 }
 
-func reconcileScannerV4DBPassword(ctx context.Context, c *platform.Central, client ctrlClient.Client, _ func(updateStatusFunc), _ logr.Logger) error {
-	return commonExtensions.ReconcileScannerV4DBPassword(ctx, c, client)
+func reconcileScannerV4DBPassword(ctx context.Context, c *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(updateStatusFunc), _ logr.Logger) error {
+	return commonExtensions.ReconcileScannerV4DBPassword(ctx, c, client, apiReader)
 }

--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -32,13 +32,13 @@ const (
 
 // ReconcileCentralTLSExtensions returns an extension that takes care of creating the central-tls and related
 // secrets ahead of time.
-func ReconcileCentralTLSExtensions(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(reconcileCentralTLS, client)
+func ReconcileCentralTLSExtensions(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(reconcileCentralTLS, client, apiReader)
 }
 
-func reconcileCentralTLS(ctx context.Context, c *platform.Central, client ctrlClient.Client, _ func(updateStatusFunc), _ logr.Logger) error {
+func reconcileCentralTLS(ctx context.Context, c *platform.Central, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(updateStatusFunc), _ logr.Logger) error {
 	run := &createCentralTLSExtensionRun{
-		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, c),
+		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, apiReader, c),
 		centralObj:          c,
 		currentTime:         time.Now(),
 	}

--- a/operator/pkg/central/extensions/reconcile_tls_test.go
+++ b/operator/pkg/central/extensions/reconcile_tls_test.go
@@ -14,6 +14,7 @@ import (
 	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	commonLabels "github.com/stackrox/rox/operator/pkg/common/labels"
 	"github.com/stackrox/rox/operator/pkg/types"
 	"github.com/stackrox/rox/operator/pkg/utils/testutils"
 	"github.com/stackrox/rox/pkg/certgen"
@@ -103,6 +104,7 @@ func TestCreateCentralTLS(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "central-tls",
 			Namespace: testutils.TestNamespace,
+			Labels:    commonLabels.DefaultLabels(),
 		},
 		Data: centralFileMapWithInvalidLeaf,
 	}
@@ -117,6 +119,7 @@ func TestCreateCentralTLS(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "central-tls",
 			Namespace: testutils.TestNamespace,
+			Labels:    commonLabels.DefaultLabels(),
 		},
 		Data: centralFileMapWithMissingCAKey,
 	}

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -62,7 +62,10 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		translation.WithEnrichment(
 			centralTranslation.New(mgr.GetClient()),
 			proxy.NewProxyEnvVarsInjector(proxyEnv, mgr.GetLogger()),
-			legacy.NewImagePullSecretReferenceInjector(mgr.GetClient(), "imagePullSecrets",
+			// Using uncached APIReader since this is reading secrets not
+			// owned by the operator so we can't guarantee labels for cache
+			// are set propperly
+			legacy.NewImagePullSecretReferenceInjector(mgr.GetAPIReader(), "imagePullSecrets",
 				"stackrox", "stackrox-scanner", "stackrox-scanner-v4")),
 		opts...,
 	)

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -33,13 +33,13 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 			// an init bundle should be created by the Central controller.
 			utils.CreateAndDeleteOnlyPredicate{},
 		),
-		pkgReconciler.WithPreExtension(extensions.ReconcileCentralTLSExtensions(mgr.GetClient())),
-		pkgReconciler.WithPreExtension(extensions.ReconcileCentralDBPasswordExtension(mgr.GetClient())),
-		pkgReconciler.WithPreExtension(extensions.ReconcileScannerDBPasswordExtension(mgr.GetClient())),
-		pkgReconciler.WithPreExtension(extensions.ReconcileAdminPasswordExtension(mgr.GetClient())),
-		pkgReconciler.WithPreExtension(extensions.ReconcilePVCExtension(mgr.GetClient(), extensions.PVCTargetCentral, extensions.DefaultCentralPVCName)),
-		pkgReconciler.WithPreExtension(extensions.ReconcilePVCExtension(mgr.GetClient(), extensions.PVCTargetCentralDB, extensions.DefaultCentralDBPVCName)),
-		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
+		pkgReconciler.WithPreExtension(extensions.ReconcileCentralTLSExtensions(mgr.GetClient(), mgr.GetAPIReader())),
+		pkgReconciler.WithPreExtension(extensions.ReconcileCentralDBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
+		pkgReconciler.WithPreExtension(extensions.ReconcileScannerDBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
+		pkgReconciler.WithPreExtension(extensions.ReconcileAdminPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
+		pkgReconciler.WithPreExtension(extensions.ReconcilePVCExtension(mgr.GetClient(), mgr.GetAPIReader(), extensions.PVCTargetCentral, extensions.DefaultCentralPVCName)),
+		pkgReconciler.WithPreExtension(extensions.ReconcilePVCExtension(mgr.GetClient(), mgr.GetAPIReader(), extensions.PVCTargetCentralDB, extensions.DefaultCentralDBPVCName)),
+		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), mgr.GetAPIReader(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
 		pkgReconciler.WithReconcilePeriod(extensions.InitBundleReconcilePeriod),
@@ -47,7 +47,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	}
 
 	if features.ScannerV4Support.Enabled() {
-		opts = append(opts, pkgReconciler.WithPreExtension(extensions.ReconcileScannerV4DBPasswordExtension(mgr.GetClient())))
+		opts = append(opts, pkgReconciler.WithPreExtension(extensions.ReconcileScannerV4DBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())))
 	}
 
 	opts, err := commonExtensions.AddSelectorOptionIfNeeded(selector, opts)

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -64,7 +64,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 			proxy.NewProxyEnvVarsInjector(proxyEnv, mgr.GetLogger()),
 			// Using uncached APIReader since this is reading secrets not
 			// owned by the operator so we can't guarantee labels for cache
-			// are set propperly
+			// are set properly
 			legacy.NewImagePullSecretReferenceInjector(mgr.GetAPIReader(), "imagePullSecrets",
 				"stackrox", "stackrox-scanner", "stackrox-scanner-v4")),
 		opts...,

--- a/operator/pkg/common/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/common/extensions/reconcile_scanner_db_password.go
@@ -26,15 +26,15 @@ type reconcileScannerDBPasswordConfig struct {
 }
 
 // ReconcileScannerDBPassword reconciles a scanner db password
-func ReconcileScannerDBPassword(ctx context.Context, obj ScannerBearingCustomResource, client ctrlClient.Client) error {
-	return reconcileScannerDBPassword(ctx, obj, client, reconcileScannerDBPasswordConfig{
+func ReconcileScannerDBPassword(ctx context.Context, obj ScannerBearingCustomResource, client ctrlClient.Client, apiReader ctrlClient.Reader) error {
+	return reconcileScannerDBPassword(ctx, obj, client, apiReader, reconcileScannerDBPasswordConfig{
 		PasswordResourceName: scannerDBPasswordResourceName,
 	})
 }
 
-func reconcileScannerDBPassword(ctx context.Context, obj ScannerBearingCustomResource, client ctrlClient.Client, config reconcileScannerDBPasswordConfig) error {
+func reconcileScannerDBPassword(ctx context.Context, obj ScannerBearingCustomResource, client ctrlClient.Client, apiReader ctrlClient.Reader, config reconcileScannerDBPasswordConfig) error {
 	run := &reconcileScannerDBPasswordExtensionRun{
-		SecretReconciliator:  NewSecretReconciliator(client, obj),
+		SecretReconciliator:  NewSecretReconciliator(client, apiReader, obj),
 		obj:                  obj,
 		passwordResourceName: config.PasswordResourceName,
 	}

--- a/operator/pkg/common/extensions/reconcile_scanner_v4_db_password.go
+++ b/operator/pkg/common/extensions/reconcile_scanner_v4_db_password.go
@@ -22,13 +22,13 @@ type ScannerV4BearingCustomResource interface {
 }
 
 // ReconcileScannerV4DBPassword reconciles a Scanner V4 db password
-func ReconcileScannerV4DBPassword(ctx context.Context, obj ScannerV4BearingCustomResource, client ctrlClient.Client) error {
-	return reconcileScannerV4DBPassword(ctx, obj, client)
+func ReconcileScannerV4DBPassword(ctx context.Context, obj ScannerV4BearingCustomResource, client ctrlClient.Client, apiReader ctrlClient.Reader) error {
+	return reconcileScannerV4DBPassword(ctx, obj, client, apiReader)
 }
 
-func reconcileScannerV4DBPassword(ctx context.Context, obj ScannerV4BearingCustomResource, client ctrlClient.Client) error {
+func reconcileScannerV4DBPassword(ctx context.Context, obj ScannerV4BearingCustomResource, client ctrlClient.Client, apiReader ctrlClient.Reader) error {
 	run := &reconcileScannerV4DBPasswordExtensionRun{
-		SecretReconciliator:  NewSecretReconciliator(client, obj),
+		SecretReconciliator:  NewSecretReconciliator(client, apiReader, obj),
 		obj:                  obj,
 		passwordResourceName: scannerV4DBPasswordResourceName,
 	}

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -139,7 +139,9 @@ func (r *SecretReconciliator) updateExisting(ctx context.Context, secret *coreV1
 		needsUpdate = true
 	}
 
-	needsUpdate = commonLabels.SetDefaultLabels(secret.Labels)
+	labels, needsLabelUpdate := commonLabels.WithDefaults(secret.Labels)
+	secret.Labels = labels
+	needsUpdate = needsUpdate || needsLabelUpdate
 	if !needsUpdate || !isManaged {
 		return nil
 	}

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	commonLabels "github.com/stackrox/rox/operator/pkg/common/labels"
 	"github.com/stackrox/rox/operator/pkg/types"
 	"github.com/stackrox/rox/operator/pkg/utils"
 	coreV1 "k8s.io/api/core/v1"
@@ -33,8 +34,9 @@ func NewSecretReconciliator(client ctrlClient.Client, obj types.K8sObject) *Secr
 
 // SecretReconciliator reconciles a secret.
 type SecretReconciliator struct {
-	client ctrlClient.Client
-	obj    types.K8sObject
+	client         ctrlClient.Client
+	uncachedReader ctrlClient.Reader
+	obj            types.K8sObject
 }
 
 // Client returns the controller-runtime client used by the extension.
@@ -76,32 +78,15 @@ func (r *SecretReconciliator) EnsureSecret(ctx context.Context, name string, val
 		secret = nil
 	}
 
-	var oldData types.SecretDataMap
-	var validateErr error
 	if secret != nil {
-		isManaged := metav1.IsControlledBy(secret, r.obj)
-		validateErr = validate(secret.Data, isManaged)
-
-		if validateErr == nil {
-			return nil // validation of existing secret successful - no reconciliation needed
-		}
-		// If the secret is unmanaged, we cannot fix it, so we should fail.
-		if !isManaged {
-			return errors.Wrapf(validateErr,
-				"existing %s secret is invalid (%s), but not owned by the CR, please delete the secret to allow fixing the issue",
-				validateErr.Error(), name)
-		}
-		oldData = secret.Data
+		err := r.updateExisting(ctx, secret, validate, generate)
+		return err
 	}
 
 	// Try to generate the secret, in order to fix it.
-	data, err := generate(oldData)
+	data, err := generate(nil)
 	if err != nil {
-		extraInfo := "new"
-		if validateErr != nil {
-			extraInfo = fmt.Sprintf("invalid (%s)", validateErr.Error())
-		}
-		return errors.Wrapf(err, "error generating data for %s %s secret", extraInfo, name)
+		return generateError(err, name, "new")
 	}
 	newSecret := &coreV1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,19 +95,74 @@ func (r *SecretReconciliator) EnsureSecret(ctx context.Context, name string, val
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(r.obj, r.obj.GroupVersionKind()),
 			},
+			Labels: commonLabels.DefaultLabels(),
 		},
 		Data: data,
 	}
 
-	if secret == nil {
-		if err := r.Client().Create(ctx, newSecret); err != nil {
+	if err := r.Client().Create(ctx, newSecret); err != nil {
+		if !apiErrors.IsAlreadyExists(err) {
 			return errors.Wrapf(err, "creating new %s secret failed", name)
 		}
-	} else {
-		newSecret.ResourceVersion = secret.ResourceVersion
-		if err := r.Client().Update(ctx, newSecret); err != nil {
-			return errors.Wrapf(err, "updating invalid %s secret (%s) failed", secret.Name, validateErr)
+
+		// the secret exists but was not in the cache, try to get and update it using
+		// an unstructured object which doesn't use the default cache
+		secret, err := utils.GetSecretWithUnstrucuteredObj(ctx, name, r.obj.GetNamespace(), r.client)
+		if err != nil {
+			return errors.Wrap(err, "getting secret with unstructured object")
+		}
+
+		err = r.updateExisting(ctx, secret, validate, generate)
+		return err
+	}
+
+	return nil
+}
+
+func (r *SecretReconciliator) updateExisting(ctx context.Context, secret *coreV1.Secret, validate validateSecretDataFunc, generate generateSecretDataFunc) error {
+	isManaged := metav1.IsControlledBy(secret, r.obj)
+	validateErr := validate(secret.Data, isManaged)
+
+	needsUpdate := false
+	// If the secret is unmanaged, we cannot fix it, so we should fail.
+	if validateErr != nil && !isManaged {
+		return errors.Wrapf(validateErr,
+			"existing %s secret is invalid (%s), but not owned by the CR, please delete the secret to allow fixing the issue",
+			validateErr.Error(), secret.Name)
+	}
+
+	if validateErr != nil {
+		oldData := secret.Data
+		data, err := generate(oldData)
+		if err != nil {
+			return generateError(err, secret.Name, fmt.Sprintf("invalid (%s)", validateErr.Error()))
+		}
+		secret.Data = data
+		needsUpdate = true
+	}
+
+	for k, v := range commonLabels.DefaultLabels() {
+		value, hasKey := secret.Labels[k]
+		if !hasKey || value != v {
+			needsUpdate = true
+			if secret.Labels == nil {
+				secret.Labels = map[string]string{}
+			}
+			secret.Labels[k] = v
 		}
 	}
+
+	if !needsUpdate || !isManaged {
+		return nil
+	}
+
+	if err := r.client.Update(ctx, secret); err != nil {
+		return errors.Wrapf(err, "updating secret %s/%s", secret.Namespace, secret.Name)
+	}
+
 	return nil
+}
+
+func generateError(err error, secretName, extraInfo string) error {
+	return errors.Wrapf(err, "error generating data for %s %s secret", extraInfo, secretName)
 }

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -34,9 +34,8 @@ func NewSecretReconciliator(client ctrlClient.Client, obj types.K8sObject) *Secr
 
 // SecretReconciliator reconciles a secret.
 type SecretReconciliator struct {
-	client         ctrlClient.Client
-	uncachedReader ctrlClient.Reader
-	obj            types.K8sObject
+	client ctrlClient.Client
+	obj    types.K8sObject
 }
 
 // Client returns the controller-runtime client used by the extension.

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -45,6 +45,7 @@ func (r *SecretReconciliator) Client() ctrlClient.Client {
 	return r.client
 }
 
+// APIReader returns the controller-runtime APIReader used by the extension.
 func (r *SecretReconciliator) APIReader() ctrlClient.Reader {
 	return r.apiReader
 }
@@ -54,7 +55,7 @@ func (r *SecretReconciliator) APIReader() ctrlClient.Reader {
 func (r *SecretReconciliator) DeleteSecret(ctx context.Context, name string) error {
 	secret := &coreV1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: r.obj.GetNamespace(), Name: name}
-	if err := r.Client().Get(ctx, key, secret); err != nil {
+	if err := utils.GetWithFallbackToAPIReader(ctx, r.Client(), r.APIReader(), key, secret); err != nil {
 		if !apiErrors.IsNotFound(err) {
 			return errors.Wrapf(err, "checking existence of %s secret", name)
 		}

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -139,17 +139,7 @@ func (r *SecretReconciliator) updateExisting(ctx context.Context, secret *coreV1
 		needsUpdate = true
 	}
 
-	for k, v := range commonLabels.DefaultLabels() {
-		value, hasKey := secret.Labels[k]
-		if !hasKey || value != v {
-			needsUpdate = true
-			if secret.Labels == nil {
-				secret.Labels = map[string]string{}
-			}
-			secret.Labels[k] = v
-		}
-	}
-
+	needsUpdate = commonLabels.SetDefaultLabels(secret.Labels)
 	if !needsUpdate || !isManaged {
 		return nil
 	}

--- a/operator/pkg/common/extensions/secret_reconciliator_test.go
+++ b/operator/pkg/common/extensions/secret_reconciliator_test.go
@@ -6,6 +6,7 @@ import (
 
 	pkgErrors "github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/pkg/common/labels"
 	"github.com/stackrox/rox/operator/pkg/types"
 	"github.com/stackrox/rox/operator/pkg/utils/testutils"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -72,6 +73,7 @@ func (s *secretReconcilerTestSuite) SetupTest() {
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(s.centralObj, platform.CentralGVK),
 			},
+			Labels: labels.DefaultLabels(),
 		},
 		Data: map[string][]byte{
 			"secret-name": []byte("existing-managed-secret"),

--- a/operator/pkg/common/extensions/secret_reconciliator_test.go
+++ b/operator/pkg/common/extensions/secret_reconciliator_test.go
@@ -83,7 +83,7 @@ func (s *secretReconcilerTestSuite) SetupTest() {
 
 	s.client = fake.NewClientBuilder().WithObjects(existingSecret, existingOwnedSecret).Build()
 
-	s.reconciliator = NewSecretReconciliator(s.client, s.centralObj)
+	s.reconciliator = NewSecretReconciliator(s.client, s.client, s.centralObj)
 }
 
 func (s *secretReconcilerTestSuite) Test_ShouldNotExist_OnNonExisting_ShouldDoNothing() {

--- a/operator/pkg/common/labels/labels.go
+++ b/operator/pkg/common/labels/labels.go
@@ -25,6 +25,24 @@ func DefaultLabels() map[string]string {
 	return labels
 }
 
+// SetDefaultLabels sets the labels defined in DefaultLabels on the given map.
+// It returns a bool to indicate whether the given map was updated or not
+func SetDefaultLabels(labels map[string]string) bool {
+	updated := false
+	for k, v := range defaultLabels {
+		value, hasKey := labels[k]
+		if !hasKey || value != v {
+			updated = true
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			labels[k] = v
+		}
+	}
+
+	return updated
+}
+
 // NewLabelPostRenderer is a postrenderer for helm operator plugin kube clients to add
 // given labels to each renderered object
 func NewLabelPostRenderer(client kube.Interface, labels map[string]string) postrender.PostRenderer {

--- a/operator/pkg/common/labels/labels.go
+++ b/operator/pkg/common/labels/labels.go
@@ -25,22 +25,24 @@ func DefaultLabels() map[string]string {
 	return labels
 }
 
-// SetDefaultLabels sets the labels defined in DefaultLabels on the given map.
-// It returns a bool to indicate whether the given map was updated or not
-func SetDefaultLabels(labels map[string]string) bool {
+// WithDefaults return a copy of the given labels with the default labels added.
+// It returns a bool as second argument to indicate whether default labels had to be added or not
+func WithDefaults(labels map[string]string) (map[string]string, bool) {
 	updated := false
+	newLabels := map[string]string{}
+	for k, v := range labels {
+		newLabels[k] = v
+	}
+
 	for k, v := range defaultLabels {
-		value, hasKey := labels[k]
+		value, hasKey := newLabels[k]
 		if !hasKey || value != v {
 			updated = true
-			if labels == nil {
-				labels = map[string]string{}
-			}
-			labels[k] = v
+			newLabels[k] = v
 		}
 	}
 
-	return updated
+	return newLabels, updated
 }
 
 // NewLabelPostRenderer is a postrenderer for helm operator plugin kube clients to add

--- a/operator/pkg/common/labels/labels.go
+++ b/operator/pkg/common/labels/labels.go
@@ -1,0 +1,89 @@
+package labels
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/kube"
+	"helm.sh/helm/v3/pkg/postrender"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/yaml"
+)
+
+var defaultLabels = map[string]string{
+	"app.stackrox.io/managed-by": "operator",
+}
+
+// DefaultLabels defines the default labels the operator should set on resources it creates
+func DefaultLabels() map[string]string {
+	labels := make(map[string]string, len(defaultLabels))
+	for k, v := range defaultLabels {
+		labels[k] = v
+	}
+
+	return labels
+}
+
+// NewLabelPostRenderer is a postrenderer for helm operator plugin kube clients to add
+// given labels to each renderered object
+func NewLabelPostRenderer(client kube.Interface, labels map[string]string) postrender.PostRenderer {
+	return &labelPostRenderer{
+		kubeClient: client,
+		labels:     labels,
+	}
+}
+
+var _ postrender.PostRenderer = &labelPostRenderer{}
+
+type labelPostRenderer struct {
+	kubeClient kube.Interface
+	labels     map[string]string
+}
+
+func (lpr labelPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	rl, err := lpr.kubeClient.Build(renderedManifests, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build resource list for label post renderer")
+	}
+
+	out := bytes.Buffer{}
+
+	err = rl.Visit(func(i *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+
+		objMeta, err := meta.Accessor(i.Object)
+		if err != nil {
+			return errors.Wrapf(err, "failed to access metadata for %s/%s", i.Namespace, i.Name)
+		}
+
+		labels := objMeta.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		for k, v := range lpr.labels {
+			labels[k] = v
+		}
+
+		objMeta.SetLabels(labels)
+
+		outData, err := yaml.Marshal(i.Object)
+		if err != nil {
+			return errors.Wrapf(err, "failed to marshal object to yaml for %s/%s", i.Namespace, i.Name)
+		}
+
+		if _, err := out.WriteString("---\n" + string(outData)); err != nil {
+			return errors.Wrapf(err, "failed to write object to output buffer for %s/%s", i.Namespace, i.Name)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to visit resources for label post renderer")
+	}
+
+	return &out, nil
+}

--- a/operator/pkg/legacy/secrets.go
+++ b/operator/pkg/legacy/secrets.go
@@ -111,9 +111,9 @@ func (i *injector) enrich(ctx context.Context, vals chartutil.Values, key string
 		return nil, err
 	}
 
-	for _, name := range existingSecretNames {
-		if slices.Contains(secretNames, name) {
-			secretNamesToAdd = append(secretNamesToAdd, name)
+	for _, existingName := range existingSecretNames {
+		if slices.Contains(secretNames, existingName) {
+			secretNamesToAdd = append(secretNamesToAdd, existingName)
 		}
 	}
 

--- a/operator/pkg/proxy/extension.go
+++ b/operator/pkg/proxy/extension.go
@@ -126,6 +126,7 @@ func updateProxyEnvSecret(ctx context.Context, obj k8sutil.Object, client ctrlCl
 		return client.Create(ctx, secret)
 	}
 
-	commonLabels.SetDefaultLabels(secret.Labels)
+	labels, _ := commonLabels.WithDefaults(secret.Labels)
+	secret.Labels = labels
 	return client.Update(ctx, secret)
 }

--- a/operator/pkg/proxy/extension.go
+++ b/operator/pkg/proxy/extension.go
@@ -126,12 +126,6 @@ func updateProxyEnvSecret(ctx context.Context, obj k8sutil.Object, client ctrlCl
 		return client.Create(ctx, secret)
 	}
 
-	for k, v := range commonLabels.DefaultLabels() {
-		if secret.Labels == nil {
-			secret.Labels = map[string]string{}
-		}
-		secret.Labels[k] = v
-	}
-
+	commonLabels.SetDefaultLabels(secret.Labels)
 	return client.Update(ctx, secret)
 }

--- a/operator/pkg/reconciler/reconciler_factory.go
+++ b/operator/pkg/reconciler/reconciler_factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/image"
+	commonLabels "github.com/stackrox/rox/operator/pkg/common/labels"
 	"github.com/stackrox/rox/operator/pkg/overlays"
 	"github.com/stackrox/rox/operator/pkg/utils"
 	"github.com/stackrox/rox/pkg/env"
@@ -82,6 +83,11 @@ func SetupReconcilerWithManager(mgr ctrl.Manager, gvk schema.GroupVersionKind, c
 	var opts = []client.ActionClientGetterOption{
 		client.AppendPostRenderers(func(rm meta.RESTMapper, kubeClient kube.Interface, obj ctrlClient.Object) postrender.PostRenderer {
 			return overlays.NewOverlayPostRenderer(obj, obj.GetNamespace())
+		}),
+		client.AppendPostRenderers(func(rm meta.RESTMapper, kubeClient kube.Interface, obj ctrlClient.Object) postrender.PostRenderer {
+			return commonLabels.NewLabelPostRenderer(kubeClient, map[string]string{
+				"app.stackrox.io/managed-by": "operator",
+			})
 		}),
 	}
 

--- a/operator/pkg/securedcluster/extensions/cluster_name.go
+++ b/operator/pkg/securedcluster/extensions/cluster_name.go
@@ -12,8 +12,8 @@ import (
 
 // CheckClusterNameExtension is an extension that ensures the spec.clusterName and status.clusterName fields are
 // in sync.
-func CheckClusterNameExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
-	return wrapExtension(checkClusterName, client, apiReader)
+func CheckClusterNameExtension() extensions.ReconcileExtension {
+	return wrapExtension(checkClusterName, nil, nil)
 }
 
 func checkClusterName(_ context.Context, sc *platform.SecuredCluster, _ ctrlClient.Client, _ ctrlClient.Reader, statusUpdater func(statusFunc updateStatusFunc), _ logr.Logger) error {

--- a/operator/pkg/securedcluster/extensions/cluster_name.go
+++ b/operator/pkg/securedcluster/extensions/cluster_name.go
@@ -12,11 +12,11 @@ import (
 
 // CheckClusterNameExtension is an extension that ensures the spec.clusterName and status.clusterName fields are
 // in sync.
-func CheckClusterNameExtension(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(checkClusterName, client)
+func CheckClusterNameExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(checkClusterName, client, apiReader)
 }
 
-func checkClusterName(_ context.Context, sc *platform.SecuredCluster, _ ctrlClient.Client, statusUpdater func(statusFunc updateStatusFunc), _ logr.Logger) error {
+func checkClusterName(_ context.Context, sc *platform.SecuredCluster, _ ctrlClient.Client, _ ctrlClient.Reader, statusUpdater func(statusFunc updateStatusFunc), _ logr.Logger) error {
 	if sc.DeletionTimestamp != nil {
 		return nil // doesn't matter on deletion
 	}

--- a/operator/pkg/securedcluster/extensions/common.go
+++ b/operator/pkg/securedcluster/extensions/common.go
@@ -18,7 +18,7 @@ var (
 	errUnexpectedGVK = errors.New("invoked reconciliation extension for object with unexpected GVK")
 )
 
-func wrapExtension(runFn func(ctx context.Context, securedCluster *platform.SecuredCluster, client ctrlClient.Client, statusUpdater func(statusFunc updateStatusFunc), log logr.Logger) error, client ctrlClient.Client) extensions.ReconcileExtension {
+func wrapExtension(runFn func(ctx context.Context, securedCluster *platform.SecuredCluster, client ctrlClient.Client, apiReader ctrlClient.Reader, statusUpdater func(statusFunc updateStatusFunc), log logr.Logger) error, client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
 	return func(ctx context.Context, u *unstructured.Unstructured, statusUpdater func(extensions.UpdateStatusFunc), log logr.Logger) error {
 		if u.GroupVersionKind() != platform.SecuredClusterGVK {
 			log.Error(errUnexpectedGVK, "unable to reconcile secured cluster", "expectedGVK", platform.SecuredClusterGVK, "actualGVK", u.GroupVersionKind())
@@ -43,6 +43,6 @@ func wrapExtension(runFn func(ctx context.Context, securedCluster *platform.Secu
 				return true
 			})
 		}
-		return runFn(ctx, &c, client, wrappedStatusUpdater, log)
+		return runFn(ctx, &c, client, apiReader, wrappedStatusUpdater, log)
 	}
 }

--- a/operator/pkg/securedcluster/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/securedcluster/extensions/reconcile_scanner_db_password.go
@@ -24,11 +24,11 @@ func (s *securedClusterWithScannerBearer) IsScannerEnabled() bool {
 
 // ReconcileLocalScannerDBPasswordExtension returns an extension that takes care of creating the scanner-db-password
 // secret ahead of time.
-func ReconcileLocalScannerDBPasswordExtension(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(reconcile, client)
+func ReconcileLocalScannerDBPasswordExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(reconcile, client, apiReader)
 }
 
-func reconcile(ctx context.Context, s *platform.SecuredCluster, client ctrlClient.Client, _ func(updateStatusFunc), _ logr.Logger) error {
+func reconcile(ctx context.Context, s *platform.SecuredCluster, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(updateStatusFunc), _ logr.Logger) error {
 	config, err := scanner.AutoSenseLocalScannerConfig(ctx, client, *s)
 	if err != nil {
 		return err
@@ -39,5 +39,5 @@ func reconcile(ctx context.Context, s *platform.SecuredCluster, client ctrlClien
 		SecuredCluster: s,
 		scannerEnabled: config.DeployScannerResources,
 	}
-	return commonExtensions.ReconcileScannerDBPassword(ctx, securedClusterWithScanner, client)
+	return commonExtensions.ReconcileScannerDBPassword(ctx, securedClusterWithScanner, client, apiReader)
 }

--- a/operator/pkg/securedcluster/extensions/reconcile_scanner_v4_db_password.go
+++ b/operator/pkg/securedcluster/extensions/reconcile_scanner_v4_db_password.go
@@ -25,11 +25,11 @@ func (s *securedClusterWithScannerV4Bearer) IsScannerV4Enabled() bool {
 
 // ReconcileLocalScannerV4DBPasswordExtension returns an extension that takes care of creating the scanner-v4-db-password
 // secret ahead of time.
-func ReconcileLocalScannerV4DBPasswordExtension(client ctrlClient.Client) extensions.ReconcileExtension {
-	return wrapExtension(reconcileScannerV4DBPassword, client)
+func ReconcileLocalScannerV4DBPasswordExtension(client ctrlClient.Client, apiReader ctrlClient.Reader) extensions.ReconcileExtension {
+	return wrapExtension(reconcileScannerV4DBPassword, client, apiReader)
 }
 
-func reconcileScannerV4DBPassword(ctx context.Context, s *platform.SecuredCluster, client ctrlClient.Client, _ func(updateStatusFunc), _ logr.Logger) error {
+func reconcileScannerV4DBPassword(ctx context.Context, s *platform.SecuredCluster, client ctrlClient.Client, apiReader ctrlClient.Reader, _ func(updateStatusFunc), _ logr.Logger) error {
 	config, err := scanner.AutoSenseLocalScannerV4Config(ctx, client, *s)
 	if err != nil {
 		return err
@@ -41,5 +41,5 @@ func reconcileScannerV4DBPassword(ctx context.Context, s *platform.SecuredCluste
 		scannerV4Enabled: config.DeployScannerResources,
 	}
 
-	return commonExtensions.ReconcileScannerV4DBPassword(ctx, securedClusterWithScannerV4, client)
+	return commonExtensions.ReconcileScannerV4DBPassword(ctx, securedClusterWithScannerV4, client, apiReader)
 }

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -29,7 +29,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 			// Only appearance and disappearance of a Central resource can influence whether
 			// a local scanner should be deployed by the SecuredCluster controller.
 			utils.CreateAndDeleteOnlyPredicate{}),
-		pkgReconciler.WithPreExtension(extensions.CheckClusterNameExtension(nil, nil)),
+		pkgReconciler.WithPreExtension(extensions.CheckClusterNameExtension()),
 		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), mgr.GetAPIReader(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -29,15 +29,15 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 			// Only appearance and disappearance of a Central resource can influence whether
 			// a local scanner should be deployed by the SecuredCluster controller.
 			utils.CreateAndDeleteOnlyPredicate{}),
-		pkgReconciler.WithPreExtension(extensions.CheckClusterNameExtension(nil)),
-		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
+		pkgReconciler.WithPreExtension(extensions.CheckClusterNameExtension(nil, nil)),
+		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), mgr.GetAPIReader(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
-		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient())),
+		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
 	}
 
 	if features.ScannerV4Support.Enabled() {
-		opts = append(opts, pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerV4DBPasswordExtension(mgr.GetClient())))
+		opts = append(opts, pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerV4DBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())))
 	}
 
 	opts, err := commonExtensions.AddSelectorOptionIfNeeded(selector, opts)

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -42,13 +42,16 @@ var (
 )
 
 // New creates a translator
-func New(client ctrlClient.Client) Translator {
-	return Translator{client: client}
+// apiReader should be a Reader without cache to allow directly
+// reading resources that don't match the caching configuration
+func New(client ctrlClient.Client, apiReader ctrlClient.Reader) Translator {
+	return Translator{client: client, apiReader: apiReader}
 }
 
 // Translator translates and enriches helm values
 type Translator struct {
-	client ctrlClient.Client
+	client    ctrlClient.Client
+	apiReader ctrlClient.Reader
 }
 
 // Translate translates and enriches helm values
@@ -147,7 +150,7 @@ func (t Translator) getTLSValues(ctx context.Context, sc platform.SecuredCluster
 	v.SetBoolValue("createSecrets", false)
 	sensorSecret := &corev1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: sc.Namespace, Name: sensorTLSSecretName}
-	if err := t.client.Get(ctx, key, sensorSecret); err != nil {
+	if err := t.apiReader.Get(ctx, key, sensorSecret); err != nil {
 		return v.SetError(errors.Wrapf(err, "failed reading %q secret", sensorTLSSecretName))
 	}
 
@@ -176,7 +179,7 @@ func (t Translator) checkInitBundleSecret(ctx context.Context, sc platform.Secur
 	namespace := sc.Namespace
 	secret := &corev1.Secret{}
 	key := ctrlClient.ObjectKey{Namespace: namespace, Name: secretName}
-	if err := t.client.Get(ctx, key, secret); err != nil {
+	if err := t.apiReader.Get(ctx, key, secret); err != nil {
 		if k8sErrors.IsNotFound(err) {
 			return errors.Wrapf(err, "init-bundle secret %q does not exist in namespace %q, please make sure you have downloaded init-bundle secrets (from UI or with roxctl) and created corresponding resources in the correct namespace", secretName, namespace)
 		}

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -49,7 +49,8 @@ func (s *TranslationTestSuite) TestImageOverrides() {
 	u, err := toUnstructured(obj)
 	s.Require().NoError(err)
 
-	translator := Translator{client: newDefaultFakeClient(s.T())}
+	fc := newDefaultFakeClient(s.T())
+	translator := Translator{client: fc, apiReader: newDefaultFakeClient(s.T())}
 
 	vals, err := translator.Translate(context.Background(), u)
 	s.Require().NoError(err)
@@ -90,7 +91,8 @@ func TestTranslateShouldCreateConfigFingerprint(t *testing.T) {
 	u, err := toUnstructured(sc)
 	require.NoError(t, err)
 
-	translator := Translator{client: newDefaultFakeClient(t)}
+	fc := newDefaultFakeClient(t)
+	translator := Translator{client: fc, apiReader: fc}
 	vals, err := translator.Translate(context.Background(), u)
 	require.NoError(t, err)
 
@@ -853,7 +855,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 			wantAsValues, err := translation.ToHelmValues(tt.want)
 			require.NoError(t, err, "error in test specification: cannot translate `want` specification to Helm values")
 
-			translator := Translator{client: tt.args.client}
+			translator := Translator{client: tt.args.client, apiReader: tt.args.client}
 			got, err := translator.translate(context.Background(), tt.args.sc)
 			require.NoError(t, err)
 

--- a/operator/pkg/utils/api.go
+++ b/operator/pkg/utils/api.go
@@ -1,7 +1,14 @@
 package utils
 
 import (
+	"context"
+
+	"github.com/pkg/errors"
+	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RemoveOwnerRef removes an owner ref of the given owner object from the given object.
@@ -14,4 +21,27 @@ func RemoveOwnerRef(obj metav1.Object, owner metav1.Object) {
 		r = append(r, v)
 	}
 	obj.SetOwnerReferences(r)
+}
+
+// GetSecretWithUnstrucuteredObj gets a secret by using a unstrucutrued.Unstructured object.
+// Using unstructured makes sure to don't use the default cache of the controller runtime client
+func GetSecretWithUnstrucuteredObj(ctx context.Context, name string, namespace string, client ctrlClient.Client) (*coreV1.Secret, error) {
+	secret := &coreV1.Secret{}
+	unstructuredSecret := unstructured.Unstructured{}
+
+	unstructuredSecret.SetKind("Secret")
+	unstructuredSecret.SetAPIVersion(coreV1.SchemeGroupVersion.Version)
+	key := ctrlClient.ObjectKey{Namespace: namespace, Name: name}
+
+	err := client.Get(ctx, key, &unstructuredSecret)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get unstructured secret")
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredSecret.Object, secret)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert unstrucutred secret to structured secret")
+	}
+
+	return secret, nil
 }

--- a/operator/pkg/utils/api.go
+++ b/operator/pkg/utils/api.go
@@ -28,7 +28,7 @@ func RemoveOwnerRef(obj metav1.Object, owner metav1.Object) {
 func GetWithFallbackToAPIReader(ctx context.Context, client ctrlClient.Client, apiReader ctrlClient.Reader, key ctrlClient.ObjectKey, obj ctrlClient.Object) error {
 	if err := client.Get(ctx, key, obj); err != nil {
 		if !apiErrors.IsNotFound(err) {
-			return errors.Wrapf(err, "checking existence of %s secret", key.Name)
+			return errors.Wrapf(err, "checking existence of %s object", key.Name)
 		}
 		return apiReader.Get(ctx, key, obj)
 	}

--- a/operator/pkg/values/translation/translation.go
+++ b/operator/pkg/values/translation/translation.go
@@ -196,7 +196,7 @@ func SetScannerDBValues(sv *ValuesBuilder, db *platform.DeploymentSpec) {
 // that the extension prevents central DB's PVC deletion on deletion of the CR.
 // Since Scanner V4's DB contains data which recovers by itself it is safe to remove the PVC
 // through the helm uninstall if a CR is deleted.
-func SetScannerV4DBValues(ctx context.Context, sv *ValuesBuilder, db *platform.ScannerV4DB, objKind string, namespace string, client ctrlClient.Client) {
+func SetScannerV4DBValues(ctx context.Context, sv *ValuesBuilder, db *platform.ScannerV4DB, objKind string, namespace string, client ctrlClient.Reader) {
 	dbVB := NewValuesBuilder()
 	persistenceVB := NewValuesBuilder()
 
@@ -265,7 +265,7 @@ func setScannerV4DBPersistence(sv *ValuesBuilder, objKind string, persistence *p
 	sv.AddChild("persistence", &persistenceVB)
 }
 
-func shouldUseEmptyDir(ctx context.Context, db *platform.ScannerV4DB, objKind string, namespace string, client ctrlClient.Client) (bool, error) {
+func shouldUseEmptyDir(ctx context.Context, db *platform.ScannerV4DB, objKind string, namespace string, client ctrlClient.Reader) (bool, error) {
 	if objKind != v1alpha1.SecuredClusterGVK.Kind {
 		return false, nil
 	}
@@ -292,7 +292,7 @@ func shouldUseEmptyDir(ctx context.Context, db *platform.ScannerV4DB, objKind st
 	return !hasSC, nil
 }
 
-func hasScannerV4DBPVC(ctx context.Context, client ctrlClient.Client, pvcName string, namespace string) (bool, error) {
+func hasScannerV4DBPVC(ctx context.Context, client ctrlClient.Reader, pvcName string, namespace string) (bool, error) {
 	lookupPvc := pvcName
 	if lookupPvc == "" {
 		lookupPvc = defaultScannerV4PVCName
@@ -314,7 +314,7 @@ func hasScannerV4DBPVC(ctx context.Context, client ctrlClient.Client, pvcName st
 
 	return false, nil
 }
-func hasDefaultStorageClass(ctx context.Context, client ctrlClient.Client) (bool, error) {
+func hasDefaultStorageClass(ctx context.Context, client ctrlClient.Reader) (bool, error) {
 	storageClassList := storagev1.StorageClassList{}
 	if err := client.List(ctx, &storageClassList); err != nil {
 		return false, fmt.Errorf("listing available StorageClasses: %w", err)


### PR DESCRIPTION
## Description

The operator consumes a lot of memory, especially in large Kubernetes clusters. There have been several customer issues where this led to OOMKilled errors, see ROX-18969 for linked tickets. Heap profiles show that all cases are related to the operator caching objects in all namespaces, especially secrets. 

This is because we don't limit the cache by namespace, label or field selectors. In all of the customer cases we had so far, caching of secrets seems to cause the majority of memory consumption. In this PR I've added a label selector to the controller-runtime cache and modified the operator code to label all created secrets accordingly.

Also some parts where we access secrets not owned by the operator had to be adjusted to use a non-cached client, because we can't control that labels required for the cache are set on those secrets.

Also in this PR:
- Label all helm created resources (for potential future cache optimization)
- Label selector for ConfigMaps, since this has potential to have similar impact as secret caching if we start watching ConfigMaps at some point later on.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ No user facing changes

If any of these don't apply, please comment below.

## Testing Performed

Tested manually that operator still picks up secrets that now have to be read by an uncached client:
- image pull secret
- proxy secret
- init bundle secrets

Did that by:
- Installing central and secured cluster with an old operator build using a manually applied image pull secret
- Running a fresh operator with `make install run`
- Making sure that operator reconciliation don't fail because of missing secrets

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
