### PR TITLE
ROX-23070: Add routing for Platform CVE cluster page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -29,7 +29,7 @@ import NodePageHeader, { NodeMetadata, nodeMetadataFragment } from './NodePageHe
 import NodePageVulnerabilities from './NodePageVulnerabilities';
 import NodePageDetails from './NodePageDetails';
 
-const nodeCveOverviewCvePath = getOverviewPagePath('Node', {
+const nodeCveOverviewPath = getOverviewPagePath('Node', {
     entityTab: 'Node',
 });
 
@@ -66,7 +66,7 @@ function NodePage() {
             <PageTitle title={`Node CVEs - Node ${nodeName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={nodeCveOverviewCvePath}>Nodes</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={nodeCveOverviewPath}>Nodes</BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {nodeName ?? (
                             <Skeleton screenreaderText="Loading Node name" width="200px" />
@@ -82,7 +82,7 @@ function NodePage() {
                             title={getAxiosErrorMessage(error)}
                             headingLevel="h2"
                             icon={ExclamationCircleIcon}
-                            iconClassName="pf-u-danger-color-100"
+                            iconClassName="pf-v5-u-danger-color-100"
                         />
                     </Bullseye>
                 </PageSection>
@@ -99,7 +99,7 @@ function NodePage() {
                                 // pagination.setPage(1);
                             }}
                             component={TabsComponent.nav}
-                            className="pf-u-pl-md pf-u-background-color-100"
+                            className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                             mountOnEnter
                             unmountOnExit
@@ -123,7 +123,7 @@ function NodePage() {
                             id={vulnTabId}
                             ref={vulnTabRef}
                             eventKey={vulnTabKey}
-                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                         >
                             <NodePageVulnerabilities />
                         </TabContent>
@@ -133,7 +133,7 @@ function NodePage() {
                             id={detailsTabId}
                             ref={detailsTabRef}
                             eventKey={detailsTabKey}
-                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                         >
                             <NodePageDetails />
                         </TabContent>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+
+import { getOverviewPagePath } from '../../utils/searchUtils';
+
+const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
+    entityTab: 'Cluster',
+});
+
+// TODO - Update for PF5
+function ClusterPage() {
+    const { clusterId } = useParams() as { clusterId: string };
+
+    const clusterName = 'TODO - cluster name';
+
+    return (
+        <>
+            <PageTitle title={`Platform CVEs - Cluster ${clusterName}`} />
+            <PageSection variant="light" className="pf-v5-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={platformCvesClusterOverviewPath}>
+                        Clusters
+                    </BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>
+                        {clusterName ?? (
+                            <Skeleton screenreaderText="Loading cluster name" width="200px" />
+                        )}
+                    </BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light">Cluster ID: {clusterId}</PageSection>
+        </>
+    );
+}
+
+export default ClusterPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -10,8 +10,10 @@ import usePermissions from 'hooks/usePermissions';
 
 import PlatformCvesOverviewPage from './Overview/PlatformCvesOverviewPage';
 import PlatformCvePage from './PlatformCve/PlatformCvePage';
+import ClusterPage from './Cluster/ClusterPage';
 
 const vulnerabilitiesPlatformCveSinglePath = `${vulnerabilitiesPlatformCvesPath}/cves/:cveId`;
+const vulnerabilitiesPlatformClusterSinglePath = `${vulnerabilitiesPlatformCvesPath}/clusters/:clusterId`;
 
 function PlatformCvesPage() {
     const { hasReadAccess } = usePermissions();
@@ -22,6 +24,7 @@ function PlatformCvesPage() {
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
                 <Route path={vulnerabilitiesPlatformCveSinglePath} component={PlatformCvePage} />
+                <Route path={vulnerabilitiesPlatformClusterSinglePath} component={ClusterPage} />
                 <Route
                     exact
                     path={vulnerabilitiesPlatformCvesPath}


### PR DESCRIPTION
## Description

Adds routing and placeholder component for Platform CVEs: Cluster single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Via direct visit in URL:
![image](https://github.com/stackrox/stackrox/assets/1292638/56db2a4d-7b70-422c-b531-2389475203a1)

Click the breadcrumb link and ensure the page navigates back to the cluster overview list:
![image](https://github.com/stackrox/stackrox/assets/1292638/c09d35ed-7a9f-4cba-9ed7-8b77712efe4c)


