### PR TITLE
chore(strings): use ReplaceAll

### DIFF
--- a/central/clusterinit/backend/render.go
+++ b/central/clusterinit/backend/render.go
@@ -128,7 +128,7 @@ func (b *InitBundleWithMeta) RenderAsK8sSecrets() ([]byte, error) {
 		}
 
 		serviceTypeStr := strings.ToLower(
-			strings.Replace(strings.TrimSuffix(svcType.String(), "_SERVICE"), "_", "-", -1))
+			strings.ReplaceAll(strings.TrimSuffix(svcType.String(), "_SERVICE"), "_", "-"))
 		secret := &v1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",

--- a/central/debug/service/db_diagnostics.go
+++ b/central/debug/service/db_diagnostics.go
@@ -23,7 +23,7 @@ func buildDBDiagnosticData(ctx context.Context, dbConfig *postgres.Config, dbPoo
 	diagnosticData.DatabaseClientVersion = getDBClientVersion()
 	// Get extensions
 	if dbConfig != nil {
-		diagnosticData.DatabaseConnectString = strings.TrimSpace(strings.Replace(dbConfig.ConnString(), dbConfig.ConnConfig.Password, "REDACTED", -1))
+		diagnosticData.DatabaseConnectString = strings.TrimSpace(strings.ReplaceAll(dbConfig.ConnString(), dbConfig.ConnConfig.Password, "REDACTED"))
 	}
 	diagnosticData.DatabaseExtensions = getPostgresExtensions(ctx, dbPool)
 

--- a/central/notifiers/cscc/convert.go
+++ b/central/notifiers/cscc/convert.go
@@ -139,7 +139,7 @@ func convertEnforcementAction(a storage.EnforcementAction) string {
 // Cloud SCC requires that Finding IDs be alphanumeric (no special characters)
 // and 1-32 characters long. UUIDs are 32 characters if you remove hyphens.
 func convertAlertUUID(u string) string {
-	return strings.Replace(u, "-", "", -1)
+	return strings.ReplaceAll(u, "-", "")
 }
 
 func convertEnforcement(alert *storage.Alert) []Enforcement {

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -226,8 +226,8 @@ func applyRfc5322TextWordWrap(text string) string {
 	// we have a combination of \n and \r\n. First, we must normalize the text.
 	// Otherwise, we will have wrong formatting if we replace \n with \r\n.
 	// If not normalized, we can get results with double \r. i.e. \r\r\n
-	wrappedText = strings.Replace(wrappedText, "\r\n", "\n", -1)
-	wrappedText = strings.Replace(wrappedText, "\n", "\r\n", -1)
+	wrappedText = strings.ReplaceAll(wrappedText, "\r\n", "\n")
+	wrappedText = strings.ReplaceAll(wrappedText, "\n", "\r\n")
 
 	return wrappedText
 }

--- a/compliance/collection/command/command_test.go
+++ b/compliance/collection/command/command_test.go
@@ -11,7 +11,7 @@ import (
 const cmdLine = `/opt/k8s/bin/kubelet --kubeconfig=/etc/kubernetes/kubelet.conf --logtostderr=true --v=0 --container-runtime=docker --pod-manifest-path=/etc/kubernetes/manifests --hostname-override=hostname --tls-cert-file=/etc/kubernetes/pki/kubelet-crt.crt --tls-private-key-file=/etc/kubernetes/pki/kubelet-key.key --anonymous-auth=false --client-ca-file=/etc/kubernetes/pki/k8s-ca.crt --fail-swap-on=false --enable-test1 --feature-gates=A,B,C`
 
 var (
-	nullSeparatedCmdLine = strings.Replace(cmdLine, " ", "\x00", -1)
+	nullSeparatedCmdLine = strings.ReplaceAll(cmdLine, " ", "\x00")
 )
 
 func TestGetCommandLineArgs(t *testing.T) {

--- a/pkg/bolthelper/bolt.go
+++ b/pkg/bolthelper/bolt.go
@@ -55,7 +55,7 @@ func NewTemp(dbPath string) (*bolt.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return New(filepath.Join(tmpDir, strings.Replace(dbPath, "/", "_", -1)))
+	return New(filepath.Join(tmpDir, strings.ReplaceAll(dbPath, "/", "_")))
 }
 
 // RegisterBucket registers a new bucket in the global DB.

--- a/pkg/compliance/checks/kubernetes/control_plane_config_test.go
+++ b/pkg/compliance/checks/kubernetes/control_plane_config_test.go
@@ -35,7 +35,7 @@ func TestControlPlaneConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]

--- a/pkg/compliance/checks/kubernetes/etcd_test.go
+++ b/pkg/compliance/checks/kubernetes/etcd_test.go
@@ -226,7 +226,7 @@ func TestETCDChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]

--- a/pkg/compliance/checks/kubernetes/master_api_server_test.go
+++ b/pkg/compliance/checks/kubernetes/master_api_server_test.go
@@ -81,7 +81,7 @@ func TestMasterAPIServerChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]

--- a/pkg/compliance/checks/kubernetes/master_config_test.go
+++ b/pkg/compliance/checks/kubernetes/master_config_test.go
@@ -176,7 +176,7 @@ func TestMasterConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]

--- a/pkg/compliance/checks/kubernetes/worker_node_config_test.go
+++ b/pkg/compliance/checks/kubernetes/worker_node_config_test.go
@@ -84,7 +84,7 @@ func TestWorkerNodeConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]

