### PR TITLE
ROX-23353: Add tech preview label to ScannerV4 UI components

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/TechPreviewLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/TechPreviewLabel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Label, LabelProps } from '@patternfly/react-core';
+
+export type TechPreviewLabelProps = LabelProps;
+
+function TechPreviewLabel({ className, ...props }: TechPreviewLabelProps) {
+    return (
+        <Label
+            isCompact
+            color="orange"
+            className={`pf-u-font-weight-light pf-u-font-family-sans-serif ${className ?? ''}`}
+            {...props}
+        >
+            Tech preview
+        </Label>
+    );
+}
+
+export default TechPreviewLabel;

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -28,7 +28,7 @@ function ScannerV4IntegrationBanner() {
     const brandedText =
         branding.type === 'RHACS_BRANDING'
             ? 'New Scanner V4 now available as Technical Preview in RHACS 4.4.'
-            : 'New Scanner V4 now available as Technical Preview StackRox 4.4.';
+            : 'New Scanner V4 now available as Technical Preview in StackRox 4.4.';
 
     const docsLink = (
         <a

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -27,8 +27,8 @@ function ScannerV4IntegrationBanner() {
 
     const brandedText =
         branding.type === 'RHACS_BRANDING'
-            ? 'New Scanner V4 now generally available in RHACS 4.4.'
-            : 'New Scanner V4 now generally available in StackRox 4.4.';
+            ? 'New Scanner V4 now available as Technical Preview in RHACS 4.4.'
+            : 'New Scanner V4 now available as Technical Preview StackRox 4.4.';
 
     const docsLink = (
         <a

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -19,6 +19,8 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { Traits } from 'types/traits.proto';
 import { TraitsOriginLabel } from 'Containers/AccessControl/TraitsOriginLabel';
 import { isUserResource } from 'Containers/AccessControl/traits';
+import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { getIntegrationLabel } from './utils/integrationsList';
 import { getEditDisabledMessage, getIsMachineAccessConfig } from './utils/integrationUtils';
 import usePageState from './hooks/usePageState';
@@ -33,11 +35,13 @@ export type IntegrationPageProps = {
 
 function IntegrationPage({ title, name, traits, children }: IntegrationPageProps): ReactElement {
     const permissions = useIntegrationPermissions();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const {
         pageState,
         params: { source, type, id },
     } = usePageState();
     const typeLabel = getIntegrationLabel(source, type);
+    const isTechPreview = isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4';
 
     const integrationsListPath = `${integrationsPath}/${source}/${type}`;
     const integrationEditPath = `${integrationsPath}/${source}/${type}/edit/${id as string}`;
@@ -60,10 +64,15 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">
-                <Flex>
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     {(name || getIsMachineAccessConfig(source, type)) && (
                         <FlexItem>
                             <Title headingLevel="h1">{name || 'Manage configuration'}</Title>
+                        </FlexItem>
+                    )}
+                    {isTechPreview && (
+                        <FlexItem>
+                            <TechPreviewLabel />
                         </FlexItem>
                     )}
                     {hasTraitsLabel && <TraitsOriginLabel traits={traits} />}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ImageIntegrationsSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ImageIntegrationsSection.tsx
@@ -33,6 +33,9 @@ function ImageIntegrationsSection(): ReactElement {
                         label={label}
                         linkTo={getIntegrationsListPath(source, type)}
                         numIntegrations={countIntegrations(type)}
+                        isTechPreview={
+                            isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4'
+                        }
                     />
                 );
             })}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
@@ -7,9 +7,12 @@ import {
     CardHeader,
     CardHeaderMain,
     CardTitle,
+    Flex,
     GalleryItem,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
+
+import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
 
 type IntegrationTileProps = {
     categories?: string;
@@ -17,6 +20,7 @@ type IntegrationTileProps = {
     label: string;
     linkTo: string;
     numIntegrations: number;
+    isTechPreview?: boolean;
 };
 
 const styleCard = {
@@ -29,6 +33,7 @@ function IntegrationTile({
     label,
     linkTo,
     numIntegrations,
+    isTechPreview = false,
 }: IntegrationTileProps): ReactElement {
     return (
         <GalleryItem>
@@ -43,7 +48,10 @@ function IntegrationTile({
                         </CardActions>
                     </CardHeader>
                     <CardTitle className="pf-u-color-100" style={{ whiteSpace: 'nowrap' }}>
-                        {label}
+                        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                            <span>{label}</span>
+                            {isTechPreview && <TechPreviewLabel />}
+                        </Flex>
                     </CardTitle>
                     {categories && <CardFooter className="pf-u-color-200">{categories}</CardFooter>}
                 </Card>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -6,6 +6,7 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Divider,
+    Flex,
 } from '@patternfly/react-core';
 import { useParams, useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -22,6 +23,8 @@ import { actions as cloudSourcesActions } from 'reducers/cloudSources';
 import { integrationsPath } from 'routePaths';
 import { ClusterInitBundle } from 'services/ClustersService';
 
+import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useIntegrations from '../hooks/useIntegrations';
 import { getIntegrationLabel } from '../utils/integrationsList';
 import {
@@ -50,6 +53,7 @@ function IntegrationsListPage({
 }): ReactElement {
     const { source, type } = useParams();
     const integrations = useIntegrations({ source, type });
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const [deletingIntegrationIds, setDeletingIntegrationIds] = useState([]);
 
     const history = useHistory();
@@ -69,6 +73,8 @@ function IntegrationsListPage({
     const isSignatureIntegration = getIsSignatureIntegration(source);
     const isScannerV4 = getIsScannerV4(source, type);
     const isCloudSource = getIsCloudSource(source);
+
+    const isTechPreview = isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4';
 
     function onDeleteIntegrations(ids) {
         setDeletingIntegrationIds(ids);
@@ -115,7 +121,17 @@ function IntegrationsListPage({
                 <Title headingLevel="h1">
                     {isSignatureIntegration ? 'Signature' : ''} Integrations
                 </Title>
-                {!isSignatureIntegration && <Title headingLevel="h2">{typeLabel}</Title>}
+                {!isSignatureIntegration && (
+                    <Title headingLevel="h2">
+                        <Flex
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                        >
+                            <span>{typeLabel}</span>
+                            {isTechPreview && <TechPreviewLabel />}
+                        </Flex>
+                    </Title>
+                )}
             </PageSection>
             <PageSection variant="default">
                 <IntegrationsTable

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationContent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationContent.tsx
@@ -1,6 +1,8 @@
 import React, { CSSProperties, ReactElement, ReactNode } from 'react';
 import { Flex, Label } from '@patternfly/react-core';
 
+import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
+
 type NavigationContentVariant = 'Deprecated' | 'TechPreview';
 
 const badgeMap: Record<string, ReactElement> = {
@@ -16,11 +18,7 @@ const badgeMap: Record<string, ReactElement> = {
             Deprecated
         </Label>
     ),
-    TechPreview: (
-        <Label isCompact color="orange">
-            Tech preview
-        </Label>
-    ),
+    TechPreview: <TechPreviewLabel />,
 }; // TODO why does tsc build fail with missing semicolon with satisfies Record<string, ReactElement>
 
 export type NavigationContentProps = {


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With `ROX_SCANNER_V4` set to `false`:

Verify the correct display of the Workload CVE Tech Preview label in the navigation and verify updated wording in the Scanner V4 banner:
![image](https://github.com/stackrox/stackrox/assets/1292638/61e47bef-571d-45e3-832c-1de5255187cc)

Verify that existing integrations have the correct layout and no Tech Preview label:

https://github.com/stackrox/stackrox/assets/1292638/fc42d80a-8708-431a-ae24-ed16ce11a6ca

With `ROX_SCANNER_V4` set to `true`:

The banner is no longer visible in the Workload CVE section:
![image](https://github.com/stackrox/stackrox/assets/1292638/7d023535-9992-439a-9796-e5c6f762a26f)

Existing integrations again have the same layout and no Tech Preview label, but Scanner V4 _does_ have the Tech Preview label:


https://github.com/stackrox/stackrox/assets/1292638/580f3bf1-81d1-40d5-995f-104dd6aa91a1


