### PR TITLE
ROX-23045: Add header to Node detail page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,21 +1,46 @@
 import React from 'react';
-import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
+import { gql, useQuery } from '@apollo/client';
+import {
+    PageSection,
+    Breadcrumb,
+    Divider,
+    BreadcrumbItem,
+    Skeleton,
+    Bullseye,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import NodePageHeader, { NodeMetadata, nodeMetadataFragment } from './NodePageHeader';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Node', {
     entityTab: 'Node',
 });
 
+const nodeMetadataQuery = gql`
+    ${nodeMetadataFragment}
+    query getNodeMetadata($id: ID!) {
+        node(id: $id) {
+            ...NodeMetadata
+        }
+    }
+`;
+
+// TODO - Update for PF5
 function NodePage() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { nodeId } = useParams() as { nodeId: string };
 
-    const nodeName: string | undefined = 'TODO';
+    const { data, error } = useQuery<{ node: NodeMetadata }, { id: string }>(nodeMetadataQuery, {
+        variables: { id: nodeId },
+    });
+
+    const nodeName = data?.node?.name ?? '-';
 
     return (
         <>
@@ -31,6 +56,24 @@ function NodePage() {
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
+            {error ? (
+                <PageSection variant="light">
+                    <Bullseye>
+                        <EmptyStateTemplate
+                            title={getAxiosErrorMessage(error)}
+                            headingLevel="h2"
+                            icon={ExclamationCircleIcon}
+                            iconClassName="pf-u-danger-color-100"
+                        />
+                    </Bullseye>
+                </PageSection>
+            ) : (
+                <>
+                    <PageSection variant="light">
+                        <NodePageHeader data={data?.node} />
+                    </PageSection>
+                </>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
+
+import { gql } from '@apollo/client';
+import { getDateTime } from 'utils/dateUtils';
+
+export const nodeMetadataFragment = gql`
+    fragment NodeMetadata on Node {
+        id
+        name
+        operatingSystem
+        kubeletVersion
+        kernelVersion
+        scanTime
+    }
+`;
+
+export type NodeMetadata = {
+    id: string;
+    name: string;
+    operatingSystem: string;
+    kubeletVersion: string;
+    kernelVersion: string;
+    scanTime?: string;
+};
+
+export type NodePageHeaderProps = {
+    data: NodeMetadata | undefined;
+};
+
+function NodePageHeader({ data }: NodePageHeaderProps) {
+    if (!data) {
+        return (
+            <Flex
+                direction={{ default: 'column' }}
+                spaceItems={{ default: 'spaceItemsXs' }}
+                className="pf-u-w-50"
+            >
+                <Skeleton screenreaderText="Loading Node name" fontSize="2xl" />
+                <Skeleton screenreaderText="Loading Node metadata" height="40px" />
+            </Flex>
+        );
+    }
+
+    const numLabels = data.scanTime ? 4 : 3;
+
+    return (
+        <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
+            <Title headingLevel="h1" className="pf-u-mb-sm">
+                {data.name}
+            </Title>
+            <LabelGroup numLabels={numLabels}>
+                <Label>OS: {data.operatingSystem}</Label>
+                <Label>Kubelet: {data.kubeletVersion}</Label>
+                <Label>Kernel version: {data.kernelVersion}</Label>
+                {data.scanTime && <Label>Scan time: {getDateTime(data.scanTime)}</Label>}
+            </LabelGroup>
+        </Flex>
+    );
+}
+
+export default NodePageHeader;


### PR DESCRIPTION
## Description

Adds a header to the Node detail page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Node page via direct URL and see the loading state:
![image](https://github.com/stackrox/stackrox/assets/1292638/dea49675-a538-4726-98a9-b27234a347e3)

After loading, the data is displayed:
![image](https://github.com/stackrox/stackrox/assets/1292638/c0c5a073-b341-47e2-b813-7833bbd83d81)
