### PR TITLE
tests: remove pod security policy

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -14,15 +14,6 @@ fi
 
 set -euo pipefail
 
-deploy_default_psp() {
-    info "Deploy Default PSP for stackrox namespace"
-    if [[ "$POD_SECURITY_POLICIES" != "false" ]]; then
-        "${ROOT}/scripts/ci/create-default-psp.sh"
-    else
-        info "POD_SECURITY_POLICIES is false, skip Deploy Default PSP for stackrox namespace"
-    fi
-}
-
 get_ECR_docker_pull_password() {
     info "Get AWS ECR Docker Pull Password"
 

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -65,7 +65,6 @@ _compatibility_test() {
         echo "Stackrox deployed"
         kubectl -n stackrox get deploy,ds -o wide
 
-        deploy_default_psp
         deploy_webhook_server
         get_ECR_docker_pull_password
     fi

--- a/qa-tests-backend/scripts/run-custom-pz.sh
+++ b/qa-tests-backend/scripts/run-custom-pz.sh
@@ -48,7 +48,6 @@ config_custom() {
     deploy_stackrox "$ROOT/$DEPLOY_DIR/client_TLS_certs"
     deploy_optional_e2e_components
 
-    deploy_default_psp
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password
     # TODO(ROX-14759): Re-enable once image pulling is fixed.

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -49,7 +49,6 @@ config_part_1() {
     deploy_optional_e2e_components
     setup_workload_identities
 
-    deploy_default_psp
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password
     # TODO(ROX-14759): Re-enable once image pulling is fixed.


### PR DESCRIPTION
## Description

Removing PSP:
> [PodSecurityPolicy was **deprecated** in Kubernetes v1.21, and removed from Kubernetes in v1.25.](https://kubernetes.io/docs/concepts/security/pod-security-policy/)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
