### PR TITLE
ROX-9331: move access token

### DIFF
--- a/ui/apps/platform/cypress/helpers/basicAuth.js
+++ b/ui/apps/platform/cypress/helpers/basicAuth.js
@@ -3,7 +3,9 @@ export default () => {
     const token = Cypress.env('ROX_AUTH_TOKEN');
     if (token) {
         beforeEach(() => {
-            localStorage.setItem('access_token', token);
+            cy.intercept('*', (req) => {
+                req.headers.Authorization = `Bearer ${token}`;
+            });
         });
     }
 };

--- a/ui/apps/platform/cypress/integration/login.test.js
+++ b/ui/apps/platform/cypress/integration/login.test.js
@@ -1,0 +1,41 @@
+import { visit } from '../helpers/visit';
+import { interactAndWaitForResponses } from '../helpers/request';
+
+const loginURL = '/login';
+
+const dashboardURL = '/main/dashboard';
+
+const username = Cypress.env('ROX_USERNAME');
+const password = Cypress.env('ROX_PASSWORD');
+
+const loginAlias = 'login';
+const routeMatcherMapForLogin = {
+    [loginAlias]: {
+        method: 'GET',
+        url: '/v1/login/authproviders',
+    },
+};
+
+const routeMatcherMapForSubmit = {
+    [loginAlias]: {
+        method: 'POST',
+        url: '/v1/authProviders/exchangeToken',
+    },
+};
+
+describe('Login', () => {
+    it('go to dashboard after login', () => {
+        visit(loginURL, routeMatcherMapForLogin);
+
+        interactAndWaitForResponses(() => {
+            cy.get('input[name=username]').type(username);
+            cy.get('input[name=password]').type(password);
+            cy.get('button[type=submit]').click();
+        }, routeMatcherMapForSubmit);
+        cy.location('pathname').should('eq', dashboardURL);
+
+        cy.getAllLocalStorage().then((result) => {
+            expect(result).to.be.empty;
+        });
+    });
+});

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -18,6 +18,8 @@ if [[ -n "$ROX_PASSWORD" ]]; then
   done
 fi
 export CYPRESS_ROX_AUTH_TOKEN=$(./scripts/get-auth-token.sh)
+export CYPRESS_ROX_USERNAME="${ROX_USERNAME:admin}"
+export CYPRESS_ROX_PASSWORD="${ROX_PASSWORD}"
 
 # eventually it should be in cypress.config.js: https://github.com/cypress-io/cypress/issues/5218
 artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/artifacts"

