### PR TITLE
Dv/exp/custom tab hook

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { gql, useQuery } from '@apollo/client';
 import {
@@ -8,20 +8,15 @@ import {
     BreadcrumbItem,
     Skeleton,
     Bullseye,
-    Tab,
-    TabContent,
-    TabTitleText,
-    Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
-import useURLStringUnion from 'hooks/useURLStringUnion';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import useTabContent from 'hooks/patternfly/useTabContent';
 import { detailsTabValues } from '../../types';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 
@@ -50,14 +45,34 @@ function NodePage() {
         variables: { id: nodeId },
     });
 
-    const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
-
-    const vulnTabKey = 'Vulnerabilities';
-    const detailsTabKey = 'Details';
-    const vulnTabId = 'node-vulnerabilities-tab';
-    const detailsTabId = 'node-details-tab';
-    const vulnTabRef = useRef<HTMLElement>(null);
-    const detailsTabRef = useRef<HTMLElement>(null);
+    const [Tabs, TabContents] = useTabContent({
+        parameterName: 'detailsTab',
+        tabKeys: detailsTabValues,
+        tabs: [
+            {
+                key: 'Vulnerabilities',
+                content: <NodePageVulnerabilities />,
+                contentProps: {
+                    className:
+                        'pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1',
+                },
+            },
+            {
+                key: 'Details',
+                content: <NodePageDetails />,
+                contentProps: {
+                    className:
+                        'pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1',
+                },
+            },
+        ],
+        tabsProps: {
+            className: 'pf-v5-u-pl-md pf-v5-u-background-color-100',
+        },
+        onTabChange: () => {
+            // pagination.setPage(1);
+        },
+    });
 
     const nodeName = data?.node?.name ?? '-';
 
@@ -91,53 +106,8 @@ function NodePage() {
                     <PageSection variant="light">
                         <NodePageHeader data={data?.node} />
                     </PageSection>
-                    <PageSection padding={{ default: 'noPadding' }}>
-                        <Tabs
-                            activeKey={activeTabKey}
-                            onSelect={(e, key) => {
-                                setActiveTabKey(key);
-                                // pagination.setPage(1);
-                            }}
-                            component={TabsComponent.nav}
-                            className="pf-v5-u-pl-md pf-v5-u-background-color-100"
-                            role="region"
-                            mountOnEnter
-                            unmountOnExit
-                        >
-                            <Tab
-                                eventKey={vulnTabKey}
-                                title={<TabTitleText>Vulnerabilities</TabTitleText>}
-                                tabContentId={vulnTabId}
-                                tabContentRef={vulnTabRef}
-                            />
-                            <Tab
-                                eventKey={detailsTabKey}
-                                title={<TabTitleText>Details</TabTitleText>}
-                                tabContentId={detailsTabId}
-                                tabContentRef={detailsTabRef}
-                            />
-                        </Tabs>
-                    </PageSection>
-                    {activeTabKey === vulnTabKey && (
-                        <TabContent
-                            id={vulnTabId}
-                            ref={vulnTabRef}
-                            eventKey={vulnTabKey}
-                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
-                        >
-                            <NodePageVulnerabilities />
-                        </TabContent>
-                    )}
-                    {activeTabKey === detailsTabKey && (
-                        <TabContent
-                            id={detailsTabId}
-                            ref={detailsTabRef}
-                            eventKey={detailsTabKey}
-                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
-                        >
-                            <NodePageDetails />
-                        </TabContent>
-                    )}
+                    <PageSection padding={{ default: 'noPadding' }}>{Tabs}</PageSection>
+                    {TabContents.map((content) => content)}
                 </>
             )}
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -29,7 +29,7 @@ import NodePageHeader, { NodeMetadata, nodeMetadataFragment } from './NodePageHe
 import NodePageVulnerabilities from './NodePageVulnerabilities';
 import NodePageDetails from './NodePageDetails';
 
