### PR TITLE
ROX-22964: Assert groups without ordering

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -301,15 +301,17 @@ splunk:
         assert authProvider
 
         // Verify the groups are created successfully, and specify the origin declarative.
-        def expectedGroups = [VALID_DEFAULT_GROUP, VALID_DECLARATIVE_GROUP]
         def groupsResponse = GroupService.getGroups(
                 GroupServiceOuterClass.GetGroupsRequest.newBuilder().setAuthProviderId(authProvider.getId()).build())
-        def expectedProperties = expectedGroups.props
-        verifyAll(groupsResponse.getGroupsList().props) {
-            it.key == expectedProperties.key
-            it.value == expectedProperties.value
-            it.traits.origin == expectedProperties.traits.origin
-            it.authProviderId.every { it == authProvider.id }
+        for (group in groupsResponse.getGroupsList()) {
+            assert group.roleName == VALID_DEFAULT_GROUP.getRoleName() || VALID_DECLARATIVE_GROUP.getRoleName()
+            def prop = group.getProps()
+            assert prop.authProviderId == authProvider.id
+            assert prop.traits.origin == Traits.Origin.DECLARATIVE
+            assert prop.key == VALID_DEFAULT_GROUP.getProps().getKey() ||
+                    VALID_DECLARATIVE_GROUP.getProps().getKey()
+            assert prop.value == VALID_DEFAULT_GROUP.getProps().getValue() ||
+                    VALID_DECLARATIVE_GROUP.getProps().getValue()
         }
 
         // Verify the notifier is created successfully, and does specify the origin declarative.


### PR DESCRIPTION
## Description

Fixes a CI flake which occasionally occurred when the ordering of groups wasn't as expected. This should now be more stable and less flaky.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
