### PR TITLE
fix: Repair failing `main` build in Konflux

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -70,14 +70,22 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:
-    # Provision more CPU to speed up build compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
     - name: build
+      # CPU requests are increased to speed up builds compared to the defaults.
+      # Defaults: https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+      #
+      # Memory is increased for UI builds to succeed. Otherwise, there's an error like this in logs:
+      # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
+      #
+      # Not using buildah-6gb/-8gb/... because these don't have memory requests equal to limits which still occasionally
+      # leads to failing builds.
       computeResources:
         limits:
           cpu: 4
+          memory: 6Gi
         requests:
           cpu: 4
+          memory: 6Gi
   - pipelineTaskName: clamav-scan
     stepSpecs:
     # Provision more CPU to speed up ClamAV scan compared to the defaults.
@@ -358,12 +366,10 @@ spec:
       - fetch-external-networks
       taskRef:
         params:
-        # buildah with more memory is needed for UI builds to succeed. Otherwise, there's an error like this in logs:
-        # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
         - name: name
-          value: buildah-6gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-6gb:0.1@sha256:00a55fa4b456fba946076c74698e65c655e9d58d2623570db6275d059b22a76a
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:ed7655b42cfff0e17c961c6d81afa682c8d9ea588e741d0414c50181d1757693
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -68,14 +68,22 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:
-    # Provision more CPU to speed up build compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
     - name: build
+      # CPU requests are increased to speed up builds compared to the defaults.
+      # Defaults: https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+      #
+      # Memory is increased for UI builds to succeed. Otherwise, there's an error like this in logs:
+      # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
+      #
+      # Not using buildah-6gb/-8gb/... because these don't have memory requests equal to limits which still occasionally
+      # leads to failing builds.
       computeResources:
         limits:
           cpu: 4
+          memory: 6Gi
         requests:
           cpu: 4
+          memory: 6Gi
   - pipelineTaskName: clamav-scan
     stepSpecs:
     # Provision more CPU to speed up ClamAV scan compared to the defaults.
@@ -356,12 +364,10 @@ spec:
       - fetch-external-networks
       taskRef:
         params:
-        # buildah with more memory is needed for UI builds to succeed. Otherwise, there's an error like this in logs:
-        # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
         - name: name
-          value: buildah-6gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-6gb:0.1@sha256:00a55fa4b456fba946076c74698e65c655e9d58d2623570db6275d059b22a76a
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:ed7655b42cfff0e17c961c6d81afa682c8d9ea588e741d0414c50181d1757693
         - name: kind
           value: task
         resolver: bundles

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -4,15 +4,15 @@ ARG FINAL_STAGE_PATH="/mnt/final"
 
 
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
-FROM registry.access.redhat.com/ubi8/ubi:latest AS rocksdb-builder-base
+FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi-base
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS go-builder-base
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS final-base
 
 # TODO(ROX-20651): use content sets instead of subscription manager for access to RHEL RPMs once available. Move dnf commands to respective stages.
-FROM registry.access.redhat.com/ubi8/ubi:latest AS rpm-installer
+FROM ubi-base AS rpm-installer
 
 ARG ROCKSDB_BUILDER_STAGE_PATH
-COPY --from=rocksdb-builder-base / "$ROCKSDB_BUILDER_STAGE_PATH"
+COPY --from=ubi-base / "$ROCKSDB_BUILDER_STAGE_PATH"
 
 ARG GO_BUILDER_STAGE_PATH
 COPY --from=go-builder-base / "$GO_BUILDER_STAGE_PATH"


### PR DESCRIPTION
## Description

`main` builds started failing roughly after <https://github.com/stackrox/stackrox/pull/10551>. Even though its CI succeeded, its merge failed.

![image](https://github.com/stackrox/stackrox/assets/537715/f1d36fb7-ee1b-4b2a-af48-60a2fb41c2bb)

It's hard for me to explain why, but the recommendation I received as part of the investigation thread <https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1712851558680229> was to reduce the number of unique `FROM` stages.

It looks like aliases don't count as unique stages and so I reduce the usage of `ubi8/ubi` (the only one possible, it seems).

## Checklist
- [x] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Three successful runs:
1. https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-xcvrc
2. https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-jn4wx
3. ~~https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-zxdpp~~ failed due to OOM kill during UI build.
4. https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-685pg
5. ~~https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-2h24z~~ build timed out after one hour. Opened a [thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1713180672587489).
6. ~~https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-qrbkv~~ same.
7. ~~https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-8mptf~~ same (almost).
8. https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-pull-request-ptlkx

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
