### PR TITLE
feat(roxctl): allow writing output and error streams to files

### DIFF
--- a/pkg/env/roxctl.go
+++ b/pkg/env/roxctl.go
@@ -48,8 +48,8 @@ var (
 	ScannerDBDownloadBaseURL = RegisterSetting("ROX_SCAN_DB_DL_BASE_URL", WithDefault("https://install.stackrox.io/scanner"))
 
 	// OutputFile specifies the path where roxctl should write its standard output
-	OutputFile = RegisterSetting("ROX_OUTPUT_FILE")
+	OutputFile = RegisterSetting("ROX_STDOUT")
 
 	// ErrorFile specifies the path where roxctl should write its standard error
-	ErrorFile = RegisterSetting("ROX_ERROR_FILE")
+	ErrorFile = RegisterSetting("ROX_STDERR")
 )

--- a/pkg/env/roxctl.go
+++ b/pkg/env/roxctl.go
@@ -46,4 +46,10 @@ var (
 
 	// ScannerDBDownloadBaseURL specifies the base URL to use when downloading offline scanner definitions.
 	ScannerDBDownloadBaseURL = RegisterSetting("ROX_SCAN_DB_DL_BASE_URL", WithDefault("https://install.stackrox.io/scanner"))
+
+	// OutputFile specifies the path where roxctl should write its standard output
+	OutputFile = RegisterSetting("ROX_OUTPUT_FILE")
+
+	// ErrorFile specifies the path where roxctl should write its standard error
+	ErrorFile = RegisterSetting("ROX_ERROR_FILE")
 )

--- a/roxctl/common/environment/environment-impl.go
+++ b/roxctl/common/environment/environment-impl.go
@@ -53,10 +53,11 @@ func CLIEnvironment() Environment {
 		} else {
 			colorPrinter = printer.DefaultColorPrinter()
 		}
+		environIO := cliIO.DefaultIO()
 		singleton = &cliEnvironmentImpl{
-			io:              cliIO.DefaultIO(),
+			io:              environIO,
 			colorfulPrinter: colorPrinter,
-			logger:          logger.NewLogger(cliIO.DefaultIO(), colorPrinter),
+			logger:          logger.NewLogger(environIO, colorPrinter),
 		}
 	})
 	return singleton

--- a/roxctl/common/io/io.go
+++ b/roxctl/common/io/io.go
@@ -37,14 +37,17 @@ func (i *ioImpl) ErrOut() io.Writer {
 	return i.errOut
 }
 
