### PR TITLE
chore(scanner): add quay tag expiry label to images

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -12,6 +12,13 @@ ifeq ($(TAG),)
 	TAG := $(shell $(MAKE) -C ../ --quiet --no-print-directory tag)
 endif
 
+# Set expiration on Quay.io for non-release tags.
+ifeq ($(findstring x,$(TAG)),x)
+QUAY_TAG_EXPIRATION=13w
+else
+QUAY_TAG_EXPIRATION=never
+endif
+
 HOST_OS := linux
 ifeq ($(shell uname -s),Darwin)
 	HOST_OS := darwin
@@ -28,6 +35,10 @@ GO_BUILD_CMD   = $(GO_BUILD_FLAGS) go build \
 GO_TEST_CMD    = $(GO_BUILD_FLAGS) go test
 
 DOCKERBUILD := $(CURDIR)/../scripts/docker-build.sh
+
+DOCKERBUILD_ARGS = --build-arg LABEL_VERSION=$(TAG) \
+                   --build-arg LABEL_RELEASE=$(TAG) \
+                   --build-arg QUAY_TAG_EXPIRATION=$(QUAY_TAG_EXPIRATION)
 
 DB_DOCKERBUILD_ARGS =
 ifeq ($(GOARCH),s390x)
@@ -147,7 +158,10 @@ image-scanner: image/scanner/bin/scanner \
                $(image-scripts-t) \
                $(if $(CI),ossls-notice-no-download,ossls-notice)
 	@echo "+ $@"
-	$(DOCKERBUILD) -t stackrox/$(image-prefix):$(TAG) -f image/scanner/Dockerfile image/scanner
+	$(DOCKERBUILD) \
+        -t stackrox/$(image-prefix):$(TAG) \
+        $(DOCKERBUILD_ARGS) \
+        -f image/scanner/Dockerfile image/scanner
 
 $(image-db-init-d):
 	mkdir -p $@
@@ -173,7 +187,11 @@ endif
 .PHONY: image-db
 image-db: $(image-db-init-t)
 	@echo "+ $@"
-	$(DOCKERBUILD) -t stackrox/$(image-prefix)-db:$(TAG) $(DB_DOCKERBUILD_ARGS) -f image/db/Dockerfile image/db
+	$(DOCKERBUILD) \
+        -t stackrox/$(image-prefix)-db:$(TAG) \
+        $(DOCKERBUILD_ARGS) \
+        $(DB_DOCKERBUILD_ARGS) \
+        -f image/db/Dockerfile image/db
 
 ###########
 ## Tools ##

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -13,11 +13,18 @@ RUN /download.sh
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
-LABEL name="scanner-db" \
+ARG LABEL_VERSION
+ARG LABEL_RELEASE
+ARG QUAY_TAG_EXPIRATION
+
+LABEL name="scanner-v4-db" \
       vendor="StackRox" \
       maintainer="https://stackrox.io/" \
       summary="Static vulnerability scanner database for the StackRox Security Platform" \
-      description="This image supports static vulnerability scanning for the StackRox Security Platform."
+      description="This image supports static vulnerability scanning for the StackRox Security Platform." \
+      version="${LABEL_VERSION}" \
+      release="${LABEL_RELEASE}" \
+      quay.expires-after="${QUAY_TAG_EXPIRATION}"
 
 # If this is updated, be sure to update postgres_major in download.sh and the signature file.
 ENV PG_MAJOR=15

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -12,11 +12,18 @@ RUN /download-mappings.sh
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
-LABEL name="scanner" \
+ARG LABEL_VERSION
+ARG LABEL_RELEASE
+ARG QUAY_TAG_EXPIRATION
+
+LABEL name="scanner-v4" \
       vendor="StackRox" \
       maintainer="https://stackrox.io/" \
       summary="Static vulnerability scanner for the StackRox Security Platform" \
-      description="This image supports static vulnerability scanning for the StackRox Security Platform."
+      description="This image supports static vulnerability scanning for the StackRox Security Platform." \
+      version="${LABEL_VERSION}" \
+      release="${LABEL_RELEASE}" \
+      quay.expires-after="${QUAY_TAG_EXPIRATION}"
 
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Description

Add expiry label to non-release builds, so we do not continue to blow up the quay registry. See https://github.com/stackrox/scanner/pull/1446 for Scanner v2

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
