### PR TITLE
chore: Explain how and when to use CVSS-based policies

### DIFF
--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -1241,7 +1241,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 			},
 		},
 		{
-			policyName: "Fixable CVSS >= 6 and Privileged",
+			policyName: "Privileged containers with fixable CVEs and CVSS >= 6",
 			expectedViolations: map[string][]*storage.Alert_Violation{
 				heartbleedDep.GetId(): {
 					{
@@ -1254,7 +1254,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 			},
 		},
 		{
-			policyName: "Fixable CVSS >= 7",
+			policyName: "Containers with fixable CVEs and CVSS >= 7",
 			expectedViolations: map[string][]*storage.Alert_Violation{
 				strutsDep.GetId(): {
 					{
@@ -1269,7 +1269,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 			},
 		},
 		{
-			policyName: "Fixable Severity at least Important",
+			policyName: "Containers with fixable CVEs and Severity at least Important",
 			expectedViolations: map[string][]*storage.Alert_Violation{
 				strutsDep.GetId(): {
 					{
@@ -1750,7 +1750,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 			},
 		},
 		{
-			policyName: "Fixable CVSS >= 7",
+			policyName: "Containers with fixable CVEs and CVSS >= 7",
 			expectedViolations: map[string][]*storage.Alert_Violation{
 				suite.imageIDFromDep(strutsDep): {
 					{
@@ -1765,7 +1765,7 @@ func (suite *DefaultPoliciesTestSuite) TestDefaultPolicies() {
 			},
 		},
 		{
-			policyName: "Fixable Severity at least Important",
+			policyName: "Containers with fixable CVEs and Severity at least Important",
 			expectedViolations: map[string][]*storage.Alert_Violation{
 				suite.imageIDFromDep(strutsDep): {
 					{

--- a/pkg/defaults/policies/files/cvss_6_privileged.json
+++ b/pkg/defaults/policies/files/cvss_6_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "93f4b2dd-ef5a-419e-8371-38aed480fb36",
   "name": "Fixable CVSS >= 6 and Privileged",
-  "description": "Alert on deployments running in privileged mode with fixable vulnerabilities with a CVSS of at least 6",
+  "description": "Alert on deployments running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Important and Critical Fixable CVEs' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_6_privileged.json
+++ b/pkg/defaults/policies/files/cvss_6_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "93f4b2dd-ef5a-419e-8371-38aed480fb36",
   "name": "Privileged containers with fixable CVEs and CVSS >= 6",
-  "description": "Alert on containers running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
+  "description": "Alert if a deployment has containers running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_6_privileged.json
+++ b/pkg/defaults/policies/files/cvss_6_privileged.json
@@ -1,6 +1,6 @@
 {
   "id": "93f4b2dd-ef5a-419e-8371-38aed480fb36",
-  "name": "Privileged Containers with Fixable CVEs and CVSS >= 6",
+  "name": "Privileged containers with fixable CVEs and CVSS >= 6",
   "description": "Alert on containers running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",

--- a/pkg/defaults/policies/files/cvss_6_privileged.json
+++ b/pkg/defaults/policies/files/cvss_6_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "93f4b2dd-ef5a-419e-8371-38aed480fb36",
-  "name": "Fixable CVSS >= 6 and Privileged",
-  "description": "Alert on deployments running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Important and Critical Fixable CVEs' to avoid multiple violations for the same problem.",
+  "name": "Privileged Containers with Fixable CVEs and CVSS >= 6",
+  "description": "Alert on containers running in privileged mode with fixable vulnerabilities with a CVSS of at least 6. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Privileged Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_7.json
+++ b/pkg/defaults/policies/files/cvss_7.json
@@ -1,7 +1,7 @@
 {
   "id": "f09f8da1-6111-4ca0-8f49-294a76c65115",
   "name": "Fixable CVSS >= 7",
-  "description": "Alert on deployments with fixable vulnerabilities with a CVSS of at least 7",
+  "description": "Alert on deployments with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Fixable Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_7.json
+++ b/pkg/defaults/policies/files/cvss_7.json
@@ -1,7 +1,7 @@
 {
   "id": "f09f8da1-6111-4ca0-8f49-294a76c65115",
-  "name": "Fixable CVSS >= 7",
-  "description": "Alert on deployments with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Fixable Severity at least Important' to avoid multiple violations for the same problem.",
+  "name": "Containers with Fixable CVEs and CVSS >= 7",
+  "description": "Alert on containers with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_7.json
+++ b/pkg/defaults/policies/files/cvss_7.json
@@ -1,7 +1,7 @@
 {
   "id": "f09f8da1-6111-4ca0-8f49-294a76c65115",
   "name": "Containers with fixable CVEs and CVSS >= 7",
-  "description": "Alert on containers with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
+  "description": "Alert if a deployment has containers with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "disabled": true,

--- a/pkg/defaults/policies/files/cvss_7.json
+++ b/pkg/defaults/policies/files/cvss_7.json
@@ -1,6 +1,6 @@
 {
   "id": "f09f8da1-6111-4ca0-8f49-294a76c65115",
-  "name": "Containers with Fixable CVEs and CVSS >= 7",
+  "name": "Containers with fixable CVEs and CVSS >= 7",
   "description": "Alert on containers with fixable vulnerabilities with a CVSS of at least 7. While we suggest to rely on Severity instead of CVSS by default, you may want to favor CVSS, for example, because of FedRAMP requirements. If you decide to use this policy, consider disabling 'Containers with Fixable CVEs and Severity at least Important' to avoid multiple violations for the same problem.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "b1df1abb-e5a5-4ff7-98fe-1d28a22b55d8",
   "name": "Privileged Containers with Important and Critical Fixable CVEs",
-  "description": "Alert on containers running in privileged mode with important or critical fixable vulnerabilities",
+  "description": "Alert on containers running in privileged mode with important or critical fixable vulnerabilities. If prefer CVSS-based policy instead, consider enabling 'Fixable CVSS >= 6 and Privileged' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly-privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "b1df1abb-e5a5-4ff7-98fe-1d28a22b55d8",
   "name": "Privileged Containers with Important and Critical Fixable CVEs",
-  "description": "Alert on containers running in privileged mode with important or critical fixable vulnerabilities. If prefer CVSS-based policy instead, consider enabling 'Fixable CVSS >= 6 and Privileged' instead.",
+  "description": "Alert on containers running in privileged mode with important or critical fixable vulnerabilities. If you prefer CVSS-based policy, consider enabling 'Fixable CVSS >= 6 and Privileged' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly-privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -11,16 +11,6 @@
   "lifecycleStages": [
     "DEPLOY"
   ],
-  "exclusions": [
-    {
-      "name": "Don't alert on kube-system namespace",
-      "deployment": {
-        "scope": {
-          "namespace": "kube-system"
-        }
-      }
-    }
-  ],
   "severity": "HIGH_SEVERITY",
   "policyVersion": "1.1",
   "policySections": [

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "b1df1abb-e5a5-4ff7-98fe-1d28a22b55d8",
-  "name": "Privileged Containers with Important and Critical Fixable CVEs",
-  "description": "Alert on containers running in privileged mode with important or critical fixable vulnerabilities. If you prefer CVSS-based policy, consider enabling 'Fixable CVSS >= 6 and Privileged' instead.",
+  "name": "Privileged Containers with Fixable CVEs and Severity at least Important",
+  "description": "Alert on containers running in privileged mode with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Privileged Containers with Fixable CVEs and CVSS >= 6' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly-privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -1,7 +1,7 @@
 {
   "id": "b1df1abb-e5a5-4ff7-98fe-1d28a22b55d8",
   "name": "Privileged containers with fixable CVEs and Severity at least Important",
-  "description": "Alert on containers running in privileged mode with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Privileged Containers with Fixable CVEs and CVSS >= 6' instead.",
+  "description": "Alert if a deployment has containers running in privileged mode with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Privileged Containers with Fixable CVEs and CVSS >= 6' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly-privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_high_privileged.json
+++ b/pkg/defaults/policies/files/severity_high_privileged.json
@@ -1,6 +1,6 @@
 {
   "id": "b1df1abb-e5a5-4ff7-98fe-1d28a22b55d8",
-  "name": "Privileged Containers with Fixable CVEs and Severity at least Important",
+  "name": "Privileged containers with fixable CVEs and Severity at least Important",
   "description": "Alert on containers running in privileged mode with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Privileged Containers with Fixable CVEs and CVSS >= 6' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly-privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",

--- a/pkg/defaults/policies/files/severity_important.json
+++ b/pkg/defaults/policies/files/severity_important.json
@@ -1,7 +1,7 @@
 {
   "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
   "name": "Fixable Severity at least Important",
-  "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important",
+  "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important. If prefer CVSS-based policy instead, consider enabling 'Fixable CVSS >= 7' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_important.json
+++ b/pkg/defaults/policies/files/severity_important.json
@@ -1,7 +1,7 @@
 {
   "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
   "name": "Fixable Severity at least Important",
-  "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important. If prefer CVSS-based policy instead, consider enabling 'Fixable CVSS >= 7' instead.",
+  "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important. If you prefer CVSS-based policy, consider enabling 'Fixable CVSS >= 7' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_important.json
+++ b/pkg/defaults/policies/files/severity_important.json
@@ -1,7 +1,7 @@
 {
   "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
   "name": "Containers with fixable CVEs and Severity at least Important",
-  "description": "Alert on containers with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Containers with Fixable CVEs and CVSS >= 7' instead.",
+  "description": "Alert if a deployment has containers with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Containers with Fixable CVEs and CVSS >= 7' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_important.json
+++ b/pkg/defaults/policies/files/severity_important.json
@@ -1,7 +1,7 @@
 {
   "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
-  "name": "Fixable Severity at least Important",
-  "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important. If you prefer CVSS-based policy, consider enabling 'Fixable CVSS >= 7' instead.",
+  "name": "Containers with Fixable CVEs and Severity at least Important",
+  "description": "Alert on containers with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Containers with Fixable CVEs and CVSS >= 7' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
   "categories": [

--- a/pkg/defaults/policies/files/severity_important.json
+++ b/pkg/defaults/policies/files/severity_important.json
@@ -1,6 +1,6 @@
 {
   "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
-  "name": "Containers with Fixable CVEs and Severity at least Important",
+  "name": "Containers with fixable CVEs and Severity at least Important",
   "description": "Alert on containers with fixable vulnerabilities with Severity rating Important or higher. If you prefer CVSS-based policy, consider enabling 'Containers with Fixable CVEs and CVSS >= 7' instead.",
   "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
   "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",

--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -27,8 +27,8 @@ class Constants {
     ]
     static final VIOLATIONS_ALLOWLIST = [
             // TODO(ROX-2659) Remove the fixable CVSS one from here, that's not okay.
-            "monitoring" : ["CVSS >= 7", "Ubuntu Package Manager in Image", "Curl in Image", "Fixable CVSS >= 7",
-                            ANY_FIXED_VULN_POLICY, "90-Day Image Age", "Fixable Severity at least Important"],
+            "monitoring" : ["CVSS >= 7", "Ubuntu Package Manager in Image", "Curl in Image", "Containers with fixable CVEs and CVSS >= 7",
+                            ANY_FIXED_VULN_POLICY, "90-Day Image Age", "Containers with fixable CVEs and Severity at least Important"],
             "scanner" : ["Red Hat Package Manager Execution", "Red Hat Package Manager in Image", "Curl in Image"],
             "collector": ["Ubuntu Package Manager in Image"],
             "authorization-plugin" : ["Latest tag", "90-Day Image Age"],

--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -27,8 +27,15 @@ class Constants {
     ]
     static final VIOLATIONS_ALLOWLIST = [
             // TODO(ROX-2659) Remove the fixable CVSS one from here, that's not okay.
-            "monitoring" : ["CVSS >= 7", "Ubuntu Package Manager in Image", "Curl in Image", "Containers with fixable CVEs and CVSS >= 7",
-                            ANY_FIXED_VULN_POLICY, "90-Day Image Age", "Containers with fixable CVEs and Severity at least Important"],
+            "monitoring" : [
+                "CVSS >= 7",
+                "Ubuntu Package Manager in Image",
+                "Curl in Image",
+                "Containers with fixable CVEs and CVSS >= 7",
+                ANY_FIXED_VULN_POLICY,
+                "90-Day Image Age",
+                "Containers with fixable CVEs and Severity at least Important"
+            ],
             "scanner" : ["Red Hat Package Manager Execution", "Red Hat Package Manager in Image", "Curl in Image"],
             "collector": ["Ubuntu Package Manager in Image"],
             "authorization-plugin" : ["Latest tag", "90-Day Image Age"],

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -56,7 +56,8 @@ class AdmissionControllerTest extends BaseSpecification {
     private final static String LATEST_TAG = "Latest tag"
     private final static String LATEST_TAG_FOR_TEST = "Latest tag ${CLONED_POLICY_SUFFIX}"
     private final static String SEVERITY = "Containers with fixable CVEs and Severity at least Important"
-    private final static String SEVERITY_FOR_TEST = "Containers with fixable CVEs and Severity at least Important ${CLONED_POLICY_SUFFIX}"
+    private final static String SEVERITY_FOR_TEST =
+                                    "Containers with fixable CVEs and Severity at least Important ${CLONED_POLICY_SUFFIX}"
 
     static final private Deployment SCAN_INLINE_DEPLOYMENT = new Deployment()
             .setName(SCAN_INLINE_DEPLOYMENT_NAME)

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -57,7 +57,7 @@ class AdmissionControllerTest extends BaseSpecification {
     private final static String LATEST_TAG_FOR_TEST = "Latest tag ${CLONED_POLICY_SUFFIX}"
     private final static String SEVERITY = "Containers with fixable CVEs and Severity at least Important"
     private final static String SEVERITY_FOR_TEST =
-                                    "Containers with fixable CVEs and Severity at least Important ${CLONED_POLICY_SUFFIX}"
+            "Containers with fixable CVEs and Severity at least Important ${CLONED_POLICY_SUFFIX}"
 
     static final private Deployment SCAN_INLINE_DEPLOYMENT = new Deployment()
             .setName(SCAN_INLINE_DEPLOYMENT_NAME)

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -55,8 +55,8 @@ class AdmissionControllerTest extends BaseSpecification {
     private final static String CLONED_POLICY_SUFFIX = "(${TEST_NAMESPACE})"
     private final static String LATEST_TAG = "Latest tag"
     private final static String LATEST_TAG_FOR_TEST = "Latest tag ${CLONED_POLICY_SUFFIX}"
-    private final static String SEVERITY = "Fixable Severity at least Important"
-    private final static String SEVERITY_FOR_TEST = "Fixable Severity at least Important ${CLONED_POLICY_SUFFIX}"
+    private final static String SEVERITY = "Containers with fixable CVEs and Severity at least Important"
+    private final static String SEVERITY_FOR_TEST = "Containers with fixable CVEs and Severity at least Important ${CLONED_POLICY_SUFFIX}"
 
     static final private Deployment SCAN_INLINE_DEPLOYMENT = new Deployment()
             .setName(SCAN_INLINE_DEPLOYMENT_NAME)
@@ -87,8 +87,8 @@ class AdmissionControllerTest extends BaseSpecification {
         clusterId = ClusterService.getClusterId()
         assert clusterId
 
-        // Create namespace scoped policies for test based on "Latest Tag" and
-        // "Fixable Severity at least Important"
+        // Create namespace scoped policies for test based on `LATEST_TAG` and
+        // `SEVERITY` policies.
         createdPolicyIds = []
         for (policy : [Services.getPolicyByName(LATEST_TAG), Services.getPolicyByName(SEVERITY)]) {
             def scopedPolicyForTest = policy.toBuilder()

--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -142,7 +142,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
         //TODO(ROX-26897)Fix regex for Curl in Image policy. Until then this test is disabled
         //"Curl in Image"                                              | TRIGGER_MOST
         "Emergency Deployment Annotation"                            | TRIGGER_MOST
-        "Fixable CVSS >= 6 and Privileged"                           | TRIGGER_MOST
+        "Privileged containers with fixable CVEs and CVSS >= 6"      | TRIGGER_MOST
         "Images with no scans"                                       | TRIGGER_UNSCANNED
         // "Improper Usage of Orchestrator Secrets Volume"          | TRIGGER_MOST  // ROX-5098 does not trigger
         "Insecure specified in CMD"                                  | TRIGGER_MOST

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -834,7 +834,7 @@ class ComplianceTest extends BaseSpecification {
 
         ]
         def enforcementPolicies = [
-                "Fixable Severity at least Important",
+                "Containers with fixable CVEs and Severity at least Important",
                 "Privileged Container",
                 "90-Day Image Age",
                 "Latest tag",
@@ -846,7 +846,7 @@ class ComplianceTest extends BaseSpecification {
         given:
         "update policies"
         Services.updatePolicyLifecycleStage(
-                "Fixable Severity at least Important",
+                "Containers with fixable CVEs and Severity at least Important",
                 [PolicyOuterClass.LifecycleStage.BUILD, PolicyOuterClass.LifecycleStage.DEPLOY])
         for (String policyName : enforcementPolicies) {
             def enforcements = []
@@ -911,7 +911,7 @@ class ComplianceTest extends BaseSpecification {
             Services.updatePolicyEnforcement(policyName, priorEnforcement.get(policyName))
         }
         Services.updatePolicyLifecycleStage(
-                "Fixable CVSS >= 7",
+                "Containers with fixable CVEs and CVSS >= 7",
                 [PolicyOuterClass.LifecycleStage.DEPLOY])
         if (policyId) {
             PolicyService.deletePolicy(policyId)

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -63,9 +63,9 @@ class DefaultPoliciesTest extends BaseSpecification {
     private String componentCount = ""
 
     static final private List<String> WHITELISTED_KUBE_SYSTEM_POLICIES = [
-            "Fixable CVSS >= 6 and Privileged",
-            "Privileged Container(s) with Important and Critical CVE(s)",
-            "Fixable Severity at least Important",
+            "Privileged containers with fixable CVEs and CVSS >= 6",
+            "Privileged containers with fixable CVEs and Severity at least Important",
+            "Containers with fixable CVEs and Severity at least Important",
             "Ubuntu Package Manager in Image",
             "Red Hat Package Manager in Image",
             "Curl in Image",
@@ -258,7 +258,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         //"30-Day Scan Age"                               | SSL_TERMINATOR | "C941" | false
 
-        "Fixable CVSS >= 7"                             | GCR_NGINX      | "C933" | false
+        "Containers with fixable CVEs and CVSS >= 7"    | GCR_NGINX      | "C933" | false
 
         "Curl in Image"                                 | WGET_CURL      | "C948" | true
     }

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -224,7 +224,7 @@ class Enforcement extends BaseSpecification {
     private final static String CONTAINER_PORT_22_POLICY = "Secure Shell (ssh) Port Exposed"
     private final static String APT_GET_POLICY = "Ubuntu Package Manager Execution"
     private final static String LATEST_TAG = "Latest tag"
-    private final static String SEVERITY = "Fixable Severity at least Important"
+    private final static String SEVERITY = "Containers with fixable CVEs and Severity at least Important"
     private final static String SCAN_AGE = "30-Day Scan Age"
     private final static String BASELINEPROCESS_POLICY = "Unauthorized Process Execution"
 

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -67,18 +67,18 @@ class ImageManagementTest extends BaseSpecification {
         where:
         "Data inputs are: "
 
-        policyName                        | imageRegistry | imageRemote                      | imageTag     | note
-        "Latest tag"                      | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | ""
+        policyName                                  | imageRegistry | imageRemote                      | imageTag     | note
+        "Latest tag"                                | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | ""
         //intentionally use the same policy twice to make sure alert count does not increment
-        "Latest tag"                      | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | "(repeat)"
-        "90-Day Image Age"                | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Latest tag"                                | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | "(repeat)"
+        "90-Day Image Age"                          | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
         // verify Azure registry
-        // "90-Day Image Age"             | "stackroxacr.azurecr.io" | "nginx"               | "1.12"       | ""
-        "Ubuntu Package Manager in Image" | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
-        "Curl in Image"                   | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
-        "Fixable CVSS >= 7"               | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "nginx-1.12" | ""
-        "Wget in Image"                   | "quay.io"     | WGET_IMAGE_NS                  | WGET_IMAGE_TAG | ""
-        "Apache Struts: CVE-2017-5638"    | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        // "90-Day Image Age"                       | "stackroxacr.azurecr.io" | "nginx"               | "1.12"       | ""
+        "Ubuntu Package Manager in Image"           | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Curl in Image"                             | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Containers with fixable CVEs and CVSS >= 7"| "quay.io"     | "rhacs-eng/qa-multi-arch"        | "nginx-1.12" | ""
+        "Wget in Image"                             | "quay.io"     | WGET_IMAGE_NS                  | WGET_IMAGE_TAG | ""
+        "Apache Struts: CVE-2017-5638"              | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
     }
 
     def "Verify two consecutive latest tag image have different scans"() {

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -67,18 +67,18 @@ class ImageManagementTest extends BaseSpecification {
         where:
         "Data inputs are: "
 
-        policyName                                  | imageRegistry | imageRemote                      | imageTag     | note
-        "Latest tag"                                | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | ""
+        policyName                        | imageRegistry | imageRemote                      | imageTag     | note
+        "Latest tag"                      | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | ""
         //intentionally use the same policy twice to make sure alert count does not increment
-        "Latest tag"                                | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | "(repeat)"
-        "90-Day Image Age"                          | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Latest tag"                      | "quay.io"     | "rhacs-eng/qa-multi-arch-nginx"  | "latest"     | "(repeat)"
+        "90-Day Image Age"                | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
         // verify Azure registry
-        // "90-Day Image Age"                       | "stackroxacr.azurecr.io" | "nginx"               | "1.12"       | ""
-        "Ubuntu Package Manager in Image"           | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
-        "Curl in Image"                             | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
-        "Containers with fixable CVEs and CVSS >= 7"| "quay.io"     | "rhacs-eng/qa-multi-arch"        | "nginx-1.12" | ""
-        "Wget in Image"                             | "quay.io"     | WGET_IMAGE_NS                  | WGET_IMAGE_TAG | ""
-        "Apache Struts: CVE-2017-5638"              | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        // "90-Day Image Age"             | "stackroxacr.azurecr.io" | "nginx"               | "1.12"       | ""
+        "Ubuntu Package Manager in Image" | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Curl in Image"                   | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
+        "Containers with fixable CVEs and CVSS >= 7"|"quay.io"|"rhacs-eng/qa-multi-arch"     | "nginx-1.12" | ""
+        "Wget in Image"                   | "quay.io"     | WGET_IMAGE_NS                    |WGET_IMAGE_TAG| ""
+        "Apache Struts: CVE-2017-5638"    | "quay.io"     | "rhacs-eng/qa-multi-arch"        | "struts-app" | ""
     }
 
     def "Verify two consecutive latest tag image have different scans"() {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -145,7 +145,7 @@ export function visitVulnerabilityManagementDashboard() {
 
 /*
  * For example, visitVulnerabilityManagementEntities('cves')
- * For example, visitVulnerabilityManagementEntities('policies', '?s[Policy]=Fixable Severity at least Important')
+ * For example, visitVulnerabilityManagementEntities('policies', '?s[Policy]=Containers with fixable CVEs and Severity at least Important')
  */
 export function visitVulnerabilityManagementEntities(entitiesKey) {
     const routeMatcherMap = getRouteMatcherMapForGraphQL([


### PR DESCRIPTION
## Description

Some of our policies focus on the same underlying problem but do it from different angles. It's not clear to the unexperienced user which one to use when.

This PR attempts to clarify why our CVSS-based policies disabled by default but are shipped with the product. It also hints the relationship between these policies and their Severity-based counterparts. Note that [Severity is calculated from CVSS](https://github.com/stackrox/stackrox/blob/a55095cb47f2cde90b60980a699acbb392f8d2fc/pkg/cvss/severity.go#L70-L103) and Severity-based policies have been introduced as a replacement for CVSS-based ones, [1](https://github.com/stackrox/rox/pull/8725/files#diff-b8c392a72f3fc22277561f5da29f79312d3011e85afb31c89752991a253fff17R7) and [2](https://github.com/stackrox/stackrox/pull/2727/files#diff-15a06517c7322d1988cf03d8b2409c99776505d966d4565b649dc73e7c4861eb). 

This PR also ensures CVE-related policies do not specify exclusions.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

See https://github.com/stackrox/stackrox/pull/14215

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
