### PR TITLE
ROX-19953: retry get summary counts

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -282,12 +282,14 @@ class SACTest extends BaseSpecification {
         createSecret(DEPLOYMENT_QA1.namespace)
         createSecret(DEPLOYMENT_QA2.namespace)
         useToken("getSummaryCountsToken")
-        def result = SummaryService.getCounts()
         then:
         "Verify correct counts are returned by GetSummaryCounts"
-        assert result.getNumDeployments() == 1
-        assert result.getNumSecrets() == orchestrator.getSecretCount(DEPLOYMENT_QA1.namespace)
-        assert result.getNumImages() == 1
+        withRetry(30, 3) {
+            def result = SummaryService.getCounts()
+            assert result.getNumDeployments() == 1
+            assert result.getNumSecrets() == orchestrator.getSecretCount(DEPLOYMENT_QA1.namespace)
+            assert result.getNumImages() == 1
+        }
         cleanup:
         "Cleanup"
         BaseService.useBasicAuth()


### PR DESCRIPTION
## Description

Previous PR that tried to fix this issues didn't solve the problem. Let's retry so we get more time to update summaries.

- https://github.com/stackrox/stackrox/pull/10106

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
