### PR TITLE
ROX-20160: Add `rocksdb` build to `main` in Konflux

### DIFF
--- a/.konflux/.gitignore
+++ b/.konflux/.gitignore
@@ -1,0 +1,2 @@
+# rocksdb source for main container builds in Konflux
+rocksdb/

--- a/.konflux/README.md
+++ b/.konflux/README.md
@@ -1,0 +1,4 @@
+# .konflux
+
+This directory is for files supporting ACS builds in Konflux.
+There's no Konflux convention to use it. Rather, we organize our scripts and tools here ourselves.

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -200,30 +200,12 @@ spec:
 
     tasks:
 
-    # This task ensures our workspace PVC gets attached to a node that has sufficient resources for the pipeline.
-    - name: spacer
-      workspaces:
-      - name: workspace
-        workspace: workspace
-      taskSpec:
-        steps:
-        - name: dummy
-          computeResources:
-            limits:
-              cpu: 4
-            requests:
-              cpu: 4
-          image: registry.access.redhat.com/ubi8/ubi:latest
-          script: echo "Done"
-
     - name: init
       params:
       - name: image-url
         value: $(params.output-image)
       - name: rebuild
         value: $(params.rebuild)
-      runAfter:
-      - spacer
       taskRef:
         params:
         - name: name

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -247,6 +247,38 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    # TODO(ROX-23257): remove once Central does not depend on rocksdb
+    - name: clone-rocksdb
+      params:
+      - name: url
+        value: 'https://github.com/facebook/rocksdb.git'
+      - name: revision
+        value: "0915c99f01b46f50af8e02da8b6528156f584b7c" # v6.7.3
+      - name: depth
+        value: "1"
+      - name: subdirectory
+        value: source/.konflux/rocksdb
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: git-clone
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:fffe6234a4d60c63b97af86642369e4931a404f6dc8be0d12743f7651a4dc802
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values: [ "true" ]
+      workspaces:
+      - name: output
+        workspace: workspace
+      - name: basic-auth
+        workspace: git-auth
+
     - name: fetch-external-content
       runAfter:
       - clone-repository
@@ -300,6 +332,7 @@ spec:
       runAfter:
       - fetch-external-content
       - prefetch-dependencies
+      - clone-rocksdb
       taskRef:
         params:
         # buildah with more memory is needed for UI builds to succeed. Otherwise, there's an error like this in logs:

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -200,12 +200,30 @@ spec:
 
     tasks:
 
+    # This task ensures our workspace PVC gets attached to a node that has sufficient resources for the pipeline.
+    - name: spacer
+      workspaces:
+      - name: workspace
+        workspace: workspace
+      taskSpec:
+        steps:
+        - name: dummy
+          computeResources:
+            limits:
+              cpu: 4
+            requests:
+              cpu: 4
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          script: echo "Done"
+
     - name: init
       params:
       - name: image-url
         value: $(params.output-image)
       - name: rebuild
         value: $(params.rebuild)
+      runAfter:
+      - spacer
       taskRef:
         params:
         - name: name

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -198,30 +198,12 @@ spec:
 
     tasks:
 
-    # This task ensures our workspace PVC gets attached to a node that has sufficient resources for the pipeline.
-    - name: spacer
-      workspaces:
-      - name: workspace
-        workspace: workspace
-      taskSpec:
-        steps:
-        - name: dummy
-          computeResources:
-            limits:
-              cpu: 4
-            requests:
-              cpu: 4
-          image: registry.access.redhat.com/ubi8/ubi:latest
-          script: echo "Done"
-
     - name: init
       params:
       - name: image-url
         value: $(params.output-image)
       - name: rebuild
         value: $(params.rebuild)
-      runAfter:
-      - spacer
       taskRef:
         params:
         - name: name

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -245,6 +245,38 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    # TODO(ROX-23257): remove once Central does not depend on rocksdb
+    - name: clone-rocksdb
+      params:
+      - name: url
+        value: 'https://github.com/facebook/rocksdb.git'
+      - name: revision
+        value: "0915c99f01b46f50af8e02da8b6528156f584b7c" # v6.7.3
+      - name: depth
+        value: "1"
+      - name: subdirectory
+        value: source/.konflux/rocksdb
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: git-clone
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:fffe6234a4d60c63b97af86642369e4931a404f6dc8be0d12743f7651a4dc802
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values: [ "true" ]
+      workspaces:
+      - name: output
+        workspace: workspace
+      - name: basic-auth
+        workspace: git-auth
+
     - name: fetch-external-content
       runAfter:
       - clone-repository
@@ -298,6 +330,7 @@ spec:
       runAfter:
       - fetch-external-content
       - prefetch-dependencies
+      - clone-rocksdb
       taskRef:
         params:
         # buildah with more memory is needed for UI builds to succeed. Otherwise, there's an error like this in logs:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -198,12 +198,30 @@ spec:
 
     tasks:
 
+    # This task ensures our workspace PVC gets attached to a node that has sufficient resources for the pipeline.
+    - name: spacer
+      workspaces:
+      - name: workspace
+        workspace: workspace
+      taskSpec:
+        steps:
+        - name: dummy
+          computeResources:
+            limits:
+              cpu: 4
+            requests:
+              cpu: 4
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          script: echo "Done"
+
     - name: init
       params:
       - name: image-url
         value: $(params.output-image)
       - name: rebuild
         value: $(params.rebuild)
+      runAfter:
+      - spacer
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
## Description

For now it's just built and not linked further.

We _may_ have rocksdb source _not_ included in the resulting source container due to the custom way I clone it. I don't know how to quickly check that but I don't think this is a big issue since we plan getting rid of rocksdb soon.

## Checklist
- [ ] Investigated and inspected CI test results

These aren't needed and won't be done.
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

1. Checked that CI is green.
2. Examined resulting container to see the files inside:

```
$ podman run --rm -it --entrypoint=/bin/bash quay.io/redhat-user-workloads/rh-acs-tenant/acs/main:on-pr-e3ababc59b2eaa5967ce4a8d34b8b0c7ab1d715c
bash-4.4$ ls -lh /lib/rocksdb    
total 587M
drwxr-xr-x 3 root root 4.0K Mar 26 15:11 include
-rw-r--r-- 1 root root 587M Mar 26 14:58 librocksdb.a
```

`rocksdb` static library is huge although it's the same for upstream builds.

```
$ podman run --rm -it --entrypoint=/bin/bash quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.67
[root@42cc13b6adbb rox]# cd /lib/rocksdb/
[root@42cc13b6adbb rocksdb]# ls -lh
total 587M
drwxr-xr-x 3 root root 4.0K Jan 14  2023 include
-rw-r--r-- 1 root root 587M Jan 14  2023 librocksdb.a
```

I'll check that Konflux-built `/stackrox/central` and `/stackrox/bin/migrator` executables remain not larger than their downstream counterparts (181M and 76M correspondingly).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
