### PR TITLE
ROX-23046: Add node detail page tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PageSection, Text } from '@patternfly/react-core';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NodePageDetailsProps = {};
+
+// eslint-disable-next-line no-empty-pattern
+function NodePageDetails({}: NodePageDetailsProps) {
+    return (
+        <>
+            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
+                <Text>View details about this node</Text>
+            </PageSection>
+            <PageSection isFilled className="pf-u-display-flex pf-u-flex-direction-column">
+                <div className="pf-u-flex-grow-1 pf-u-background-color-100">Details</div>
+            </PageSection>
+        </>
+    );
+}
+
+export default NodePageDetails;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PageSection, Text } from '@patternfly/react-core';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NodePageVulnerabilitiesProps = {};
+
+// eslint-disable-next-line no-empty-pattern
+function NodePageVulnerabilities({}: NodePageVulnerabilitiesProps) {
+    return (
+        <>
+            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
+                <Text>Review and triage vulnerability data scanned on this node</Text>
+            </PageSection>
+            <PageSection isFilled className="pf-u-display-flex pf-u-flex-direction-column">
+                <div className="pf-u-flex-grow-1 pf-u-background-color-100">vulns</div>
+            </PageSection>
+        </>
+    );
+}
+
+export default NodePageVulnerabilities;

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -5,7 +5,7 @@
  */
 
 .ReactModal__Content,
-#main-page-container > div > :not(.pf-c-page__main-section) {
+#main-page-container > div > :not(.pf-c-page__main-section):not(.pf-c-tab-content) {
   font-size: 0.875rem;
   color: var(--base-600);
 }


### PR DESCRIPTION
## Description

Adds Vulnerability and Detail tabs to node detail page with URL integration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a node detail page and see that Vulnerabilities is the default selected tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/f6b42696-8de1-4560-9555-16fda090b121)

Switch to the Details tab and see that the container and URL are updated accordingly:
![image](https://github.com/stackrox/stackrox/assets/1292638/7fb84a53-3ec9-44be-a372-b4d11a33dbe2)

