### PR TITLE
ROX-22101: Remove gogo protobuf imports from central NetworkGraph

### DIFF
--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/timestamp"
 )
@@ -13,8 +12,8 @@ import (
 //
 //go:generate mockgen-wrapper
 type FlowDataStore interface {
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string, adjustForGraph bool) ([]*storage.NetworkFlow, error)
 

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/networkgraph/aggregator"
 	graphConfigDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
@@ -27,7 +26,7 @@ type flowDataStoreImpl struct {
 	deletedDeploymentsCache   expiringcache.Cache
 }
 
-func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	flows, ts, err := fds.storage.GetAllFlows(ctx, since)
 	if err != nil {
 		return nil, nil, nil
@@ -40,7 +39,7 @@ func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *types.Time
 	return flows, ts, nil
 }
 
-func (fds *flowDataStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (fds *flowDataStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	flows, ts, err := fds.storage.GetMatchingFlows(ctx, pred, since)
 	if err != nil {
 		return nil, nil, nil

--- a/central/networkgraph/flow/datastore/internal/store/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/flow.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/timestamp"
 )
@@ -13,8 +12,8 @@ import (
 //
 //go:generate mockgen-wrapper
 type FlowStore interface {
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error)
 

--- a/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	types "github.com/gogo/protobuf/types"
 	storage "github.com/stackrox/rox/generated/storage"
 	timestamp "github.com/stackrox/rox/pkg/timestamp"
 	gomock "go.uber.org/mock/gomock"
@@ -44,11 +43,11 @@ func (m *MockFlowStore) EXPECT() *MockFlowStoreMockRecorder {
 }
 
 // GetAllFlows mocks base method.
-func (m *MockFlowStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (m *MockFlowStore) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllFlows", ctx, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(*types.Timestamp)
+	ret1, _ := ret[1].(*time.Time)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -75,11 +74,11 @@ func (mr *MockFlowStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID any
 }
 
 // GetMatchingFlows mocks base method.
-func (m *MockFlowStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (m *MockFlowStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMatchingFlows", ctx, pred, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(*types.Timestamp)
+	ret1, _ := ret[1].(*time.Time)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/sync"
@@ -112,8 +111,8 @@ var (
 // FlowStore stores all of the flows for a single cluster.
 type FlowStore interface {
 	// GetAllFlows The methods below are the ones that match the flow interface which is what we probably have to match.
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error)
 
@@ -417,19 +416,19 @@ func (s *flowStoreImpl) removeDeploymentFlows(ctx context.Context, deleteStmt st
 }
 
 // GetAllFlows returns the object, if it exists from the store, timestamp and error
-func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "NetworkFlow")
 
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *types.Timestamp, error) {
+	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetAllFlows(ctx, since)
 	})
 }
 
-func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	var rows pgx.Rows
 	var err error
 	// Default to Now as that is when we are reading them
-	lastUpdateTS := protocompat.TimestampNow()
+	lastUpdateTime := time.Now()
 
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
@@ -440,7 +439,7 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, protocompat.NilOrTime(since))
+		rows, err = s.db.Query(ctx, partitionSinceStmt, since)
 	}
 	if err != nil {
 		return nil, nil, pgutils.ErrNilIfNoRows(err)
@@ -452,24 +451,24 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 		return nil, nil, pgutils.ErrNilIfNoRows(err)
 	}
 
-	return flows, lastUpdateTS, nil
+	return flows, &lastUpdateTime, nil
 }
 
 // GetMatchingFlows iterates over all of the objects in the store and applies the closure
-func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "NetworkFlow")
 
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *types.Timestamp, error) {
+	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetMatchingFlows(ctx, pred, since)
 	})
 }
 
-func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	var rows pgx.Rows
 	var err error
 
 	// Default to Now as that is when we are reading them
