### PR TITLE
ROX-23523: Fix policy categories filter

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -406,6 +406,7 @@ func (m *managerImpl) HandleResourceAlerts(clusterID string, alerts []*storage.A
 func (m *managerImpl) UpsertPolicy(policy *storage.Policy) error {
 	m.policyAlertsLock.Lock()
 	defer m.policyAlertsLock.Unlock()
+
 	// Add policy to set.
 	if policies.AppliesAtBuildTime(policy) {
 		if err := m.buildTimeDetector.PolicySet().UpsertPolicy(policy); err != nil {
@@ -428,7 +429,8 @@ func (m *managerImpl) UpsertPolicy(policy *storage.Policy) error {
 			return errors.Wrapf(err, "adding policy %s to runtime detector", policy.GetName())
 		}
 		// Perform notifications and update DB.
-		modifiedDeployments, err := m.alertManager.AlertAndNotify(lifecycleMgrCtx, nil, alertmanager.WithPolicyID(policy.GetId()))
+		modifiedDeployments, err := m.alertManager.AlertAndNotify(lifecycleMgrCtx, nil,
+			alertmanager.WithPolicyID(policy.GetId()))
 		if err != nil {
 			return err
 		}

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -241,14 +241,14 @@ func (ds *datastoreImpl) AddPolicy(ctx context.Context, policy *storage.Policy) 
 	clonedPolicy.Categories = []string{}
 	err = ds.storage.Upsert(ctx, clonedPolicy)
 	if err != nil {
-		return policy.Id, err
+		return clonedPolicy.Id, err
 	}
 
-	err = ds.categoriesDatastore.SetPolicyCategoriesForPolicy(ctx, policy.GetId(), policyCategories)
+	err = ds.categoriesDatastore.SetPolicyCategoriesForPolicy(ctx, clonedPolicy.GetId(), policyCategories)
 	if err != nil {
-		return policy.Id, err
+		return clonedPolicy.Id, err
 	}
-	return policy.Id, nil
+	return clonedPolicy.Id, nil
 }
 
 // UpdatePolicy updates a policy from the storage.

--- a/central/policy/service/service.go
+++ b/central/policy/service/service.go
@@ -5,7 +5,6 @@ import (
 
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
-	"github.com/stackrox/rox/central/detection"
 	"github.com/stackrox/rox/central/detection/lifecycle"
 	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
@@ -37,7 +36,6 @@ func New(policies datastore.DataStore,
 	notifiers notifierDataStore.DataStore,
 	mitreStore mitreDS.AttackReadOnlyDataStore,
 	reprocessor reprocessor.Loop,
-	buildTimePolicies detection.PolicySet,
 	manager lifecycle.Manager,
 	processor notifier.Processor,
 	metadataCache expiringcache.Cache,
@@ -51,7 +49,6 @@ func New(policies datastore.DataStore,
 		reprocessor:       reprocessor,
 		notifiers:         notifiers,
 		mitreStore:        mitreStore,
-		buildTimePolicies: buildTimePolicies,
 		lifecycleManager:  manager,
 		connectionManager: connectionManager,
 		networkPolicies:   networkPolicies,

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -570,7 +570,7 @@ func (s *serviceImpl) addActivePolicy(policy *storage.Policy) error {
 }
 
 func (s *serviceImpl) removeActivePolicy(id string) error {
-	return errors.Wrap(s.lifecycleManager.RemovePolicy(id), "removing policy from detection: ")
+	return errors.Wrap(s.lifecycleManager.RemovePolicy(id), "removing policy from detection cache")
 }
 
 func (s *serviceImpl) EnableDisablePolicyNotification(ctx context.Context, request *v1.EnableDisablePolicyNotificationRequest) (*v1.Empty, error) {

--- a/central/policy/service/singleton.go
+++ b/central/policy/service/singleton.go
@@ -3,7 +3,6 @@ package service
 import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
-	buildTimeDetection "github.com/stackrox/rox/central/detection/buildtime"
 	"github.com/stackrox/rox/central/detection/lifecycle"
 	"github.com/stackrox/rox/central/enrichment"
 	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
@@ -30,7 +29,6 @@ func initialize() {
 		notifierDataStore.Singleton(),
 		mitreDataStore.Singleton(),
 		reprocessor.Singleton(),
-		buildTimeDetection.SingletonPolicySet(),
 		lifecycle.SingletonManager(),
 		notifierProcessor.Singleton(),
 		enrichment.ImageMetadataCacheSingleton(),

--- a/qa-tests-backend/src/main/groovy/services/PolicyCategoryService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyCategoryService.groovy
@@ -1,0 +1,39 @@
+package services
+
+import groovy.util.logging.Slf4j
+
+import io.stackrox.proto.api.v1.PolicyCategoryServiceGrpc
+import io.stackrox.proto.api.v1.PolicyCategoryServiceOuterClass
+
+@Slf4j
+class PolicyCategoryService extends BaseService {
+    static getPolicyCategoryClient() {
+        return PolicyCategoryServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    static String createNewPolicyCategory(String name) {
+        String categoryID = ""
+        try {
+            categoryID = getPolicyCategoryClient().postPolicyCategory(
+                    PolicyCategoryServiceOuterClass.PostPolicyCategoryRequest.newBuilder().
+                        setPolicyCategory(
+                                PolicyCategoryServiceOuterClass.PolicyCategory.newBuilder().setName(name).build()).
+                            build()
+            ).getId()
+        } catch (Exception e) {
+            log.error("Error creating policy category", e)
+        }
+
+        return categoryID
+    }
+
+    static deletePolicyCategory(String id) {
+        try {
+            getPolicyCategoryClient().deletePolicyCategory(
+                    PolicyCategoryServiceOuterClass.DeletePolicyCategoryRequest.
+                            newBuilder().setId(id).build())
+        } catch (Exception e) {
+            log.error("Error deleting policy category", e)
+        }
+    }
+}

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -22,7 +22,7 @@ import spock.lang.Tag
 
 class DeploymentCheck extends BaseSpecification {
     private final static String DEPLOYMENT_CHECK = "check-deployments"
-    private final static String DEPLOYMENT_CHECK_POLICY_CATEGORY = "Deployment Check"
+    private final static String DEPLOYMENT_CHECK_POLICY_CATEGORY = "Test Category Filter"
 
     @Shared
     private String clusterId
@@ -96,9 +96,9 @@ class DeploymentCheck extends BaseSpecification {
     def "Test Deployment Check - Filtered by Category"() {
         given:
         "create the builder, policy category, and policy"
-        def image = "custom-registry"
+        def registry = "custom-registry"
         def builder = DetectionServiceOuterClass.DeployYAMLDetectionRequest.newBuilder()
-        builder.setYaml(createDeploymentYaml(DEPLOYMENT_CHECK, DEPLOYMENT_CHECK, "custom-registry/nginx:latest"))
+        builder.setYaml(createDeploymentYaml(DEPLOYMENT_CHECK, DEPLOYMENT_CHECK, registry+"nginx:latest"))
         builder.setNamespace(DEPLOYMENT_CHECK)
         builder.setCluster(clusterId)
         builder.setPolicyCategories(0, DEPLOYMENT_CHECK_POLICY_CATEGORY)
@@ -115,7 +115,7 @@ class DeploymentCheck extends BaseSpecification {
                         PolicyOuterClass.PolicyGroup.newBuilder().setFieldName("Image Registry").
                                 setBooleanOperator(PolicyOuterClass.BooleanOperator.AND).
                                 addAllValues(
-                                        [image].collect { PolicyOuterClass.
+                                        [registry].collect { PolicyOuterClass.
                                                 PolicyValue.newBuilder().setValue(it).build() }
                                 ).build()
                 )).


### PR DESCRIPTION
## Description

Currently, if you attempt to filter policies by category when using e.g. `roxctl deployment check` (i.e. the detection service), it won't be possible to filter for policies _iff_ they have been either added or updated _without_ a Central restart.

The culprit lies within the datastore implementation and the policy sets used for the build-time and deploy-time detectors: the same reference that is stored in the policy set is beforehand passed to the datastore.
Within the datastore, the policy reference's `policy_categories` field is being reset due to the categories being stored in the policycategories edge store. This leads to the reference that finally gets upserted to the policy set to not contain any policy categories, thus making it unable to filter by categories.

After Central has been restarted once, it will be possible to filter by categories again since the policy sets are populated with references read from the datastore, which in turn have the `policy_categories` field correctly populated.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI and the added E2E tests.

Manual tests:

1. Create a policy category:
```bash
roxcurl v1/policycategories -d '{"name": "Cool Policies"}'
```

2. Create a sample policy with an arbitrary criteria referencing the new policy category:
```bash
roxcurl v1/policies -d '{"categories": ["Cool Policies"], "lifecycleStages": ["BUILD"], "name": "testing categories", "policySections": [{"policyGroups": [{"boolenOperator": "OR", "fieldName": "Image Tag", "values": [{"value": "1.23"}]}]}], "severity": "LOW_SEVERITY"}'
```

3. Run roxctl image check:
```bash
roxctl image check --categories "Cool Policies" --image nginx:1.23
Policy check results for image: nginx:1.23
(TOTAL: 1, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

+--------------------+----------+--------------+-------------+------------------------+-------------+
|       POLICY       | SEVERITY | BREAKS BUILD | DESCRIPTION |       VIOLATION        | REMEDIATION |
+--------------------+----------+--------------+-------------+------------------------+-------------+
| testing categories |   LOW    |      -       |      -      | - Image has tag '1.23' |      -      |
+--------------------+----------+--------------+-------------+------------------------+-------------+
WARN:	A total of 1 policies have been violated
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
