### PR TITLE
ROX-22724: registry timeout env vars

### DIFF
--- a/pkg/env/registry.go
+++ b/pkg/env/registry.go
@@ -1,7 +1,27 @@
 package env
 
+import "time"
+
 var (
 	// DisableRegistryRepoList disables building and matching registry integrations using
 	// repo lists (`/v2/_catalog`).
 	DisableRegistryRepoList = RegisterBooleanSetting("ROX_DISABLE_REGISTRY_REPO_LIST", false)
+
+	// RegistryDialerTimeout is the net.Dialer timeout of the client transport.
+	// It limits the time the dialer attempts the connection. The timeout is
+	// chosen as a small value to prevent unavailable registries from blocking
+	// image scanning.
+	RegistryDialerTimeout = registerDurationSetting("ROX_REGISTRY_DIALER_TIMEOUT", 5*time.Second)
+
+	// RegistryResponseTimeout is the response header timeout of the client transport.
+	// It limits the time to wait for a server's response headers after fully
+	// writing the request.
+	RegistryResponseTimeout = registerDurationSetting("ROX_REGISTRY_RESPONSE_TIMEOUT", 60*time.Second)
+
+	// RegistryClientTimeout is used as http.Client.Timeout for the registry's HTTP
+	// client and hence includes everything from connection to reading the
+	// response body. The timeout has been chosen rather arbitrarily, it is
+	// probably less harm in waiting a bit longer than in aborting early a
+	// request that is about to succeed.
+	RegistryClientTimeout = registerDurationSetting("ROX_REGISTRY_CLIENT_TIMEOUT", 90*time.Second)
 )

--- a/pkg/env/registry.go
+++ b/pkg/env/registry.go
@@ -10,18 +10,18 @@ var (
 	// RegistryDialerTimeout is the net.Dialer timeout of the client transport.
 	// It limits the time the dialer attempts the connection. The timeout is
 	// chosen as a small value to prevent unavailable registries from blocking
-	// image scanning.
+	// image scanning. When connecting to a proxy, this timeout only limits the
+	// connection attempt to the proxy and not the proxy target.
 	RegistryDialerTimeout = registerDurationSetting("ROX_REGISTRY_DIALER_TIMEOUT", 5*time.Second)
 
 	// RegistryResponseTimeout is the response header timeout of the client transport.
 	// It limits the time to wait for a server's response headers after fully
 	// writing the request.
-	RegistryResponseTimeout = registerDurationSetting("ROX_REGISTRY_RESPONSE_TIMEOUT", 60*time.Second)
+	RegistryResponseTimeout = registerDurationSetting("ROX_REGISTRY_RESPONSE_TIMEOUT", 10*time.Second)
 
 	// RegistryClientTimeout is used as http.Client.Timeout for the registry's HTTP
 	// client and hence includes everything from connection to reading the
-	// response body. The timeout has been chosen rather arbitrarily, it is
-	// probably less harm in waiting a bit longer than in aborting early a
-	// request that is about to succeed.
-	RegistryClientTimeout = registerDurationSetting("ROX_REGISTRY_CLIENT_TIMEOUT", 90*time.Second)
+	// response body. This timeout must not be chosen too large because it serves
+	// as a connection timeout for proxied registries.
+	RegistryClientTimeout = registerDurationSetting("ROX_REGISTRY_CLIENT_TIMEOUT", 10*time.Second)
 )

