### PR TITLE
fix(CI): DefaultPoliciesTest: wait for violations to clear

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -39,7 +39,6 @@ import util.SlackUtil
 
 import org.junit.Assume
 import spock.lang.IgnoreIf
-import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Tag
@@ -575,7 +574,6 @@ class DefaultPoliciesTest extends BaseSpecification {
         return total
     }
 
-    @Retry(count = 3)
     def "Verify that alert counts API is consistent with alerts"()  {
         given:
         def alertReq = queryForDeployments()

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -234,7 +234,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             )
             log.info "Re-disabled policy '${policyName}'"
             if (!expectNoViolations(deploymentName,  policyName, VIOLATION_CLEARED_TIMEOUT)) {
-                log.warn("[ROX-23466] '${policyName}' violation was not cleared before proceeding with other tests")
+                log.warn("[ROX-23466] Policy '${policyName}' violation was not cleared before proceeding with other tests")
                 log.warn("[ROX-23466] This may affect the alert count API test")
             }
         }

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -1,3 +1,4 @@
+import static Services.expectNoViolations
 import static Services.getPolicies
 import static Services.waitForViolation
 
@@ -116,6 +117,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     ]
 
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 300
+    static final private Integer VIOLATION_CLEARED_TIMEOUT = WAIT_FOR_VIOLATION_TIMEOUT
 
     @Shared
     private String gcrId
@@ -223,8 +225,6 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         then:
         "Verify Violation for #policyName is triggered"
-        // Some of these policies require scans so extend the timeout as the scan will be done inline
-        // with our scanner
         assert waitForViolation(deploymentName,  policyName, WAIT_FOR_VIOLATION_TIMEOUT)
 
         cleanup:
@@ -233,6 +233,10 @@ class DefaultPoliciesTest extends BaseSpecification {
                     PolicyServiceOuterClass.PatchPolicyRequest.newBuilder().setId(policy.id).setDisabled(true).build()
             )
             log.info "Re-disabled policy '${policyName}'"
+            if (!expectNoViolations(deploymentName,  policyName, VIOLATION_CLEARED_TIMEOUT)) {
+                log.warn("[ROX-23466] '${policyName}' violation was not cleared before proceeding with other tests")
+                log.warn("[ROX-23466] This may affect the alert count API test")
+            }
         }
 
         where:

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -234,7 +234,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             )
             log.info "Re-disabled policy '${policyName}'"
             if (!expectNoViolations(deploymentName,  policyName, VIOLATION_CLEARED_TIMEOUT)) {
-                log.warn("[ROX-23466] Policy '${policyName}' violation was not cleared before proceeding with other tests")
+                log.warn("[ROX-23466] Policy '${policyName}' violation was not cleared before proceeding")
                 log.warn("[ROX-23466] This may affect the alert count API test")
             }
         }

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -39,6 +39,7 @@ import util.SlackUtil
 
 import org.junit.Assume
 import spock.lang.IgnoreIf
+import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Tag
@@ -574,6 +575,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         return total
     }
 
+    @Retry(count = 3)
     def "Verify that alert counts API is consistent with alerts"()  {
         given:
         def alertReq = queryForDeployments()

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -222,6 +222,22 @@ class Services extends BaseService {
         return violations == null || violations.size() == 0
     }
 
+    static boolean expectNoViolations(String deploymentName, String policyName, int timeoutSeconds = 60) {
+        int intervalSeconds = 3
+        int retries = (timeoutSeconds / intervalSeconds).intValue()
+        String query = "Deployment:${deploymentName}+Policy:${policyName}"
+
+        Timer t = new Timer(retries, intervalSeconds)
+        while (t.IsValid()) {
+            def violations = AlertService.getViolations(ListAlertsRequest.newBuilder().setQuery(query).build())
+            LOG.info "Deployment '${deploymentName}' has ${violations.size()} violation(s) for '${policyName}'"
+            if (violations.size() == 0) {
+                return true
+            }
+        }
+        return false
+    }
+
     static boolean checkForNoViolationsByDeploymentID(String deploymentID, String policyName, int checkSeconds = 5) {
         def violations = getViolationsByDeploymentID(deploymentID, policyName, false, checkSeconds)
         return violations == null || violations.isEmpty()

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -231,7 +231,7 @@ class Services extends BaseService {
         while (t.IsValid()) {
             def violations = AlertService.getViolations(ListAlertsRequest.newBuilder().setQuery(query).build())
             LOG.info "Deployment '${deploymentName}' has ${violations.size()} violation(s) for '${policyName}'"
-            if (violations.size() == 0) {
+            if (violations.isEmpty()) {
                 return true
             }
         }


### PR DESCRIPTION
## Description

The `DefaultPoliciesTest.Verify that alert counts API is consistent with alerts` test flakes because the alerts count API is 1 less compared to the alerts API. e.g. [1](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-ocp-4-11-merge-qa-e2e-tests/1768047113523957760) & [2](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-aro-qa-e2e-tests/1775317181928574976). I suspect this is due to the `Verify policy X is triggered` test enabling and disabling a policy. This PR adds a wait to that test for the alert to clear before proceeding. If all is well that will avoid the flake and if not it will help with debug.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI+:
- `ci-all-qa-tests` to exercise the alert count API test
- OCP QA to verify that the wait for the alert to clear runs as expected

The additional wait is visible in GKE and OCP logs:
```
DefaultPoliciesTest > Verify policy #policyName is triggered > Verify policy Curl in Image is triggered STANDARD_OUT
    20:11:11 | INFO  | DefaultPoliciesTest       | DefaultPoliciesTest       | Starting testcase: Verify policy Curl in Image is triggered
    20:11:12 | INFO  | DefaultPoliciesTest       | DefaultPoliciesTest       | Temporarily enabled policy 'Curl in Image'
    20:11:15 | INFO  | DefaultPoliciesTest       | Services                  | violation size is: 1
    20:11:15 | INFO  | DefaultPoliciesTest       | Services                  | Curl in Image triggered after waiting 3 seconds
    20:11:15 | INFO  | DefaultPoliciesTest       | DefaultPoliciesTest       | Re-disabled policy 'Curl in Image'
    20:11:15 | INFO  | DefaultPoliciesTest       | Services                  | Deployment 'qadefpolstruts' has 1 violation(s) for 'Curl in Image'
    20:11:18 | INFO  | DefaultPoliciesTest       | Services                  | Deployment 'qadefpolstruts' has 0 violation(s) for 'Curl in Image'
    20:11:18 | INFO  | DefaultPoliciesTest       | DefaultPoliciesTest       | Ending testcase
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
