### PR TITLE
chore: add internal deserialize proto tool

### DIFF
--- a/tools/deserialize-proto/README.md
+++ b/tools/deserialize-proto/README.md
@@ -1,0 +1,22 @@
+# deserialize-proto
+
+Internal too to deserialize central database objects for debugging purposes. 
+
+## Usage
+
+This tool reads from stdin, so you'll need to copy the deserialized value and pipe it in or run a psql command and pipe
+in the stdout of that command.
+
+Here are some examples:
+
+```sh
+# If you're on macOS and copied the deserialized object to your clipboard
+$ pbpaste | go run tools/deserialize-proto/*.go --type storage.IntegrationHealth
+```
+
+```sh
+# If you have a central database running locally
+$ psql -U postgres -h localhost -d central_data -t \
+  -c 'SELECT serialized FROM integration_healths' | \
+  go run tools/deserialize-proto/*.go --type storage.IntegrationHealth
+```

--- a/tools/deserialize-proto/README.md
+++ b/tools/deserialize-proto/README.md
@@ -1,6 +1,6 @@
 # deserialize-proto
 
-Internal too to deserialize central database objects for debugging purposes. 
+Internal tool to deserialize central database objects for debugging purposes. 
 
 ## Usage
 

--- a/tools/deserialize-proto/init.go
+++ b/tools/deserialize-proto/init.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+var typeRegistry = make(map[string]proto.Unmarshaler)
+
+func init() {
+	for _, v := range []proto.Unmarshaler{
+		&storage.ActiveComponent{},
+		&storage.AdministrationEvent{},
+		&storage.AuthMachineToMachineConfig{},
+		&storage.AuthProvider{},
+		&storage.Blob{},
+		&storage.CloudSource{},
+		&storage.ClusterHealthStatus{},
+		&storage.ClusterCVE{},
+		&storage.ClusterCVEEdge{},
+		&storage.ComplianceConfig{},
+		&storage.ComplianceControlResult{},
+		&storage.ComplianceDomain{},
+		&storage.ComplianceIntegration{},
+		&storage.ComplianceOperatorCheckResult{},
+		&storage.ComplianceOperatorCheckResultV2{},
+		&storage.ComplianceOperatorClusterScanConfigStatus{},
+		&storage.ComplianceOperatorProfile{},
+		&storage.ComplianceOperatorProfileV2{},
+		&storage.ComplianceOperatorRule{},
+		&storage.ComplianceOperatorRuleV2{},
+		&storage.ComplianceOperatorScan{},
+		&storage.ComplianceOperatorScanConfigurationV2{},
+		&storage.ComplianceOperatorScanV2{},
+		&storage.ComplianceOperatorScanSettingBinding{},
+		&storage.ComplianceOperatorSuiteV2{},
+		&storage.ComplianceRunMetadata{},
+		&storage.ComplianceRunResults{},
+		&storage.ComplianceStrings{},
+		&storage.ComponentCVEEdge{},
+		&storage.Config{},
+		&storage.DeclarativeConfigHealth{},
+		&storage.DelegatedRegistryConfig{},
+		&storage.DiscoveredCluster{},
+		&storage.ExternalBackup{},
+		&storage.Group{},
+		&storage.Hash{},
+		&storage.ImageComponent{},
+		&storage.ImageComponentEdge{},
+		&storage.ImageCVE{},
+		&storage.ImageCVEEdge{},
+		&storage.ImageIntegration{},
+		&storage.IntegrationHealth{},
+		&storage.K8SRoleBinding{},
+		&storage.K8SRole{},
+		&storage.LogImbue{},
+		&storage.NamespaceMetadata{},
+		&storage.NetworkBaseline{},
+		&storage.NetworkEntity{},
+		&storage.NetworkFlow{},
+		&storage.NetworkGraphConfig{},
+		&storage.NetworkPolicyApplicationUndoDeploymentRecord{},
+		&storage.NetworkPolicyApplicationUndoRecord{},
+		&storage.NodeComponent{},
+		&storage.NodeComponentCVEEdge{},
+		&storage.NodeComponentEdge{},
+		&storage.NodeCVE{},
+		&storage.NotificationSchedule{},
+		&storage.Notifier{},
+		&storage.NotifierEncConfig{},
+		&storage.PermissionSet{},
+		&storage.Pod{},
+		&storage.Policy{},
+		&storage.PolicyCategory{},
+		&storage.PolicyCategoryEdge{},
+		&storage.ProcessBaselineResults{},
+		&storage.ProcessBaseline{},
+		&storage.ProcessIndicator{},
+		&storage.ProcessListeningOnPortStorage{},
+		&storage.ReportConfiguration{},
+		&storage.ReportSnapshot{},
+		&storage.ResourceCollection{},
+		&storage.Risk{},
+		&storage.Role{},
+		&storage.ComplianceOperatorScanSettingBindingV2{},
+		&storage.SecuredUnits{},
+		&storage.SensorUpgradeConfig{},
+		&storage.ServiceIdentity{},
+		&storage.SignatureIntegration{},
+		&storage.SimpleAccessScope{},
+		&storage.SystemInfo{},
+		&storage.TelemetryConfiguration{},
+		&storage.TokenMetadata{},
+		&storage.User{},
+	} {
+		// All the string representations of the type of the value are pointers, so remove the "*" in front of the
+		// those string representations (e.g., "*storage.ActiveComponent" -> "storage.ActiveComponent") for each key
+		typeRegistry[fmt.Sprintf("%T", v)[1:]] = v
+	}
+}

