### PR TITLE
chore(ui): pf5 tweaks round 3 icon colors

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -44,11 +44,19 @@ function BacklogTable<Item>({
 }: BacklogTableProps<Item>) {
     const actionIcon =
         type === 'selected' ? (
-            <Icon color="var(--pf-v5-global--danger-color--200)">
+            <Icon
+                style={{
+                    '--pf-v5-c-icon__content--Color': 'var(--pf-v5-global--danger-color--200)',
+                }}
+            >
                 <MinusCircleIcon />
             </Icon>
         ) : (
-            <Icon color="var(--pf-v5-global--primary-color--100)">
+            <Icon
+                style={{
+                    '--pf-v5-c-icon__content--Color': 'var(--pf-v5-global--primary-color--100)',
+                }}
+            >
                 <PlusCircleIcon />
             </Icon>
         );

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -44,20 +44,12 @@ function BacklogTable<Item>({
 }: BacklogTableProps<Item>) {
     const actionIcon =
         type === 'selected' ? (
-            <Icon
-                style={{
-                    '--pf-v5-c-icon__content--Color': 'var(--pf-v5-global--danger-color--200)',
-                }}
-            >
-                <MinusCircleIcon />
+            <Icon>
+                <MinusCircleIcon color="var(--pf-v5-global--danger-color--200)" />
             </Icon>
         ) : (
-            <Icon
-                style={{
-                    '--pf-v5-c-icon__content--Color': 'var(--pf-v5-global--primary-color--100)',
-                }}
-            >
-                <PlusCircleIcon />
+            <Icon>
+                <PlusCircleIcon color="var(--pf-v5-global--primary-color--100)" />
             </Icon>
         );
 

--- a/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
@@ -20,8 +20,8 @@ function ExternalLink({ children }: ExternalLinkProps): ReactElement {
             spaceItems={{ default: 'spaceItemsSm' }}
         >
             {children}
-            <Icon color="var(--pf-v5-global--link--Color)">
-                <ExternalLinkAltIcon />
+            <Icon>
+                <ExternalLinkAltIcon color="var(--pf-v5-global--link--Color)" />
             </Icon>
         </Flex>
     );

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
@@ -11,12 +11,12 @@ export type PolicyStatusIconTextProps = {
 
 function PolicyStatusIconText({ isPass, isTextOnly }: PolicyStatusIconTextProps): ReactElement {
     const icon = isPass ? (
-        <Icon color="var(--pf-v5-global--success-color--100)">
-            <CheckCircleIcon />
+        <Icon>
+            <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
         </Icon>
     ) : (
-        <Icon color="var(--pf-v5-global--danger-color--100)">
-            <ExclamationCircleIcon />
+        <Icon>
+            <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
         </Icon>
     );
     const text = isPass ? 'Pass' : 'Fail';

--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -23,57 +23,39 @@ import { PolicySeverity } from 'types/policy.proto';
 // Color can be overridden by passing the standard `color` prop to the icon component.
 // For example, colors={count === 0 ? noViolationsColor: undefined} prop.
 
-export const CriticalSeverityIcon = (props) => (
-    <Icon
-        style={{
-            '--pf-v5-c-icon__content--Color': props.color ?? CRITICAL_SEVERITY_COLOR,
-        }}
-    >
-        <CriticalRiskIcon {...props} />
-    </Icon>
+export const CriticalSeverityIcon = ({ color, ...props }: SVGIconProps) => (
+    <>
+        <Icon>
+            <CriticalRiskIcon color={color ?? CRITICAL_SEVERITY_COLOR} {...props} />
+        </Icon>
+    </>
 );
 
-export const ImportantSeverityIcon = (props) => (
-    <Icon
-        style={{
-            '--pf-v5-c-icon__content--Color': props.color ?? IMPORTANT_HIGH_SEVERITY_COLOR,
-        }}
-    >
-        <AngleDoubleUpIcon {...props} />
+export const ImportantSeverityIcon = ({ color, ...props }: SVGIconProps) => (
+    <Icon>
+        <AngleDoubleUpIcon color={color ?? IMPORTANT_HIGH_SEVERITY_COLOR} {...props} />
     </Icon>
 );
 
 export const HighSeverityIcon = ImportantSeverityIcon; // High is for policy severity
 
-export const ModerateSeverityIcon = (props) => (
-    <Icon
-        style={{
-            '--pf-v5-c-icon__content--Color': props.color ?? MODERATE_MEDIUM_SEVERITY_COLOR,
-        }}
-    >
-        <EqualsIcon {...props} />
+export const ModerateSeverityIcon = ({ color, ...props }: SVGIconProps) => (
+    <Icon>
+        <EqualsIcon color={color ?? MODERATE_MEDIUM_SEVERITY_COLOR} {...props} />
     </Icon>
 );
 
 export const MediumSeverityIcon = ModerateSeverityIcon; // Medium is for policy severity
 
-export const LowSeverityIcon = (props) => (
-    <Icon
-        style={{
-            '--pf-v5-c-icon__content--Color': props.color ?? LOW_SEVERITY_COLOR,
-        }}
-    >
-        <AngleDoubleDownIcon {...props} />
+export const LowSeverityIcon = ({ color, ...props }: SVGIconProps) => (
+    <Icon>
+        <AngleDoubleDownIcon color={color ?? LOW_SEVERITY_COLOR} {...props} />
     </Icon>
 );
 
-export const UnknownSeverityIcon = (props) => (
-    <Icon
-        style={{
-            '--pf-v5-c-icon__content--Color': props.color ?? UNKNOWN_SEVERITY_COLOR,
-        }}
-    >
-        <UnknownIcon {...props} />
+export const UnknownSeverityIcon = ({ color, ...props }: SVGIconProps) => (
+    <Icon>
+        <UnknownIcon color={color ?? UNKNOWN_SEVERITY_COLOR} {...props} />
     </Icon>
 );
 

--- a/ui/apps/platform/src/Components/TooltipFieldValue/TooltipFieldValue.tsx
+++ b/ui/apps/platform/src/Components/TooltipFieldValue/TooltipFieldValue.tsx
@@ -6,14 +6,14 @@ import { Icon } from '@patternfly/react-core';
 // TODO import the following function components:
 
 export const DangerIcon = (props: SVGIconProps) => (
-    <Icon color="var(--pf-v5-global--danger-color--100)">
-        <ExclamationCircleIcon {...props} />
+    <Icon>
+        <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" {...props} />
     </Icon>
 );
 
 export const WarningIcon = (props: SVGIconProps) => (
-    <Icon color="var(--pf-v5-global--warning-color--100)">
-        <ExclamationTriangleIcon {...props} />
+    <Icon>
+        <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" {...props} />
     </Icon>
 );
 

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeStateIcon.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeStateIcon.tsx
@@ -19,8 +19,8 @@ const unknownColor = 'var(--pf-v5-global--warning-color--100)';
  */
 
 const notAllowedIcon = (
-    <Icon color={notAllowedColor}>
-        <BanIcon />;
+    <Icon>
+        <BanIcon color={notAllowedColor} />
     </Icon>
 );
 const notAllowedCluster = (
@@ -45,8 +45,8 @@ const notAllowedNamespace = (
 );
 
 const allowedIcon = (
-    <Icon color={allowedColor}>
-        <CheckIcon />
+    <Icon>
+        <CheckIcon color={allowedColor} />
     </Icon>
 );
 const allowedCluster = (
@@ -63,8 +63,11 @@ const allowedCluster = (
     >
         <span>
             {allowedIcon}
-            <Icon color={allowedColor}>
-                <LongArrowAltDownIcon style={{ transform: 'rotate(-45deg)' }} />
+            <Icon>
+                <LongArrowAltDownIcon
+                    color={allowedColor}
+                    style={{ transform: 'rotate(-45deg)' }}
+                />
             </Icon>
         </span>
     </Tooltip>
@@ -89,8 +92,8 @@ const partialCluster = (
     >
         <span>
             {allowedIcon}
-            <Icon color={allowedColor}>
-                <LongArrowAltUpIcon style={{ transform: 'rotate(-45deg)' }} />
+            <Icon>
+                <LongArrowAltUpIcon color={allowedColor} style={{ transform: 'rotate(-45deg)' }} />
             </Icon>
         </span>
     </Tooltip>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRow.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRow.tsx
@@ -96,8 +96,8 @@ function RequirementRow({
                                             isDisabled={values.length === 1}
                                             onClick={() => handleValueDelete(indexValue)}
                                         >
-                                            <Icon color="var(--pf-v5-global--danger-color--100)">
-                                                <MinusCircleIcon />
+                                            <Icon>
+                                                <MinusCircleIcon color="var(--pf-v5-global--danger-color--100)" />
                                             </Icon>
                                         </Button>
                                     </Tooltip>
@@ -129,8 +129,8 @@ function RequirementRow({
                                             isDisabled={isDisabledAddValue}
                                             onClick={onAddValue}
                                         >
-                                            <Icon color="var(--pf-v5-global--primary-color--100)">
-                                                <PlusCircleIcon />
+                                            <Icon>
+                                                <PlusCircleIcon color="var(--pf-v5-global--primary-color--100)" />
                                             </Icon>
                                         </Button>
                                     </Tooltip>
@@ -162,8 +162,8 @@ function RequirementRow({
                                     isDisabled={values.length === 0 || valueInput.length !== 0}
                                     onClick={handleRequirementOK}
                                 >
-                                    <Icon color="var(--pf-v5-global--primary-color--100)">
-                                        <CheckCircleIcon />
+                                    <Icon>
+                                        <CheckCircleIcon color="var(--pf-v5-global--primary-color--100)" />
                                     </Icon>
                                 </Button>
                             </Tooltip>
@@ -174,8 +174,8 @@ function RequirementRow({
                                     className="pf-m-smallest"
                                     onClick={handleRequirementCancel}
                                 >
-                                    <Icon color="var(--pf-v5-global--color--100)">
-                                        <TimesCircleIcon />
+                                    <Icon>
+                                        <TimesCircleIcon color="var(--pf-v5-global--color--100)" />
                                     </Icon>
                                 </Button>
                             </Tooltip>
@@ -191,8 +191,8 @@ function RequirementRow({
                                         isDisabled={activity === 'DISABLED'}
                                         onClick={handleRequirementEdit}
                                     >
-                                        <Icon color="var(--pf-v5-global--primary-color--100)">
-                                            <PencilAltIcon />
+                                        <Icon>
+                                            <PencilAltIcon color="var(--pf-v5-global--primary-color--100)" />
                                         </Icon>
                                     </Button>
                                 </Tooltip>
@@ -205,8 +205,8 @@ function RequirementRow({
                                     isDisabled={activity === 'DISABLED'}
                                     onClick={handleRequirementDelete}
                                 >
-                                    <Icon color="var(--pf-v5-global--danger-color--100)">
-                                        <MinusCircleIcon />
+                                    <Icon>
+                                        <MinusCircleIcon color="var(--pf-v5-global--danger-color--100)" />
                                     </Icon>
                                 </Button>
                             </Tooltip>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRowAddKey.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRowAddKey.tsx
@@ -76,8 +76,11 @@ function RequirementRowAddKey({
                                 isDisabled={isDisabledOK}
                                 onClick={onClickRequirementKeyOK}
                             >
-                                <Icon color="var(--pf-v5-global--primary-color--100)">
-                                    <ArrowCircleDownIcon style={{ transform: 'rotate(-90deg)' }} />
+                                <Icon>
+                                    <ArrowCircleDownIcon
+                                        color="var(--pf-v5-global--primary-color--100)"
+                                        style={{ transform: 'rotate(-90deg)' }}
+                                    />
                                 </Icon>
                             </Button>
                         </Tooltip>
@@ -97,8 +100,8 @@ function RequirementRowAddKey({
                         className="pf-m-smallest"
                         onClick={handleRequirementKeyCancel}
                     >
-                        <Icon color="var(--pf-v5-global--color--100)">
-                            <TimesCircleIcon />
+                        <Icon>
+                            <TimesCircleIcon color="var(--pf-v5-global--color--100)" />
                         </Icon>
                     </Button>
                 </Tooltip>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/AccessIcons.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/AccessIcons.tsx
@@ -7,13 +7,13 @@ import { Icon } from '@patternfly/react-core';
 import { getIsReadAccess, getIsWriteAccess } from './permissionSets.utils';
 
 const forbiddenIcon = (
-    <Icon color="var(--pf-v5-global--danger-color--100)" size="sm">
-        <TimesIcon aria-label="forbidden" />
+    <Icon size="sm">
+        <TimesIcon color="var(--pf-v5-global--danger-color--100)" aria-label="forbidden" />
     </Icon>
 );
 const permittedIcon = (
-    <Icon color="var(--pf-v5-global--success-color--100)" size="sm">
-        <CheckIcon aria-label="permitted" />
+    <Icon size="sm">
+        <CheckIcon color="var(--pf-v5-global--success-color--100)" aria-label="permitted" />
     </Icon>
 );
 

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEvent.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEvent.tsx
@@ -15,28 +15,28 @@ import {
 
 const iconMap: Record<AdministrationEventLevel, ReactElement> = {
     ADMINISTRATION_EVENT_LEVEL_ERROR: (
-        <Icon color="var(--pf-v5-global--danger-color--100)">
-            <ExclamationCircleIcon />
+        <Icon>
+            <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
         </Icon>
     ),
     ADMINISTRATION_EVENT_LEVEL_INFO: (
-        <Icon color="var(--pf-v5-global--info-color--100)">
-            <InfoCircleIcon />
+        <Icon>
+            <InfoCircleIcon color="var(--pf-v5-global--info-color--100)" />
         </Icon>
     ),
     ADMINISTRATION_EVENT_LEVEL_SUCCESS: (
-        <Icon color="var(--pf-v5-global--success-color--100)">
-            <CheckCircleIcon />
+        <Icon>
+            <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
         </Icon>
     ),
     ADMINISTRATION_EVENT_LEVEL_UNKNOWN: (
-        <Icon color="var(--pf-v5-global--default-color--200)">
-            <BellIcon />
+        <Icon>
+            <BellIcon color="var(--pf-v5-global--default-color--200)" />
         </Icon>
     ),
     ADMINISTRATION_EVENT_LEVEL_WARNING: (
-        <Icon color="var(--pf-v5-global--warning-color--100)">
-            <ExclamationTriangleIcon />
+        <Icon>
+            <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
         </Icon>
     ),
 };

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -159,14 +159,14 @@ function ClusterLabelsTable({
                                     isDisabled={!isValid}
                                     onClick={() => onAddLabel()}
                                 >
-                                    <Icon
-                                        color={
-                                            isReplace
-                                                ? 'var(--pf-v5-global--warning-color--100)'
-                                                : 'var(--pf-v5-global--success-color--100)'
-                                        }
-                                    >
-                                        <PlusCircleIcon />
+                                    <Icon>
+                                        <PlusCircleIcon
+                                            color={
+                                                isReplace
+                                                    ? 'var(--pf-v5-global--warning-color--100)'
+                                                    : 'var(--pf-v5-global--success-color--100)'
+                                            }
+                                        />
                                     </Icon>
                                 </Button>
                             </Tooltip>

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
@@ -26,13 +26,13 @@ export function getProviderRegionText(providerType: DiscoveredClusterProviderTyp
 
 const iconMap: Record<DiscoveredClusterStatus, ReactElement> = {
     STATUS_SECURED: (
-        <Icon color="var(--pf-v5-global--success-color--100)">
-            <CheckCircleIcon />
+        <Icon>
+            <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
         </Icon>
     ),
     STATUS_UNSECURED: (
-        <Icon color="var(--pf-v5-global--danger-color--100)">
-            <SecurityIcon />
+        <Icon>
+            <SecurityIcon color="var(--pf-v5-global--danger-color--100)" />
         </Icon>
     ),
     STATUS_UNSPECIFIED: <UnknownIcon />,

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -184,8 +184,11 @@ function ByLabelSelector({
                                                 variant="plain"
                                                 onClick={() => onDeleteValue(ruleIndex, valueIndex)}
                                             >
-                                                <Icon color="var(--pf-v5-global--Color--dark-200)">
-                                                    <TrashIcon style={{ cursor: 'pointer' }} />
+                                                <Icon>
+                                                    <TrashIcon
+                                                        color="var(--pf-v5-global--Color--dark-200)"
+                                                        style={{ cursor: 'pointer' }}
+                                                    />
                                                 </Icon>
                                             </Button>
                                         )}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -155,8 +155,9 @@ function ByNameSelector({
                                     variant="plain"
                                     onClick={() => onDeleteValue(index)}
                                 >
-                                    <Icon color="var(--pf-v5-global--Color--dark-200)">
+                                    <Icon>
                                         <TrashIcon
+                                            color="var(--pf-v5-global--Color--dark-200)"
                                             className="pf-v5-u-flex-shrink-1"
                                             style={{ cursor: 'pointer' }}
                                         />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
@@ -113,8 +113,8 @@ export function getComplianceLabelGroupColor(
 const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject } = {
     [ComplianceCheckStatus.PASS]: {
         icon: (
-            <Icon color="var(--pf-v5-global--success-color--100)">
-                <CheckCircleIcon />
+            <Icon>
+                <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
             </Icon>
         ),
         statusText: 'Pass',
@@ -122,8 +122,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.FAIL]: {
         icon: (
-            <Icon color="var(--pf-v5-global--danger-color--100)">
-                <SecurityIcon />
+            <Icon>
+                <SecurityIcon color="var(--pf-v5-global--danger-color--100)" />
             </Icon>
         ),
         statusText: 'Fail',
@@ -131,8 +131,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.ERROR]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <ExclamationTriangleIcon />
+            <Icon>
+                <ExclamationTriangleIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Error',
@@ -140,8 +140,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.INFO]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <ExclamationCircleIcon />
+            <Icon>
+                <ExclamationCircleIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Info',
@@ -150,8 +150,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.MANUAL]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <WrenchIcon />
+            <Icon>
+                <WrenchIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Manual',
@@ -159,8 +159,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.NOT_APPLICABLE]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <BanIcon />
+            <Icon>
+                <BanIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Not Applicable',
@@ -168,8 +168,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.INCONSISTENT]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <UnknownIcon />
+            <Icon>
+                <UnknownIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Inconsistent',
@@ -177,8 +177,8 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     },
     [ComplianceCheckStatus.UNSET_CHECK_STATUS]: {
         icon: (
-            <Icon color="var(--pf-v5-global--disabled-color--100)">
-                <ResourcesEmptyIcon />
+            <Icon>
+                <ResourcesEmptyIcon color="var(--pf-v5-global--disabled-color--100)" />
             </Icon>
         ),
         statusText: 'Unset', // TODO: ask about this status

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ComplianceClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ComplianceClusterStatus.tsx
@@ -18,16 +18,16 @@ function ComplianceClusterStatus({ errors }: ComplianceClusterStatusProps) {
         return errors && errors.length && errors[0] !== ''
             ? {
                   icon: (
-                      <Icon color="var(--pf-v5-global--danger-color--100)">
-                          <ExclamationCircleIcon />
+                      <Icon>
+                          <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
                       </Icon>
                   ),
                   statusText: 'Unhealthy',
               }
             : {
                   icon: (
-                      <Icon color="var(--pf-v5-global--success-color--100)">
-                          <CheckCircleIcon />
+                      <Icon>
+                          <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
                       </Icon>
                   ),
                   statusText: 'Healthy',

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
@@ -15,8 +15,8 @@ export type NoEntitiesIconTextProps = {
  */
 function NoEntitiesIconText({ text, isTextOnly }: NoEntitiesIconTextProps): ReactElement {
     const icon = (
-        <Icon color="var(--pf-v5-global--warning-color--100)">
-            <ExclamationTriangleIcon />
+        <Icon>
+            <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
         </Icon>
     );
 

--- a/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
@@ -19,18 +19,18 @@ export const ErrorIcon = <MinusIcon />;
 
 // Icons to render for health after request succeeds.
 export const DangerIcon = (
-    <Icon color="var(--pf-v5-global--danger-color--100)">
-        <ExclamationCircleIcon />
+    <Icon>
+        <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
     </Icon>
 );
 export const SuccessIcon = (
-    <Icon color="var(--pf-v5-global--success-color--100)">
-        <CheckCircleIcon />
+    <Icon>
+        <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
     </Icon>
 );
 export const WarningIcon = (
-    <Icon color="var(--pf-v5-global--warning-color--100)">
-        <ExclamationTriangleIcon />
+    <Icon>
+        <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
     </Icon>
 );
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
@@ -62,8 +62,8 @@ export function TdUnhealthy({ count, dataLabel }: TdStatusWithDataLabelProps): R
             {count !== 0 ? (
                 <IconText
                     icon={
-                        <Icon color="var(--pf-v5-global--danger-color--100)">
-                            <ExclamationCircleIcon />
+                        <Icon>
+                            <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
                         </Icon>
                     }
                     text={String(count)}
@@ -81,8 +81,8 @@ export function TdDegraded({ count, dataLabel }: TdStatusWithDataLabelProps): Re
             {count !== 0 ? (
                 <IconText
                     icon={
-                        <Icon color="var(--pf-v5-global--warning-color--100)">
-                            <ExclamationTriangleIcon />
+                        <Icon>
+                            <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
                         </Icon>
                     }
                     text={String(count)}

--- a/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
+++ b/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
@@ -6,13 +6,13 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { userBasePath } from 'routePaths';
 
 const forbiddenIcon = (
-    <Icon color="var(--pf-v5-global--danger-color--100)" size="sm">
-        <TimesIcon aria-label="forbidden" />
+    <Icon size="sm">
+        <TimesIcon color="var(--pf-v5-global--danger-color--100)" aria-label="forbidden" />
     </Icon>
 );
 const permittedIcon = (
-    <Icon color="var(--pf-v5-global--success-color--100)" size="sm">
-        <CheckIcon aria-label="permitted" />
+    <Icon size="sm">
+        <CheckIcon color="var(--pf-v5-global--success-color--100)" aria-label="permitted" />
     </Icon>
 );
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
@@ -60,8 +60,8 @@ function WatchedImagesTable({
                                         variant="link"
                                         isInline
                                         icon={
-                                            <Icon color="var(--pf-v5-global--Color--200)">
-                                                <MinusCircleIcon />
+                                            <Icon>
+                                                <MinusCircleIcon color="var(--pf-v5-global--danger-color--100)" />
                                             </Icon>
                                         }
                                         onClick={() => unwatchImage(name)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
@@ -15,8 +15,8 @@ function ComponentLocation({ location, source }: ComponentLocationProps) {
             <Truncate content={location || 'N/A'} position="middle" />
             {source === 'OS' && location === '' && (
                 <Tooltip content="Location is unavailable for operating system packages">
-                    <Icon color="var(--pf-v5-global--info-color--100)">
-                        <InfoCircleIcon />
+                    <Icon>
+                        <InfoCircleIcon color="var(--pf-v5-global--info-color--100)" />
                     </Icon>
                 </Tooltip>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/DynamicIcon.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/DynamicIcon.tsx
@@ -5,8 +5,8 @@ import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 export function DynamicIcon(props: SVGIconProps) {
     return (
-        <Icon color="var(--pf-v5-global--palette--blue-300)">
-            <FilterIcon {...props} />
+        <Icon>
+            <FilterIcon color="var(--pf-v5-global--palette--blue-300)" {...props} />
         </Icon>
     );
 }


### PR DESCRIPTION
## Description

Fixes icon colors throughout.

Why?

The codemod wraps all icons in an `<Icon>` component, and moves the color prop from the specific icon to this wrapper. Due to the way these props are handled, the color does not get applied on the inner icon, so we move the `color` prop back to its original location.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Attached collections:
![image](https://github.com/stackrox/stackrox/assets/1292638/2d9a997b-fb7d-43b0-8e3f-30135f9dae4f)
![image](https://github.com/stackrox/stackrox/assets/1292638/b12590c2-2243-4c93-b86c-9ef1491a2467)

External link icon:
![image](https://github.com/stackrox/stackrox/assets/1292638/1a64ae41-dccd-47d5-b057-50d27c4d5f63)

Policy status icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/1909e219-e2cf-43e8-a4af-ad44007860e4)

Access scope state icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad003b1c-0933-4b0a-aab5-13a3fac4160e)

Access scope label selector:
![image](https://github.com/stackrox/stackrox/assets/1292638/362aadca-44f0-4aae-94ad-38c782772f7c)

Permission sets icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/d294360c-e1be-4766-bcd9-3931906c5bda)

Administration event icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/2d68d1b6-6e88-4a8b-bdaf-d024bc4ff9e2)

Fix clusters label table:
![image](https://github.com/stackrox/stackrox/assets/1292638/819a437e-64ea-4302-ac37-f2c649dc2753)

Fix collection trash icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/856687cd-1263-484c-9c1b-1f8318b49212)

Fix Compliance V2 icons:
TODO - Need to test this in another environment

Fix "no entities" icons in Config Mgmt:
![image](https://github.com/stackrox/stackrox/assets/1292638/c8210d74-73e4-4abe-b989-9bc77cc08bdb)

Fix system health card header icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e8e62c5-67bf-4ea5-89e1-72f839c90b6c)

User role icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/95d68146-af53-4c3e-af27-3c9fcf0138c3)

Workload CVE Icons:
![image](https://github.com/stackrox/stackrox/assets/1292638/b217795c-af40-489f-abd1-f5fe7564af2d)

Watched images table:
![image](https://github.com/stackrox/stackrox/assets/1292638/81b0e48a-8691-4a14-8ef2-00f257901f43)

