### PR TITLE
chore(slices): use stdlib slices.Reverse

### DIFF
--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -11,9 +11,9 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"slices"
 	"testing"
 
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -232,8 +232,8 @@ func createCertChainWithLengthOf(length int) ([]*x509.Certificate, []*ecdsa.Priv
 		privateKeys = append(privateKeys, privateKey)
 	}
 	// inverse the order of the certs so that the leaf is first
-	sliceutils.ReverseInPlace(certs)
-	sliceutils.ReverseInPlace(privateKeys)
+	slices.Reverse(certs)
+	slices.Reverse(privateKeys)
 	return certs, privateKeys, nil
 }
 

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -18,7 +18,6 @@ func Map[T, U any](slice []T, mapFunc func(T) U) []U {
 
 // MapsIntersect returns true if there is at least one key-value pair that is present in both maps
 // If both, or either maps are empty, it returns false
-// TODO : Convert to generics after upgrade to go 1.18
 func MapsIntersect[K, V comparable](m1 map[K]V, m2 map[K]V) bool {
 	if len(m2) == 0 {
 		return false

--- a/pkg/sliceutils/reverse.go
+++ b/pkg/sliceutils/reverse.go
@@ -1,18 +1,10 @@
 package sliceutils
 
-// ReverseInPlace reverses the elements of the given slice in-place.
-func ReverseInPlace[T any](slice []T) {
-	l := len(slice)
-	for i := 0; i < l/2; i++ {
-		slice[i], slice[l-1-i] = slice[l-1-i], slice[i]
-	}
-}
+import "slices"
 
 // Reversed returns a slice that contains the elements of the input slice in reverse order.
 func Reversed[T any](slice []T) []T {
-	out := make([]T, 0, len(slice))
-	for i := len(slice) - 1; i >= 0; i-- {
-		out = append(out, slice[i])
-	}
-	return out
+	cloned := slices.Clone(slice)
+	slices.Reverse(cloned)
+	return cloned
 }

--- a/pkg/sliceutils/reverse_test.go
+++ b/pkg/sliceutils/reverse_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReverseInPlace(t *testing.T) {
-	in := []string{"foo", "bar", "baz"}
-	ReverseInPlace(in)
-	assert.Equal(t, []string{"baz", "bar", "foo"}, in)
-}
-
 func TestReversed(t *testing.T) {
 	in := []string{"foo", "bar", "baz"}
 	out := Reversed(in)


### PR DESCRIPTION
## Description

With the release of go1.21 the [slices](https://pkg.go.dev/slices@go1.21.8) package has been added, and we can replace a few of our internal slice utils with it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
