### PR TITLE
refactor: Move errorhelpers/utils under errox

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/httputil"
@@ -217,7 +217,7 @@ func writeErrorBadRequest(w http.ResponseWriter) {
 }
 
 func writeErrorForFile(w http.ResponseWriter, err error, path string) {
-	if errorhelpers.IsAny(err, fs.ErrNotExist, snapshot.ErrBlobNotExist) {
+	if errox.IsAny(err, fs.ErrNotExist, snapshot.ErrBlobNotExist) {
 		writeErrorNotFound(w)
 		return
 	}

--- a/pkg/errox/utils.go
+++ b/pkg/errox/utils.go
@@ -1,4 +1,4 @@
-package errorhelpers
+package errox
 
 import "github.com/pkg/errors"
 

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/set"
 	"golang.org/x/net/context"
 )
@@ -66,16 +67,16 @@ func IsTransientError(err error) bool {
 	if pgconn.SafeToRetry(err) {
 		return true
 	}
-	if errorhelpers.IsAny(err, pgx.ErrNoRows, pgx.ErrTxClosed, pgx.ErrTxCommitRollback) {
+	if errox.IsAny(err, pgx.ErrNoRows, pgx.ErrTxClosed, pgx.ErrTxCommitRollback) {
 		return false
 	}
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		return true
 	}
-	if errorhelpers.IsAny(err, context.DeadlineExceeded) {
+	if errox.IsAny(err, context.DeadlineExceeded) {
 		return true
 	}
-	if errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE) {
+	if errox.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE) {
 		return true
 	}
 	if err := errors.Unwrap(err); err != nil {


### PR DESCRIPTION
## Description

As we prepare to remove `pkg/errorhelpers` (see https://github.com/stackrox/stackrox/pull/10099), move error utils to the new home under `errox`.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Build success is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