-	lastUpdateTS := protocompat.TimestampNow()
+	lastUpdateTime := time.Now()
 
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
@@ -480,7 +479,7 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, protocompat.NilOrTime(since))
+		rows, err = s.db.Query(ctx, partitionSinceStmt, since)
 	}
 
 	if err != nil {
@@ -493,7 +492,7 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 		return nil, nil, err
 	}
 
-	return flows, lastUpdateTS, nil
+	return flows, &lastUpdateTime, nil
 }
 
 // GetFlowsForDeployment returns the flows matching the deployment ID

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/sync"

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
@@ -334,11 +333,6 @@ func (s *flowStoreImpl) readRows(rows pgx.Rows, pred func(*storage.NetworkFlowPr
 			return nil, pgutils.ErrNilIfNoRows(err)
 		}
 
-		var ts *types.Timestamp
-		if lastTime != nil {
-			ts = protoconv.MustConvertTimeToTimestamp(*lastTime)
-		}
-
 		flow := &storage.NetworkFlow{
 			Props: &storage.NetworkFlowProperties{
 				SrcEntity: &storage.NetworkEntityInfo{
@@ -352,8 +346,11 @@ func (s *flowStoreImpl) readRows(rows pgx.Rows, pred func(*storage.NetworkFlowPr
 				DstPort:    port,
 				L4Protocol: protocol,
 			},
-			LastSeenTimestamp: ts,
-			ClusterId:         clusterID,
+			ClusterId: clusterID,
+		}
+
+		if lastTime != nil {
+			flow.LastSeenTimestamp = protoconv.MustConvertTimeToTimestamp(*lastTime)
 		}
 
 		// Apply the predicate function.  Will phase out as we move away form Rocks to where clause

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -103,7 +103,8 @@ func (s *NetworkflowStoreSuite) TestStore() {
 	s.Equal(networkFlow, foundNetworkFlows[0])
 
 	// Check the get all flows by since time
-	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, getTimestamp(3))
+	time3 := time.Unix(3, 0)
+	foundNetworkFlows, _, err = s.store.GetAllFlows(s.ctx, &time3)
 	s.NoError(err)
 	s.Len(foundNetworkFlows, 0)
 

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -43,8 +43,9 @@ func (suite *FlowStoreTestSuite) SetupSuite() {
 func (suite *FlowStoreTestSuite) TestStore() {
 	// Postgres timestamp only goes to the microsecond level, so we need to truncate these test times
 	// to ensure the comparisons of the results works correctly.
+	now := time.Now()
 	t1 := time.Now().Add(-5 * time.Minute).Truncate(time.Microsecond)
-	t2 := time.Now().Truncate(time.Microsecond)
+	t2 := now.Truncate(time.Microsecond)
 	flows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -86,11 +87,11 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows)
 
-	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), protoconv.ConvertTimeToTimestamp(t2))
+	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), &t2)
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[1:])
 
