### PR TITLE
fix(test): load unit test metrics into bq

### DIFF
--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -5,7 +5,7 @@ branding:
   color: 'blue'
 inputs:
   create-jiras:
-    description: 'Weather to report failures to jira'
+    description: 'Whether to report failures to Jira'
     required: false
     default: 'true'
   gcp-account:
@@ -47,7 +47,7 @@ runs:
         extra_args=(--dry-run)
         echo "Will use junit2jira to create CSV for BigQuery input"
       else
-        echo "Will create JIRA issues for junit failures found in ${{ inputs.directory }}"
+        echo "Will create JIRA issues for JUnit failures found in ${{ inputs.directory }}"
       fi
       csv_output="$(mktemp --suffix=.csv)"
       ./junit2jira \

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -45,7 +45,6 @@ runs:
       extra_args=()
       if [[ "${{ inputs.create-jiras }}" == "false" ]]; then
         extra_args=(--dry-run)
-        echo "Will use junit2jira to create CSV for BigQuery input"
       else
         echo "Will create JIRA issues for JUnit failures found in ${{ inputs.directory }}"
       fi

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -42,7 +42,7 @@ runs:
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ inputs.gcp-account }}
       JIRA_TOKEN: ${{ inputs.jira-token }}
     run: |
-      local extra_args=()
+      extra_args=()
       if [[ "${{ inputs.create-jiras }}" == "false" ]]; then
         extra_args=(--dry-run)
         info "Will use junit2jira to create CSV for BigQuery input"

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -4,6 +4,10 @@ branding:
   icon: 'archive'
   color: 'blue'
 inputs:
+  create-jiras:
+    description: 'Weather to report failures to jira'
+    required: false
+    default: 'true'
   jira-token:
     description: 'Token used to authenticate with Jira.'
     required: true
@@ -35,6 +39,14 @@ runs:
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       JIRA_TOKEN: ${{ inputs.jira-token }}
     run: |
+      local extra_args=()
+      if [[ "${{ inputs.create-jiras }}" == "false" ]]; then
+        extra_args=(--dry-run)
+        info "Will use junit2jira to create CSV for BigQuery input"
+      else
+        info "Will create JIRA issues for junit failures found in ${{ inputs.directory }}"
+      fi
+      ${{ inputs.debug_mode == true }}
       csv_output="$(mktemp --suffix=.csv)"
       ./junit2jira \
           -base-link "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" \
@@ -45,7 +57,8 @@ runs:
           -job-name "${{ github.job }}" \
           -junit-reports-dir "${{ inputs.directory }}" \
           -orchestrator "${{ runner.name }} ${{ runner.os }}-${{ runner.arch }}" \
-          -threshold "${{ inputs.threshold }}"
+          -threshold "${{ inputs.threshold }}" \
+          "${extra_args[@]}"
 
       source scripts/ci/lib.sh
       setup_gcp

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -32,14 +32,21 @@ runs:
   - name: Check files
     shell: bash
     env:
+      GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       JIRA_TOKEN: ${{ inputs.jira-token }}
     run: |
+      csv_output="$(mktemp --suffix=.csv)"
       ./junit2jira \
           -base-link "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" \
           -build-id "${{ github.run_id }}"  \
           -build-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -build-tag "${{ github.ref_name }}@${{ github.sha }}" \
+          -csv-output "${csv_output}" \
           -job-name "${{ github.job }}" \
           -junit-reports-dir "${{ inputs.directory }}" \
           -orchestrator "${{ runner.name }} ${{ runner.os }}-${{ runner.arch }}" \
           -threshold "${{ inputs.threshold }}"
+
+      source scripts/ci/lib.sh
+      setup_gcp
+      save_test_metrics "${csv_output}"

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -45,9 +45,9 @@ runs:
       extra_args=()
       if [[ "${{ inputs.create-jiras }}" == "false" ]]; then
         extra_args=(--dry-run)
-        info "Will use junit2jira to create CSV for BigQuery input"
+        echo "Will use junit2jira to create CSV for BigQuery input"
       else
