### PR TITLE
chore(release): Fix test broken by cherry pick

### DIFF
--- a/sensor/kubernetes/listener/resources/convert_override_test.go
+++ b/sensor/kubernetes/listener/resources/convert_override_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/kubernetes"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -113,7 +112,7 @@ func TestConvertWithRegistryOverride(t *testing.T) {
 			LabelSelector: &storage.LabelSelector{
 				MatchLabels: map[string]string{},
 			},
-			Created:                      protocompat.GetProtoTimestampFromSeconds(1000),
+			Created:                      &timestamp.Timestamp{Seconds: 1000},
 			Tolerations:                  []*storage.Toleration{},
 			ServiceAccount:               "default",
 			AutomountServiceAccountToken: true,
@@ -186,64 +185,6 @@ func TestConvertWithRegistryOverride(t *testing.T) {
 					Tag:      "latest",
 					FullName: "quay.io/stackrox/kafka:latest",
 				},
-			},
-			expectedDeployment: &storage.Deployment{
-				Id:          "FooID",
-				ClusterId:   testClusterID,
-				Name:        "deployment",
-				Namespace:   "namespace",
-				NamespaceId: "FAKENSID",
-				Type:        kubernetes.Deployment,
-				LabelSelector: &storage.LabelSelector{
-					MatchLabels: map[string]string{},
-				},
-				Created:                      &timestamp.Timestamp{Seconds: 1000},
-				Tolerations:                  []*storage.Toleration{},
-				ServiceAccount:               "default",
-				AutomountServiceAccountToken: true,
-				ImagePullSecrets:             []string{},
-				Containers: []*storage.Container{
-					{
-						Id:   "FooID:container1",
-						Name: "container1",
-						Config: &storage.ContainerConfig{
-							Env: []*storage.ContainerConfig_EnvironmentConfig{},
-						},
-						SecurityContext: &storage.SecurityContext{},
-						Resources:       &storage.Resources{},
-						Image: &storage.ContainerImage{
-							Id: "sha256:aa561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a",
-							Name: &storage.ImageName{
-								Registry: "hello.io",
-								Remote:   "stackrox/kafka",
-								Tag:      "latest",
-								FullName: "hello.io/stackrox/kafka:latest",
-							},
-							NotPullable: true,
-						},
-						LivenessProbe:  &storage.LivenessProbe{Defined: false},
-						ReadinessProbe: &storage.ReadinessProbe{Defined: false},
-					},
-					{
-						Id:   "FooID:container2",
-						Name: "container2",
-						Config: &storage.ContainerConfig{
-							Env: []*storage.ContainerConfig_EnvironmentConfig{},
-						},
-						Image: &storage.ContainerImage{
-							Id: "sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a",
-							Name: &storage.ImageName{
-								Registry: "hello.io",
-								Remote:   "stackrox/policy-engine",
-								Tag:      "1.3",
-								FullName: "hello.io/stackrox/policy-engine:1.3",
-							},
-						},
-						SecurityContext: &storage.SecurityContext{},
-						Resources:       &storage.Resources{},
-						LivenessProbe:   &storage.LivenessProbe{Defined: false},
-						ReadinessProbe:  &storage.ReadinessProbe{Defined: false},
-					},
 				{
 					Registry: "quay.io",
 					Remote:   "stackrox/policy-engine",


### PR DESCRIPTION
## Description

Fixes a unit test that doesn't merge nicely.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
go test -timeout 5m -tags e2e,integration,sql_integration,scanner_integration,scanner_db_integration -run ^TestConvertWithRegistryOverride$ github.com/stackrox/rox/sensor/kubernetes/listener/resources -count=1 -race

=== RUN   TestConvertWithRegistryOverride
=== RUN   TestConvertWithRegistryOverride/use_registry_override
=== RUN   TestConvertWithRegistryOverride/use_registry_from_runtime
--- PASS: TestConvertWithRegistryOverride (0.00s)
    --- PASS: TestConvertWithRegistryOverride/use_registry_override (0.00s)
    --- PASS: TestConvertWithRegistryOverride/use_registry_from_runtime (0.00s)
PASS
ok  	github.com/stackrox/rox/sensor/kubernetes/listener/resources	1.717s
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
