### PR TITLE
ROX-17544: Link image in deployment details of risk to VM 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import lowerCase from 'lodash/lowerCase';
 import capitalize from 'lodash/capitalize';
 
-import { vulnManagementPath } from 'routePaths';
+import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import CollapsibleCard from 'Components/CollapsibleCard';
 
 import KeyValuePairs from './KeyValuePairs';
@@ -47,7 +47,7 @@ const ContainerImage = ({ image }) => {
             <div className="font-700 inline">Image Name: </div>
             <Link
                 className="hover:text-primary-800 leading-normal word-break"
-                to={`${vulnManagementPath}/image/${image.id}`}
+                to={`${vulnerabilitiesWorkloadCvesPath}/images/${image.id}`}
             >
                 {image.name.fullName}
             </Link>


### PR DESCRIPTION
## Description

We want to have the image name link point to VM 2.0 instead of VM 1.0

<img width="1438" alt="Screenshot 2024-04-04 at 4 18 48 PM" src="https://github.com/stackrox/stackrox/assets/4805485/4cefd011-a661-49c3-8dee-c734341354dd">
<img width="1437" alt="Screenshot 2024-04-04 at 4 19 07 PM" src="https://github.com/stackrox/stackrox/assets/4805485/70ffa10a-0476-403c-a337-ce27664d3558">
