### PR TITLE
chore(ui): Refactor header loading skeleton

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const nodeMetadataFragment = gql`
     fragment NodeMetadata on Node {
@@ -31,14 +33,10 @@ export type NodePageHeaderProps = {
 function NodePageHeader({ data }: NodePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Node name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Node metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Node name"
+                metadataScreenreaderText="Loading Node metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const clusterMetadataFragment = gql`
     fragment ClusterMetadata on Cluster {
@@ -35,14 +37,10 @@ export type ClusterPageHeaderProps = {
 function ClusterPageHeader({ data }: ClusterPageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Cluster name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Cluster metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Cluster name"
+                metadataScreenreaderText="Loading Cluster metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import { Flex, Title, LabelGroup, Label, Skeleton } from '@patternfly/react-core';
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export type DeploymentMetadata = {
     id: string;
@@ -42,14 +44,10 @@ function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {
             </LabelGroup>
         </Flex>
     ) : (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsXs' }}
-            className="pf-v5-u-w-50"
-        >
-            <Skeleton screenreaderText="Loading Deployment name" fontSize="2xl" />
-            <Skeleton screenreaderText="Loading Deployment metadata" fontSize="sm" />
-        </Flex>
+        <HeaderLoadingSkeleton
+            nameScreenreaderText="Loading Deployment name"
+            metadataScreenreaderText="Loading Deployment metadata"
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -28,6 +28,7 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
 
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
@@ -146,14 +147,10 @@ function ImagePage() {
                             )}
                         </Flex>
                     ) : (
-                        <Flex
-                            direction={{ default: 'column' }}
-                            spaceItems={{ default: 'spaceItemsXs' }}
-                            className="pf-v5-u-w-50"
-                        >
-                            <Skeleton screenreaderText="Loading image name" fontSize="2xl" />
-                            <Skeleton screenreaderText="Loading image metadata" fontSize="sm" />
-                        </Flex>
+                        <HeaderLoadingSkeleton
+                            nameScreenreaderText="Loading image name"
+                            metadataScreenreaderText="Loading image metadata"
+                        />
                     )}
                 </PageSection>
                 <PageSection

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-    Flex,
-    LabelGroup,
-    Label,
-    Skeleton,
-    Text,
-    Title,
-    List,
-    ListItem,
-} from '@patternfly/react-core';
+import { Flex, LabelGroup, Label, Text, Title, List, ListItem } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
@@ -16,6 +7,7 @@ import { getDateTime } from 'utils/dateUtils';
 
 import { getDistroLinkText } from '../utils/textUtils';
 import { sortCveDistroList } from '../utils/sortUtils';
+import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
 
 export type CveMetadata = {
     cve: string;
@@ -34,14 +26,10 @@ export type CvePageHeaderProps = {
 function CvePageHeader({ data }: CvePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading CVE name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading CVE metadata" height="100px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading CVE name"
+                metadataScreenreaderText="Loading CVE metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Flex, Skeleton } from '@patternfly/react-core';
+
+export type HeaderLoadingSkeletonProps = {
+    nameScreenreaderText: string;
+    metadataScreenreaderText: string;
+};
+
+function HeaderLoadingSkeleton({
+    nameScreenreaderText,
+    metadataScreenreaderText,
+}: HeaderLoadingSkeletonProps) {
+    return (
+        <Flex
+            direction={{ default: 'column' }}
+            spaceItems={{ default: 'spaceItemsXs' }}
+            className="pf-u-w-50"
+        >
+            <Skeleton screenreaderText={nameScreenreaderText} fontSize="2xl" />
+            <Skeleton screenreaderText={metadataScreenreaderText} height="100px" />
+        </Flex>
+    );
+}
+
+export default HeaderLoadingSkeleton;


### PR DESCRIPTION
## Description

Refactors nearly identical code used in 5 (so far) places in VM 2.0 into a common component.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit each of the Workload/Node/Platform CVE pages that currently exist and verify the loading skeletons are still displayed while the data is in transit.