### PR TITLE
chore: prepare protos for v2

### DIFF
--- a/proto/api/integrations/splunk_service.proto
+++ b/proto/api/integrations/splunk_service.proto
@@ -9,7 +9,7 @@ import "storage/deployment.proto";
 import "storage/policy.proto";
 import "storage/process_indicator.proto";
 
-option go_package = "integrations";
+option go_package = "./;integrations";
 option java_package = "io.stackrox.proto.api.integrations";
 
 // SplunkViolationsResponse is what StackRox Platform returns on the request from Splunk Technology Addon for StackRox.

--- a/proto/api/v1/administration_events_service.proto
+++ b/proto/api/v1/administration_events_service.proto
@@ -7,7 +7,7 @@ import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // AdministrationEvents are administrative events emitted by Central. They are used to create

--- a/proto/api/v1/administration_usage_service.proto
+++ b/proto/api/v1/administration_usage_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // TimeRange allows for requesting data by a time range.

--- a/proto/api/v1/alert_service.proto
+++ b/proto/api/v1/alert_service.proto
@@ -11,7 +11,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/alert.proto";
 import "storage/policy.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message CountAlertsResponse {

--- a/proto/api/v1/api_token_service.proto
+++ b/proto/api/v1/api_token_service.proto
@@ -8,7 +8,7 @@ import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/api_token.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GenerateTokenRequest {

--- a/proto/api/v1/audit.proto
+++ b/proto/api/v1/audit.proto
@@ -6,7 +6,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/user.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message Audit {

--- a/proto/api/v1/auth_service.proto
+++ b/proto/api/v1/auth_service.proto
@@ -10,7 +10,7 @@ import "storage/auth_provider.proto";
 import "storage/service_identity.proto";
 import "storage/user.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message UserAttribute {

--- a/proto/api/v1/authprovider_service.proto
+++ b/proto/api/v1/authprovider_service.proto
@@ -8,7 +8,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/auth_provider.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetAuthProviderRequest {

--- a/proto/api/v1/backup_service.proto
+++ b/proto/api/v1/backup_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/external_backup.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetExternalBackupsResponse {

--- a/proto/api/v1/central_health_service.proto
+++ b/proto/api/v1/central_health_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetUpgradeStatusResponse {

--- a/proto/api/v1/cloud_source_service.proto
+++ b/proto/api/v1/cloud_source_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // CloudSource is an integration which provides a source for discovered

--- a/proto/api/v1/cluster_init_service.proto
+++ b/proto/api/v1/cluster_init_service.proto
@@ -7,7 +7,7 @@ import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/user.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message InitBundleMeta {

--- a/proto/api/v1/cluster_service.proto
+++ b/proto/api/v1/cluster_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/cluster.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 enum DeploymentFormat {

--- a/proto/api/v1/common.proto
+++ b/proto/api/v1/common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v1;
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ResourceByID {

--- a/proto/api/v1/compliance_management_service.proto
+++ b/proto/api/v1/compliance_management_service.proto
@@ -5,7 +5,7 @@ package v1;
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ComplianceRunSelection {

--- a/proto/api/v1/compliance_service.proto
+++ b/proto/api/v1/compliance_service.proto
@@ -8,7 +8,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/compliance.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // Next available tag: 4

--- a/proto/api/v1/config_service.proto
+++ b/proto/api/v1/config_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/config.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message PutConfigRequest {

--- a/proto/api/v1/credential_expiry_service.proto
+++ b/proto/api/v1/credential_expiry_service.proto
@@ -5,7 +5,7 @@ package v1;
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetCertExpiry {

--- a/proto/api/v1/cve_service.proto
+++ b/proto/api/v1/cve_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message SuppressCVERequest {

--- a/proto/api/v1/db_service.proto
+++ b/proto/api/v1/db_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message DBRestoreRequestHeader {

--- a/proto/api/v1/debug_service.proto
+++ b/proto/api/v1/debug_service.proto
@@ -8,7 +8,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/role.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetLogLevelRequest {

--- a/proto/api/v1/declarative_config_health_service.proto
+++ b/proto/api/v1/declarative_config_health_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/declarative_config_health.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetDeclarativeConfigHealthsResponse {

--- a/proto/api/v1/delegated_registry_config_service.proto
+++ b/proto/api/v1/delegated_registry_config_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message DelegatedRegistryClustersResponse {

--- a/proto/api/v1/deployment_service.proto
+++ b/proto/api/v1/deployment_service.proto
@@ -10,7 +10,7 @@ import "storage/deployment.proto";
 import "storage/process_baseline.proto";
 import "storage/risk.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message DeploymentLabelsResponse {

--- a/proto/api/v1/detection_service.proto
+++ b/proto/api/v1/detection_service.proto
@@ -6,7 +6,7 @@ import weak "google/api/annotations.proto";
 import "storage/alert.proto";
 import "storage/deployment.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message BuildDetectionRequest {

--- a/proto/api/v1/discovered_cluster_service.proto
+++ b/proto/api/v1/discovered_cluster_service.proto
@@ -6,7 +6,7 @@ import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // DiscoveredCluster represents a cluster discovered from a cloud source.

--- a/proto/api/v1/empty.proto
+++ b/proto/api/v1/empty.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v1;
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message Empty {}

--- a/proto/api/v1/feature_flag_service.proto
+++ b/proto/api/v1/feature_flag_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message FeatureFlag {

--- a/proto/api/v1/group_service.proto
+++ b/proto/api/v1/group_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/group.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetGroupsRequest {

--- a/proto/api/v1/grpc_preference_service.proto
+++ b/proto/api/v1/grpc_preference_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message Preferences {

--- a/proto/api/v1/image_integration_service.proto
+++ b/proto/api/v1/image_integration_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/image_integration.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetImageIntegrationsRequest {

--- a/proto/api/v1/image_service.proto
+++ b/proto/api/v1/image_service.proto
@@ -11,7 +11,7 @@ import "scanner/api/v1/note.proto";
 import "storage/deployment.proto";
 import "storage/image.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetImageRequest {

--- a/proto/api/v1/integration_health_service.proto
+++ b/proto/api/v1/integration_health_service.proto
@@ -7,7 +7,7 @@ import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/integration_health.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetIntegrationHealthResponse {

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/system_info.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message Metadata {

--- a/proto/api/v1/mitre_service.proto
+++ b/proto/api/v1/mitre_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/mitre.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ListMitreAttackVectorsResponse {

--- a/proto/api/v1/namespace_service.proto
+++ b/proto/api/v1/namespace_service.proto
@@ -7,7 +7,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/namespace_metadata.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message Namespace {

--- a/proto/api/v1/network_baseline_service.proto
+++ b/proto/api/v1/network_baseline_service.proto
@@ -8,7 +8,7 @@ import weak "google/api/annotations.proto";
 import "storage/network_baseline.proto";
 import "storage/network_flow.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message NetworkBaselinePeerEntity {

--- a/proto/api/v1/network_graph_service.proto
+++ b/proto/api/v1/network_graph_service.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/network_flow.proto";
 import "storage/network_graph_config.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message NetworkGraphScope {

--- a/proto/api/v1/network_policy_service.proto
+++ b/proto/api/v1/network_policy_service.proto
@@ -12,7 +12,7 @@ import "storage/network_baseline.proto";
 import "storage/network_flow.proto";
 import "storage/network_policy.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // API specific objects.

--- a/proto/api/v1/node_service.proto
+++ b/proto/api/v1/node_service.proto
@@ -5,7 +5,7 @@ package v1;
 import weak "google/api/annotations.proto";
 import "storage/node.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ListNodesRequest {

--- a/proto/api/v1/notifications.proto
+++ b/proto/api/v1/notifications.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v1;
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message NetworkPolicyNotification {

--- a/proto/api/v1/notifier_service.proto
+++ b/proto/api/v1/notifier_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/notifier.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetNotifiersRequest {

--- a/proto/api/v1/pagination.proto
+++ b/proto/api/v1/pagination.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v1;
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message AggregateBy {

--- a/proto/api/v1/ping_service.proto
+++ b/proto/api/v1/ping_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message PongMessage {

--- a/proto/api/v1/pod_service.proto
+++ b/proto/api/v1/pod_service.proto
@@ -6,7 +6,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/deployment.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message PodsResponse {

--- a/proto/api/v1/policy_category_service.proto
+++ b/proto/api/v1/policy_category_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message PolicyCategory {

--- a/proto/api/v1/policy_service.proto
+++ b/proto/api/v1/policy_service.proto
@@ -9,7 +9,7 @@ import weak "google/api/annotations.proto";
 import "storage/mitre.proto";
 import "storage/policy.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message DryRunResponse {

--- a/proto/api/v1/probe_upload_service.proto
+++ b/proto/api/v1/probe_upload_service.proto
@@ -4,7 +4,7 @@ package v1;
 
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ProbeUploadManifest {

--- a/proto/api/v1/process_baseline_service.proto
+++ b/proto/api/v1/process_baseline_service.proto
@@ -5,7 +5,7 @@ package v1;
 import weak "google/api/annotations.proto";
 import "storage/process_baseline.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // These protobuf messages replace the family of existing *ProcessWhitelists* ones

--- a/proto/api/v1/process_listening_on_port_service.proto
+++ b/proto/api/v1/process_listening_on_port_service.proto
@@ -5,7 +5,7 @@ package v1;
 import weak "google/api/annotations.proto";
 import "storage/process_listening_on_port.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetProcessesListeningOnPortsRequest {

--- a/proto/api/v1/process_service.proto
+++ b/proto/api/v1/process_service.proto
@@ -6,7 +6,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/process_indicator.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetProcessesByDeploymentRequest {

--- a/proto/api/v1/rbac_service.proto
+++ b/proto/api/v1/rbac_service.proto
@@ -7,7 +7,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/rbac.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // API specific objects.

--- a/proto/api/v1/report_configuration_service.proto
+++ b/proto/api/v1/report_configuration_service.proto
@@ -8,7 +8,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/report_configuration.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetReportConfigurationsResponse {

--- a/proto/api/v1/report_service.proto
+++ b/proto/api/v1/report_service.proto
@@ -6,7 +6,7 @@ import "api/v1/common.proto";
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 service ReportService {

--- a/proto/api/v1/resource_collection_service.proto
+++ b/proto/api/v1/resource_collection_service.proto
@@ -9,7 +9,7 @@ import weak "google/api/annotations.proto";
 import "storage/deployment.proto";
 import "storage/resource_collection.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ListCollectionSelectorsResponse {

--- a/proto/api/v1/role_service.proto
+++ b/proto/api/v1/role_service.proto
@@ -8,7 +8,7 @@ import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 import "storage/role.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // storage.Access values should be in escalating order. IE READ_WRITE means you have READ as well.

--- a/proto/api/v1/search_service.proto
+++ b/proto/api/v1/search_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // Next available tag: 70

--- a/proto/api/v1/secret_service.proto
+++ b/proto/api/v1/secret_service.proto
@@ -7,7 +7,7 @@ import "api/v1/search_service.proto";
 import weak "google/api/annotations.proto";
 import "storage/secret.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // API specific objects.

--- a/proto/api/v1/sensor_upgrade_service.proto
+++ b/proto/api/v1/sensor_upgrade_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/sensor_upgrade.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message UpdateSensorUpgradeConfigRequest {

--- a/proto/api/v1/service_account_service.proto
+++ b/proto/api/v1/service_account_service.proto
@@ -9,7 +9,7 @@ import weak "google/api/annotations.proto";
 import "storage/rbac.proto";
 import "storage/service_account.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // API specific objects.

--- a/proto/api/v1/service_identity_service.proto
+++ b/proto/api/v1/service_identity_service.proto
@@ -6,7 +6,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/service_identity.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ServiceIdentityResponse {

--- a/proto/api/v1/signal.proto
+++ b/proto/api/v1/signal.proto
@@ -5,7 +5,7 @@ package v1;
 import "storage/process_indicator.proto";
 
 option cc_enable_arenas = true;
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // Signal message tracks process and network activity.

--- a/proto/api/v1/signature_integration_service.proto
+++ b/proto/api/v1/signature_integration_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/signature_integration.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ListSignatureIntegrationsResponse {

--- a/proto/api/v1/summary_service.proto
+++ b/proto/api/v1/summary_service.proto
@@ -5,7 +5,7 @@ package v1;
 import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message SummaryCountsResponse {

--- a/proto/api/v1/telemetry_service.proto
+++ b/proto/api/v1/telemetry_service.proto
@@ -7,7 +7,7 @@ import weak "google/api/annotations.proto";
 import "internalapi/central/telemetry.proto";
 import "storage/telemetry.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message ConfigureTelemetryRequest {

--- a/proto/api/v1/user_service.proto
+++ b/proto/api/v1/user_service.proto
@@ -7,7 +7,7 @@ import "api/v1/empty.proto";
 import weak "google/api/annotations.proto";
 import "storage/user.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 // Next Tag: 2

--- a/proto/api/v1/vuln_req_service.proto
+++ b/proto/api/v1/vuln_req_service.proto
@@ -9,7 +9,7 @@ import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "storage/vuln_requests.proto";
 
-option go_package = "v1";
+option go_package = "./;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
 message GetVulnerabilityRequestResponse {

--- a/proto/api/v2/common.proto
+++ b/proto/api/v2/common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v2;
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 message ResourceByID {

--- a/proto/api/v2/compliance_integration_service.proto
+++ b/proto/api/v2/compliance_integration_service.proto
@@ -5,7 +5,7 @@ package v2;
 import "api/v2/search_query.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 // Next Tag: 8

--- a/proto/api/v2/compliance_profile_service.proto
+++ b/proto/api/v2/compliance_profile_service.proto
@@ -6,7 +6,7 @@ import "api/v2/common.proto";
 import "api/v2/search_query.proto";
 import weak "google/api/annotations.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 // Next Tag: 11

--- a/proto/api/v2/compliance_results_service.proto
+++ b/proto/api/v2/compliance_results_service.proto
@@ -7,7 +7,7 @@ import "api/v2/search_query.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 enum ComplianceCheckStatus {

--- a/proto/api/v2/compliance_scan_configuration_service.proto
+++ b/proto/api/v2/compliance_scan_configuration_service.proto
@@ -8,7 +8,7 @@ import "api/v2/user.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 // ClusterScanStatus holds status based on cluster in the event that a scan configuration

--- a/proto/api/v2/pagination.proto
+++ b/proto/api/v2/pagination.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v2;
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 message AggregateBy {

--- a/proto/api/v2/report_service.proto
+++ b/proto/api/v2/report_service.proto
@@ -8,7 +8,7 @@ import "api/v2/user.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 message ReportConfiguration {

--- a/proto/api/v2/search_query.proto
+++ b/proto/api/v2/search_query.proto
@@ -4,7 +4,7 @@ package v2;
 
 import "api/v2/pagination.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 // RawQuery represents the search query string.

--- a/proto/api/v2/user.proto
+++ b/proto/api/v2/user.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v2;
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 message SlimUser {

--- a/proto/api/v2/vuln_exception_service.proto
+++ b/proto/api/v2/vuln_exception_service.proto
@@ -9,7 +9,7 @@ import "api/v2/vuln_state.proto";
 import weak "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 //// begin request and response messages

--- a/proto/api/v2/vuln_state.proto
+++ b/proto/api/v2/vuln_state.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v2;
 
-option go_package = "v2";
+option go_package = "./;v2";
 option java_package = "io.stackrox.proto.api.v2";
 
 // VulnerabilityState are the possible applicable to CVE. By default all vulnerabilities are in observed state.

--- a/proto/internalapi/central/auth.proto
+++ b/proto/internalapi/central/auth.proto
@@ -4,7 +4,7 @@ package central;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message ServiceCertAuth {
   bytes cert_der = 1;

--- a/proto/internalapi/central/baseline_sync.proto
+++ b/proto/internalapi/central/baseline_sync.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/process_baseline.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message BaselineSync {
   repeated storage.ProcessBaseline baselines = 1;

--- a/proto/internalapi/central/cluster_config.proto
+++ b/proto/internalapi/central/cluster_config.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/cluster.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message ClusterConfig {
   storage.DynamicClusterConfig config = 1;

--- a/proto/internalapi/central/cluster_metrics.proto
+++ b/proto/internalapi/central/cluster_metrics.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package central;
 
-option go_package = "central";
+option go_package = "./;central";
 
 // ClusterMetrics defines a set of metrics, which are collected by Sensor and
 // send to Central.

--- a/proto/internalapi/central/cluster_status.proto
+++ b/proto/internalapi/central/cluster_status.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/cluster.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message DeploymentEnvironmentUpdate {
   repeated string environments = 1;

--- a/proto/internalapi/central/compliance_operator.proto
+++ b/proto/internalapi/central/compliance_operator.proto
@@ -4,7 +4,7 @@ package central;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 // ComplianceOperatorInfo has basic info and status about the compliance operator.
 message ComplianceOperatorInfo {

--- a/proto/internalapi/central/delegated_registry_config.proto
+++ b/proto/internalapi/central/delegated_registry_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package central;
 
-option go_package = "central";
+option go_package = "./;central";
 
 // DelegatedRegistryConfig determines how to handle scan requests.
 //

--- a/proto/internalapi/central/deployment_enhancement.proto
+++ b/proto/internalapi/central/deployment_enhancement.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/deployment.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message DeploymentEnhancementMessage {
   string id = 1;

--- a/proto/internalapi/central/development_service.proto
+++ b/proto/internalapi/central/development_service.proto
@@ -6,7 +6,7 @@ package central;
 
 import weak "google/api/annotations.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 option java_package = "io.stackrox.proto.internalapi.central";
 
 message URLHasValidCertRequest {

--- a/proto/internalapi/central/hello.proto
+++ b/proto/internalapi/central/hello.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/cluster.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message HelmManagedConfigInit {
   storage.CompleteClusterConfig cluster_config = 1;

--- a/proto/internalapi/central/image.proto
+++ b/proto/internalapi/central/image.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/image_integration.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 // ScanImage is sent to sensor to request a local scan of an image.
 message ScanImage {

--- a/proto/internalapi/central/local_scanner.proto
+++ b/proto/internalapi/central/local_scanner.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/service_identity.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message LocalScannerCertsIssueError {
   string message = 1;

--- a/proto/internalapi/central/network_baseline_sync.proto
+++ b/proto/internalapi/central/network_baseline_sync.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/network_baseline.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message NetworkBaselineSync {
   repeated storage.NetworkBaseline network_baselines = 1;

--- a/proto/internalapi/central/network_flow.proto
+++ b/proto/internalapi/central/network_flow.proto
@@ -5,7 +5,7 @@ package central;
 import "google/protobuf/timestamp.proto";
 import "storage/network_flow.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message NetworkFlowUpdate {
   // Network flows that were added or removed from the last time state was sent to Central.

--- a/proto/internalapi/central/policy_sync.proto
+++ b/proto/internalapi/central/policy_sync.proto
@@ -4,7 +4,7 @@ package central;
 
 import "storage/policy.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message PolicySync {
   repeated storage.Policy policies = 1;

--- a/proto/internalapi/central/process_listening_on_ports_update.proto
+++ b/proto/internalapi/central/process_listening_on_ports_update.proto
@@ -5,7 +5,7 @@ package central;
 import "google/protobuf/timestamp.proto";
 import "storage/process_listening_on_port.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message ProcessListeningOnPortsUpdate {
   repeated storage.ProcessListeningOnPortFromSensor processes_listening_on_ports = 1;

--- a/proto/internalapi/central/sensor_events.proto
+++ b/proto/internalapi/central/sensor_events.proto
@@ -18,7 +18,7 @@ import "storage/rbac.proto";
 import "storage/secret.proto";
 import "storage/service_account.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 enum ResourceAction {
   UNSET_ACTION_RESOURCE = 0;

--- a/proto/internalapi/central/sensor_iservice.proto
+++ b/proto/internalapi/central/sensor_iservice.proto
@@ -22,7 +22,7 @@ import "internalapi/central/telemetry.proto";
 import "storage/cluster.proto";
 import "storage/image.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 // next available tag: 19
 message MsgFromSensor {

--- a/proto/internalapi/central/sensor_upgrade.proto
+++ b/proto/internalapi/central/sensor_upgrade.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package central;
 
-option go_package = "central";
+option go_package = "./;central";
 
 message SensorUpgradeTrigger {
   message EnvVarDef {

--- a/proto/internalapi/central/sensor_upgrade_ctrl_iservice.proto
+++ b/proto/internalapi/central/sensor_upgrade_ctrl_iservice.proto
@@ -4,7 +4,7 @@ package central;
 
 import "google/protobuf/empty.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message UpgradeCheckInFromUpgraderRequest {
   string cluster_id = 5;

--- a/proto/internalapi/central/telemetry.proto
+++ b/proto/internalapi/central/telemetry.proto
@@ -4,7 +4,7 @@ package central;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "central";
+option go_package = "./;central";
 
 message CancelPullTelemetryDataRequest {
   string request_id = 1;

--- a/proto/internalapi/compliance/compliance_data.proto
+++ b/proto/internalapi/compliance/compliance_data.proto
@@ -5,7 +5,7 @@ package compliance;
 import "google/protobuf/timestamp.proto";
 import "storage/compliance.proto";
 
-option go_package = "compliance";
+option go_package = "./;compliance";
 option java_package = "io.stackrox.proto.compliance";
 
 // Next Available Tag: 2

--- a/proto/internalapi/scanner/v4/common.proto
+++ b/proto/internalapi/scanner/v4/common.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 
 package scanner.v4;
 
-option go_package = "v4";
+option go_package = "./;v4";
 
 message Contents {
   repeated Package packages = 1;

--- a/proto/internalapi/scanner/v4/index_report.proto
+++ b/proto/internalapi/scanner/v4/index_report.proto
@@ -7,7 +7,7 @@ package scanner.v4;
 
 import "internalapi/scanner/v4/common.proto";
 
-option go_package = "v4";
+option go_package = "./;v4";
 
 message IndexReport {
   string hash_id = 1;

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -8,7 +8,7 @@ package scanner.v4;
 
 import "internalapi/scanner/v4/index_report.proto";
 
-option go_package = "v4";
+option go_package = "./;v4";
 
 // Provide information to retrieve container images and their layers.
 message ContainerImageLocator {

--- a/proto/internalapi/scanner/v4/matcher_service.proto
+++ b/proto/internalapi/scanner/v4/matcher_service.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "internalapi/scanner/v4/common.proto";
 import "internalapi/scanner/v4/vulnerability_report.proto";
 
-option go_package = "v4";
+option go_package = "./;v4";
 
 message GetVulnerabilitiesRequest {
   string hash_id = 1;

--- a/proto/internalapi/scanner/v4/vulnerability_report.proto
+++ b/proto/internalapi/scanner/v4/vulnerability_report.proto
@@ -9,7 +9,7 @@ package scanner.v4;
 import "google/protobuf/timestamp.proto";
 import "internalapi/scanner/v4/common.proto";
 
-option go_package = "v4";
+option go_package = "./;v4";
 
 message VulnerabilityReport {
   message Vulnerability {

--- a/proto/internalapi/sensor/admission_control.proto
+++ b/proto/internalapi/sensor/admission_control.proto
@@ -9,7 +9,7 @@ import "storage/deployment.proto";
 import "storage/namespace_metadata.proto";
 import "storage/policy.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message AdmissionControlSettings {
   storage.DynamicClusterConfig cluster_config = 1;

--- a/proto/internalapi/sensor/admission_control_iservice.proto
+++ b/proto/internalapi/sensor/admission_control_iservice.proto
@@ -5,7 +5,7 @@ package sensor;
 import "google/protobuf/empty.proto";
 import "internalapi/sensor/admission_control.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message MsgFromAdmissionControl {}
 

--- a/proto/internalapi/sensor/cert_distribution_iservice.proto
+++ b/proto/internalapi/sensor/cert_distribution_iservice.proto
@@ -4,7 +4,7 @@ package sensor;
 
 import "storage/service_identity.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message FetchCertificateRequest {
   storage.ServiceType service_type = 1;

--- a/proto/internalapi/sensor/collector.proto
+++ b/proto/internalapi/sensor/collector.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package sensor;
 
 option cc_enable_arenas = true;
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 // A request message sent by collector to register with Sensor. Typically the first message in any streams.
 message CollectorRegisterRequest {

--- a/proto/internalapi/sensor/compliance_iservice.proto
+++ b/proto/internalapi/sensor/compliance_iservice.proto
@@ -8,7 +8,7 @@ import "storage/container_runtime.proto";
 import "storage/kube_event.proto";
 import "storage/node.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message GetScrapeConfigRequest {
   string node_name = 1;

--- a/proto/internalapi/sensor/deployment_iservice.proto
+++ b/proto/internalapi/sensor/deployment_iservice.proto
@@ -4,7 +4,7 @@ package sensor;
 
 import "storage/deployment.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message GetDeploymentForPodRequest {
   string pod_name = 1;

--- a/proto/internalapi/sensor/image_iservice.proto
+++ b/proto/internalapi/sensor/image_iservice.proto
@@ -5,7 +5,7 @@ package sensor;
 import "storage/deployment.proto";
 import "storage/image.proto";
 
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message GetImageRequest {
   storage.ContainerImage image = 1;

--- a/proto/internalapi/sensor/network_connection_info.proto
+++ b/proto/internalapi/sensor/network_connection_info.proto
@@ -8,7 +8,7 @@ import "storage/network_flow.proto";
 import "storage/process_indicator.proto";
 
 option cc_enable_arenas = true;
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message NetworkConnectionInfo {
   // Network connections that were added from the last time state was sent.

--- a/proto/internalapi/sensor/network_connection_iservice.proto
+++ b/proto/internalapi/sensor/network_connection_iservice.proto
@@ -6,7 +6,7 @@ import "internalapi/sensor/collector.proto";
 import "internalapi/sensor/network_connection_info.proto";
 
 option cc_enable_arenas = true;
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 message NetworkConnectionInfoMessage {
   oneof msg {

--- a/proto/internalapi/sensor/network_enums.proto
+++ b/proto/internalapi/sensor/network_enums.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package sensor;
 
 option cc_enable_arenas = true;
-option go_package = "sensor";
+option go_package = "./;sensor";
 option java_package = "io.stackrox.proto.api.v1";
 
 enum ClientServerRole {

--- a/proto/internalapi/sensor/signal_iservice.proto
+++ b/proto/internalapi/sensor/signal_iservice.proto
@@ -7,7 +7,7 @@ import "api/v1/signal.proto";
 import "internalapi/sensor/collector.proto";
 
 option cc_enable_arenas = true;
-option go_package = "sensor";
+option go_package = "./;sensor";
 
 // A single message in the event stream between Collector and Sensor.
 message SignalStreamMessage {

--- a/proto/internalapi/wrapper/splunk_alert.proto
+++ b/proto/internalapi/wrapper/splunk_alert.proto
@@ -4,7 +4,7 @@ package wrapper;
 
 import "google/protobuf/any.proto";
 
-option go_package = "wrapper";
+option go_package = "./;wrapper";
 
 // Splunk notification needs the source of data
 // and the type of data.

--- a/proto/storage/active_component.proto
+++ b/proto/storage/active_component.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next available tag: 3

--- a/proto/storage/administration_event.proto
+++ b/proto/storage/administration_event.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // AdministrationEvent is the storage representation of administrative events in Central.

--- a/proto/storage/administration_usage.proto
+++ b/proto/storage/administration_usage.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // SecuredUnits represents a record of an aggregated secured clusters usage

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -8,7 +8,7 @@ import "storage/network_flow.proto";
 import "storage/policy.proto";
 import "storage/process_indicator.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Alert {

--- a/proto/storage/api_token.proto
+++ b/proto/storage/api_token.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message TokenMetadata {

--- a/proto/storage/auth_machine_to_machine.proto
+++ b/proto/storage/auth_machine_to_machine.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // AuthMachineToMachineConfig is the storage representation of auth machine to machine configs in Central.

--- a/proto/storage/auth_provider.proto
+++ b/proto/storage/auth_provider.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/traits.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 15.

--- a/proto/storage/blob.proto
+++ b/proto/storage/blob.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 7

--- a/proto/storage/cloud_source.proto
+++ b/proto/storage/cloud_source.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message CloudSource {

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 enum ClusterType {

--- a/proto/storage/cluster_init.proto
+++ b/proto/storage/cluster_init.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message InitBundleMeta {

--- a/proto/storage/common.proto
+++ b/proto/storage/common.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message KeyValuePair {

--- a/proto/storage/compliance.proto
+++ b/proto/storage/compliance.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/image.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ComplianceResource {

--- a/proto/storage/compliance_config.proto
+++ b/proto/storage/compliance_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ComplianceConfig {

--- a/proto/storage/compliance_integration.proto
+++ b/proto/storage/compliance_integration.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 7

--- a/proto/storage/compliance_operator.proto
+++ b/proto/storage/compliance_operator.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 10

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/schedule.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Represents the role of the node within the cluster

--- a/proto/storage/config.proto
+++ b/proto/storage/config.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/telemetry.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message LoginNotice {

--- a/proto/storage/container_runtime.proto
+++ b/proto/storage/container_runtime.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 enum ContainerRuntime {

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // VulnerabilityState indicates if vulnerability is being observed or deferred(/suppressed). By default, it vulnerabilities are observed.

--- a/proto/storage/declarative_config_health.proto
+++ b/proto/storage/declarative_config_health.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message DeclarativeConfigHealth {

--- a/proto/storage/delegated_registry_config.proto
+++ b/proto/storage/delegated_registry_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // DelegatedRegistryConfig determines how to handle scan requests.

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -9,7 +9,7 @@ import "storage/labels.proto";
 import "storage/rbac.proto";
 import "storage/taints.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next available tag: 35

--- a/proto/storage/discovered_cluster.proto
+++ b/proto/storage/discovered_cluster.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/cluster.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // DiscoveredCluster is the storage representation of discovered clusters.

--- a/proto/storage/external_backup.proto
+++ b/proto/storage/external_backup.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/schedule.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ExternalBackup {

--- a/proto/storage/group.proto
+++ b/proto/storage/group.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/traits.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Group is a GroupProperties : Role mapping.

--- a/proto/storage/hash.proto
+++ b/proto/storage/hash.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Hash {

--- a/proto/storage/helm_cluster.proto
+++ b/proto/storage/helm_cluster.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/cluster.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message HelmCluster {

--- a/proto/storage/http_endpoint.proto
+++ b/proto/storage/http_endpoint.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/common.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message HTTPEndpointConfig {

--- a/proto/storage/image.proto
+++ b/proto/storage/image.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/vulnerability.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 19

--- a/proto/storage/image_component.proto
+++ b/proto/storage/image_component.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/image.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ImageComponent {

--- a/proto/storage/image_integration.proto
+++ b/proto/storage/image_integration.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 25

--- a/proto/storage/installation.proto
+++ b/proto/storage/installation.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message InstallationInfo {

--- a/proto/storage/integration_health.proto
+++ b/proto/storage/integration_health.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message IntegrationHealth {

--- a/proto/storage/kube_event.proto
+++ b/proto/storage/kube_event.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message KubernetesEvent {

--- a/proto/storage/labels.proto
+++ b/proto/storage/labels.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Label selector components are joined with logical AND, see

--- a/proto/storage/log.proto
+++ b/proto/storage/log.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message LogImbue {

--- a/proto/storage/mitre.proto
+++ b/proto/storage/mitre.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message MitreTactic {

--- a/proto/storage/namespace_metadata.proto
+++ b/proto/storage/namespace_metadata.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NamespaceMetadata {

--- a/proto/storage/network_baseline.proto
+++ b/proto/storage/network_baseline.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/network_flow.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // NetworkBaselineConnectionProperties represents information about a baseline connection

--- a/proto/storage/network_flow.proto
+++ b/proto/storage/network_flow.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NetworkFlow {

--- a/proto/storage/network_graph_config.proto
+++ b/proto/storage/network_graph_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NetworkGraphConfig {

--- a/proto/storage/network_policy.proto
+++ b/proto/storage/network_policy.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/labels.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NetworkPolicy {

--- a/proto/storage/node.proto
+++ b/proto/storage/node.proto
@@ -7,7 +7,7 @@ import "storage/container_runtime.proto";
 import "storage/taints.proto";
 import "storage/vulnerability.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Node represents information about a node in the cluster.

--- a/proto/storage/node_component.proto
+++ b/proto/storage/node_component.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NodeComponent {

--- a/proto/storage/node_integration.proto
+++ b/proto/storage/node_integration.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/image_integration.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 6

--- a/proto/storage/notification_schedule.proto
+++ b/proto/storage/notification_schedule.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message NotificationSchedule {

--- a/proto/storage/notifier.proto
+++ b/proto/storage/notifier.proto
@@ -6,7 +6,7 @@ import "storage/common.proto";
 import "storage/policy.proto";
 import "storage/traits.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 19

--- a/proto/storage/notifier_enc_config.proto
+++ b/proto/storage/notifier_enc_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 2

--- a/proto/storage/operation_status.proto
+++ b/proto/storage/operation_status.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 enum OperationStatus {

--- a/proto/storage/orchestrator_integration.proto
+++ b/proto/storage/orchestrator_integration.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/image_integration.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 5

--- a/proto/storage/policy.proto
+++ b/proto/storage/policy.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/image.proto";
 import "storage/scope.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Policy {

--- a/proto/storage/policy_category.proto
+++ b/proto/storage/policy_category.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package storage;
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message PolicyCategory {

--- a/proto/storage/process_baseline.proto
+++ b/proto/storage/process_baseline.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // These protobuf messages replace the family of existing ProcessWhitelists* ones

--- a/proto/storage/process_indicator.proto
+++ b/proto/storage/process_indicator.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next available tag: 13

--- a/proto/storage/process_listening_on_port.proto
+++ b/proto/storage/process_listening_on_port.proto
@@ -7,7 +7,7 @@ import "storage/network_flow.proto";
 import "storage/process_indicator.proto";
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 
 // The API returns an array of these
 message ProcessListeningOnPort {

--- a/proto/storage/rbac.proto
+++ b/proto/storage/rbac.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 enum SubjectKind {

--- a/proto/storage/relations.proto
+++ b/proto/storage/relations.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/cve.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 //// Image related relations.

--- a/proto/storage/report_configuration.proto
+++ b/proto/storage/report_configuration.proto
@@ -8,7 +8,7 @@ import "storage/role.proto";
 import "storage/schedule.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ReportConfiguration {

--- a/proto/storage/report_snapshot.proto
+++ b/proto/storage/report_snapshot.proto
@@ -7,7 +7,7 @@ import "storage/report_configuration.proto";
 import "storage/schedule.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // ReportSnapshot stores the snapshot of a report job. It stores a projection of ReportConfiguration, collection,

--- a/proto/storage/resource_collection.proto
+++ b/proto/storage/resource_collection.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/policy.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ResourceCollection {

--- a/proto/storage/risk.proto
+++ b/proto/storage/risk.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Risk {

--- a/proto/storage/role.proto
+++ b/proto/storage/role.proto
@@ -5,7 +5,7 @@ package storage;
 import "storage/labels.proto";
 import "storage/traits.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // A role specifies which actions are allowed for which subset of cluster

--- a/proto/storage/schedule.proto
+++ b/proto/storage/schedule.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Schedule {

--- a/proto/storage/scope.proto
+++ b/proto/storage/scope.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Scope {

--- a/proto/storage/secret.proto
+++ b/proto/storage/secret.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // We use a graph model of the data in the backend.

--- a/proto/storage/sensor_upgrade.proto
+++ b/proto/storage/sensor_upgrade.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // SensorUpgradeConfig encapsulates configuration relevant to sensor auto-upgrades.

--- a/proto/storage/service_account.proto
+++ b/proto/storage/service_account.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Any properties of an individual service account.

--- a/proto/storage/service_identity.proto
+++ b/proto/storage/service_identity.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message ServiceIdentity {

--- a/proto/storage/signature_integration.proto
+++ b/proto/storage/signature_integration.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message SignatureIntegration {

--- a/proto/storage/system_info.proto
+++ b/proto/storage/system_info.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/operation_status.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message BackupInfo {

--- a/proto/storage/taints.proto
+++ b/proto/storage/taints.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 enum TaintEffect {

--- a/proto/storage/telemetry.proto
+++ b/proto/storage/telemetry.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message TelemetryConfiguration {

--- a/proto/storage/test.proto
+++ b/proto/storage/test.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message TestSingleKeyStruct {

--- a/proto/storage/traits.proto
+++ b/proto/storage/traits.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package storage;
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Traits {

--- a/proto/storage/user.proto
+++ b/proto/storage/user.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "storage/role.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message SlimUser {

--- a/proto/storage/version.proto
+++ b/proto/storage/version.proto
@@ -4,7 +4,7 @@ package storage;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message Version {

--- a/proto/storage/vuln_requests.proto
+++ b/proto/storage/vuln_requests.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "storage/cve.proto";
 import "storage/user.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 message RequestComment {

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -5,7 +5,7 @@ package storage;
 import "google/protobuf/timestamp.proto";
 import "storage/cve.proto";
 
-option go_package = "storage";
+option go_package = "./;storage";
 option java_package = "io.stackrox.proto.storage";
 
 // Next Tag: 21

--- a/proto/test/test.proto
+++ b/proto/test/test.proto
@@ -5,7 +5,7 @@ package test;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "test";
+option go_package = "./;test";
 option java_package = "io.stackrox.proto.test";
 
 message TestCloneSubMessage {


### PR DESCRIPTION
## Description

This PR prepares our proto files for next version of protobuf that requires go packages to have `/` in package name
See: 
- https://github.com/techschool/pcbook-go/issues/3#issuecomment-823206034

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

`make proto-generated-srcs`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
