### PR TITLE
ROX-22101: move pgutils.NilOrTime logic to protocompat

### DIFF
--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -54,15 +54,7 @@ func ConvertEnumSliceToIntArray[T ~int32](enumSlice []T) []int32 {
 
 // NilOrTime allows for a proto timestamp to be stored a timestamp type in Postgres
 func NilOrTime(t *types.Timestamp) *time.Time {
-	if t == nil {
-		return nil
-	}
-	ts, err := protocompat.ConvertTimestampToTimeOrError(t)
-	if err != nil {
-		return nil
-	}
-	ts = ts.Round(time.Microsecond)
-	return &ts
+	return protocompat.NilOrTime(t)
 }
 
 // NilOrNow allows for a proto timestamp to be stored a timestamp type in Postgres

--- a/pkg/protocompat/time.go
+++ b/pkg/protocompat/time.go
@@ -45,6 +45,19 @@ func GetProtoTimestampZero() *gogoTimestamp.Timestamp {
 	return &gogoTimestamp.Timestamp{}
 }
 
+// NilOrTime allows for a proto timestamp to be stored a timestamp type in Postgres
+func NilOrTime(t *gogoTimestamp.Timestamp) *time.Time {
+	if t == nil {
+		return nil
+	}
+	ts, err := ConvertTimestampToTimeOrError(t)
+	if err != nil {
+		return nil
+	}
+	ts = ts.Round(time.Microsecond)
+	return &ts
+}
+
 // CompareTimestamps compares two timestamps and returns zero if equal, a negative value if
 // the first timestamp is before the second or a positive value if the first timestamp is
 // after the second.


### PR DESCRIPTION
## Description

The goal is to remove direct calls to the gogo protobuf layer and have all of them happen through an abstraction layer in order to ease the migration to a new protobuf library.

This PR moves the timestamp conversion logic from the `pgutils` package to the `protocompat` one.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
