### PR TITLE
fix(scanner): add CA to scanner client library

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -138,6 +138,7 @@ func createGRPCConn(ctx context.Context, o connOptions) (*grpc.ClientConn, error
 		clientconn.ServerName(o.serverName),
 		clientconn.MaxMsgReceiveSize(maxRespMsgSize),
 		clientconn.WithDialOptions(dialOpts...),
+		clientconn.AddRootCAs(),
 	}
 	return clientconn.AuthenticatedGRPCConnection(ctx, address, o.mTLSSubject, connOpts...)
 }


### PR DESCRIPTION
## Description

There's currently a bug with `scannerctl` that causes a TLS error when it communicates with `scanner-v4`:
```
{"level":"debug","method":"GetOrCreateImageIndex","component":"scanner/client","image":"quay.io/podman/hello@sha256:1e7354ef111bc9f53fc5fdf4898585d105ce6a7698f7fd03710024dd9775d6f5","rpc":"indexer.GetOrCreateIndexReport","error":"rpc error: code = Unavailable desc = last connection error: connection error: desc = \"transport: authentication handshake failed: x509: “scanner-v4.stackrox” certificate is not trusted\"","duration":1018.714706,"time":"2024-04-09T11:19:05-07:00","message":"retrying gRPC call"}
```

I'm not sure if this is the correct approach (e.g., sensor doesn't have this problem, but I couldn't immediately figure out how sensor configures the CA).

These changes configure the command CA between `scannerctl` and `scanner-v4`.

## Checklist
- ~~[ ] Investigated and inspected CI test results~~
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

N/A. `scannerctl` is intended for local development only.

## Testing Performed

### Here I tell how I validated my change

Before patch:
```
❯ go run ./cmd/scannerctl \
    --certs certs/scannerctl \
    scan --index-only https://quay.io/podman/hello:latest
2024/04/09 11:19:04 auth unspecified: using anonymous auth (use ROX_SCANNERCTL_BASIC_AUTH to set auth)
2024/04/09 11:19:05 image digest: sha256:1e7354ef111bc9f53fc5fdf4898585d105ce6a7698f7fd03710024dd9775d6f5
{"level":"debug","method":"GetOrCreateImageIndex","component":"scanner/client","image":"quay.io/podman/hello@sha256:1e7354ef111bc9f53fc5fdf4898585d105ce6a7698f7fd03710024dd9775d6f5","rpc":"indexer.GetOrCreateIndexReport","error":"rpc error: code = Unavailable desc = last connection error: connection error: desc = \"transport: authentication handshake failed: x509: “scanner-v4.stackrox” certificate is not trusted\"","duration":1018.714706,"time":"2024-04-09T11:19:05-07:00","message":"retrying gRPC call"}
```

After patch:
```
❯ go run ./cmd/scannerctl \
    --certs certs/scannerctl \
    scan --index-only https://quay.io/podman/hello:latest
2024/04/09 11:19:40 auth unspecified: using anonymous auth (use ROX_SCANNERCTL_BASIC_AUTH to set auth)
2024/04/09 11:19:41 image digest: sha256:1e7354ef111bc9f53fc5fdf4898585d105ce6a7698f7fd03710024dd9775d6f5
{
  "hash_id": "/v4/containerimage/sha256:1e7354ef111bc9f53fc5fdf4898585d105ce6a7698f7fd03710024dd9775d6f5",
  "state": "IndexFinished",
  "success": true,
  "contents": {}
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
