### PR TITLE
ROX-22101: remove gogo protobuf from vulnerability management

### DIFF
--- a/central/cve/cluster/datastore/datastore.go
+++ b/central/cve/cluster/datastore/datastore.go
@@ -2,8 +2,8 @@ package datastore
 
 import (
 	"context"
+	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/search"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
 	"github.com/stackrox/rox/central/cve/common"
@@ -26,7 +26,7 @@ type DataStore interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	GetBatch(ctx context.Context, id []string) ([]*storage.ClusterCVE, error)
 
-	Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error
+	Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error
 	Unsuppress(ctx context.Context, cves ...string) error
 
 	// UpsertInternal and DeleteInternal provide functionality to add and remove k8s, openshift and istio vulnerabilities.

--- a/central/cve/cluster/datastore/datastore_impl_test.go
+++ b/central/cve/cluster/datastore/datastore_impl_test.go
@@ -1,0 +1,81 @@
+package datastore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/central/cve/common"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSuppressExpiry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+
+	expiry1, err := getSuppressExpiry(nil, nil)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry1)
+
+	expiry2, err := getSuppressExpiry(nil, &duration)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry2)
+
+	expiry3, err := getSuppressExpiry(&startTime, nil)
+	assert.ErrorIs(t, err, errNilSuppressionDuration)
+	assert.Nil(t, expiry3)
+
+	expiry4, err := getSuppressExpiry(&startTime, &duration)
+	assert.NoError(t, err)
+	truncatedStart := startTime.Truncate(time.Second)
+	truncatedDuration := duration.Truncate(time.Second)
+	expectedExpiry4 := truncatedStart.Add(truncatedDuration)
+	assert.Equal(t, &expectedExpiry4, expiry4)
+}
+
+func TestGetSuppressionCacheEntry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+	activation := startTime.Truncate(time.Nanosecond)
+	expiration := startTime.Add(duration)
+
+	protoStart, err := protocompat.ConvertTimeToTimestampOrError(startTime)
+	assert.NoError(t, err)
+	protoExpiration, err := protocompat.ConvertTimeToTimestampOrError(expiration)
+	assert.NoError(t, err)
+
+	cve1 := &storage.ClusterCVE{}
+	expectedEntry1 := common.SuppressionCacheEntry{}
+	entry1 := getSuppressionCacheEntry(cve1)
+	assert.Equal(t, expectedEntry1, entry1)
+
+	cve2 := &storage.ClusterCVE{
+		SnoozeStart: protoStart,
+	}
+	expectedEntry2 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+	}
+	entry2 := getSuppressionCacheEntry(cve2)
+	assert.Equal(t, expectedEntry2, entry2)
+
+	cve3 := &storage.ClusterCVE{
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry3 := common.SuppressionCacheEntry{
+		SuppressExpiry: &expiration,
+	}
+	entry3 := getSuppressionCacheEntry(cve3)
+	assert.Equal(t, expectedEntry3, entry3)
+
+	cve4 := &storage.ClusterCVE{
+		SnoozeStart:  protoStart,
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry4 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+		SuppressExpiry:     &expiration,
+	}
+	entry4 := getSuppressionCacheEntry(cve4)
+	assert.Equal(t, expectedEntry4, entry4)
+}

--- a/central/cve/cluster/datastore/mocks/datastore.go
+++ b/central/cve/cluster/datastore/mocks/datastore.go
@@ -12,8 +12,8 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
-	types "github.com/gogo/protobuf/types"
 	converter "github.com/stackrox/rox/central/cve/converter/v2"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
@@ -165,7 +165,7 @@ func (mr *MockDataStoreMockRecorder) SearchRawCVEs(ctx, q any) *gomock.Call {
 }
 
 // Suppress mocks base method.
