### PR TITLE
Revert "fix(declarative-config): validate notifiers before upserting"

### DIFF
--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -10,7 +10,6 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/policycleaner"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
-	"github.com/stackrox/rox/central/notifiers/validation"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
@@ -70,11 +69,9 @@ func (u *notifierUpdater) Upsert(ctx context.Context, m protocompat.Message) err
 			return errors.Errorf("Error securing declarative config notifier %s, notifications to this notifier will fail", notifierProto.GetName())
 		}
 	}
-	if err := validation.ValidateNotifierConfig(notifierProto, true); err != nil {
-		return errox.InvalidArgs.CausedBy(err)
-	}
-	if _, err := u.notifierDS.UpsertNotifier(ctx, notifierProto); err != nil {
-		return errors.Wrap(err, "storing notifier")
+	_, err := u.notifierDS.UpsertNotifier(ctx, notifierProto)
+	if err != nil {
+		return err
 	}
 	notifier, err := notifiers.CreateNotifier(notifierProto)
 	if err != nil {

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -171,7 +171,6 @@ func (b *datastoreImpl) AddNotifier(ctx context.Context, notifier *storage.Notif
 	} else if !ok {
 		return "", sac.ErrResourceAccessDenied
 	}
-
 	notifier.Id = uuid.NewV4().String()
 
 	if err := verifyNotifierOrigin(ctx, notifier); err != nil {

--- a/central/notifier/datastore/datastsore_test.go
+++ b/central/notifier/datastore/datastsore_test.go
@@ -162,24 +162,14 @@ func (s *notifierDataStoreTestSuite) TestAllowsAdd() {
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
-	})
+	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *notifierDataStoreTestSuite) TestErrorOnAdd() {
 	s.storage.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, nil)
 
-	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
-	})
+	_, err := s.dataStore.AddNotifier(s.hasWriteCtx, &storage.Notifier{})
 	s.Error(err)
 }
 
@@ -197,24 +187,14 @@ func (s *notifierDataStoreTestSuite) TestAllowsUpdate() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, true, nil).Times(1)
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
-	})
+	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{Id: "id"})
 	s.NoError(err, "expected no error trying to write with permissions")
 }
 
 func (s *notifierDataStoreTestSuite) TestErrorOnUpdate() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, false, nil).Times(1)
 
-	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
-	})
+	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{Id: "id"})
 	s.Error(err)
 }
 
