### PR TITLE
fix(CI): retry alert count test

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -39,6 +39,7 @@ import util.SlackUtil
 
 import org.junit.Assume
 import spock.lang.IgnoreIf
+import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Tag
@@ -574,6 +575,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         return total
     }
 
+    @Retry(count = 3)
     def "Verify that alert counts API is consistent with alerts"()  {
         given:
         def alertReq = queryForDeployments()


### PR DESCRIPTION
## Description

The `Verify that alert counts API is consistent with alerts` test makes numerous AlertService API calls and expects state to remain constant between those calls. That creates a potential race condition. This PR reduces the potential for flakiness with an `@Retry`. 

Is that the reason for the flakiness in this test? Follow ROX-23466 for developments.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI + `ci-all-qa-tests`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
