### PR TITLE
fix(editorconfig): protobuf configuration matches buf format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,10 @@
 [{Makefile,**.mk}]
 indent_style = tab
 
-[**.{proto,sh}]
+[**.sh]
 indent_style = space
 indent_size = 4
 
+[**.proto]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Description

After #9130, all protobuf files are formatted with 2 spaces for indentation. This is different to the configuration provided in .editorconfig and causes editors that use this file to use 4 spaces instead. Easy fix is to set the indentation to 2 spaces in editorconfig so everything stays consistent.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Opened a protobuf file with the .proto extension on NeoVim and indentation was properly configured.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
