### PR TITLE
ROX-17543: Link image in deployment details of network graph to VM 2.0

### DIFF
--- a/ui/apps/platform/src/Components/ContainerImageInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerImageInfo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 
-import { vulnManagementPath } from 'routePaths';
+import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { ContainerImage } from 'types/deployment.proto';
 
 type ContainerImageInfoProps = {
@@ -28,7 +28,9 @@ function ContainerImageInfo({ image }: ContainerImageInfoProps) {
         <Card>
             <CardTitle>Image</CardTitle>
             <CardBody>
-                <Link to={`${vulnManagementPath}/image/${image.id}`}>{image.name.fullName}</Link>
+                <Link to={`${vulnerabilitiesWorkloadCvesPath}/images/${image.id}`}>
+                    {image.name.fullName}
+                </Link>
             </CardBody>
         </Card>
     );


### PR DESCRIPTION
## Description

We want to have the image name link point to VM 2.0 instead of VM 1.0

<img width="1439" alt="Screenshot 2024-04-04 at 4 14 51 PM" src="https://github.com/stackrox/stackrox/assets/4805485/25452377-5b60-41ef-84b9-45b98d3e3d5f">
<img width="1437" alt="Screenshot 2024-04-04 at 4 15 12 PM" src="https://github.com/stackrox/stackrox/assets/4805485/f08bfc85-f8b0-4380-a1c1-ec0f46c29087">
