### PR TITLE
ROX-22101: New conversion functions in proto compatibility layer

### DIFF
--- a/pkg/protocompat/time.go
+++ b/pkg/protocompat/time.go
@@ -22,6 +22,30 @@ func ConvertTimestampToTimeOrError(gogo *gogoTimestamp.Timestamp) (time.Time, er
 	return gogoTimestamp.TimestampFromProto(gogo)
 }
 
+// ConvertTimestampToTimeOrNil converts a proto timestamp to a golang Time, defaulting to nil in case of error.
+func ConvertTimestampToTimeOrNil(gogo *gogoTimestamp.Timestamp) *time.Time {
+	if gogo == nil {
+		return nil
+	}
+	goTime, err := ConvertTimestampToTimeOrError(gogo)
+	if err != nil {
+		return nil
+	}
+	return &goTime
+}
+
+// ConvertTimeToTimestampOrNil converts a golang Time to a proto timestamp, defaulting to nil in case of error.
+func ConvertTimeToTimestampOrNil(goTime *time.Time) *gogoTimestamp.Timestamp {
+	if goTime == nil {
+		return nil
+	}
+	gogo, err := ConvertTimeToTimestampOrError(*goTime)
+	if err != nil {
+		return nil
+	}
+	return gogo
+}
+
 // ConvertTimeToTimestampOrError converts golang time to proto timestamp.
 func ConvertTimeToTimestampOrError(goTime time.Time) (*gogoTimestamp.Timestamp, error) {
 	return gogoTimestamp.TimestampProto(goTime)

--- a/pkg/protocompat/time_test.go
+++ b/pkg/protocompat/time_test.go
@@ -54,6 +54,38 @@ func TestConvertTimeToTimestampOrError(t *testing.T) {
 	assert.Equal(t, &types.Timestamp{Seconds: seconds1, Nanos: nanos1}, protoTS1)
 }
 
+func TestConvertTimestampToTimeOrNil(t *testing.T) {
+	seconds := int64(2345678901)
+	nanos := int32(123456789)
+
+	var protoTS1 *types.Timestamp
+	protoTS2 := &types.Timestamp{
+		Seconds: seconds,
+		Nanos:   nanos,
+	}
+
+	goTS1 := ConvertTimestampToTimeOrNil(protoTS1)
+	assert.Nil(t, goTS1)
+
+	expectedTimeTS2 := time.Unix(seconds, int64(nanos))
+
+	goTS2 := ConvertTimestampToTimeOrNil(protoTS2)
+	assert.Equal(t, expectedTimeTS2.Local(), goTS2.Local())
+}
+
+func TestConvertTimeToTimestampOrNil(t *testing.T) {
+	var timeNil *time.Time
+	protoTSNil := ConvertTimeToTimestampOrNil(timeNil)
+	assert.Nil(t, protoTSNil)
+
+	seconds1 := int64(2345678901)
+	nanos1 := int32(123456789)
+	time1 := time.Unix(seconds1, int64(nanos1))
+
+	protoTS1 := ConvertTimeToTimestampOrNil(&time1)
+	assert.Equal(t, &types.Timestamp{Seconds: seconds1, Nanos: nanos1}, protoTS1)
+}
+
 func TestGetProtoTimestampFromSeconds(t *testing.T) {
 	seconds1 := int64(1234567890)
 	seconds2 := int64(23456789012)

--- a/pkg/protocompat/time_test.go
+++ b/pkg/protocompat/time_test.go
@@ -71,6 +71,12 @@ func TestConvertTimestampToTimeOrNil(t *testing.T) {
 
 	goTS2 := ConvertTimestampToTimeOrNil(protoTS2)
 	assert.Equal(t, expectedTimeTS2.Local(), goTS2.Local())
+
+	protoTSInvalid := &types.Timestamp{
+		Seconds: -62135683200,
+	}
+	goTSInvalid := ConvertTimestampToTimeOrNil(protoTSInvalid)
+	assert.Nil(t, goTSInvalid)
 }
 
 func TestConvertTimeToTimestampOrNil(t *testing.T) {
@@ -84,6 +90,10 @@ func TestConvertTimeToTimestampOrNil(t *testing.T) {
 
 	protoTS1 := ConvertTimeToTimestampOrNil(&time1)
 	assert.Equal(t, &types.Timestamp{Seconds: seconds1, Nanos: nanos1}, protoTS1)
+
+	timeInvalid := time.Date(0, 12, 25, 23, 59, 59, 0, time.UTC)
+	protoTSInvalid := ConvertTimeToTimestampOrNil(&timeInvalid)
+	assert.Nil(t, protoTSInvalid)
 }
 
 func TestGetProtoTimestampFromSeconds(t *testing.T) {

--- a/pkg/protoconv/time.go
+++ b/pkg/protoconv/time.go
@@ -54,11 +54,6 @@ func ConvertTimeToTimestamp(goTime time.Time) *gogoTimestamp.Timestamp {
 	return t
 }
 
-// ConvertTimeToTimestampOrError converts golang time to proto timestamp.
-func ConvertTimeToTimestampOrError(goTime time.Time) (*gogoTimestamp.Timestamp, error) {
-	return gogoTimestamp.TimestampProto(goTime)
-}
-
 // ConvertTimeToTimestampOrNil converts golang time to proto timestamp or if it fails returns nil.
 func ConvertTimeToTimestampOrNil(goTime time.Time) *gogoTimestamp.Timestamp {
 	t, err := gogoTimestamp.TimestampProto(goTime)


### PR DESCRIPTION
## Description

Add conversion functions to convert between go time and proto timestamp.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
