### PR TITLE
Revert "ROX-22724: registry timeout env vars"

### DIFF
--- a/pkg/env/registry.go
+++ b/pkg/env/registry.go
@@ -1,27 +1,7 @@
 package env
 
-import "time"
-
 var (
 	// DisableRegistryRepoList disables building and matching registry integrations using
 	// repo lists (`/v2/_catalog`).
 	DisableRegistryRepoList = RegisterBooleanSetting("ROX_DISABLE_REGISTRY_REPO_LIST", false)
-
-	// RegistryDialerTimeout is the net.Dialer timeout of the client transport.
-	// It limits the time the dialer attempts the connection. The timeout is
-	// chosen as a small value to prevent unavailable registries from blocking
-	// image scanning. When connecting to a proxy, this timeout only limits the
-	// connection attempt to the proxy and not the proxy target.
-	RegistryDialerTimeout = registerDurationSetting("ROX_REGISTRY_DIALER_TIMEOUT", 5*time.Second)
-
-	// RegistryResponseTimeout is the response header timeout of the client transport.
-	// It limits the time to wait for a server's response headers after fully
-	// writing the request.
-	RegistryResponseTimeout = registerDurationSetting("ROX_REGISTRY_RESPONSE_TIMEOUT", 10*time.Second)
-
-	// RegistryClientTimeout is used as http.Client.Timeout for the registry's HTTP
-	// client and hence includes everything from connection to reading the
-	// response body. This timeout must not be chosen too large because it serves
-	// as a connection timeout for proxied registries.
-	RegistryClientTimeout = registerDurationSetting("ROX_REGISTRY_CLIENT_TIMEOUT", 10*time.Second)
 )

--- a/pkg/registries/docker/config.go
+++ b/pkg/registries/docker/config.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/urlfmt"
@@ -53,14 +52,14 @@ func (c *Config) formatURL() string {
 // DefaultTransport returns the default transport based on the configuration.
 func DefaultTransport(cfg *Config) registry.Transport {
 	transport := proxy.RoundTripper(
-		proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
-		proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
+		proxy.WithDialTimeout(registryDialerTimeout),
+		proxy.WithResponseHeaderTimeout(registryResponseTimeout),
 	)
 	if cfg.Insecure {
 		transport = proxy.RoundTripper(
 			proxy.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-			proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
-			proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
+			proxy.WithDialTimeout(registryDialerTimeout),
+			proxy.WithResponseHeaderTimeout(registryResponseTimeout),
 		)
 	}
 	username, password := cfg.GetCredentials()

--- a/pkg/registries/docker/docker_integration_test.go
+++ b/pkg/registries/docker/docker_integration_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func TestGetMetadataIntegration(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	dockerHubClient, err := NewDockerRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{
@@ -35,9 +32,6 @@ func TestGetMetadataIntegration(t *testing.T) {
 }
 
 func TestOCIImageIndexManifest(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	gcrClient, err := NewDockerRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{
@@ -61,9 +55,6 @@ func TestOCIImageIndexManifest(t *testing.T) {
 }
 
 func TestOCIImageIndexManifestWithoutManifestCall(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	gcrClient, err := NewRegistryWithoutManifestCall(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{

--- a/pkg/registries/google/google_integration_test.go
+++ b/pkg/registries/google/google_integration_test.go
@@ -18,9 +18,6 @@ func TestGoogle(t *testing.T) {
 		t.Skip("SERVICE_ACCOUNT env variable required")
 		return
 	}
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Google{
 			Google: &storage.GoogleConfig{

--- a/pkg/registries/ibm/ibm_integration_test.go
+++ b/pkg/registries/ibm/ibm_integration_test.go
@@ -18,9 +18,6 @@ const (
 
 func TestIBM(t *testing.T) {
 	t.Skip("This registry is currently broken (ROX-3589)")
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	reg, err := newRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Ibm{
 			Ibm: &storage.IBMRegistryConfig{

--- a/pkg/registries/nexus/nexus_integration_test.go
+++ b/pkg/registries/nexus/nexus_integration_test.go
@@ -12,9 +12,6 @@ import (
 
 // This requires a Nexus Sonatype registry with a proxy to Dockerhub
 func TestNexus(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	endpoint := os.Getenv("NEXUS_ENDPOINT")
 	if endpoint == "" {
 		t.Skipf("ENDPOINT is required for Nexus integration test")

--- a/pkg/registries/quay/quay_integration_test.go
+++ b/pkg/registries/quay/quay_integration_test.go
@@ -16,9 +16,6 @@ const (
 )
 
 func TestQuay(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Quay{
 			Quay: &storage.QuayConfig{

--- a/pkg/registries/rhel/rhel_integration_test.go
+++ b/pkg/registries/rhel/rhel_integration_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestRHEL(t *testing.T) {
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
-
 	_, creator := Creator()
 	reg, err := creator(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{

--- a/pkg/scanners/google/google_integration_test.go
+++ b/pkg/scanners/google/google_integration_test.go
@@ -21,8 +21,6 @@ func TestGoogle(t *testing.T) {
 		t.Skip("SERVICE_ACCOUNT is required for Google integration test")
 		return
 	}
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
 
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Google{

--- a/pkg/scanners/quay/quay_integration_test.go
+++ b/pkg/scanners/quay/quay_integration_test.go
@@ -18,8 +18,6 @@ const (
 
 func TestQuayIntegrationSuite(t *testing.T) {
 	t.Skip("See ROX-9448 for re-enabling")
-	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
-	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
 	suite.Run(t, new(QuayIntegrationSuite))
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -155,8 +155,6 @@ export_test_environment() {
     ci_export ROX_AUTH_MACHINE_TO_MACHINE "${ROX_AUTH_MACHINE_TO_MACHINE:-true}"
     ci_export ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA "${ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA:-true}"
     ci_export ROX_COMPLIANCE_REPORTING "${ROX_COMPLIANCE_REPORTING:-true}"
-    ci_export ROX_REGISTRY_RESPONSE_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-90s}"
-    ci_export ROX_REGISTRY_CLIENT_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-120s}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -271,10 +269,6 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_REPORTING'
     customize_envVars+=$'\n        value: "true"'
-    customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
-    customize_envVars+=$'\n        value: "90s"'
-    customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
-    customize_envVars+=$'\n        value: "120s"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images


### PR DESCRIPTION
Reverts stackrox/stackrox#10431

This broke OCP installs. Possibly due to dupe of envVar name.