### PR TITLE
chore(dec-config): add tests to access scope updater

### DIFF
--- a/central/declarativeconfig/health/datastore/datastore.go
+++ b/central/declarativeconfig/health/datastore/datastore.go
@@ -2,9 +2,12 @@ package datastore
 
 import (
 	"context"
+	"testing"
 
 	"github.com/stackrox/rox/central/declarativeconfig/health/datastore/store"
+	pgStore "github.com/stackrox/rox/central/declarativeconfig/health/datastore/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
 )
 
 // DataStore is the entry point for modifying declarative config health data.
@@ -23,4 +26,9 @@ func New(storage store.Store) DataStore {
 	return &datastoreImpl{
 		store: storage,
 	}
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+	return New(pgStore.New(pool))
 }

--- a/central/declarativeconfig/health/datastore/datastore_impl_test.go
+++ b/central/declarativeconfig/health/datastore/datastore_impl_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/declarativeconfig/health/datastore/store"
-	postgresHealthStore "github.com/stackrox/rox/central/declarativeconfig/health/datastore/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/errox"
@@ -36,12 +34,9 @@ type declarativeConfigHealthDatastoreSuite struct {
 }
 
 func (s *declarativeConfigHealthDatastoreSuite) SetupTest() {
-	var declarativeConfigHealthStore store.Store
-
 	s.postgresTest = pgtest.ForT(s.T())
 	s.Require().NotNil(s.postgresTest)
-	declarativeConfigHealthStore = postgresHealthStore.New(s.postgresTest.DB)
-	s.datastore = New(declarativeConfigHealthStore)
+	s.datastore = GetTestPostgresDataStore(s.T(), s.postgresTest.DB)
 
 	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/declarativeconfig/updater/access_scope_updater_test.go
+++ b/central/declarativeconfig/updater/access_scope_updater_test.go
@@ -1,0 +1,216 @@
+//go:build sql_integration
+
+package updater
+
+import (
+	"context"
+	"testing"
+
+	declarativeConfigHealth "github.com/stackrox/rox/central/declarativeconfig/health/datastore"
+	roleDS "github.com/stackrox/rox/central/role/datastore"
+	roleMocks "github.com/stackrox/rox/central/role/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAccessScopeUpdater(t *testing.T) {
+	suite.Run(t, new(updaterTestSuite))
+}
+
+type updaterTestSuite struct {
+	suite.Suite
+
+	ctx     context.Context
+	pgTest  *pgtest.TestPostgres
+	updater *accessScopeUpdater
+}
+
+func (s *updaterTestSuite) SetupTest() {
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access, resources.Integration),
+		),
+	)
+	s.ctx = declarativeconfig.WithModifyDeclarativeOrImperative(s.ctx)
+
+	s.pgTest = pgtest.ForT(s.T())
+	s.Require().NotNil(s.pgTest)
+	ds, err := roleDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
+	s.Require().NoError(err)
+	s.updater = newAccessScopeUpdater(ds,
+		declarativeConfigHealth.GetTestPostgresDataStore(s.T(), s.pgTest.DB)).(*accessScopeUpdater)
+}
+
+func (s *updaterTestSuite) TearDownTest() {
+	s.pgTest.Teardown(s.T())
+	s.pgTest.Close()
+}
+
+func (s *updaterTestSuite) TestUpsert() {
+	cases := map[string]struct {
+		m   protocompat.Message
+		err error
+	}{
+		"invalid message type should yield an error": {
+			m:   &storage.Role{Name: "something"},
+			err: errox.InvariantViolation,
+		},
+		"valid message type should be upserted": {
+			m: &storage.SimpleAccessScope{
+				Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+				Name:        "testing",
+				Description: "testing",
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusters: []string{"cluster1"},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			err := s.updater.Upsert(s.ctx, tc.m)
+			s.ErrorIs(err, tc.err)
+			if tc.err == nil {
+				_, exists, err := s.updater.roleDS.GetAccessScope(s.ctx, s.updater.idExtractor(tc.m))
+				s.NoError(err)
+				s.True(exists)
+			}
+		})
+	}
+}
+
+func (s *updaterTestSuite) TestDelete_Successful() {
+	scopes := []*storage.SimpleAccessScope{
+		{
+			Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+			Name:        "test-1",
+			Description: "",
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedClusters: []string{"cluster1"},
+			},
+			Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		},
+		{
+			Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+			Name:        "test-2",
+			Description: "",
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedClusters: []string{"cluster1"},
+			},
+			Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		},
+		{
+			Id:          "0925514f-3a33-5931-b431-756406e1a008",
+			Name:        "test-3",
+			Description: "",
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedClusters: []string{"cluster1"},
+			},
+			Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		},
+	}
+
+	for _, scope := range scopes {
+		s.Require().NoError(s.updater.roleDS.AddAccessScope(s.ctx, scope))
+	}
+
+	failedIDs, err := s.updater.DeleteResources(s.ctx, "0925514f-3a33-5931-b431-756406e1a008")
+	s.NoError(err)
+	s.Empty(failedIDs)
+
+	_, exists, err := s.updater.roleDS.GetAccessScope(s.ctx, scopes[0].GetId())
+	s.False(exists)
+	s.NoError(err)
+
+	_, exists, err = s.updater.roleDS.GetAccessScope(s.ctx, scopes[1].GetId())
+	s.False(exists)
+	s.NoError(err)
+
+	_, exists, err = s.updater.roleDS.GetAccessScope(s.ctx, scopes[2].GetId())
+	s.True(exists)
+	s.NoError(err)
+}
+
+func (s *updaterTestSuite) TestDelete_Error() {
+	invalidErr := errox.InvalidArgs.New("something is wrong")
+	referenceErr := errox.ReferencedByAnotherObject.New("something is referenced")
+
+	m := roleMocks.NewMockDataStore(gomock.NewController(s.T()))
+	scopes := []*storage.SimpleAccessScope{
+		{
+			Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+			Name:        "test-1",
+			Description: "",
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedClusters: []string{"cluster1"},
+			},
+			Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		},
+		{
+			Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+			Name:        "test-2",
+			Description: "",
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedClusters: []string{"cluster1"},
+			},
+			Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		},
+	}
+	orphanedScope := scopes[1].Clone()
+	orphanedScope.Traits.Origin = storage.Traits_DECLARATIVE_ORPHANED
+
+	healths := []*storage.DeclarativeConfigHealth{
+		{
+			Id:           "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+			Name:         "test-1",
+			Status:       storage.DeclarativeConfigHealth_HEALTHY,
+			ResourceName: "test-1",
+			ResourceType: storage.DeclarativeConfigHealth_ACCESS_SCOPE,
+		},
+		{
+			Id:           "04a87e34-b568-5e14-90ac-380d25c8689b",
+			Name:         "test-2",
+			Status:       storage.DeclarativeConfigHealth_HEALTHY,
+			ResourceName: "test-2",
+			ResourceType: storage.DeclarativeConfigHealth_ACCESS_SCOPE,
+		},
+	}
+
+	for _, health := range healths {
+		s.Require().NoError(s.updater.healthDS.UpsertDeclarativeConfig(s.ctx, health))
+	}
+
+	gomock.InOrder(
+		m.EXPECT().GetAccessScopesFiltered(gomock.Any(), gomock.Any()).Return(scopes, nil),
+		m.EXPECT().RemoveAccessScope(gomock.Any(), scopes[0].GetId()).Return(invalidErr),
+		m.EXPECT().RemoveAccessScope(gomock.Any(), scopes[1].GetId()).Return(referenceErr),
+		m.EXPECT().UpsertAccessScope(gomock.Any(), orphanedScope).Return(nil),
+	)
+
+	s.updater.roleDS = m
+
+	failedIDs, err := s.updater.DeleteResources(s.ctx)
+	s.Error(err)
+	s.ElementsMatch([]string{scopes[0].GetId(), scopes[1].GetId()}, failedIDs)
+
+	health, exists, err := s.updater.healthDS.GetDeclarativeConfig(s.ctx, scopes[0].GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(storage.DeclarativeConfigHealth_UNHEALTHY, health.GetStatus())
+	s.Contains(health.GetErrorMessage(), invalidErr.Error())
+
+	health, exists, err = s.updater.healthDS.GetDeclarativeConfig(s.ctx, scopes[1].GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(storage.DeclarativeConfigHealth_UNHEALTHY, health.GetStatus())
+	s.Contains(health.GetErrorMessage(), referenceErr.Error())
+}

--- a/pkg/declarativeconfig/context.go
+++ b/pkg/declarativeconfig/context.go
@@ -31,7 +31,8 @@ type ResourceWithTraits interface {
 // HasModifyDeclarativeResourceKey returns a bool indicating whether the given context allows to modify
 // proto messages that are created declaratively.
 func HasModifyDeclarativeResourceKey(ctx context.Context) bool {
-	return ctx.Value(originCheckerKey{}) == allowOnlyDeclarativeOperations
+	val := ctx.Value(originCheckerKey{})
+	return val == allowOnlyDeclarativeOperations || val == allowModifyDeclarativeOrImperative
 }
 
 // CanModifyResource returns whether context holder is allowed to modify resource.

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"database/sql/driver"
 	"fmt"
+	"strings"
 
 	"github.com/gofrs/uuid"
 )
@@ -155,11 +156,14 @@ func NewDummy() UUID {
 }
 
 // NewTestUUID returns a UUID for testing purposes with the given number.
+// If number is negative or greater than 9 then zeroes are returned.
 // Example: 11111111-1111-1111-1111-111111111111.
 func NewTestUUID(d int) UUID {
-	return FromStringOrNil(fmt.Sprintf(
-		"%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d-"+
-			"%[1]d%[1]d%[1]d%[1]d-"+
-			"%[1]d%[1]d%[1]d%[1]d-"+
-			"%[1]d%[1]d%[1]d%[1]d-%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d", d))
+	s := fmt.Sprintf("%d", d)
+	return FromStringOrNil(
+		strings.Repeat(s, 8) +
+			strings.Repeat(s, 4) +
+			strings.Repeat(s, 4) +
+			strings.Repeat(s, 4) +
+			strings.Repeat(s, 12))
 }

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -5,6 +5,7 @@ package uuid
 import (
 	"crypto/sha256"
 	"database/sql/driver"
+	"fmt"
 
 	"github.com/gofrs/uuid"
 )
@@ -151,4 +152,14 @@ func NewV5(ns UUID, name string) UUID {
 // NewDummy returns a uuid for testing purposes
 func NewDummy() UUID {
 	return FromStringOrNil("aaaaaaaa-bbbb-4011-0000-111111111111")
+}
+
+// NewTestUUID returns a UUID for testing purposes with the given number.
+// Example: 11111111-1111-1111-1111-111111111111.
+func NewTestUUID(d int) UUID {
+	return FromStringOrNil(fmt.Sprintf(
+		"%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d-"+
+			"%[1]d%[1]d%[1]d%[1]d-"+
+			"%[1]d%[1]d%[1]d%[1]d-"+
+			"%[1]d%[1]d%[1]d%[1]d-%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d%[1]d", d))
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -65,4 +65,12 @@ func TestNewTestUUID(t *testing.T) {
 	test := NewTestUUID(1)
 	require.NotNil(t, test)
 	assert.Equal(t, "11111111-1111-1111-1111-111111111111", test.String())
+
+	test = NewTestUUID(-1)
+	require.NotNil(t, test)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", test.String())
+
+	test = NewTestUUID(10)
+	require.NotNil(t, test)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", test.String())
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -60,3 +60,9 @@ func TestFromString(t *testing.T) {
 		t.Errorf("Couldn't find UUID, %s, in map", second)
 	}
 }
+
+func TestNewTestUUID(t *testing.T) {
+	test := NewTestUUID(1)
+	require.NotNil(t, test)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", test.String())
+}


### PR DESCRIPTION
## Description

Improve the test coverage of the access scope updater for declarative config.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
