### PR TITLE
ROX-22868: Fix race condition allowing multiple vuln reqs with same CVEs

### DIFF
--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -109,10 +109,12 @@ func insertIntoVulnerabilityRequests(batch *pgx.Batch, obj *storage.Vulnerabilit
 		pgutils.NilOrTime(obj.GetDeferralReq().GetExpiry().GetExpiresOn()),
 		obj.GetDeferralReq().GetExpiry().GetExpiryType(),
 		obj.GetCves().GetCves(),
+		obj.GetDeferralUpdate().GetCVEs(),
+		obj.GetFalsePositiveUpdate().GetCVEs(),
 		serialized,
 	}
 
-	finalStr := "INSERT INTO vulnerability_requests (Id, Name, TargetState, Status, Expired, Requestor_Name, CreatedAt, LastUpdated, Scope_ImageScope_Registry, Scope_ImageScope_Remote, Scope_ImageScope_Tag, RequesterV2_Id, RequesterV2_Name, DeferralReq_Expiry_ExpiresWhenFixed, DeferralReq_Expiry_ExpiresOn, DeferralReq_Expiry_ExpiryType, Cves_Cves, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name = EXCLUDED.Name, TargetState = EXCLUDED.TargetState, Status = EXCLUDED.Status, Expired = EXCLUDED.Expired, Requestor_Name = EXCLUDED.Requestor_Name, CreatedAt = EXCLUDED.CreatedAt, LastUpdated = EXCLUDED.LastUpdated, Scope_ImageScope_Registry = EXCLUDED.Scope_ImageScope_Registry, Scope_ImageScope_Remote = EXCLUDED.Scope_ImageScope_Remote, Scope_ImageScope_Tag = EXCLUDED.Scope_ImageScope_Tag, RequesterV2_Id = EXCLUDED.RequesterV2_Id, RequesterV2_Name = EXCLUDED.RequesterV2_Name, DeferralReq_Expiry_ExpiresWhenFixed = EXCLUDED.DeferralReq_Expiry_ExpiresWhenFixed, DeferralReq_Expiry_ExpiresOn = EXCLUDED.DeferralReq_Expiry_ExpiresOn, DeferralReq_Expiry_ExpiryType = EXCLUDED.DeferralReq_Expiry_ExpiryType, Cves_Cves = EXCLUDED.Cves_Cves, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO vulnerability_requests (Id, Name, TargetState, Status, Expired, Requestor_Name, CreatedAt, LastUpdated, Scope_ImageScope_Registry, Scope_ImageScope_Remote, Scope_ImageScope_Tag, RequesterV2_Id, RequesterV2_Name, DeferralReq_Expiry_ExpiresWhenFixed, DeferralReq_Expiry_ExpiresOn, DeferralReq_Expiry_ExpiryType, Cves_Cves, DeferralUpdate_CVEs, FalsePositiveUpdate_CVEs, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name = EXCLUDED.Name, TargetState = EXCLUDED.TargetState, Status = EXCLUDED.Status, Expired = EXCLUDED.Expired, Requestor_Name = EXCLUDED.Requestor_Name, CreatedAt = EXCLUDED.CreatedAt, LastUpdated = EXCLUDED.LastUpdated, Scope_ImageScope_Registry = EXCLUDED.Scope_ImageScope_Registry, Scope_ImageScope_Remote = EXCLUDED.Scope_ImageScope_Remote, Scope_ImageScope_Tag = EXCLUDED.Scope_ImageScope_Tag, RequesterV2_Id = EXCLUDED.RequesterV2_Id, RequesterV2_Name = EXCLUDED.RequesterV2_Name, DeferralReq_Expiry_ExpiresWhenFixed = EXCLUDED.DeferralReq_Expiry_ExpiresWhenFixed, DeferralReq_Expiry_ExpiresOn = EXCLUDED.DeferralReq_Expiry_ExpiresOn, DeferralReq_Expiry_ExpiryType = EXCLUDED.DeferralReq_Expiry_ExpiryType, Cves_Cves = EXCLUDED.Cves_Cves, DeferralUpdate_CVEs = EXCLUDED.DeferralUpdate_CVEs, FalsePositiveUpdate_CVEs = EXCLUDED.FalsePositiveUpdate_CVEs, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	var query string
@@ -221,6 +223,8 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 		"deferralreq_expiry_expireson",
 		"deferralreq_expiry_expirytype",
 		"cves_cves",
