### PR TITLE
test(scanv4): Skip Scanner V4 tests if image is not available

### DIFF
--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -113,6 +113,7 @@ load_state() {
         echo >&2 "ERROR: Bats state file ${BATS_STATE_FILE} does not exist"
         exit 1
     fi
+    # shellcheck source=/dev/null
     source "${BATS_STATE_FILE}"
 }
 
@@ -230,7 +231,9 @@ teardown_file() {
 }
 
 @test "Verify freshly built main image is available" {
+    # shellcheck source=../../deploy/common/env.sh
     source "${ROOT}/deploy/common/env.sh" > /dev/null
+    # shellcheck source=../../deploy/common/deploy.sh
     source "${ROOT}/deploy/common/deploy.sh" > /dev/null
     # We use the image inspection functionality baked into `oc` -- works on OpenShift and vanilla K8s.
     info "Checking availability of image ${MAIN_IMAGE}"
@@ -243,6 +246,7 @@ teardown_file() {
 @test "Upgrade from old Helm chart to HEAD Helm chart with Scanner v4 enabled" {
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=helm
+    # shellcheck disable=SC2030,SC2031
     local main_image_tag="${MAIN_IMAGE_TAG}"
 
     # Deploy earlier version without Scanner V4.


### PR DESCRIPTION
## Description

This PR changes the Scanner V4 test suite so that the tests are skipped if the target image is missing.

It should make it easier to diagnose and triage CI failures because the reason of the failure is now obvious and the rest of the test noise is skipped.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Manual + CI.
