### PR TITLE
fix: upgrade test with Go 1.21

### DIFF
--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -123,7 +123,7 @@ test_upgrade_paths() {
     find $PWD -type f -name "go.mod" -printf '%h\n' | xargs -IDIR bash -c 'cd DIR && go mod tidy'
     git add .
     git commit -m "Upgrade to Go 1.21"
-    git tag -f $LAST_POSTGRES_TAG
+    git tag -f -a -m $LAST_POSTGRES_TAG $LAST_POSTGRES_TAG
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -123,7 +123,7 @@ test_upgrade_paths() {
     find $PWD -type f -name "go.mod" -printf '%h\n' | xargs -IDIR bash -c 'cd DIR && go mod tidy'
     git add .
     git commit -m "Upgrade to Go 1.21"
-    git tag -fa $LAST_POSTGRES_TAG
+    git tag -f $LAST_POSTGRES_TAG
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 # TODO(ROX-23154) will add a test to ensure an upgrade from RocksDB to 4.5 will return an error
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-LAST_POSTGRES_TAG="4.4.0"
-LAST_POSTGRES_SHA="9a475905b70cb7ce54dd54e2d77f88fd8a3c81be"
+LAST_POSTGRES_TAG="4.4.0-rc.11-1-gba4856e48c"
+LAST_POSTGRES_SHA="ba4856e48ceba45a81a77cbbe07062ea723fbb75"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
@@ -116,14 +116,6 @@ test_upgrade_paths() {
 
     cd "$TEST_ROOT"
     git checkout "$LAST_POSTGRES_SHA"
-
-    #TODO(janisz): remove below section once 4.5 is released
-    info "Upgrade go.mod to Go 1.21 commit and replace tag"
-    info "This is a hack to make 4.4.0 code working on Go 1.21"
-    find $PWD -type f -name "go.mod" -printf '%h\n' | xargs -IDIR bash -c 'cd DIR && go mod tidy'
-    git add .
-    git commit -m "Upgrade to Go 1.21"
-    git tag -f -a -m $LAST_POSTGRES_TAG $LAST_POSTGRES_TAG
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 # TODO(ROX-23154) will add a test to ensure an upgrade from RocksDB to 4.5 will return an error
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-LAST_POSTGRES_TAG="4.4.0-rc.11-1-gba4856e48c"
-LAST_POSTGRES_SHA="ba4856e48ceba45a81a77cbbe07062ea723fbb75"
+LAST_POSTGRES_TAG="4.4.0-rc.11-2-g5bdff1f851"
+LAST_POSTGRES_SHA="5bdff1f851bd3c551674797370da04d508b0f6ab"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -115,7 +115,9 @@ test_upgrade_paths() {
     export API_TOKEN
 
     cd "$TEST_ROOT"
-    git fetch origin release-4.4.x/go_1.21
+    git branch -r | grep -v '\->' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" | while read remote; do git branch --track "${remote#origin/}" "$remote"; done
+    git fetch --all
+    git pull --all
     git checkout "$LAST_POSTGRES_SHA"
 
     ########################################################################################

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -115,9 +115,8 @@ test_upgrade_paths() {
     export API_TOKEN
 
     cd "$TEST_ROOT"
-    git branch -r | grep -v '\->' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" | while read remote; do git branch --track "${remote#origin/}" "$remote"; done
-    git fetch --all
-    git pull --all
+    git remote add origin https://github.com/stackrox/stackrox.git
+    git fetch origin release-4.4.x/go_1.21
     git checkout "$LAST_POSTGRES_SHA"
 
     ########################################################################################

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -117,6 +117,12 @@ test_upgrade_paths() {
     cd "$TEST_ROOT"
     git checkout "$LAST_POSTGRES_SHA"
 
+    # Upgrade go.mod to Go 1.21
+    find $PWD -type f -name "go.mod" -printf '%h\n' | xargs -IDIR bash -c 'cd DIR && go mod tidy'
+    git add .
+    git commit -m "Upgrade to Go 1.21"
+    export BUILD_TAG=$LAST_POSTGRES_TAG
+
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #
     ########################################################################################

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -117,11 +117,13 @@ test_upgrade_paths() {
     cd "$TEST_ROOT"
     git checkout "$LAST_POSTGRES_SHA"
 
-    # Upgrade go.mod to Go 1.21
+    #TODO(janisz): remove below section once 4.5 is released
+    info "Upgrade go.mod to Go 1.21 commit and replace tag"
+    info "This is a hack to make 4.4.0 code working on Go 1.21"
     find $PWD -type f -name "go.mod" -printf '%h\n' | xargs -IDIR bash -c 'cd DIR && go mod tidy'
     git add .
     git commit -m "Upgrade to Go 1.21"
-    export BUILD_TAG=$LAST_POSTGRES_TAG
+    git tag -fa $LAST_POSTGRES_TAG
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -115,6 +115,7 @@ test_upgrade_paths() {
     export API_TOKEN
 
     cd "$TEST_ROOT"
+    git fetch origin release-4.4.x/go_1.21
     git checkout "$LAST_POSTGRES_SHA"
 
     ########################################################################################


### PR DESCRIPTION
## Description

In upgrade test we checkout to 4.4 release that is not ready for Go 1.21. This PR runs `go mod tidy` and commit changes to ensure we will have no issues with modules.

https://github.com/stackrox/stackrox/blob/211318441a1a3958acf5e5b3cd44fb67795cf435/tests/upgrade/legacy_to_postgres_run.sh#L17-L18

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Upgrade test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
