### PR TITLE
ROX-22389: add CRD watcher

### DIFF
--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -64,7 +64,10 @@ func (s *centralCommunicationImpl) Start(client central.SensorServiceClient, cen
 	go s.sendEvents(client, centralReachable, syncDone, configHandler, detector, s.receiver.Stop, s.sender.Stop)
 }
 
-func (s *centralCommunicationImpl) Stop(_ error) {
+func (s *centralCommunicationImpl) Stop(err error) {
+	if err != nil {
+		log.Errorf("Stopping connection due to error: %v", err)
+	}
 	s.stopper.Client().Stop()
 }
 

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -66,7 +66,11 @@ func (s *centralCommunicationImpl) Start(client central.SensorServiceClient, cen
 
 func (s *centralCommunicationImpl) Stop(err error) {
 	if err != nil {
-		log.Errorf("Stopping connection due to error: %v", err)
+		if errors.Is(err, errForcedConnectionRestart) {
+			log.Infof("Connection restart requested: %v", err)
+		} else {
+			log.Errorf("Stopping connection due to error: %v", err)
+		}
 	}
 	s.stopper.Client().Stop()
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -35,7 +35,7 @@ import (
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int, pubSub *internalmessage.MessageSubscriber) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	depResolver := resolver.New(outputQueue, storeProvider, queueSize)
-	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider)
+	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider, pubSub)
 
 	offlineMode := &atomic.Bool{}
 	offlineMode.Store(true)
@@ -50,6 +50,5 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		detector:    detector,
 		reprocessor: reprocessor,
 		offlineMode: offlineMode,
-		pubSub:      pubSub,
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
-	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -31,7 +30,6 @@ type eventPipeline struct {
 	reprocessor reprocessor.Handler
 
 	offlineMode *atomic.Bool
-	pubSub      *internalmessage.MessageSubscriber
 
 	eventsC chan *message.ExpiringMessage
 	stopper concurrency.Stopper

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,6 +30,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		outputQueue:        queue,
 		storeProvider:      storeProvider,
 		mayCreateHandlers:  concurrency.NewSignal(),
+		crdWatcherStatusC:  make(chan *watcher.Status),
 	}
 	k.mayCreateHandlers.Signal()
 	return k

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
@@ -20,7 +21,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.StoreProvider) component.ContextListener {
+func New(client client.Interface, configHandler config.Handler, nodeName string, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.StoreProvider, pubSub *internalmessage.MessageSubscriber) component.ContextListener {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),
@@ -31,6 +32,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		storeProvider:      storeProvider,
 		mayCreateHandlers:  concurrency.NewSignal(),
 		crdWatcherStatusC:  make(chan *watcher.Status),
+		pubSub:             pubSub,
 	}
 	k.mayCreateHandlers.Signal()
 	return k

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
@@ -40,6 +41,7 @@ type listenerImpl struct {
 	mayCreateHandlers  concurrency.Signal
 	context            context.Context
 	crdWatcherStatusC  chan *watcher.Status
+	pubSub             *internalmessage.MessageSubscriber
 }
 
 func (k *listenerImpl) StartWithContext(ctx context.Context) error {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -91,8 +91,6 @@ func (k *listenerImpl) handleAllEvents() {
 	crdHandlerFn := func(status *watcher.Status) {
 		if status.Available {
 			log.Infof("Resources %v became available", status.Resources)
-		} else {
-			log.Infof("Resources %v became unavailable", status.Resources)
 		}
 	}
 	if coAvailabilityChecker.Available(k.client) {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -94,7 +94,7 @@ func (k *listenerImpl) handleAllEvents() {
 			log.Infof("Resources %v became available", status.Resources)
 			if err := k.pubSub.Publish(&internalmessage.SensorInternalMessage{
 				Kind:     internalmessage.SensorMessageSoftRestart,
-				Text:     "The resources for the Compliance Operator have been detected in the cluster. Sensor will restart the connection to reconcile resources with Central.",
+				Text:     "Compliance Operator resources have been updated. Connection will restart to force reconciliation with Central",
 				Validity: k.context,
 			}); err != nil {
 				log.Errorf("Unable to publish message %s: %v", internalmessage.SensorMessageSoftRestart, err)
@@ -119,7 +119,7 @@ func (k *listenerImpl) handleAllEvents() {
 				log.Infof("Resources %v became unavailable", status.Resources)
 				if err := k.pubSub.Publish(&internalmessage.SensorInternalMessage{
 					Kind:     internalmessage.SensorMessageSoftRestart,
-					Text:     "The resources for the Compliance Operator have been removed from the cluster. Sensor will restart the connection to reconcile resources with Central.",
+					Text:     "Compliance Operator resources have been removed. Connection will restart to force reconciliation with Central",
 					Validity: k.context,
 				}); err != nil {
 					log.Errorf("Unable to publish message %s: %v", internalmessage.SensorMessageSoftRestart, err)

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -86,7 +86,7 @@ func (k *listenerImpl) handleAllEvents() {
 		log.Errorf("Unable to add the Resource to the CRD Watcher: %v", err)
 	}
 	if err := crdWatcher.Watch(k.crdWatcherStatusC); err != nil {
-		log.Errorf("failed to start watching the CRDs: %v", err)
+		log.Errorf("Failed to start watching the CRDs: %v", err)
 	}
 	crdHandlerFn := func(status *watcher.Status) {
 		if status.Available {
@@ -161,18 +161,18 @@ func (k *listenerImpl) handleAllEvents() {
 		} else {
 			osConfigFactory = osConfigExtVersions.NewSharedInformerFactory(k.client.OpenshiftConfig(), noResyncPeriod)
 
-			if listenerUtils.ResourceExists(resourceList, osClusterOperatorsResourceName) {
+			if listenerUtils.ResourceExists(resourceList, osClusterOperatorsResourceName, osConfigGroupVersion) {
 				log.Infof("Initializing %q informer", osClusterOperatorsResourceName)
 				handle(k.context, osConfigFactory.Config().V1().ClusterOperators().Informer(), dispatchers.ForClusterOperators(), k.outputQueue, nil, noDependencyWaitGroup, stopSignal, &eventLock)
 			}
 
 			if env.RegistryMirroringEnabled.BooleanSetting() {
-				if listenerUtils.ResourceExists(resourceList, osImageDigestMirrorSetsResourceName) {
+				if listenerUtils.ResourceExists(resourceList, osImageDigestMirrorSetsResourceName, osConfigGroupVersion) {
 					log.Infof("Initializing %q informer", osImageDigestMirrorSetsResourceName)
 					handle(k.context, osConfigFactory.Config().V1().ImageDigestMirrorSets().Informer(), dispatchers.ForRegistryMirrors(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 				}
 
-				if listenerUtils.ResourceExists(resourceList, osImageTagMirrorSetsResourceName) {
+				if listenerUtils.ResourceExists(resourceList, osImageTagMirrorSetsResourceName, osConfigGroupVersion) {
 					log.Infof("Initializing %q informer", osImageTagMirrorSetsResourceName)
 					handle(k.context, osConfigFactory.Config().V1().ImageTagMirrorSets().Informer(), dispatchers.ForRegistryMirrors(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 				}
@@ -187,7 +187,7 @@ func (k *listenerImpl) handleAllEvents() {
 		} else {
 			osOperatorFactory = osOperatorExtVersions.NewSharedInformerFactory(k.client.OpenshiftOperator(), noResyncPeriod)
 
-			if listenerUtils.ResourceExists(resourceList, osImageContentSourcePoliciesResourceName) {
+			if listenerUtils.ResourceExists(resourceList, osImageContentSourcePoliciesResourceName, osOperatorAlphaGroupVersion) {
 				log.Infof("Initializing %q informer", osImageContentSourcePoliciesResourceName)
 				handle(k.context, osOperatorFactory.Operator().V1alpha1().ImageContentSourcePolicies().Informer(), dispatchers.ForRegistryMirrors(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 			}

--- a/sensor/kubernetes/listener/utils/utils.go
+++ b/sensor/kubernetes/listener/utils/utils.go
@@ -17,15 +17,15 @@ func ServerResourcesForGroup(client client.Interface, group string) (*metav1.API
 }
 
 // ResourceExists returns true if resource exists in list.  Use with output from
-// `serverResourcesForGroup` to verify a resource exists prior to starting an
+// `ServerResourcesForGroup` to verify a resource exists prior to starting an
 // Informer to prevent client-go from spamming the k8s API and logs.
-func ResourceExists(list *metav1.APIResourceList, resource string) bool {
+func ResourceExists(list *metav1.APIResourceList, resource string, group string) bool {
 	for _, apiResource := range list.APIResources {
 		if apiResource.Name == resource {
 			return true
 		}
 	}
 
-	log.Warnf("Resource %q does not exist...", resource)
+	log.Warnf("Resource %q does not exist in the group %s", resource, group)
 	return false
 }

--- a/sensor/kubernetes/listener/utils/utils.go
+++ b/sensor/kubernetes/listener/utils/utils.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/kubernetes/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+// ServerResourcesForGroup retrieves the APIResourceList of the given group.
+func ServerResourcesForGroup(client client.Interface, group string) (*metav1.APIResourceList, error) {
+	resourceList, err := client.Kubernetes().Discovery().ServerResourcesForGroupVersion(group)
+	return resourceList, err
+}
+
+// ResourceExists returns true if resource exists in list.  Use with output from
+// `serverResourcesForGroup` to verify a resource exists prior to starting an
+// Informer to prevent client-go from spamming the k8s API and logs.
+func ResourceExists(list *metav1.APIResourceList, resource string) bool {
+	for _, apiResource := range list.APIResources {
+		if apiResource.Name == resource {
+			return true
+		}
+	}
+
+	log.Warnf("Resource %q does not exist...", resource)
+	return false
+}

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
@@ -1,0 +1,73 @@
+package complianceoperator
+
+import (
+	"fmt"
+
+	"github.com/stackrox/rox/pkg/complianceoperator"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/kubernetes/client"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/utils"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type availabilityChecker struct {
+	gv        schema.GroupVersion
+	resources []complianceoperator.APIResource
+}
+
+func apiResourceToNameGroupString(resource complianceoperator.APIResource) string {
+	return fmt.Sprintf("%s.%s", resource.Name, resource.Group)
+}
+
+// NewComplianceOperatorAvailabilityChecker creates a new AvailabilityChecker
+func NewComplianceOperatorAvailabilityChecker() *availabilityChecker {
+	resources := []complianceoperator.APIResource{
+		complianceoperator.Profile,
+		complianceoperator.Rule,
+		complianceoperator.ScanSetting,
+		complianceoperator.ScanSettingBinding,
+		complianceoperator.ComplianceScan,
+		complianceoperator.ComplianceSuite,
+		complianceoperator.ComplianceCheckResult,
+		complianceoperator.TailoredProfile,
+	}
+	return &availabilityChecker{
+		gv:        complianceoperator.GetGroupVersion(),
+		resources: resources,
+	}
+}
+
+// Available returns 'true' if the Compliance Operator resources are available in the cluster
+func (w *availabilityChecker) Available(client client.Interface) bool {
+	var resourceList *v1.APIResourceList
+	var err error
+	if resourceList, err = utils.ServerResourcesForGroup(client, w.gv.String()); err != nil {
+		log.Errorf("Checking API resources for group %q: %v", w.gv.String(), err)
+		return false
+	}
+	for _, r := range w.resources {
+		if !utils.ResourceExists(resourceList, r.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+type crdWatcher interface {
+	AddResourceToWatch(string) error
+}
+
+// AppendToCRDWatcher adds the Compliance Operator resources to the CRD watcher
+func (w *availabilityChecker) AppendToCRDWatcher(watcher crdWatcher) error {
+	for _, r := range w.resources {
+		if err := watcher.AddResourceToWatch(apiResourceToNameGroupString(r)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
@@ -51,7 +51,7 @@ func (w *availabilityChecker) Available(client client.Interface) bool {
 		return false
 	}
 	for _, r := range w.resources {
-		if !utils.ResourceExists(resourceList, r.Name) {
+		if !utils.ResourceExists(resourceList, r.Name, w.gv.String()) {
 			return false
 		}
 	}

--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher.go
@@ -1,0 +1,124 @@
+package crd
+
+import (
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	customResourceDefinitionsName = "customresourcedefinitions"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type crdWatcher struct {
+	stopSig            *concurrency.Signal
+	resources          set.StringSet
+	availableResources set.StringSet
+	resourceC          chan *resourceEvent
+	sif                dynamicinformer.DynamicSharedInformerFactory
+	status             *atomic.Bool
+	started            *atomic.Bool
+}
+
+// NewCRDWatcher creates a new CRDWatcher
+func NewCRDWatcher(stopSig *concurrency.Signal, sif dynamicinformer.DynamicSharedInformerFactory) *crdWatcher {
+	return &crdWatcher{
+		stopSig:            stopSig,
+		resources:          set.NewStringSet(),
+		availableResources: set.NewStringSet(),
+		resourceC:          make(chan *resourceEvent),
+		sif:                sif,
+		status:             &atomic.Bool{},
+		started:            &atomic.Bool{},
+	}
+}
+
+type resourceEvent struct {
+	resourceName string
+	action       central.ResourceAction
+}
+
+func (w *crdWatcher) startHandler() error {
+	handler := newCRDHandler(w.stopSig, w.resourceC)
+	informer := w.sif.ForResource(v1.SchemeGroupVersion.WithResource(customResourceDefinitionsName)).Informer()
+	if _, err := informer.AddEventHandler(handler); err != nil {
+		return err
+	}
+	wg := concurrency.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Add(-1)
+		if !cache.WaitForCacheSync(w.stopSig.Done(), informer.HasSynced) {
+			return
+		}
+	}()
+	w.sif.Start(w.stopSig.Done())
+	if !concurrency.WaitInContext(&wg, w.stopSig) {
+		return errors.New("Unable to start the CRD Handler")
+	}
+	return nil
+}
+
+// AddResourceToWatch adds a resource to be watched
+func (w *crdWatcher) AddResourceToWatch(name string) error {
+	if w.started.Load() {
+		return errors.New("Adding resources to watch after calling 'Watch' is not supported")
+	}
+	w.resources.Add(name)
+	return nil
+}
+
+// Watch starts the CRD handler that will dispatch any events coming from k8s related to CRDs to be manage by the CRDWatcher
+func (w *crdWatcher) Watch(statusC chan<- *watcher.Status) error {
+	w.started.Store(true)
+	go func() {
+		for {
+			select {
+			case <-w.stopSig.Done():
+				return
+			case event, ok := <-w.resourceC:
+				if !ok {
+					return
+				}
+				if !w.resources.Contains(event.resourceName) {
+					continue
+				}
+				switch event.action {
+				case central.ResourceAction_CREATE_RESOURCE:
+					w.availableResources.Add(event.resourceName)
+				case central.ResourceAction_REMOVE_RESOURCE:
+					w.availableResources.Remove(event.resourceName)
+				}
+			}
+			var status *watcher.Status
+			if len(w.resources) == len(w.availableResources) && w.status.CompareAndSwap(false, true) {
+				status = &watcher.Status{}
+			}
+			if len(w.resources) > len(w.availableResources) && w.status.CompareAndSwap(true, false) {
+				status = &watcher.Status{}
+			}
+			if status != nil {
+				status.Available = w.status.Load()
+				status.Resources = w.resources
+				select {
+				case <-w.stopSig.Done():
+					return
+				case statusC <- status:
+				}
+			}
+		}
+	}()
+	return w.startHandler()
+}

--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
@@ -1,0 +1,175 @@
+package crd
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+const (
+	group                            = "apiextensions.k8s.io"
+	version                          = "v1"
+	kind                             = "CustomResourceDefinition"
+	customResourceDefinitionListName = "CustomResourceDefinitionList"
+	crdName                          = "fake-crd"
+	defaultTimeout                   = 5 * time.Second
+)
+
+var (
+	apiVersion = fmt.Sprintf("%s/%s", group, version)
+	gvr        = schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: customResourceDefinitionsName,
+	}
+)
+
+type watcherSuite struct {
+	suite.Suite
+	dynamicClient dynamic.Interface
+}
+
+func TestWatcherSuite(t *testing.T) {
+	suite.Run(t, new(watcherSuite))
+}
+
+func (s *watcherSuite) setupDynamicClient() {
+	scheme := runtime.NewScheme()
+	s.dynamicClient = fake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{gvr: customResourceDefinitionListName})
+}
+
+func (s *watcherSuite) createWatcher(stopSig *concurrency.Signal) *crdWatcher {
+	return NewCRDWatcher(stopSig, dynamicinformer.NewDynamicSharedInformerFactory(s.dynamicClient, 0))
+}
+
+func newFakeCRD(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+}
+
+func (s *watcherSuite) createWithRandomTicker(names ...string) {
+	go func() {
+		ticker := time.NewTicker(time.Duration(rand.Intn(100)) * time.Millisecond)
+		for _, name := range names {
+			select {
+			case <-ticker.C:
+				s.createFakeCRDs(context.Background(), name)
+			case <-time.NewTimer(defaultTimeout).C:
+				s.Fail("timeout creating resources")
+			}
+		}
+	}()
+}
+
+func (s *watcherSuite) createFakeCRDs(ctx context.Context, names ...string) {
+	for _, name := range names {
+		_, err := s.dynamicClient.Resource(gvr).Create(ctx, newFakeCRD(name), metav1.CreateOptions{})
+		s.Assert().NoError(err)
+	}
+}
+
+func (s *watcherSuite) removeFakeCRDs(ctx context.Context, names ...string) {
+	for _, name := range names {
+		err := s.dynamicClient.Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
+		s.Assert().NoError(err)
+	}
+}
+
+func (s *watcherSuite) Test_CreateDeleteCRD() {
+	cases := map[string]struct {
+		resourcesToWatch     []string
+		shouldStartAtAnytime bool
+	}{
+		"One resource": {
+			resourcesToWatch: []string{crdName},
+		},
+		"Multiple resources after calling Watch": {
+			resourcesToWatch: []string{crdName, "fake-crd2", "fake-crd3"},
+		},
+		"Multiple resources before/after calling Watch": {
+			resourcesToWatch:     []string{crdName, "fake-crd2", "fake-crd3"},
+			shouldStartAtAnytime: true,
+		},
+	}
+	for tName, tCase := range cases {
+		s.Run(tName, func() {
+			s.setupDynamicClient()
+			stopSig := concurrency.NewSignal()
+			callbackC := make(chan *watcher.Status)
+			defer func() {
+				stopSig.Done()
+				close(callbackC)
+			}()
+			// This will create the resources in a goroutine with a random ticker
+			if tCase.shouldStartAtAnytime {
+				s.createWithRandomTicker(tCase.resourcesToWatch...)
+			}
+			w := s.createWatcher(&stopSig)
+			for _, rName := range tCase.resourcesToWatch {
+				s.Assert().NoError(w.AddResourceToWatch(rName))
+			}
+			s.Assert().NoError(w.Watch(callbackC))
+
+			if !tCase.shouldStartAtAnytime {
+				s.createFakeCRDs(context.Background(), tCase.resourcesToWatch...)
+			}
+
+			select {
+			case <-time.NewTimer(defaultTimeout).C:
+				s.Fail("timeout reached waiting for watcher to report")
+			case st, ok := <-callbackC:
+				s.Assert().True(ok)
+				s.Assert().True(st.Available)
+				for _, rName := range tCase.resourcesToWatch {
+					s.Assert().Contains(st.Resources, rName)
+				}
+			}
+
+			s.removeFakeCRDs(context.Background(), tCase.resourcesToWatch...)
+
+			select {
+			case <-time.NewTimer(defaultTimeout).C:
+				s.Fail("timeout reached waiting for watcher to report")
+			case st, ok := <-callbackC:
+				s.Assert().True(ok)
+				s.Assert().False(st.Available)
+				for _, rName := range tCase.resourcesToWatch {
+					s.Assert().Contains(st.Resources, rName)
+				}
+			}
+		})
+	}
+}
+
+func (s *watcherSuite) Test_AddResourceAfterWatchFails() {
+	s.setupDynamicClient()
+	stopSig := concurrency.NewSignal()
+	callbackC := make(chan *watcher.Status)
+	defer func() {
+		stopSig.Done()
+		close(callbackC)
+	}()
+	w := s.createWatcher(&stopSig)
+	s.Assert().NoError(w.Watch(callbackC))
+	s.Assert().Error(w.AddResourceToWatch(crdName))
+}

--- a/sensor/kubernetes/listener/watcher/crd/handler.go
+++ b/sensor/kubernetes/listener/watcher/crd/handler.go
@@ -1,0 +1,49 @@
+package crd
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type crdHandler struct {
+	stopSig *concurrency.Signal
+	eventC  chan *resourceEvent
+}
+
+func newCRDHandler(stopSig *concurrency.Signal, eventC chan *resourceEvent) *crdHandler {
+	return &crdHandler{
+		stopSig: stopSig,
+		eventC:  eventC,
+	}
+}
+
+// OnAdd this function is called by the informer whenever a resource is created in the cluster
+func (h *crdHandler) OnAdd(obj interface{}, _ bool) {
+	h.processEvent(nil, obj, central.ResourceAction_CREATE_RESOURCE)
+}
+
+// OnUpdate this function is called by the informer whenever a resource is updated in the cluster
+func (h *crdHandler) OnUpdate(_, _ interface{}) {}
+
+// OnDelete this function is called by the informer whenever a resource is deleted the cluster
+func (h *crdHandler) OnDelete(obj interface{}) {
+	h.processEvent(nil, obj, central.ResourceAction_REMOVE_RESOURCE)
+}
+
+func (h *crdHandler) processEvent(_, new interface{}, action central.ResourceAction) {
+	unstructuredObj, ok := new.(*unstructured.Unstructured)
+	if !ok {
+		log.Errorf("Object %v is not an unstructured object", new)
+		return
+	}
+	log.Debugf("Process CRD %s with action %s", unstructuredObj.GetName(), action)
+	select {
+	case <-h.stopSig.Done():
+		return
+	case h.eventC <- &resourceEvent{
+		resourceName: unstructuredObj.GetName(),
+		action:       action,
+	}:
+	}
+}

--- a/sensor/kubernetes/listener/watcher/status.go
+++ b/sensor/kubernetes/listener/watcher/status.go
@@ -1,0 +1,11 @@
+package watcher
+
+import "github.com/stackrox/rox/pkg/set"
+
+// Status represents the state of a watcher. Available means all the Resources are available in the cluster.
+type Status struct {
+	// Available is 'true' is all the Resources are available
+	Available bool
+	// Resources a StringSet with all the resources that are being watched
+	Resources set.StringSet
+}

--- a/tests/complianceoperator/crds/scansetting.yaml
+++ b/tests/complianceoperator/crds/scansetting.yaml
@@ -1,0 +1,273 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operatorframework.io/installed-alongside-6cfa656b08efb427: openshift-compliance/compliance-operator.v1.4.0
+  creationTimestamp: "2024-04-15T13:29:36Z"
+  generation: 1
+  labels:
+    olm.managed: "true"
+    operators.coreos.com/compliance-operator.openshift-compliance: ""
+  name: scansettings.compliance.openshift.io
+  resourceVersion: "95034"
+  uid: 9b397ebf-30d6-43b2-8dee-fdae5af8c442
+spec:
+  conversion:
+    strategy: None
+  group: compliance.openshift.io
+  names:
+    kind: ScanSetting
+    listKind: ScanSettingList
+    plural: scansettings
+    shortNames:
+    - ss
+    singular: scansetting
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScanSetting is the Schema for the scansettings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          autoApplyRemediations:
+            description: Defines whether or not the remediations should be applied
+              automatically
+            type: boolean
+          autoUpdateRemediations:
+            description: Defines whether or not the remediations should be updated
+              automatically. This is done by deleting the "outdated" object from the
+              remediation.
+            type: boolean
+          debug:
+            description: Enable debug logging of workloads and OpenSCAP
+            type: boolean
+          httpsProxy:
+            description: It is recommended to set the proxy via the config.openshift.io/Proxy
+              object Defines a proxy for the scan to get external resources from.
+              This is useful for disconnected installations with access to a proxy.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          maxRetryOnTimeout:
+            default: 3
+            description: MaxRetryOnTimeout is the maximum number of times the scan
+              will be retried if it times out.
+            type: integer
+          metadata:
+            type: object
+          noExternalResources:
+            description: Defines that no external resources in the Data Stream should
+              be used. External resources could be, for instance, CVE feeds. This
+              is useful for disconnected installations without access to a proxy.
+            type: boolean
+          priorityClass:
+            description: Defines the PriorityClass to use for launching scan related
+              pods, the Name of a desired PriorityClass should be set here, this is
+              an optional field, if PriorityClass is invalid or not found, it will
+              be ignored.
+            type: string
+          rawResultStorage:
+            description: Specifies settings that pertain to raw result storage.
+            properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: By setting this, it's possible to configure where the
+                  result server instances are run. These instances will mount a Persistent
+                  Volume to store the raw results, so special care should be taken
+                  to schedule these in trusted nodes.
+                type: object
+              pvAccessModes:
+                default:
+                - ReadWriteOnce
+                description: Specifies the access modes that the PersistentVolume
+                  will be created with. The persistent volume will hold the raw results
+                  of the scan.
+                items:
+                  type: string
+                type: array
+              rotation:
+                default: 3
+                description: Specifies the amount of scans for which the raw results
+                  will be stored. Older results will get rotated, and it's the responsibility
+                  of administrators to store these results elsewhere before rotation
+                  happens. Note that a rotation policy of '0' disables rotation entirely.
+                  Defaults to 3.
+                type: integer
+              size:
+                default: 1Gi
+                description: Specifies the amount of storage to ask for storing the
+                  raw results. Note that if re-scans happen, the new results will
+                  also need to be stored. Defaults to 1Gi.
+                type: string
+              storageClassName:
+                description: Specifies the StorageClassName to use when creating the
+                  PersistentVolumeClaim to hold the raw results. By default this is
+                  null, which will attempt to use the default storage class configured
+                  in the cluster. If there is no default class specified then this
+                  needs to be set.
+                nullable: true
+                type: string
+              tolerations:
+                description: Specifies tolerations needed for the result server to
+                  run on the nodes. This is useful in case the target set of nodes
+                  have custom taints that don't allow certain workloads to run. Defaults
+                  to allowing scheduling on master nodes.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          remediationEnforcement:
+            description: 'Specifies what to do with remediations of Enforcement type.
+              If left empty, this defaults to "off" which doesn''t create nor apply
+              any enforcement remediations. If set to "all" this creates any enforcement
+              remediations it encounters. Subsequently, this can also be set to a
+              specific type. e.g. setting it to "gatekeeper" will apply any enforcement
+              remediations relevant to the Gatekeeper OPA system. These objects will
+              annotated in the content itself with: complianceascode.io/enforcement-type:
+              <type>'
+            type: string
+          roles:
+            description: "The list of roles to apply node-specific checks to. \n This
+              will be translated to the standard Kubernetes role label `node-role.kubernetes.io/<role
+              name>`. \n It's also possible to specify `@all` as a role, which will
+              run a scan on all nodes by not specifying a node selector as we normally
+              do. The usage of `@all` in OpenShift is discouraged as the operator
+              won't be able to apply remediations unless roles are specified. \n Note
+              that tolerations must still be configured for the opeartor to appropriately
+              schedule scans."
+            items:
+              type: string
+            type: array
+          scanLimits:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: ScanLimits allows to set the resource limits that the scan
+              pods are allowed to use. By default, compliance operator will use sensible
+              defaults (500Mi memory, 100m CPU for the scanner container and 200Mi
+              memory with 100m CPU for the api-resource-collector container).
+            type: object
+          scanTolerations:
+            default:
+            - operator: Exists
+            description: Specifies tolerations needed for the scan to run on the nodes.
+              This is useful in case the target set of nodes have custom taints that
+              don't allow certain workloads to run. Defaults to allowing scheduling
+              on all nodes.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: Effect indicates the taint effect to match. Empty means
+                    match all taint effects. When specified, allowed values are NoSchedule,
+                    PreferNoSchedule and NoExecute.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: Operator represents a key's relationship to the value.
+                    Valid operators are Exists and Equal. Defaults to Equal. Exists
+                    is equivalent to wildcard for value, so that a pod can tolerate
+                    all taints of a particular category.
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          schedule:
+            description: Defines a schedule for the scans to run. This is in cronjob
+              format. Note the scan will still be triggered immediately, and the scheduled
+              scans will start running only after the initial results are ready.
+            type: string
+          showNotApplicable:
+            default: false
+            description: Determines whether to hide or show results that are not applicable.
+            type: boolean
+          strictNodeScan:
+            default: true
+            description: Defines whether the scan should proceed if we're not able
+              to scan all the nodes or not. `true` means that the operator should
+              be strict and error out. `false` means that we don't need to be strict
+              and we can proceed.
+            type: boolean
+          suspend:
+            default: false
+            description: Defines if a schedule should be suspended and is a boolean
+              value, defaulting to False.
+            type: boolean
+          timeout:
+            default: 30m
+            description: Timeout is the maximum amount of time the scan can run. If
+              the scan hasn't finished by then, it will be aborted.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Description

Adds a new CRD watcher that will trigger an event if the CRDs for CO become/stop-being available.

- [x] A follow-up needs to be done after #10729 is merged to publish an internal message in sensor to restart the connection.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Installing the CO logs the message `Resources became available`. If CO is uninstalled (and the CRD's deleted) sensor logs the message `Resources became unavailable`.
- [x] Manual test that installing the CO after the secure cluster restarts the connection and the informers are started upon reconnection.
- [x] Manual test that uninstalling the CO restarts the connection and the informers are not started upon reconnection

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
