### PR TITLE
test: test fixes on release 4.3

### DIFF
--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -27,17 +27,7 @@ const (
 	// GenericDockerRegistryType exposes the default registry type
 	GenericDockerRegistryType = "docker"
 
-	// This timeout is used as http.Client.Timeout for the registry's HTTP
-	// client and hence includes everything from connection to reading the
-	// response body. The timeout has been chosen rather arbitrarily, it is
-	// probably less harm in waiting a bit longer than in aborting early a
-	// request that is about to succeed.
-	//
-	// TODO(alexr): Consider setting ResponseHeaderTimeout for registry's
-	//   transport to make timeout errors more specific and hence facilitate
-	//   retries and troubleshooting.
-	registryClientTimeout = 90 * time.Second
-
+	registryTimeout  = 5 * time.Second
 	repoListInterval = 10 * time.Minute
 )
 
@@ -122,7 +112,7 @@ func NewDockerRegistryWithConfig(cfg Config, integration *storage.ImageIntegrati
 		return nil, err
 	}
 
-	client.Client.Timeout = registryClientTimeout
+	client.Client.Timeout = registryTimeout
 
 	var repoSet set.Set[string]
 	var ticker *time.Ticker

--- a/pkg/registries/ibm/ibm.go
+++ b/pkg/registries/ibm/ibm.go
@@ -2,6 +2,7 @@ package ibm
 
 import (
 	"errors"
+	"time"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -11,6 +12,8 @@ import (
 
 const (
 	username = "iamapikey"
+
+	registryTimeout = 10 * time.Second
 )
 
 // Creator provides the type and registries.Creator to add to the registries Registry.
@@ -58,5 +61,7 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 	if err != nil {
 		return nil, err
 	}
+	// IBM needs a custom timeout because it's pretty slow
+	registry.Client.Client.Timeout = registryTimeout
 	return registry, nil
 }


### PR DESCRIPTION
Get tests to pass on release-4.3 at least once (https://github.com/openshift/release/pull/49452):

* Cherry-pick of two minimal fixes to qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
* Disabling ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js "Workload CVE watched images flow"