### PR TITLE
chore(CI): hide unnecessary panels

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -333,7 +333,7 @@ create_log_explorer_links() {
         return
     fi
 
-    artifact_file="$ARTIFACT_DIR/gke-logs-summary.html"
+    artifact_file="$ARTIFACT_DIR/gke-logs.html"
 
     cat > "$artifact_file" <<- HEAD
 <html>

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1881,7 +1881,7 @@ highlight_cluster_versions() {
         return
     fi
 
-    artifact_file="$ARTIFACT_DIR/cluster-version-summary.html"
+    artifact_file="$ARTIFACT_DIR/cluster-version.html"
 
     cat > "$artifact_file" <<- HEAD
 <html>


### PR DESCRIPTION
## Description

The cluster versions and GKE logs explorer panels are of less utility nowadays. Keep them in artifacts but hide them from the prow UI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] check prow UI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
