### PR TITLE
ci(shell-style): disable shellcheck config lookup

### DIFF
--- a/scripts/style/shellcheck.sh
+++ b/scripts/style/shellcheck.sh
@@ -57,7 +57,7 @@ update_failing_list() {
     pushd "$ROOT" > /dev/null
 
     for shell in $(retrieve_shell_scripts); do
-        if ! shellcheck -P SCRIPTDIR -x "$shell" > /dev/null; then
+        if ! shellcheck --norc -P SCRIPTDIR -x "$shell" > /dev/null; then
             echo "$shell" >> "$known_failures_file"
         fi
     done


### PR DESCRIPTION
## Description

Running `make shell-style` can find .shellcheckrc files outside the repository in parent directories or user home locations. This may give different results than when executed in CI.

* Disable this lookup to only use the config specified in the shell-style commands (none right now; using defaults).
* Match junit results shellcheck execution to tested arguments (`--norc and -P SCRIPTDIR`)

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~

## Testing Performed

### Here I tell how I validated my change

local test runs with a ~/.shellcheckrc that has additional rules. Running with `CI=true` to see tested execution output and to check if second execution creates junit xml files.

Before this change:
```
$ cat ~/.shellcheckrc 
# ~/.shellcheckrc

# Suggest ${VAR} in place of $VAR
enable=require-variable-braces

$ CI=true make shell-style
INFO: Wed Mar 20 09:37:01 MDT 2024: Running shellcheck on all .sh files (excluding scripts/style/shellcheck_skip.txt)

In .github/workflows/scripts/check-jira-issues.sh line 24:
JQL_OPEN_ISSUES="project IN ($PROJECTS) \
                             ^-------^ SC2250 (style): Prefer putting braces around variable references even when not strictly required.

Did you mean: 
...
$ du shellcheck-reports/
1600	shellcheck-reports/
```

After this change: confirmed those additional rules were not reported:
```
$ rm -rf shellcheck-reports
$ CI=true make shell-style
+ shell-style
INFO: Wed Mar 20 09:42:34 MDT 2024: Running shellcheck on all .sh files (excluding scripts/style/shellcheck_skip.txt)
$ du shellcheck-reports/
du: shellcheck-reports/: No such file or directory
```


Additional:
Matching arguments for the junit collection run. Before shows additional lint found (did not find sourced files because the SOURCEDIR magic was not provided as an arg for path lookups):
```
$ diff shellcheck-reports.before shellcheck-reports.matchtest | tail -10
> <testsuite tests="1" failures="3">
4d3
< <failure type="ShellCheck.SC1091">Line 9: Not following: ./../common.sh: openBinaryFile: does not exist (No such file or directory) See https://www.shellcheck.net/wiki/SC1091</failure>
diff shellcheck-reports.before/tests_scripts_setup-certs.xml shellcheck-reports.matchtest/tests_scripts_setup-certs.xml
2c2
< <testsuite tests="1" failures="17">
---
> <testsuite tests="1" failures="16">
4d3
< <failure type="ShellCheck.SC1091">Line 8: Not following: ../../scripts/lib.sh: openBinaryFile: does not exist (No such file or directory) See https://www.shellcheck.net/wiki/SC1091</failure>
$ 
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