--- a/tools/deserialize-proto/main.go
+++ b/tools/deserialize-proto/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	flag "github.com/spf13/pflag"
+)
+
+var protobufType *string = flag.String("type", "", "name of protobuf, e.g., storage.Alert")
+
+func unmarshalProto[T proto.Unmarshaler](t T, b []byte) error {
+	return t.Unmarshal(b)
+}
+
+func main() {
+	flag.Parse()
+
+	if *protobufType == "" {
+		log.Fatal("must provide --type")
+	}
+
+	messageType, ok := typeRegistry[*protobufType]
+	if !ok {
+		log.Fatalf("%s is an invalid storage type", *protobufType)
+	}
+
+	var text string
+
+	reader := bufio.NewScanner(os.Stdin)
+	for reader.Scan() {
+		text = reader.Text()
+		if len(text) == 0 {
+			break
+		}
+
+		// It's not clear why we need to both unquote *and* prepend 0A but it works ¯\_(ツ)_/¯
+		s, err := strconv.Unquote(fmt.Sprintf("\"%s\"", text))
+		if err != nil {
+			log.Fatalf("error while unquote the serialized text, text = %s, err = %v", text, err)
+		}
+
+		s = "0A" + strings.TrimSpace(s)
+
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			log.Fatalf("error while decoding the hex value of the serialized text, text = %s, err = %v",
+				text, err)
+		}
+
+		message := messageType
+		if err := unmarshalProto(message, b); err != nil {
+			log.Fatalf("error unmarshaling proto, text = %s, err = %v", text, err)
+		}
+
+		pjson, err := json.MarshalIndent(message, "", "  ")
+		if err != nil {
+			log.Fatalf("error while prettifying, message = %s, err = %v", message, err)
+		}
+		fmt.Println(string(pjson))
+	}
+
+	if err := reader.Err(); err != nil {
+		log.Fatalf("error while reading from stdin, err = %v", err)
+	}
+}


### PR DESCRIPTION
## Description

We sometimes find ourselves needing to read serialized protobuf objects from the central database, particular when debugging CI issues.

These changes introduce a tool to deserialize such objects by reading the serialized object from stdin and using a user-provided storage type.

## Checklist
- ~~Investigated and inspected CI test results~~
- ~~Unit test and regression tests added~~
- ~~Evaluated and added CHANGELOG entry if required~~
- ~~Determined and documented upgrade steps~~
- ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

Checklist doesn't apply since this is an internal tool meant only for developers.

## Testing Performed

### Here I tell how I validated my change

I had loaded a postgres dump of central from a CI run into a locally running docker postgres container.

```
❯ psql -U postgres -h localhost -d central_data -t \
  -c 'SELECT serialized FROM integration_healths' | \
  go run tools/deserialize-proto/*.go --type storage.IntegrationHealth
{
  "id": "10d3b4dc-8295-41bc-bb50-6da5484cdb1a",
  "name": "Public DockerHub",
  "type": 1,
  "last_timestamp": {
    "seconds": 1707958769,
    "nanos": 769484369
  }
}
{
  "id": "c6a1a26d-8947-4cb0-a50d-a018856f9390",
  "name": "Public Kubernetes GCR (deprecated)",
  "type": 1,
  "last_timestamp": {
    "seconds": 1707958769,
    "nanos": 770092380
  }
}

... # More integrations

```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
