### PR TITLE
ROX-12746: Fix curl retries, related improvements.

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -50,7 +50,7 @@ popd
 # arguments:
 #   - anything else `curl` will accept, including the URL
 function curl_central_once() {
-    cmd=(curl --silent --show-error --insecure)
+    local cmd=(curl --silent --show-error --insecure)
     local admin_user="${ROX_ADMIN_USER:-admin}"
     if [[ -n "${ROX_ADMIN_PASSWORD:-}" ]]; then
         cmd+=(-u "${admin_user}:${ROX_ADMIN_PASSWORD}")
@@ -71,7 +71,7 @@ function curl_central_retry() {
     # On top of --retry we do our own retry loop, to make sure no corner cases slip through.
     # https://github.com/curl/curl/issues/6712#issuecomment-796534491
     for _ in $(seq 3); do
-        if "${cmd[@]}" --fail --retry 3 --retry-delay "${delay_sec}" --retry-connrefused "$@" > "${tmp_out}"; then
+        if curl_central_once --fail --retry 3 --retry-delay "${delay_sec}" --retry-connrefused "$@" > "${tmp_out}"; then
             cat "${tmp_out}"
             rm -f "${tmp_out}"
             return 0

--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -71,7 +71,7 @@ function curl_central_retry() {
     # On top of --retry we do our own retry loop, to make sure no corner cases slip through.
     # https://github.com/curl/curl/issues/6712#issuecomment-796534491
     for _ in $(seq 3); do
-        if "${cmd[@]}" --fail --retry 3 --retry-delay "${delay_sec}" --retry-all-errors "$@" > "${tmp_out}"; then
+        if "${cmd[@]}" --fail --retry 3 --retry-delay "${delay_sec}" --retry-connrefused "$@" > "${tmp_out}"; then
             cat "${tmp_out}"
             rm -f "${tmp_out}"
             return 0

--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This file is only sourced, but the following line helps set the stage for shellcheck.
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -42,13 +42,43 @@ echo "Image flavor for roxctl set to $ROXCTL_ROX_IMAGE_FLAVOR"
 
 popd
 
-function curl_central() {
-	cmd=(curl --retry 10 --retry-delay 10 --retry-connrefused --silent --show-error --insecure)
-	local admin_user="${ROX_ADMIN_USER:-admin}"
-	if [[ -n "${ROX_ADMIN_PASSWORD:-}" ]]; then
-		cmd+=(-u "${admin_user}:${ROX_ADMIN_PASSWORD}")
-	fi
-	"${cmd[@]}" "$@"
+# curl_central_once
+# Runs curl with --silent --show-error --insecure.
+# Obeys $ROX_ADMIN_USER and $ROX_ADMIN_PASSWORD.
+# arguments:
+#   - anything else `curl` will accept, including the URL
+function curl_central_once() {
+    cmd=(curl --silent --show-error --insecure)
+    local admin_user="${ROX_ADMIN_USER:-admin}"
+    if [[ -n "${ROX_ADMIN_PASSWORD:-}" ]]; then
+        cmd+=(-u "${admin_user}:${ROX_ADMIN_PASSWORD}")
+    fi
+    "${cmd[@]}" "$@"
+}
+
+
+# curl_central_retry
+# Runs curl like curl_central_once, but with retries and --fail.
+# Captures stdout and emits it only once (for the last invocation of curl).
+# arguments:
+#   - anything else `curl` will accept, including the URL
+function curl_central_retry() {
+    local tmp_out
+    tmp_out="$(mktemp)"
+    local delay_sec=10
+    # On top of --retry we do our own retry loop, to make sure no corner cases slip through.
+    # https://github.com/curl/curl/issues/6712#issuecomment-796534491
+    for _ in $(seq 3); do
+        if "${cmd[@]}" --fail --retry 3 --retry-delay "${delay_sec}" --retry-all-errors "$@" > "${tmp_out}"; then
+            cat "${tmp_out}"
+            rm -f "${tmp_out}"
+            return 0
+        fi
+        sleep "${delay_sec}"
+    done
+    cat "${tmp_out}"
+    rm -f "${tmp_out}"
+    return 1
 }
 
 # generate_ca
@@ -81,7 +111,7 @@ function wait_for_central {
     local start_time
     start_time="$(date '+%s')"
     local deadline=$((start_time + 10*60))  # 10 minutes
-    until curl_central --output /dev/null --silent --fail "https://$LOCAL_API_ENDPOINT/v1/ping"; do
+    until curl_central_once --output /dev/null --fail "https://$LOCAL_API_ENDPOINT/v1/ping"; do
         if [[ "$(date '+%s')" -gt "$deadline" ]]; then
             echo >&2 "Exceeded deadline waiting for Central, aborting its process."
             "${ORCH_CMD}" -n "${central_namespace}" exec deployment/central -c central -- kill -ABRT 1
@@ -128,9 +158,8 @@ function get_cluster_zip {
     export CLUSTER_JSON="{\"name\": \"$CLUSTER_NAME\", \"type\": \"$CLUSTER_TYPE\", \"main_image\": \"$CLUSTER_IMAGE\", \"central_api_endpoint\": \"$CLUSTER_API_ENDPOINT\", \"collection_method\": \"$COLLECTION_METHOD_ENUM\", \"admission_controller\": $ADMISSION_CONTROLLER $EXTRA_JSON}"
 
     TMP=$(mktemp)
-    STATUS=$(curl_central -X POST \
+    STATUS=$(curl_central_retry -X POST \
         -d "$CLUSTER_JSON" \
-        -s \
         -o "$TMP" \
         -w "%{http_code}\n" \
         "https://$LOCAL_API_ENDPOINT/v1/clusters")
@@ -143,9 +172,8 @@ function get_cluster_zip {
     ID="$(jq -r .cluster.id "${TMP}")"
 
     echo "Getting zip file for cluster ${ID}"
-    STATUS=$(curl_central -X POST \
+    STATUS=$(curl_central_retry -X POST \
         -d "{\"id\": \"$ID\", \"createUpgraderSA\": true}" \
-        -s \
         -o "$OUTPUT_DIR/sensor-deploy.zip" \
         -w "%{http_code}\n" \
         "https://$LOCAL_API_ENDPOINT/api/extensions/clusters/zip")

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -672,8 +672,7 @@ function launch_sensor {
         exit 1
       fi
       mkdir "$k8s_dir/sensor-deploy"
-      touch "$k8s_dir/sensor-deploy/init-bundle.yaml"
-      chmod 0600 "$k8s_dir/sensor-deploy/init-bundle.yaml"
+      (umask 077; touch "$k8s_dir/sensor-deploy/init-bundle.yaml")
       curl_central "https://${API_ENDPOINT}/v1/cluster-init/init-bundles" \
           -XPOST -d '{"name":"deploy-'"${CLUSTER}-$(date '+%Y%m%d%H%M%S')"'"}' \
           | jq '.helmValuesBundle' -r | base64 --decode >"$k8s_dir/sensor-deploy/init-bundle.yaml"


### PR DESCRIPTION
## Description

Improve retries around `curl` which is a subtle topic:
1. ~replace `--retry-connrefused` with `--retry-all-errors` which retries "all **transfer** errors"~ nope, [our base image is from the previous decade, and bumping it is a bigger effort](https://redhat-internal.slack.com/archives/CELUQKESC/p1710939795485529)
2. use `--fail` which is necessary for 4xx and 5xx to be retried, since it turns out these are not transfer errors 🤦🏻‍♂️ 
3. do our own retry loop on top to prevent further ~unexpected corner cases of~ failures popping up 
4. don't retry in `wait_for_central` which has its own retry logic
5. in `launch_sensor` do a custom retry loop with different name every time when fetching init bundle, to cover rare situations where bundle would be created on central but `curl` failed to read response for whatever reason - previously we'd insist on the same bundle name on retries which would never succeed.

Also a few improvements in nearby code while at it:
- drop duplicate `-s` (same as `--silent`) flags
- in `wait_for_central` replace "pod lookup + k exec pod" with simpler direct "k exec deployment" which is [supported](https://github.com/kubernetes/kubernetes/commit/0c39d7d3806f1a45148f159b8480ab86df9f23ff) by kubectl for almost 5 years now, and drop `set +e` thanks to this simplification
- in `launch_sensor` fix a permissions race between `touch` and `chmod` by using a umask when touching

## Checklist
- [x] Investigated and inspected CI test results
- [x] Manual tests
- [x] Before merge shout out on slack to make sure folks have a recent enough `kubectl`/`oc`
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] check every affected function is actually invoked in some CI test
  - [x] [manifest mode](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/10451/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1770437089146441728/artifacts/gke-qa-e2e-tests/stackrox-stackrox-e2e-test/build-log.txt)
  - [x] [helm mode](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/10451/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1770437088873811968/artifacts/gke-nongroovy-e2e-tests/stackrox-stackrox-e2e-test/build-log.txt)
- [x] ~if not, manually run them~

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
