### PR TITLE
ROX-20036: migrate google scanner integration test images

### DIFF
--- a/pkg/registries/google/google_integration_test.go
+++ b/pkg/registries/google/google_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const project = "ultra-current-825"
+const project = "acs-san-stackroxci"
 
 func TestGoogle(t *testing.T) {
 	if os.Getenv("SERVICE_ACCOUNT") == "" {
@@ -38,5 +38,5 @@ func TestGoogle(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Len(t, metadata.LayerShas, 14)
+	assert.Len(t, metadata.LayerShas, 10)
 }

--- a/pkg/registries/google/google_test.go
+++ b/pkg/registries/google/google_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGoogleMatch(t *testing.T) {
-	// Registry integrated is for us.gcr.io and ultra-current-825
+	// Registry integrated is for us.gcr.io and acs-san-stackroxci
 	cases := []struct {
 		name    *storage.ImageName
 		matches bool
@@ -26,23 +26,23 @@ func TestGoogleMatch(t *testing.T) {
 		{
 			name: &storage.ImageName{
 				Registry: "gcr.io",
-				Remote:   "ultra-current-825/nginx",
+				Remote:   "acs-san-stackroxci/nginx",
 			},
 			matches: false, // does not match gcr.io, matches us.gcr.io
 		},
 		{
 			name: &storage.ImageName{
 				Registry: "us.gcr.io",
-				Remote:   "ultra-current-825/nginx",
+				Remote:   "acs-san-stackroxci/nginx",
 			},
-			matches: true, // matches both us.gcr.io and ultra-current-825
+			matches: true, // matches both us.gcr.io and acs-san-stackroxci
 		},
 		{
 			name: &storage.ImageName{
 				Registry: "us.gcr.io",
-				Remote:   "ultra-current-825/nginx/another",
+				Remote:   "acs-san-stackroxci/nginx/another",
 			},
-			matches: true, // matches both us.gcr.io and ultra-current-825
+			matches: true, // matches both us.gcr.io and acs-san-stackroxci
 		},
 		{
 			name: &storage.ImageName{
@@ -60,7 +60,7 @@ func TestGoogleMatch(t *testing.T) {
 
 	gr := &googleRegistry{
 		Registry: reg,
-		project:  "ultra-current-825",
+		project:  "acs-san-stackroxci",
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s/%s", c.name.GetRegistry(), c.name.GetRemote()), func(t *testing.T) {

--- a/pkg/scanners/google/google_integration_test.go
+++ b/pkg/scanners/google/google_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const project = "ultra-current-825"
+const project = "acs-san-stackroxci"
 
 func TestGoogle(t *testing.T) {
 	serviceAccount := os.Getenv("SERVICE_ACCOUNT")
@@ -34,16 +34,16 @@ func TestGoogle(t *testing.T) {
 
 	_, creator := google.Creator()
 
-	registry, err := creator(integration, nil)
+	registry, err := creator(integration)
 	require.NoError(t, err)
 
 	scanner, err := newScanner(integration)
 	require.NoError(t, err)
 
 	var images = []string{
-		"us.gcr.io/ultra-current-825/music-nginx:latest",
-		"us.gcr.io/ultra-current-825/nginx:slim",
-		"us.gcr.io/ultra-current-825/ubuntu:latest",
+		"us.gcr.io/acs-san-stackroxci/music-nginx:latest",
+		"us.gcr.io/acs-san-stackroxci/nginx:slim",
+		"us.gcr.io/acs-san-stackroxci/ubuntu:latest",
 	}
 
 	for _, i := range images {


### PR DESCRIPTION
## Description

Migrates the GCR images from the deprecated `ultra-current-825` GCP project to `acs-san-stackroxci`, which is part of the redhat.com GCP organization. A service account with suitable permissions is `stackrox-ci-qa-gcr-tests@acs-san-stackroxci.iam.gserviceaccount.com`.

Note that these tests are currently skipped in our CI pipeline. We should reevaluate the need for the tests and either re-enable them or delete them. That is outside the scope of this PR however.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

`gotest -v ./... -tags=integration`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
