### PR TITLE
chore(qa): do not use deprecated create

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -88,6 +88,7 @@ import io.fabric8.kubernetes.client.dsl.Deletable
 import io.fabric8.kubernetes.client.dsl.ExecListener
 import io.fabric8.kubernetes.client.dsl.ExecWatch
 import io.fabric8.kubernetes.client.dsl.MixedOperation
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation
 import io.fabric8.kubernetes.client.dsl.Resource
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource
 import io.fabric8.kubernetes.client.dsl.ScalableResource
@@ -158,7 +159,7 @@ class Kubernetes implements OrchestratorMain {
     def ensureNamespaceExists(String ns) {
         Namespace namespace = newNamespace(ns)
         try {
-            client.namespaces().create(namespace)
+            client.resource(namespace).create()
             log.info "Created namespace ${ns}"
             defaultPspForNamespace(ns)
             provisionDefaultServiceAccount(ns)
@@ -447,7 +448,8 @@ class Kubernetes implements OrchestratorMain {
     def createOrchestratorDeployment(K8sDeployment dep) {
         dep.setApiVersion("")
         dep.metadata.setResourceVersion("")
-        return this.deployments.inNamespace(dep.metadata.namespace).create(dep)
+
+        return client.resource(dep).create()
     }
 
     K8sDeployment getOrchestratorDeployment(String ns, String name) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -71,7 +71,7 @@ class OpenShift extends Kubernetes {
                     setAllowedCapabilities(["*"])
                     setAllowedUnsafeSysctls(["*"])
                 }
-                oClient.securityContextConstraints().createOrReplace(anyuid)
+                oClient.resource(anyuid).serverSideApply()
             }
         } catch (Exception e) {
             log.warn("could not check if namespace exists", e)
@@ -98,7 +98,7 @@ class OpenShift extends Kubernetes {
         withRetry(2, 3) {
             Route route = new RouteBuilder().withNewMetadata().withName(routeName).endMetadata()
                     .withNewSpec().withNewTo().withName(routeName).endTo().endSpec().build()
-            oClient.routes().inNamespace(namespace).createOrReplace(route)
+            oClient.resource(route).serverSideApply()
         }
     }
 
@@ -107,7 +107,7 @@ class OpenShift extends Kubernetes {
         log.debug "Deleting a route: " + routeName
         withRetry(2, 3) {
             Route route = new RouteBuilder().withNewMetadata().withName(routeName).endMetadata().build()
-            oClient.routes().inNamespace(namespace).delete(route)
+            oClient.resource(route).delete()
         }
     }
 


### PR DESCRIPTION
## Description

From source
```java
  /**
   * Creates an item
   *
   * @see CreateOrReplaceable#create()
   *
   * @param item to create
   * @return the item from the api server
   * @deprecated use resource(item).create()
   */
  @Deprecated
  T create(T item);
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
