### PR TITLE
chore(dec-config): add tests to group updater

### DIFF
--- a/central/declarativeconfig/updater/group_updater_test.go
+++ b/central/declarativeconfig/updater/group_updater_test.go
@@ -1,0 +1,178 @@
+//go:build sql_integration
+
+package updater
+
+import (
+	"context"
+	"testing"
+
+	authProviderDS "github.com/stackrox/rox/central/authprovider/datastore"
+	declarativeConfigHealth "github.com/stackrox/rox/central/declarativeconfig/health/datastore"
+	groupDS "github.com/stackrox/rox/central/group/datastore"
+	roleDS "github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGroupUpdater(t *testing.T) {
+	suite.Run(t, new(groupUpdaterTestSuite))
+}
+
+type groupUpdaterTestSuite struct {
+	suite.Suite
+
+	ctx     context.Context
+	pgTest  *pgtest.TestPostgres
+	updater *groupUpdater
+	ads     authproviders.Store
+	rds     roleDS.DataStore
+}
+
+func (s *groupUpdaterTestSuite) SetupTest() {
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access, resources.Integration),
+		),
+	)
+	s.ctx = declarativeconfig.WithModifyDeclarativeOrImperative(s.ctx)
+
+	s.pgTest = pgtest.ForT(s.T())
+	s.Require().NotNil(s.pgTest)
+	rds, err := roleDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
+	s.Require().NoError(err)
+	s.rds = rds
+	s.ads = authProviderDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
+	s.updater = newGroupUpdater(
+		groupDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB, s.rds, s.ads),
+		declarativeConfigHealth.GetTestPostgresDataStore(s.T(), s.pgTest.DB)).(*groupUpdater)
+}
+
+func (s *groupUpdaterTestSuite) TearDownTest() {
+	s.pgTest.Teardown(s.T())
+	s.pgTest.Close()
+}
+
+func (s *groupUpdaterTestSuite) TestUpsert() {
+	cases := map[string]struct {
+		prepData func()
+		m        protocompat.Message
+		err      error
+	}{
+		"invalid message type should yield an error": {
+			m:   &storage.PermissionSet{Id: "some-id"},
+			err: errox.InvariantViolation,
+		},
+		"valid message type should be upserted": {
+			prepData: func() {
+				s.Require().NoError(s.rds.AddAccessScope(s.ctx, &storage.SimpleAccessScope{
+					Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+					Name:        "testing",
+					Description: "testing",
+					Rules: &storage.SimpleAccessScope_Rules{
+						IncludedClusters: []string{"cluster1"},
+					},
+					Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+				}))
+				s.Require().NoError(s.rds.AddPermissionSet(s.ctx, &storage.PermissionSet{
+					Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+					Name:        "testing",
+					Description: "testing",
+					Traits:      &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+				}))
+				s.Require().NoError(s.rds.AddRole(s.ctx, &storage.Role{
+					Name:            "test",
+					Description:     "test",
+					PermissionSetId: "04a87e34-b568-5e14-90ac-380d25c8689b",
+					AccessScopeId:   "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+					Traits:          &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+				}))
+				s.Require().NoError(s.ads.AddAuthProvider(s.ctx, &storage.AuthProvider{
+					Id:         "4df1b98c-24ed-4073-a9ad-356aec6bb62d",
+					Name:       "basic",
+					Type:       "basic",
+					UiEndpoint: "http://localhost",
+					LoginUrl:   "sso/something",
+					Traits:     &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+				}))
+			},
+			m: &storage.Group{
+				Props: &storage.GroupProperties{
+					AuthProviderId: "4df1b98c-24ed-4073-a9ad-356aec6bb62d",
+					Key:            "",
+					Value:          "",
+				},
+				RoleName: "test",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			if tc.prepData != nil {
+				tc.prepData()
+			}
+			err := s.updater.Upsert(s.ctx, tc.m)
+			s.ErrorIs(err, tc.err)
+			if tc.err == nil {
+				_, err := s.updater.groupDS.Get(s.ctx, &storage.GroupProperties{
+					Id:             s.updater.idExtractor(tc.m),
+					AuthProviderId: "4df1b98c-24ed-4073-a9ad-356aec6bb62d",
+				})
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *groupUpdaterTestSuite) TestDelete_Successful() {
+	s.Require().NoError(s.rds.AddAccessScope(s.ctx, &storage.SimpleAccessScope{
+		Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+		Name:        "testing",
+		Description: "testing",
+		Rules: &storage.SimpleAccessScope_Rules{
+			IncludedClusters: []string{"cluster1"},
+		},
+		Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.rds.AddPermissionSet(s.ctx, &storage.PermissionSet{
+		Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+		Name:        "testing",
+		Description: "testing",
+		Traits:      &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.rds.AddRole(s.ctx, &storage.Role{
+		Name:            "test",
+		Description:     "test",
+		PermissionSetId: "04a87e34-b568-5e14-90ac-380d25c8689b",
+		AccessScopeId:   "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+		Traits:          &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.ads.AddAuthProvider(s.ctx, &storage.AuthProvider{
+		Id:         "4df1b98c-24ed-4073-a9ad-356aec6bb62d",
+		Name:       "basic",
+		Type:       "basic",
+		UiEndpoint: "http://localhost",
+		LoginUrl:   "sso/something",
+		Traits:     &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.updater.groupDS.Add(s.ctx, &storage.Group{
+		Props: &storage.GroupProperties{
+			AuthProviderId: "4df1b98c-24ed-4073-a9ad-356aec6bb62d",
+			Key:            "",
+			Value:          "",
+		},
+		RoleName: "test",
+	}))
+
+	names, err := s.updater.DeleteResources(s.ctx)
+	s.NoError(err)
+	s.Empty(names)
+}

--- a/central/declarativeconfig/updater/permission_set_updater_test.go
+++ b/central/declarativeconfig/updater/permission_set_updater_test.go
@@ -1,0 +1,142 @@
+//go:build sql_integration
+
+package updater
+
+import (
+	"context"
+	"testing"
+
+	declarativeConfigHealth "github.com/stackrox/rox/central/declarativeconfig/health/datastore"
+	roleDS "github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestPermissionSetUpdater(t *testing.T) {
+	suite.Run(t, new(permissionSetUpdaterTestSuite))
+}
+
+type permissionSetUpdaterTestSuite struct {
+	suite.Suite
+
+	ctx     context.Context
+	pgTest  *pgtest.TestPostgres
+	updater *permissionSetUpdater
+}
+
+func (s *permissionSetUpdaterTestSuite) SetupTest() {
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access, resources.Integration),
+		),
+	)
+	s.ctx = declarativeconfig.WithModifyDeclarativeOrImperative(s.ctx)
+
+	s.pgTest = pgtest.ForT(s.T())
+	s.Require().NotNil(s.pgTest)
+	rds, err := roleDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
+	s.Require().NoError(err)
+	s.updater = newPermissionSetUpdater(rds, declarativeConfigHealth.GetTestPostgresDataStore(s.T(),
+		s.pgTest.DB)).(*permissionSetUpdater)
+}
+
+func (s *permissionSetUpdaterTestSuite) TearDownTest() {
+	s.pgTest.Teardown(s.T())
+	s.pgTest.Close()
+}
+
+func (s *permissionSetUpdaterTestSuite) TestUpsert() {
+	cases := map[string]struct {
+		m   protocompat.Message
+		err error
+	}{
+		"invalid message type should yield an error": {
+			m:   &storage.Role{Name: "test"},
+			err: errox.InvariantViolation,
+		},
+		"valid message type should be upserted": {
+			m: &storage.PermissionSet{
+				Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+				Name:        "testing",
+				Description: "testing",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			err := s.updater.Upsert(s.ctx, tc.m)
+			s.ErrorIs(err, tc.err)
+			if tc.err == nil {
+				_, exists, err := s.updater.roleDS.GetPermissionSet(s.ctx, s.updater.idExtractor(tc.m))
+				s.NoError(err)
+				s.True(exists)
+			}
+		})
+	}
+}
+
+func (s *permissionSetUpdaterTestSuite) TestDelete_Successful() {
+	s.Require().NoError(s.updater.roleDS.AddPermissionSet(s.ctx, &storage.PermissionSet{
+		Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+		Name:        "testing",
+		Description: "testing",
+		Traits:      &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+
+	names, err := s.updater.DeleteResources(s.ctx)
+	s.NoError(err)
+	s.Empty(names)
+}
+
+func (s *permissionSetUpdaterTestSuite) TestDelete_Error() {
+	s.Require().NoError(s.updater.roleDS.AddAccessScope(s.ctx, &storage.SimpleAccessScope{
+		Id:          "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+		Name:        "testing",
+		Description: "testing",
+		Rules: &storage.SimpleAccessScope_Rules{
+			IncludedClusters: []string{"cluster1"},
+		},
+		Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.updater.roleDS.AddPermissionSet(s.ctx, &storage.PermissionSet{
+		Id:          "04a87e34-b568-5e14-90ac-380d25c8689b",
+		Name:        "testing",
+		Description: "testing",
+		Traits:      &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.updater.roleDS.AddRole(s.ctx, &storage.Role{
+		Name:            "test",
+		Description:     "test",
+		PermissionSetId: "04a87e34-b568-5e14-90ac-380d25c8689b",
+		AccessScopeId:   "61a68f2a-2599-5a9f-a98a-8fc83e2c06cf",
+		Traits:          &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}))
+	s.Require().NoError(s.updater.healthDS.UpsertDeclarativeConfig(s.ctx, &storage.DeclarativeConfigHealth{
+		Id:     "04a87e34-b568-5e14-90ac-380d25c8689b",
+		Name:   "testing",
+		Status: storage.DeclarativeConfigHealth_HEALTHY,
+	}))
+
+	names, err := s.updater.DeleteResources(s.ctx)
+	s.Contains(names, "04a87e34-b568-5e14-90ac-380d25c8689b")
+	s.ErrorIs(err, errox.ReferencedByAnotherObject)
+
+	health, exists, err := s.updater.healthDS.GetDeclarativeConfig(s.ctx,
+		"04a87e34-b568-5e14-90ac-380d25c8689b")
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(storage.DeclarativeConfigHealth_UNHEALTHY, health.GetStatus())
+
+	permSet, exists, err := s.updater.roleDS.GetPermissionSet(s.ctx, "04a87e34-b568-5e14-90ac-380d25c8689b")
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(permSet.GetTraits().GetOrigin(), storage.Traits_DECLARATIVE_ORPHANED)
+}


### PR DESCRIPTION
## Description

Improve test coverage for the group updater in declarative config.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
