### PR TITLE
chore(go.mod): extract replaces owned by 🧙

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -447,17 +447,8 @@ require (
 // for Go build tools to accept the `go.mod`.
 replace (
 	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e
-	github.com/gogo/protobuf => github.com/connorgorman/protobuf v1.2.2-0.20240207122816-e936d453291c
 
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20230714151239-78b1f5f70b8a
-
-	// github.com/mikefarah/yaml/v2 is a clone of github.com/go-yaml/yaml/v2.
-	// Both github.com/go-yaml/yaml/v2 and github.com/go-yaml/yaml/v3 do not provide go.sum
-	// so dependabot is not able to check dependecies.
-	// See https://github.com/go-yaml/yaml/issues/772
-	// Therefore we point all to our fork of `go-yaml` - github.com/stackrox/yaml/v2|v3
-	// where we provide the actual `go.sum`.
-	github.com/mikefarah/yamlg/v2 => gopkg.in/yaml.v2 v2.4.0
 
 	github.com/nxadm/tail => github.com/stackrox/tail v1.4.9-0.20210831224919-407035634f5d
 
@@ -465,10 +456,29 @@ replace (
 	// we currently depend on.
 	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46
 
+	github.com/tecbot/gorocksdb => github.com/DataDog/gorocksdb v0.0.0-20200107201226-9722c3a2e063
+)
+
+// @stackrox/merlin
+replace (
+	// Our fork has following features:
+	// - generate MessageClone() and Clone() functions
+	// - error on nil unmarshal instead of panic
+	// - trailing comments propagation to generated code
+	github.com/gogo/protobuf => github.com/stackrox/protobuf v1.2.2-0.20240207122816-e936d453291c
+
+	// Our fork has the following changes:
+	// - fetch signatures without fetching the image manifest
+	// This has been added since we already fetch the image manifest
+	// in a previous step as a prereq.
 	github.com/sigstore/cosign/v2 => github.com/stackrox/cosign/v2 v2.0.0-20231206143943-626efb842da7
 
-	github.com/tecbot/gorocksdb => github.com/DataDog/gorocksdb v0.0.0-20200107201226-9722c3a2e063
+	// Our fok has following features:
+	// - console log field ordering
+	// - not verbose error logging
+	// TODO(ROX-23217): upgrade to latest version
 	go.uber.org/zap => github.com/stackrox/zap v1.18.2-0.20240314134248-5f932edd0404
+
 	// Our fork has a change exposing a method to do generic POST requests
 	// against the OAuth server in order to realize the refresh token flow.
 	// The problem is that:
@@ -479,6 +489,11 @@ replace (
 	//       want to reimplement in our code.
 	golang.org/x/oauth2 => github.com/stackrox/oauth2 v0.0.0-20240305225512-3737c3c758df
 
+	// Both github.com/go-yaml/yaml/v2 and github.com/go-yaml/yaml/v3 do not provide go.sum
+	// so dependabot is not able to check dependecies.
+	// See https://github.com/go-yaml/yaml/issues/772
+	// Therefore we point all to our fork of `go-yaml` - github.com/stackrox/yaml/v2|v3
+	// where we provide the actual `go.sum`.
 	gopkg.in/yaml.v2 => github.com/stackrox/yaml/v2 v2.4.1
 	gopkg.in/yaml.v3 => github.com/stackrox/yaml/v3 v3.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,6 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
-github.com/connorgorman/protobuf v1.2.2-0.20240207122816-e936d453291c h1:Uan3mDsQz3G6k2uS16TATAgf9yHyjLhBGxDPVBivr9U=
-github.com/connorgorman/protobuf v1.2.2-0.20240207122816-e936d453291c/go.mod h1:4n/qquk+A505mqkK9+o7Xth9+UxUWFc4/5faDXkYyyU=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
 github.com/containerd/containerd v1.7.11 h1:lfGKw3eU35sjV0aG2eYZTiwFEY1pCzxdzicHP3SZILw=
@@ -1816,6 +1814,8 @@ github.com/stackrox/oauth2 v0.0.0-20240305225512-3737c3c758df h1:759L43a+41f3z+4
 github.com/stackrox/oauth2 v0.0.0-20240305225512-3737c3c758df/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi8=
 github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d h1:aLCTq23tpBhbmrLa/3+21rESx7VXgkrjIKJpbhcrvVk=
 github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d/go.mod h1:zwEXo3PEZZb6QQZBrBORMX0Hvnnwst3PduSaTQZMFYc=
+github.com/stackrox/protobuf v1.2.2-0.20240207122816-e936d453291c h1:qEJYZA6jpEQ+xhUIhnsnTX56h09S28tIa7zOdB5GY90=
+github.com/stackrox/protobuf v1.2.2-0.20240207122816-e936d453291c/go.mod h1:4n/qquk+A505mqkK9+o7Xth9+UxUWFc4/5faDXkYyyU=
 github.com/stackrox/scanner v0.0.0-20240110222630-351caa1e0024 h1:g0Taj+vFHCzrFsLFLnm+5eaUdLFhzthcBqPBTSCGIUY=
 github.com/stackrox/scanner v0.0.0-20240110222630-351caa1e0024/go.mod h1:HziPXIAPcO7GcxEI9Cc8iB80dxyoleexmdp17r0v7hc=
 github.com/stackrox/tail v1.4.9-0.20210831224919-407035634f5d h1:jeM6QMtwE9BU0rfDYcmkI/aOChOUfIO18LDp/DSnZpI=


### PR DESCRIPTION
## Description

This PR creates a new `replace` section in `go.mod` and keep all replaces that are owned by @stackrox/merlin

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
