### PR TITLE
ROX-23063: Platform CVE overview page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTableContainer.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Bullseye, Divider, Spinner } from '@patternfly/react-core';
+
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import useURLPagination from 'hooks/useURLPagination';
+
+import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
+import { QuerySearchFilter } from '../../types';
+
+export type CVEsTableContainerProps = {
+    filterToolbar: TableEntityToolbarProps['filterToolbar'];
+    entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
+    querySearchFilter: QuerySearchFilter;
+    isFiltered: boolean;
+    rowCount: number;
+    pagination: ReturnType<typeof useURLPagination>;
+};
+
+function CVEsTableContainer({
+    filterToolbar,
+    entityToggleGroup,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    querySearchFilter,
+    isFiltered,
+    rowCount,
+    pagination,
+}: CVEsTableContainerProps) {
+    // TODO - Placeholders for query results
+    const data = [];
+    const previousData = undefined;
+    const error: Error | undefined = undefined;
+    const loading = false;
+
+    const tableData = data ?? previousData;
+
+    return (
+        <>
+            <TableEntityToolbar
+                filterToolbar={filterToolbar}
+                entityToggleGroup={entityToggleGroup}
+                pagination={pagination}
+                tableRowCount={rowCount}
+                isFiltered={isFiltered}
+            />
+            <Divider component="div" />
+            {loading && !tableData && (
+                <Bullseye>
+                    <Spinner isSVG />
+                </Bullseye>
+            )}
+            {error && (
+                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            )}
+            {!error && tableData && (
+                <div role="region" aria-live="polite" aria-busy={loading ? 'true' : 'false'}>
+                    CVE table goes here
+                </div>
+            )}
+        </>
+    );
+}
+
+export default CVEsTableContainer;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTableContainer.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Bullseye, Divider, Spinner } from '@patternfly/react-core';
+
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import useURLPagination from 'hooks/useURLPagination';
+
+import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
+import { QuerySearchFilter } from '../../types';
+
+export type ClustersTableContainerProps = {
+    filterToolbar: TableEntityToolbarProps['filterToolbar'];
+    entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
+    querySearchFilter: QuerySearchFilter;
+    isFiltered: boolean;
+    rowCount: number;
+    pagination: ReturnType<typeof useURLPagination>;
+};
+
+function ClustersTableContainer({
+    filterToolbar,
+    entityToggleGroup,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    querySearchFilter,
+    isFiltered,
+    rowCount,
+    pagination,
+}: ClustersTableContainerProps) {
+    // TODO - Placeholders for query results
+    const data = [];
+    const previousData = undefined;
+    const error: Error | undefined = undefined;
+    const loading = false;
+
+    const tableData = data ?? previousData;
+
+    return (
+        <>
+            <TableEntityToolbar
+                filterToolbar={filterToolbar}
+                entityToggleGroup={entityToggleGroup}
+                pagination={pagination}
+                tableRowCount={rowCount}
+                isFiltered={isFiltered}
+            />
+            <Divider component="div" />
+            {loading && !tableData && (
+                <Bullseye>
+                    <Spinner isSVG />
+                </Bullseye>
+            )}
+            {error && (
+                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            )}
+            {!error && tableData && (
+                <div role="region" aria-live="polite" aria-busy={loading ? 'true' : 'false'}>
+                    Cluster table goes here
+                </div>
+            )}
+        </>
+    );
+}
+
+export default ClustersTableContainer;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+    PageSection,
+    Title,
+    Divider,
+    Flex,
+    FlexItem,
+    Card,
+    CardBody,
+} from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import { getHasSearchApplied } from 'utils/searchUtils';
+
+import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
+import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
+import { platformEntityTabValues } from '../../types';
+
+import CVEsTableContainer from './CVEsTableContainer';
+import ClustersTableContainer from './ClustersTableContainer';
+
+function PlatformCvesOverviewPage() {
+    const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
+    const { searchFilter } = useURLSearch();
+    const pagination = useURLPagination(20);
+
+    // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
+    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const isFiltered = getHasSearchApplied(querySearchFilter);
+
+    function onEntityTabChange() {
+        pagination.setPage(1);
+        // TODO - set default sort here
+    }
+
+    // TODO - needs to be connected to a query
+    const entityCounts = {
+        CVE: 0,
+        Cluster: 0,
+    };
+
+    const filterToolbar = <></>;
+
+    const entityToggleGroup = (
+        <EntityTypeToggleGroup
+            entityTabs={['CVE', 'Cluster']}
+            entityCounts={entityCounts}
+            onChange={onEntityTabChange}
+        />
+    );
+
+    return (
+        <>
+            <PageTitle title="Platform CVEs Overview" />
+            <Divider component="div" />
+            <PageSection
+                className="pf-u-display-flex pf-u-flex-direction-row pf-u-align-items-center"
+                variant="light"
+            >
+                <Flex direction={{ default: 'column' }} className="pf-u-flex-grow-1">
+                    <Title headingLevel="h1">Platform CVEs</Title>
+                    <FlexItem>Prioritize and manage scanned CVEs across clusters</FlexItem>
+                </Flex>
+            </PageSection>
+            <PageSection padding={{ default: 'noPadding' }}>
+                <PageSection isCenterAligned>
+                    <Card>
+                        <CardBody>
+                            {activeEntityTabKey === 'CVE' && (
+                                <CVEsTableContainer
+                                    filterToolbar={filterToolbar}
+                                    entityToggleGroup={entityToggleGroup}
+                                    querySearchFilter={querySearchFilter}
+                                    isFiltered={isFiltered}
+                                    rowCount={entityCounts.CVE}
+                                    pagination={pagination}
+                                />
+                            )}
+                            {activeEntityTabKey === 'Cluster' && (
+                                <ClustersTableContainer
+                                    filterToolbar={filterToolbar}
+                                    entityToggleGroup={entityToggleGroup}
+                                    querySearchFilter={querySearchFilter}
+                                    isFiltered={isFiltered}
+                                    rowCount={entityCounts.Cluster}
+                                    pagination={pagination}
+                                />
+                            )}
+                        </CardBody>
+                    </Card>
+                </PageSection>
+            </PageSection>
+        </>
+    );
+}
+
+export default PlatformCvesOverviewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -8,9 +8,7 @@ import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import { vulnerabilitiesPlatformCvesPath } from 'routePaths';
 import usePermissions from 'hooks/usePermissions';
 
