### PR TITLE
ROX-22734: Add a namespace overview page

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -43,7 +43,7 @@ export function visitWorkloadCveOverview() {
  * @param {('Fixable' | 'Not fixable')[]} fixabilities
  */
 export function applyDefaultFilters(severities, fixabilities) {
-    cy.get('button:contains("Default vulnerability filters")').click();
+    cy.get('button:contains("Default filters")').click();
     severities.forEach((severity) => {
         cy.get(`label:contains("${severity}")`).click();
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -9,19 +10,18 @@ import {
 } from '@patternfly/react-core';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
-import React from 'react';
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 
 function NamespaceViewPage() {
     return (
         <>
-            <PageTitle title="Workload CVEs - Namespace View" />
+            <PageTitle title="Workload CVEs - Namespace view" />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={vulnerabilitiesWorkloadCvesPath}>
                         Workload CVEs
                     </BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>Namespace overview</BreadcrumbItem>
+                    <BreadcrumbItem isActive>Namespace view</BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
@@ -31,7 +31,7 @@ function NamespaceViewPage() {
                     alignItems={{ default: 'alignItemsFlexStart' }}
                 >
                     <Title headingLevel="h1" className="pf-u-mb-sm">
-                        Namespace overview
+                        Namespace view
                     </Title>
                     <FlexItem>Discover and prioritize namespaces by risk priority</FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -1,0 +1,45 @@
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Divider,
+    Flex,
+    FlexItem,
+    PageSection,
+    Title,
+} from '@patternfly/react-core';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import React from 'react';
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+
+function NamespaceViewPage() {
+    return (
+        <>
+            <PageTitle title="Workload CVEs - Namespace View" />
+            <PageSection variant="light" className="pf-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={vulnerabilitiesWorkloadCvesPath}>
+                        Workload CVEs
+                    </BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>Namespace overview</BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light">
+                <Flex
+                    direction={{ default: 'column' }}
+                    alignItems={{ default: 'alignItemsFlexStart' }}
+                >
+                    <Title headingLevel="h1" className="pf-u-mb-sm">
+                        Namespace overview
+                    </Title>
+                    <FlexItem>Discover and prioritize namespaces by risk priority</FlexItem>
+                </Flex>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection padding={{ default: 'noPadding' }}></PageSection>
+        </>
+    );
+}
+
+export default NamespaceViewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -1,20 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import {
-    PageSection,
-    Title,
-    Divider,
-    Flex,
-    FlexItem,
-    Card,
-    CardBody,
-    Button,
-    Toolbar,
-    ToolbarItem,
-} from '@patternfly/react-core';
+import { PageSection, Title, Flex, FlexItem, Card, CardBody, Button } from '@patternfly/react-core';
 import { gql, useApolloClient, useQuery } from '@apollo/client';
 import cloneDeep from 'lodash/cloneDeep';
 import difference from 'lodash/difference';
 import isEmpty from 'lodash/isEmpty';
+import { Link } from 'react-router-dom';
 
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
@@ -29,6 +19,7 @@ import useAnalytics, {
 } from 'hooks/useAnalytics';
 import useLocalStorage from 'hooks/useLocalStorage';
 import { SearchFilter } from 'types/search';
+import { vulnerabilityNamespaceViewPath } from 'routePaths';
 import {
     getDefaultWorkloadSortOption,
     getWorkloadSortFields,
@@ -111,8 +102,11 @@ function mergeDefaultAndLocalFilters(
 
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
+
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
+    const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
+
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
     const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');
@@ -236,19 +230,6 @@ function WorkloadCvesOverviewPage() {
     return (
         <>
             <PageTitle title="Workload CVEs Overview" />
-            {isFixabilityFiltersEnabled && (
-                <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                    <Toolbar>
-                        <ToolbarItem alignment={{ default: 'alignRight' }}>
-                            <DefaultFilterModal
-                                defaultFilters={localStorageValue.preferences.defaultFilters}
-                                setLocalStorage={updateDefaultFilters}
-                            />
-                        </ToolbarItem>
-                    </Toolbar>
-                </PageSection>
-            )}
-            <Divider component="div" />
             <PageSection
                 className="pf-u-display-flex pf-u-flex-direction-row pf-u-align-items-center"
                 variant="light"
@@ -259,8 +240,15 @@ function WorkloadCvesOverviewPage() {
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>
                 </Flex>
-                {hasWriteAccessForWatchedImage && (
-                    <FlexItem>
+                <Flex>
+                    {hasReadAccessForNamespaces && (
+                        <Link to={vulnerabilityNamespaceViewPath}>
+                            <Button variant="secondary" onClick={() => {}}>
+                                Namespace overview
+                            </Button>
+                        </Link>
+                    )}
+                    {hasWriteAccessForWatchedImage && (
                         <Button
                             variant="secondary"
                             onClick={() => {
@@ -271,8 +259,14 @@ function WorkloadCvesOverviewPage() {
                         >
                             Manage watched images
                         </Button>
-                    </FlexItem>
-                )}
+                    )}
+                    {isFixabilityFiltersEnabled && (
+                        <DefaultFilterModal
+                            defaultFilters={localStorageValue.preferences.defaultFilters}
+                            setLocalStorage={updateDefaultFilters}
+                        />
+                    )}
+                </Flex>
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
                 <PageSection

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -244,7 +244,7 @@ function WorkloadCvesOverviewPage() {
                     {hasReadAccessForNamespaces && (
                         <Link to={vulnerabilityNamespaceViewPath}>
                             <Button variant="secondary" onClick={() => {}}>
-                                Namespace overview
+                                Namespace view
                             </Button>
                         </Link>
                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -26,8 +26,9 @@ const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCves
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
 function WorkloadCvesPage() {
-    const { hasReadAccess } = usePermissions();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
+    const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
 
     return (
         <>
@@ -38,13 +39,15 @@ function WorkloadCvesPage() {
                 routeKey="vulnerability-management"
             />
             <Switch>
+                {hasReadAccessForNamespaces && (
+                    <Route path={vulnerabilityNamespaceViewPath} component={NamespaceViewPage} />
+                )}
                 <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />
                 <Route path={vulnerabilitiesWorkloadCveImageSinglePath} component={ImagePage} />
                 <Route
                     path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
                     component={DeploymentPage}
                 />
-                <Route path={vulnerabilityNamespaceViewPath} component={NamespaceViewPage} />
                 <Route
                     exact
                     path={vulnerabilitiesWorkloadCvesPath}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -5,7 +5,11 @@ import { PageSection } from '@patternfly/react-core';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 
-import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import {
+    vulnManagementPath,
+    vulnerabilitiesWorkloadCvesPath,
+    vulnerabilityNamespaceViewPath,
+} from 'routePaths';
 import TechPreviewBanner from 'Components/TechPreviewBanner';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import usePermissions from 'hooks/usePermissions';
@@ -13,6 +17,7 @@ import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCve/ImageCvePage';
+import NamespaceViewPage from './NamespaceView/NamespaceViewPage';
 
 import './WorkloadCvesPage.css';
 
@@ -39,6 +44,7 @@ function WorkloadCvesPage() {
                     path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
                     component={DeploymentPage}
                 />
+                <Route path={vulnerabilityNamespaceViewPath} component={NamespaceViewPage} />
                 <Route
                     exact
                     path={vulnerabilitiesWorkloadCvesPath}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -86,10 +86,10 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
                     className: 'custom-badge-unread',
                 }}
             >
-                Default vulnerability filters
+                Default filters
             </Button>
             <Modal
-                title="Default vulnerability filters"
+                title="Default filters"
                 description="Select default vulnerability filters to be applied across all views."
                 isOpen={isOpen}
                 onClose={handleModalToggle}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Badge, Modal, Form, FormGroup, Checkbox, Flex } from '@patternfly/react-core';
+import { Button, Modal, Form, FormGroup, Checkbox } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import { useFormik, FormikProvider } from 'formik';
 import { Globe } from 'react-feather';
@@ -76,14 +76,17 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
 
     return (
         <>
-            <Button variant="plain" className="pf-u-color-300" onClick={handleModalToggle}>
-                <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                    <Globe className="pf-u-mr-sm" />
-                    Default vulnerability filters
-                    <Badge key={1} isRead className="pf-u-ml-sm">
-                        {totalFilters}
-                    </Badge>
-                </Flex>
+            <Button
+                variant="tertiary"
+                onClick={handleModalToggle}
+                icon={<Globe className="pf-u-mr-sm" />}
+                countOptions={{
+                    isRead: true,
+                    count: totalFilters,
+                    className: 'custom-badge-unread',
+                }}
+            >
+                Default vulnerability filters
             </Button>
             <Modal
                 title="Default vulnerability filters"

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -371,7 +371,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     'workload-cves': {
         featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_WORKLOAD_CVES']),
-        resourceAccessRequirements: everyResource(['Deployment', 'Image', 'Namespace']),
+        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },
 };
 

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -76,6 +76,7 @@ export const vulnManagementPath = `${mainPath}/vulnerability-management`;
 export const vulnManagementReportsPath = `${vulnManagementPath}/reports`;
 export const vulnManagementRiskAcceptancePath = `${vulnManagementPath}/risk-acceptance`;
 export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
+export const vulnerabilityNamespaceViewPath = `${vulnerabilitiesWorkloadCvesPath}/namespace-view`;
 export const vulnerabilitiesPlatformCvesPath = `${vulnerabilitiesBasePath}/platform-cves`;
 export const vulnerabilitiesNodeCvesPath = `${vulnerabilitiesBasePath}/node-cves`;
 export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
@@ -370,7 +371,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     'workload-cves': {
         featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_WORKLOAD_CVES']),
-        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
+        resourceAccessRequirements: everyResource(['Deployment', 'Image', 'Namespace']),
     },
 };
 
@@ -451,6 +452,7 @@ const vulnManagementPathToLabelMap: Record<string, string> = {
 const vulnerabilitiesPathToLabelMap: Record<string, string> = {
     [vulnerabilitiesBasePath]: 'Vulnerabilities',
     [vulnerabilitiesWorkloadCvesPath]: 'Workload CVEs',
+    [vulnerabilityNamespaceViewPath]: 'Namespace View',
     [vulnerabilitiesPlatformCvesPath]: 'Platform CVEs',
     [vulnerabilitiesNodeCvesPath]: 'Node CVEs',
     [vulnerabilityReportsPath]: 'Vulnerability Reporting',


### PR DESCRIPTION
## Description

This PR does the following:
- Renders the "Namespace overview" button in the top right section of the page
- Relocates the "Default filters" button
- Clicking on the button should take you to a new page
- The page should include breadcrumbs that navigate back to Workload CVEs
- The page should include a page header and subtitle

<img width="1435" alt="Screenshot 2024-03-14 at 3 36 44 PM" src="https://github.com/stackrox/stackrox/assets/4805485/ed833160-0fe4-4c03-954a-54f130ef1757">
<img width="1436" alt="Screenshot 2024-03-14 at 3 36 36 PM" src="https://github.com/stackrox/stackrox/assets/4805485/8ac6511e-6041-45b2-9bce-c033b42d4180">

