### PR TITLE
fix(tests): make TestBroker/TestScaleSize deterministic

### DIFF
--- a/pkg/sensor/queue/scaler_test.go
+++ b/pkg/sensor/queue/scaler_test.go
@@ -18,43 +18,51 @@ func TestBroker(t *testing.T) {
 }
 
 func (s *scalerTestSuite) TestScaleSize() {
-	cases := map[string]struct {
+	cases := []struct {
+		name              string
 		inputQueueSize    int
 		sensorMemLimit    int
 		bufferCeiling     int
 		expectedQueueSize int
 	}{
-		"50% memlimit": {
+		{
+			name:              "50% memlimit",
 			inputQueueSize:    100,
 			sensorMemLimit:    int(defaultMemlimit * 0.5),
 			expectedQueueSize: 50,
 		},
-		"50% memlimit - rounding up": {
+		{
+			name:              "50% memlimit - rounding up",
 			inputQueueSize:    5,
 			sensorMemLimit:    int(defaultMemlimit * 0.5),
 			expectedQueueSize: 3,
 		},
-		"200% memlimit": {
+		{
+			name:              "200% memlimit",
 			inputQueueSize:    100,
 			sensorMemLimit:    int(defaultMemlimit * 2),
 			expectedQueueSize: 200,
 		},
-		"At least size 1": {
+		{
+			name:              "At least size 1",
 			inputQueueSize:    100,
 			sensorMemLimit:    1,
 			expectedQueueSize: 1,
 		},
-		"Default on memlimit 0": {
+		{
+			name:              "Default on memlimit 0",
 			inputQueueSize:    100,
 			sensorMemLimit:    0,
 			expectedQueueSize: 100,
 		},
-		"Upper limit hit": {
+		{
+			name:              "Upper limit hit",
 			inputQueueSize:    100,
 			sensorMemLimit:    int(defaultMemlimit * 10),
 			expectedQueueSize: 300,
 		},
-		"Custom upper limit": {
+		{
+			name:              "Custom upper limit",
 			inputQueueSize:    100,
 			sensorMemLimit:    int(defaultMemlimit * 10),
 			bufferCeiling:     5,
@@ -62,12 +70,16 @@ func (s *scalerTestSuite) TestScaleSize() {
 		},
 	}
 
-	for name, c := range cases {
-		s.Run(name, func() {
+	for _, c := range cases {
+		s.Run(c.name, func() {
 			err := os.Setenv("ROX_MEMLIMIT", strconv.Itoa(c.sensorMemLimit))
 			s.NoError(err)
 			if c.bufferCeiling != 0 {
 				err := os.Setenv("ROX_SENSOR_BUFFER_SCALE_CEILING", strconv.Itoa(c.bufferCeiling))
+				s.NoError(err)
+			} else {
+				val := strconv.Itoa(env.BufferScaleCeiling.DefaultValue())
+				err := os.Setenv("ROX_SENSOR_BUFFER_SCALE_CEILING", val)
 				s.NoError(err)
 			}
 


### PR DESCRIPTION
## Description

Example run where the subtest sequence makes the test break:
```
=== RUN   TestBroker/TestScaleSize
=== RUN   TestBroker/TestScaleSize/Custom_upper_limit
=== RUN   TestBroker/TestScaleSize/At_least_size_1
=== RUN   TestBroker/TestScaleSize/Default_on_memlimit_0
pkg/sensor/queue: 2024/03/28 16:36:25.028550 scaler.go:30: Warn: ROX_MEMLIMIT is set to 0!
=== RUN   TestBroker/TestScaleSize/50%_memlimit
=== RUN   TestBroker/TestScaleSize/50%_memlimit_-_rounding_up
=== RUN   TestBroker/TestScaleSize/200%_memlimit
=== RUN   TestBroker/TestScaleSize/Upper_limit_hit
    scaler_test.go:84: 
        	Error Trace:	/__w/stackrox/stackrox/pkg/sensor/queue/scaler_test.go:84
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Not equal: 
        	            	expected: 300
        	            	actual  : 500
        	Test:       	TestBroker/TestScaleSize/Upper_limit_hit
```

Due to the fact that `Custom_upper_limit` ran before `Upper_limit_hit`, the environment state makes the test break.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