--- a/pkg/registries/docker/config.go
+++ b/pkg/registries/docker/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/urlfmt"
@@ -52,13 +53,13 @@ func (c *Config) formatURL() string {
 // DefaultTransport returns the default transport based on the configuration.
 func DefaultTransport(cfg *Config) registry.Transport {
 	transport := proxy.RoundTripper(
-		proxy.WithDialTimeout(registryDialerTimeout),
-		proxy.WithResponseHeaderTimeout(registryResponseTimeout),
+		proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
+		proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
 	)
 	if cfg.Insecure {
 		transport = proxy.RoundTripper(
 			proxy.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-			proxy.WithDialTimeout(registryDialerTimeout),
+			proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
 			proxy.WithResponseHeaderTimeout(registryResponseTimeout),
 		)
 	}

--- a/pkg/registries/docker/config.go
+++ b/pkg/registries/docker/config.go
@@ -60,7 +60,7 @@ func DefaultTransport(cfg *Config) registry.Transport {
 		transport = proxy.RoundTripper(
 			proxy.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 			proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
-			proxy.WithResponseHeaderTimeout(registryResponseTimeout),
+			proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
 		)
 	}
 	username, password := cfg.GetCredentials()

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries/types"
@@ -99,7 +100,7 @@ func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegrat
 		return nil, err
 	}
 
-	client.Client.Timeout = registryClientTimeout
+	client.Client.Timeout = env.RegistryClientTimeout.DurationSetting()
 
 	var repoSet set.Set[string]
 	var ticker *time.Ticker

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -23,22 +23,7 @@ import (
 )
 
 const (
-	// registryDialerTimeout is the net.Dialer timeout of the client transport.
-	// It limits the time the dialer attempts the connection. The timeout is
-	// chosen as a small value to prevent unavailable registries from blocking
-	// image scanning. When connecting to a proxy, this timeout only limits the
-	// connection attempt to the proxy and not the proxy target.
-	registryDialerTimeout = 5 * time.Second
-	// registryResponseTimeout is the response header timeout of the client transport.
-	// It limits the time to wait for a server's response headers after fully
-	// writing the request.
-	registryResponseTimeout = 10 * time.Second
-	// registryClientTimeout is used as http.Client.Timeout for the registry's HTTP
-	// client and hence includes everything from connection to reading the
-	// response body. This timeout must not be chosen too large because it serves
-	// as a connection timeout for proxied registries.
-	registryClientTimeout = 10 * time.Second
-	repoListInterval      = 10 * time.Minute
+	repoListInterval = 10 * time.Minute
 )
 
 var log = logging.LoggerForModule()

--- a/pkg/registries/docker/docker_integration_test.go
+++ b/pkg/registries/docker/docker_integration_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestGetMetadataIntegration(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	dockerHubClient, err := NewDockerRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{
@@ -32,6 +35,9 @@ func TestGetMetadataIntegration(t *testing.T) {
 }
 
 func TestOCIImageIndexManifest(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	gcrClient, err := NewDockerRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{
@@ -55,6 +61,9 @@ func TestOCIImageIndexManifest(t *testing.T) {
 }
 
 func TestOCIImageIndexManifestWithoutManifestCall(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	gcrClient, err := NewRegistryWithoutManifestCall(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{
 			Docker: &storage.DockerConfig{

--- a/pkg/registries/google/google_integration_test.go
+++ b/pkg/registries/google/google_integration_test.go
@@ -18,6 +18,9 @@ func TestGoogle(t *testing.T) {
 		t.Skip("SERVICE_ACCOUNT env variable required")
 		return
 	}
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Google{
 			Google: &storage.GoogleConfig{

--- a/pkg/registries/ibm/ibm_integration_test.go
+++ b/pkg/registries/ibm/ibm_integration_test.go
@@ -18,6 +18,9 @@ const (
 
 func TestIBM(t *testing.T) {
 	t.Skip("This registry is currently broken (ROX-3589)")
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	reg, err := newRegistry(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Ibm{
 			Ibm: &storage.IBMRegistryConfig{

--- a/pkg/registries/nexus/nexus_integration_test.go
+++ b/pkg/registries/nexus/nexus_integration_test.go
@@ -12,6 +12,9 @@ import (
 
 // This requires a Nexus Sonatype registry with a proxy to Dockerhub
 func TestNexus(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	endpoint := os.Getenv("NEXUS_ENDPOINT")
 	if endpoint == "" {
 		t.Skipf("ENDPOINT is required for Nexus integration test")

--- a/pkg/registries/quay/quay_integration_test.go
+++ b/pkg/registries/quay/quay_integration_test.go
@@ -16,6 +16,9 @@ const (
 )
 
 func TestQuay(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Quay{
 			Quay: &storage.QuayConfig{

--- a/pkg/registries/rhel/rhel_integration_test.go
+++ b/pkg/registries/rhel/rhel_integration_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestRHEL(t *testing.T) {
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
+
 	_, creator := Creator()
 	reg, err := creator(&storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Docker{

--- a/pkg/scanners/google/google_integration_test.go
+++ b/pkg/scanners/google/google_integration_test.go
@@ -21,6 +21,8 @@ func TestGoogle(t *testing.T) {
 		t.Skip("SERVICE_ACCOUNT is required for Google integration test")
 		return
 	}
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
 
 	integration := &storage.ImageIntegration{
 		IntegrationConfig: &storage.ImageIntegration_Google{

--- a/pkg/scanners/quay/quay_integration_test.go
+++ b/pkg/scanners/quay/quay_integration_test.go
@@ -18,6 +18,8 @@ const (
 
 func TestQuayIntegrationSuite(t *testing.T) {
 	t.Skip("See ROX-9448 for re-enabling")
+	t.Setenv("ROX_REGISTRY_RESPONSE_TIMEOUT", "90s")
+	t.Setenv("ROX_REGISTRY_CLIENT_TIMEOUT", "120s")
 	suite.Run(t, new(QuayIntegrationSuite))
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -155,6 +155,8 @@ export_test_environment() {
     ci_export ROX_AUTH_MACHINE_TO_MACHINE "${ROX_AUTH_MACHINE_TO_MACHINE:-true}"
     ci_export ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA "${ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA:-true}"
     ci_export ROX_COMPLIANCE_REPORTING "${ROX_COMPLIANCE_REPORTING:-true}"
+    ci_export ROX_REGISTRY_RESPONSE_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-90s}"
+    ci_export ROX_REGISTRY_CLIENT_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-120s}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -269,6 +271,10 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_REPORTING'
     customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
+    customize_envVars+=$'\n        value: "90s"'
+    customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
+    customize_envVars+=$'\n        value: "120s"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -156,7 +156,7 @@ export_test_environment() {
     ci_export ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA "${ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA:-true}"
     ci_export ROX_COMPLIANCE_REPORTING "${ROX_COMPLIANCE_REPORTING:-true}"
     ci_export ROX_REGISTRY_RESPONSE_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-90s}"
-    ci_export ROX_REGISTRY_CLIENT_TIMEOUT "${ROX_REGISTRY_RESPONSE_TIMEOUT:-120s}"
+    ci_export ROX_REGISTRY_CLIENT_TIMEOUT "${ROX_REGISTRY_CLIENT_TIMEOUT:-120s}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -272,9 +272,9 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_REPORTING'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
-    customize_envVars+=$'\n        value: "90s"'
-    customize_envVars+=$'\n      - name: ROX_REGISTRY_RESPONSE_TIMEOUT'
-    customize_envVars+=$'\n        value: "120s"'
+    customize_envVars+=$'\n        value: '"${ROX_REGISTRY_RESPONSE_TIMEOUT:-90s}"
+    customize_envVars+=$'\n      - name: ROX_REGISTRY_CLIENT_TIMEOUT'
+    customize_envVars+=$'\n        value: '"${ROX_REGISTRY_CLIENT_TIMEOUT:-120s}"
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images


### PR DESCRIPTION
## Description

Re-revert after I messed up one of the env vars in #10431. See also https://github.com/stackrox/stackrox/pull/10620.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

OCP CI passes.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
