### PR TITLE
ROX-19523: Set `features.operators.openshift.io` annotations

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -17,6 +17,13 @@ metadata:
     createdAt: ''
     description: Red Hat Advanced Cluster Security (RHACS) operator provisions the
       services necessary to secure each of your OpenShift and Kubernetes clusters.
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'true'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -9,6 +9,13 @@ metadata:
     createdAt: "1999-12-31T23:59:59Z"
     description: Red Hat Advanced Cluster Security (RHACS) operator provisions the
       services necessary to secure each of your OpenShift and Kubernetes clusters.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat


### PR DESCRIPTION
## Description

These are needed because CVP tests fail without these labels.
Example: http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/rhacs-operator-bundle-container-4.4.0-9/57bac96c-1a9a-45b9-aad9-af94adcef146/operator-infrastructure-feature-bundle-image-output.txt

Documentation https://docs.openshift.com/container-platform/4.15/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs

Context threads:
- https://redhat-internal.slack.com/archives/C06K8MT821Y/p1710150581879999
- https://redhat-internal.slack.com/archives/C02HTD51SMD/p1693403960061209

## Checklist
- [x] Investigated and inspected CI test results

None of the following will be done.
- [ ] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~ - I don't think it's worth documenting since we had former `operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'` and new labels communicate the same.
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

I don't know how to check this but @daynewlee will find out whether CVP likes these labels. Unfortunately that'll happen after the PR is merged.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
