### PR TITLE
chore: change label for auto retest

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,7 @@ updates:
     labels:
       - "dependencies"
       - "area/ui"
+      - "auto-retest"
     reviewers:
       - "stackrox/ui-dep-updaters"
     commit-message:
@@ -31,6 +32,7 @@ updates:
       - "ci-all-qa-tests"
       - "dependencies"
       - "auto-merge"
+      - "auto-retest"
     reviewers:
       - "stackrox/backend-dep-updaters"
     commit-message:
@@ -46,6 +48,7 @@ updates:
       - "ci-all-qa-tests"
       - "dependencies"
       - "auto-merge"
+      - "auto-retest"
     reviewers:
       - "stackrox/backend-dep-updaters"
     commit-message:
@@ -71,6 +74,7 @@ updates:
     labels:
     - "dependencies"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
       - "stackrox/backend-dep-updaters"
     commit-message:
@@ -86,6 +90,7 @@ updates:
     labels:
     - "dependencies"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -101,6 +106,7 @@ updates:
     labels:
     - "dependencies"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
       - "stackrox/backend-dep-updaters"
     commit-message:
@@ -116,6 +122,7 @@ updates:
     labels:
     - "dependencies"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -132,6 +139,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -148,6 +156,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -164,6 +173,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -180,6 +190,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -196,6 +207,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -212,6 +224,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:
@@ -228,6 +241,7 @@ updates:
     - "dependencies"
     - "area/scanner"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/scanner"
     commit-message:
@@ -244,6 +258,7 @@ updates:
     - "dependencies"
     - "area/operator"
     - "auto-merge"
+    - "auto-retest"
     reviewers:
     - "stackrox/backend-dep-updaters"
     commit-message:

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -18,7 +18,7 @@ func main() {
 	client := github.NewClient(nil).WithAuthToken(os.Getenv("GITHUB_TOKEN"))
 
 	//TODO(janisz): handle pagination
-	search, _, err := client.Search.Issues(ctx, `repo:stackrox/stackrox label:auto-merge state:open type:pr status:failure`, nil)
+	search, _, err := client.Search.Issues(ctx, `repo:stackrox/stackrox label:auto-retest state:open type:pr status:failure`, nil)
 	handleError(err)
 	log.Printf("Found %d PRs", search.GetTotal())
 


### PR DESCRIPTION
## Description

As discussed auto-merge label is not a best name for auto retest feature. This PR changes the label name and adds it to dependabot so we do not need to retest manually.

See: https://redhat-internal.slack.com/archives/CELUQKESC/p1711383807553069?thread_ts=1711124692.089649&cid=CELUQKESC

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
