### PR TITLE
[ROX-23566] Update alerts when violations in an alert changes

### DIFF
--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -187,7 +187,7 @@ type Alert struct {
 	//	*Alert_Resource_
 	Entity isAlert_Entity `protobuf_oneof:"Entity"`
 	// For run-time phase alert, a maximum of 40 violations are retained.
-	Violations       []*Alert_Violation      `protobuf:"bytes,5,rep,name=violations,proto3" json:"violations,omitempty" sensorhash:"ignore" search:"-"`                                      // @gotags: sensorhash:"ignore" search:"-"
+	Violations       []*Alert_Violation      `protobuf:"bytes,5,rep,name=violations,proto3" json:"violations,omitempty" search:"-"`                                      // @gotags: search:"-"
 	ProcessViolation *Alert_ProcessViolation `protobuf:"bytes,13,opt,name=process_violation,json=processViolation,proto3" json:"process_violation,omitempty" search:"-"` // @gotags: search:"-"
 	Enforcement      *Alert_Enforcement      `protobuf:"bytes,6,opt,name=enforcement,proto3" json:"enforcement,omitempty"`
 	Time             *types.Timestamp        `protobuf:"bytes,7,opt,name=time,proto3" json:"time,omitempty" sensorhash:"ignore" search:"Violation Time"`                                         // @gotags: sensorhash:"ignore" search:"Violation Time"

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -127,7 +127,7 @@ message Alert {
   }
 
   // For run-time phase alert, a maximum of 40 violations are retained.
-  repeated Violation violations = 5; // @gotags: sensorhash:"ignore" search:"-"
+  repeated Violation violations = 5; // @gotags: search:"-"
   ProcessViolation process_violation = 13; // @gotags: search:"-"
 
   Enforcement enforcement = 6;


### PR DESCRIPTION
## Description

This fixes a regression introduced by the sensor event deduper. The deduper ignored `.violations` field when computing the hash. 

A few deploy-time policies bundled multiple violations into one alert. For example, the `Severity at least Moderate` policy criteria will bundle multiple violation messages into one alert for any CVE with at least moderate severity. Therefore, when new CVEs are detected for a deployment that already has an alert for the policy, the violation bundle changes. However, the changes to the violation bundle are ignored. The same applies to the case when a previously detected violation needs to be removed based on the most recent evaluation.

We ignore a few other alert fields when deduping, which is fair:
1. Alert ID: Alert ID is a deterministic ID given a deployment and a policy.
2. Time: Alerts are evaluated periodically. Thus, the timestamp ought to change, hence, ignored while deduping.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  