### PR TITLE
chore(ci): revert go version replace

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -936,23 +936,6 @@ get_pr_details() {
 openshift_ci_mods() {
     info "BEGIN OpenShift CI mods"
 
-    #TODO(janisz): remove after https://github.com/openshift/release/pull/49962 is merged
-    if [ -e "/tmp/go/" ]; then
-        info "Go already exists"
-    else
-        info "Replace Go"
-        go version
-        whoami
-        GOLANG_VERSION=1.21.8
-        GOLANG_SHA256=538b3b143dc7f32b093c8ffe0e050c260b57fc9d57a12c4140a639a8dd2b4e4f
-        url="https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz"
-        wget --no-verbose -O /tmp/go.tgz "$url"
-        echo "$GOLANG_SHA256 /tmp/go.tgz" | sha256sum -c -
-        tar -C /tmp/ -xzf /tmp/go.tgz
-    fi
-    export PATH=/tmp/go/bin:$PATH
-    go version
-
     openshift_ci_debug
 
     info "Current Status:"


### PR DESCRIPTION
## Description

We can revert changes to lib.sh that installs custom go version once following PR is merged
- https://github.com/openshift/release/pull/49962

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
CI (prow)
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
