### PR TITLE
ROX-22207: Isolate test

### DIFF
--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"path"
@@ -23,10 +24,11 @@ import (
 
 // Grab the backup DB and open it, ensuring that there are values for deployments
 func TestBackup(t *testing.T) {
-	setupNginxLatestTagDeployment(t)
-	defer teardownNginxLatestTagDeployment(t)
+	deploymentName := fmt.Sprintf("test-backup-%d", rand.Intn(10000))
 
-	waitForDeployment(t, nginxDeploymentName)
+	setupDeployment(t, "nginx", deploymentName)
+	defer teardownDeploymentWithoutCheck(deploymentName)
+	waitForDeployment(t, deploymentName)
 
 	for _, includeCerts := range []bool{false, true} {
 		t.Run(fmt.Sprintf("includeCerts=%t", includeCerts), func(t *testing.T) {

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -203,10 +203,6 @@ func getPodFromFile(t testutils.T, path string) *coreV1.Pod {
 	return &pod
 }
 
-func setupNginxLatestTagDeployment(t *testing.T) {
-	setupDeployment(t, "nginx", nginxDeploymentName)
-}
-
 func setupDeployment(t *testing.T, image, deploymentName string) {
 	setupDeploymentWithReplicas(t, image, deploymentName, 1)
 }
@@ -272,8 +268,10 @@ func teardownDeployment(t *testing.T, deploymentName string) {
 	waitForTermination(t, deploymentName)
 }
 
-func teardownNginxLatestTagDeployment(t *testing.T) {
-	teardownDeployment(t, nginxDeploymentName)
+func teardownDeploymentWithoutCheck(deploymentName string) {
+	// In cases where deployment will not impact other tests,
+	// we can trigger deletion and assume that it will be deleted eventually.
+	exec.Command(`kubectl`, `delete`, `deployment`, deploymentName, `--ignore-not-found=true`, `--grace-period=1`)
 }
 
 func getConfig(t *testing.T) *rest.Config {

--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -20,8 +20,7 @@ func TestExcludedScopes(t *testing.T) {
 	deploymentName := fmt.Sprintf("test-excluded-scopes-%d", rand.Intn(10000))
 
 	setupDeployment(t, "nginx", deploymentName)
-	// TODO: TESTING: If leftover will cause other tests to fail!!!
-	//defer teardownTestExcludedScopes(deploymentName)
+	defer teardownTestExcludedScopes(deploymentName)
 	waitForDeployment(t, deploymentName)
 
 	verifyNoAlertForExcludedScopes(t, deploymentName)

--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ func TestExcludedScopes(t *testing.T) {
 	deploymentName := fmt.Sprintf("test-excluded-scopes-%d", rand.Intn(10000))
 
 	setupDeployment(t, "nginx", deploymentName)
-	defer teardownTestExcludedScopes(deploymentName)
+	defer teardownDeploymentWithoutCheck(deploymentName)
 	waitForDeployment(t, deploymentName)
 
 	verifyNoAlertForExcludedScopes(t, deploymentName)
@@ -122,10 +121,4 @@ func verifyAlertForExcludedScopesRemoval(t *testing.T, deploymentName string) {
 	waitForAlert(t, alertService, &v1.ListAlertsRequest{
 		Query: qb.Query(),
 	}, 1)
-}
-
-func teardownTestExcludedScopes(deploymentName string) {
-	// Since deployment name is randomized, and it will not cause issues to other test,
-	// we can assume that deployment will be deleted eventually.
-	exec.Command(`kubectl`, `delete`, `deployment`, deploymentName, `--ignore-not-found=true`, `--grace-period=1`)
 }


### PR DESCRIPTION
## Description

This PR fixes the flaky test.

It does the following changes:
1. **Decoupling of tests:** Currently, failure of cleanup for `BackupTest` will cause the failure of `TestExcludedScopes`. We are decoupling them by using different deployment names, and on top of that, we are using random names per run, so even multiple cleanup failures will not impact the actual test.

2. **Make cleanup optional:** We should not test if `kubectl` works properly. Changed that test does not fail on timed out cleanup.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

1. Letting tests run in CI pipeline
2. Tested locally with removed teardown, to confirm that leftover deployments are not impacting the test
3. Test in CI, to check that leftover will not cause other tests to fail: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/10399/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1768719348333023232 - it looks good

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
