### PR TITLE
fix: Switch Konflux golang builder from 1.20 to 1.21

### DIFF
--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -6,7 +6,7 @@
 #
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -1,6 +1,6 @@
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/stackrox/pull/10305 otherwise `roxctl` and `operator` builds fail like [here](https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/roxctl-on-pull-request-gzftv).

I'd love to make a check around `EXPECTED_GO_VERSION` but it's not clear what the value should be (see [this thread](https://redhat-internal.slack.com/archives/CELUQKESC/p1711456341751489)).

## Checklist
- [x] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Will only check Konflux CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
