### PR TITLE
ROX-22764: Scaling Sensor queues based on available memory

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -70,6 +70,11 @@ var (
 	// Multiple items can hold a pointer to the same object (e.g. same Deployment) so these numbers are pessimistic because we assume all items hold different objects.
 	DetectorNetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_NETWORK_FLOW_BUFFER_SIZE", 20000)
 
+	// BufferScaleCeiling sets the upper limit queue.ScaleSize will scale buffers and queues to.
+	// In its default, the ceiling is defined as triple the relative size.
+	// For example, the NetflowBufferSize will never surpass 100 * 3 = 300.
+	BufferScaleCeiling = RegisterIntegerSetting("ROX_SENSOR_BUFFER_SCALE_CEILING", 3)
+
 	// DiagnosticDataCollectionTimeout defines the timeout for the diagnostic data collection on Sensor side.
 	DiagnosticDataCollectionTimeout = registerDurationSetting("ROX_DIAGNOSTIC_DATA_COLLECTION_TIMEOUT",
 		2*time.Minute)

--- a/pkg/sensor/queue/scaler.go
+++ b/pkg/sensor/queue/scaler.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 )
@@ -16,15 +17,17 @@ var (
 
 // ScaleSize will scale the size of a given queue size based on the Sensor memory limit relative
 // to the default memory limit of 4GB. It returns the scaled queue size variable, which is at least 1.
+// On errors, the unscaled size is returned, together with an error.
 func ScaleSize(queueSize int) (int, error) {
 	if roxLimit := os.Getenv("ROX_MEMLIMIT"); roxLimit != "" {
 		l, err := strconv.ParseInt(roxLimit, 10, 64)
 		if err != nil {
 			log.Errorf("ROX_MEMLIMIT must be an integer in bytes: %v", err)
-			return -1, err
+			return queueSize, err
 		}
 		if l == 0 {
 			log.Warn("ROX_MEMLIMIT is set to 0!")
+			return queueSize, errors.New("ROX_MEMLIMIT is set to 0")
 		}
 		ratio := float64(l) / defaultMemlimit
 

--- a/pkg/sensor/queue/scaler.go
+++ b/pkg/sensor/queue/scaler.go
@@ -38,7 +38,7 @@ func ScaleSize(queueSize int) (int, error) {
 }
 
 // ScaleSizeOnNonDefault only scales the given integer setting if it is
-// set to its default value (e.g. not changed by hand).
+// set to its default value (i.e. not changed).
 func ScaleSizeOnNonDefault(setting *env.IntegerSetting) int {
 	v := setting.IntegerSetting()
 	if v != setting.DefaultValue() {

--- a/pkg/sensor/queue/scaler.go
+++ b/pkg/sensor/queue/scaler.go
@@ -49,7 +49,7 @@ func ScaleSizeOnNonDefault(setting *env.IntegerSetting) int {
 
 	scaled, err := ScaleSize(v)
 	if err != nil {
-		log.Warnf("Failed to scale setting %s. Returning its unscaled value", setting.EnvVar())
+		log.Warnf("Failed to scale setting: %s. Returning its unscaled value: %s", err, setting.EnvVar())
 		return v
 	}
 

--- a/pkg/sensor/queue/scaler.go
+++ b/pkg/sensor/queue/scaler.go
@@ -26,9 +26,7 @@ func ScaleSize(queueSize int) (int, error) {
 		if l == 0 {
 			log.Warn("ROX_MEMLIMIT is set to 0!")
 		}
-		ratio := float64(l) / defaultMemlimit // FIXME: Convert correctly
-
-		log.Warnf("Got effective memlimit of %d. Scaling queue to %.2f percent", l, ratio*100) // FIXME: Remove
+		ratio := float64(l) / defaultMemlimit
 
 		queueSize = int(math.Round(ratio * float64(queueSize)))
 		if queueSize <= 0 {
@@ -55,6 +53,6 @@ func ScaleSizeOnNonDefault(setting *env.IntegerSetting) int {
 		return v
 	}
 
-	log.Infof("Scaling %s - Default: %d, Scaled: %d", setting.EnvVar(), v, scaled)
+	log.Debugf("Scaling %s - Default: %d, Scaled: %d", setting.EnvVar(), v, scaled)
 	return scaled
 }

--- a/pkg/sensor/queue/scaler.go
+++ b/pkg/sensor/queue/scaler.go
@@ -1,0 +1,39 @@
+package queue
+
+import (
+	"math"
+	"os"
+	"strconv"
+
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log              = logging.LoggerForModule()
+	DEFAULT_MEMLIMIT = float64(4194304000)
+)
+
+// ScaleSize will scale the size of a given queue size based on the Sensor memory limit relative
+// to the default memory limit of 4GB. It returns the scaled queue size variable, which is at least 1.
+func ScaleSize(queueSize int) (int, error) {
+	if roxLimit := os.Getenv("ROX_MEMLIMIT"); roxLimit != "" {
+		l, err := strconv.ParseInt(roxLimit, 10, 64)
+		if err != nil {
+			log.Errorf("ROX_MEMLIMIT must be an integer in bytes: %v", err)
+			return -1, err
+		}
+		if l == 0 {
+			log.Warn("ROX_MEMLIMIT is set to 0!")
+		}
+		ratio := float64(l) / DEFAULT_MEMLIMIT // FIXME: Convert correctly
+
+		log.Warnf("Got effective memlimit of %d. Scaling queue to %.2f percent", l, ratio*100) // FIXME: Remove
+
+		queueSize = int(math.Round(ratio * float64(queueSize)))
+		if queueSize <= 0 {
+			// Ensure that we always have at least a queue size of 1
+			queueSize = 1
+		}
+	}
+	return queueSize, nil
+}

--- a/pkg/sensor/queue/scaler_test.go
+++ b/pkg/sensor/queue/scaler_test.go
@@ -25,7 +25,7 @@ func (s *scalerTestSuite) TestScaleSize() {
 	}{
 		"50% memlimit": {
 			inputQueueSize:    100,
-			sensorMemLimit:    2097152000,
+			sensorMemLimit:    defaultMemLimit * 0.5,
 			expectedQueueSize: 50,
 		},
 		"50% memlimit - rounding up": {

--- a/pkg/sensor/queue/scaler_test.go
+++ b/pkg/sensor/queue/scaler_test.go
@@ -1,0 +1,70 @@
+package queue
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type scalerTestSuite struct {
+	suite.Suite
+}
+
+func TestBroker(t *testing.T) {
+	suite.Run(t, &scalerTestSuite{})
+}
+
+func (s *scalerTestSuite) TestScaleSize() {
+	cases := map[string]struct {
+		inputQueueSize    int
+		SensorMemLimit    int
+		expectedQueueSize int
+	}{
+		"50% memlimit": {
+			inputQueueSize:    100,
+			SensorMemLimit:    2097152000,
+			expectedQueueSize: 50,
+		},
+		"50% memlimit - rounding up": {
+			inputQueueSize:    5,
+			SensorMemLimit:    2097152000,
+			expectedQueueSize: 3,
+		},
+		"200% memlimit": {
+			inputQueueSize:    100,
+			SensorMemLimit:    8388608000,
+			expectedQueueSize: 200,
+		},
+		"At least size 1": {
+			inputQueueSize:    100,
+			SensorMemLimit:    1,
+			expectedQueueSize: 1,
+		},
+		"At least size 1 on memlimit 0": {
+			inputQueueSize:    100,
+			SensorMemLimit:    0,
+			expectedQueueSize: 1,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			err := os.Setenv("ROX_MEMLIMIT", strconv.Itoa(c.SensorMemLimit))
+			s.NoError(err)
+
+			actual, err := ScaleSize(c.inputQueueSize)
+			s.NoError(err)
+			s.Equal(c.expectedQueueSize, actual)
+		})
+	}
+}
+
+func (s *scalerTestSuite) TestScaleSizeEnvConversion() {
+	err := os.Setenv("ROX_MEMLIMIT", "definitelyNotAnInteger")
+	s.NoError(err)
+
+	_, err = ScaleSize(100)
+	s.ErrorContains(err, "strconv.ParseInt: parsing")
+}

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/networkbaseline"
 	"github.com/stackrox/rox/pkg/protocompat"
+	queueScaler "github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
@@ -78,8 +79,8 @@ func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.Sett
 	netFlowQueueSize := 0
 	piQueueSize := 0
 	if features.SensorCapturesIntermediateEvents.Enabled() {
-		netFlowQueueSize = env.DetectorNetworkFlowBufferSize.IntegerSetting()
-		piQueueSize = env.DetectorProcessIndicatorBufferSize.IntegerSetting()
+		netFlowQueueSize = queueScaler.ScaleSizeOnNonDefault(env.DetectorNetworkFlowBufferSize)
+		piQueueSize = queueScaler.ScaleSizeOnNonDefault(env.DetectorProcessIndicatorBufferSize)
 	}
 	netFlowQueue := queue.NewQueue[*queue.FlowQueueItem](
 		detectorStopper,

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -262,16 +262,17 @@ func NewManager(
 				log.Errorf("ROX_MEMLIMIT must be an integer in bytes: %v", err)
 			}
 			defaultMemlimit := float64(4194304000)
-			ratio := defaultMemlimit / float64(l) // FIXME: Convert correctly
+			ratio := float64(l) / defaultMemlimit // FIXME: Convert correctly
 
 			log.Errorf("Got effective memlimit of %d. Scaling queues to %f percent", l, ratio*100)
 
-			nfBufferSize = int(math.Round(ratio)) // FIXME: Ensure this is always at least 1
+			nfBufferSize = int(math.Round(ratio * float64(nfBufferSize))) // FIXME: Ensure this is always at least 1
 		}
 
 	}
 
 	if features.SensorCapturesIntermediateEvents.Enabled() {
+		log.Infof("Scaling netflow buffer. Default: %i, Scaled: %i", env.NetworkFlowBufferSize.IntegerSetting(), nfBufferSize)
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage, nfBufferSize)
 	} else {
 		enricherTicker.Stop()

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -250,18 +250,8 @@ func NewManager(
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicator),
 	}
 
-	nfBufferSize := env.NetworkFlowBufferSize.IntegerSetting()
-	if nfBufferSize == env.NetworkFlowBufferSize.DefaultValue() {
-		// Only apply autoscaling if this var is not overridden
-		scaledBuffer, err := queue.ScaleSize(nfBufferSize)
-		if err == nil {
-			nfBufferSize = scaledBuffer
-		}
-	}
-
 	if features.SensorCapturesIntermediateEvents.Enabled() {
-		log.Infof("Scaling netflow buffer. Default: %i, Scaled: %i", env.NetworkFlowBufferSize.IntegerSetting(), nfBufferSize)
-		mgr.sensorUpdates = make(chan *message.ExpiringMessage, nfBufferSize)
+		mgr.sensorUpdates = make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.NetworkFlowBufferSize))
 	} else {
 		enricherTicker.Stop()
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage)

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/sensor/common/centralclient"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/fake"
@@ -38,7 +39,7 @@ func ConfigWithDefaults() *CreateOptions {
 		k8sClient:                          nil,
 		localSensor:                        false,
 		traceWriter:                        nil,
-		eventPipelineQueueSize:             env.EventPipelineQueueSize.IntegerSetting(),
+		eventPipelineQueueSize:             queue.ScaleSizeOnNonDefault(env.EventPipelineQueueSize),
 		networkFlowServiceAuthFuncOverride: nil,
 		signalServiceAuthFuncOverride:      nil,
 		networkFlowWriter:                  nil,

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/namespaces"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/satoken"
+	"github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
 	"github.com/stackrox/rox/sensor/common/certdistribution"
@@ -125,7 +126,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
 
 	// Create Process Pipeline
-	indicators := make(chan *message.ExpiringMessage, env.ProcessIndicatorBufferSize.IntegerSetting())
+	indicators := make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.ProcessIndicatorBufferSize))
 	processPipeline := processsignal.NewProcessPipeline(indicators, storeProvider.Entities(), processfilter.Singleton(), policyDetector)
 	var processSignals signalService.Service
 	if cfg.signalServiceAuthFuncOverride != nil && cfg.localSensor {


### PR DESCRIPTION
## Description

The default values for Sensor queues and buffers are roughly based on expected 4GB of memory limit at runtime.
If we have more (or less) memory available, Sensor now tweaks the queue and buffer sizes relatively.
This means that we halve the queue sizes at 2GB and double them at 8GB.
The introduced scaling function will only scale each queue/buffer size, if it wasn't changed from its default value.


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Introduced unit tests plus manual testing.
The manual testing was concluded by deploying to a cluster, enabling debug logs and looking for correct scaling operations.
The deployment shown was locally to Minikube, with 500MB memory (12.5% of default 4GB):
```
pkg/sensor/queue: 2024/03/13 13:41:13.748213 scaler.go:56: Info: Scaling ROX_EVENT_PIPELINE_QUEUE_SIZE - Default: 1000, Scaled: 125                                                                                  
pkg/sensor/queue: 2024/03/13 13:41:13.794766 scaler.go:56: Info: Scaling ROX_SENSOR_DETECTOR_NETWORK_FLOW_BUFFER_SIZE - Default: 20000, Scaled: 2500                                                                 
pkg/sensor/queue: 2024/03/13 13:41:13.794777 scaler.go:56: Info: Scaling ROX_SENSOR_DETECTOR_PROCESS_INDICATOR_BUFFER_SIZE - Default: 20000, Scaled: 2500                                                            
pkg/sensor/queue: 2024/03/13 13:41:13.795636 scaler.go:56: Info: Scaling ROX_SENSOR_PROCESS_INDICATOR_BUFFER_SIZE - Default: 50000, Scaled: 6250                                                                     
pkg/sensor/queue: 2024/03/13 13:41:13.795667 scaler.go:56: Info: Scaling ROX_SENSOR_NETFLOW_OFFLINE_BUFFER_SIZE - Default: 100, Scaled: 13                                                                           
pkg/sensor/queue: 2024/03/13 13:41:13.795674 scaler.go:56: Info: Scaling ROX_SENSOR_DEPLOYMENT_ENHANCEMENT_QUEUE_SIZE - Default: 50, Scaled: 6 
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
