### PR TITLE
chore(slices): use stdlib slices.Clone

### DIFF
--- a/central/administration/events/datastore/internal/writer/writer_impl.go
+++ b/central/administration/events/datastore/internal/writer/writer_impl.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/administration/events/datastore/internal/store"
@@ -45,7 +46,7 @@ func (c *writerImpl) flushNoLock(ctx context.Context) error {
 		return nil
 	}
 
-	eventsToAdd := sliceutils.ShallowClone(maputil.Values(c.buffer))
+	eventsToAdd := slices.Clone(maputil.Values(c.buffer))
 
 	ids := protoutils.GetIDs(eventsToAdd)
 	// The events we currently hold in the buffer are de-duplicated within the context of the buffer. However, they are

--- a/central/deploymentenvs/manager_impl.go
+++ b/central/deploymentenvs/manager_impl.go
@@ -2,12 +2,12 @@ package deploymentenvs
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/deploymentenvs"
 	"github.com/stackrox/rox/pkg/providers"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -97,7 +97,7 @@ func (m *manager) GetDeploymentEnvironmentsByClusterID(block bool) map[string][]
 	result := make(map[string][]string, len(m.deploymentEnvsByClusterID))
 
 	for clusterID, envs := range m.deploymentEnvsByClusterID {
-		result[clusterID] = sliceutils.ShallowClone(envs)
+		result[clusterID] = slices.Clone(envs)
 	}
 
 	return result

--- a/central/networkpolicies/graph/diff.go
+++ b/central/networkpolicies/graph/diff.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -27,7 +28,7 @@ func adjacentNodeIDsToMap(adjacencies []string) map[string]*v1.NetworkEdgeProper
 }
 
 func getPolicyIDs(node *v1.NetworkNode) []string {
-	result := sliceutils.ShallowClone(node.GetPolicyIds())
+	result := slices.Clone(node.GetPolicyIds())
 	sort.Strings(result)
 	return result
 }

