### PR TITLE
feat(enhancement): Enhance local-sensor clientset with ocp clients

### DIFF
--- a/sensor/debugger/k8s/fake.go
+++ b/sensor/debugger/k8s/fake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 	"time"
@@ -221,7 +220,7 @@ func (f *FakeEventsManager) eventsCreation() (<-chan string, <-chan error) {
 				return
 			}
 			if f.Verbose {
-				log.Printf("%s Event: %s", msg.Action, msg.ObjectType)
+				log.Infof("%s Event: %s", msg.Action, msg.ObjectType)
 			}
 			if err := f.createEvent(msg, ch); err != nil {
 				errorCh <- errors.Wrapf(err, "cannot create event for %s", msg.ObjectType)

--- a/sensor/debugger/k8s/k8sclient.go
+++ b/sensor/debugger/k8s/k8sclient.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"log"
 	"testing"
 
 	appVersioned "github.com/openshift/client-go/apps/clientset/versioned"
@@ -10,6 +9,8 @@ import (
 	operatorVersioned "github.com/openshift/client-go/operator/clientset/versioned"
 	routeVersioned "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	k8sConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // MakeFakeClient creates a k8s client that is not connected to any cluster
@@ -63,8 +68,65 @@ func MakeOutOfClusterClient() (*ClientSet, error) {
 	}
 
 	return &ClientSet{
-		k8s: k8sClient,
+		k8s:               k8sClient,
+		dynamic:           mustCreateDynamicClient(config),
+		openshiftApps:     mustCreateOpenshiftAppsClient(config),
+		openshiftConfig:   mustCreateOpenshiftConfigClient(config),
+		openshiftRoute:    mustCreateOpenshiftRouteClient(config),
+		openshiftOperator: mustCreateOpenshiftOperatorClient(config),
 	}, nil
+}
+
+func mustCreateOpenshiftRouteClient(config *rest.Config) routeVersioned.Interface {
+	if !env.OpenshiftAPI.BooleanSetting() {
+		return nil
+	}
+	client, err := routeVersioned.NewForConfig(config)
+	if err != nil {
+		log.Panicf("Could not generate openshift routes client: %v", err)
+	}
+	return client
+}
+
+func mustCreateOpenshiftAppsClient(config *rest.Config) appVersioned.Interface {
+	if !env.OpenshiftAPI.BooleanSetting() {
+		return nil
+	}
+	client, err := appVersioned.NewForConfig(config)
+	if err != nil {
+		log.Panicf("Could not generate openshift apps client: %v", err)
+	}
+	return client
+}
+
+func mustCreateOpenshiftConfigClient(config *rest.Config) configVersioned.Interface {
+	if !env.OpenshiftAPI.BooleanSetting() {
+		return nil
+	}
+	client, err := configVersioned.NewForConfig(config)
+	if err != nil {
+		log.Warnf("Could not generate openshift config client: %v", err)
+	}
+	return client
+}
+
+func mustCreateOpenshiftOperatorClient(config *rest.Config) operatorVersioned.Interface {
+	if !env.OpenshiftAPI.BooleanSetting() {
+		return nil
+	}
+	client, err := operatorVersioned.NewForConfig(config)
+	if err != nil {
+		log.Warnf("Could not generate openshift operator client: %v", err)
+	}
+	return client
+}
+
+func mustCreateDynamicClient(config *rest.Config) dynamic.Interface {
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.Panicf("Creating dynamic client: %v", err)
+	}
+	return client
 }
 
 // Kubernetes returns the kubernetes interface


### PR DESCRIPTION
## Description

Enhance local-sensor `clientset` to also include openshift and the dynamic clients.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Run local-sensor in openshift

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
