### PR TITLE
ROX-23431: fix test on OCP

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
@@ -35,7 +35,7 @@ class Deployment {
     Map<String , String> request = [:]
     Boolean hostNetwork = false
     List<String> addCapabilities = []
-    List<String> dropCapabilities = []
+    List<String> dropCapabilities = ['ALL']
 
     // Misc
     String loadBalancerIP = null

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1744,7 +1744,7 @@ class Kubernetes implements OrchestratorMain {
      * @deprecated PodSecurityPolicy was deprecated in Kubernetes 1.21 and removed in Kubernetes 1.25.
      */
     protected defaultPspForNamespace(String namespace) {
-        if (Env.get("POD_SECURITY_POLICIES") == "true") {
+        if (Env.get("POD_SECURITY_POLICIES") != "false") {
             PodSecurityPolicy psp = new PodSecurityPolicyBuilder().withNewMetadata()
                 .withName("allow-all-for-test")
                 .endMetadata()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.Probe
 import io.fabric8.kubernetes.api.model.Quantity
 import io.fabric8.kubernetes.api.model.ResourceFieldSelectorBuilder
 import io.fabric8.kubernetes.api.model.ResourceRequirements
+import io.fabric8.kubernetes.api.model.SeccompProfile
 import io.fabric8.kubernetes.api.model.Secret as K8sSecret
 import io.fabric8.kubernetes.api.model.SecretEnvSource
 import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder
@@ -2285,7 +2286,9 @@ class Kubernetes implements OrchestratorMain {
                 envFrom: envFrom,
                 resources: new ResourceRequirements([], limits, requests),
                 securityContext: new SecurityContext(privileged: deployment.isPrivileged,
+                                                     allowPrivilegeEscalation: deployment.isPrivileged,
                                                      readOnlyRootFilesystem: deployment.readOnlyRootFilesystem,
+                                                     seccompProfile: new SeccompProfile(type: 'RuntimeDefault'),
                                                      capabilities: new Capabilities(add: deployment.addCapabilities,
                                                                                     drop: deployment.dropCapabilities)),
         )

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1743,7 +1743,7 @@ class Kubernetes implements OrchestratorMain {
      * @deprecated PodSecurityPolicy was deprecated in Kubernetes 1.21 and removed in Kubernetes 1.25.
      */
     protected defaultPspForNamespace(String namespace) {
-        if (Env.get("POD_SECURITY_POLICIES") != "false") {
+        if (Env.get("POD_SECURITY_POLICIES") == "true") {
             PodSecurityPolicy psp = new PodSecurityPolicyBuilder().withNewMetadata()
                 .withName("allow-all-for-test")
                 .endMetadata()

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -44,71 +44,27 @@ class ProcessBaselinesTest extends BaseSpecification {
 
     static final private List<Deployment> DEPLOYMENTS =
         [
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_RESOLVE_VIOLATION)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_RESOLVE_AND_BASELINE_VIOLATION)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_LOCK)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_DELETE)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_DELETE_API)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_POST_DELETE_API)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
-             new Deployment()
-                     .setName(DEPLOYMENTNGINX_REMOVEPROCESS)
-                     .setNamespace(TEST_NAMESPACE)
-                     .setImage(TEST_IMAGE)
-                     .addPort(22, "TCP")
-                     .addAnnotation("test", "annotation")
-                     .setEnv(["CLUSTER_NAME": "main"])
-                     .addLabel("app", "test"),
+                deployment(DEPLOYMENTNGINX),
+                deployment(DEPLOYMENTNGINX_RESOLVE_VIOLATION),
+                deployment(DEPLOYMENTNGINX_RESOLVE_AND_BASELINE_VIOLATION),
+                deployment(DEPLOYMENTNGINX_LOCK),
+                deployment(DEPLOYMENTNGINX_DELETE),
+                deployment(DEPLOYMENTNGINX_DELETE_API),
+                deployment(DEPLOYMENTNGINX_POST_DELETE_API),
+                deployment(DEPLOYMENTNGINX_REMOVEPROCESS),
             ]
+
+    private static Deployment deployment(String name) {
+        return new Deployment()
+                .setName(name)
+                .setNamespace(TEST_NAMESPACE)
+                .setImage(TEST_IMAGE)
+                .addPort(22, "TCP")
+                .addAnnotation("test", "annotation")
+                .setEnv(["CLUSTER_NAME": "main"])
+                .addLabel("app", "test")
+                .setCapabilities([], [])
+    }
 
     @Shared
     private Policy unauthorizedProcessExecution


### PR DESCRIPTION
## Description

```bash
Error creating: pods "sac-deploymentnginx-qa1-76cd46f5d7-kv2gn" is forbidden: 
violates PodSecurity "restricted:v1.24": 
allowPrivilegeEscalation != false (container "sac-deploymentnginx-qa1" must set securityContext.allowPrivilegeEscalation=false), 
unrestricted capabilities (container "sac-deploymentnginx-qa1" must set securityContext.capabilities.drop=["ALL"]),
runAsNonRoot != true (pod or container "sac-deploymentnginx-qa1" must set securityContext.runAsNonRoot=true), 
seccompProfile (pod or container "sac-deploymentnginx-qa1" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")   
```
so this PR set's mentioned fileds.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

If CI pass I'd like to run periodic

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