--- a/central/networkpolicies/graph/diff_test.go
+++ b/central/networkpolicies/graph/diff_test.go
@@ -1,13 +1,13 @@
 package graph
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ type nodeSpec struct {
 type nodeSpecMap map[string]nodeSpec
 
 func sortedIDs(ids []string) []string {
-	result := sliceutils.ShallowClone(ids)
+	result := slices.Clone(ids)
 	sort.Strings(result)
 	return result
 }

--- a/pkg/concurrency/key_fence.go
+++ b/pkg/concurrency/key_fence.go
@@ -2,6 +2,7 @@ package concurrency
 
 import (
 	"bytes"
+	"slices"
 
 	"github.com/stackrox/rox/pkg/concurrency/sortedkeys"
 	"github.com/stackrox/rox/pkg/dbhelper"
@@ -150,8 +151,8 @@ func (rks *rangeKeySetImpl) Equals(in KeySet) bool {
 
 func (rks *rangeKeySetImpl) Clone() KeySet {
 	return &rangeKeySetImpl{
-		lower: sliceutils.ShallowClone(rks.lower),
-		upper: sliceutils.ShallowClone(rks.upper),
+		lower: slices.Clone(rks.lower),
+		upper: slices.Clone(rks.upper),
 	}
 }
 
@@ -192,7 +193,7 @@ func (pkr *prefixKeySetImpl) Equals(in KeySet) bool {
 
 func (pkr *prefixKeySetImpl) Clone() KeySet {
 	return &prefixKeySetImpl{
-		prefix: sliceutils.ShallowClone(pkr.prefix),
+		prefix: slices.Clone(pkr.prefix),
 	}
 }
 

--- a/pkg/concurrency/sortedkeys/serialization.go
+++ b/pkg/concurrency/sortedkeys/serialization.go
@@ -3,14 +3,13 @@ package sortedkeys
 import (
 	"encoding/binary"
 	"errors"
-
-	"github.com/stackrox/rox/pkg/sliceutils"
+	"slices"
 )
 
 // Unmarshal unmarshals a set of SortedKeys.
 func Unmarshal(marshalled []byte) (SortedKeys, error) {
 	var unmarshalled SortedKeys
-	buf := sliceutils.ShallowClone(marshalled)
+	buf := slices.Clone(marshalled)
 	for len(buf) >= 2 {
 		// First two bytes encode the length.
 		length := decodeLength(buf[:2])

--- a/pkg/dbhelper/db.go
+++ b/pkg/dbhelper/db.go
@@ -2,8 +2,7 @@ package dbhelper
 
 import (
 	"bytes"
-
-	"github.com/stackrox/rox/pkg/sliceutils"
+	"slices"
 )
 
 var (
@@ -30,7 +29,7 @@ func GetPrefix(key []byte) (prefix []byte) {
 	if idx == -1 {
 		return nil
 	}
-	return sliceutils.ShallowClone(key[:idx])
+	return slices.Clone(key[:idx])
 }
 
 // HasPrefix returns if the given key has the given prefix.

--- a/pkg/grpc/client/authn/servicecerttoken/client_creds.go
+++ b/pkg/grpc/client/authn/servicecerttoken/client_creds.go
@@ -5,12 +5,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/grpc/common/authn/servicecerttoken"
 	"github.com/stackrox/rox/pkg/httputil"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -43,7 +43,7 @@ func NewServiceCertInjectingRoundTripper(cert *tls.Certificate, rt http.RoundTri
 		reqShallowCopy := *req
 		newHeader := make(http.Header)
 		for k, vs := range req.Header {
-			newHeader[k] = sliceutils.ShallowClone(vs)
+			newHeader[k] = slices.Clone(vs)
 		}
 
 		newHeader.Set("authorization", fmt.Sprintf("%s %s", servicecerttoken.TokenType, token))

--- a/pkg/ioutils/chan_writer.go
+++ b/pkg/ioutils/chan_writer.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-
-	"github.com/stackrox/rox/pkg/sliceutils"
+	"slices"
 )
 
 var (
@@ -44,7 +43,7 @@ func (w *chanWriter) Write(buf []byte) (int, error) {
 	}
 
 	select {
-	case w.ch <- sliceutils.ShallowClone(buf):
+	case w.ch <- slices.Clone(buf):
 		return len(buf), nil
 	case <-w.ctx.Done():
 		w.err = w.ctx.Err()

--- a/pkg/istioutils/istio_api_resources.go
+++ b/pkg/istioutils/istio_api_resources.go
@@ -1,11 +1,11 @@
 package istioutils
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
@@ -327,5 +327,5 @@ func GetAPIResourcesByVersion(istioVersion string) ([]string, error) {
 
 // ListKnownIstioVersions lists all known istio versions in sorted order.
 func ListKnownIstioVersions() []string {
-	return sliceutils.ShallowClone(allIstioVersions)
+	return slices.Clone(allIstioVersions)
 }

--- a/pkg/mtls/ca.go
+++ b/pkg/mtls/ca.go
@@ -4,12 +4,12 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"slices"
 
 	"github.com/cloudflare/cfssl/helpers"
 	cfsslSigner "github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/sliceutils"
 )
 
 // CA represents a StackRox service certificate authority.
@@ -60,8 +60,8 @@ func LoadCAForValidation(certPEM []byte) (CA, error) {
 
 func loadCA(certPEM, keyPEM []byte, forSigning bool) (CA, error) {
 	ca := &ca{
-		certPEM: sliceutils.ShallowClone(certPEM),
-		keyPEM:  sliceutils.ShallowClone(keyPEM),
+		certPEM: slices.Clone(certPEM),
+		keyPEM:  slices.Clone(keyPEM),
 	}
 
 	if forSigning {
@@ -116,11 +116,11 @@ func (c *ca) PrivateKey() crypto.PrivateKey {
 }
 
 func (c *ca) CertPEM() []byte {
-	return sliceutils.ShallowClone(c.certPEM)
+	return slices.Clone(c.certPEM)
 }
 
 func (c *ca) KeyPEM() []byte {
-	return sliceutils.ShallowClone(c.keyPEM)
+	return slices.Clone(c.keyPEM)
 }
 
 func (c *ca) CertPool() *x509.CertPool {

--- a/pkg/printers/csv.go
+++ b/pkg/printers/csv.go
@@ -4,9 +4,9 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/stackrox/rox/pkg/gjson"
-	"github.com/stackrox/rox/pkg/sliceutils"
 )
 
 // CSVPrinterOption is a functional option for the CSVPrinter.
@@ -15,7 +15,7 @@ type CSVPrinterOption func(*CSVPrinter)
 // WithCSVColumnHeaders is a functional option for setting the CSV column headers.
 func WithCSVColumnHeaders(headers []string) CSVPrinterOption {
 	return func(p *CSVPrinter) {
-		p.columnHeaders = sliceutils.ShallowClone(headers)
+		p.columnHeaders = slices.Clone(headers)
 	}
 }
 

--- a/pkg/sliceutils/clone.go
+++ b/pkg/sliceutils/clone.go
@@ -1,18 +1,6 @@
 package sliceutils
 
-// ShallowClone clones a slice, creating a new slice and copying the contents of the underlying array.
-// If `in` is a nil slice, a nil slice is returned. If `in` is an empty slice, an empty slice is returned.
-func ShallowClone[T any](in []T) []T {
-	if in == nil {
-		return nil
-	}
-	if len(in) == 0 {
-		return []T{}
-	}
-	out := make([]T, len(in))
-	copy(out, in)
-	return out
-}
+import "slices"
 
 // ShallowClone2DSlice clones a 2D slice, creating a new slice and copying the contents of the underlying array.
 // If `in` is a nil slice, a nil slice is returned. If `in` is an empty slice, an empty slice is returned.
@@ -25,7 +13,7 @@ func ShallowClone2DSlice[T any](in [][]T) [][]T {
 	}
 	out := make([][]T, len(in))
 	for idx := range in {
-		out[idx] = ShallowClone[T](in[idx])
+		out[idx] = slices.Clone(in[idx])
 	}
 	return out
 }

--- a/pkg/sliceutils/clone_test.go
+++ b/pkg/sliceutils/clone_test.go
@@ -6,23 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClone(t *testing.T) {
-	a := assert.New(t)
-
-	var slice []string
-	a.Nil(ShallowClone(slice))
-
-	slice = make([]string, 0)
-	a.NotNil(ShallowClone(slice))
-	a.Equal(ShallowClone(slice), []string{})
-
-	slice = append(slice, "a", "b")
-	cloned := ShallowClone(slice)
-	a.Equal([]string{"a", "b"}, cloned)
-	slice[1] = "c"
-	a.Equal([]string{"a", "b"}, cloned)
-}
-
 func Test2DSliceClone(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
## Description

With the release of go1.21 the [slices](https://pkg.go.dev/slices@go1.21.8) package has been added, and we can replace a few of our internal slice utils with it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
