### PR TITLE
ROX-23081: add roxctl ARM binary download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,6 +633,7 @@ ifdef CI
 	cp bin/linux_ppc64le/roxctl image/rhel/bin/roxctl-linux-ppc64le
 	cp bin/linux_s390x/roxctl image/rhel/bin/roxctl-linux-s390x
 	cp bin/darwin_amd64/roxctl image/rhel/bin/roxctl-darwin-amd64
+	cp bin/darwin_arm64/roxctl image/rhel/bin/roxctl-darwin-arm64
 	cp bin/windows_amd64/roxctl.exe image/rhel/bin/roxctl-windows-amd64.exe
 else
 ifneq ($(HOST_OS),linux)

--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -44,11 +44,25 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
             Mac x86_64
         </ApplicationLauncherItem>,
         <ApplicationLauncherItem
+            key="app-launcher-item-cli-mac-arm64"
+            component="button"
+            onClick={handleDownloadCLI('darwin-arm64')}
+        >
+            Mac arm_64
+        </ApplicationLauncherItem>,
+        <ApplicationLauncherItem
             key="app-launcher-item-cli-linux-amd64"
             component="button"
             onClick={handleDownloadCLI('linux-amd64')}
         >
             Linux x86_64
+        </ApplicationLauncherItem>,
+        <ApplicationLauncherItem
+            key="app-launcher-item-cli-linux-arm64"
+            component="button"
+            onClick={handleDownloadCLI('linux-arm64')}
+        >
+            Linux arm_64
         </ApplicationLauncherItem>,
         <ApplicationLauncherItem
             key="app-launcher-item-cli-linux-ppc64le"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
@@ -43,8 +43,14 @@ function DownloadCLIDropdown({ hasBuild }) {
                 <DropdownItem value="darwin-amd64" component="button">
                     Mac x86_64
                 </DropdownItem>,
+                <DropdownItem value="darwin-arm64" component="button">
+                    Mac arm_64
+                </DropdownItem>,
                 <DropdownItem value="linux-amd64" component="button">
                     Linux x86_64
+                </DropdownItem>,
+                <DropdownItem value="linux-arm64" component="button">
+                    Linux arm_64
                 </DropdownItem>,
                 <DropdownItem value="linux-ppc64le" component="button">
                     Linux ppc64le


### PR DESCRIPTION
## Description

Add options in Central's UI to download ARM binaries for Darwin and Linux.

I became interested in the ARM builds as preparation for our new roxctl GitHub action, which might use ARM binaries. I noticed that we already build ARM binaries in the Makefile but don't expose them. I don't see a reason to not make them available in Central given the increasing popularity of ARM chips.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Downloaded the ARM binaries from the UI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
