### PR TITLE
ROX-23540: Add Central cap to display Internal Entities in the NWG 

### DIFF
--- a/central/sensor/service/pipeline/networkflowupdate/pipeline.go
+++ b/central/sensor/service/pipeline/networkflowupdate/pipeline.go
@@ -36,7 +36,7 @@ type pipelineImpl struct {
 }
 
 func (s *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
-	return nil
+	return []centralsensor.CentralCapability{centralsensor.NetworkGraphInternalEntitiesSupported}
 }
 
 func (s *pipelineImpl) Reconcile(_ context.Context, _ string, _ *reconciliation.StoreMap) error {

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -48,4 +48,7 @@ const (
 
 	// ScannerV4Supported identifies the capability of Central to support Scanner V4 related requests from Sensor.
 	ScannerV4Supported = "ScannerV4Supported"
+
+	// NetworkGraphInternalEntitiesSupported identifies the capability of Central (UI) to display internal entities in the network graph.
+	NetworkGraphInternalEntitiesSupported = "NetworkGraphInternalEntitiesSupported"
 )

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
@@ -555,7 +556,8 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				log.Debugf("Not showing flow on the network graph: %v", err)
 				return
 			}
-			if !isExternal {
+			if !isExternal && centralcaps.Has(centralsensor.NetworkGraphInternalEntitiesSupported) {
+				// Central without the capability would crash the UI if we make it display "Internal Entities".
 				entityType = networkgraph.InternalEntities()
 			}
 
@@ -571,6 +573,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				entitiesName = "External Entities"
 			}
 			if conn.incoming {
+				// Keep internal wording even if central lacks `NetworkGraphInternalEntitiesSupported` capability.
 				log.Debugf("Incoming connection to container %s/%s from %s:%s. "+
 					"Marking it as '%s' in the network graph.",
 					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String(), strconv.Itoa(int(port)), entitiesName)
@@ -581,6 +584,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			}
 
 			if !status.used {
+				// Count internal metrics even if central lacks `NetworkGraphInternalEntitiesSupported` capability.
 				if isExternal {
 					flowMetrics.ExternalFlowCounter.With(metricDirection).Inc()
 				} else {


### PR DESCRIPTION
## Description

Central has now a capability to mark that it is able to display the 'Internal Entities' node on the network graph. If this cap is missing, Sensor would return all internal entities as external entities (as those are supported by older centrals). 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I manually deployed various combinations of Central and Sensor and looked at the Network Graph for the `stackrox` namespace. Here are the results:

#### (1) Reproducing the bug: Central 4.3.6, Sensor 4.4.0

Result: ❌  Network Graph does not load

![central-4 3 6-sensor-4 4 0-nwg-does-not-load](https://github.com/stackrox/stackrox/assets/114479/40db5668-7267-492d-9bf9-219af48b3c82)

#### (2) Fixing the bug: Central 4.3.6, Sensor this PR

Result: ✅ Network Graph works, all unknown flows are treated as external (default behavior for versions 4.3 and older)

![central-4 3 6-sensor-this-PR](https://github.com/stackrox/stackrox/assets/114479/8902300e-f97e-411b-9a65-ccbfbb53a897)

#### (3) Checking backwards compat of this patch: Central: this PR, Sensor 4.4.0

Result: All good, internal entities are visible. Adding Central capability first in this PR, does not prevent 4.4.0 Sensor from sending flows of type 5 (internal).

![central-this-PR-sensor-4 4 0-internal-OK](https://github.com/stackrox/stackrox/assets/114479/9d5cc9af-25ac-4061-a886-9a08cab655c7)

#### (4) Checking deeper backwards compat of this patch: Central: this PR, Sensor 4.3.6

Result: ✅ Sensor sends only flows of type 4 (external) as type 5 (internal) was not implemented in 4.3. 

![central-this-PR-sensor-4 3 6-only-external](https://github.com/stackrox/stackrox/assets/114479/b9e8c964-9eae-49b5-af56-50569fddd425)

#### (5) Checking new installs: Central this PR, Sensor this PR

Result: ✅ internal entities are visible. Sensor recognizes Central's capability and sends flows of type 5 (internal).

![central-this-PR-sensor-this-PR-internal-OK](https://github.com/stackrox/stackrox/assets/114479/f3e345cd-440e-40e7-a708-8095d9ec2b0a)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and

 you are satisfied with it.
