### PR TITLE
chore(GO): extend vuln ingore

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -573,7 +573,7 @@ jobs:
 
   scan-go-binaries:
     if: |
-      github.event_name == 'push' || 
+      github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -572,7 +572,9 @@ jobs:
           make -C operator/ docker-push-index | cat
 
   scan-go-binaries:
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' || 
+      contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest

--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -5,7 +5,7 @@
     },
     "GO-2023-2186": {
       "reason": "False positive as this path is not exercised in the codebase",
-      "until": "2024-03-22T00:00:00Z"
+      "until": "2024-04-07T00:00:00Z"
     },
     "GO-2023-2382": {
       "reason": "Requires version bump",


### PR DESCRIPTION
## Description

Extend the vuln ignore until go1.21 lands #10305. Also run the job on PRs if `scan-go-binaries` label is present.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] CI with label

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
