### PR TITLE
chore(ui): Swap button style from tertiary to secondary

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -412,7 +412,7 @@ function ClustersTablePanel({
                             )}
                             {hasAdminRole && (
                                 <ToolbarItem>
-                                    <Button variant="tertiary">
+                                    <Button variant="secondary">
                                         <ManageTokensButton />
                                     </Button>
                                 </ToolbarItem>


### PR DESCRIPTION
## Description

Changes a rogue tertiary button to secondary to match others in the same UI section. This is a holdover from when there were two buttons (one secondary one tertiary) but seems out of place now that there are four.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before:
<img width="755" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/d33c192a-a0b6-4aba-86bb-2cb8b2cf46f5">

After:
<img width="755" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/99e52a82-bcae-4e53-b435-40f49cd22cca">
