### PR TITLE
fix(ui): pf5 visual glitches

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import {
     AngleDoubleDownIcon,
     AngleDoubleUpIcon,
@@ -24,13 +24,25 @@ import { PolicySeverity } from 'types/policy.proto';
 // For example, colors={count === 0 ? noViolationsColor: undefined} prop.
 
 export const CriticalSeverityIcon = (props) => (
-    <Icon color={props.color ?? CRITICAL_SEVERITY_COLOR}>
+    <Icon
+        style={
+            {
+                '--pf-v5-c-icon__content--Color': props.color ?? CRITICAL_SEVERITY_COLOR,
+            } as CSSProperties
+        }
+    >
         <CriticalRiskIcon {...props} />
     </Icon>
 );
 
 export const ImportantSeverityIcon = (props) => (
-    <Icon color={props.color ?? IMPORTANT_HIGH_SEVERITY_COLOR}>
+    <Icon
+        style={
+            {
+                '--pf-v5-c-icon__content--Color': props.color ?? IMPORTANT_HIGH_SEVERITY_COLOR,
+            } as CSSProperties
+        }
+    >
         <AngleDoubleUpIcon {...props} />
     </Icon>
 );
@@ -38,7 +50,13 @@ export const ImportantSeverityIcon = (props) => (
 export const HighSeverityIcon = ImportantSeverityIcon; // High is for policy severity
 
 export const ModerateSeverityIcon = (props) => (
-    <Icon color={props.color ?? MODERATE_MEDIUM_SEVERITY_COLOR}>
+    <Icon
+        style={
+            {
+                '--pf-v5-c-icon__content--Color': props.color ?? MODERATE_MEDIUM_SEVERITY_COLOR,
+            } as CSSProperties
+        }
+    >
         <EqualsIcon {...props} />
     </Icon>
 );
@@ -46,13 +64,25 @@ export const ModerateSeverityIcon = (props) => (
 export const MediumSeverityIcon = ModerateSeverityIcon; // Medium is for policy severity
 
 export const LowSeverityIcon = (props) => (
-    <Icon color={props.color ?? LOW_SEVERITY_COLOR}>
+    <Icon
+        style={
+            {
+                '--pf-v5-c-icon__content--Color': props.color ?? LOW_SEVERITY_COLOR,
+            } as CSSProperties
+        }
+    >
         <AngleDoubleDownIcon {...props} />
     </Icon>
 );
 
 export const UnknownSeverityIcon = (props) => (
-    <Icon color={props.color ?? UNKNOWN_SEVERITY_COLOR}>
+    <Icon
+        style={
+            {
+                '--pf-v5-c-icon__content--Color': props.color ?? UNKNOWN_SEVERITY_COLOR,
+            } as CSSProperties
+        }
+    >
         <UnknownIcon {...props} />
     </Icon>
 );

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -337,13 +337,6 @@ function CollectionForm({
                     <Flex direction={{ default: 'column', lg: 'row' }}>
                         <FlexItem flex={{ default: 'flex_1' }}>
                             <FormGroup label="Name" fieldId="name" isRequired={!isReadOnly}>
-                                <FormHelperText>
-                                    <HelperText>
-                                        <HelperTextItem variant={nameError ? 'error' : 'default'}>
-                                            {nameError}
-                                        </HelperTextItem>
-                                    </HelperText>
-                                </FormHelperText>
                                 <TextInput
                                     id="name"
                                     name="name"
@@ -361,6 +354,13 @@ function CollectionForm({
                                     onBlur={handleBlur}
                                     readOnlyVariant={isReadOnly ? 'plain' : undefined}
                                 />
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant={nameError ? 'error' : 'default'}>
+                                            {nameError}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
                             </FormGroup>
                         </FlexItem>
                         <FlexItem flex={{ default: 'flex_2' }}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -152,13 +152,6 @@ function ByLabelSelector({
                                             className="rule-selector-name-value-input"
                                             fieldId={inputId}
                                         >
-                                            <FormHelperText>
-                                                <HelperText>
-                                                    <HelperTextItem variant={inputValidated}>
-                                                        {errorMessage}
-                                                    </HelperTextItem>
-                                                </HelperText>
-                                            </FormHelperText>
                                             <TextInput
                                                 id={inputId}
                                                 aria-label={ariaLabel}
@@ -176,6 +169,13 @@ function ByLabelSelector({
                                                 value={value}
                                                 isDisabled={isDisabled}
                                             />
+                                            <FormHelperText>
+                                                <HelperText>
+                                                    <HelperTextItem variant={inputValidated}>
+                                                        {errorMessage}
+                                                    </HelperTextItem>
+                                                </HelperText>
+                                            </FormHelperText>
                                         </FormGroup>
                                         {!isDisabled && (
                                             <Button

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -127,13 +127,6 @@ function ByNameSelector({
                                     className="rule-selector-name-value-input"
                                     fieldId={inputId}
                                 >
-                                    <FormHelperText>
-                                        <HelperText>
-                                            <HelperTextItem variant={inputValidated}>
-                                                {errorMessage}
-                                            </HelperTextItem>
-                                        </HelperText>
-                                    </FormHelperText>
                                     <TextInput
                                         id={inputId}
                                         aria-label={inputAriaLabel}
@@ -146,6 +139,13 @@ function ByNameSelector({
                                         value={value}
                                         isDisabled={isDisabled}
                                     />
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant={inputValidated}>
+                                                {errorMessage}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
                                 </FormGroup>
                             </div>
                             {!isDisabled && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -99,7 +99,7 @@ function DeploymentSelector({
     const deploymentSelectMenu = (
         <Menu onSelect={onDeploymentSelect} selected={selectedDeployments} isScrollable>
             <MenuSearch>
-                <MenuSearchInput className="pf-v5-u-p-md">
+                <MenuSearchInput>
                     <SearchInput
                         value={input}
                         aria-label="Filter deployments"

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -127,7 +127,7 @@ function NamespaceSelector({
     const namespaceSelectMenu = (
         <Menu onSelect={onNamespaceSelect} selected={selectedNamespaces} isScrollable>
             <MenuSearch>
-                <MenuSearchInput className="pf-v5-u-p-md">
+                <MenuSearchInput>
                     <SearchInput
                         value={input}
                         aria-label="Filter namespaces"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -55,14 +55,6 @@ function WatchedImagesForm({
     return (
         <Form onSubmit={handleSubmit}>
             <FormGroup label="Image name" fieldId="imageName" isRequired>
-                <FormHelperText>
-                    <HelperText>
-                        <HelperTextItem variant={nameFieldValidated}>
-                            {errors.imageName ||
-                                'The fully-qualified image name, beginning with the registry, and ending with the tag.'}
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
                 <TextInput
                     id="imageName"
                     type="text"
@@ -73,6 +65,14 @@ function WatchedImagesForm({
                     placeholder="registry.example.com/namespace/image-name:tag"
                     isRequired
                 />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem variant={nameFieldValidated}>
+                            {errors.imageName ||
+                                'The fully-qualified image name, beginning with the registry, and ending with the tag.'}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
             <div>
                 <Button

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -61,7 +61,6 @@ body {
     border-right-color: var(--pf-v5-global--BorderColor--300);
     border-bottom-color: var(--pf-v5-global--BorderColor--200);
     border-left-color: var(--pf-v5-global--BorderColor--300);
-    padding: var(--pf-v5-c-form-control--PaddingTop) var(--pf-v5-c-form-control--PaddingRight) var(--pf-v5-c-form-control--PaddingBottom) var(--pf-v5-c-form-control--PaddingLeft);
 }
 
 .pf-v5-c-form-control:disabled {

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -122,15 +122,7 @@ body {
 
 
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
-.pf-v5-c-button__icon.pf-m-start svg,
-.pf-v5-c-button__icon.pf-m-end svg,
-.pf-v5-c-empty-state__content svg,
-.pf-v5-c-progress__status-icon svg,
-.pf-v5-c-table__toggle-icon svg,
-.pf-v5-c-expandable-section__toggle-icon svg,
-.chr-c-feedback-modal svg,
-.pf-v5-c-breadcrumb__item-divider svg,
-.pf-v5-c-modal-box__title-icon svg {
+.pf-v5-c-page svg {
     display: inline;
 }
 

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -56,12 +56,6 @@ body {
     border-top: var(--pf-v5-global--BorderColor--100) var(--pf-v5-global--BorderWidth--sm) solid;
 }
 
-/* overrides for forms, until we remove Tailwind */
-.pf-v5-c-check__input {
-    height: var(--pf-v5-c-check__input--Height);
-    width: var(--pf-v5-c-check__input--Height);
-}
-
 .pf-v5-c-form-control {
     border-top-color: var(--pf-v5-global--BorderColor--300);
     border-right-color: var(--pf-v5-global--BorderColor--300);

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -4,6 +4,11 @@
    We should have a goal of eventually being able to delete this file.
  */
 
+body {
+    /* Overrides the tailwind default font-family that clashes with the upgrade to PF 5 */
+    font-family: var(--pf-v5-global--FontFamily--text);
+}
+
 .ReactModal__Content,
 #main-page-container > div > :not(.pf-v5-c-page__main-section) {
   font-size: 0.875rem;


### PR DESCRIPTION
## Description

1. [A change in where the global default font-family is applied results in our Tailwind font-family overriding the Red Hat font.](https://github.com/stackrox/stackrox/pull/10505/commits/aaa98443656e0c443c201048bcf4b1bf80194557)
2. A global checkbox size override relied on CSS vars that are no longer valid (at least at the scope we were using them from). [Removing the rules entirely fixes the issue.](https://github.com/stackrox/stackrox/pull/10505/commits/58cb0baa6fef849f7fc3e5327b9af8883af03b16)
3. [The color prop passed to Icon components previously was set](https://github.com/stackrox/stackrox/pull/10505/commits/5ca155fe1bbbd93c8ff70e59ef9da793c852fe44) as the svg's `fill` attribute. Now, that attribute has a value of `currentColor` and a wrapper element with the style: `color: var(--pf-v5-c-icon__content--Color, inherit);`
4. The codemod changed a helperText prop into a passed child component, but by default passes the new child _first_. This results in bad form layout. [Moving the child to the last position resolves this in most cases.](https://github.com/stackrox/stackrox/pull/10505/commits/793a34a28077622de9259416b559a872e939624f)
5. An extra padding override was causing layout shift of some form components. [The newest version of PF makes this additional padding unnecessary.](https://github.com/stackrox/stackrox/pull/10505/commits/c1042638c7a9ec1f18d545394fd978bd6e5e81e8)
6. Our Tailwind config sets all svgs to `display: block`, which is almost never what we want in PatternFly components. This was causing an issue in some dropdowns, but instead of adding yet another exception,[ I changed the default for all svg elements on PF pages.](https://github.com/stackrox/stackrox/pull/10505/commits/2b02aeebc02ab2ab01f0305d61e0b71cce081770)

## Known Residue

1. There are many other instances where icons are not the correct color.
2. There are likely many other instances where error messages are displayed above input components
3. There are mostly minor issues with spacing and alignment throughout the UI (less of an issue, but makes the app look bad)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Change 1
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/9182a1ee-3c98-4fb0-aa81-01bd0406cc48)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/1f4c48c5-9c3f-4d42-a513-c028a05208e0)


Change 2
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/650cadd9-9736-4def-8c14-a1f04a95506f)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/0e1dc784-a815-44e3-bda4-40487ca134d1)

Change 3
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/1b4a8dac-2e3e-4a45-9c67-2aaa428cb413)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/9ea23b5c-3bdb-4f48-83e2-124c27e18662)


Change 4
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/521ff8fe-5fbf-4876-b717-3a9b1756c46d)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/a7b30487-e853-4a83-89f2-1e1754154c69)


Change 5
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/650cf2d1-46e6-4980-9ec3-a4d1ff55f3bf)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/a7bbd94d-b214-475a-9944-5e7fabd56930)

Change 6
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/72a54b2f-f6f0-40b1-a539-4c31c6e6dd41)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e189de9-ffed-4181-9a95-fb5a1d73703a)
