### PR TITLE
ROX-23071: Platform cves cluster page layout

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,21 +1,49 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+import {
+    PageSection,
+    Breadcrumb,
+    Divider,
+    BreadcrumbItem,
+    Skeleton,
+    Bullseye,
+} from '@patternfly/react-core';
+import { gql, useQuery } from '@apollo/client';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 
 const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
     entityTab: 'Cluster',
 });
 
+const clusterMetadataQuery = gql`
+    ${clusterMetadataFragment}
+    query getClusterMetadata($id: ID!) {
+        cluster(id: $id) {
+            ...ClusterMetadata
+        }
+    }
+`;
+
 // TODO - Update for PF5
 function ClusterPage() {
     const { clusterId } = useParams() as { clusterId: string };
 
-    const clusterName = 'TODO - cluster name';
+    const { data, error } = useQuery<{ cluster: ClusterMetadata }, { id: string }>(
+        clusterMetadataQuery,
+        {
+            variables: { id: clusterId },
+        }
+    );
+
+    const clusterName = data?.cluster?.name ?? '';
 
     return (
         <>
@@ -33,7 +61,22 @@ function ClusterPage() {
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
-            <PageSection variant="light">Cluster ID: {clusterId}</PageSection>
+            {error ? (
+                <PageSection variant="light">
+                    <Bullseye>
+                        <EmptyStateTemplate
+                            title={getAxiosErrorMessage(error)}
+                            headingLevel="h2"
+                            icon={ExclamationCircleIcon}
+                            iconClassName="pf-v5-u-danger-color-100"
+                        />
+                    </Bullseye>
+                </PageSection>
+            ) : (
+                <PageSection variant="light">
+                    <ClusterPageHeader data={data?.cluster} />
+                </PageSection>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
+
+import { gql } from '@apollo/client';
+import { getDateTime } from 'utils/dateUtils';
+
+export const clusterMetadataFragment = gql`
+    fragment ClusterMetadata on Cluster {
+        id
+        name
+        status {
+            orchestratorMetadata {
+                buildDate
+                version
+            }
+        }
+    }
+`;
+
+export type ClusterMetadata = {
+    id: string;
+    name: string;
+    status?: {
+        orchestratorMetadata?: {
+            buildDate?: string; // ISO 8601 date format
+            version: string;
+        };
+    };
+};
+
+export type ClusterPageHeaderProps = {
+    data: ClusterMetadata | undefined;
+};
+
+function ClusterPageHeader({ data }: ClusterPageHeaderProps) {
+    if (!data) {
+        return (
+            <Flex
+                direction={{ default: 'column' }}
+                spaceItems={{ default: 'spaceItemsXs' }}
+                className="pf-v5-u-w-50"
+            >
+                <Skeleton screenreaderText="Loading Cluster name" fontSize="2xl" />
+                <Skeleton screenreaderText="Loading Cluster metadata" height="40px" />
+            </Flex>
+        );
+    }
+
+    const buildDate = data.status?.orchestratorMetadata?.buildDate;
+    const version = data.status?.orchestratorMetadata?.version;
+    const numLabels = 0 + (buildDate ? 1 : 0) + (version ? 1 : 0);
+
+    return (
+        <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
+            <Title headingLevel="h1" className="pf-v5-u-mb-sm">
+                {data.name}
+            </Title>
+            {numLabels > 0 && (
+                <LabelGroup numLabels={numLabels}>
+                    {version && <Label>K8s version: {version}</Label>}
+                    {buildDate && <Label>Build date: {getDateTime(buildDate)}</Label>}
+                </LabelGroup>
+            )}
+        </Flex>
+    );
+}
+
+export default ClusterPageHeader;


### PR DESCRIPTION
## Description

Adds the metadata query and loading headers to the Platform CVEs cluster page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a cluster page manually by editing the URL with a valid cluster id:

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/69ef6d0b-c032-4f54-beb6-624c94524cff)

Loading complete:
![image](https://github.com/stackrox/stackrox/assets/1292638/868d76e7-4f3d-48d5-a3fd-321dd06adda0)

