### PR TITLE
chore(CI): skip junit2jira for interop jobs

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1193,6 +1193,8 @@ post_process_test_results() {
         else
             if [[ "${PULL_BASE_REF:-unknown}" =~ ^release ]]; then
                 create_jiras="false"
+            elif [[ "${JOB_NAME:-unknown}" =~ interop ]]; then
+                create_jiras="false"
             else
                 create_jiras="true"
             fi


### PR DESCRIPTION
## Description

The interop team use firewatch to file JIRAs for test failures. The ACS team uses other jobs to onboard new OCP versions where junit2jira will still run.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