--- a/ui/apps/platform/src/sagas/authSagas.test.js
+++ b/ui/apps/platform/src/sagas/authSagas.test.js
@@ -24,6 +24,7 @@ describe('Auth Sagas', () => {
                 ...createStateSelectors(),
                 [call(AuthService.fetchLoginAuthProviders), dynamic(fetchMock)],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -43,6 +44,7 @@ describe('Auth Sagas', () => {
                 [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
                 [call(AuthService.getAccessToken), null],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), throwError(new Error('no auth'))],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -85,7 +87,7 @@ describe('Auth Sagas', () => {
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.LOGGED_IN),
                 [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(AuthService.logout), dynamic(logout)],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
@@ -106,6 +108,7 @@ describe('Auth Sagas', () => {
                 ...createStateSelectors(),
                 [call(AuthService.fetchLoginAuthProviders), { response: [] }],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(AuthService.storeRequestedLocation, from), dynamic(storeLocationMock)],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
@@ -135,6 +138,7 @@ describe('Auth Sagas', () => {
                 [call(AuthService.storeAccessToken, exchangedToken), dynamic(storeAccessTokenMock)],
                 [call(AuthService.getAndClearRequestedLocation), requestedLocation],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -172,6 +176,7 @@ describe('Auth Sagas', () => {
                 [call(AuthService.storeAccessToken, token), dynamic(storeAccessTokenMock)],
                 [call(AuthService.getAndClearRequestedLocation), requestedLocation],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -214,6 +219,7 @@ describe('Auth Sagas', () => {
                     dynamic(storeLocationMock),
                 ],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -240,6 +246,7 @@ describe('Auth Sagas', () => {
                 [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
                 [call(AuthService.getAccessToken), 'my-token'],
                 [call(AuthService.logout), null],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
             ])
@@ -254,6 +261,7 @@ describe('Auth Sagas', () => {
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.LOGGED_IN),
                 [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
                 [call(AuthService.getAccessToken), 'my-token'],
+                [call(AuthService.getAuthStatus), 'ok'],
                 [call(AuthService.logout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
                 [call(AuthService.fetchAvailableProviderTypes), { response: [] }],

--- a/ui/apps/platform/src/services/AuthService/AccessTokenManager.js
+++ b/ui/apps/platform/src/services/AuthService/AccessTokenManager.js
@@ -1,4 +1,3 @@
-import store from 'store';
 /* eslint-disable import/no-duplicates */
 import differenceInMilliSeconds from 'date-fns/difference_in_milliseconds';
 import subSeconds from 'date-fns/sub_seconds';
@@ -39,8 +38,6 @@ import RefreshTokenTimeout from './RefreshTokenTimeout';
  * @callback RefreshTokenListener
  * @param {!RefreshTokenOpPromise} opPromise - Operation Promise
  */
-
-const accessTokenKey = 'access_token';
 
 /**
  * Performs all the operations for storing, accessing and refreshing access token.
@@ -120,7 +117,7 @@ export default class AccessTokenManager {
      * @param {TokenInfo} [info] - Token info
      */
     setToken = (token, info = null) => {
-        store.set(accessTokenKey, token);
+        this.token = token;
         this.updateTokenInfo(info);
     };
 
@@ -129,7 +126,7 @@ export default class AccessTokenManager {
      * @method
      * @returns {?string} Token
      */
-    getToken = () => store.get(accessTokenKey) || null;
+    getToken = () => this.token || null;
 
     /**
      * Deletes any stored token.
@@ -137,7 +134,7 @@ export default class AccessTokenManager {
      * @returns {void}
      */
     clearToken = () => {
-        store.remove(accessTokenKey);
+        this.token = '';
         this.updateTokenInfo(null);
     };
 

--- a/ui/apps/platform/src/services/AuthService/AccessTokenManager.js
+++ b/ui/apps/platform/src/services/AuthService/AccessTokenManager.js
@@ -3,6 +3,7 @@ import differenceInMilliSeconds from 'date-fns/difference_in_milliseconds';
 import subSeconds from 'date-fns/sub_seconds';
 /* eslint-enable import/no-duplicates */
 import EventEmitter from 'events';
+import store from 'store';
 
 import RefreshTokenTimeout from './RefreshTokenTimeout';
 
@@ -58,6 +59,8 @@ export default class AccessTokenManager {
         this.refreshTokenOpPromise = null;
         this.refreshTokenSymbol = Symbol('Refresh Token');
         this.eventEmitter = new EventEmitter();
+        this.token = store.get('access_token');
+        store.remove('access_token');
     }
 
     /**

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -313,7 +313,12 @@ export function loginWithBasicAuth(
     const basicAuthPseudoToken = queryString.stringify({ username, password });
     return exchangeAuthToken(basicAuthPseudoToken, authProvider.type, authProvider.id).then(
         ({ token }) => {
-            storeAccessToken(token);
+            // We need to temporarily store the token in-browser to be persistent
+            // in-between redirects.
+            // It will be automatically removed once the access token manager is reloaded.
+            // This is only required during the basic auth login flow due to its nature of
+            // calling `window.location`.
+            store.set('access_token', token);
             // window.location.href might be better, however
             // @ts-ignore 2322
             window.location = getAndClearRequestedLocation() || '/';


### PR DESCRIPTION
## Description

As an alternative to [pull/10188](https://github.com/stackrox/stackrox/pull/10188) this one moves the short-lived access token to in-memory for the time being.

This has the following caveats:
- For basic auth, a special flow had to be added due to its nature of calling `window.location` doing a hard refresh on the page.
- For any auth provider that is not refresh token enabled (i.e. UserPKI, SAML, Basic); a refresh will trigger a new login, even though the session is still ongoing. These auth providers are the lowest used ones, and basic isn't recommended to be used at all in production.
- As a caveat to the above ^; in case an OIDC provider is used with the fragment mode (e.g. Auth0) where _no_ refresh token is going to be issued, this will have the same effects.

The effects of this is going to be a limited UX for users using SAML, UserPKI, Auth0 auth providers.

Additional research:
The only places _within our application_ that trigger a hard refresh (i.e. assigning `window.location`) is the auth service during basic auth, and in case the telemetry values are changed from enabled to disabled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

Manual testing:

For different types of auth providers, the following actions were manually tested: `Navigate within the UI, Refresh page, open page in new tab`.

| Auth provider                 | Refresh    | New tab    | Naviagate within UI |
|-------------------------------|------------|------------|---------------------|
| Basic | Logged out | Logged out | Logged in           |

| Auth provider                 | Refresh    | New tab    | Naviagate within UI |
|-------------------------------|------------|------------|---------------------|
| Auth0 (OIDC w/ fragment mode) | Logged out | Logged out | Logged in           |

| Auth provider                 | Refresh    | New tab    | Naviagate within UI |
|-------------------------------|------------|------------|---------------------|
| OIDC (w/ post/query mode) | Logged in | Logged in | Logged in           |

| Auth provider                 | Refresh    | New tab    | Naviagate within UI |
|-------------------------------|------------|------------|---------------------|
| OpenShift Auth | Logged in | Logged in | Logged in           |

The following auth providers haven't been tested, but looking through the code should have similar effects:
- SAML & UserPKI - similar to Auth0 / Basic
- IAP - similar to OIDC / OpenShift

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
