### PR TITLE
ROX-22724: add reprocessor duration metric

### DIFF
--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -37,5 +37,7 @@ func init() {
 		grpcLastMessageSizeReceived,
 		grpcError,
 		deploymentEnhancementRoundTripDuration,
+		reprocessorDurationGauge,
+		signatureVerificationReprocessorDurationGauge,
 	)
 }

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -10,6 +10,7 @@ import (
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/enrichment"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
+	"github.com/stackrox/rox/central/metrics"
 	nodeDatastore "github.com/stackrox/rox/central/node/datastore"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/sensor/service/connection"
@@ -488,6 +489,7 @@ func (l *loopImpl) runReprocessing(imageFetchOpt imageEnricher.FetchOption) {
 	if l.reprocessingInProgress.TestAndSet(true) {
 		return
 	}
+	defer metrics.SetReprocessorDuration(time.Now())
 	l.reprocessNodes()
 	l.reprocessWatchedImages()
 	l.reprocessImagesAndResyncDeployments(imageFetchOpt, l.enrichImage, allImagesQuery)
@@ -496,6 +498,7 @@ func (l *loopImpl) runReprocessing(imageFetchOpt imageEnricher.FetchOption) {
 }
 
 func (l *loopImpl) runSignatureVerificationReprocessing() {
+	defer metrics.SetSignatureVerificationReprocessorDuration(time.Now())
 	l.reprocessWatchedImages()
 	l.reprocessImagesAndResyncDeployments(imageEnricher.ForceRefetchSignaturesOnly,
 		l.forceEnrichImageSignatureVerificationResults, imagesWithSignatureVerificationResultsQuery)


### PR DESCRIPTION
## Description

Add a duration gauge metric for the reprocessor loop. This will help us determine the effects of future performance optimizations of the reprocessor loop.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Verified the Prometheus metric contains the duration.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