-        info "Will create JIRA issues for junit failures found in ${{ inputs.directory }}"
+        echo "Will create JIRA issues for junit failures found in ${{ inputs.directory }}"
       fi
       ${{ inputs.debug_mode == true }}
       csv_output="$(mktemp --suffix=.csv)"

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -8,6 +8,9 @@ inputs:
     description: 'Weather to report failures to jira'
     required: false
     default: 'true'
+  gcp-account:
+    description: 'Account to be used to upload tests data'
+    required: true
   jira-token:
     description: 'Token used to authenticate with Jira.'
     required: true
@@ -36,7 +39,7 @@ runs:
   - name: Check files
     shell: bash
     env:
-      GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ inputs.gcp-account }}
       JIRA_TOKEN: ${{ inputs.jira-token }}
     run: |
       local extra_args=()

--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -49,7 +49,6 @@ runs:
       else
         echo "Will create JIRA issues for junit failures found in ${{ inputs.directory }}"
       fi
-      ${{ inputs.debug_mode == true }}
       csv_output="$(mktemp --suffix=.csv)"
       ./junit2jira \
           -base-link "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -623,6 +623,7 @@ jobs:
       if: always()
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
   scan-images-with-roxctl:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -70,6 +70,7 @@ jobs:
       with:
         create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
   go-postgres:
@@ -122,6 +123,7 @@ jobs:
       with:
         create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
   go-bench:
@@ -199,6 +201,7 @@ jobs:
       with:
         create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'ui/apps/platform/test-results/reports'
 
   local-roxctl-tests:
@@ -234,6 +237,7 @@ jobs:
       with:
         create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'roxctl-test-output'
 
   shell-unit-tests:
@@ -264,6 +268,7 @@ jobs:
       with:
         create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'shell-test-output'
 
   openshift-ci-unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -65,9 +65,10 @@ jobs:
         paths: 'junit-reports/report.xml'
 
     - name: Report test failures to Jira
-      if: (!cancelled()) && github.event_name == 'push'
+      if: (!cancelled())
       uses: ./.github/actions/junit2jira
       with:
+        create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'junit-reports'
 
@@ -116,9 +117,10 @@ jobs:
         paths: 'junit-reports/report.xml'
 
     - name: Report junit failures in jira
-      if: (!cancelled()) && github.event_name == 'push'
+      if: (!cancelled())
       uses: ./.github/actions/junit2jira
       with:
+        create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'junit-reports'
 
@@ -192,9 +194,10 @@ jobs:
         paths: 'ui/apps/platform/test-results/reports/*.xml'
 
     - name: Report junit failures in jira
-      if: (!cancelled()) && github.event_name == 'push'
+      if: (!cancelled())
       uses: ./.github/actions/junit2jira
       with:
+        create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'ui/apps/platform/test-results/reports'
 
@@ -226,9 +229,10 @@ jobs:
         paths: 'roxctl-test-output/*.xml'
 
     - name: Report junit failures in jira
-      if: (!cancelled()) && github.event_name == 'push'
+      if: (!cancelled())
       uses: ./.github/actions/junit2jira
       with:
+        create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'roxctl-test-output'
 
@@ -255,9 +259,10 @@ jobs:
         paths: 'shell-test-output/*.xml'
 
     - name: Report junit failures in jira
-      if: (!cancelled()) && github.event_name == 'push'
+      if: (!cancelled())
       uses: ./.github/actions/junit2jira
       with:
+        create-jiras: ${{ github.event_name == 'push' }}
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'shell-test-output'
 


### PR DESCRIPTION
## Description

This PR enhance junit2jira action with uploading test metrics into bigquery.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```sql 
SELECT JobName FROM `acs-san-stackroxci.ci_metrics.stackrox_tests`
WHERE BuildTag = '10474/merge@ffeacd0b325c0fcc4a9c997c325db4d549377317'
GROUP BY JobName
```
```
Row	| JobName
1       | ui
2       | shell-unit-tests
3       | go
4       | local-roxctl-tests
5       | go-postgres
```



### Here I tell how I validated my change

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
