### PR TITLE
chore: set owners for roxctl netpol

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@ tests/performance           @stackrox/merlin
 /ui/**/* @stackrox/ui
 
 pkg/images/defaults/**/*    @stackrox/maple
+roxctl/netpol/**/*          @stackrox/maple
 sensor/**/*                 @stackrox/maple
 
 operator/**/* @stackrox/draco


### PR DESCRIPTION
## Description

Let's add codeowners for netpoll part of roxctl.