-	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), protoconv.ConvertTimeToTimestamp(time.Now()))
+	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), &now)
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[2:])
 

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -43,8 +43,8 @@ func (suite *FlowStoreTestSuite) SetupSuite() {
 func (suite *FlowStoreTestSuite) TestStore() {
 	// Postgres timestamp only goes to the microsecond level, so we need to truncate these test times
 	// to ensure the comparisons of the results works correctly.
-	now := time.Now()
-	t1 := time.Now().Add(-5 * time.Minute).Truncate(time.Microsecond)
+	now := time.Now().UTC()
+	t1 := now.Add(-5 * time.Minute).Truncate(time.Microsecond)
 	t2 := now.Truncate(time.Microsecond)
 	flows := []*storage.NetworkFlow{
 		{

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -43,8 +43,8 @@ func (suite *FlowStoreTestSuite) SetupSuite() {
 func (suite *FlowStoreTestSuite) TestStore() {
 	// Postgres timestamp only goes to the microsecond level, so we need to truncate these test times
 	// to ensure the comparisons of the results works correctly.
-	t1 := time.Now().Add(-5 * time.Minute).Truncate(time.Microsecond)
-	t2 := time.Now().Truncate(time.Microsecond)
+	t1 := time.Now().UTC().Add(-5 * time.Minute).Truncate(time.Microsecond)
+	t2 := time.Now().UTC().Truncate(time.Microsecond)
 	flows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -90,7 +90,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[1:])
 
-	now := time.Now()
+	now := time.Now().UTC()
 	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), &now)
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[2:])

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -43,9 +43,8 @@ func (suite *FlowStoreTestSuite) SetupSuite() {
 func (suite *FlowStoreTestSuite) TestStore() {
 	// Postgres timestamp only goes to the microsecond level, so we need to truncate these test times
 	// to ensure the comparisons of the results works correctly.
-	now := time.Now().UTC()
-	t1 := now.Add(-5 * time.Minute).Truncate(time.Microsecond)
-	t2 := now.Truncate(time.Microsecond)
+	t1 := time.Now().Add(-5 * time.Minute).Truncate(time.Microsecond)
+	t2 := time.Now().Truncate(time.Microsecond)
 	flows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -91,6 +90,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[1:])
 
+	now := time.Now()
 	readFlows, _, err = suite.tested.GetAllFlows(context.Background(), &now)
 	suite.Require().NoError(err)
 	suite.ElementsMatch(readFlows, flows[2:])

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	types "github.com/gogo/protobuf/types"
 	storage "github.com/stackrox/rox/generated/storage"
 	timestamp "github.com/stackrox/rox/pkg/timestamp"
 	gomock "go.uber.org/mock/gomock"
@@ -44,11 +43,11 @@ func (m *MockFlowDataStore) EXPECT() *MockFlowDataStoreMockRecorder {
 }
 
 // GetAllFlows mocks base method.
-func (m *MockFlowDataStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (m *MockFlowDataStore) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllFlows", ctx, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(*types.Timestamp)
+	ret1, _ := ret[1].(*time.Time)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -75,11 +74,11 @@ func (mr *MockFlowDataStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID
 }
 
 // GetMatchingFlows mocks base method.
-func (m *MockFlowDataStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+func (m *MockFlowDataStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMatchingFlows", ctx, pred, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(*types.Timestamp)
+	ret1, _ := ret[1].(*time.Time)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -429,12 +429,9 @@ func (s *serviceImpl) addDeploymentFlowsToGraph(
 		}
 	}
 
-	since, err := protocompat.ConvertTimestampToTimeOrError(request.GetSince())
-	if err != nil {
-		return err
-	}
+	since := protocompat.ConvertTimestampToTimeOrNil(request.GetSince())
 
-	flows, _, err := flowStore.GetMatchingFlows(networkGraphGenElevatedCtx, pred, &since)
+	flows, _, err := flowStore.GetMatchingFlows(networkGraphGenElevatedCtx, pred, since)
 	if err != nil {
 		return err
 	}

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -429,7 +429,12 @@ func (s *serviceImpl) addDeploymentFlowsToGraph(
 		}
 	}
 
-	flows, _, err := flowStore.GetMatchingFlows(networkGraphGenElevatedCtx, pred, request.GetSince())
+	since, err := protocompat.ConvertTimestampToTimeOrError(request.GetSince())
+	if err != nil {
+		return err
+	}
+
+	flows, _, err := flowStore.GetMatchingFlows(networkGraphGenElevatedCtx, pred, &since)
 	if err != nil {
 		return err
 	}

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
-	"github.com/gogo/protobuf/types"
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	dDSMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	graphConfigDSMocks "github.com/stackrox/rox/central/networkgraph/config/datastore/mocks"
@@ -266,7 +266,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			flows := []*storage.NetworkFlow{depFlow("depA", "depB"),
 				depFlow("depA", "depD"),
 				depFlow("depA", "depE"),
@@ -312,7 +312,8 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, "depD", storage.NetworkEntityInfo_DEPLOYMENT),
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, es2ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE),
 			}
-			return networkgraph.FilterFlowsByPredicate(flows, pred), protocompat.TimestampNow(), nil
+			now := time.Now()
+			return networkgraph.FilterFlowsByPredicate(flows, pred), &now, nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)
@@ -810,8 +811,9 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
-			return networkgraph.FilterFlowsByPredicate(flowsOrdered, pred), protocompat.TimestampNow(), nil
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
+			now := time.Now()
+			return networkgraph.FilterFlowsByPredicate(flowsOrdered, pred), &now, nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)
@@ -850,8 +852,9 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
-			return networkgraph.FilterFlowsByPredicate(flowsShuffled, pred), protocompat.TimestampNow(), nil
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
+			now := time.Now()
+			return networkgraph.FilterFlowsByPredicate(flowsShuffled, pred), &now, nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)
@@ -971,7 +974,7 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 		})
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			flows := []*storage.NetworkFlow{
 				depFlow("depA", "depB"),
 				depFlow("depA", "depD"),
@@ -1008,7 +1011,8 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, "depD", storage.NetworkEntityInfo_DEPLOYMENT),
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, es1ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE),
 			}