-func (m *MockDataStore) Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error {
+func (m *MockDataStore) Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, start, duration}
 	for _, a := range cves {

--- a/central/cve/cluster/datastore/store/postgres/full_store.go
+++ b/central/cve/cluster/datastore/store/postgres/full_store.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	protoTypes "github.com/gogo/protobuf/types"
 	"github.com/jackc/pgx/v5"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
 	"github.com/stackrox/rox/central/cve/converter/v2"
@@ -71,7 +70,7 @@ func (s *fullStoreImpl) DeleteClusterCVEsForCluster(ctx context.Context, cluster
 }
 
 func (s *fullStoreImpl) ReconcileClusterCVEParts(ctx context.Context, cveType storage.CVE_CVEType, cvePartsArr ...converter.ClusterCVEParts) error {
-	iTime := protocompat.TimestampNow()
+	iTime := time.Now()
 
 	cves := make([]*storage.ClusterCVE, 0, len(cvePartsArr))
 	var edges []*storage.ClusterCVEEdge
@@ -110,7 +109,7 @@ func (s *fullStoreImpl) ReconcileClusterCVEParts(ctx context.Context, cveType st
 	return tx.Commit(ctx)
 }
 
-func copyFromCVEs(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timestamp, objs ...*storage.ClusterCVE) error {
+func copyFromCVEs(ctx context.Context, tx *postgres.Tx, iTime time.Time, objs ...*storage.ClusterCVE) error {
 	batchSize := pgSearch.MaxBatchSize
 	if len(objs) < batchSize {
 		batchSize = len(objs)
@@ -151,7 +150,7 @@ func copyFromCVEs(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timest
 			obj.SnoozeStart = storedCVE.GetSnoozeStart()
 			obj.SnoozeExpiry = storedCVE.GetSnoozeExpiry()
 		} else {
-			obj.CveBaseInfo.CreatedAt = iTime
+			obj.CveBaseInfo.CreatedAt = protocompat.ConvertTimeToTimestampOrNil(&iTime)
 		}
 
 		serialized, marshalErr := obj.Marshal()

--- a/central/cve/cluster/service/service_impl.go
+++ b/central/cve/cluster/service/service_impl.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stackrox/rox/central/cve/cluster/datastore"
@@ -54,11 +55,15 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // SuppressCVEs suppresses CVEs from policy workflow and API endpoints that include cve in the responses.
 func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVERequest) (*v1.Empty, error) {
-	createdAt := protocompat.TimestampNow()
+	createdAt := time.Now()
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to snooze")
 	}
-	if err := s.cves.Suppress(ctx, createdAt, request.GetDuration(), request.GetCves()...); err != nil {
+	suppressDuration, err := protocompat.DurationFromProto(request.GetDuration())
+	if err != nil {
+		return nil, err
+	}
+	if err := s.cves.Suppress(ctx, &createdAt, &suppressDuration, request.GetCves()...); err != nil {
 		return nil, err
 	}
 	// Clusters are not part of policy workflow, and we do not reprocess risk on cve snooze. Hence, nothing to do.

--- a/central/cve/common/types.go
+++ b/central/cve/common/types.go
@@ -1,12 +1,12 @@
 package common
 
-import "github.com/gogo/protobuf/types"
+import "time"
 
 // CVESuppressionCache holds suppressed vulnerabilities' information.
 type CVESuppressionCache map[string]SuppressionCacheEntry
 
 // SuppressionCacheEntry represents cache entry for suppressed resources.
 type SuppressionCacheEntry struct {
-	SuppressActivation *types.Timestamp
-	SuppressExpiry     *types.Timestamp
+	SuppressActivation *time.Time
+	SuppressExpiry     *time.Time
 }

--- a/central/cve/fetcher/manager_impl_postgres_test.go
+++ b/central/cve/fetcher/manager_impl_postgres_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
@@ -530,10 +529,10 @@ func (s *TestClusterCVEOpsInPostgresTestSuite) TestBasicOps() {
 	s.Len(results, 10)
 
 	// Suppress CVEs
-	start := protocompat.TimestampNow()
-	duration := protocompat.DurationProto(10 * time.Minute)
+	start := time.Now()
+	duration := 10 * time.Minute
 	clusterCVE := utils.EmbeddedVulnerabilityToClusterCVE(storage.CVE_K8S_CVE, vulns[0])
-	err = s.clusterCVEDatastore.Suppress(s.ctx, start, duration, vulns[0].GetCve())
+	err = s.clusterCVEDatastore.Suppress(s.ctx, &start, &duration, vulns[0].GetCve())
 	s.NoError(err)
 
 	storedCVE, found, err := s.clusterCVEDatastore.Get(s.ctx, clusterCVE.GetId())

--- a/central/cve/image/datastore/datastore.go
+++ b/central/cve/image/datastore/datastore.go
@@ -3,8 +3,8 @@ package datastore
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/central/cve/common"
 	"github.com/stackrox/rox/central/cve/image/datastore/search"
 	"github.com/stackrox/rox/central/cve/image/datastore/store"
@@ -29,12 +29,12 @@ type DataStore interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	GetBatch(ctx context.Context, id []string) ([]*storage.ImageCVE, error)
 
-	Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error
+	Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error
 	Unsuppress(ctx context.Context, cves ...string) error
 
 	// Deprecated: ApplyException and RevertException are used for database backward compatibility purpose only.
 	// Those functions can be removed after a few releases.
-	ApplyException(ctx context.Context, start *types.Timestamp, expiry *types.Timestamp, cves ...string) error
+	ApplyException(ctx context.Context, start *time.Time, expiry *time.Time, cves ...string) error
 	RevertException(ctx context.Context, cves ...string) error
 
 	EnrichImageWithSuppressedCVEs(image *storage.Image)

--- a/central/cve/image/datastore/datastore_impl_test.go
+++ b/central/cve/image/datastore/datastore_impl_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -124,10 +125,10 @@ func (suite *ImageCVEDataStoreSuite) TestSuppressionCacheImages() {
 	suite.datastore.EnrichImageWithSuppressedCVEs(img)
 	suite.verifySuppressionStateImage(img, []string{"CVE-ABC", "CVE-DEF"}, []string{"CVE-GHI"})
 
-	start := protocompat.TimestampNow()
-	duration := protocompat.DurationProto(10 * time.Minute)
+	start := time.Now()
+	duration := 10 * time.Minute
 
-	expiry, err := getSuppressExpiry(start, duration)
+	expiry, err := getSuppressExpiry(&start, &duration)
 	suite.NoError(err)
 
 	suite.searcher.EXPECT().SearchRawImageCVEs(testAllAccessContext, gomock.Any()).Return([]*storage.ImageCVE{{CveBaseInfo: &storage.CVEInfo{Cve: "CVE-GHI"}}}, nil)
@@ -136,14 +137,14 @@ func (suite *ImageCVEDataStoreSuite) TestSuppressionCacheImages() {
 			Cve: "CVE-GHI",
 		},
 		Snoozed:      true,
-		SnoozeStart:  start,
-		SnoozeExpiry: expiry,
+		SnoozeStart:  protocompat.ConvertTimeToTimestampOrNil(&start),
+		SnoozeExpiry: protocompat.ConvertTimeToTimestampOrNil(expiry),
 	}
 	suite.storage.EXPECT().UpsertMany(testAllAccessContext, []*storage.ImageCVE{storedCVE}).Return(nil)
 
 	// Clear image before suppressing
 	img = getImageWithCVEs("CVE-ABC", "CVE-DEF", "CVE-GHI")
-	err = suite.datastore.Suppress(testAllAccessContext, start, duration, "CVE-GHI")
+	err = suite.datastore.Suppress(testAllAccessContext, &start, &duration, "CVE-GHI")
 	suite.NoError(err)
 	suite.datastore.EnrichImageWithSuppressedCVEs(img)
 	suite.verifySuppressionStateImage(img, []string{"CVE-ABC", "CVE-DEF", "CVE-GHI"}, nil)
@@ -156,4 +157,74 @@ func (suite *ImageCVEDataStoreSuite) TestSuppressionCacheImages() {
 	suite.NoError(err)
 	suite.datastore.EnrichImageWithSuppressedCVEs(img)
 	suite.verifySuppressionStateImage(img, []string{"CVE-ABC", "CVE-DEF"}, []string{"CVE-GHI"})
+}
+
+func TestGetSuppressExpiry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+
+	expiry1, err := getSuppressExpiry(nil, nil)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry1)
+
+	expiry2, err := getSuppressExpiry(nil, &duration)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry2)
+
+	expiry3, err := getSuppressExpiry(&startTime, nil)
+	assert.ErrorIs(t, err, errNilSuppressionDuration)
+	assert.Nil(t, expiry3)
+
+	expiry4, err := getSuppressExpiry(&startTime, &duration)
+	assert.NoError(t, err)
+	truncatedStart := startTime.Truncate(time.Second)
+	truncatedDuration := duration.Truncate(time.Second)
+	expectedExpiry4 := truncatedStart.Add(truncatedDuration)
+	assert.Equal(t, &expectedExpiry4, expiry4)
+}
+
+func TestGetSuppressionCacheEntry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+	activation := startTime.Truncate(time.Nanosecond)
+	expiration := startTime.Add(duration)
+
+	protoStart, err := protocompat.ConvertTimeToTimestampOrError(startTime)
+	assert.NoError(t, err)
+	protoExpiration, err := protocompat.ConvertTimeToTimestampOrError(expiration)
+	assert.NoError(t, err)
+
+	cve1 := &storage.ImageCVE{}
+	expectedEntry1 := common.SuppressionCacheEntry{}
+	entry1 := getSuppressionCacheEntry(cve1)
+	assert.Equal(t, expectedEntry1, entry1)
+
+	cve2 := &storage.ImageCVE{
+		SnoozeStart: protoStart,
+	}
+	expectedEntry2 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+	}
+	entry2 := getSuppressionCacheEntry(cve2)
+	assert.Equal(t, expectedEntry2, entry2)
+
+	cve3 := &storage.ImageCVE{
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry3 := common.SuppressionCacheEntry{
+		SuppressExpiry: &expiration,
+	}
+	entry3 := getSuppressionCacheEntry(cve3)
+	assert.Equal(t, expectedEntry3, entry3)
+
+	cve4 := &storage.ImageCVE{
+		SnoozeStart:  protoStart,
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry4 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+		SuppressExpiry:     &expiration,
+	}
+	entry4 := getSuppressionCacheEntry(cve4)
+	assert.Equal(t, expectedEntry4, entry4)
 }

--- a/central/cve/image/datastore/mocks/datastore.go
+++ b/central/cve/image/datastore/mocks/datastore.go
@@ -12,8 +12,8 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
-	types "github.com/gogo/protobuf/types"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	search "github.com/stackrox/rox/pkg/search"
@@ -44,7 +44,7 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // ApplyException mocks base method.
-func (m *MockDataStore) ApplyException(ctx context.Context, start, expiry *types.Timestamp, cves ...string) error {
+func (m *MockDataStore) ApplyException(ctx context.Context, start, expiry *time.Time, cves ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, start, expiry}
 	for _, a := range cves {
@@ -200,7 +200,7 @@ func (mr *MockDataStoreMockRecorder) SearchRawImageCVEs(ctx, q any) *gomock.Call
 }
 
 // Suppress mocks base method.
-func (m *MockDataStore) Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error {
+func (m *MockDataStore) Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, start, duration}
 	for _, a := range cves {

--- a/central/cve/node/datastore/datastore.go
+++ b/central/cve/node/datastore/datastore.go
@@ -3,8 +3,8 @@ package datastore
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/central/cve/common"
 	"github.com/stackrox/rox/central/cve/node/datastore/search"
 	"github.com/stackrox/rox/central/cve/node/datastore/store"
@@ -30,7 +30,7 @@ type DataStore interface {
 	GetBatch(ctx context.Context, id []string) ([]*storage.NodeCVE, error)
 
 	// Suppress suppresses node vulnerabilities with provided cve names (not ids) for the duration provided.
-	Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error
+	Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error
 	// Unsuppress unsuppresses node vulnerabilities with provided cve names (not ids).
 	Unsuppress(ctx context.Context, cves ...string) error
 	EnrichNodeWithSuppressedCVEs(node *storage.Node)

--- a/central/cve/node/datastore/datastore_impl_test.go
+++ b/central/cve/node/datastore/datastore_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -128,10 +129,10 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
 	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#"}, []string{"CVE-GHI#"})
 
-	start := protocompat.TimestampNow()
-	duration := protocompat.DurationProto(10 * time.Minute)
+	start := time.Now()
+	duration := 10 * time.Minute
 
-	expiry, err := getSuppressExpiry(start, duration)
+	expiry, err := getSuppressExpiry(&start, &duration)
 	suite.NoError(err)
 
 	suite.searcher.EXPECT().SearchRawCVEs(testAllAccessContext, gomock.Any()).Return(
@@ -149,14 +150,14 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 			Cve: "CVE-GHI",
 		},
 		Snoozed:      true,
-		SnoozeStart:  start,
-		SnoozeExpiry: expiry,
+		SnoozeStart:  protocompat.ConvertTimeToTimestampOrNil(&start),
+		SnoozeExpiry: protocompat.ConvertTimeToTimestampOrNil(expiry),
 	}
 	suite.storage.EXPECT().UpsertMany(testAllAccessContext, []*storage.NodeCVE{storedCVE}).Return(nil)
 
 	// Clear image before suppressing
 	node = getNodeWithCVEs("CVE-ABC", "CVE-DEF", "CVE-GHI")
-	err = suite.datastore.Suppress(testAllAccessContext, start, duration, "CVE-GHI")
+	err = suite.datastore.Suppress(testAllAccessContext, &start, &duration, "CVE-GHI")
 	suite.NoError(err)
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
 	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#", "CVE-GHI#"}, nil)
@@ -171,4 +172,74 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 	suite.NoError(err)
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
 	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#"}, []string{"CVE-GHI#"})
+}
+
+func TestGetSuppressionCacheEntry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+	activation := startTime.Truncate(time.Nanosecond)
+	expiration := startTime.Add(duration)
+
+	protoStart, err := protocompat.ConvertTimeToTimestampOrError(startTime)
+	assert.NoError(t, err)
+	protoExpiration, err := protocompat.ConvertTimeToTimestampOrError(expiration)
+	assert.NoError(t, err)
+
+	cve1 := &storage.NodeCVE{}
+	expectedEntry1 := common.SuppressionCacheEntry{}
+	entry1 := getSuppressionCacheEntry(cve1)
+	assert.Equal(t, expectedEntry1, entry1)
+
+	cve2 := &storage.NodeCVE{
+		SnoozeStart: protoStart,
+	}
+	expectedEntry2 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+	}
+	entry2 := getSuppressionCacheEntry(cve2)
+	assert.Equal(t, expectedEntry2, entry2)
+
+	cve3 := &storage.NodeCVE{
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry3 := common.SuppressionCacheEntry{
+		SuppressExpiry: &expiration,
+	}
+	entry3 := getSuppressionCacheEntry(cve3)
+	assert.Equal(t, expectedEntry3, entry3)
+
+	cve4 := &storage.NodeCVE{
+		SnoozeStart:  protoStart,
+		SnoozeExpiry: protoExpiration,
+	}
+	expectedEntry4 := common.SuppressionCacheEntry{
+		SuppressActivation: &activation,
+		SuppressExpiry:     &expiration,
+	}
+	entry4 := getSuppressionCacheEntry(cve4)
+	assert.Equal(t, expectedEntry4, entry4)
+}
+
+func TestGetSuppressExpiry(t *testing.T) {
+	startTime := time.Now().UTC()
+	duration := 10 * time.Minute
+
+	expiry1, err := getSuppressExpiry(nil, nil)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry1)
+
+	expiry2, err := getSuppressExpiry(nil, &duration)
+	assert.ErrorIs(t, err, errNilSuppressionStart)
+	assert.Nil(t, expiry2)
+
+	expiry3, err := getSuppressExpiry(&startTime, nil)
+	assert.ErrorIs(t, err, errNilSuppressionDuration)
+	assert.Nil(t, expiry3)
+
+	expiry4, err := getSuppressExpiry(&startTime, &duration)
+	assert.NoError(t, err)
+	truncatedStart := startTime.Truncate(time.Second)
+	truncatedDuration := duration.Truncate(time.Second)
+	expectedExpiry4 := truncatedStart.Add(truncatedDuration)
+	assert.Equal(t, &expectedExpiry4, expiry4)
 }

--- a/central/cve/node/datastore/mocks/datastore.go
+++ b/central/cve/node/datastore/mocks/datastore.go
@@ -12,8 +12,8 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
-	types "github.com/gogo/protobuf/types"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	search "github.com/stackrox/rox/pkg/search"
@@ -162,7 +162,7 @@ func (mr *MockDataStoreMockRecorder) SearchRawCVEs(ctx, q any) *gomock.Call {
 }
 
 // Suppress mocks base method.
-func (m *MockDataStore) Suppress(ctx context.Context, start *types.Timestamp, duration *types.Duration, cves ...string) error {
+func (m *MockDataStore) Suppress(ctx context.Context, start *time.Time, duration *time.Duration, cves ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, start, duration}
 	for _, a := range cves {

--- a/central/cve/node/service/service_impl.go
+++ b/central/cve/node/service/service_impl.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stackrox/rox/central/cve/node/datastore"
@@ -54,11 +55,15 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // SuppressCVEs suppresses CVEs from policy workflow and API endpoints that include cve in the responses.
 func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVERequest) (*v1.Empty, error) {
-	createdAt := protocompat.TimestampNow()
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to snooze")
 	}
-	if err := s.cves.Suppress(ctx, createdAt, request.GetDuration(), request.GetCves()...); err != nil {
+	createdAt := time.Now()
+	suppressDuration, err := protocompat.DurationFromProto(request.GetDuration())
+	if err != nil {
+		return nil, err
+	}
+	if err := s.cves.Suppress(ctx, &createdAt, &suppressDuration, request.GetCves()...); err != nil {
 		return nil, err
 	}
 	// Nodes are not part of policy workflow, and we do not reprocess risk on cve snooze. Hence, nothing to do.

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	protoTypes "github.com/gogo/protobuf/types"
 	"github.com/jackc/pgx/v5"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/pkg/errors"
@@ -83,7 +82,7 @@ func (s *storeImpl) insertIntoImages(
 	ctx context.Context,
 	tx *postgres.Tx, parts *imagePartsAsSlice,
 	metadataUpdated, scanUpdated bool,
-	iTime *protoTypes.Timestamp,
+	iTime time.Time,
 ) error {
 	cloned := parts.image
 	if cloned.GetScan().GetComponents() != nil {
@@ -330,7 +329,7 @@ func copyFromImageComponentEdges(ctx context.Context, tx *postgres.Tx, imageID s
 	return err
 }
 
-func copyFromImageCves(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timestamp, objs ...*storage.ImageCVE) error {
+func copyFromImageCves(ctx context.Context, tx *postgres.Tx, iTime time.Time, objs ...*storage.ImageCVE) error {
 	inputRows := [][]interface{}{}
 
 	var err error
@@ -368,7 +367,7 @@ func copyFromImageCves(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.T
 			obj.SnoozeStart = storedCVE.GetSnoozeStart()
 			obj.SnoozeExpiry = storedCVE.GetSnoozeExpiry()
 		} else {
-			obj.CveBaseInfo.CreatedAt = iTime
+			obj.CveBaseInfo.CreatedAt = protocompat.ConvertTimeToTimestampOrNil(&iTime)
 		}
 
 		serialized, marshalErr := obj.Marshal()
@@ -475,7 +474,7 @@ func copyFromImageComponentCVEEdges(ctx context.Context, tx *postgres.Tx, objs .
 	return nil
 }
 
-func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timestamp, vulnStateUpdate bool,
+func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime time.Time, vulnStateUpdate bool,
 	objs ...*storage.ImageCVEEdge) error {
 
 	if vulnStateUpdate {
@@ -502,7 +501,7 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 		if oldEdgeIDs.Remove(edge.GetId()) {
 			continue
 		}
-		edge.FirstImageOccurrence = iTime
+		edge.FirstImageOccurrence = protocompat.ConvertTimeToTimestampOrNil(&iTime)
 
 		inputRow, err := getImageCVEEdgeRowToInsert(edge)
 		if err != nil {
@@ -698,10 +697,10 @@ func populateImageScanHash(scan *storage.ImageScan) error {
 }
 
 func (s *storeImpl) upsert(ctx context.Context, obj *storage.Image) error {
-	iTime := protocompat.TimestampNow()
+	iTime := time.Now()
 
 	if !s.noUpdateTimestamps {
-		obj.LastUpdated = iTime
+		obj.LastUpdated = protocompat.ConvertTimeToTimestampOrNil(&iTime)
 	}
 
 	oldImage, _, err := s.GetImageMetadata(ctx, obj.GetId())
@@ -1410,7 +1409,7 @@ func (s *storeImpl) retryableUpdateVulnState(ctx context.Context, cve string, im
 	}
 
 	return s.keyFence.DoStatusWithLock(concurrency.DiscreteKeySet(keys...), func() error {
-		err = copyFromImageCVEEdges(ctx, tx, protocompat.TimestampNow(), true, imageCVEEdges...)
+		err = copyFromImageCVEEdges(ctx, tx, time.Now(), true, imageCVEEdges...)
 		if err != nil {
 			if err := tx.Rollback(ctx); err != nil {
 				return err

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	timestamp "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	imgCVEDataStore "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
@@ -29,6 +28,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -313,12 +313,13 @@ func (m *managerImpl) SnoozeVulnerabilityOnRequest(_ context.Context, request *s
 	// If the exception has global scope then update the legacy fields for database
 	// backward compatibility purpose.
 	if utils.V2GlobalScope(request.GetScope()) {
-		var expiry *timestamp.Timestamp
+		var expiry *time.Time
 		if request.GetDeferralReq() != nil &&
 			request.GetDeferralReq().GetExpiry().GetExpiryType() == storage.RequestExpiry_TIME {
-			expiry = request.GetDeferralReq().GetExpiry().GetExpiresOn()
+			expiry = protocompat.ConvertTimestampToTimeOrNil(request.GetDeferralReq().GetExpiry().GetExpiresOn())
 		}
-		err := m.imageCVEs.ApplyException(allAccessCtx, request.GetCreatedAt(), expiry, request.GetCves().GetCves()...)
+		createdAt := protocompat.ConvertTimestampToTimeOrNil(request.GetCreatedAt())
+		err := m.imageCVEs.ApplyException(allAccessCtx, createdAt, expiry, request.GetCves().GetCves()...)
 		// Log the error and continue since this is done for backward compatibility purpose.
 		if err != nil {
 			log.Errorf("Failed to update 'image_cves' table for vulnerability exception %s", request.GetId())

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -106,8 +105,8 @@ func (s *VulnRequestManagerRevertExceptionTestSuite) setupDataStores(pendingReqC
 }
 
 func (s *VulnRequestManagerTestSuite) TestReObserveExpiredDeferralsMarksAllAsInactive() {
-	expiredInThePast := protoconv.ConvertTimeToTimestamp(time.Now().Add(-96 * time.Hour))
-	expiresInFuture := protoconv.ConvertTimeToTimestamp(time.Now().Add(30 * 24 * time.Hour))
+	expiredInThePast := time.Now().Add(-96 * time.Hour)
+	expiresInFuture := time.Now().Add(30 * 24 * time.Hour)
 
 	fpRequest := fixtures.GetGlobalFPRequest("cve-a-b")
 	fpRequest.Status = storage.RequestStatus_APPROVED
@@ -213,10 +212,10 @@ func (s *VulnRequestManagerRevertExceptionTestSuite) TestReObserveFixableDeferra
 	fixableCVE1 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[0].GetCve()
 	unfixableCVE := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[2].GetCve()
 
-	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, protoconv.ConvertTimeToTimestamp(time.Now().Add(1*time.Hour)), fixableCVE1)
+	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, time.Now().Add(1*time.Hour), fixableCVE1)
 	fixableDeferralPendingUpdate := newDeferralExpiresWhenFixable("fixable-deferral-pending-update", false, storage.RequestStatus_APPROVED, nil, false, fixableCVE1)
 	fixableDeferralPendingUpdate.UpdatedReq = getDeferralExpiryTimeUpdate(1 * time.Hour)
-	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, protoconv.ConvertTimeToTimestamp(time.Now().Add(30*24*time.Hour)), fixableCVE1)
+	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, time.Now().Add(30*24*time.Hour), fixableCVE1)
 	timedDeferralPendingUpdate.UpdatedReq = getDeferralExpiryFixableUpdate(true)
 
 	shouldExpireReqs := []*storage.VulnerabilityRequest{
@@ -316,10 +315,10 @@ func (s *VulnRequestManagerRevertExceptionTestSuite) TestReObserveFixableDeferra
 	fixableCVE3 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[2].GetCve()
 	unfixableCVE := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[3].GetCve()
 
-	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, protoconv.ConvertTimeToTimestamp(time.Now().Add(1*time.Hour)), fixableCVE1, fixableCVE2)
+	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, time.Now().Add(1*time.Hour), fixableCVE1, fixableCVE2)
 	fixableDeferralPendingUpdate := newDeferralExpiresWhenFixable("fixable-deferral-pending-update", false, storage.RequestStatus_APPROVED, nil, false, fixableCVE1, fixableCVE2)
 	fixableDeferralPendingUpdate.UpdatedReq = getDeferralExpiryTimeUpdate(1 * time.Hour)
-	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, protoconv.ConvertTimeToTimestamp(time.Now().Add(30*24*time.Hour)), fixableCVE1)
+	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, time.Now().Add(30*24*time.Hour), fixableCVE1)
 	timedDeferralPendingUpdate.UpdatedReq = getDeferralExpiryFixableUpdate(true)
 
 	shouldExpireReqs := []*storage.VulnerabilityRequest{

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	imageDS "github.com/stackrox/rox/central/image/datastore"
@@ -26,6 +25,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -296,7 +296,7 @@ func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
 	s.manager.Stop()
 
 	// Add in a request that should be expired if it wasn't stopped
-	req := newDeferral("req", false, storage.RequestStatus_APPROVED, protoconv.ConvertTimeToTimestamp(time.Now().Add(-24*time.Hour)))
+	req := newDeferral("req", false, storage.RequestStatus_APPROVED, time.Now().Add(-24*time.Hour))
 	err := s.vulnReqDataStore.AddRequest(allAllowedCtx, req)
 	s.NoError(err)
 
@@ -339,7 +339,7 @@ func (s *VulnRequestManagerTestSuite) TestBuildCacheActiveRequests() {
 
 //// start test utilities
 
-func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *types.Timestamp, cves ...string) *storage.VulnerabilityRequest {
+func newDeferral(id string, expired bool, status storage.RequestStatus, expiry time.Time, cves ...string) *storage.VulnerabilityRequest {
 	id = id + "-" + uuid.NewV4().String()
 	ret := &storage.VulnerabilityRequest{
 		Id:          id,
@@ -349,7 +349,11 @@ func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *
 		TargetState: storage.VulnerabilityState_DEFERRED,
 		Req: &storage.VulnerabilityRequest_DeferralReq{
 			DeferralReq: &storage.DeferralRequest{
-				Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: expiry}},
+				Expiry: &storage.RequestExpiry{
+					Expiry: &storage.RequestExpiry_ExpiresOn{
+						ExpiresOn: protocompat.ConvertTimeToTimestampOrNil(&expiry),
+					},
+				},
 			},
 		},
 		Scope: &storage.VulnerabilityRequest_Scope{


### PR DESCRIPTION
## Description

The goal is to remove direct calls to the gogo protobuf library and have all of them happen through an abstraction layer in order to ease the migration to a new protobuf library.

The current PR aims at changing the functions around vulnerability management in central and migrator to use time rather than gogo timestamps as parameters or return values.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
