### PR TITLE
fix(ROX-23596): fix policy creation in test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -338,7 +338,6 @@ class ImageManagementTest extends BaseSpecification {
             .clearLifecycleStages()
             .addLifecycleStages(LifecycleStage.BUILD)
             .addNotifiers(notifier.id)
-            .addCategories("DevOps Best Practices") // required for putPolicy
             .clearExclusions()
             .build()
         Services.updatePolicy(update)


### PR DESCRIPTION
## Description

After [#10649](https://github.com/stackrox/stackrox/pull/10649) has landed, the policy API now correctly returned the categories. Previously this field was empty. A test tried to workaround this issue and thus started failing due to duplicating categories now.

This has gone unnotice due to the prow outage.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
