### PR TITLE
ROX-20437: disable jira creation for interop

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1200,6 +1200,12 @@ post_process_test_results() {
             fi
         fi
 
+        if [[ "$JOB_NAME" == *"interop"* ]]; then
+          info "Disable jira issue creation for Interop tests"
+          create_jiras="false"
+        fi
+
+
         if [[ "${create_jiras}" == "false" ]]; then
             extra_args=(--dry-run)
             info "Will use junit2jira to create CSV for BigQuery input"


### PR DESCRIPTION
## Description

As per title

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
```
export JOB_NAME="periodic-ci-stackrox-stackrox-master-ocp-4-16-lp-interop-acs-tests-aws" 
if [[ "$JOB_NAME" == *"interop"* ]]; then; echo "OK"                                     
fi
OK
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
