### PR TITLE
ROX-23036: Add route and page component for NodeCVEs - CVE Single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom';
+
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import { getOverviewCvesPath } from '../utils/searchUtils';
+
+const workloadCveOverviewCvePath = getOverviewCvesPath({
+    entityTab: 'CVE',
+});
+
+function NodeCvePage() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { cveId } = useParams() as { cveId: string };
+
+    const nodeCveName = cveId; // TODO Replace me with queried data
+
+    return (
+        <>
+            <PageTitle title={`Node CVEs - NodeCVE ${nodeCveName}`} />
+            <PageSection variant="light" className="pf-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>{nodeCveName} </BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light"></PageSection>
+        </>
+    );
+}
+
+export default NodeCvePage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
@@ -8,6 +8,9 @@ import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import { vulnerabilitiesNodeCvesPath } from 'routePaths';
 import usePermissions from 'hooks/usePermissions';
 import NodeCvesOverviewPage from './Overview/NodeCvesOverviewPage';
+import NodeCvePage from './NodeCve/NodeCvePage';
+
+const vulnerabilitiesNodeCveSinglePath = `${vulnerabilitiesNodeCvesPath}/cves/:cveId`;
 
 function NodeCvesPage() {
     const { hasReadAccess } = usePermissions();
@@ -17,6 +20,7 @@ function NodeCvesPage() {
         <>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
+                <Route path={vulnerabilitiesNodeCveSinglePath} component={NodeCvePage} />
                 <Route exact path={vulnerabilitiesNodeCvesPath} component={NodeCvesOverviewPage} />
                 <Route>
                     <PageSection variant="light">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/utils/searchUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/utils/searchUtils.ts
@@ -1,0 +1,14 @@
+import { vulnerabilitiesNodeCvesPath } from 'routePaths';
+import { SearchFilter } from 'types/search';
+import { getQueryString } from 'utils/queryStringUtils';
+
+import { NodeEntityTab } from '../../types';
+
+type NodeCvesSearch = {
+    entityTab?: NodeEntityTab;
+    s?: SearchFilter;
+};
+
+export function getOverviewCvesPath(nodeCvesSearch: NodeCvesSearch): string {
+    return `${vulnerabilitiesNodeCvesPath}${getQueryString(nodeCvesSearch)}`;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -62,17 +62,9 @@ export const workloadEntityTabValues = ['CVE', 'Image', 'Deployment'] as const;
 
 export type WorkloadEntityTab = (typeof workloadEntityTabValues)[number];
 
-export function isValidWorkloadEntityTab(value: unknown): value is WorkloadEntityTab {
-    return workloadEntityTabValues.some((tab) => tab === value);
-}
-
 export const nodeEntityTabValues = ['CVE', 'Node'] as const;
 
 export type NodeEntityTab = (typeof nodeEntityTabValues)[number];
-
-export function isValidNodeEntityTab(value: unknown): value is NodeEntityTab {
-    return nodeEntityTabValues.some((tab) => tab === value);
-}
 
 export type EntityTab = WorkloadEntityTab | NodeEntityTab;
 


### PR DESCRIPTION
## Description

Adds routing and a page component for the Node CVE single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Directly visit a URL ending in `vulnerabilities/node-cves/cves/<cve_id>`:
<img width="1679" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/3878c985-9593-4edd-a0c4-4fd3d3e3d188">

Click the breadcrumb link and verify it navigates back to the Node CVE overview page:
![image](https://github.com/stackrox/stackrox/assets/1292638/8e58474f-b53c-4331-b775-4ebd4cfb81a6)

