### PR TITLE
ROX-23044: Add route and page component for Node single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom';
+
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import { getOverviewCvesPath } from '../utils/searchUtils';
+
+const workloadCveOverviewCvePath = getOverviewCvesPath({
+    entityTab: 'Node',
+});
+
+function NodePage() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { nodeId } = useParams() as { nodeId: string };
+
+    const nodeName: string | undefined = 'TODO';
+
+    return (
+        <>
+            <PageTitle title={`Node CVEs - Node ${nodeName}`} />
+            <PageSection variant="light" className="pf-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>Nodes</BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>
+                        {nodeName ?? (
+                            <Skeleton screenreaderText="Loading Node name" width="200px" />
+                        )}
+                    </BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+        </>
+    );
+}
+
+export default NodePage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
@@ -9,8 +9,10 @@ import { vulnerabilitiesNodeCvesPath } from 'routePaths';
 import usePermissions from 'hooks/usePermissions';
 import NodeCvesOverviewPage from './Overview/NodeCvesOverviewPage';
 import NodeCvePage from './NodeCve/NodeCvePage';
+import NodePage from './Node/NodePage';
 
 const vulnerabilitiesNodeCveSinglePath = `${vulnerabilitiesNodeCvesPath}/cves/:cveId`;
+const vulnerabilitiesNodeSinglePath = `${vulnerabilitiesNodeCvesPath}/nodes/:nodeId`;
 
 function NodeCvesPage() {
     const { hasReadAccess } = usePermissions();
@@ -21,6 +23,7 @@ function NodeCvesPage() {
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
                 <Route path={vulnerabilitiesNodeCveSinglePath} component={NodeCvePage} />
+                <Route path={vulnerabilitiesNodeSinglePath} component={NodePage} />
                 <Route exact path={vulnerabilitiesNodeCvesPath} component={NodeCvesOverviewPage} />
                 <Route>
                     <PageSection variant="light">


### PR DESCRIPTION
## Description

Adds routing and a simple page component for the Node CVEs - Node single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit `/node-cves/nodes/<placeholder-node-id>':
![image](https://github.com/stackrox/stackrox/assets/1292638/8f37ef3e-f595-4ebb-aabe-2571736c75a4)

