### PR TITLE
ci(shell-style): un-fail generated when shell style fails

### DIFF
--- a/tools/detect-large-files.sh
+++ b/tools/detect-large-files.sh
@@ -14,7 +14,7 @@ allowed_files=""
 if [[ -n "$allowlist_path" ]]
 then
   LC_ALL=C LC_COLLATE=C sort --check "${allowlist_path}"
-  allowed_files=$(grep -E -v '^\s*(#.*)$' "${allowlist_path}" | xargs git -C "$GIT_REPO_TOP" ls-files --)
+  allowed_files=$(egrep -v '^\s*(#.*)$' "${allowlist_path}" | xargs git -C "$GIT_REPO_TOP" ls-files --)
 fi
 
 large_files=$(git ls-tree --full-tree -l -r HEAD "$GIT_REPO_TOP" | awk '$4 > 50*1024 {print$5}')


### PR DESCRIPTION
## Description

When lint appears, the generated-check adds the new failing file to the skipped list file. This then appears as an error in the check-generated job.
* Only fail check-shellcheck-failing-list if a file needs to be removed from the skip list.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

Local testing with removing files from `scripts/style/shellcheck_skip.txt` and adding or removing lint.

New lint. File added, but not marked as a job failure (lint fails, generated-files job passes):
https://github.com/stackrox/stackrox/actions/runs/8369321511/job/22914866733#step:7:6223

Lint fixed, but fixed script still in skip file (lint passes, generated-files job fails):
https://github.com/stackrox/stackrox/actions/runs/8369473421/job/22915271628#step:7:6223

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
