### PR TITLE
ROX-22735: Adding a namespace table to the Namespace view

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { pluralize } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import { getQueryString } from 'utils/queryStringUtils';
+
+export type DeploymentFilterLinkProps = {
+    deploymentCount: number;
+    namespaceName: string;
+    clusterName: string;
+};
+
+function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName }) {
+    const query = getQueryString({
+        vulnerabilityState: 'OBSERVED',
+        entityTab: 'Deployment',
+        s: {
+            NAMESPACE: namespaceName,
+            CLUSTER: clusterName,
+        },
+    });
+    return (
+        <Link to={`${vulnerabilitiesWorkloadCvesPath}${query}`}>
+            {pluralize(deploymentCount, 'deployment')}
+        </Link>
+    );
+}
+
+export default DeploymentFilterLink;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -16,8 +16,8 @@ function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName }) {
         vulnerabilityState: 'OBSERVED',
         entityTab: 'Deployment',
         s: {
-            NAMESPACE: namespaceName,
-            CLUSTER: clusterName,
+            NAMESPACE: `^${namespaceName}$`,
+            CLUSTER: `^${clusterName}$`,
         },
     });
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/LabelsModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/LabelsModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Button, List, ListItem, Modal, pluralize } from '@patternfly/react-core';
+import useModal from 'hooks/useModal';
+
+export type DeploymentFilterLinkProps = {
+    labels: {
+        key: string;
+        value: string;
+    }[];
+};
+
+function LabelsModal({ labels }) {
+    const { isModalOpen, openModal, closeModal } = useModal();
+
+    const text = pluralize(labels.length, 'label');
+
+    return (
+        <>
+            <Button variant="link" isInline onClick={openModal}>
+                {text}
+            </Button>
+            <Modal
+                variant="small"
+                title={text}
+                isOpen={isModalOpen}
+                onClose={closeModal}
+                actions={[
+                    <Button key="cancel" variant="primary" onClick={closeModal}>
+                        Cancel
+                    </Button>,
+                ]}
+            >
+                <List isPlain isBordered className="pf-u-py-sm">
+                    {labels.map((label) => {
+                        const labelText = `${label.key}: ${label.value}`;
+                        return <ListItem key={labelText}>{labelText}</ListItem>;
+                    })}
+                </List>
+            </Modal>
+        </>
+    );
+}
+
+export default LabelsModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -2,17 +2,141 @@ import React from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
+    Bullseye,
+    Button,
     Divider,
     Flex,
     FlexItem,
     PageSection,
+    Pagination,
+    Spinner,
+    Text,
     Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
 } from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