+		"deferralupdate_cves",
+		"falsepositiveupdate_cves",
 		"serialized",
 	}
 
@@ -253,6 +257,8 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			pgutils.NilOrTime(obj.GetDeferralReq().GetExpiry().GetExpiresOn()),
 			obj.GetDeferralReq().GetExpiry().GetExpiryType(),
 			obj.GetCves().GetCves(),
+			obj.GetDeferralUpdate().GetCVEs(),
+			obj.GetFalsePositiveUpdate().GetCVEs(),
 			serialized,
 		})
 

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -140,29 +140,47 @@ func (m *managerImpl) Approve(ctx context.Context, id string, reqParams *common.
 		return nil, errors.Wrap(errox.InvalidArgs, "comment must be provided")
 	}
 
-	// Process one request at a time since there could be a race with vulnerability request creation.
+	// Process one request at a time since there could be a race with vulnerability request creation or another request approval.
 	//
 	// Once the request is approved, it is enforced. Thus, the vulnerability request creation may validate against a
 	// system state prior to this approval and may upsert after this approval.
-	req, err := m.updateRequestStatus(ctx, id, reqParams.Comment, storage.RequestStatus_APPROVED)
+	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
+		return nil, errors.Wrapf(err, "approving vulnerability request %s", id)
+	}
+	defer m.upsertSem.Release(1)
+	req, err := m.vulnReqs.UpdateRequestStatus(ctx, id, reqParams.Comment, storage.RequestStatus_APPROVED)
 	if err != nil {
 		return nil, errors.Wrapf(err, "approving vulnerability request %s", id)
 	}
 
 	// Find and invalidate the pending requests covering the same CVEs and scope.
-	existingReqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetPendingRequestsV1Query(req.GetCves().GetCves()...))
+	var existingReqsQ *v1.Query
+	if features.UnifiedCVEDeferral.Enabled() {
+		existingReqsQ = search.DisjunctionQuery(
+			utils.GetPendingRequestsV1Query(req.GetCves().GetCves()...),
+			utils.GetPendingUpdateRequestsV1Query(req.GetCves().GetCves()...),
+		)
+	} else {
+		existingReqsQ = utils.GetPendingRequestsV1Query(req.GetCves().GetCves()...)
+	}
+
+	existingReqs, err := m.vulnReqs.SearchRawRequests(ctx, existingReqsQ)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not search for other vulnerability requests")
 	}
 
