### PR TITLE
ROX-23037: Add page layout and header to node cve single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { PageSection, Breadcrumb, Divider, BreadcrumbItem } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { getOverviewCvesPath } from '../utils/searchUtils';
+import NodeCvePageHeader, { NodeCveMetadata } from './NodeCvePageHeader';
 
 const workloadCveOverviewCvePath = getOverviewCvesPath({
     entityTab: 'CVE',
@@ -14,7 +15,25 @@ function NodeCvePage() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { cveId } = useParams() as { cveId: string };
 
-    const nodeCveName = cveId; // TODO Replace me with queried data
+    const [nodeCveMetadata, setNodeCveMetadata] = useState<NodeCveMetadata>();
+    const nodeCveName = nodeCveMetadata?.cve;
+
+    // TODO - Simulate a loading state, will replace metadata with results from a query
+    useEffect(() => {
+        setTimeout(() => {
+            setNodeCveMetadata({
+                cve: cveId,
+                firstDiscoveredInSystem: '2021-01-01T00:00:00Z',
+                distroTuples: [
+                    {
+                        summary: 'This is a sample description used during development',
+                        link: `https://access.redhat.com/security/cve/${cveId}`,
+                        operatingSystem: 'rhel',
+                    },
+                ],
+            });
+        }, 1500);
+    }, []);
 
     return (
         <>
@@ -22,11 +41,21 @@ function NodeCvePage() {
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>{nodeCveName} </BreadcrumbItem>
+                    <BreadcrumbItem isActive>
+                        {nodeCveName ?? (
+                            <Skeleton screenreaderText="Loading CVE name" width="200px" />
+                        )}
+                    </BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
-            <PageSection variant="light"></PageSection>
+            <PageSection variant="light">
+                <NodeCvePageHeader data={nodeCveMetadata} />
+            </PageSection>
+            <Divider component="div" />
+            <PageSection className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1">
+                <div className="pf-u-background-color-100 pf-u-flex-grow-1"></div>
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePageHeader.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePageHeader.cy.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import ComponentTestProviders from 'test-utils/ComponentProviders';
+
+import NodeCvePageHeader from './NodeCvePageHeader';
+
+function setup(data) {
+    cy.mount(
+        <ComponentTestProviders>
+            <NodeCvePageHeader data={data} />
+        </ComponentTestProviders>
+    );
+}
+
+describe(Cypress.spec.relative, () => {
+    it('should render loading skeletons when data is `undefined`', () => {
+        setup(undefined);
+
+        cy.get('h1').should('not.exist');
+        cy.findByText('Loading CVE name');
+        cy.findByText('Loading CVE metadata');
+    });
+
+    it('should not render empty elements when data is missing', () => {
+        setup({ cve: 'CVE-2021-1234', firstDiscoveredInSystem: undefined, distroTuples: [] });
+
+        // No distros, no link
+        cy.findByRole('link').should('not.exist');
+        // firstDiscoveredInSystem is undefined, so do not show labels
+        cy.get('.pf-c-label-group').should('not.exist');
+        cy.get('.pf-c-label').should('not.exist');
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePageHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { gql } from '@apollo/client';
 import {
     Flex,
     LabelGroup,
@@ -18,7 +17,7 @@ import { getDateTime } from 'utils/dateUtils';
 import { getDistroLinkText } from '../../utils/textUtils';
 import { sortCveDistroList } from '../../utils/sortUtils';
 
-export type ImageCveMetadata = {
+export type NodeCveMetadata = {
     cve: string;
     firstDiscoveredInSystem: string | null;
     distroTuples: {
@@ -28,42 +27,42 @@ export type ImageCveMetadata = {
     }[];
 };
 
-export const imageCveMetadataFragment = gql`
-    fragment ImageCVEMetadata on ImageCVECore {
-        cve
-        firstDiscoveredInSystem
-        distroTuples {
-            summary
-            link
-            operatingSystem
-        }
-    }
-`;
-
-export type ImageCvePageHeaderProps = {
-    data?: ImageCveMetadata;
+export type NodeCvePageHeaderProps = {
+    data: NodeCveMetadata | undefined;
 };
 
-function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
-    const prioritizedDistros = uniqBy(
-        sortCveDistroList(data?.distroTuples ?? []),
-        getDistroLinkText
-    );
-    return data ? (
+function NodeCvePageHeader({ data }: NodeCvePageHeaderProps) {
+    if (!data) {
+        return (
+            <Flex
+                direction={{ default: 'column' }}
+                spaceItems={{ default: 'spaceItemsXs' }}
+                className="pf-u-w-50"
+            >
+                <Skeleton screenreaderText="Loading CVE name" fontSize="2xl" />
+                <Skeleton screenreaderText="Loading CVE metadata" height="100px" />
+            </Flex>
+        );
+    }
+
+    const prioritizedDistros = uniqBy(sortCveDistroList(data.distroTuples), getDistroLinkText);
+    const topDistro = prioritizedDistros[0];
+
+    return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
             <Title headingLevel="h1" className="pf-u-mb-sm">
                 {data.cve}
             </Title>
-            <LabelGroup numLabels={1}>
-                {data.firstDiscoveredInSystem && (
+            {data.firstDiscoveredInSystem && (
+                <LabelGroup numLabels={1}>
                     <Label>
                         First discovered in system {getDateTime(data.firstDiscoveredInSystem)}
                     </Label>
-                )}
-            </LabelGroup>
-            {prioritizedDistros.length > 0 && (
+                </LabelGroup>
+            )}
+            {topDistro && (
                 <>
-                    <Text>{prioritizedDistros[0].summary}</Text>
+                    <Text>{topDistro.summary}</Text>
                     <List isPlain>
                         {prioritizedDistros.map((distro) => (
                             <ListItem key={distro.operatingSystem}>
@@ -78,16 +77,7 @@ function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
                 </>
             )}
         </Flex>
-    ) : (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsXs' }}
-            className="pf-u-w-50"
-        >
-            <Skeleton screenreaderText="Loading CVE name" fontSize="2xl" />
-            <Skeleton screenreaderText="Loading CVE metadata" fontSize="sm" />
-        </Flex>
     );
 }
 
-export default ImageCvePageHeader;
+export default NodeCvePageHeader;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -346,7 +346,7 @@ function ImageCvePage() {
                     {!metadataRequest.error && (
                         <BreadcrumbItem isActive>
                             {cveName ?? (
-                                <Skeleton screenreaderText="Loading image name" width="200px" />
+                                <Skeleton screenreaderText="Loading CVE name" width="200px" />
                             )}
                         </BreadcrumbItem>
                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.ts
@@ -1,0 +1,22 @@
+import { ensureExhaustive } from 'utils/type.utils';
+import { Distro } from './sortUtils';
+
+export function getDistroLinkText({ distro }: { distro: Distro }): string {
+    switch (distro) {
+        case 'rhel':
+        case 'centos':
+            return 'View in Red Hat CVE database';
+        case 'ubuntu':
+            return 'View in Ubuntu CVE database';
+        case 'debian':
+            return 'View in Debian CVE database';
+        case 'alpine':
+            return 'View in Alpine Linux CVE database';
+        case 'amzn':
+            return 'View in Amazon Linux CVE database';
+        case 'other':
+            return 'View additional information';
+        default:
+            return ensureExhaustive(distro);
+    }
+}


### PR DESCRIPTION
## Description

Adds the main page layout and header rendering to the Node CVE single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Node CVE page by manually entering a URL ending with `node-cves/cve/<cve-id>` and view the simulated loading state:
![image](https://github.com/stackrox/stackrox/assets/1292638/99dfd55d-09f4-4312-b36e-06fa15a513a3)

After the metadata loads, see the rendered header:
![image](https://github.com/stackrox/stackrox/assets/1292638/33f44ee6-35ae-4233-9b0f-65b9653361e2)
