### PR TITLE
chore(deps): use datadog instead of replace

### DIFF
--- a/central/globaldb/v2backuprestore/formats/roxdbv1/rocks.go
+++ b/central/globaldb/v2backuprestore/formats/roxdbv1/rocks.go
@@ -6,12 +6,12 @@ import (
 	"io"
 	"os"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	pkgTar "github.com/stackrox/rox/pkg/tar"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	cloud.google.com/go/storage v1.37.0
 	github.com/BurntSushi/toml v1.3.2
 	github.com/ComplianceAsCode/compliance-operator v1.4.0
+	github.com/DataDog/gorocksdb v0.0.0-20200107201226-9722c3a2e063
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/NYTimes/gziphandler v1.1.1
@@ -110,7 +111,6 @@ require (
 	github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d
 	github.com/stackrox/scanner v0.0.0-20240110222630-351caa1e0024
 	github.com/stretchr/testify v1.8.4
-	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c
 	github.com/tidwall/gjson v1.17.1
 	github.com/tkuchiki/go-timezone v0.2.2
 	github.com/travelaudience/go-promhttp v1.0.1
@@ -456,7 +456,6 @@ replace (
 	// we currently depend on.
 	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46
 
-	github.com/tecbot/gorocksdb => github.com/DataDog/gorocksdb v0.0.0-20200107201226-9722c3a2e063
 	go.uber.org/zap => github.com/stackrox/zap v1.15.1-0.20230918235618-2bd149903d0e
 )
 

--- a/local/expand/main.go
+++ b/local/expand/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/tecbot/gorocksdb"
 )
 
 func main() {

--- a/migrator/migrations/m_104_to_m_105_active_component/migration.go
+++ b/migrator/migrations/m_104_to_m_105_active_component/migration.go
@@ -4,12 +4,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_106_to_m_107_policy_categories/migration.go
+++ b/migrator/migrations/m_106_to_m_107_policy_categories/migration.go
@@ -3,6 +3,7 @@ package m106to107
 import (
 	"strings"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -12,7 +13,6 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/uuid"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_106_to_m_107_policy_categories/migration_test.go
+++ b/migrator/migrations/m_106_to_m_107_policy_categories/migration_test.go
@@ -3,6 +3,7 @@ package m106to107
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/generated/storage"
 	dbTypes "github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -11,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
+++ b/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
@@ -1,12 +1,12 @@
 package m107tom108
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 	"go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_108_to_m_109_compliance_run_schedules/migration.go
+++ b/migrator/migrations/m_108_to_m_109_compliance_run_schedules/migration.go
@@ -1,12 +1,12 @@
 package m108tom109
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/m_110_to_m_111_replace_deprecated_resources/migration.go
+++ b/migrator/migrations/m_110_to_m_111_replace_deprecated_resources/migration.go
@@ -1,12 +1,12 @@
 package m110tom111
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_58_to_m_59_node_scanning_flag_on/migration.go
+++ b/migrator/migrations/m_58_to_m_59_node_scanning_flag_on/migration.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/log"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_61_to_m_62_multiple_cve_types/migration.go
+++ b/migrator/migrations/m_61_to_m_62_multiple_cve_types/migration.go
@@ -1,6 +1,7 @@
 package m61tom62
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
@@ -8,7 +9,6 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
 	rocksdb "github.com/stackrox/rox/pkg/rocksdb/crud"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration.go
+++ b/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration.go
@@ -1,12 +1,12 @@
 package m64to65
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration_test.go
+++ b/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration_test.go
@@ -3,6 +3,7 @@ package m64to65
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -10,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestExecWebhookMigration(t *testing.T) {

--- a/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration.go
+++ b/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration.go
@@ -1,13 +1,13 @@
 package m70tom71
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration_test.go
+++ b/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration_test.go
@@ -3,6 +3,7 @@ package m70tom71
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -10,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestDisableAuditLogCollectionMigration(t *testing.T) {

--- a/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration.go
+++ b/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration.go
@@ -1,11 +1,11 @@
 package m71tom72
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration_test.go
+++ b/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration_test.go
@@ -3,10 +3,10 @@ package m71tom72
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestMigration(t *testing.T) {

--- a/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration.go
+++ b/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration.go
@@ -1,6 +1,7 @@
 package m72tom73
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
@@ -8,7 +9,6 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/uuid"
-	"github.com/tecbot/gorocksdb"
 	"go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration_test.go
+++ b/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration_test.go
@@ -3,6 +3,7 @@ package m72tom73
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
@@ -12,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration.go
+++ b/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration.go
@@ -1,13 +1,13 @@
 package m76to77
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 	"go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration_test.go
+++ b/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration_test.go
@@ -3,6 +3,7 @@ package m76to77
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	dbTypes "github.com/stackrox/rox/migrator/types"
@@ -11,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/migrations/m_89_to_m_90_vuln_state/migration.go
+++ b/migrator/migrations/m_89_to_m_90_vuln_state/migration.go
@@ -1,6 +1,7 @@
 package m89tom90
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
@@ -8,7 +9,6 @@ import (
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_90_to_m_91_snooze_permissions/migration.go
+++ b/migrator/migrations/m_90_to_m_91_snooze_permissions/migration.go
@@ -1,12 +1,12 @@
 package m90tom91
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_91_to_m_92_write_edges_to_graph/migration.go
+++ b/migrator/migrations/m_91_to_m_92_write_edges_to_graph/migration.go
@@ -1,6 +1,7 @@
 package m91tom92
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
@@ -8,7 +9,6 @@ import (
 	"github.com/stackrox/rox/migrator/migrations/m_91_to_m_92_write_edges_to_graph/sortedkeys"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_92_to_m_93_cleanup_orphaned_rbac_cluster_objs/migration.go
+++ b/migrator/migrations/m_92_to_m_93_cleanup_orphaned_rbac_cluster_objs/migration.go
@@ -1,6 +1,7 @@
 package m92tom93
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/log"
@@ -9,7 +10,6 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration.go
+++ b/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration.go
@@ -1,13 +1,13 @@
 package m93tom94
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const unrestrictedScopeID = "io.stackrox.authz.accessscope.unrestricted"

--- a/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration_test.go
+++ b/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration_test.go
@@ -3,6 +3,7 @@ package m93tom94
 import (
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/rockshelper"
@@ -10,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestMigration(t *testing.T) {

--- a/migrator/migrations/m_94_to_m_95_cluster_health_status_id/migration.go
+++ b/migrator/migrations/m_94_to_m_95_cluster_health_status_id/migration.go
@@ -1,13 +1,13 @@
 package m94tom95
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration.go
+++ b/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration.go
@@ -1,13 +1,13 @@
 package m95tom96
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration_test.go
+++ b/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/rockshelper"
@@ -12,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestMigration(t *testing.T) {

--- a/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration.go
+++ b/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration.go
@@ -3,13 +3,13 @@ package m96tom97
 import (
 	"fmt"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration_test.go
+++ b/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/golang/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
@@ -11,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/suite"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestMigration(t *testing.T) {

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/legacy/rocksdb_store.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/legacy/rocksdb_store.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/legacy/rocksdb_store.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/legacy/rocksdb_store.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/legacy/rocksdb_store.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/legacy/rocksdb_store.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/legacy/rocksdb_store.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/legacy/rocksdb_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dbhelper"
@@ -14,7 +15,6 @@ import (
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/uuid"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/flow_impl.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/flow_impl.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/n_30_to_n_31_postgres_network_flows/common"
@@ -14,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/rocksdb"
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"github.com/tecbot/gorocksdb"
 )
 
 type flowStoreImpl struct {

--- a/migrator/rockshelper/rocksdb.go
+++ b/migrator/rockshelper/rocksdb.go
@@ -3,13 +3,13 @@ package rockshelper
 import (
 	"path/filepath"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/migrator/migrations/rocksdbmigration"
 	"github.com/stackrox/rox/migrator/option"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/tecbot/gorocksdb"
 )
 
 const (

--- a/migrator/runner/version_amd64.go
+++ b/migrator/runner/version_amd64.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/bolthelpers"
@@ -14,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/migrations"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/migrator/types/databases_amd64.go
+++ b/migrator/types/databases_amd64.go
@@ -5,9 +5,9 @@ package types
 import (
 	"context"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/rocksdb"
-	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 	"gorm.io/gorm"
 )

--- a/migrator/upgrade_amd64.go
+++ b/migrator/upgrade_amd64.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/migrator/bolthelpers"
 	"github.com/stackrox/rox/migrator/compact"
@@ -22,7 +23,6 @@ import (
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
-	"github.com/tecbot/gorocksdb"
 	"go.etcd.io/bbolt"
 	"gorm.io/gorm"
 )

--- a/pkg/dackbox/transactions/rocksdb/rocksdb.go
+++ b/pkg/dackbox/transactions/rocksdb/rocksdb.go
@@ -1,10 +1,10 @@
 package rocksdb
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/dackbox/transactions"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	generic "github.com/stackrox/rox/pkg/rocksdb/crud"
-	"github.com/tecbot/gorocksdb"
 )
 
 type rocksDBWrapper struct {

--- a/pkg/rocksdb/close_test.go
+++ b/pkg/rocksdb/close_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tecbot/gorocksdb"
 )
 
 func TestSynchronousCloseBaseCase(t *testing.T) {

--- a/pkg/rocksdb/crud/generic_impl.go
+++ b/pkg/rocksdb/crud/generic_impl.go
@@ -1,11 +1,11 @@
 package generic
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/rocksdb"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/pkg/rocksdb/crud/iteration.go
+++ b/pkg/rocksdb/crud/iteration.go
@@ -1,9 +1,9 @@
 package generic
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/rocksdb"
-	"github.com/tecbot/gorocksdb"
 )
 
 // BucketKeyForEach ensures that the keys iterated over has the bucket prefix

--- a/pkg/rocksdb/crud/options.go
+++ b/pkg/rocksdb/crud/options.go
@@ -1,6 +1,6 @@
 package generic
 
-import "github.com/tecbot/gorocksdb"
+import "github.com/DataDog/gorocksdb"
 
 // DefaultReadOptions define the default read options to be used for RocksDB
 func DefaultReadOptions() *gorocksdb.ReadOptions {

--- a/pkg/rocksdb/crud/transactions.go
+++ b/pkg/rocksdb/crud/transactions.go
@@ -1,9 +1,9 @@
 package generic
 
 import (
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/dbhelper"
 	"github.com/stackrox/rox/pkg/rocksdb"
-	"github.com/tecbot/gorocksdb"
 )
 
 var (

--- a/pkg/rocksdb/rocksdb.go
+++ b/pkg/rocksdb/rocksdb.go
@@ -7,15 +7,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/stackrox/rox/pkg/devbuild"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/tecbot/gorocksdb"
 	"go.uber.org/atomic"
 )
 
 // Make sure we link against the liblz4 compression library, as this is the compression algorithm
 // we want to use.
-// Note: older versions of github.com/tecbot/gorocksdb already add this to LDFLAGS, but more recent
+// Note: older versions of github.com/DataDog/gorocksdb already add this to LDFLAGS, but more recent
 // ones do not.
 
 // #cgo LDFLAGS: -llz4

--- a/tools/rocksdbdump/main.go
+++ b/tools/rocksdbdump/main.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/DataDog/gorocksdb"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -18,7 +19,6 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/tecbot/gorocksdb"
 )
 
 func main() {


### PR DESCRIPTION
## Description

We were pinned to https://github.com/DataDog/gorocksdb/commit/f0fad39f321 as before with replace.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI should be enough and no changes to `go.sum`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
