### PR TITLE
fix(ui): Fix rendering performance issues in Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/EntityTypeToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/EntityTypeToggleGroup.tsx
@@ -29,6 +29,7 @@ export function EntityTabToggleGroup<EntityTabType extends EntityTab>({
         <ToggleGroup className={className} aria-label="Entity type toggle items">
             {entityTabs.map((tab) => (
                 <ToggleGroupItem
+                    key={tab}
                     text={`${pluralize(entityCounts[tab], tab)}`}
                     buttonId={tab}
                     isSelected={activeEntityTabKey === tab}

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -1,4 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+
 import useURLParameter from 'hooks/useURLParameter';
 import { SortAggregate, SortDirection, SortOption, ThProps } from 'types/table';
 import { ApiSortOption } from 'types/search';
@@ -74,7 +76,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
 
     // we'll construct a map of sort fields to indices that will make it easier to work with
     // PatternFly
-    useEffect(() => {
+    useDeepCompareEffect(() => {
         const newFieldToIndexMap = sortFields.reduce(
             (acc, curr, index) => {
                 acc[curr] = index;


### PR DESCRIPTION
## Description

Fixes two issues introduced by a recent refactoring, discovered by @pedrottimark (TY!).

1. Missing React `key` prop for an array of children
2. `useEffect` render loop due to referential change of identical sort parameters

Instead of extracting the sort parameters as constants again, I opted to update the useURLSort() hook itself to use a deep comparison effect since this issue has popped up a handful of times and behaviorally this is what we intend. If the incoming sort fields are an identical string array each time, there is no need to constantly rebuild the hook's local state. This makes checking for infinite render loops no longer the responsibility of the caller.

## Possible follow ups

It would be nice if we could catch these types of errors more easily before merges to master. I see there is a disabled lint rule that would catch one: `'react/jsx-key': 'off', // more that 30 errors`.

We could also put a check in Cypress tests to fail a test if it detects a "Maximum update depth exceeded" in the console, which IMO is a more serious performance issue than the key issue above.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of sort fields across all Workload CVE tables and entity tabs.
- Sorting continues to work as expected
- No errors are thrown in the console
