### PR TITLE
ROX-17541: Link image in deployment details of violations to VM 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
-import { vulnManagementPath } from 'routePaths';
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import DescriptionListItem from 'Components/DescriptionListItem';
 
 type ContainerImageProps = {
@@ -33,7 +33,11 @@ function ContainerImage({ image }: ContainerImageProps): ReactElement {
     return (
         <DescriptionListItem
             term="Image name"
-            desc={<Link to={`${vulnManagementPath}/image/${image.id}`}>{image.name.fullName}</Link>}
+            desc={
+                <Link to={`${vulnerabilitiesWorkloadCvesPath}/images/${image.id}`}>
+                    {image.name.fullName}
+                </Link>
+            }
         />
     );
 }


### PR DESCRIPTION
## Description

We want to have the image name link point to VM 2.0 instead of VM 1.0

<img width="1436" alt="Screenshot 2024-04-04 at 4 09 37 PM" src="https://github.com/stackrox/stackrox/assets/4805485/f3276224-eff0-4f2f-867a-9b8dc1b23d47">
<img width="1437" alt="Screenshot 2024-04-04 at 4 10 13 PM" src="https://github.com/stackrox/stackrox/assets/4805485/6128c641-e4a6-4d71-bd20-7a3849b6b2a5">