--- a/pkg/compliance/checks/nist800-190/check421/check_test.go
+++ b/pkg/compliance/checks/nist800-190/check421/check_test.go
@@ -43,7 +43,7 @@ func TestDockerInfoBasedChecks(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		t.Run(strings.Replace(c.name, ":", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 
 			checks := standards.NodeChecks[standards.NIST800190]

--- a/pkg/netutil/default_port_test.go
+++ b/pkg/netutil/default_port_test.go
@@ -27,7 +27,7 @@ func TestWithDefaultPort(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		// Test names must not contain colons.
-		t.Run(strings.Replace(c.input, ":", ";", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(c.input, ":", ";"), func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, c.expected, WithDefaultPort(c.input, 1337))
 		})

--- a/pkg/notifiers/format.go
+++ b/pkg/notifiers/format.go
@@ -151,8 +151,8 @@ func FormatAlert(alert *storage.Alert, alertLink string, funcMap template.FuncMa
 
 	// Remove all the formatting
 	format := bplPolicyFormat
-	f := strings.Replace(format, "\t", "", -1)
-	f = strings.Replace(f, "\n", "", -1)
+	f := strings.ReplaceAll(format, "\t", "")
+	f = strings.ReplaceAll(f, "\n", "")
 
 	tmpl, err := template.New("").Funcs(funcMap).Parse(f)
 	if err != nil {

--- a/pkg/services/convert.go
+++ b/pkg/services/convert.go
@@ -15,6 +15,6 @@ func ServiceTypeToSlugName(ty storage.ServiceType) string {
 		return ""
 	}
 	tyName = strings.ToLower(tyName)
-	tyName = strings.Replace(tyName, "_", "-", -1)
+	tyName = strings.ReplaceAll(tyName, "_", "-")
 	return tyName
 }

--- a/pkg/stringutils/wrap.go
+++ b/pkg/stringutils/wrap.go
@@ -11,6 +11,6 @@ import (
 func Wrap(text string) string {
 	wrapped := wordwrap.WrapString(text, 80)
 	wrapped = strings.TrimSpace(wrapped)
-	wrapped = strings.Replace(wrapped, "\n", "\n      ", -1)
+	wrapped = strings.ReplaceAll(wrapped, "\n", "\n      ")
 	return wrapped
 }

--- a/pkg/testutils/db_name.go
+++ b/pkg/testutils/db_name.go
@@ -26,7 +26,7 @@ type testingT interface {
 
 // DBFileNameForT returns an appropriate, unique, DB file name for the given test.
 func DBFileNameForT(t testingT) string {
-	return strings.Replace(t.Name(), "/", "_", -1) + ".db"
+	return strings.ReplaceAll(t.Name(), "/", "_") + ".db"
 }
 
 // DBForT creates and returns a new DB to use for this test, failing the test if creating/opening

--- a/pkg/version/compare.go
+++ b/pkg/version/compare.go
@@ -141,7 +141,7 @@ func getEffectVersion(version string) string {
 	// 3.0.58.x-189-dirty -> 3.0.58.2147483647-189-dirty to make dev build greater than release and rc build
 	version = strings.Replace(version, "x", strconv.Itoa(math.MaxInt32), 1)
 	// 3.0.58.2147483647-189-dirty -> 3.0.58.2147483647.189.dirty
-	version = strings.Replace(version, "-", ".", -1)
+	version = strings.ReplaceAll(version, "-", ".")
 	// 3.0.58.2147483647.189.dirty -> 3.0.58.2147483647.189.1, dirty version is greater than its base dev build
 	version = strings.Replace(version, "dirty", "1", 1)
 	return version

--- a/roxctl/central/generate/file_format.go
+++ b/roxctl/central/generate/file_format.go
@@ -16,7 +16,7 @@ func (f *fileFormatWrapper) String() string {
 }
 
 func (f *fileFormatWrapper) Set(input string) error {
-	val, ok := v1.DeploymentFormat_value[strings.Replace(strings.ToUpper(input), "-", "_", -1)]
+	val, ok := v1.DeploymentFormat_value[strings.ReplaceAll(strings.ToUpper(input), "-", "_")]
 	if !ok {
 		return errox.InvalidArgs.Newf("%q is not a valid option", input)
 	}

--- a/scanner/updater/rhel/updaterset.go
+++ b/scanner/updater/rhel/updaterset.go
@@ -126,7 +126,7 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 	}
 
 	for _, e := range m {
-		name := strings.TrimSuffix(strings.Replace(e.Path, "/", "-", -1), ".oval.xml.bz2")
+		name := strings.TrimSuffix(strings.ReplaceAll(e.Path, "/", "-"), ".oval.xml.bz2")
 		// We need to disregard this OVAL stream because some advisories therein have
 		// been released with the CPEs identical to those used in classic RHEL stream.
 		// This in turn causes false CVEs to appear in scanned images. Red Hat Product


### PR DESCRIPTION
## Description

Use `strings.ReplaceAll` instead of `strings.Replace`

https://pkg.go.dev/strings#ReplaceAll

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