-	invalidateReqComment := func(reqIDToDeny string) *common.VulnRequestParams {
+	invalidateReqComment := func(reqToDeny *storage.VulnerabilityRequest) *common.VulnRequestParams {
+		prefix := "Vulnerability request"
+		if reqToDeny.Status == storage.RequestStatus_APPROVED_PENDING_UPDATE {
+			prefix = "Vulnerability update request"
+		}
 		return &common.VulnRequestParams{
-			Comment: fmt.Sprintf("Vulnerability request %s was auto-declined when request %s covering one or more requested CVEs was approved", reqIDToDeny, id),
+			Comment: fmt.Sprintf("%s %s was auto-declined when request %s covering one or more requested CVEs was approved", prefix, reqToDeny.GetId(), id),
 		}
 	}
 	for _, coveredReq := range utils.RequestsWithCoveredScope(req, existingReqs) {
 		// Use the identity of approving user to decline similar requests.
-		_, err := m.Deny(ctx, coveredReq.GetId(), invalidateReqComment(coveredReq.GetId()))
+		_, err := m.Deny(ctx, coveredReq.GetId(), invalidateReqComment(coveredReq))
 		if err != nil {
 			return nil, err
 		}
@@ -390,16 +408,6 @@ func (m *managerImpl) UnSnoozeVulnerabilityOnRequest(_ context.Context, request 
 
 	go m.reprocessAffectedEntities(request.GetId(), imageIDs...)
 	return nil
-}
-
-func (m *managerImpl) updateRequestStatus(ctx context.Context, id string, comment string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
-	// Process one request at a time since updating request status could race with creating new request.
-	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
-		return nil, err
-	}
-	defer m.upsertSem.Release(1)
-
-	return m.vulnReqs.UpdateRequestStatus(ctx, id, comment, status)
 }
 
 func (m *managerImpl) reprocessAffectedEntities(requestID string, affectedImages ...string) {

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -1,10 +1,9 @@
-//go:build sql_integration
-
 package requestmgr
 
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	imageCVEDSMocks "github.com/stackrox/rox/central/cve/image/datastore/mocks"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
@@ -163,7 +163,25 @@ func testCreate(t *testing.T) {
 	}
 }
 
-func TestApproval(t *testing.T) {
+func TestApprovalWithUnifiedDeferral(t *testing.T) {
+	t.Setenv(features.UnifiedCVEDeferral.EnvVar(), "true")
+	if !features.UnifiedCVEDeferral.Enabled() {
+		t.Skipf("%s=false. Skipping test", features.UnifiedCVEDeferral.EnvVar())
+	}
+
+	testApproval(t)
+}
+
+func TestApprovalWithoutUnifiedDeferral(t *testing.T) {
+	t.Setenv(features.UnifiedCVEDeferral.EnvVar(), "false")
+	if features.UnifiedCVEDeferral.Enabled() {
+		t.Skipf("%s=true. Skipping test", features.UnifiedCVEDeferral.EnvVar())
+	}
+
+	testApproval(t)
+}
+
+func testApproval(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	testDB := pgtest.ForT(t)
@@ -183,12 +201,33 @@ func TestApproval(t *testing.T) {
 	allTagCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", ".*", "cve-1")
 	otherImageReq := fixtures.GetImageScopeDeferralRequest("reg2", "img1", "1.0", "cve-2")
 
+	globalCVE1DefUpdateReq := fixtures.GetGlobalDeferralRequest("cve-2")
+	globalCVE1DefUpdateReq.UpdatedReq = &storage.VulnerabilityRequest_DeferralUpdate{
+		DeferralUpdate: &storage.DeferralUpdate{
+			CVEs: []string{"cve-1"},
+			Expiry: &storage.RequestExpiry{
+				Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: protocompat.TimestampNow()},
+			},
+		},
+	}
+	globalCVE1DefUpdateReq.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+
+	globalCVE1FpUpdateReq := fixtures.GetGlobalFPRequest("cve-2")
+	globalCVE1FpUpdateReq.UpdatedReq = &storage.VulnerabilityRequest_FalsePositiveUpdate{
+		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+			CVEs: []string{"cve-1"},
+		},
+	}
+	globalCVE1FpUpdateReq.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
+
 	existingReqs := []*storage.VulnerabilityRequest{
 		globalCVE1DefReq,
 		globalCVE1FPReq,
 		imageScopedCVE1Req,
 		allTagCVE1Req,
 		otherImageReq,
+		globalCVE1DefUpdateReq,
+		globalCVE1FpUpdateReq,
 	}
 
 	approver := &storage.SlimUser{
@@ -199,14 +238,16 @@ func TestApproval(t *testing.T) {
 	approverCtx := authn.ContextWithIdentity(sac.WithAllAccess(context.Background()), mockID, t)
 	deniedReqQ := search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_DENIED.String()).ProtoQuery()
 	for _, tc := range []struct {
-		desc             string
-		approvedReq      *storage.VulnerabilityRequest
-		expectedDeclined []string
+		desc                    string
+		approvedReq             *storage.VulnerabilityRequest
+		expectedDeclined        []string
+		expectedDeniedUpdateIDs []string
 	}{
 		{
-			desc:             "decline cve-1 requests in covered scopes; global, all tags, specific tag",
-			approvedReq:      globalCVE1DefReq,
-			expectedDeclined: []string{globalCVE1FPReq.GetId(), allTagCVE1Req.GetId(), imageScopedCVE1Req.GetId()},
+			desc:                    "decline cve-1 requests and update requests in covered scopes; global, all tags, specific tag",
+			approvedReq:             globalCVE1DefReq,
+			expectedDeclined:        []string{globalCVE1FPReq.GetId(), allTagCVE1Req.GetId(), imageScopedCVE1Req.GetId()},
+			expectedDeniedUpdateIDs: []string{globalCVE1DefUpdateReq.GetId(), globalCVE1FpUpdateReq.GetId()},
 		},
 		{
 			desc:             "decline cve-1 requests in covered scopes; all tags, specific tag",
@@ -236,9 +277,30 @@ func TestApproval(t *testing.T) {
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedDeclined, search.ResultsToIDs(results))
 
+			if features.UnifiedCVEDeferral.Enabled() {
+				deniedUpdateIDs := getDeniedUpdateReqIDs(t, datastore)
+				assert.ElementsMatch(t, tc.expectedDeniedUpdateIDs, deniedUpdateIDs)
+			}
+
 			for _, req := range existingReqs {
 				assert.NoError(t, datastore.RemoveRequestsInternal(allAccessCtx, []string{req.GetId()}))
 			}
 		})
 	}
+}
+
+func getDeniedUpdateReqIDs(t *testing.T, datastore vulReqDS.DataStore) []string {
+	// When a req with status RequestStatus_APPROVED_PENDING_UPDATE is denied, its status is set to RequestStatus_APPROVED
+	// and the comment gives the explanation of denial
+	approvedReqQ := search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String()).ProtoQuery()
+	reqs, err := datastore.SearchRawRequests(allAccessCtx, approvedReqQ)
+	assert.NoError(t, err)
+
+	var deniedUpdateIDs []string
+	for _, req := range reqs {
+		if len(req.Comments) > 0 && strings.Contains(req.Comments[len(req.Comments)-1].Message, "declined") {
+			deniedUpdateIDs = append(deniedUpdateIDs, req.GetId())
+		}
+	}
+	return deniedUpdateIDs
 }

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package requestmgr
 
 import (

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -107,6 +107,20 @@ func GetPendingRequestsV1Query(cve ...string) *v1.Query {
 		ProtoQuery()
 }
 
+// GetPendingUpdateRequestsV1Query returns a *v1.Query which will search for all pending update requests with specified CVEs
+func GetPendingUpdateRequestsV1Query(cve ...string) *v1.Query {
+	return search.ConjunctionQuery(
+		search.NewQueryBuilder().
+			AddBools(search.ExpiredRequest, false).
+			AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).
+			ProtoQuery(),
+		search.DisjunctionQuery(
+			search.NewQueryBuilder().AddExactMatches(search.DeferralUpdateCVEs, cve...).ProtoQuery(),
+			search.NewQueryBuilder().AddExactMatches(search.FalsePositiveUpdateCVEs, cve...).ProtoQuery(),
+		),
+	)
+}
+
 // GetAffectedImagesQuery returns a *v1.Query object that can be used to fetch images affected by
 // the vuln request as well as satisfying the incoming query.
 func GetAffectedImagesQuery(request *storage.VulnerabilityRequest, query *v1.Query) (*v1.Query, error) {

--- a/generated/storage/vuln_requests.pb.go
+++ b/generated/storage/vuln_requests.pb.go
@@ -426,8 +426,8 @@ func (m *FalsePositiveRequest) Clone() *FalsePositiveRequest {
 }
 
 type DeferralUpdate struct {
-	CVEs                 []string       `protobuf:"bytes,1,rep,name=CVEs,proto3" json:"CVEs,omitempty"`
-	Expiry               *RequestExpiry `protobuf:"bytes,2,opt,name=expiry,proto3" json:"expiry,omitempty"`
+	CVEs                 []string       `protobuf:"bytes,1,rep,name=CVEs,proto3" json:"CVEs,omitempty" search:"Deferral Update CVEs"`     // @gotags: search:"Deferral Update CVEs"
+	Expiry               *RequestExpiry `protobuf:"bytes,2,opt,name=expiry,proto3" json:"expiry,omitempty" search:"-"` // @gotags: search:"-"
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -499,7 +499,7 @@ func (m *DeferralUpdate) Clone() *DeferralUpdate {
 }
 
 type FalsePositiveUpdate struct {
-	CVEs                 []string `protobuf:"bytes,1,rep,name=CVEs,proto3" json:"CVEs,omitempty"`
+	CVEs                 []string `protobuf:"bytes,1,rep,name=CVEs,proto3" json:"CVEs,omitempty" search:"False Positive Update CVEs"` // @gotags: search:"False Positive Update CVEs"
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -806,7 +806,7 @@ type VulnerabilityRequest_UpdatedDeferralReq struct {
 	UpdatedDeferralReq *DeferralRequest `protobuf:"bytes,21,opt,name=updated_deferral_req,json=updatedDeferralReq,proto3,oneof" json:"updated_deferral_req,omitempty" search:"-"` // @gotags: search:"-"
 }
 type VulnerabilityRequest_DeferralUpdate struct {
-	DeferralUpdate *DeferralUpdate `protobuf:"bytes,22,opt,name=deferral_update,json=deferralUpdate,proto3,oneof" json:"deferral_update,omitempty" search:"-"` // @gotags: search:"-"
+	DeferralUpdate *DeferralUpdate `protobuf:"bytes,22,opt,name=deferral_update,json=deferralUpdate,proto3,oneof" json:"deferral_update,omitempty"`
 }
 type VulnerabilityRequest_FalsePositiveUpdate struct {
 	FalsePositiveUpdate *FalsePositiveUpdate `protobuf:"bytes,23,opt,name=false_positive_update,json=falsePositiveUpdate,proto3,oneof" json:"false_positive_update,omitempty"`

--- a/pkg/postgres/schema/vulnerability_requests.go
+++ b/pkg/postgres/schema/vulnerability_requests.go
@@ -82,6 +82,8 @@ type VulnerabilityRequests struct {
 	DeferralReqExpiryExpiresOn        *time.Time                       `gorm:"column:deferralreq_expiry_expireson;type:timestamp"`
 	DeferralReqExpiryExpiryType       storage.RequestExpiry_ExpiryType `gorm:"column:deferralreq_expiry_expirytype;type:integer"`
 	CvesCves                          *pq.StringArray                  `gorm:"column:cves_cves;type:text[]"`
+	DeferralUpdateCVEs                *pq.StringArray                  `gorm:"column:deferralupdate_cves;type:text[]"`
+	FalsePositiveUpdateCVEs           *pq.StringArray                  `gorm:"column:falsepositiveupdate_cves;type:text[]"`
 	Serialized                        []byte                           `gorm:"column:serialized;type:bytea"`
 }
 

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -329,6 +329,8 @@ var (
 	RequesterUserName           = newFieldLabel("Requester User Name")
 	ApproverUserID              = newFieldLabel("Approver User ID")
 	ApproverUserName            = newFieldLabel("Approver User Name")
+	DeferralUpdateCVEs          = newFieldLabel("Deferral Update CVEs")
+	FalsePositiveUpdateCVEs     = newFieldLabel("False Positive Update CVEs")
 
 	ComplianceDomainID             = newFieldLabel("Compliance Domain ID")
 	ComplianceRunID                = newFieldLabel("Compliance Run ID")

--- a/proto/storage/vuln_requests.proto
+++ b/proto/storage/vuln_requests.proto
@@ -59,12 +59,12 @@ message DeferralRequest {
 message FalsePositiveRequest {}
 
 message DeferralUpdate {
-  repeated string CVEs = 1;
-  RequestExpiry expiry = 2;
+  repeated string CVEs = 1; // @gotags: search:"Deferral Update CVEs"
+  RequestExpiry expiry = 2; // @gotags: search:"-"
 }
 
 message FalsePositiveUpdate {
-  repeated string CVEs = 1;
+  repeated string CVEs = 1; // @gotags: search:"False Positive Update CVEs"
 }
 
 message Requester {
@@ -133,7 +133,7 @@ message VulnerabilityRequest {
   // 21 to 25 reserved for the updated request type oneof.
   oneof updated_req {
     DeferralRequest updated_deferral_req = 21 [deprecated = true]; // @gotags: search:"-"
-    DeferralUpdate deferral_update = 22; // @gotags: search:"-"
+    DeferralUpdate deferral_update = 22;
     FalsePositiveUpdate false_positive_update = 23;
   }
 }


### PR DESCRIPTION
A race condition in approval workflow allowed creating multiple vuln requests with same CVEs and scope. Below is an example flow that allowed to create multiple approved vuln requests with same CVEs and scope:

1) Create deferral req v1 : cves: cve1, scope: global
2) Create deferral req v2 : cves: cve2, scope: global
3) Approve req v1
4) Approve req v2
5) Update req v1 : Remove cve1 and add cve3 : status becomes APPROVED_PENDING_UPDATE
6) Update req v2 : Remove cve2 and add cve3 : status becomes APPROVED_PENDING_UPDATE
7) Approve updated req v1
8) Approve updated req v2
9) Now we have two vuln requests with same CVEs and scope

This PR fixes the race condition by automatically denying any pending update request with same CVEs and scope as the request being approved. The vuln request proto and db schema are also changed to make searching for pending updates with a given list of CVEs easier.

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

#### Unit tests

#### Manual test by replicating the reproducing workflow and ensuring that it did not result in an invalid state.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