-			return networkgraph.FilterFlowsByPredicate(flows, pred), protocompat.TimestampNow(), nil
+			now := time.Now()
+			return networkgraph.FilterFlowsByPredicate(flows, pred), &now, nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph/testutils"
 	"github.com/stackrox/rox/pkg/networkgraph/tree"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	sacTestutils "github.com/stackrox/rox/pkg/sac/testutils"
@@ -191,7 +192,8 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 				},
 			}))
 
-	ts := protocompat.TimestampNow()
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.NetworkGraphRequest{
 		ClusterId: "mycluster",
 		Query:     "Namespace: foo,bar,far",
@@ -265,7 +267,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).DoAndReturn(
 		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			flows := []*storage.NetworkFlow{depFlow("depA", "depB"),
 				depFlow("depA", "depD"),
@@ -791,7 +793,8 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 				},
 			}))
 
-	ts := protocompat.TimestampNow()
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.NetworkGraphRequest{
 		ClusterId: "mycluster",
 		Query:     "Namespace: foo,bar,far",
@@ -810,7 +813,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).DoAndReturn(
 		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			now := time.Now()
 			return networkgraph.FilterFlowsByPredicate(flowsOrdered, pred), &now, nil
@@ -851,7 +854,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).DoAndReturn(
 		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			now := time.Now()
 			return networkgraph.FilterFlowsByPredicate(flowsShuffled, pred), &now, nil
@@ -908,7 +911,8 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 
 	ctx := sac.WithAllAccess(context.Background())
 
-	ts := protocompat.TimestampNow()
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.NetworkGraphRequest{
 		ClusterId: "mycluster",
 		Query:     "Namespace: foo,bar,far",
@@ -973,7 +977,7 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 			sac.ClusterScopeKey("mycluster"),
 		})
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).DoAndReturn(
 		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
 			flows := []*storage.NetworkFlow{
 				depFlow("depA", "depB"),

--- a/central/networkpolicies/generator/generator_impl.go
+++ b/central/networkpolicies/generator/generator_impl.go
@@ -3,8 +3,8 @@ package generator
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	dDS "github.com/stackrox/rox/central/deployment/datastore"
 	nsDS "github.com/stackrox/rox/central/namespace/datastore"
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/tree"
 	"github.com/stackrox/rox/pkg/objects"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
@@ -106,7 +107,7 @@ func (g *generator) getNetworkPolicies(ctx context.Context, deleteExistingMode v
 	}
 }
 
-func (g *generator) generateGraph(ctx context.Context, clusterID string, query *v1.Query, since *types.Timestamp, includePorts bool) (map[networkgraph.Entity]*node, error) {
+func (g *generator) generateGraph(ctx context.Context, clusterID string, query *v1.Query, since *time.Time, includePorts bool) (map[networkgraph.Entity]*node, error) {
 	// Temporarily elevate permissions to obtain all network flows in cluster.
 	networkGraphGenElevatedCtx := sac.WithGlobalAccessScopeChecker(ctx,
 		sac.AllowFixedScopes(
@@ -276,7 +277,12 @@ func (g *generator) Generate(ctx context.Context, req *v1.GenerateNetworkPolicie
 		return nil, nil, errors.Wrap(err, "could not parse query")
 	}
 
-	graph, err := g.generateGraph(ctx, req.GetClusterId(), parsedQuery, req.GetNetworkDataSince(), req.GetIncludePorts())
+	since, err := protocompat.ConvertTimestampToTimeOrError(req.GetNetworkDataSince())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "parsing network data since")
+	}
+
+	graph, err := g.generateGraph(ctx, req.GetClusterId(), parsedQuery, &since, req.GetIncludePorts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "generating network graph")
 	}

--- a/central/networkpolicies/generator/generator_impl.go
+++ b/central/networkpolicies/generator/generator_impl.go
@@ -277,12 +277,9 @@ func (g *generator) Generate(ctx context.Context, req *v1.GenerateNetworkPolicie
 		return nil, nil, errors.Wrap(err, "could not parse query")
 	}
 
-	since, err := protocompat.ConvertTimestampToTimeOrError(req.GetNetworkDataSince())
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "parsing network data since")
-	}
+	since := protocompat.ConvertTimestampToTimeOrNil(req.GetNetworkDataSince())
 
