### PR TITLE
feat(roxctl): add m2m exchange as a command

### DIFF
--- a/roxctl/central/central.go
+++ b/roxctl/central/central.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/roxctl/central/generate"
 	"github.com/stackrox/rox/roxctl/central/initbundles"
 	"github.com/stackrox/rox/roxctl/central/login"
+	"github.com/stackrox/rox/roxctl/central/m2m"
 	"github.com/stackrox/rox/roxctl/central/userpki"
 	"github.com/stackrox/rox/roxctl/central/whoami"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -33,6 +34,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		initbundles.Command(cliEnvironment),
 		login.Command(cliEnvironment),
 		export.Command(cliEnvironment),
+		m2m.Command(cliEnvironment),
 	)
 	return c
 }

--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -248,15 +248,9 @@ func (l *loginCommand) storeConfiguration(token string, expiresAt time.Time, ref
 		return errors.Wrap(err, "reading configuration")
 	}
 
-	// We store the config under <endpoint>:<port> and omit the scheme. This way it's agnostic to use either HTTP or
-	// HTTPS.
-	centralURL := l.centralURL.Hostname() + ":" + l.centralURL.Port()
+	configKey := config.NewConfigKey(l.centralURL)
 
-	centralCfg := cfg.GetCentralConfigs().GetCentralConfig(centralURL)
-	if centralCfg == nil {
-		centralCfg = &config.CentralConfig{}
-		cfg.CentralConfigs[centralURL] = centralCfg
-	}
+	centralCfg := cfg.GetCentralConfigs().GetCentralConfig(configKey)
 	now := time.Now()
 	centralCfg.AccessConfig = &config.CentralAccessConfig{
 		AccessToken:  token,
@@ -273,7 +267,7 @@ func (l *loginCommand) storeConfiguration(token string, expiresAt time.Time, ref
 
 You can now use the retrieved access token for all other roxctl commands!
 
-In case the access token is expired and cannot be refreshed, you have to run "roxctl central login" again.`, centralURL)
+In case the access token is expired and cannot be refreshed, you have to run "roxctl central login" again.`, configKey)
 	return nil
 }
 

--- a/roxctl/central/m2m/exchange/exchange.go
+++ b/roxctl/central/m2m/exchange/exchange.go
@@ -1,0 +1,121 @@
+package exchange
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/auth"
+	"github.com/stackrox/rox/roxctl/common/config"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/util"
+)
+
+// Command to exchange an OIDC token for a short-lived access token.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	exchangeCmd := exchangeCommand{env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use:   "exchange",
+		Short: "Exchanges a OIDC token for a short-lived access token",
+		Long: `Obtain a short-lived access token from Central by exchanging an OIDC token.
+This works by configuring a machine-to-machine access configuration within Central beforehand.
+Based on the OIDC token's issuer, a short-lived access token will be exchanged.`,
+		RunE: util.RunENoArgs(func(command *cobra.Command) error {
+			if err := exchangeCmd.construct(command); err != nil {
+				return err
+			}
+			return exchangeCmd.exchange()
+		}),
+	}
+	cmd.Flags().StringVar(&exchangeCmd.token, "token", "",
+		"OIDC identity token to exchange for a short-lived access token")
+	utils.Must(cmd.MarkFlagRequired("token"))
+	flags.AddTimeoutWithDefault(cmd, 1*time.Minute)
+	return cmd
+}
+
+type exchangeCommand struct {
+	env        environment.Environment
+	timeout    time.Duration
+	centralURL *url.URL
+	token      string
+}
+
+func (e *exchangeCommand) construct(cmd *cobra.Command) error {
+	e.timeout = flags.Timeout(cmd)
+	centralURL, err := flags.CentralURL()
+	if err != nil {
+		return errors.Wrap(err, "retrieving Central URL")
+	}
+	e.centralURL = centralURL
+	return nil
+}
+
+func (e *exchangeCommand) exchange() error {
+	// The exchange API is anonymous, no auth is required.
+	httpClient, err := e.env.HTTPClient(e.timeout, auth.Anonymous())
+	if err != nil {
+		return errors.Wrap(err, "creating HTTP client")
+	}
+
+	req := &v1.ExchangeAuthMachineToMachineTokenRequest{
+		IdToken: e.token,
+	}
+	buf := &bytes.Buffer{}
+	m := jsonpb.Marshaler{}
+	if err := m.Marshal(buf, req); err != nil {
+		return errors.Wrap(err, "creating request body")
+	}
+
+	// Exchange the OIDC token for a short-lived access token.
+
+	resp, err := httpClient.DoReqAndVerifyStatusCode("/v1/auth/m2m/exchange", http.MethodPost,
+		http.StatusOK, buf)
+	if err != nil {
+		return errors.Wrap(err, "exchange request failed")
+	}
+	var exchangeResp v1.ExchangeAuthMachineToMachineTokenResponse
+	if err := jsonpb.Unmarshal(resp.Body, &exchangeResp); err != nil {
+		return errors.Wrap(err, "unmarshalling exchange request response")
+	}
+
+	// Store the OIDC token locally to allow other commands to make use of it.
+
+	cfgStore, err := e.env.ConfigStore()
+	if err != nil {
+		return errors.Wrap(err, "retrieving config store")
+	}
+	cfg, err := cfgStore.Read()
+	if err != nil {
+		return errors.Wrap(err, "reading configuration")
+	}
+	configKey := config.NewConfigKey(e.centralURL)
+
+	existingCfg := cfg.GetCentralConfigs().GetCentralConfig(configKey)
+	now := time.Now()
+	existingCfg.AccessConfig = &config.CentralAccessConfig{
+		AccessToken:  exchangeResp.GetAccessToken(),
+		IssuedAt:     &now,
+		ExpiresAt:    nil,
+		RefreshToken: "",
+	}
+
+	if err := cfgStore.Write(cfg); err != nil {
+		return errors.Wrap(err, "writing configuration")
+	}
+
+	e.env.Logger().InfofLn(`Successfully persisted the authentication information for central %s.
+
+You can now use the exchanged short-lived access token for all other commands!
+
+Note that in case the token is expired, you have to run "roxctl central machine-to-machine exchange" again.`, configKey)
+	return nil
+}

