### PR TITLE
ROX-23118: Include query string in login redirect URL

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
@@ -32,7 +32,7 @@ function AuthenticatedRoutes(): ReactElement {
                 <Redirect
                     to={{
                         pathname: '/login',
-                        state: { from: location.pathname },
+                        state: { from: `${location.pathname}${location.search}` },
                     }}
                 />
             );


### PR DESCRIPTION
## Description

Based on a customer bug report, I investigated why the query string portion of a link was being dropped if a user visited the link, was not already logged in, and was redirected to the login page before then getting to the followed link.

What I thought might involve significant refactoring or a change to routing dependencies, turned out to be much simpler: where we were manually saving the original link before the redirect to the login page, we had only bothered to save the URL path part **before** the query string `?...`.

(This code dates back 6 years, when almost all of each page's internal state was being held in redux or memory, and not reflected in the URL.)

This PR simply saves both the path AND the query string before redirect.

## Checklist
- [x] Investigated and inspected CI test results (failures in one flavor of ui-e2e-tests are flakes)

## Testing Performed

### Here I tell how I validated my change

#### Manual test cases based on the URL pattern in the Jira bug report

Before this change
1. Log out
2. Follow this link, which includes a "Fixable:true" query string: `Expected URL: /main/vulnerability-management/image/sha256:e0a4a8fc5b90715278772af1fb8025c63bf9cd14319b34a6f5319ca8fe10421e/image-components?s%5BFixable%5D=true`
3. After logging in, see that you are redirected to that page but without the query string part of the URL, so that you see more items in the table than expected, ` /main/vulnerability-management/image/sha256:e0a4a8fc5b90715278772af1fb8025c63bf9cd14319b34a6f5319ca8fe10421e/image-components`
![Screenshot 2024-03-13 at 4 41 14 PM](https://github.com/stackrox/stackrox/assets/715729/a572c84f-63dc-4394-8867-2b6f6571e8f0)




Before this change
1. Log out
2. Follow this link, which includes a "Fixable:true" query string: `Expected URL: /main/vulnerability-management/image/sha256:e0a4a8fc5b90715278772af1fb8025c63bf9cd14319b34a6f5319ca8fe10421e/image-components?s%5BFixable%5D=true`
3. After logging in, see that you are redirected to that page but **with** the query string part of the URL, so that you see only the items in the table that you expected
![Screenshot 2024-03-13 at 4 39 41 PM](https://github.com/stackrox/stackrox/assets/715729/4f57b0ef-6605-4801-aa3f-673706221a66)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
