### PR TITLE
chore(ui): pf5 tweaks round 2

### DIFF
--- a/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
@@ -41,7 +41,7 @@ function ContainerSecretInfo({ secrets }: ContainerSecretInfoProps) {
                             <StackItem key={`${secret.name}-${index}`}>
                                 <ExpandableSection
                                     toggleText={secret.name}
-                                    onToggle={(_e, v) => setToggleAtIndex(v)}
+                                    onToggle={() => setToggleAtIndex(index)}
                                     isExpanded={secretToggles[index]}
                                     className="pf-expandable-not-large"
                                 >

--- a/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
@@ -37,8 +37,7 @@ function ContainerSecretInfo({ secrets }: ContainerSecretInfoProps) {
                 <Stack hasGutter>
                     {secrets.length > 0 ? (
                         secrets.map((secret, index) => (
-                            // eslint-disable-next-line react/no-array-index-key
-                            <StackItem key={`${secret.name}-${index}`}>
+                            <StackItem key={secret.name}>
                                 <ExpandableSection
                                     toggleText={secret.name}
                                     onToggle={() => setToggleAtIndex(index)}

--- a/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
@@ -40,7 +40,7 @@ function ContainerVolumeInfo({ volumes }: ContainerVolumeInfoProps) {
                             <StackItem key={volume.name}>
                                 <ExpandableSection
                                     toggleText={volume.name}
-                                    onToggle={(_e, v) => setToggleAtIndex(v)}
+                                    onToggle={() => setToggleAtIndex(index)}
                                     isExpanded={volumeToggles[index]}
                                     className="pf-expandable-not-large"
                                 >

--- a/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
+++ b/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
@@ -31,7 +31,7 @@ const NotFoundMessage = ({
     return (
         <Bullseye className="pf-v5-u-flex-grow-1">
             <EmptyState>
-                <EmptyStateHeader titleText={<>{title}</>} headingLevel="h1" />
+                <EmptyStateHeader titleText={title} headingLevel="h1" />
                 <EmptyStateFooter>
                     {message && <EmptyStateBody>{message}</EmptyStateBody>}
                     {isButtonVisible && <Button variant="primary">{actionText}</Button>}

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import { BaseCellProps, Table /* data-codemods */, Tbody, Td, Tr } from '@patternfly/react-table';
+import { BaseCellProps, Table, Tbody, Td, Tr } from '@patternfly/react-table';
 
 type BacklogTableProps<Item> = {
     type: 'selected' | 'deselected';

--- a/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
@@ -33,6 +33,7 @@ function FormLabelGroup<T>({
 
     return (
         <FormGroup fieldId={fieldId} {...rest}>
+            {children}
             <FormHelperText>
                 <HelperText>
                     <HelperTextItem variant={validated}>
@@ -40,7 +41,6 @@ function FormLabelGroup<T>({
                     </HelperTextItem>
                 </HelperText>
             </FormHelperText>
-            {children}
         </FormGroup>
     );
 }

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
@@ -168,13 +168,6 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
         <Form id="access-scope-form">
             {alertSubmit}
             <FormGroup label="Name" fieldId="name" isRequired className="pf-m-horizontal">
-                <FormHelperText>
-                    <HelperText>
-                        <HelperTextItem variant={nameValidatedState}>
-                            {nameErrorMessage}
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
                 <TextInput
                     type="text"
                     id="name"
@@ -185,6 +178,13 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
                     isRequired
                     className="pf-m-limit-width"
                 />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem variant={nameValidatedState}>
+                            {nameErrorMessage}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
             <FormGroup label="Description" fieldId="description" className="pf-m-horizontal">
                 <TextInput

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -9,7 +9,7 @@ import {
     pluralize,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
 import { Role } from 'services/RolesService';

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
@@ -1,15 +1,7 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 import { Badge, Button, Flex, FlexItem, Switch, TextInput } from '@patternfly/react-core';
 import { AngleDownIcon, AngleUpIcon } from '@patternfly/react-icons';
-import {
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Thead,
-    Th,
-    Tr,
-    TreeRowWrapper,
-} from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr, TreeRowWrapper } from '@patternfly/react-table';
 
 import {
     EffectiveAccessScopeCluster,

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelSelectorCard.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelSelectorCard.tsx
@@ -15,7 +15,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { LabelSelectorRequirement, LabelSelectorsKey } from 'services/AccessScopesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -420,13 +420,6 @@ function AuthProviderForm({
                     <Grid hasGutter>
                         <GridItem span={12} lg={6}>
                             <FormGroup label="Name" fieldId="name" isRequired>
-                                <FormHelperText>
-                                    <HelperText>
-                                        <HelperTextItem variant={nameValidated}>
-                                            {errors.name || ''}
-                                        </HelperTextItem>
-                                    </HelperText>
-                                </FormHelperText>
                                 <TextInput
                                     type="text"
                                     id="name"
@@ -441,6 +434,13 @@ function AuthProviderForm({
                                             : 'default'
                                     }
                                 />
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant={nameValidated}>
+                                            {errors.name || ''}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
                             </FormGroup>
                         </GridItem>
                         <GridItem span={12} lg={6}>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -237,7 +237,7 @@ function AuthProviderForm({
     const { dirty, handleChange, isValid, setFieldValue, handleBlur, values, errors, touched } =
         formik;
 
-    function onChange(_value, event) {
+    function onChange(event: React.FormEvent) {
         handleChange(event);
     }
 
@@ -424,7 +424,7 @@ function AuthProviderForm({
                                     type="text"
                                     id="name"
                                     value={values.name}
-                                    onChange={(event, _value) => onChange(_value, event)}
+                                    onChange={onChange}
                                     isDisabled={isDisabled}
                                     isRequired
                                     onBlur={handleBlur}
@@ -548,9 +548,7 @@ function AuthProviderForm({
                                                                 type="text"
                                                                 id={`requiredAttributes[${index}].attributeKey`}
                                                                 value={attribute.attributeKey}
-                                                                onChange={(event, _value) =>
-                                                                    onChange(_value, event)
-                                                                }
+                                                                onChange={onChange}
                                                                 isDisabled={isDisabled}
                                                             />
                                                         </FormGroup>
@@ -562,9 +560,7 @@ function AuthProviderForm({
                                                                 type="text"
                                                                 id={`requiredAttributes[${index}].attributeValue`}
                                                                 value={attribute.attributeValue}
-                                                                onChange={(event, _value) =>
-                                                                    onChange(_value, event)
-                                                                }
+                                                                onChange={onChange}
                                                                 isDisabled={isDisabled}
                                                             />
                                                         </FormGroup>
@@ -666,9 +662,7 @@ function AuthProviderForm({
                                                             type="text"
                                                             id={`claimMappings[${index}][0]`}
                                                             value={mapping[0]}
-                                                            onChange={(event, _value) =>
-                                                                onChange(_value, event)
-                                                            }
+                                                            onChange={onChange}
                                                             isDisabled={isDisabled}
                                                         />
                                                     </FormGroup>
@@ -680,9 +674,7 @@ function AuthProviderForm({
                                                             type="text"
                                                             id={`claimMappings[${index}][1]`}
                                                             value={mapping[1]}
-                                                            onChange={(event, _value) =>
-                                                                onChange(_value, event)
-                                                            }
+                                                            onChange={onChange}
                                                             isDisabled={isDisabled}
                                                         />
                                                     </FormGroup>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -3,7 +3,7 @@ import pluralize from 'pluralize';
 import { useSelector, useDispatch } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
@@ -22,8 +22,7 @@ export type ConfigurationFormFieldsProps = {
     config: AuthProviderConfig;
     isViewing: boolean;
     onChange: (
-        event: React.FormEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
-        _value: unknown
+        event: React.FormEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
     ) => void;
     onBlur: (event?: React.FocusEvent<HTMLTextAreaElement, Element>) => void;
     setFieldValue: (name: string, value: string | boolean) => void;
@@ -106,6 +105,16 @@ function ConfigurationFormFields({
                 <>
                     <GridItem span={12} lg={6}>
                         <FormGroup label="Auth0 tenant" fieldId="config.issuer" isRequired>
+                            <TextInput
+                                type="text"
+                                id="config.issuer"
+                                value={(config.issuer as string) || ''}
+                                onChange={onChange}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
+                                isRequired
+                                onBlur={onBlur}
+                                validated={showIssuerError ? ValidatedOptions.error : 'default'}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem
@@ -124,20 +133,20 @@ function ConfigurationFormFields({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                type="text"
-                                id="config.issuer"
-                                value={(config.issuer as string) || ''}
-                                onChange={onChange}
-                                isDisabled={isViewing || isActiveModificationsDisabled}
-                                isRequired
-                                onBlur={onBlur}
-                                validated={showIssuerError ? ValidatedOptions.error : 'default'}
-                            />
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12} lg={6}>
                         <FormGroup label="Client ID" fieldId="config.client_id" isRequired>
+                            <TextInput
+                                type="text"
+                                id="config.client_id"
+                                value={(config.client_id as string) || ''}
+                                onChange={onChange}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
+                                isRequired
+                                onBlur={onBlur}
+                                validated={showClientIdError ? ValidatedOptions.error : 'default'}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem
@@ -149,16 +158,6 @@ function ConfigurationFormFields({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                type="text"
-                                id="config.client_id"
-                                value={(config.client_id as string) || ''}
-                                onChange={onChange}
-                                isDisabled={isViewing || isActiveModificationsDisabled}
-                                isRequired
-                                onBlur={onBlur}
-                                validated={showClientIdError ? ValidatedOptions.error : 'default'}
-                            />
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12}>
@@ -196,6 +195,16 @@ function ConfigurationFormFields({
                     </GridItem>
                     <GridItem span={12} lg={6}>
                         <FormGroup label="Issuer" fieldId="config.issuer" isRequired>
+                            <TextInput
+                                type="text"
+                                id="config.issuer"
+                                value={(config.issuer as string) || ''}
+                                onChange={onChange}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
+                                isRequired
+                                onBlur={onBlur}
+                                validated={showIssuerError ? ValidatedOptions.error : 'default'}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem
@@ -214,20 +223,20 @@ function ConfigurationFormFields({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                type="text"
-                                id="config.issuer"
-                                value={(config.issuer as string) || ''}
-                                onChange={onChange}
-                                isDisabled={isViewing || isActiveModificationsDisabled}
-                                isRequired
-                                onBlur={onBlur}
-                                validated={showIssuerError ? ValidatedOptions.error : 'default'}
-                            />
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12} lg={6}>
                         <FormGroup label="Client ID" fieldId="config.client_id" isRequired>
+                            <TextInput
+                                type="text"
+                                id="config.client_id"
+                                value={(config.client_id as string) || ''}
+                                onChange={onChange}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
+                                isRequired
+                                onBlur={onBlur}
+                                validated={showClientIdError ? ValidatedOptions.error : 'default'}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem
@@ -239,16 +248,6 @@ function ConfigurationFormFields({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                type="text"
-                                id="config.client_id"
-                                value={(config.client_id as string) || ''}
-                                onChange={onChange}
-                                isDisabled={isViewing || isActiveModificationsDisabled}
-                                isRequired
-                                onBlur={onBlur}
-                                validated={showClientIdError ? ValidatedOptions.error : 'default'}
-                            />
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12} lg={6}>
@@ -263,23 +262,6 @@ function ConfigurationFormFields({
                                 )
                             }
                         >
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem
-                                        variant={
-                                            showClientSecretError
-                                                ? ValidatedOptions.error
-                                                : 'default'
-                                        }
-                                    >
-                                        {configErrors?.client_secret || (
-                                            <span className="pf-v5-u-font-size-sm">
-                                                {clientSecretHelperText}
-                                            </span>
-                                        )}
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <TextInput
                                 type="password"
                                 id="config.client_secret"
@@ -300,6 +282,23 @@ function ConfigurationFormFields({
                                 }
                                 placeholder={isViewing ? '*****' : ''}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem
+                                        variant={
+                                            showClientSecretError
+                                                ? ValidatedOptions.error
+                                                : 'default'
+                                        }
+                                    >
+                                        {configErrors?.client_secret || (
+                                            <span className="pf-v5-u-font-size-sm">
+                                                {clientSecretHelperText}
+                                            </span>
+                                        )}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormGroup>
                     </GridItem>
                     <GridItem span={6} lg={6}>
@@ -321,16 +320,6 @@ function ConfigurationFormFields({
                     </GridItem>
                     <GridItem span={6} lg={6}>
                         <FormGroup fieldId="config.disable_offline_access_scope">
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem>
-                                        <span className="pf-v5-u-font-size-sm">
-                                            Use if the identity provider has a limit on the number
-                                            of offline tokens that it can issue.
-                                        </span>
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <Checkbox
                                 isChecked={config.disable_offline_access_scope as boolean}
                                 label="Disable 'offline_access' scope"
@@ -342,6 +331,16 @@ function ConfigurationFormFields({
                                 }}
                                 isDisabled={isViewing || isAuthProviderDeclarative}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem>
+                                        <span className="pf-v5-u-font-size-sm">
+                                            Use if the identity provider has a limit on the number
+                                            of offline tokens that it can issue.
+                                        </span>
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12}>
@@ -367,6 +366,16 @@ function ConfigurationFormFields({
                             fieldId="config.sp_issuer"
                             isRequired
                         >
+                            <TextInput
+                                type="text"
+                                id="config.sp_issuer"
+                                value={(config.sp_issuer as string) || ''}
+                                onChange={onChange}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
+                                isRequired
+                                onBlur={onBlur}
+                                validated={showSpIssuerError ? ValidatedOptions.error : 'default'}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem
@@ -385,16 +394,6 @@ function ConfigurationFormFields({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                type="text"
-                                id="config.sp_issuer"
-                                value={(config.sp_issuer as string) || ''}
-                                onChange={onChange}
-                                isDisabled={isViewing || isActiveModificationsDisabled}
-                                isRequired
-                                onBlur={onBlur}
-                                validated={showSpIssuerError ? ValidatedOptions.error : 'default'}
-                            />
                         </FormGroup>
                     </GridItem>
                     <GridItem span={12} lg={6}>
@@ -426,6 +425,20 @@ function ConfigurationFormFields({
                                     fieldId="config.idp_metadata_url"
                                     isRequired
                                 >
+                                    <TextInput
+                                        type="text"
+                                        id="config.idp_metadata_url"
+                                        value={(config.idp_metadata_url as string) || ''}
+                                        onChange={onChange}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
+                                        isRequired
+                                        onBlur={onBlur}
+                                        validated={
+                                            showIdpMetadataUrlError
+                                                ? ValidatedOptions.error
+                                                : 'default'
+                                        }
+                                    />
                                     <FormHelperText>
                                         <HelperText>
                                             <HelperTextItem
@@ -446,20 +459,6 @@ function ConfigurationFormFields({
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
-                                    <TextInput
-                                        type="text"
-                                        id="config.idp_metadata_url"
-                                        value={(config.idp_metadata_url as string) || ''}
-                                        onChange={onChange}
-                                        isDisabled={isViewing || isActiveModificationsDisabled}
-                                        isRequired
-                                        onBlur={onBlur}
-                                        validated={
-                                            showIdpMetadataUrlError
-                                                ? ValidatedOptions.error
-                                                : 'default'
-                                        }
-                                    />
                                 </FormGroup>
                             </GridItem>
                         </>
@@ -472,6 +471,18 @@ function ConfigurationFormFields({
                                     fieldId="config.idp_issuer"
                                     isRequired={config.configurationType === 'static'}
                                 >
+                                    <TextInput
+                                        type="text"
+                                        id="config.idp_issuer"
+                                        value={(config.idp_issuer as string) || ''}
+                                        onChange={onChange}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
+                                        isRequired={config.configurationType === 'static'}
+                                        onBlur={onBlur}
+                                        validated={
+                                            showIdpIssuerError ? ValidatedOptions.error : 'default'
+                                        }
+                                    />
                                     <FormHelperText>
                                         <HelperText>
                                             <HelperTextItem
@@ -497,18 +508,6 @@ function ConfigurationFormFields({
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
-                                    <TextInput
-                                        type="text"
-                                        id="config.idp_issuer"
-                                        value={(config.idp_issuer as string) || ''}
-                                        onChange={onChange}
-                                        isDisabled={isViewing || isActiveModificationsDisabled}
-                                        isRequired={config.configurationType === 'static'}
-                                        onBlur={onBlur}
-                                        validated={
-                                            showIdpIssuerError ? ValidatedOptions.error : 'default'
-                                        }
-                                    />
                                 </FormGroup>
                             </GridItem>
                             <GridItem span={12} lg={6}>
@@ -517,6 +516,18 @@ function ConfigurationFormFields({
                                     fieldId="config.idp_sso_url"
                                     isRequired={config.configurationType === 'static'}
                                 >
+                                    <TextInput
+                                        type="text"
+                                        id="config.idp_sso_url"
+                                        value={(config.idp_sso_url as string) || ''}
+                                        onChange={onChange}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
+                                        isRequired={config.configurationType === 'static'}
+                                        onBlur={onBlur}
+                                        validated={
+                                            showIdpSsoUrlError ? ValidatedOptions.error : 'default'
+                                        }
+                                    />
                                     <FormHelperText>
                                         <HelperText>
                                             <HelperTextItem
@@ -537,18 +548,6 @@ function ConfigurationFormFields({
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
-                                    <TextInput
-                                        type="text"
-                                        id="config.idp_sso_url"
-                                        value={(config.idp_sso_url as string) || ''}
-                                        onChange={onChange}
-                                        isDisabled={isViewing || isActiveModificationsDisabled}
-                                        isRequired={config.configurationType === 'static'}
-                                        onBlur={onBlur}
-                                        validated={
-                                            showIdpSsoUrlError ? ValidatedOptions.error : 'default'
-                                        }
-                                    />
                                 </FormGroup>
                             </GridItem>
                             <GridItem span={12} lg={6}>
@@ -556,6 +555,14 @@ function ConfigurationFormFields({
                                     label="Name/ID Format"
                                     fieldId="config.idp_nameid_format"
                                 >
+                                    <TextInput
+                                        type="text"
+                                        id="config.idp_nameid_format"
+                                        value={(config.idp_nameid_format as string) || ''}
+                                        onChange={onChange}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
+                                        onBlur={onBlur}
+                                    />
                                     <FormHelperText>
                                         <HelperText>
                                             <HelperTextItem>
@@ -568,14 +575,6 @@ function ConfigurationFormFields({
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
-                                    <TextInput
-                                        type="text"
-                                        id="config.idp_nameid_format"
-                                        value={(config.idp_nameid_format as string) || ''}
-                                        onChange={onChange}
-                                        isDisabled={isViewing || isActiveModificationsDisabled}
-                                        onBlur={onBlur}
-                                    />
                                 </FormGroup>
                             </GridItem>
                             <GridItem span={12} lg={6}>
@@ -584,19 +583,6 @@ function ConfigurationFormFields({
                                     fieldId="config.idp_cert_pem"
                                     isRequired={config.configurationType === 'static'}
                                 >
-                                    <FormHelperText>
-                                        <HelperText>
-                                            <HelperTextItem
-                                                variant={
-                                                    showIdpCertPemError
-                                                        ? ValidatedOptions.error
-                                                        : 'default'
-                                                }
-                                            >
-                                                {configErrors?.idp_cert_pem || ''}
-                                            </HelperTextItem>
-                                        </HelperText>
-                                    </FormHelperText>
                                     <TextArea
                                         className="certificate-input"
                                         autoResize
@@ -614,6 +600,19 @@ function ConfigurationFormFields({
                                             showIdpCertPemError ? ValidatedOptions.error : 'default'
                                         }
                                     />
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem
+                                                variant={
+                                                    showIdpCertPemError
+                                                        ? ValidatedOptions.error
+                                                        : 'default'
+                                                }
+                                            >
+                                                {configErrors?.idp_cert_pem || ''}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
                                 </FormGroup>
                             </GridItem>
                         </>
@@ -637,17 +636,6 @@ function ConfigurationFormFields({
             {type === 'userpki' && (
                 <GridItem span={12} lg={6}>
                     <FormGroup label="CA certificate(s) (PEM)" fieldId="config.keys" isRequired>
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem
-                                    variant={
-                                        showUserPkiKeysError ? ValidatedOptions.error : 'default'
-                                    }
-                                >
-                                    {configErrors?.keys || ''}
-                                </HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <TextArea
                             className="certificate-input"
                             autoResize
@@ -663,12 +651,33 @@ function ConfigurationFormFields({
                             onBlur={onBlur}
                             validated={showUserPkiKeysError ? ValidatedOptions.error : 'default'}
                         />
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem
+                                    variant={
+                                        showUserPkiKeysError ? ValidatedOptions.error : 'default'
+                                    }
+                                >
+                                    {configErrors?.keys || ''}
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                 </GridItem>
             )}
             {type === 'iap' && (
                 <GridItem span={12} lg={6}>
                     <FormGroup label="Audience" fieldId="config.audience" isRequired>
+                        <TextInput
+                            type="text"
+                            id="config.audience"
+                            value={(config.audience as string) || ''}
+                            onChange={onChange}
+                            isDisabled={isViewing || isActiveModificationsDisabled}
+                            isRequired
+                            onBlur={onBlur}
+                            validated={showAudienceError ? ValidatedOptions.error : 'default'}
+                        />
                         <FormHelperText>
                             <HelperText>
                                 <HelperTextItem
@@ -685,16 +694,6 @@ function ConfigurationFormFields({
                                 </HelperTextItem>
                             </HelperText>
                         </FormHelperText>
-                        <TextInput
-                            type="text"
-                            id="config.audience"
-                            value={(config.audience as string) || ''}
-                            onChange={onChange}
-                            isDisabled={isViewing || isActiveModificationsDisabled}
-                            isRequired
-                            onBlur={onBlur}
-                            validated={showAudienceError ? ValidatedOptions.error : 'default'}
-                        />
                     </FormGroup>
                 </GridItem>
             )}

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -100,19 +100,6 @@ function RuleGroups({
                                 </FlexItem>
                                 <FlexItem>
                                     <FormGroup label="Key" fieldId={`groups[${index}].props.key`}>
-                                        <FormHelperText>
-                                            <HelperText>
-                                                <HelperTextItem
-                                                    variant={
-                                                        errors[index]?.props?.key
-                                                            ? 'error'
-                                                            : 'default'
-                                                    }
-                                                >
-                                                    {errors[index]?.props?.key ?? ''}
-                                                </HelperTextItem>
-                                            </HelperText>
-                                        </FormHelperText>
                                         <SelectSingle
                                             id={`groups[${index}].props.key`}
                                             value={groups[`${index}`].props.key ?? ''}
@@ -127,6 +114,19 @@ function RuleGroups({
                                                 <SelectOption key={ruleKey} value={ruleKey} />
                                             ))}
                                         </SelectSingle>
+                                        <FormHelperText>
+                                            <HelperText>
+                                                <HelperTextItem
+                                                    variant={
+                                                        errors[index]?.props?.key
+                                                            ? 'error'
+                                                            : 'default'
+                                                    }
+                                                >
+                                                    {errors[index]?.props?.key ?? ''}
+                                                </HelperTextItem>
+                                            </HelperText>
+                                        </FormHelperText>
                                     </FormGroup>
                                 </FlexItem>
                                 <FlexItem>
@@ -134,6 +134,13 @@ function RuleGroups({
                                         label="Value"
                                         fieldId={`groups[${index}].props.value`}
                                     >
+                                        <TextInput
+                                            type="text"
+                                            id={`groups[${index}].props.value`}
+                                            value={groups[`${index}`].props.value}
+                                            onChange={onChange}
+                                            isDisabled={isDisabled(group)}
+                                        />
                                         <FormHelperText>
                                             <HelperText>
                                                 <HelperTextItem
@@ -147,13 +154,6 @@ function RuleGroups({
                                                 </HelperTextItem>
                                             </HelperText>
                                         </FormHelperText>
-                                        <TextInput
-                                            type="text"
-                                            id={`groups[${index}].props.value`}
-                                            value={groups[`${index}`].props.value}
-                                            onChange={onChange}
-                                            isDisabled={isDisabled(group)}
-                                        />
                                     </FormGroup>
                                 </FlexItem>
                                 <FlexItem>
@@ -161,6 +161,18 @@ function RuleGroups({
                                 </FlexItem>
                                 <FlexItem>
                                     <FormGroup label="Role" fieldId={`groups[${index}].roleName`}>
+                                        <SelectSingle
+                                            id={`groups[${index}].roleName`}
+                                            value={groups[`${index}`].roleName}
+                                            isDisabled={isDisabled(group)}
+                                            handleSelect={setFieldValue}
+                                            direction="up"
+                                            placeholderText="Select a role"
+                                        >
+                                            {roles.map(({ name }) => (
+                                                <SelectOption key={name} value={name} />
+                                            ))}
+                                        </SelectSingle>
                                         <FormHelperText>
                                             <HelperText>
                                                 <HelperTextItem
@@ -174,18 +186,6 @@ function RuleGroups({
                                                 </HelperTextItem>
                                             </HelperText>
                                         </FormHelperText>
-                                        <SelectSingle
-                                            id={`groups[${index}].roleName`}
-                                            value={groups[`${index}`].roleName}
-                                            isDisabled={isDisabled(group)}
-                                            handleSelect={setFieldValue}
-                                            direction="up"
-                                            placeholderText="Select a role"
-                                        >
-                                            {roles.map(({ name }) => (
-                                                <SelectOption key={name} value={name} />
-                                            ))}
-                                        </SelectSingle>
                                     </FormGroup>
                                 </FlexItem>
                                 {!isDisabled(group) && (

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -155,13 +155,6 @@ function PermissionSetForm({
             </Toolbar>
             {alertSubmit}
             <FormGroup label="Name" fieldId="name" isRequired className="pf-m-horizontal">
-                <FormHelperText>
-                    <HelperText>
-                        <HelperTextItem variant={nameValidatedState}>
-                            {nameErrorMessage}
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
                 <TextInput
                     type="text"
                     id="name"
@@ -172,6 +165,13 @@ function PermissionSetForm({
                     isRequired
                     className="pf-m-limit-width"
                 />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem variant={nameValidatedState}>
+                            {nameErrorMessage}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
             <FormGroup label="Description" fieldId="description" className="pf-m-horizontal">
                 <TextInput

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -9,7 +9,7 @@ import {
     pluralize,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { PermissionSet, Role } from 'services/RolesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Badge } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core/deprecated';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import SelectSingle from 'Components/SelectSingle';
 import { accessControl as accessTypeLabels } from 'messages/common';

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEventHandler, ReactElement } from 'react';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/PermissionSetsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/PermissionSetsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEventHandler, ReactElement } from 'react';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { PermissionSet } from 'services/RolesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -149,13 +149,6 @@ function RoleForm({
             </Toolbar>
             {alertSubmit}
             <FormGroup label="Name" fieldId="name" isRequired className="pf-m-horizontal">
-                <FormHelperText>
-                    <HelperText>
-                        <HelperTextItem variant={nameValidatedState}>
-                            {nameErrorMessage}
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
                 <TextInput
                     type="text"
                     id="name"
@@ -166,6 +159,13 @@ function RoleForm({
                     isRequired
                     className="pf-m-limit-width"
                 />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem variant={nameValidatedState}>
+                            {nameErrorMessage}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
             <FormGroup label="Description" fieldId="description" className="pf-m-horizontal">
                 <TextInput

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -9,7 +9,7 @@ import {
     pluralize,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
 import { Group } from 'services/AuthService';

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -1,14 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { Button, ButtonVariant, Card, Text } from '@patternfly/react-core';
-import { Tbody, Tr, Td, Table /* data-codemods */, Th, Thead } from '@patternfly/react-table';
+import { Tbody, Tr, Td, Table, Th, Thead } from '@patternfly/react-table';
 
 import { riskBasePath } from 'routePaths';
 import LinkShim from 'Components/PatternFly/LinkShim';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useRef, useState } from 'react';
 import { Button, Icon, TextInput, Tooltip, ValidatedOptions } from '@patternfly/react-core';
 import { PlusCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { ClusterLabels } from 'services/ClustersService';
 import { getIsValidLabelKey, getIsValidLabelValue } from 'utils/labels';

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import { Button, TextInput } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import {
-    Table /* data-codemods */,
+    Table,
     Tbody,
     // TbodyProps,
     Td,

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -174,14 +174,6 @@ function InitBundleForm(): ReactElement {
                             label="Installation method for secured cluster services"
                             isRequired
                         >
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem>
-                                        You can use one bundle to secure multiple clusters that have
-                                        the same installation method.
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <Select
                                 variant="single"
                                 toggleAriaLabel="Installation method menu toggle"
@@ -205,6 +197,14 @@ function InitBundleForm(): ReactElement {
                                         </SelectOption>
                                     ))}
                             </Select>
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem>
+                                        You can use one bundle to secure multiple clusters that have
+                                        the same installation method.
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormGroup>
                     </Form>
                     <Alert variant="info" isInline title="Download YAML file" component="p">

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
@@ -1,14 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import {
-    ActionsColumn,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ClusterInitBundle } from 'services/ClustersService';
 import { clustersInitBundlesPath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -21,7 +21,7 @@ import {
     HelperTextItem,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Tbody, Tr, Td } from '@patternfly/react-table';
+import { Table, Tbody, Tr, Td } from '@patternfly/react-table';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -14,7 +14,7 @@ import {
     Truncate,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
@@ -15,7 +15,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import omit from 'lodash/omit';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/ClustersCoverageTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/ClustersCoverageTable.tsx
@@ -16,7 +16,7 @@ import {
     ToolbarItem,
     Tooltip,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
 import { CubesIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Table/ScanConfigsTablePage.tsx
@@ -23,15 +23,7 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import {
-    ActionsColumn,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
 
 import {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
@@ -13,7 +13,7 @@ import {
     Spinner,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
@@ -12,15 +12,7 @@ import {
     Text,
     Title,
 } from '@patternfly/react-core';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -2,15 +2,7 @@
 // eslint-disable @typescript-eslint/ban-ts-comment
 import React, { useState } from 'react';
 import { Card, CardBody, CardHeader, CardTitle, Pagination } from '@patternfly/react-core';
-import {
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    ThProps,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 
 import { ClusterScanStatus } from 'services/ComplianceEnhancedService';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ScanResultsOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ScanResultsOverviewTable.tsx
@@ -1,14 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-    ActionsColumn,
-    IAction,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { format } from 'date-fns';
 import { Link, generatePath } from 'react-router-dom';

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Truncate } from '@patternfly/react-core';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 import { ListDeployment } from 'types/deployment.proto';
 import { riskBasePath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HashLink as Link } from 'react-router-hash-link';
 import { Tooltip, Truncate } from '@patternfly/react-core';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 import { CriticalSeverityIcon, ImportantSeverityIcon } from 'Components/PatternFly/SeverityIcons';
 import { noViolationsColor } from 'constants/severityColors';

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Flex, Title, Truncate } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Tr, Td } from '@patternfly/react-table';
+import { Table, Tbody, Tr, Td } from '@patternfly/react-table';
 
 import ResourceIcon from 'Components/PatternFly/ResourceIcon';
 import { policySeverityIconMap } from 'Components/PatternFly/SeverityIcons';

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
@@ -61,11 +61,6 @@ function NumericSetting({
         <>
             <GridItem span={8} md={4} xl={3}>
                 <FormGroup>
-                    <FormHelperText>
-                        <HelperText>
-                            <HelperTextItem variant={validated}>{helperTextInvalid}</HelperTextItem>
-                        </HelperText>
-                    </FormHelperText>
                     <Flex direction={{ default: 'row' }} flexWrap={{ default: 'nowrap' }}>
                         <TextInput
                             id={`${fieldId}.numDays`}
@@ -78,6 +73,11 @@ function NumericSetting({
                         />
                         <span>days</span>
                     </Flex>
+                    <FormHelperText>
+                        <HelperText>
+                            <HelperTextItem variant={validated}>{helperTextInvalid}</HelperTextItem>
+                        </HelperText>
+                    </FormHelperText>
                 </FormGroup>
             </GridItem>
             <GridItem span={4} md={8} xl={9}>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/FormLabelGroup.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/FormLabelGroup.tsx
@@ -31,6 +31,7 @@ function FormLabelGroup<T>({
 
     return (
         <FormGroup fieldId={fieldId} {...rest}>
+            {children}
             <FormHelperText>
                 <HelperText>
                     <HelperTextItem
@@ -42,7 +43,6 @@ function FormLabelGroup<T>({
                     </HelperTextItem>
                 </HelperText>
             </FormHelperText>
-            {children}
         </FormGroup>
     );
 }

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -174,11 +174,6 @@ function MachineAccessIntegrationForm({
                             touched={touched}
                             errors={errors}
                         >
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem>For example, 3h20m20s</HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <TextInput
                                 isRequired
                                 type="text"
@@ -188,6 +183,11 @@ function MachineAccessIntegrationForm({
                                 onBlur={handleBlur}
                                 isDisabled={!isEditable}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem>For example, 3h20m20s</HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormLabelGroup>
                         <FormSection title="Rules" titleElement="h3" className="pf-v5-u-mt-0">
                             <FieldArray
@@ -294,19 +294,6 @@ function MachineAccessIntegrationForm({
                                                             label="Role"
                                                             fieldId={`mappings[${index}].role`}
                                                         >
-                                                            <FormHelperText>
-                                                                <HelperText>
-                                                                    <HelperTextItem
-                                                                        variant={
-                                                                            errors[index]?.role
-                                                                                ? 'error'
-                                                                                : 'default'
-                                                                        }
-                                                                    >
-                                                                        {errors[index]?.role || ''}
-                                                                    </HelperTextItem>
-                                                                </HelperText>
-                                                            </FormHelperText>
                                                             <SelectSingle
                                                                 id={`mappings[${index}].role`}
                                                                 value={
@@ -324,6 +311,19 @@ function MachineAccessIntegrationForm({
                                                                     />
                                                                 ))}
                                                             </SelectSingle>
+                                                            <FormHelperText>
+                                                                <HelperText>
+                                                                    <HelperTextItem
+                                                                        variant={
+                                                                            errors[index]?.role
+                                                                                ? 'error'
+                                                                                : 'default'
+                                                                        }
+                                                                    >
+                                                                        {errors[index]?.role || ''}
+                                                                    </HelperTextItem>
+                                                                </HelperText>
+                                                            </FormHelperText>
                                                         </FormGroup>
                                                     </FlexItem>
                                                     {isEditable && (

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -9,7 +9,7 @@ import {
     PageSectionVariants,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { useParams, Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -3,7 +3,7 @@ import {
     ActionsColumn,
     ExpandableRowContent,
     IAction,
-    Table /* data-codemods */,
+    Table,
     Tbody,
     Td,
     Th,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
@@ -27,6 +27,12 @@ const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
     return (
         <Flex>
             <FormGroup label={idx === 0 ? 'CIDR name' : ''} isRequired fieldId="cidr-name">
+                <Field
+                    name={`entities.${idx as string}.entity.name`}
+                    type="text"
+                    id="cidr-name"
+                    placeholder="CIDR name"
+                />
                 <FormHelperText>
                     <HelperText>
                         <HelperTextItem variant={showNameError ? 'error' : 'default'}>
@@ -34,14 +40,14 @@ const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
                         </HelperTextItem>
                     </HelperText>
                 </FormHelperText>
-                <Field
-                    name={`entities.${idx as string}.entity.name`}
-                    type="text"
-                    id="cidr-name"
-                    placeholder="CIDR name"
-                />
             </FormGroup>
             <FormGroup label={idx === 0 ? 'CIDR address' : ''} isRequired>
+                <Field
+                    name={`entities.${idx as string}.entity.cidr`}
+                    type="text"
+                    id="cidr-block-address"
+                    placeholder="192.0.0.2/24"
+                />
                 <FormHelperText>
                     <HelperText>
                         <HelperTextItem variant={showCidrError ? 'error' : 'default'}>
@@ -49,12 +55,6 @@ const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
                         </HelperTextItem>
                     </HelperText>
                 </FormHelperText>
-                <Field
-                    name={`entities.${idx as string}.entity.cidr`}
-                    type="text"
-                    id="cidr-block-address"
-                    placeholder="192.0.0.2/24"
-                />
             </FormGroup>
             <FlexItem className={buttonClassName}>
                 <Button

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -14,7 +14,7 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { getEdgesByNodeId, getNodeById } from '../utils/networkGraphUtils';
 import {
     CIDRBlockNodeModel,

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -10,7 +10,7 @@ import {
     Text,
     TextContent,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import usePagination from 'hooks/patternfly/usePagination';
 
 const columnNames = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -10,7 +10,7 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -12,7 +12,7 @@ import {
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import useFetchNotifiers from 'hooks/useFetchNotifiers';
 import useTableSelection from 'hooks/useTableSelection';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { notifyNetworkPolicyModification } from 'services/NetworkService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 import capitalize from 'lodash/capitalize';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
@@ -36,13 +36,6 @@ const RenamePolicySection = ({ changeRadio, changeText }: RenamePolicySectionPro
                         form.touched.newName && form.errors.newName ? 'error' : 'default';
                     return (
                         <FormGroup fieldId="policy-rename" className="pf-v5-u-pt-sm">
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem variant={validated}>
-                                        {form.errors.newName}
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <TextInput
                                 name={field.name}
                                 value={field.value}
@@ -53,6 +46,13 @@ const RenamePolicySection = ({ changeRadio, changeText }: RenamePolicySectionPro
                                 isDisabled={isDisabled}
                                 validated={validated}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant={validated}>
+                                        {form.errors.newName}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormGroup>
                     );
                 }}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -17,15 +17,7 @@ import {
     DropdownSeparator,
     DropdownToggle,
 } from '@patternfly/react-core/deprecated';
-import {
-    Table /* data-codemods */,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    ExpandableRowContent,
-} from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/AttachNotifiersFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/AttachNotifiersFormSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { Title, Button, Bullseye } from '@patternfly/react-core';
 import { useField } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -41,13 +41,6 @@ function PolicyCategoriesSelectField(): ReactElement {
 
     return (
         <FormGroup fieldId="policy-categories" label="Categories" isRequired>
-            <FormHelperText>
-                <HelperText>
-                    <HelperTextItem>
-                        Select policy categories you want to apply to this policy
-                    </HelperTextItem>
-                </HelperText>
-            </FormHelperText>
             <Select
                 variant={SelectVariant.typeaheadMulti}
                 name={field.name}
@@ -63,6 +56,13 @@ function PolicyCategoriesSelectField(): ReactElement {
                     <SelectOption key={id} value={name} />
                 ))}
             </Select>
+            <FormHelperText>
+                <HelperText>
+                    <HelperTextItem>
+                        Select policy categories you want to apply to this policy
+                    </HelperTextItem>
+                </HelperText>
+            </FormHelperText>
         </FormGroup>
     );
 }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
@@ -103,23 +103,29 @@ function PolicyMetadataFormSection(): ReactElement {
             <Field name="description">
                 {({ field }) => (
                     <FormGroup fieldId="policy-description" label="Description">
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>Enter details about the policy</HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <TextArea
                             id={field.name}
                             name={field.name}
                             value={field.value}
                             onChange={(event, _value) => onChange(_value, event)}
                         />
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>Enter details about the policy</HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                 )}
             </Field>
             <Field name="rationale">
                 {({ field }) => (
                     <FormGroup fieldId="policy-rationale" label="Rationale">
+                        <TextArea
+                            id={field.name}
+                            name={field.name}
+                            value={field.value}
+                            onChange={(event, _value) => onChange(_value, event)}
+                        />
                         <FormHelperText>
                             <HelperText>
                                 <HelperTextItem>
@@ -127,18 +133,18 @@ function PolicyMetadataFormSection(): ReactElement {
                                 </HelperTextItem>
                             </HelperText>
                         </FormHelperText>
-                        <TextArea
-                            id={field.name}
-                            name={field.name}
-                            value={field.value}
-                            onChange={(event, _value) => onChange(_value, event)}
-                        />
                     </FormGroup>
                 )}
             </Field>
             <Field name="remediation">
                 {({ field }) => (
                     <FormGroup fieldId="policy-guidance" label="Guidance">
+                        <TextArea
+                            id={field.name}
+                            name={field.name}
+                            value={field.value}
+                            onChange={(event, _value) => onChange(_value, event)}
+                        />
                         <FormHelperText>
                             <HelperText>
                                 <HelperTextItem>
@@ -146,12 +152,6 @@ function PolicyMetadataFormSection(): ReactElement {
                                 </HelperTextItem>
                             </HelperText>
                         </FormHelperText>
-                        <TextArea
-                            id={field.name}
-                            name={field.name}
-                            value={field.value}
-                            onChange={(event, _value) => onChange(_value, event)}
-                        />
                     </FormGroup>
                 )}
             </Field>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -215,14 +215,6 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
             <Form>
                 <div className="pf-v5-u-px-lg">
                     <FormGroup fieldId="policy-lifecycle-stage" label="Lifecycle stages" isRequired>
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>
-                                    Choose lifecycle stage to which your policy is applicable. You
-                                    can select more than one stage.
-                                </HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <Flex direction={{ default: 'row' }} className="pf-v5-u-pb-sm">
                             <Checkbox
                                 label="Build"
@@ -252,6 +244,14 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                                 isDisabled={hasActiveViolations}
                             />
                         </Flex>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>
+                                    Choose lifecycle stage to which your policy is applicable. You
+                                    can select more than one stage.
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                     {hasActiveViolations && (
                         <Alert
@@ -267,11 +267,6 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         isRequired={hasRuntime}
                         className="pf-v5-u-pt-lg"
                     >
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>{eventSourceHelperText}</HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <Flex direction={{ default: 'row' }}>
                             <Radio
                                 label="Deployment"
@@ -290,6 +285,11 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                                 isDisabled={!hasRuntime || hasActiveViolations}
                             />
                         </Flex>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>{eventSourceHelperText}</HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                 </div>
                 <Divider component="div" />
@@ -303,11 +303,6 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         Select a method to address violations of this policy.
                     </div>
                     <FormGroup fieldId="policy-response-method" className="pf-v5-u-mb-lg">
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>{responseMethodHelperText}</HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <Flex direction={{ default: 'row' }}>
                             <Radio
                                 label="Inform"
@@ -327,6 +322,11 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                                 onChange={() => setShowEnforcement(true)}
                             />
                         </Flex>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>{responseMethodHelperText}</HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                     {showEnforcement && (
                         <div>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -9,7 +9,7 @@ import {
     PageSection,
     TextInput,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import isEqual from 'lodash/isEqual';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -188,14 +188,6 @@ function PolicyScopeForm() {
                         label="Exclude images (Build lifecycle only)"
                         fieldId="exclude-images"
                     >
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem>
-                                    Select all images from the list for which you don&apos;t want to
-                                    trigger a violation for the policy.
-                                </HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <Select
                             onToggle={() => setIsExcludeImagesOpen(!isExcludeImagesOpen)}
                             isOpen={isExcludeImagesOpen}
@@ -215,6 +207,14 @@ function PolicyScopeForm() {
                                 </SelectOption>
                             ))}
                         </Select>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>
+                                    Select all images from the list for which you don&apos;t want to
+                                    trigger a violation for the policy.
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                 </FlexItem>
             </Flex>

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -67,7 +67,7 @@ function CreatePolicyCategoryModal({
 
     const { values, handleChange, handleSubmit, resetForm, isValid } = formik;
 
-    function onChange(_value, event) {
+    function onChange(event: React.FormEvent) {
         handleChange(event);
     }
 
@@ -90,6 +90,12 @@ function CreatePolicyCategoryModal({
                 <FormikProvider value={formik}>
                     <Form onSubmit={handleSubmit}>
                         <FormGroup fieldId="name" label="Category name" isRequired>
+                            <TextInput
+                                id="name"
+                                type="text"
+                                value={values.name}
+                                onChange={onChange}
+                            />
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem>
@@ -97,12 +103,6 @@ function CreatePolicyCategoryModal({
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
-                            <TextInput
-                                id="name"
-                                type="text"
-                                value={values.name}
-                                onChange={(event, _value) => onChange(_value, event)}
-                            />
                         </FormGroup>
                     </Form>
                 </FormikProvider>

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -54,7 +54,7 @@ function PolicyCategorySidePanel({
 
     const { values, handleChange, dirty, handleSubmit } = formik;
 
-    function onChange(_value, event) {
+    function onChange(event: React.FormEvent) {
         handleChange(event);
     }
 
@@ -85,6 +85,12 @@ function PolicyCategorySidePanel({
                                 label="Category name"
                                 isRequired
                             >
+                                <TextInput
+                                    id="name"
+                                    type="text"
+                                    value={values.name}
+                                    onChange={onChange}
+                                />
                                 <FormHelperText>
                                     <HelperText>
                                         <HelperTextItem>
@@ -92,12 +98,6 @@ function PolicyCategorySidePanel({
                                         </HelperTextItem>
                                     </HelperText>
                                 </FormHelperText>
-                                <TextInput
-                                    id="name"
-                                    type="text"
-                                    value={values.name}
-                                    onChange={(event, _value) => onChange(_value, event)}
-                                />
                             </FormGroup>
                             <ActionGroup>
                                 {dirty && (

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import { SearchResult, SearchResultCategory } from 'services/SearchService';

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -362,15 +362,6 @@ const SystemConfigForm = ({
                         isRequired
                         fieldId="privateConfig.reportRetentionConfig.downloadableReportGlobalRetentionBytes"
                     >
-                        <FormHelperText>
-                            <HelperText>
-                                <HelperTextItem
-                                    variant={downloadableReportRetentionError ? 'error' : 'default'}
-                                >
-                                    {downloadableReportRetentionError}
-                                </HelperTextItem>
-                            </HelperText>
-                        </FormHelperText>
                         <Split hasGutter className="pf-v5-u-align-items-center">
                             <SplitItem isFilled>
                                 <TextInput
@@ -396,6 +387,15 @@ const SystemConfigForm = ({
                                 <Text>MB</Text>
                             </SplitItem>
                         </Split>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem
+                                    variant={downloadableReportRetentionError ? 'error' : 'default'}
+                                >
+                                    {downloadableReportRetentionError}
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
                     </FormGroup>
                 </GridItem>
                 {isFeatureFlagEnabled('ROX_ADMINISTRATION_EVENTS') && (

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
 import { Cluster } from 'types/cluster.proto';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
 import { Cluster } from 'types/cluster.proto';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
 import { Cluster } from 'types/cluster.proto';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { getDateTime } from 'utils/dateUtils';
 
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { IntegrationMergedItem } from '../utils/integrations';
 
 type Props = {

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -8,7 +8,7 @@ import {
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import { fetchDeclarativeConfigurationsHealth } from 'services/DeclarativeConfigHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -83,13 +83,6 @@ function DiagnosticBundleForm({
             <p>You can filter which platform data to include in the Zip file (max size 50MB)</p>
             {hasReadAccessForCluster && (
                 <FormGroup label="Filter by clusters" fieldId="filterByClusters">
-                    <FormHelperText>
-                        <HelperText>
-                            <HelperTextItem>
-                                No clusters selected will include all clusters
-                            </HelperTextItem>
-                        </HelperText>
-                    </FormHelperText>
                     <Select
                         id="filterByClusters"
                         variant={SelectVariant.typeaheadMulti}
@@ -104,6 +97,13 @@ function DiagnosticBundleForm({
                             <SelectOption key={cluster} value={cluster} />
                         ))}
                     </Select>
+                    <FormHelperText>
+                        <HelperText>
+                            <HelperTextItem>
+                                No clusters selected will include all clusters
+                            </HelperTextItem>
+                        </HelperText>
+                    </FormHelperText>
                 </FormGroup>
             )}
             <FormGroup
@@ -118,13 +118,6 @@ function DiagnosticBundleForm({
                 }
                 fieldId="filterByStartingTime"
             >
-                <FormHelperText>
-                    <HelperText>
-                        <HelperTextItem>
-                            To override default, use UTC format (seconds are optional)
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
                 <TextInput
                     type="text"
                     id="filterByStartingTime"
@@ -133,6 +126,13 @@ function DiagnosticBundleForm({
                     onChange={(event, value: string) => startingTimeChangeHandler(value, event)}
                     onBlur={handleBlur}
                 />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            To override default, use UTC format (seconds are optional)
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
         </Form>
     );

--- a/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactElement } from 'react';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import RolesForResourceAccess from './RolesForResourceAccess';
 

--- a/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Table /* data-codemods */, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { PermissionsMap } from 'services/RolesService';
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -12,15 +12,7 @@ import {
     pluralize,
 } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
-import {
-    ActionsColumn,
-    Table /* data-codemods */,
-    Tbody,
-    Thead,
-    Td,
-    Th,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Thead, Td, Th, Tr } from '@patternfly/react-table';
 
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
 import VIOLATION_STATES from 'constants/violationStates';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
@@ -16,7 +16,7 @@ import {
 } from '@patternfly/react-core';
 import { DropdownItem } from '@patternfly/react-core/deprecated';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import usePermissions from 'hooks/usePermissions';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -10,15 +10,7 @@ import {
     TextInput,
     InputGroupItem,
 } from '@patternfly/react-core';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import entityTypes from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Divider,
     Pagination,

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Divider,

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntitiesModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntitiesModal.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { Flex, FlexItem, Modal, ModalVariant, Title } from '@patternfly/react-core';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement, useState } from 'react';
-import {
-    Table /* data-codemods */,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    IActions,
-} from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td, IActions } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Divider,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -11,7 +11,7 @@ import {
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -11,7 +11,7 @@ import {
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -11,7 +11,7 @@ import {
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -11,7 +11,7 @@ import {
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { Bullseye, Flex, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    Table /* data-codemods */,
+    Table,
     Tbody,
     Td,
     Th,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -28,15 +28,7 @@ import {
     EmptyStateHeader,
 } from '@patternfly/react-core';
 import { DropdownItem } from '@patternfly/react-core/deprecated';
-import {
-    ActionsColumn,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon, FileIcon, SearchIcon } from '@patternfly/react-icons';
 
 import { vulnerabilityReportsPath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -166,7 +166,7 @@ function CollectionSelection({
                         placeholderText="Select a collection"
                         variant={SelectVariant.typeahead}
                         isOpen={isOpen}
-                        onToggle={() => onToggle}
+                        onToggle={(_e, isExpanded) => onToggle(isExpanded)}
                         onTypeaheadInputChanged={(value) => {
                             setSearch(value);
                             onValidateField(id);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/EmailTemplateFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/EmailTemplateFormModal.tsx
@@ -128,13 +128,6 @@ function EmailTemplateFormModal({
                 <Tab eventKey={0} title={<TabTitleText>Edit</TabTitleText>}>
                     <Form className="pf-v5-u-py-lg pf-v5-u-px-lg" onSubmit={handleSubmit}>
                         <FormGroup label="Email subject" fieldId="emailSubject">
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem variant={emailSubjectValidated}>
-                                        {errors.emailSubject}
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <TextInput
                                 id="emailSubject"
                                 type="text"
@@ -145,6 +138,13 @@ function EmailTemplateFormModal({
                                 isDisabled={isSubmitting}
                                 placeholder={defaultEmailSubject}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant={emailSubjectValidated}>
+                                        {errors.emailSubject}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                             <Flex>
                                 <FlexItem flex={{ default: 'flex_1' }}>
                                     <TextContent>
@@ -172,13 +172,6 @@ function EmailTemplateFormModal({
                             </Flex>
                         </FormGroup>
                         <FormGroup label="Email body" fieldId="emailBody">
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem variant={emailBodyValidated}>
-                                        {errors.emailBody}
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
                             <TextArea
                                 id="emailBody"
                                 type="text"
@@ -190,6 +183,13 @@ function EmailTemplateFormModal({
                                 style={{ minHeight: '250px' }}
                                 placeholder={defaultEmailBody}
                             />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant={emailBodyValidated}>
+                                        {errors.emailBody}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                             <Flex>
                                 <FlexItem flex={{ default: 'flex_1' }}>
                                     <TextContent>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -29,6 +29,7 @@ import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { cloneDeep } from 'lodash';
+import { CollectionSlim } from 'services/CollectionsService';
 import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormParams = {
@@ -47,11 +48,12 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
         formik.setFieldValue(fieldName, selection);
     };
 
-    const handleDateSelection = (fieldName: string) => (_event, selection) => {
-        formik.setFieldValue(fieldName, selection);
-    };
+    const handleDateSelection =
+        (fieldName: string) => (_event: React.FormEvent, selection: string) => {
+            formik.setFieldValue(fieldName, selection);
+        };
 
-    const handleCollectionSelection = (fieldName: string) => (selection) => {
+    const handleCollectionSelection = (fieldName: string) => (selection: CollectionSlim | null) => {
         formik.setFieldValue(fieldName, selection);
     };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
@@ -14,7 +14,7 @@ import {
     TextVariants,
     Title,
 } from '@patternfly/react-core';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import exampleReportsCSVData from 'Containers/Vulnerabilities/VulnerablityReporting/exampleReportsCSVData';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Flex, pluralize, Truncate } from '@patternfly/react-core';
-import {
-    Table /* data-codemods */,
-    Thead,
-    Tr,
-    Th,
-    Tbody,
-    Td,
-    ExpandableRowContent,
-} from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import useSet from 'hooks/useSet';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Thead,
-    Th,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -5,7 +5,7 @@ import {
     ActionsColumn,
     ExpandableRowContent,
     IAction,
-    Table /* data-codemods */,
+    Table,
     Tbody,
     Td,
     Th,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import useTableSort from 'hooks/patternfly/useTableSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-    ExpandableRowContent,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 import { min } from 'date-fns';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Truncate } from '@patternfly/react-core';
 
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table /* data-codemods */, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import useTableSort from 'hooks/patternfly/useTableSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -4,7 +4,7 @@ import {
     ActionsColumn,
     ExpandableRowContent,
     IAction,
-    Table /* data-codemods */,
+    Table,
     Tbody,
     Td,
     Th,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
-import {
-    ActionsColumn,
-    Table /* data-codemods */,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Flex, Label } from '@patternfly/react-core';
 
 import { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { Bullseye, Button, Icon } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -28,15 +28,6 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
 
     return (
         <FormGroup fieldId={fieldId} label={label} isRequired>
-            <FormHelperText>
-                <HelperText>
-                    <HelperTextItem>
-                        {isImageWithoutTag
-                            ? `This image does not have a tag and the exception will apply to all tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`
-                            : undefined}
-                    </HelperTextItem>
-                </HelperText>
-            </FormHelperText>
             {scopeContext === 'GLOBAL' && (
                 <Radio
                     id="scope-global"
@@ -85,6 +76,15 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
                     label={`Only ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}:${scopeContext.imageName.tag}`}
                 />
             )}
+            <FormHelperText>
+                <HelperText>
+                    <HelperTextItem>
+                        {isImageWithoutTag
+                            ? `This image does not have a tag and the exception will apply to all tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`
+                            : undefined}
+                    </HelperTextItem>
+                </HelperText>
+            </FormHelperText>
         </FormGroup>
     );
 }

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -122,6 +122,7 @@ body {
 
 
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
+.pf-v5-svg,
 .pf-v5-c-page svg {
     display: inline;
 }


### PR DESCRIPTION
## Description

To the reviewer: I beg your forgiveness for creating a 100+ files changed PR that targets a 600+ files changed PR 🙏. This is only the first of multiple though...

A handful of fixes to the main PF5 PR:

- Fixes an issue where expandable sections in the NetGraph side panel do not open
- Removes unneeded `codemod` comments from new Table imports
- Moves all codemod generated `<FormHelperText>` components to be _after_ the input field instead of before it. (This caused the helper text to be displayed above the form element.) **This is the *vast majority* of the code changes in this PR, even though it is a structurally small change.**
- Fixes an issue where the Collection dropdown doesn't open in the VM 2.0 reporting form
- Fixes a handful of places where an icon is shifted to a newline due to `display: block` styling (single code change in acs.css)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test expandable volume and secret sections of NetGraph side panel:
![image](https://github.com/stackrox/stackrox/assets/1292638/6c4eebf4-7138-479a-b6fb-abf381e90539)
![image](https://github.com/stackrox/stackrox/assets/1292638/2314374d-9e75-4ec3-9a6c-a52c2683f0b5)

HelperText fix for FormLabelGroup (various usage):
![image](https://github.com/stackrox/stackrox/assets/1292638/57535ce0-1270-4f2d-97fe-0e05d2017490)
![image](https://github.com/stackrox/stackrox/assets/1292638/af530a1c-0702-41c5-b8fb-dd57d6210e98)

HelperText fix for Access Scopes:
![image](https://github.com/stackrox/stackrox/assets/1292638/a3535adc-05ec-414b-bd21-b1c5d095095b)

HelperText fix for Auth Provider (also includes a fix for incorrect usage of `onChange` due to inferred `any` types):
![image](https://github.com/stackrox/stackrox/assets/1292638/a4572b19-0c9c-44bf-b0c6-61322eb9e702)
![image](https://github.com/stackrox/stackrox/assets/1292638/37ce36d4-ea71-440a-a5e5-ac645684431b)
![image](https://github.com/stackrox/stackrox/assets/1292638/72182226-014e-4f95-98ed-2b81331aa458)
![image](https://github.com/stackrox/stackrox/assets/1292638/f45f807c-f93b-47b1-8f88-48275fde3652)
![image](https://github.com/stackrox/stackrox/assets/1292638/c867ad48-50ad-4ba0-88bb-fb5b2e09f73e)

HelperText fix for Auth Provider rules:
![image](https://github.com/stackrox/stackrox/assets/1292638/4c901dc8-0436-4224-915b-4803b364ddeb)

HelperText for Permission Set form:
![image](https://github.com/stackrox/stackrox/assets/1292638/57d91152-cbb1-40a8-affe-32b2bb1bd42f)

HelperText for Role form:
![image](https://github.com/stackrox/stackrox/assets/1292638/c736f276-ecac-4208-b99d-12001a204554)

HelperText for Init Bundle form:
![image](https://github.com/stackrox/stackrox/assets/1292638/b782863c-68f1-40f4-8139-9858609e1102)

HelperText for VulnConfig:
![image](https://github.com/stackrox/stackrox/assets/1292638/e45892cd-292d-427a-8024-004126acf3d9)

HelperText for _other_ FormLabelGroup (many many locations):
![image](https://github.com/stackrox/stackrox/assets/1292638/9de873e3-85b6-4c16-95b4-900631603bd6)

HelperText for machine access conf Integrations:
![image](https://github.com/stackrox/stackrox/assets/1292638/5b544af5-af3a-4195-8bd9-2b4e41bb737b)

HelperText for CIDR form:
![image](https://github.com/stackrox/stackrox/assets/1292638/f8c47ea2-d4a5-4518-a253-5dedd4d3bd22)

HelperText in Duplicate Policy Modal:
![image](https://github.com/stackrox/stackrox/assets/1292638/61407582-2f9f-4c8d-9b9e-a04a686b2d66)

HelperText in Policy Form:
![image](https://github.com/stackrox/stackrox/assets/1292638/b462f24a-a71f-49b1-aa7c-e0c9b57502b0)
![image](https://github.com/stackrox/stackrox/assets/1292638/288182de-b989-4134-871b-bdebe3df56d5)
![image](https://github.com/stackrox/stackrox/assets/1292638/1fe24378-494a-4832-95f3-d209d4ec6e02)

HelperText in Create Policy Category modal/Policy cat sidebar:
![image](https://github.com/stackrox/stackrox/assets/1292638/8d6fe465-6e13-401d-b79e-9e4d02329b58)
![image](https://github.com/stackrox/stackrox/assets/1292638/331c3ffd-a216-4e42-8d99-38f5237338ae)

HelperText in system config form:
![image](https://github.com/stackrox/stackrox/assets/1292638/78f76696-ebba-42b6-8012-599b3df1e076)

HelperText in Generate Diag Bundle form:
![image](https://github.com/stackrox/stackrox/assets/1292638/3ed6131d-41c6-4945-9807-429211057c30)

HelperText in exception request form:
![image](https://github.com/stackrox/stackrox/assets/1292638/cae28229-e249-4b66-b01f-35e38aefc2b5)

HelperText in email template form
![image](https://github.com/stackrox/stackrox/assets/1292638/3044c5c4-f8c0-443f-9ebe-0c3498de7132)