-const nodeCveOverviewCvePath = getOverviewPagePath('Node', {
+const nodeCveOverviewPath = getOverviewPagePath('Node', {
     entityTab: 'Node',
 });
 
@@ -66,7 +66,7 @@ function NodePage() {
             <PageTitle title={`Node CVEs - Node ${nodeName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={nodeCveOverviewCvePath}>Nodes</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={nodeCveOverviewPath}>Nodes</BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {nodeName ?? (
                             <Skeleton screenreaderText="Loading Node name" width="200px" />
@@ -82,7 +82,7 @@ function NodePage() {
                             title={getAxiosErrorMessage(error)}
                             headingLevel="h2"
                             icon={ExclamationCircleIcon}
-                            iconClassName="pf-u-danger-color-100"
+                            iconClassName="pf-v5-u-danger-color-100"
                         />
                     </Bullseye>
                 </PageSection>
@@ -99,7 +99,7 @@ function NodePage() {
                                 // pagination.setPage(1);
                             }}
                             component={TabsComponent.nav}
-                            className="pf-u-pl-md pf-u-background-color-100"
+                            className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                             mountOnEnter
                             unmountOnExit
@@ -123,7 +123,7 @@ function NodePage() {
                             id={vulnTabId}
                             ref={vulnTabRef}
                             eventKey={vulnTabKey}
-                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                         >
                             <NodePageVulnerabilities />
                         </TabContent>
@@ -133,7 +133,7 @@ function NodePage() {
                             id={detailsTabId}
                             ref={detailsTabRef}
                             eventKey={detailsTabKey}
-                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                         >
                             <NodePageDetails />
                         </TabContent>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const nodeMetadataFragment = gql`
     fragment NodeMetadata on Node {
@@ -31,14 +33,10 @@ export type NodePageHeaderProps = {
 function NodePageHeader({ data }: NodePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Node name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Node metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Node name"
+                metadataScreenreaderText="Loading Node metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+
+import { getOverviewPagePath } from '../../utils/searchUtils';
+
+const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
+    entityTab: 'Cluster',
+});
+
+// TODO - Update for PF5
+function ClusterPage() {
+    const { clusterId } = useParams() as { clusterId: string };
+
+    const clusterName = 'TODO - cluster name';
+
+    return (
+        <>
+            <PageTitle title={`Platform CVEs - Cluster ${clusterName}`} />
+            <PageSection variant="light" className="pf-v5-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={platformCvesClusterOverviewPath}>
+                        Clusters
+                    </BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>
+                        {clusterName ?? (
+                            <Skeleton screenreaderText="Loading cluster name" width="200px" />
+                        )}
+                    </BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light">Cluster ID: {clusterId}</PageSection>
+        </>
+    );
+}
+
+export default ClusterPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,21 +1,49 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+import {
+    PageSection,
+    Breadcrumb,
+    Divider,
+    BreadcrumbItem,
+    Skeleton,
+    Bullseye,
+} from '@patternfly/react-core';
+import { gql, useQuery } from '@apollo/client';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 
 const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
     entityTab: 'Cluster',
 });
 
+const clusterMetadataQuery = gql`
+    ${clusterMetadataFragment}
+    query getClusterMetadata($id: ID!) {
+        cluster(id: $id) {
+            ...ClusterMetadata
+        }
+    }
+`;
+
 // TODO - Update for PF5
 function ClusterPage() {
     const { clusterId } = useParams() as { clusterId: string };
 
-    const clusterName = 'TODO - cluster name';
+    const { data, error } = useQuery<{ cluster: ClusterMetadata }, { id: string }>(
+        clusterMetadataQuery,
+        {
+            variables: { id: clusterId },
+        }
+    );
+
+    const clusterName = data?.cluster?.name ?? '';
 
     return (
         <>
@@ -33,7 +61,22 @@ function ClusterPage() {
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
-            <PageSection variant="light">Cluster ID: {clusterId}</PageSection>
+            {error ? (
+                <PageSection variant="light">
+                    <Bullseye>
+                        <EmptyStateTemplate
+                            title={getAxiosErrorMessage(error)}
+                            headingLevel="h2"
+                            icon={ExclamationCircleIcon}
+                            iconClassName="pf-v5-u-danger-color-100"
+                        />
+                    </Bullseye>
+                </PageSection>
+            ) : (
+                <PageSection variant="light">
+                    <ClusterPageHeader data={data?.cluster} />
+                </PageSection>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
+
+import { gql } from '@apollo/client';
+import { getDateTime } from 'utils/dateUtils';
+
+export const clusterMetadataFragment = gql`
+    fragment ClusterMetadata on Cluster {
+        id
+        name
+        status {
+            orchestratorMetadata {
+                buildDate
+                version
+            }
+        }
+    }
+`;
+
+export type ClusterMetadata = {
+    id: string;
+    name: string;
+    status?: {
+        orchestratorMetadata?: {
+            buildDate?: string; // ISO 8601 date format
+            version: string;
+        };
+    };
+};
+
+export type ClusterPageHeaderProps = {
+    data: ClusterMetadata | undefined;
+};
+
+function ClusterPageHeader({ data }: ClusterPageHeaderProps) {
+    if (!data) {
+        return (
+            <Flex
+                direction={{ default: 'column' }}
+                spaceItems={{ default: 'spaceItemsXs' }}
+                className="pf-v5-u-w-50"
+            >
+                <Skeleton screenreaderText="Loading Cluster name" fontSize="2xl" />
+                <Skeleton screenreaderText="Loading Cluster metadata" height="40px" />
+            </Flex>
+        );
+    }
+
+    const buildDate = data.status?.orchestratorMetadata?.buildDate;
+    const version = data.status?.orchestratorMetadata?.version;
+    const numLabels = 0 + (buildDate ? 1 : 0) + (version ? 1 : 0);
+
+    return (
+        <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
+            <Title headingLevel="h1" className="pf-v5-u-mb-sm">
+                {data.name}
+            </Title>
+            {numLabels > 0 && (
+                <LabelGroup numLabels={numLabels}>
+                    {version && <Label>K8s version: {version}</Label>}
+                    {buildDate && <Label>Build date: {getDateTime(buildDate)}</Label>}
+                </LabelGroup>
+            )}
+        </Flex>
+    );
+}
+
+export default ClusterPageHeader;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const clusterMetadataFragment = gql`
     fragment ClusterMetadata on Cluster {
@@ -35,14 +37,10 @@ export type ClusterPageHeaderProps = {
 function ClusterPageHeader({ data }: ClusterPageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Cluster name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Cluster metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Cluster name"
+                metadataScreenreaderText="Loading Cluster metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -10,8 +10,10 @@ import usePermissions from 'hooks/usePermissions';
 
 import PlatformCvesOverviewPage from './Overview/PlatformCvesOverviewPage';
 import PlatformCvePage from './PlatformCve/PlatformCvePage';
+import ClusterPage from './Cluster/ClusterPage';
 
 const vulnerabilitiesPlatformCveSinglePath = `${vulnerabilitiesPlatformCvesPath}/cves/:cveId`;
+const vulnerabilitiesPlatformClusterSinglePath = `${vulnerabilitiesPlatformCvesPath}/clusters/:clusterId`;
 
 function PlatformCvesPage() {
     const { hasReadAccess } = usePermissions();
@@ -22,6 +24,7 @@ function PlatformCvesPage() {
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
                 <Route path={vulnerabilitiesPlatformCveSinglePath} component={PlatformCvePage} />
+                <Route path={vulnerabilitiesPlatformClusterSinglePath} component={ClusterPage} />
                 <Route
                     exact
                     path={vulnerabilitiesPlatformCvesPath}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import { Flex, Title, LabelGroup, Label, Skeleton } from '@patternfly/react-core';
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export type DeploymentMetadata = {
     id: string;
@@ -42,14 +44,10 @@ function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {
             </LabelGroup>
         </Flex>
     ) : (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsXs' }}
-            className="pf-v5-u-w-50"
-        >
-            <Skeleton screenreaderText="Loading Deployment name" fontSize="2xl" />
-            <Skeleton screenreaderText="Loading Deployment metadata" fontSize="sm" />
-        </Flex>
+        <HeaderLoadingSkeleton
+            nameScreenreaderText="Loading Deployment name"
+            metadataScreenreaderText="Loading Deployment metadata"
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -28,6 +28,7 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
 
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
@@ -146,14 +147,10 @@ function ImagePage() {
                             )}
                         </Flex>
                     ) : (
-                        <Flex
-                            direction={{ default: 'column' }}
-                            spaceItems={{ default: 'spaceItemsXs' }}
-                            className="pf-v5-u-w-50"
-                        >
-                            <Skeleton screenreaderText="Loading image name" fontSize="2xl" />
-                            <Skeleton screenreaderText="Loading image metadata" fontSize="sm" />
-                        </Flex>
+                        <HeaderLoadingSkeleton
+                            nameScreenreaderText="Loading image name"
+                            metadataScreenreaderText="Loading image metadata"
+                        />
                     )}
                 </PageSection>
                 <PageSection

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-    Flex,
-    LabelGroup,
-    Label,
-    Skeleton,
-    Text,
-    Title,
-    List,
-    ListItem,
-} from '@patternfly/react-core';
+import { Flex, LabelGroup, Label, Text, Title, List, ListItem } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
@@ -16,6 +7,7 @@ import { getDateTime } from 'utils/dateUtils';
 
 import { getDistroLinkText } from '../utils/textUtils';
 import { sortCveDistroList } from '../utils/sortUtils';
+import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
 
 export type CveMetadata = {
     cve: string;
@@ -34,14 +26,10 @@ export type CvePageHeaderProps = {
 function CvePageHeader({ data }: CvePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading CVE name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading CVE metadata" height="100px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading CVE name"
+                metadataScreenreaderText="Loading CVE metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Flex, Skeleton } from '@patternfly/react-core';
+
+export type HeaderLoadingSkeletonProps = {
+    nameScreenreaderText: string;
+    metadataScreenreaderText: string;
+};
+
+/**
+ *  Layout component for loading state of a page header.
+ * @param {string} nameScreenreaderText - Screenreader text for the name skeleton.
+ * @param {string} metadataScreenreaderText - Screenreader text for the metadata skeleton.
+ * @returns {JSX.Element}
+ */
+function HeaderLoadingSkeleton({
+    nameScreenreaderText,
+    metadataScreenreaderText,
+}: HeaderLoadingSkeletonProps) {
+    return (
+        <Flex
+            direction={{ default: 'column' }}
+            spaceItems={{ default: 'spaceItemsXs' }}
+            className="pf-u-w-50"
+        >
+            <Skeleton screenreaderText={nameScreenreaderText} fontSize="2xl" />
+            <Skeleton screenreaderText={metadataScreenreaderText} height="100px" />
+        </Flex>
+    );
+}
+
+export default HeaderLoadingSkeleton;

--- a/ui/apps/platform/src/hooks/patternfly/useTabContent.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useTabContent.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import {
+    Tab,
+    TabContent,
+    TabContentProps,
+    TabTitleText,
+    Tabs,
+    TabsComponent,
+    TabsProps,
+} from '@patternfly/react-core';
+import noop from 'lodash/noop';
+
+import useURLStringUnion from 'hooks/useURLStringUnion';
+
+export type TabDescriptor = {
+    key: string;
+    content: React.ReactNode;
+    contentProps?: Omit<TabContentProps, 'id' | 'ref' | 'eventKey'>;
+};
+
+export type UseTabContentOptions<TabTuple extends TabDescriptor[]> = {
+    parameterName: string;
+    tabKeys: Parameters<typeof useURLStringUnion>[1];
+    tabs: [...TabTuple];
+    tabsProps?: Omit<TabsProps, 'children' | 'ref'>;
+    onTabChange?: TabsProps['onSelect'];
+};
+
+export default function useTabContent<TabTuple extends TabDescriptor[]>({
+    parameterName,
+    tabKeys,
+    tabs,
+    tabsProps = {},
+    onTabChange = noop,
+}: UseTabContentOptions<TabTuple>): [JSX.Element, (JSX.Element | null)[]] {
+    const [activeKey, setActiveTabKey] = useURLStringUnion(parameterName, tabKeys);
+
+    const refsById = useMemo(() => {
+        const refs = {};
+        tabs.forEach(({ key }) => {
+            refs[key] = React.createRef<HTMLElement>();
+        });
+        return refs;
+    }, [tabs]);
+
+    const tabComponents = tabs.map(({ key, content, contentProps }) => {
+        const id = `${key}-tab`;
+        const ref = refsById[key];
+        return [
+            <Tab
+                key={key}
+                eventKey={key}
+                title={<TabTitleText>{key}</TabTitleText>}
+                tabContentId={id}
+                tabContentRef={ref}
+            />,
+            activeKey === key ? (
+                <TabContent {...contentProps} id={id} ref={ref} key={key} eventKey={key}>
+                    {content}
+                </TabContent>
+            ) : null,
+        ];
+    });
+
+    const tabsComponent = (
+        <Tabs
+            {...tabsProps}
+            activeKey={activeKey}
+            onSelect={(e, key) => {
+                setActiveTabKey(key);
+                onTabChange?.(e, key);
+            }}
+            component={TabsComponent.nav}
+            role="region"
+            mountOnEnter
+            unmountOnExit
+        >
+            {tabComponents.map(([tab]) => tab)}
+        </Tabs>
+    );
+
+    return [tabsComponent, tabComponents.map(([, content]) => content)];
+}

--- a/ui/apps/platform/src/utils/type.utils.ts
+++ b/ui/apps/platform/src/utils/type.utils.ts
@@ -52,3 +52,7 @@ export function tupleTypeGuard<const T extends readonly string[]>(
 }
 
 export type UnionFrom<T extends readonly string[]> = T[number];
+
+export type Tuple<T, N extends number, A extends unknown[] = []> = A extends { length: N }
+    ? A
+    : Tuple<T, N, [...A, T]>;


### PR DESCRIPTION
## Description

Experimenting with an idea for abstracting <Tab> usage into a custom hook.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
