### PR TITLE
ROX-23072: Add detail tabs to cluster single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { gql, useQuery } from '@apollo/client';
 import {
@@ -9,8 +9,6 @@ import {
     Skeleton,
     Bullseye,
     Tab,
-    TabContent,
-    TabTitleText,
     Tabs,
     TabsComponent,
 } from '@patternfly/react-core';
@@ -52,12 +50,8 @@ function NodePage() {
 
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
-    const vulnTabKey = 'Vulnerabilities';
-    const detailsTabKey = 'Details';
-    const vulnTabId = 'node-vulnerabilities-tab';
-    const detailsTabId = 'node-details-tab';
-    const vulnTabRef = useRef<HTMLElement>(null);
-    const detailsTabRef = useRef<HTMLElement>(null);
+    const vulnTabKey = detailsTabValues[0];
+    const detailTabKey = detailsTabValues[1];
 
     const nodeName = data?.node?.name ?? '-';
 
@@ -101,43 +95,19 @@ function NodePage() {
                             component={TabsComponent.nav}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
-                            mountOnEnter
-                            unmountOnExit
                         >
-                            <Tab
-                                eventKey={vulnTabKey}
-                                title={<TabTitleText>Vulnerabilities</TabTitleText>}
-                                tabContentId={vulnTabId}
-                                tabContentRef={vulnTabRef}
-                            />
-                            <Tab
-                                eventKey={detailsTabKey}
-                                title={<TabTitleText>Details</TabTitleText>}
-                                tabContentId={detailsTabId}
-                                tabContentRef={detailsTabRef}
-                            />
+                            <Tab eventKey={vulnTabKey} title={vulnTabKey} />
+                            <Tab eventKey={detailTabKey} title={detailTabKey} />
                         </Tabs>
                     </PageSection>
-                    {activeTabKey === vulnTabKey && (
-                        <TabContent
-                            id={vulnTabId}
-                            ref={vulnTabRef}
-                            eventKey={vulnTabKey}
-                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
-                        >
-                            <NodePageVulnerabilities />
-                        </TabContent>
-                    )}
-                    {activeTabKey === detailsTabKey && (
-                        <TabContent
-                            id={detailsTabId}
-                            ref={detailsTabRef}
-                            eventKey={detailsTabKey}
-                            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
-                        >
-                            <NodePageDetails />
-                        </TabContent>
-                    )}
+                    <PageSection
+                        isFilled
+                        padding={{ default: 'noPadding' }}
+                        className="pf-v5-u-display-flex pf-v5-u-flex-direction-column"
+                    >
+                        {activeTabKey === vulnTabKey && <NodePageVulnerabilities />}
+                        {activeTabKey === detailTabKey && <NodePageDetails />}
+                    </PageSection>
                 </>
             )}
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const nodeMetadataFragment = gql`
     fragment NodeMetadata on Node {
@@ -31,14 +33,10 @@ export type NodePageHeaderProps = {
 function NodePageHeader({ data }: NodePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Node name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Node metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Node name"
+                metadataScreenreaderText="Loading Node metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -8,11 +8,11 @@ export type NodePageVulnerabilitiesProps = {};
 function NodePageVulnerabilities({}: NodePageVulnerabilitiesProps) {
     return (
         <>
-            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
+            <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
                 <Text>Review and triage vulnerability data scanned on this node</Text>
             </PageSection>
-            <PageSection isFilled className="pf-u-display-flex pf-u-flex-direction-column">
-                <div className="pf-u-flex-grow-1 pf-u-background-color-100">vulns</div>
+            <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
+                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">vulns</div>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -7,6 +7,9 @@ import {
     BreadcrumbItem,
     Skeleton,
     Bullseye,
+    Tab,
+    Tabs,
+    TabsComponent,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -14,10 +17,15 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
 import { getOverviewPagePath } from '../../utils/searchUtils';
+import { detailsTabValues } from '../../types';
+
+import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
+import ClusterPageDetails from './ClusterPageDetails';
+import ClusterPageVulnerabilities from './ClusterPageVulnerabilities';
 
 const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
     entityTab: 'Cluster',
@@ -42,6 +50,11 @@ function ClusterPage() {
             variables: { id: clusterId },
         }
     );
+
+    const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
+
+    const vulnTabKey = detailsTabValues[0];
+    const detailTabKey = detailsTabValues[1];
 
     const clusterName = data?.cluster?.name ?? '';
 
@@ -73,9 +86,34 @@ function ClusterPage() {
                     </Bullseye>
                 </PageSection>
             ) : (
-                <PageSection variant="light">
-                    <ClusterPageHeader data={data?.cluster} />
-                </PageSection>
+                <>
+                    <PageSection variant="light">
+                        <ClusterPageHeader data={data?.cluster} />
+                    </PageSection>
+                    <PageSection padding={{ default: 'noPadding' }}>
+                        <Tabs
+                            activeKey={activeTabKey}
+                            onSelect={(e, key) => {
+                                setActiveTabKey(key);
+                                // pagination.setPage(1);
+                            }}
+                            component={TabsComponent.nav}
+                            className="pf-v5-u-pl-md pf-v5-u-background-color-100"
+                            role="region"
+                        >
+                            <Tab eventKey={vulnTabKey} title={vulnTabKey} />
+                            <Tab eventKey={detailTabKey} title={detailTabKey} />
+                        </Tabs>
+                    </PageSection>
+                    <PageSection
+                        isFilled
+                        padding={{ default: 'noPadding' }}
+                        className="pf-v5-u-display-flex pf-v5-u-flex-direction-column"
+                    >
+                        {activeTabKey === vulnTabKey && <ClusterPageVulnerabilities />}
+                        {activeTabKey === detailTabKey && <ClusterPageDetails />}
+                    </PageSection>
+                </>
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { PageSection, Text } from '@patternfly/react-core';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type NodePageDetailsProps = {};
+export type ClusterPageDetailsProps = {};
 
 // eslint-disable-next-line no-empty-pattern
-function NodePageDetails({}: NodePageDetailsProps) {
+function ClusterPageDetails({}: ClusterPageDetailsProps) {
     return (
         <>
-            <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
-                <Text>View details about this node</Text>
+            <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-u-px-xl">
+                <Text>View details about this cluster</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
                 <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">Details</div>
@@ -18,4 +18,4 @@ function NodePageDetails({}: NodePageDetailsProps) {
     );
 }
 
-export default NodePageDetails;
+export default ClusterPageDetails;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Flex, Skeleton, Title, LabelGroup, Label } from '@patternfly/react-core';
-
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
+
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export const clusterMetadataFragment = gql`
     fragment ClusterMetadata on Cluster {
@@ -35,14 +37,10 @@ export type ClusterPageHeaderProps = {
 function ClusterPageHeader({ data }: ClusterPageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading Cluster name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading Cluster metadata" height="40px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading Cluster name"
+                metadataScreenreaderText="Loading Cluster metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 import { PageSection, Text } from '@patternfly/react-core';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type NodePageDetailsProps = {};
+export type ClusterPageVulnerabilitiesProps = {};
 
 // eslint-disable-next-line no-empty-pattern
-function NodePageDetails({}: NodePageDetailsProps) {
+function ClusterPageVulnerabilities({}: ClusterPageVulnerabilitiesProps) {
     return (
         <>
             <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
-                <Text>View details about this node</Text>
+                <Text>Review and triage vulnerability data scanned on this cluster</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
-                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">Details</div>
+                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">vulns</div>
             </PageSection>
         </>
     );
 }
 
-export default NodePageDetails;
+export default ClusterPageVulnerabilities;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import { Flex, Title, LabelGroup, Label, Skeleton } from '@patternfly/react-core';
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { getDateTime } from 'utils/dateUtils';
+
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 
 export type DeploymentMetadata = {
     id: string;
@@ -42,14 +44,10 @@ function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {
             </LabelGroup>
         </Flex>
     ) : (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsXs' }}
-            className="pf-v5-u-w-50"
-        >
-            <Skeleton screenreaderText="Loading Deployment name" fontSize="2xl" />
-            <Skeleton screenreaderText="Loading Deployment metadata" fontSize="sm" />
-        </Flex>
+        <HeaderLoadingSkeleton
+            nameScreenreaderText="Loading Deployment name"
+            metadataScreenreaderText="Loading Deployment metadata"
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -28,6 +28,7 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
 
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
@@ -146,14 +147,10 @@ function ImagePage() {
                             )}
                         </Flex>
                     ) : (
-                        <Flex
-                            direction={{ default: 'column' }}
-                            spaceItems={{ default: 'spaceItemsXs' }}
-                            className="pf-v5-u-w-50"
-                        >
-                            <Skeleton screenreaderText="Loading image name" fontSize="2xl" />
-                            <Skeleton screenreaderText="Loading image metadata" fontSize="sm" />
-                        </Flex>
+                        <HeaderLoadingSkeleton
+                            nameScreenreaderText="Loading image name"
+                            metadataScreenreaderText="Loading image metadata"
+                        />
                     )}
                 </PageSection>
                 <PageSection

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-    Flex,
-    LabelGroup,
-    Label,
-    Skeleton,
-    Text,
-    Title,
-    List,
-    ListItem,
-} from '@patternfly/react-core';
+import { Flex, LabelGroup, Label, Text, Title, List, ListItem } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
@@ -16,6 +7,7 @@ import { getDateTime } from 'utils/dateUtils';
 
 import { getDistroLinkText } from '../utils/textUtils';
 import { sortCveDistroList } from '../utils/sortUtils';
+import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
 
 export type CveMetadata = {
     cve: string;
@@ -34,14 +26,10 @@ export type CvePageHeaderProps = {
 function CvePageHeader({ data }: CvePageHeaderProps) {
     if (!data) {
         return (
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsXs' }}
-                className="pf-v5-u-w-50"
-            >
-                <Skeleton screenreaderText="Loading CVE name" fontSize="2xl" />
-                <Skeleton screenreaderText="Loading CVE metadata" height="100px" />
-            </Flex>
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading CVE name"
+                metadataScreenreaderText="Loading CVE metadata"
+            />
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Flex, Skeleton } from '@patternfly/react-core';
+
+export type HeaderLoadingSkeletonProps = {
+    nameScreenreaderText: string;
+    metadataScreenreaderText: string;
+};
+
+function HeaderLoadingSkeleton({
+    nameScreenreaderText,
+    metadataScreenreaderText,
+}: HeaderLoadingSkeletonProps) {
+    return (
+        <Flex
+            direction={{ default: 'column' }}
+            spaceItems={{ default: 'spaceItemsXs' }}
+            className="pf-u-w-50"
+        >
+            <Skeleton screenreaderText={nameScreenreaderText} fontSize="2xl" />
+            <Skeleton screenreaderText={metadataScreenreaderText} height="100px" />
+        </Flex>
+    );
+}
+
+export default HeaderLoadingSkeleton;


### PR DESCRIPTION
## Description

Adds "Vulnerability" and "Details" tabs to the cluster single page.

Refactors the tabs on the node single page to reduce noise in the code.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a cluster single page. The tab parameter should default to "Vulnerabilities" and be visible in the URL.
![image](https://github.com/stackrox/stackrox/assets/1292638/6c972986-46d7-4a19-8e7a-341c098521ed)

Click on "Details" to view the tab, content, and URL change:
![image](https://github.com/stackrox/stackrox/assets/1292638/8c986cea-1d16-45f0-a138-2590d54546c6)
