### PR TITLE
ROX-20160: Add Go build to main in Konflux

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -42,7 +42,8 @@ spec:
   - name: prefetch-input
     value: |
       [
-        { "type": "npm", "path": "scripts/konflux/bootstrap-yarn" }
+        { "type": "npm", "path": "scripts/konflux/bootstrap-yarn" },
+        { "type": "gomod", "path": "." }
       ]
   - name: build-source-image
     value: 'true'

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -87,6 +87,10 @@ spec:
         requests:
           cpu: 1
 
+  # The pipeline regularly takes >1h to finish.
+  timeouts:
+    pipeline: 1h30m0s
+
   pipelineSpec:
 
     finally:

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 3Gi
       status: { }
   - name: git-auth
     secret:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -40,7 +40,8 @@ spec:
   - name: prefetch-input
     value: |
       [
-        { "type": "npm", "path": "scripts/konflux/bootstrap-yarn" }
+        { "type": "npm", "path": "scripts/konflux/bootstrap-yarn" },
+        { "type": "gomod", "path": "." }
       ]
   - name: build-source-image
     value: 'true'

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -55,7 +55,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 3Gi
       status: { }
   - name: git-auth
     secret:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -85,6 +85,10 @@ spec:
         requests:
           cpu: 1
 
+  # The pipeline regularly takes >1h to finish.
+  timeouts:
+    pipeline: 1h30m0s
+
   pipelineSpec:
 
     finally:

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -127,8 +127,20 @@ COPY --from=rpm-installer "$FINAL_STAGE_PATH" /
 
 COPY --from=ui-builder /go/src/github.com/stackrox/rox/app/ui/build /ui/
 
-# TODO: others
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/migrator /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/central /stackrox/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/compliance /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/roxctl* /assets/downloads/cli/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/kubernetes-sensor /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/sensor-upgrader /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/admission-control /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/static-bin/* /stackrox/
+RUN GOARCH=$(uname -m) ; \
+    case $GOARCH in x86_64) GOARCH=amd64 ;; aarch64) GOARCH=arm64 ;; esac ; \
+    ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /stackrox/roxctl ; \
+    ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /assets/downloads/cli/roxctl-linux
+
+# TODO: rhacs-main/Dockerfile.in?ref_type=heads#L107-122
 
 LABEL \
     com.redhat.component="rhacs-main-container" \
@@ -160,3 +172,5 @@ ENV PATH="/stackrox:$PATH" \
     ROX_PRODUCT_BRANDING="STACKROX_BRANDING"
 
 USER 4000:4000
+
+# TODO: rhacs-main/Dockerfile.in?ref_type=heads#L127

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -72,9 +72,6 @@ WORKDIR /go/src/github.com/stackrox/rox/app
 
 COPY . .
 
-# TODO: remove me
-RUN git diff scripts/konflux/bootstrap-yarn/package-lock.json
-
 # Ensure there will be no unintended -dirty suffix. package-lock is restored because it's touched by Cachi2.
 RUN git restore scripts/konflux/bootstrap-yarn/package-lock.json && \
     scripts/konflux/fail-build-if-git-is-dirty.sh
@@ -140,8 +137,6 @@ RUN GOARCH=$(uname -m) ; \
     ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /stackrox/roxctl ; \
     ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /assets/downloads/cli/roxctl-linux
 
-# TODO: rhacs-main/Dockerfile.in?ref_type=heads#L107-122
-
 LABEL \
     com.redhat.component="rhacs-main-container" \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
@@ -172,5 +167,3 @@ ENV PATH="/stackrox:$PATH" \
     ROX_PRODUCT_BRANDING="STACKROX_BRANDING"
 
 USER 4000:4000
-
-HEALTHCHECK CMD curl --insecure --fail https://127.0.0.1:8443/v1/ping

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -72,7 +72,12 @@ WORKDIR /go/src/github.com/stackrox/rox/app
 
 COPY . .
 
-RUN scripts/konflux/fail-build-if-git-is-dirty.sh
+# TODO: remove me
+RUN git diff scripts/konflux/bootstrap-yarn/package-lock.json
+
+# Ensure there will be no unintended -dirty suffix. package-lock is restored because it's touched by Cachi2.
+RUN git restore scripts/konflux/bootstrap-yarn/package-lock.json && \
+    scripts/konflux/fail-build-if-git-is-dirty.sh
 
 ENV GOFLAGS=""
 ENV CGO_CFLAGS="-I/lib/rocksdb/include"

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -173,4 +173,4 @@ ENV PATH="/stackrox:$PATH" \
 
 USER 4000:4000
 
-# TODO: rhacs-main/Dockerfile.in?ref_type=heads#L127
+HEALTHCHECK CMD curl --insecure --fail https://127.0.0.1:8443/v1/ping

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -78,7 +78,7 @@ ENV GOFLAGS=""
 ENV CGO_CFLAGS="-I/lib/rocksdb/include"
 ENV CGO_LDFLAGS="-L/lib/rocksdb -L/usr/lib64"
 ENV CGO_ENABLED=1
-# TODO(): figure out BUILD_TAG
+# TODO(ROX-19958): figure out if we need BUILD_TAG
 # ENV BUILD_TAG="${CI_VERSION}"
 ENV GOTAGS="release"
 ENV CI=1

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir -p image/bin
 # TODO(ROX-20240): enable non-release development builds.
 ENV CI=1 GOFLAGS="" GOTAGS="release"
 
+# TODO(ROX-19958): figure out if setting BUILD_TAG is actually needed.
 RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) BUILD_TAG=$(make tag) scripts/go-build.sh ./roxctl && \
     cp bin/linux_$(go env GOARCH)/roxctl image/bin/roxctl
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -12,6 +12,7 @@ RUN scripts/konflux/fail-build-if-git-is-dirty.sh
 # TODO(ROX-20240): enable non-release development builds.
 ENV CI=1 GOFLAGS="" GOTAGS="release" CGO_ENABLED=1
 
+# TODO(ROX-19958): figure out if setting BUILD_TAG is actually needed.
 RUN GOOS=linux GOARCH=$(go env GOARCH) BUILD_TAG=$(make tag) scripts/go-build.sh operator && \
     cp bin/linux_$(go env GOARCH)/operator image/bin/operator
 


### PR DESCRIPTION
## Description

Onboarding the Go binary builds into the main image build on Konflux.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Konflux build succeeds.

Running image `quay.io/redhat-user-workloads/rh-acs-tenant/acs/main:on-pr-e7a2cd4e454aecc8b6f3e0f5e2a09ab3ff2b9345` with Docker/Podman locally and testing that all binaries can be executed (failures expected due to missing configuration files). 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