-	graph, err := g.generateGraph(ctx, req.GetClusterId(), parsedQuery, &since, req.GetIncludePorts())
+	graph, err := g.generateGraph(ctx, req.GetClusterId(), parsedQuery, since, req.GetIncludePorts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "generating network graph")
 	}

--- a/central/networkpolicies/generator/generator_impl_test.go
+++ b/central/networkpolicies/generator/generator_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	dDSMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	nsDSMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
@@ -16,6 +17,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/namespaces"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	sacTestutils "github.com/stackrox/rox/pkg/sac/testutils"
@@ -214,7 +216,8 @@ func sortPolicies(policies []*storage.NetworkPolicy) {
 }
 
 func (s *generatorTestSuite) TestGenerate() {
-	ts := protocompat.TimestampNow()
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.GenerateNetworkPoliciesRequest{
 		ClusterId:        "mycluster",
 		DeleteExisting:   v1.GenerateNetworkPoliciesRequest_NONE,
@@ -321,7 +324,7 @@ func (s *generatorTestSuite) TestGenerate() {
 			sac.ClusterScopeKey("mycluster"),
 		})
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).Return(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).Return(
 		[]*storage.NetworkFlow{
 			{
 				Props: &storage.NetworkFlowProperties{
@@ -382,7 +385,7 @@ func (s *generatorTestSuite) TestGenerate() {
 					},
 				},
 			},
-		}, protocompat.TimestampNow(), nil)
+		}, &now, nil)
 
 	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)
@@ -529,7 +532,8 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 				},
 			}))
 
-	ts := protocompat.TimestampNow()
+	now := time.Now().UTC()
+	ts := protoconv.ConvertTimeToTimestampOrNow(&now)
 	req := &v1.GenerateNetworkPoliciesRequest{
 		ClusterId:        "mycluster",
 		Query:            "Namespace: foo,bar,qux",
@@ -645,7 +649,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 			sac.ClusterScopeKey("mycluster"),
 		})
 
-	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).Return(
+	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(&now)).Return(
 		[]*storage.NetworkFlow{
 			depFlow("depA", "depB"),
 			depFlow("depA", "depD"),
@@ -660,7 +664,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 			depFlow("depF", "depC"),
 			depFlow("depF", "depD"),
 			depFlow("depF", "depG"),
-		}, protocompat.TimestampNow(), nil)
+		}, &now, nil)
 
 	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater.go