+import { gql, useQuery } from '@apollo/client';
+
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import { getTableUIState } from 'utils/getTableUIState';
+import useURLSearch from 'hooks/useURLSearch';
+import {
+    CLUSTER_SEARCH_OPTION,
+    NAMESPACE_LABEL_SEARCH_OPTION,
+    NAMESPACE_SEARCH_OPTION,
+    SearchOption,
+} from 'Containers/Vulnerabilities/searchOptions';
+
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
-import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
+import FilterAutocompleteSelect from 'Containers/Vulnerabilities/components/FilterAutocomplete';
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import DeploymentFilterLink from './DeploymentFilterLink';
+import LabelsModal from './LabelsModal';
+
+type Namespace = {
+    metadata: {
+        id: string;
+        name: string;
+        clusterId: string;
+        clusterName: string;
+        labels: {
+            key: string;
+            value: string;
+        }[];
+        priority: number;
+    };
+    deploymentCount: number;
+};
+
+const namespacesQuery = gql`
+    query getNamespaces($query: String, $pagination: Pagination) {
+        namespaces(query: $query, pagination: $pagination) {
+            metadata {
+                id
+                name
+                clusterId
+                clusterName
+                labels {
+                    key
+                    value
+                }
+                priority
+            }
+            deploymentCount(query: $query)
+        }
+    }
+`;
+
+const defaultSearchFilters = {
+    'Vulnerability State': 'OBSERVED',
+};
+
+const searchOptions: SearchOption[] = [
+    NAMESPACE_SEARCH_OPTION,
+    NAMESPACE_LABEL_SEARCH_OPTION,
+    CLUSTER_SEARCH_OPTION,
+];
+
+const sortFields = ['Namespace Risk Priority', 'Namespace', 'Cluster', 'Deployment Count'];
+const defaultSortOption = {
+    field: sortFields[0],
+    direction: 'asc',
+} as const;
+
+const pollInterval = 30000;
 
 function NamespaceViewPage() {
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
+
+    const {
+        data,
+        previousData,
+        loading: isLoading,
+        error,
+    } = useQuery<{ namespaces: Namespace[] }>(namespacesQuery, {
+        variables: {
+            query: getRequestQueryStringForSearchFilter({
+                ...searchFilter,
+                ...defaultSearchFilters,
+            }),
+            pagination: {
+                limit: perPage,
+                offset: page - 1,
+                sortOption,
+            },
+        },
+        pollInterval,
+    });
+
+    const namespacesData = data?.namespaces ?? previousData?.namespaces;
+
+    const tableUIState = getTableUIState({
+        isLoading,
+        data: namespacesData,
+        error,
+        searchFilter,
+    });
+
+    function onFilterChange() {
+        setPage(1);
+    }
+
     return (
         <>
             <PageTitle title="Workload CVEs - Namespace view" />
@@ -37,7 +161,149 @@ function NamespaceViewPage() {
                 </Flex>
             </PageSection>
             <Divider component="div" />
-            <PageSection padding={{ default: 'noPadding' }}></PageSection>
+            <PageSection>
+                <Toolbar>
+                    <ToolbarContent>
+                        <FilterAutocompleteSelect
+                            searchFilter={searchFilter}
+                            onFilterChange={(newFilter) => setSearchFilter(newFilter)}
+                            searchOptions={searchOptions}
+                        />
+                        <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                            <Pagination
+                                toggleTemplate={({ firstIndex, lastIndex }) => (
+                                    <span>
+                                        <b>
+                                            {firstIndex} - {lastIndex}
+                                        </b>{' '}
+                                        of <b>many</b>
+                                    </span>
+                                )}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                                isCompact
+                            />
+                        </ToolbarItem>
+                        <ToolbarGroup aria-label="applied search filters" className="pf-u-w-100">
+                            <SearchFilterChips
+                                onFilterChange={onFilterChange}
+                                filterChipGroupDescriptors={searchOptions.map(
+                                    ({ label, value }) => {
+                                        return {
+                                            displayName: label,
+                                            searchFilterName: value,
+                                        };
+                                    }
+                                )}
+                            />
+                        </ToolbarGroup>
+                    </ToolbarContent>
+                </Toolbar>
+                <TableComposable borders={false}>
+                    <Thead noWrap>
+                        <Tr>
+                            <Th sort={getSortParams('Namespace')} width={30}>
+                                Namespace
+                            </Th>
+                            <Th sort={getSortParams('Namespace Risk Priority')}>Risk priority</Th>
+                            <Th sort={getSortParams('Cluster')}>Cluster</Th>
+                            <Th sort={getSortParams('Deployment Count')}>Deployments</Th>
+                            <Th>Labels</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {tableUIState.type === 'ERROR' && (
+                            <Tr>
+                                <Td colSpan={5}>
+                                    <TableErrorComponent
+                                        error={tableUIState.error}
+                                        message="An error occurred. Try refreshing again"
+                                    />
+                                </Td>
+                            </Tr>
+                        )}
+                        {tableUIState.type === 'LOADING' && (
+                            <Tr>
+                                <Td colSpan={5}>
+                                    <Bullseye>
+                                        <Spinner isSVG aria-label="Loading table data" />
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
+                        {tableUIState.type === 'EMPTY' && (
+                            <Tr>
+                                <Td colSpan={5}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No pending exception requests"
+                                            headingLevel="h2"
+                                            icon={FileAltIcon}
+                                        >
+                                            <Text>There are currently no namespaces.</Text>
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
+                        {tableUIState.type === 'FILTERED_EMPTY' && (
+                            <Tr>
+                                <Td colSpan={5}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No results found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        >
+                                            <Text>
+                                                We couldn’t find any items matching your search
+                                                criteria. Try adjusting your filters or search terms
+                                                for better results
+                                            </Text>
+                                            <Button
+                                                variant="link"
+                                                onClick={() => {
+                                                    setPage(1);
+                                                    setSearchFilter({});
+                                                }}
+                                            >
+                                                Clear search filters
+                                            </Button>
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
+                        {(tableUIState.type === 'COMPLETE' || tableUIState.type === 'POLLING') &&
+                            tableUIState.data.map((namespace) => {
+                                const {
+                                    metadata: { id, name, clusterName, labels, priority },
+                                    deploymentCount,
+                                } = namespace;
+
+                                return (
+                                    <Tr key={id}>
+                                        <Td dataLabel="Namespace">{name}</Td>
+                                        <Td dataLabel="Risk priority">{priority}</Td>
+                                        <Td dataLabel="Cluster">{clusterName}</Td>
+                                        <Td dataLabel="Deployments">
+                                            <DeploymentFilterLink
+                                                deploymentCount={deploymentCount}
+                                                namespaceName={name}
+                                                clusterName={clusterName}
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Labels">
+                                            <LabelsModal labels={labels} />
+                                        </Td>
+                                    </Tr>
+                                );
+                            })}
+                    </Tbody>
+                </TableComposable>
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -23,7 +23,10 @@ import { gql, useQuery } from '@apollo/client';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { getTableUIState } from 'utils/getTableUIState';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
 import {
     CLUSTER_SEARCH_OPTION,
     NAMESPACE_LABEL_SEARCH_OPTION,
@@ -35,11 +38,8 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
-import useURLPagination from 'hooks/useURLPagination';
-import useURLSort from 'hooks/useURLSort';
 import FilterAutocompleteSelect from 'Containers/Vulnerabilities/components/FilterAutocomplete';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import DeploymentFilterLink from './DeploymentFilterLink';
 import LabelsModal from './LabelsModal';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -59,7 +59,7 @@ type Namespace = {
 };
 
 const namespacesQuery = gql`
-    query getNamespaces($query: String, $pagination: Pagination) {
+    query getNamespaceViewNamespaces($query: String, $pagination: Pagination) {
         namespaces(query: $query, pagination: $pagination) {
             metadata {
                 id
@@ -238,7 +238,7 @@ function NamespaceViewPage() {
                                 <Td colSpan={5}>
                                     <Bullseye>
                                         <EmptyStateTemplate
-                                            title="No pending exception requests"
+                                            title="There are currently no namespaces"
                                             headingLevel="h2"
                                             icon={FileAltIcon}
                                         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
@@ -1,26 +1,28 @@
 import { SearchCategory } from 'services/SearchService';
 
 export type SearchOptionValue =
-    | 'SEVERITY'
-    | 'FIXABLE'
-    | 'CVE'
-    | 'IMAGE'
-    | 'DEPLOYMENT'
-    | 'NAMESPACE'
     | 'CLUSTER'
     | 'COMPONENT'
     | 'COMPONENT SOURCE'
+    | 'CVE'
+    | 'DEPLOYMENT'
+    | 'FIXABLE'
+    | 'IMAGE'
+    | 'NAMESPACE'
+    | 'Namespace Label'
     | 'Request Name'
-    | 'Requester User Name';
+    | 'Requester User Name'
+    | 'SEVERITY';
 
 // Search fields that will default to regex search
 export const regexSearchOptions: SearchOptionValue[] = [
-    'CVE',
-    'IMAGE',
-    'DEPLOYMENT',
-    'NAMESPACE',
     'CLUSTER',
     'COMPONENT',
+    'CVE',
+    'DEPLOYMENT',
+    'IMAGE',
+    'NAMESPACE',
+    'Namespace Label',
     'Request Name',
     'Requester User Name',
 ] as const;
@@ -66,6 +68,12 @@ export const DEPLOYMENT_SEARCH_OPTION = {
 export const NAMESPACE_SEARCH_OPTION = {
     label: 'Namespace',
     value: 'NAMESPACE',
+    category: 'NAMESPACES',
+} as const;
+
+export const NAMESPACE_LABEL_SEARCH_OPTION = {
+    label: 'Namespace label',
+    value: 'Namespace Label',
     category: 'NAMESPACES',
 } as const;
 


### PR DESCRIPTION
## Description

This PR includes the following:
1. Adding the namespaces table
2. Adding sorting for the table
3. Adding pagination for the table
4. Adding search filters for the table
5. Clicking on the Deployment link will take you to the Workload CVEs Deployments table and filter by Namespace and Cluster
6. Clicking on the Labels link will open up a modal and display a list of labels

## Screen Recording

https://github.com/stackrox/stackrox/assets/4805485/8e542a47-050b-469a-8db1-be1283b0acc3

This is what shows up when there is an error while polling. Once we settle on the table UI state management work, a lot of this boilerplate work should become unnecessary.
 
<img width="1437" alt="Screenshot 2024-03-22 at 5 47 59 PM" src="https://github.com/stackrox/stackrox/assets/4805485/221d1f85-1ee5-48b8-ba5c-2359bc9c9505">

