### PR TITLE
fix: upgrade test

### DIFF
--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 # TODO(ROX-23154) will add a test to ensure an upgrade from RocksDB to 4.5 will return an error
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-LAST_POSTGRES_TAG="4.4.0-rc.11-2-g5bdff1f851"
-LAST_POSTGRES_SHA="5bdff1f851bd3c551674797370da04d508b0f6ab"
+LAST_POSTGRES_TAG="4.4.0"
+LAST_POSTGRES_SHA="9a475905b70cb7ce54dd54e2d77f88fd8a3c81be"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
@@ -115,8 +115,6 @@ test_upgrade_paths() {
     export API_TOKEN
 
     cd "$TEST_ROOT"
-    git remote add origin https://github.com/stackrox/stackrox.git
-    git fetch origin release-4.4.x/go_1.21
     git checkout "$LAST_POSTGRES_SHA"
     export GOTOOLCHAIN=go1.20.10 GOSUMDB=off
 

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -118,6 +118,7 @@ test_upgrade_paths() {
     git remote add origin https://github.com/stackrox/stackrox.git
     git fetch origin release-4.4.x/go_1.21
     git checkout "$LAST_POSTGRES_SHA"
+    export GOTOOLCHAIN=go1.20.10 GOSUMDB=off
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -116,7 +116,7 @@ test_upgrade_paths() {
 
     cd "$TEST_ROOT"
     git checkout "$LAST_POSTGRES_SHA"
-    export GOTOOLCHAIN=go1.20.10 GOSUMDB=off
+    export GOTOOLCHAIN=go1.20.10
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #


### PR DESCRIPTION
## Description

This PR have a better fix for upgrade test. Instead of relying on existence of some artificial branch it just changes the toolchain to 1.20.10

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Upgrade test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