+// getOutputFile opens a file in write (append) mode for output or error writing.
+// A nil output means that the specified path is either empty, or
+// that something prevented the file from being opened in write mode.
 func getOutputFile(filePath string) *os.File {
-	// This function opens a file in write (append) mode for output or error writing.
-	// A nil output means that the specified path is either empty, or
-	// that something prevented the file from being opened in write mode.
 	if len(filePath) == 0 {
 		return nil
 	}
 	fileInfo, err := os.Stat(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil
+	}
 	if os.IsNotExist(err) {
 		// If the output file does not exist, try to create it along with the path to it.
 		dirPath := filepath.Dir(filePath)

--- a/roxctl/common/io/io.go
+++ b/roxctl/common/io/io.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
+
+	"github.com/stackrox/rox/pkg/env"
 )
 
 // IO holds information about io streams used within commands of roxctl.
@@ -34,13 +37,53 @@ func (i *ioImpl) ErrOut() io.Writer {
 	return i.errOut
 }
 
+func getOutputFile(filePath string) *os.File {
+	// This function opens a file in write (append) mode for output or error writing.
+	// A nil output means that the specified path is either empty, or
+	// that something prevented the file from being opened in write mode.
+	if len(filePath) == 0 {
+		return nil
+	}
+	fileInfo, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		// If the output file does not exist, try to create it along with the path to it.
+		dirPath := filepath.Dir(filePath)
+		err := os.MkdirAll(dirPath, 0755)
+		if err != nil {
+			// Could not create directory to store the output file
+			// Revert to default output
+			return nil
+		}
+		file, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0600)
+		if err != nil {
+			return nil
+		}
+		return file
+	}
+	if fileInfo.Mode()&0200 != 0 {
+		file, err := os.OpenFile(filePath, os.O_RDWR|os.O_APPEND, 0600)
+		if err != nil {
+			return nil
+		}
+		return file
+	}
+	return nil
+}
+
 // DefaultIO uses the default os specific streams for input / output
 func DefaultIO() IO {
-	return &ioImpl{
+	readerAndWriters := &ioImpl{
 		in:     os.Stdin,
 		out:    os.Stdout,
 		errOut: os.Stderr,
 	}
+	if newOutput := getOutputFile(env.OutputFile.Setting()); newOutput != nil {
+		readerAndWriters.out = newOutput
+	}
+	if newErrorOutput := getOutputFile(env.ErrorFile.Setting()); newErrorOutput != nil {
+		readerAndWriters.errOut = newErrorOutput
+	}
+	return readerAndWriters
 }
 
 // DiscardIO discards IO.Out and IO.ErrOut

--- a/roxctl/common/io/io_test.go
+++ b/roxctl/common/io/io_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,8 +90,8 @@ func TestDefaultIO(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			t.Setenv("ROX_OUTPUT_FILE", testCase.outFilePath)
-			t.Setenv("ROX_ERROR_FILE", testCase.errFilePath)
+			t.Setenv(env.OutputFile.EnvVar(), testCase.outFilePath)
+			t.Setenv(env.ErrorFile.EnvVar(), testCase.errFilePath)
 			defaultIO := DefaultIO()
 
 			outImpl := defaultIO.Out().(*os.File)

--- a/roxctl/common/io/io_test.go
+++ b/roxctl/common/io/io_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func cleanup(t *testing.T, tmpPath string) {
+	err := os.RemoveAll(tmpPath)
+	assert.NoError(t, err)
+}
+
 func TestDefaultIO(t *testing.T) {
 	t.Run("default environment", func(t *testing.T) {
 		defaultIO := DefaultIO()
@@ -24,14 +29,10 @@ func TestDefaultIO(t *testing.T) {
 
 	tmpPath, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmpPath)
+	defer cleanup(t, tmpPath)
 
 	writeableSubDirPath := filepath.Join(tmpPath, "writeable-dir")
 	err = os.Mkdir(writeableSubDirPath, 0777)
-	assert.NoError(t, err)
-
-	notWriteableSubDirPath := filepath.Join(tmpPath, "not-writeable-dir")
-	err = os.Mkdir(notWriteableSubDirPath, 0555)
 	assert.NoError(t, err)
 
 	writeableFilePath := filepath.Join(tmpPath, "writeable-file")
@@ -78,10 +79,10 @@ func TestDefaultIO(t *testing.T) {
 			expectedErrFileName: writeableFileWithMissingSubDirPath,
 		},
 		{
-			testName:            "out points to a non-writeable file and err points to a path in a non-writeable directory -> use defaults",
+			testName:            "out and err point to a non-writeable file -> use defaults",
 			outFilePath:         notWriteableFilePath,
 			expectedOutFileName: stdoutPath,
-			errFilePath:         filepath.Join(notWriteableSubDirPath, "missing-file"),
+			errFilePath:         notWriteableFilePath,
 			expectedErrFileName: stderrPath,
 		},
 	}
@@ -110,8 +111,6 @@ func TestDefaultIO(t *testing.T) {
 		})
 	}
 
-	err = os.Chmod(notWriteableSubDirPath, 0777)
-	assert.NoError(t, err)
 	err = os.Chmod(notWriteableFilePath, 0666)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

The roxctl image is a bare image. It is the base image for some tekton actions.
Currently, tekton does not allow output redirection out of the box. In order to allow users to process roxctl output (e.g. open a ticket if CVEs are reported in an image scan output), it would be good to allow roxctl to redirect the standard output and the standard error without the standard shell output redirections.

The choice of environment variables rather than command line flags is driven by the fact that the roxctl environment (including output and error stream initialization) is setup before the command line flags are actually parsed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
