### PR TITLE
ROX-20291: Move FE sorting of Policies table to avoid re-render

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -82,12 +82,23 @@ describe('Policies table', () => {
         // 0. Initial table state is sorted by the Policy column.
         cy.get(thSelector).should('have.attr', 'aria-sort', 'none');
 
-        // 1. Sort ascending by the Severity column.
+        // 1. Sort descending by the Severity column.
         cy.get(thSelector).click();
-        // TODO Move sort order from invisible page state to visible query parameters in page address.
-        /*
-        cy.location('search').should('eq', '?sort[id]=Severity&sort[desc]=false');
-        */
+        cy.location('search').should(
+            'eq',
+            '?sortOption[field]=Severity&sortOption[direction]=desc'
+        );
+
+        cy.wait(1000);
+
+        cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
+        cy.get(tdSelector).then((items) => {
+            assertSortedItems(items, callbackForPairOfDescendingPolicySeverityValuesFromElements);
+        });
+
+        // 2. Sort ascending by the Severity column.
+        cy.get(thSelector).click();
+        cy.location('search').should('eq', '?sortOption[field]=Severity&sortOption[direction]=asc');
 
         // There is no request because front-end sorting.
         cy.wait(1000);
@@ -97,32 +108,14 @@ describe('Policies table', () => {
             assertSortedItems(items, callbackForPairOfAscendingPolicySeverityValuesFromElements);
         });
 
-        // 2. Sort descending by the Severity column.
+        // 3. Sort descending by the Severity column.
         cy.get(thSelector).click();
-        // TODO Move sort order from invisible page state to visible query parameters in page address.
-        /*
         cy.location('search').should(
             'eq',
-            '?sort[id]=Severity&sort[desc]=true'
+            '?sortOption[field]=Severity&sortOption[direction]=desc'
         );
-        */
-
-        // There is no request because front-end sorting.
-        cy.wait(1000);
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
-        cy.get(tdSelector).then((items) => {
-            assertSortedItems(items, callbackForPairOfDescendingPolicySeverityValuesFromElements);
-        });
-
-        // 3. Sort ascending by the Severity column.
-        cy.get(thSelector).click();
-        // TODO Move sort order from invisible page state to visible query parameters in page address.
-        /*
-        cy.location('search').should('eq', '?sort[id]=Severity&sort[desc]=false');
-        */
-
-        cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
     });
 
     it('should have expected status values', () => {

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -25,11 +25,9 @@ import {
     ExpandableRowContent,
 } from '@patternfly/react-table';
 import { CaretDownIcon } from '@patternfly/react-icons';
-import orderBy from 'lodash/orderBy';
 import pluralize from 'pluralize';
 
 import { ListPolicy } from 'types/policy.proto';
-import { sortSeverity, sortAsciiCaseInsensitive, sortValueByLength } from 'sorters/sorters';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import PolicyDisabledIconText from 'Components/PatternFly/IconText/PolicyDisabledIconText';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
@@ -42,11 +40,11 @@ import EnableDisableNotificationModal, {
 import useTableSelection from 'hooks/useTableSelection';
 import useSet from 'hooks/useSet';
 import { AlertVariantType } from 'hooks/patternfly/useToasts';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { policiesBasePath } from 'routePaths';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { SearchFilter } from 'types/search';
-import { SortDirection } from 'types/table';
-
+import { columns, defaultPolicyLabel, userPolicyLabel } from './PoliciesTable.utils';
 import {
     LabelAndNotifierIdsForType,
     formatLifecycleStages,
@@ -55,48 +53,6 @@ import {
 } from '../policies.utils';
 
 import './PoliciesTable.css';
-
-const columns = [
-    {
-        Header: 'Policy',
-        accessor: 'name',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => sortAsciiCaseInsensitive(a.name, b.name),
-        width: 30 as const,
-    },
-    {
-        Header: 'Status',
-        accessor: 'disabled',
-    },
-    {
-        Header: 'Origin',
-        accessor: 'isDefault',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => sortPolicyOrigin(a.isDefault, b.isDefault),
-    },
-    {
-        Header: 'Notifiers',
-        accessor: 'notifiers',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => sortValueByLength(a.notifiers, b.notifiers),
-    },
-    {
-        Header: 'Severity',
-        accessor: 'severity',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => -sortSeverity(a.severity, b.severity),
-    },
-    {
-        Header: 'Lifecycle',
-        accessor: 'lifecycleStages',
-    },
-];
-
-const defaultPolicyLabel = 'System';
-const userPolicyLabel = 'User';
-
-function sortPolicyOrigin(a, b) {
-    const aOrigin = a ? defaultPolicyLabel : userPolicyLabel;
-    const bOrigin = b ? defaultPolicyLabel : userPolicyLabel;
-
-    return sortAsciiCaseInsensitive(aOrigin, bOrigin);
-}
 
 type PoliciesTableProps = {
     notifiers: NotifierIntegration[];
@@ -110,6 +66,7 @@ type PoliciesTableProps = {
     disablePoliciesHandler: (ids) => void;
     handleChangeSearchFilter: (searchFilter: SearchFilter) => void;
     onClickReassessPolicies: () => void;
+    getSortParams: UseURLSortResult['getSortParams'];
     searchFilter?: SearchFilter;
     searchOptions: string[];
 };
@@ -126,6 +83,7 @@ function PoliciesTable({
     disablePoliciesHandler,
     handleChangeSearchFilter,
     onClickReassessPolicies,
+    getSortParams,
     searchFilter,
     searchOptions,
 }: PoliciesTableProps): React.ReactElement {
@@ -141,13 +99,10 @@ function PoliciesTable({
     const [enableDisableType, setEnableDisableType] = useState<EnableDisableType | null>(null);
 
     // index of the currently active column
-    const [activeSortIndex, setActiveSortIndex] = useState(0);
     // sort direction of the currently active column
-    const [activeSortDirection, setActiveSortDirection] = useState<SortDirection>('asc');
     // Handle Bulk Actions dropdown state.
     const [isActionsOpen, setIsActionsOpen] = useState(false);
     // For sorting data client side
-    const [rows, setRows] = useState<ListPolicy[]>([]);
 
     useEffect(() => {
         setLabelAndNotifierIdsForTypes(getLabelAndNotifierIdsForTypes(notifiers));
@@ -179,11 +134,6 @@ function PoliciesTable({
         setIsActionsOpen(false);
     }
 
-    function onSort(e, index, direction) {
-        setActiveSortIndex(index);
-        setActiveSortDirection(direction);
-    }
-
     function onEditPolicy(id: string) {
         history.push({
             pathname: `${policiesBasePath}/${id}`,
@@ -213,21 +163,6 @@ function PoliciesTable({
             numDeletable += 1;
         }
     });
-
-    // If we use server side page management, this becomes unnecessary
-    useEffect(() => {
-        const { sortMethod, accessor } = columns[activeSortIndex];
-        let sortedPolicies = [...policies];
-        if (sortMethod) {
-            sortedPolicies.sort(sortMethod);
-            if (activeSortDirection === 'desc') {
-                sortedPolicies.reverse();
-            }
-        } else {
-            sortedPolicies = orderBy(sortedPolicies, [accessor], [activeSortDirection]);
-        }
-        setRows(sortedPolicies);
-    }, [policies, activeSortIndex, activeSortDirection]);
 
     function onConfirmDeletePolicy() {
         setIsDeleting(true);
@@ -364,9 +299,9 @@ function PoliciesTable({
                             <Pagination
                                 isCompact
                                 isDisabled
-                                itemCount={rows.length}
+                                itemCount={policies.length}
                                 page={1}
-                                perPage={rows.length}
+                                perPage={policies.length}
                             />
                         </ToolbarItem>
                     </ToolbarContent>
@@ -385,19 +320,24 @@ function PoliciesTable({
                                     isSelected: allRowsSelected,
                                 }}
                             />
-                            {columns.map(({ Header, width }, columnIndex) => {
-                                const sortParams = {
-                                    sort: {
-                                        sortBy: {
-                                            index: activeSortIndex,
-                                            direction: activeSortDirection,
-                                        },
-                                        onSort,
-                                        columnIndex,
-                                    },
-                                };
+                            {columns.map(({ Header, width }) => {
+                                // const sortParams = {
+                                //     sort: {
+                                //         sortBy: {
+                                //             index: activeSortIndex,
+                                //             direction: activeSortDirection,
+                                //         },
+                                //         onSort,
+                                //         columnIndex,
+                                //     },
+                                // };
                                 return (
-                                    <Th key={Header} modifier="wrap" width={width} {...sortParams}>
+                                    <Th
+                                        key={Header}
+                                        modifier="wrap"
+                                        width={width}
+                                        sort={getSortParams(Header)}
+                                    >
                                         {Header}
                                     </Th>
                                 );
@@ -405,7 +345,7 @@ function PoliciesTable({
                             <Td />
                         </Tr>
                     </Thead>
-                    {rows.map((policy) => {
+                    {policies.map((policy) => {
                         const {
                             description,
                             disabled,

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -98,8 +98,6 @@ function PoliciesTable({
 
     const [enableDisableType, setEnableDisableType] = useState<EnableDisableType | null>(null);
 
-    // index of the currently active column
-    // sort direction of the currently active column
     // Handle Bulk Actions dropdown state.
     const [isActionsOpen, setIsActionsOpen] = useState(false);
     // For sorting data client side

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -1,0 +1,44 @@
+import { sortSeverity, sortAsciiCaseInsensitive, sortValueByLength } from 'sorters/sorters';
+import { ListPolicy } from 'types/policy.proto';
+
+export const defaultPolicyLabel = 'System';
+export const userPolicyLabel = 'User';
+
+function sortPolicyOrigin(a, b) {
+    const aOrigin = a ? defaultPolicyLabel : userPolicyLabel;
+    const bOrigin = b ? defaultPolicyLabel : userPolicyLabel;
+
+    return sortAsciiCaseInsensitive(aOrigin, bOrigin);
+}
+
+export const columns = [
+    {
+        Header: 'Policy',
+        accessor: 'name',
+        sortMethod: (a: ListPolicy, b: ListPolicy) => sortAsciiCaseInsensitive(a.name, b.name),
+        width: 30 as const,
+    },
+    {
+        Header: 'Status',
+        accessor: 'disabled',
+    },
+    {
+        Header: 'Origin',
+        accessor: 'isDefault',
+        sortMethod: (a: ListPolicy, b: ListPolicy) => sortPolicyOrigin(a.isDefault, b.isDefault),
+    },
+    {
+        Header: 'Notifiers',
+        accessor: 'notifiers',
+        sortMethod: (a: ListPolicy, b: ListPolicy) => sortValueByLength(a.notifiers, b.notifiers),
+    },
+    {
+        Header: 'Severity',
+        accessor: 'severity',
+        sortMethod: (a: ListPolicy, b: ListPolicy) => -sortSeverity(a.severity, b.severity),
+    },
+    {
+        Header: 'Lifecycle',
+        accessor: 'lifecycleStages',
+    },
+];

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -28,7 +28,7 @@ import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService'
 import { getSearchOptionsForCategory } from 'services/SearchService';
 import { ListPolicy } from 'types/policy.proto';
 import { NotifierIntegration } from 'types/notifier.proto';
-import { SearchFilter } from 'types/search';
+import { ApiSortOption, SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
@@ -88,7 +88,7 @@ function PoliciesTablePage({
             });
     }
 
-    function fetchPolicies(query: string) {
+    function fetchPolicies(query: string, sortOption: ApiSortOption) {
         setIsLoading(true);
         getPolicies(query)
             .then((data) => {
@@ -121,7 +121,7 @@ function PoliciesTablePage({
         const policyText = pluralize('policy', ids.length);
         return deletePolicies(ids)
             .then(() => {
-                fetchPolicies(query);
+                fetchPolicies(query, sortOption);
                 addToast(`Successfully deleted ${policyText}`, 'success');
             })
             .catch(({ response }) => {
@@ -148,7 +148,7 @@ function PoliciesTablePage({
         const policyText = pluralize('policy', ids.length);
         updatePoliciesDisabledState(ids, false)
             .then(() => {
-                fetchPolicies(query);
+                fetchPolicies(query, sortOption);
                 addToast(`Successfully enabled ${policyText}`, 'success');
             })
             .catch(({ response }) => {
@@ -160,7 +160,7 @@ function PoliciesTablePage({
         const policyText = pluralize('policy', ids.length);
         updatePoliciesDisabledState(ids, true)
             .then(() => {
-                fetchPolicies(query);
+                fetchPolicies(query, sortOption);
                 addToast(`Successfully disabled ${policyText}`, 'success');
             })
             .catch(({ response }) => {
@@ -192,8 +192,7 @@ function PoliciesTablePage({
     }, []);
 
     useEffect(() => {
-        fetchPolicies(query);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        fetchPolicies(query, sortOption);
     }, [query, sortOption]);
 
     let pageContent = (
@@ -219,7 +218,7 @@ function PoliciesTablePage({
             <PoliciesTable
                 notifiers={notifiers}
                 policies={policies}
-                fetchPoliciesHandler={() => fetchPolicies(query)}
+                fetchPoliciesHandler={() => fetchPolicies(query, sortOption)}
                 addToast={addToast}
                 hasWriteAccessForPolicy={hasWriteAccessForPolicy}
                 deletePoliciesHandler={deletePoliciesHandler}
@@ -263,7 +262,7 @@ function PoliciesTablePage({
                 cancelModal={() => {
                     setIsImportModalOpen(false);
                 }}
-                fetchPoliciesWithQuery={() => fetchPolicies(query)}
+                fetchPoliciesWithQuery={() => fetchPolicies(query, sortOption)}
             />
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }: Toast) => (


### PR DESCRIPTION
## Description

This PR refactors the client-side sorting on the Policies table, by moving it up from the `PoliciesTable.tsx` component file, up to its parent `PoliciesTablePage.tsx` component. This is done to prevent the layout shift that occurs when the table was being rendered with an empty array, and then fed an unsorted API response, and then immediately re-rendered with the sorted list, which was sorted in a useEffect block. The initial render did not have wide empty header for the turndown triangle column--PatternFly did not render that header if there were no rows--and the subsequent layout shift was causing frequent "element is animating" failures in CI.

I decided move the sorting up into the promise-resolved block for the `/policies` API call in the parent, because that API call gets refreshed on Import, as well as Deletion and Reassess All functions. I could have attempted a more radical refactoring to move the API call down, but this seemed like a safer, easier-to-review option.

After the Policies API is paginated in the API--which should come soon--we can use start passing the URL sort parameters that I have added here directly to the API call. That's why I decided to take the performance hit of making the API call for every change in sort, because it will make moving to backend sorting easier. 


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

1. Inspect existing CI
2. Manual testing of each column sorted in each direction

Default with no sort specified in URL, sorts on Policy (name) column ascending (note the API response is not sort--sorting still happens on FE)
![policies_with_no_sort_specified-uses_default_sort](https://github.com/stackrox/stackrox/assets/715729/eeb06e95-76ab-4fb3-a35a-0480d1f89292)

Clicking on Policy column header adds sort parameters to the URL and reverses the sort on Policy column
![policies_with_Policy_column_reversed](https://github.com/stackrox/stackrox/assets/715729/e7ca6e75-4719-480a-9f5b-dfe0e5512793)

Clicking on Status column header sorts that column ascending
![policies_with_Status_column_asc](https://github.com/stackrox/stackrox/assets/715729/4ff1178a-070a-41c7-9f17-42a4bf1e470f)

Clicking on Status column header again reverses its sort
![policies_with_Status_column_reversed](https://github.com/stackrox/stackrox/assets/715729/6a4c44a8-3789-4afd-b193-5208b7c88e95)


Clicking on Origin column header sorts that column ascending
![policies_with_Origin_column_asc](https://github.com/stackrox/stackrox/assets/715729/347ac3ad-9b5a-45df-8987-45204fc8cf89)

Clicking on Origin column header again reverses its sort
![policies_with_Origin_column_reversed](https://github.com/stackrox/stackrox/assets/715729/ed1518ae-e94d-4e8b-9c09-6ae6dffb34c1)


Clicking on Notifiers column header sorts that column ascending
![policies_with_Notifiers_column_asc](https://github.com/stackrox/stackrox/assets/715729/5cc3771b-d0c0-4afb-ba4e-b8ad433f01d5)

Clicking on Notifiers column header again reverses its sort
![policies_with_Notifiers_column_reversed](https://github.com/stackrox/stackrox/assets/715729/b3852a1a-2a3b-40b5-a288-e2eaa8604511)


Clicking on Severity column header sorts that column ascending
![policies_with_Severity_column_reversed](https://github.com/stackrox/stackrox/assets/715729/3de23658-0fed-4168-ab81-1c855709945d)

(note: I don't show clicking on Severity column header again to reverse it, but it works--it's just not an interesting use case, and I'm testing if the reviewer is paying attention :) )


Clicking on Lifecycle column header sorts that column ascending
![policies_with_Lifecycle_column_asc](https://github.com/stackrox/stackrox/assets/715729/6ec02343-80fd-4841-9dcc-2852add98aea)

Clicking on Lifecycle column header again reverses its sort
![policies_with_Lifecycle_column_reversed](https://github.com/stackrox/stackrox/assets/715729/d2dd71a4-299d-422d-95f6-4338d68e149d)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