@@ -2,8 +2,8 @@ package networkflowupdate
 
 import (
 	"context"
+	"time"
 
-	protobuf "github.com/gogo/protobuf/types"
 	networkBaselineManager "github.com/stackrox/rox/central/networkbaseline/manager"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	"github.com/stackrox/rox/generated/storage"
@@ -11,7 +11,7 @@ import (
 )
 
 type flowPersister interface {
-	update(ctx context.Context, newFlows []*storage.NetworkFlow, updateTS *protobuf.Timestamp) error
+	update(ctx context.Context, newFlows []*storage.NetworkFlow, updateTS *time.Time) error
 }
 
 func newFlowPersister(flowStore datastore.FlowDataStore, networkBaselines networkBaselineManager.Manager) flowPersister {

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -57,7 +57,7 @@ func (suite *FlowStoreUpdaterTestSuite) TearDownSuite() {
 }
 
 func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
-	firstTimestamp := protoconv.ConvertTimeToTimestamp(time.Now())
+	firstTimestamp := time.Now()
 	storedFlows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -66,7 +66,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 				DstPort:    1,
 				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 			},
-			LastSeenTimestamp: firstTimestamp,
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestampOrNow(&firstTimestamp),
 		},
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -83,7 +83,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 				DstPort:    2,
 				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 			},
-			LastSeenTimestamp: firstTimestamp,
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestampOrNow(&firstTimestamp),
 		},
 	}
 
@@ -132,7 +132,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 	}
 
 	// Return storedFlows on DB read.
-	suite.mockFlows.EXPECT().GetAllFlows(suite.hasWriteCtx, gomock.Any()).Return(storedFlows, firstTimestamp, nil)
+	suite.mockFlows.EXPECT().GetAllFlows(suite.hasWriteCtx, gomock.Any()).Return(storedFlows, &firstTimestamp, nil)
 
 	suite.mockBaselines.EXPECT().ProcessFlowUpdate(testutils.PredMatcher("equivalent map except for timestamp", func(got map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) bool {
 		expectedMap := map[networkgraph.NetworkConnIndicator]timestamp.MicroTS{

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -87,7 +87,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 		},
 	}
 
-	secondTimestamp := protoconv.ConvertTimeToTimestamp(time.Now())
+	secondTimestamp := time.Now()
 	newFlows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -105,7 +105,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 				DstPort:    2,
 				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 			},
-			LastSeenTimestamp: secondTimestamp,
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(secondTimestamp),
 		},
 	}
 
@@ -159,7 +159,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 				},
 				DstPort:  2,
 				Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
-			}: timestamp.FromProtobuf(secondTimestamp),
+			}: timestamp.FromGoTime(secondTimestamp),
 		}
 
 		if len(expectedMap) != len(got) {
@@ -206,6 +206,6 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 	}), gomock.Any()).Return(nil)
 
 	// Run test.
-	err := suite.tested.update(suite.hasWriteCtx, newFlows, secondTimestamp)
+	err := suite.tested.update(suite.hasWriteCtx, newFlows, &secondTimestamp)
 	suite.NoError(err, "update should succeed on first insert")
 }

--- a/central/sensor/service/pipeline/networkflowupdate/pipeline.go
+++ b/central/sensor/service/pipeline/networkflowupdate/pipeline.go
@@ -3,6 +3,7 @@ package networkflowupdate
 import (
 	"context"
 	"errors"
+	"time"
 
 	countMetrics "github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/sensor/service/common"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/protocompat"
 )
 
 var (
@@ -66,7 +68,15 @@ func (s *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 		return nil
 	}
 
-	if err = s.storeUpdater.update(ctx, allUpdatedFlows, update.Time); err != nil {
+	var updateTime *time.Time
+	if update.Time != nil {
+		updateRawTime, err := protocompat.ConvertTimestampToTimeOrError(update.Time)
+		if err != nil {
+			return err
+		}
+		updateTime = &updateRawTime
+	}
+	if err = s.storeUpdater.update(ctx, allUpdatedFlows, updateTime); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Description

The goal is to remove direct calls to the gogo protobuf library and have all of them happen through an abstraction layer in order to ease the migration to a new protobuf library.

The current PR aims at changing the functions around network graph management in central to use time rather than gogo timestamps as parameters or return values.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
