### PR TITLE
ROX-23397: Set the default telemetry endpoint to RH proxy

### DIFF
--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -6,7 +6,8 @@ var (
 	// Phone-Home telemetry variables:
 
 	// TelemetryEndpoint is the URL to send telemetry to.
-	TelemetryEndpoint = RegisterSetting("ROX_TELEMETRY_ENDPOINT", AllowEmpty())
+	TelemetryEndpoint = RegisterSetting("ROX_TELEMETRY_ENDPOINT",
+		WithDefault("https://console.redhat.com/connections/api"), AllowEmpty())
 
 	// TelemetryConfigURL to retrieve the telemetry configuration from.
 	// TODO(ROX-17726): Set default URL for self-managed installations use.


### PR DESCRIPTION
## Description

The endpoint value is propagated to the UI, and the manifests.

UI doesn't make use of this value though, will be fixed separately.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* I set the variable, and checked the arrival of the events from my installation on Segment.
* I set an incorrect variable value, and confirmed the appearance of communication errors in the central logs.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
