### PR TITLE
fix(ui): Add workaround for bug in access scopes to avoid crash

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
@@ -111,7 +111,7 @@ function EffectiveAccessScopeTable({
                 >
                     {/*
                         In rare cases this value can be an empty string which will cause a runtime error in PatternFly
-                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185 
+                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185
                         In this case, we display a dash instead to avoid a crash.
                     */}
                     {clusterName || '-'}
@@ -191,7 +191,7 @@ function EffectiveAccessScopeTable({
                     >
                         {/*
                         In rare cases this value can be an empty string which will cause a runtime error in PatternFly
-                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185 
+                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185
                         In this case, we display a dash instead to avoid a crash.
                     */}
                         {namespaceName || '-'}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
@@ -109,7 +109,12 @@ function EffectiveAccessScopeTable({
                         props: clusterProps,
                     }}
                 >
-                    {clusterName}
+                    {/*
+                        In rare cases this value can be an empty string which will cause a runtime error in PatternFly
+                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185 
+                        In this case, we display a dash instead to avoid a crash.
+                    */}
+                    {clusterName || '-'}
                 </Td>
                 <Td dataLabel="Cluster allowed">
                     <EffectiveAccessScopeStateIcon state={clusterState} isCluster />
@@ -184,7 +189,12 @@ function EffectiveAccessScopeTable({
                             props: namespaceProps,
                         }}
                     >
-                        {namespaceName}
+                        {/*
+                        In rare cases this value can be an empty string which will cause a runtime error in PatternFly
+                        due to a bug in the table component.https://github.com/patternfly/patternfly-react/issues/10185 
+                        In this case, we display a dash instead to avoid a crash.
+                    */}
+                        {namespaceName || '-'}
                     </Td>
                     <Td dataLabel="Namespace allowed">
                         <EffectiveAccessScopeStateIcon state={namespaceState} isCluster={false} />


### PR DESCRIPTION
## Description

As titled. See more information in https://www.github.com/patternfly/patternfly-react/issues/10185

If needed, we can add this to the patch release milestones for supported ACS versions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Override the response of `computeeffectiveaccessscope` when visiting an individual access scope or attempting to create an access scope, and ensure the response has an empty string for a cluster or namespace name. Instead of a runtime error, the cluster/namespace should show up in the "Allowed resources" section as a single dash `-`.

![image](https://github.com/stackrox/stackrox/assets/1292638/526f1c44-2708-497e-b33f-74bf783a8f6b)