-function TmpPlatformCvesOverviewPage() {
-    return <div>PlatformCvesOverviewPage</div>;
-}
+import PlatformCvesOverviewPage from './Overview/PlatformCvesOverviewPage';
 
 function PlatformCvesPage() {
     const { hasReadAccess } = usePermissions();
@@ -23,7 +21,7 @@ function PlatformCvesPage() {
                 <Route
                     exact
                     path={vulnerabilitiesPlatformCvesPath}
-                    component={TmpPlatformCvesOverviewPage}
+                    component={PlatformCvesOverviewPage}
                 />
                 <Route>
                     <PageSection variant="light">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -66,7 +66,11 @@ export const nodeEntityTabValues = ['CVE', 'Node'] as const;
 
 export type NodeEntityTab = (typeof nodeEntityTabValues)[number];
 
-export type EntityTab = WorkloadEntityTab | NodeEntityTab;
+export const platformEntityTabValues = ['CVE', 'Cluster'] as const;
+
+export type PlatformEntityTab = (typeof platformEntityTabValues)[number];
+
+export type EntityTab = WorkloadEntityTab | NodeEntityTab | PlatformEntityTab;
 
 export type WatchStatus = 'WATCHED' | 'NOT_WATCHED' | 'UNKNOWN';
 


### PR DESCRIPTION
## Description

Adds routing and the main layout for the Platform CVE Overview/List page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Platform CVEs from the sidebar, the "CVE" tab should be the default and reflected in the URL:
![image](https://github.com/stackrox/stackrox/assets/1292638/21f0a81d-c94c-40cc-9899-6f18cc83b55a)

Click the "Cluster" tab, and see the placeholder text change and the URL update:
![image](https://github.com/stackrox/stackrox/assets/1292638/afb82a96-a2d3-48a6-aede-d912caf6c901)