@@ -238,20 +218,16 @@ func (s *notifierDataStoreTestSuite) TestAllowsRemove() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateMutableToImmutable() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE,
 		},
 	}, true, nil).Times(1)
 
 	err := s.dataStore.UpdateNotifier(s.hasWriteCtx, &storage.Notifier{
-		Id:         "id",
-		Name:       "new name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "new name",
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
@@ -261,10 +237,8 @@ func (s *notifierDataStoreTestSuite) TestUpdateMutableToImmutable() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeViaAPI() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -276,10 +250,8 @@ func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeSuccess() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -292,10 +264,8 @@ func (s *notifierDataStoreTestSuite) TestRemoveDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -308,10 +278,8 @@ func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -325,10 +293,8 @@ func (s *notifierDataStoreTestSuite) TestUpdateDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestRemoveImperativeDeclaratively() {
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -340,10 +306,8 @@ func (s *notifierDataStoreTestSuite) TestRemoveImperativeDeclaratively() {
 
 func (s *notifierDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},
@@ -356,10 +320,8 @@ func (s *notifierDataStoreTestSuite) TestUpdateImperativeDeclaratively() {
 
 func (s *notifierDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -371,10 +333,8 @@ func (s *notifierDataStoreTestSuite) TestAddDeclarativeViaAPI() {
 
 func (s *notifierDataStoreTestSuite) TestAddDeclarativeSuccess() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -388,10 +348,8 @@ func (s *notifierDataStoreTestSuite) TestAddDeclarativeSuccess() {
 
 func (s *notifierDataStoreTestSuite) TestAddImperativeDeclaratively() {
 	ap := &storage.Notifier{
-		Id:         "id",
-		Name:       "name",
-		Type:       "notifier",
-		UiEndpoint: "test",
+		Id:   "id",
+		Name: "name",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_IMPERATIVE,
 		},

--- a/central/notifiers/validation/validate.go
+++ b/central/notifiers/validation/validate.go
@@ -10,65 +10,40 @@ import (
 	"github.com/stackrox/rox/central/notifiers/pagerduty"
 	"github.com/stackrox/rox/central/notifiers/splunk"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/endpoints"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 )
 
 // ValidateNotifierConfig validates notifier configuration based on the given notifier's type
 func ValidateNotifierConfig(notifier *storage.Notifier, validateSecret bool) error {
-	if notifier == nil {
-		return errors.New("empty notifier")
-	}
-	errorList := errorhelpers.NewErrorList("Validation")
-	if notifier.GetName() == "" {
-		errorList.AddString("notifier name must be defined")
-	}
-	if notifier.GetType() == "" {
-		errorList.AddString("notifier type must be defined")
-	}
-	if notifier.GetUiEndpoint() == "" {
-		errorList.AddString("notifier UI endpoint must be defined")
-	}
-	if err := endpoints.ValidateEndpoints(notifier.Config); err != nil {
-		errorList.AddWrap(err, "invalid endpoint")
-	}
 	switch notifier.GetType() {
 	case pkgNotifiers.AWSSecurityHubType:
 		if err := awssh.Validate(notifier.GetAwsSecurityHub(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate AWS SecurityHub config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate AWS SecurityHub config")
 		}
 	case pkgNotifiers.CSCCType:
 		if err := cscc.Validate(notifier.GetCscc(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate CSCC config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate CSCC config")
 		}
 	case pkgNotifiers.JiraType:
 		if err := jira.Validate(notifier.GetJira(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate Jira config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate Jira config")
 		}
 	case pkgNotifiers.EmailType:
 		if err := email.Validate(notifier.GetEmail(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate Email config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate Email config")
 		}
 	case pkgNotifiers.GenericType:
 		if err := generic.Validate(notifier.GetGeneric(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate Generic config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate Generic config")
 		}
 	case pkgNotifiers.PagerDutyType:
 		if err := pagerduty.Validate(notifier.GetPagerduty(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate PagerDuty config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate PagerDuty config")
 		}
 	case pkgNotifiers.SplunkType:
 		if err := splunk.Validate(notifier.GetSplunk(), validateSecret); err != nil {
-			errorList.AddWrap(err, "failed to validate Splunk config")
-			return errorList.ToError()
+			return errors.Wrap(err, "failed to validate Splunk config")
 		}
 	}
-	return errorList.ToError()
+	return nil
 }

--- a/central/reports/config/datastore/datastore_impl_v2_test.go
+++ b/central/reports/config/datastore/datastore_impl_v2_test.go
@@ -169,7 +169,7 @@ func (s *ReportConfigurationDatastoreV2Tests) TestSortReportConfigByCompletionTi
 func (s *ReportConfigurationDatastoreV2Tests) storeNotifier(name string) *storage.NotifierConfiguration_Id {
 	allCtx := sac.WithAllAccess(context.Background())
 
-	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name, Type: "email", UiEndpoint: "http://localhost"})
+	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name})
 	s.Require().NoError(err)
 	return &storage.NotifierConfiguration_Id{Id: id}
 }

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -56,7 +56,7 @@ func (s *ServiceLevelConfigSeparationSuite) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier", Type: "generic", UiEndpoint: "http://localhost"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
 	s.Require().NoError(err)
 
 	// Add collection

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -77,7 +77,7 @@ func (s *ServiceLevelConfigSeparationSuiteV2) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier", Type: "generic", UiEndpoint: "http://localhost"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
 	s.Require().NoError(err)
 
 	// Add collection

--- a/central/reports/snapshot/datastore/datastore_impl_test.go
+++ b/central/reports/snapshot/datastore/datastore_impl_test.go
@@ -164,7 +164,7 @@ func (s *ReportSnapshotDatastoreTestSuite) TestReportMetadataWorkflows() {
 func (s *ReportSnapshotDatastoreTestSuite) storeNotifier(name string) *storage.NotifierConfiguration_Id {
 	allCtx := sac.WithAllAccess(context.Background())
 
-	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name, Type: "generic", UiEndpoint: "http://localhost"})
+	id, err := s.notifierDataStore.AddNotifier(allCtx, &storage.Notifier{Name: name})
 	s.Require().NoError(err)
 	return &storage.NotifierConfiguration_Id{Id: id}
 }


### PR DESCRIPTION
Reverts stackrox/stackrox#10201

This lead to test failures, since the UIEndpoint field that is now required isn't exposed in declarative config.

It also isn't used besides the AWSSH notifier; will re-introduce the logic once this has been figured out.