--- a/roxctl/central/m2m/exchange/exchange.go
+++ b/roxctl/central/m2m/exchange/exchange.go
@@ -24,10 +24,12 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "exchange",
-		Short: "Exchanges a OIDC token for a short-lived access token",
+		Short: "Exchanges an OIDC token for a short-lived access token",
 		Long: `Obtain a short-lived access token from Central by exchanging an OIDC token.
 This works by configuring a machine-to-machine access configuration within Central beforehand.
-Based on the OIDC token's issuer, a short-lived access token will be exchanged.`,
+Based on the OIDC token's issuer, a short-lived access token will be exchanged.
+
+The access token will be stored in the roxctl configuration file and used for authentication in other commands.`,
 		RunE: util.RunENoArgs(func(command *cobra.Command) error {
 			if err := exchangeCmd.construct(command); err != nil {
 				return err

--- a/roxctl/central/m2m/exchange/exchange_test.go
+++ b/roxctl/central/m2m/exchange/exchange_test.go
@@ -1,0 +1,107 @@
+package exchange
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/jsonpb"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/auth"
+	"github.com/stackrox/rox/roxctl/common/config"
+	cfgMock "github.com/stackrox/rox/roxctl/common/config/mocks"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/environment/mocks"
+	"github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func mockEnvWithHTTPClient(t *testing.T, store *cfgMock.MockStore) environment.Environment {
+	mockEnv := mocks.NewMockEnvironment(gomock.NewController(t))
+	testIO, _, _, _ := io.TestIO()
+	env := environment.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter())
+
+	mockEnv.EXPECT().InputOutput().AnyTimes().Return(env.InputOutput())
+	mockEnv.EXPECT().Logger().AnyTimes().Return(env.Logger())
+	mockEnv.EXPECT().GRPCConnection(gomock.Any()).AnyTimes().Return(nil, nil)
+	mockEnv.EXPECT().ColorWriter().AnyTimes().Return(env.ColorWriter())
+	mockEnv.EXPECT().ConfigStore().AnyTimes().Return(store, nil)
+	mockEnv.EXPECT().HTTPClient(gomock.Any(), gomock.Any()).AnyTimes().Return(
+		common.GetRoxctlHTTPClient(auth.Anonymous(), 30*time.Second, false, true, env.Logger()))
+
+	return mockEnv
+}
+
+func TestExchange(t *testing.T) {
+	server := httptest.NewServer(exchangeHandle(t, "test-token"))
+	defer server.Close()
+	// Required for picking up the endpoint used by GetRoxctlHTTPClient. Currently, it is not possible to inject this
+	// otherwise.
+	t.Setenv("ROX_ENDPOINT", server.URL)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mockStore := cfgMock.NewMockStore(gomock.NewController(t))
+	emptyCfg := &config.RoxctlConfig{CentralConfigs: map[string]*config.CentralConfig{}}
+	mockStore.EXPECT().Read().AnyTimes().Return(emptyCfg, nil)
+	cfgKey := config.NewConfigKey(serverURL)
+	mockStore.EXPECT().Write(matchesConfig(&config.RoxctlConfig{CentralConfigs: map[config.CentralURL]*config.CentralConfig{
+		cfgKey: {AccessConfig: &config.CentralAccessConfig{
+			AccessToken: "test-token",
+		}},
+	}}, cfgKey)).AnyTimes().Return(nil)
+
+	env := mockEnvWithHTTPClient(t, mockStore)
+
+	exchangeCmd := exchangeCommand{
+		env:        env,
+		centralURL: serverURL,
+	}
+	assert.NoError(t, exchangeCmd.exchange())
+}
+
+type centralCfgMatcher struct {
+	roxctlConfig *config.RoxctlConfig
+	configKey    string
+}
+
+func (c centralCfgMatcher) String() string {
+	return "config matcher"
+}
+
+func (c centralCfgMatcher) Matches(arg interface{}) bool {
+	cfgArg := arg.(*config.RoxctlConfig)
+	if cfgArg == nil {
+		return false
+	}
+
+	centralCfg, exists := cfgArg.CentralConfigs[c.configKey]
+	if !exists {
+		return false
+	}
+
+	return c.roxctlConfig.CentralConfigs[c.configKey].AccessConfig.AccessToken == centralCfg.AccessConfig.AccessToken &&
+		centralCfg.AccessConfig.IssuedAt != nil &&
+		centralCfg.AccessConfig.ExpiresAt == nil &&
+		c.roxctlConfig.CentralConfigs[c.configKey].AccessConfig.RefreshToken == centralCfg.AccessConfig.RefreshToken
+}
+
+func matchesConfig(roxctlConfig *config.RoxctlConfig, key string) gomock.Matcher {
+	return centralCfgMatcher{configKey: key, roxctlConfig: roxctlConfig}
+}
+
+func exchangeHandle(t *testing.T, token string) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		m := jsonpb.Marshaler{Indent: "  "}
+		assert.NoError(t, m.Marshal(writer, &v1.ExchangeAuthMachineToMachineTokenResponse{
+			AccessToken: token,
+		}))
+	}
+}

--- a/roxctl/central/m2m/m2m.go
+++ b/roxctl/central/m2m/m2m.go
@@ -1,0 +1,19 @@
+package m2m
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/central/m2m/exchange"
+	"github.com/stackrox/rox/roxctl/common/environment"
+)
+
+// Command adds the m2m command.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	c := &cobra.Command{
+		Use:     "machine-to-machine",
+		Aliases: []string{"m2m"},
+		Short:   "Commands for managing machine to machine authentication",
+	}
+
+	c.AddCommand(exchange.Command(cliEnvironment))
+	return c
+}

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -72,6 +72,7 @@ func GetRoxctlHTTPClient(am auth.Method, timeout time.Duration, forceHTTP1 bool,
 	retryClient.HTTPClient.Transport = transport
 	retryClient.HTTPClient.Timeout = timeout
 	retryClient.RetryWaitMin = 10 * time.Second
+	// Silence the default log output of the HTTP retry client to not pollute output.
 	retryClient.Logger = nil
 
 	client := retryClient.StandardClient()

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -72,6 +72,7 @@ func GetRoxctlHTTPClient(am auth.Method, timeout time.Duration, forceHTTP1 bool,
 	retryClient.HTTPClient.Transport = transport
 	retryClient.HTTPClient.Timeout = timeout
 	retryClient.RetryWaitMin = 10 * time.Second
+	retryClient.Logger = nil
 
 	client := retryClient.StandardClient()
 	return &roxctlClientImpl{http: client, am: am, forceHTTP1: forceHTTP1, useInsecure: useInsecure}, nil

--- a/roxctl/common/config/config.go
+++ b/roxctl/common/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -35,6 +36,11 @@ func (r *RoxctlConfig) GetCentralConfigs() CentralConfigs {
 // CentralURL is the URL of central.
 type CentralURL = string
 
+// NewConfigKey returns a new CentralURL to use for configurations based on a url.URL.
+func NewConfigKey(url *url.URL) CentralURL {
+	return url.Hostname() + ":" + url.Port()
+}
+
 // CentralConfigs is the list of configurations per central.
 type CentralConfigs map[CentralURL]*CentralConfig
 
@@ -44,7 +50,13 @@ func (c CentralConfigs) GetCentralConfig(centralURL CentralURL) *CentralConfig {
 	if c == nil {
 		return nil
 	}
-	return c[centralURL]
+	cfg := c[centralURL]
+	if cfg != nil {
+		return cfg
+	}
+	cfg = &CentralConfig{}
+	c[centralURL] = cfg
+	return cfg
 }
 
 // CentralConfig contains all configurations available for a single central. Currently, it only holds access information.


### PR DESCRIPTION
## Description

This adds the machine-to-machine access token exchange as a roxctl command, which also neatly integrates with the configuration store for roxctl.

This will allow people to call the command within scripts and benefit from setting up authentication later on, without requiring them to execute API calls manually but rather
have everything bundled within the CLI.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Manual testing:
Create a m2m config:
```json
        {
            "type": "GENERIC",
            "tokenExpirationDuration": "10m",
            "mappings": [
                {
                    "key": "sub",
                    "valueExpression": "<your-sub>",
                    "role": "Admin"
                }
            ],
            "issuer": "https://sso.redhat.com/auth/realms/redhat-external"
        }
```
Retrieve an ID token via `rhoas` CLI:
```bash
rhoas login

rhoas authtoken
```
Exchange the token and call `whoami`:
```bash
roxctl central m2m exchange --token $(rhoas authtoken)

roxctl central whoami
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
