### PR TITLE
ROX-23657: NVD CVSS score ADR

### DIFF
--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -93,8 +93,8 @@ message VulnerabilityReport {
       }
       V2 v2 = 1;
       V3 v3 = 2;
-      Source source = 3; <-- New field.
-      string url = 4; <-- New field
+      Source source = 3; <-- New field
+      string url = 4;    <-- New field
     }
     ...
     string severity = 6;

--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -1,0 +1,121 @@
+# 0008 - NVD CVSS Scores
+
+- **Author(s):** Ross Tannenbaum
+- **Created:** [2024-04-11 Thurs]
+
+## Status
+
+Status: Accepted.
+
+## Context
+
+Users who require FedRAMP compliance [must be able see NVD's CVSS scores associated with each CVE](https://www.fedramp.gov/assets/resources/documents/CSP_Vulnerability_Scanning_Requirements.pdf).
+
+Currently, Scanner V4 provides a single CVSS score and severity, which is preferably from the vendor.
+In reality, the CVSS scores that are shown are from NVD except in the following cases:
+
+* RHEL-base images
+  * Red Hat-provided CVSS scores/severities are used.
+* OSV-provided data
+  * If OSV.dev has a CVSS score, then that score is used.
+    * The score is converted into a severity based on the CVSS version's specification.
+  * Note: it is likely, if not always true, the score displayed by OSV is the same as NVD.
+
+The current API looks like the following:
+
+```
+message VulnerabilityReport {
+  message Vulnerability {
+    enum Severity {
+      SEVERITY_UNSPECIFIED = 0;
+      SEVERITY_LOW = 1;
+      SEVERITY_MODERATE = 2;
+      SEVERITY_IMPORTANT = 3;
+      SEVERITY_CRITICAL = 4;
+    }
+    message CVSS {
+      message V2 {
+        float base_score = 1;
+        string vector = 2;
+      }
+      message V3 {
+        float base_score = 1;
+        string vector = 2;
+      }
+      V2 v2 = 1;
+      V3 v3 = 2;
+    }
+    ...
+    string severity = 6;
+    ...
+    CVSS cvss = 12;
+  }
+  ...
+}
+```
+
+## Decision
+
+The VulnerabilityReport API will be extended to support more than one CVSS message. This will be done as follows:
+
+```
+message VulnerabilityReport {
+  message Vulnerability {
+    enum Severity {
+      SEVERITY_UNSPECIFIED = 0;
+      SEVERITY_LOW = 1;
+      SEVERITY_MODERATE = 2;
+      SEVERITY_IMPORTANT = 3;
+      SEVERITY_CRITICAL = 4;
+    }
+    message CVSS {
+      message V2 {
+        float base_score = 1;
+        string vector = 2;
+      }
+      message V3 {
+        float base_score = 1;
+        string vector = 2;
+      }
+      V2 v2 = 1;
+      V3 v3 = 2;
+    }
+    ...
+    string severity = 6;
+    ...
+    CVSS cvss = 12;
+    CVSS nvd_cvss = 13; <-- New field.
+  }
+  ...
+}
+```
+
+Currently, there is only a need to have CVSS scores from the vendor (if available) and NVD (if available), no more.
+Making this explicit, then, makes it easy and clear to users to find each scores and choose between the two.
+
+Another option is to provide a more generic solution. One way to do this would be to update `CVSS cvss = 12` to 
+`repeated CVSS cvss = 12` (note: the [proto3 spec](https://protobuf.dev/programming-guides/proto3/#updating) indicates this is compatible).
+Doing it this way gives us a more generic way of supporting multiple CVSS scores vs adding a new `nvd_cvss` field,
+and it may certainly be the way to go in the future should we want to support a variety of score sources; however,
+there is no need for a generic solution at this time, and adding the new field make it very easy to choose between the two options.
+
+### Handling RHSA/RHBA/RHEA
+
+Without loss of generality, RHSA/RHBA/RHEA will just be referred to as the more well-known RHSA variant of the three.
+
+Scanner V4 currently shows RHSA as the top-level entity, rather than the related CVE(s), when the CVE(s) is/are fixed.
+When this is done, Scanner V4 gives the RHSA the highest CVSS score from the associated CVE(s). We acknowledge this is not
+ideal, and there are plans to resolve this in the future. For now, we will need to support NVD scores in a compatible manner.
+
+The [`claircore.Vulnerability.Severity`](https://github.com/quay/claircore/blob/v1.5.25/vulnerability.go#L24) is currently set to the following:
+
+`severity=<severity>&cvss3_score=<score3>&cvss3_vector=<vector3>cvss2_score=<score2>&cvss2_vector=<vector2>`
+
+This URL encoding will be extended to include `cve=<CVE ID>`. 
+By doing this, Scanner V4 has the ability to relate the RHSA back to the CVE which has the highest score and search NVD for that CVE's score.
+
+## Consequences
+
+NVD only tracks CVEs, while Scanner V4 shows a variety of advisories (CVE, RHSA/RHBA/RHEA, ALAS, etc).
+
+The current plan is only to support CVEs as well as RHSA/RHBA/RHEA.

--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -131,7 +131,7 @@ This URL encoding will be extended to include `cve=<CVE ID>`.
 * Introducing `string` field `CVSS.updater` ensures consistency and limits mistakes which may be made
 with misspelled or differently spelled strings because `updater` values directly come from Scanner vulnerability updater names.
 * `repeated CVSS` field `cvss_metrics` will always include CVSS metrics from all updaters/data sources, including the Scanner's preferred CVSS metric.
-This approach simplifies data querying and filtering, as `cvss_metrics` will be the sole field used for filtering data or making policies.
+  * This approach simplifies data querying and filtering, as `cvss_metrics` will be the sole field used for filtering data or making policies.
 * Encoding the RHSA/RHEA/RHBA's related CVE allows Scanner V4 to relate the advisory back to the CVE which has the highest score and search NVD for that CVE's score.
 * Other type of advisories like ALAS and USN will not have a score from NVD.
 * OSV.dev sometimes does not related non-CVEs (like GHSAs) back to CVEs. When this happens, we cannot determine the CVSS score from NVD.

--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -88,7 +88,7 @@ message VulnerabilityReport {
       V2 v2 = 1;
       V3 v3 = 2;
       string updater = 3; <-- New field.
-      string cvss_url = 4; <-- New field, cvss source URL
+      string cvss_url = 4; <-- New field
     }
     ...
     string severity = 6;
@@ -104,6 +104,8 @@ There will be a new type plus two new fields added:
 
 * `CVSS.updater`
   * This specifies the source of the particular CVSS metrics. The value will be the name of the scanner updater, indicating the data source from which the updater is fetching vulnerabilities.
+* `CVSS.cvss_url`
+  * This specifies the CVSS score source URL, aiding both API and UI users in tracking the origin of this metric.
 * `cvss_metrics`
   * This is a list of each unique CVSS metric based on the source.
 
@@ -126,8 +128,10 @@ This URL encoding will be extended to include `cve=<CVE ID>`.
 
 ## Consequences
 
-* Creating an `enum` for `Source` instead of just using a `string` ensures consistency and limits mistakes which may be made
-with misspelled or differently spelled strings.
+* Introducing `string` field `CVSS.updater` ensures consistency and limits mistakes which may be made
+with misspelled or differently spelled strings because `updater` values directly come from Scanner vulnerability updater names.
+* `repeated CVSS` field `cvss_metrics` will always include CVSS metrics from all updaters/data sources, including the Scanner's preferred CVSS metric.
+This approach simplifies data querying and filtering, as `cvss_metrics` will be the sole field used for filtering data or making policies.
 * Encoding the RHSA/RHEA/RHBA's related CVE allows Scanner V4 to relate the advisory back to the CVE which has the highest score and search NVD for that CVE's score.
 * Other type of advisories like ALAS and USN will not have a score from NVD.
 * OSV.dev sometimes does not related non-CVEs (like GHSAs) back to CVEs. When this happens, we cannot determine the CVSS score from NVD.

--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -10,6 +10,7 @@ Status: Accepted.
 ## Context
 
 Users who require FedRAMP compliance [must be able see NVD's CVSS scores associated with each CVE](https://www.fedramp.gov/assets/resources/documents/CSP_Vulnerability_Scanning_Requirements.pdf).
+Note: NVD tracks CVEs, so all of tis data is CVE-based.
 
 Currently, Scanner V4 provides a single CVSS score and severity, which is preferably from the vendor.
 In reality, the CVSS scores that are shown are from NVD except in the following cases:
@@ -18,8 +19,15 @@ In reality, the CVSS scores that are shown are from NVD except in the following 
   * Red Hat-provided CVSS scores/severities are used.
 * OSV-provided data
   * If OSV.dev has a CVSS score, then that score is used.
-    * The score is converted into a severity based on the CVSS version's specification.
-  * Note: it is likely, if not always true, the score displayed by OSV is the same as NVD.
+    * The severity is derived from the score based on the CVSS version's specification.
+  * Note: From personal experience, it is very common for the score displayed by OSV is the same as NVD.
+
+Currently, there is only a need to have CVSS scores from the vendor (if available) and NVD (if available), no more.
+However, it is possible this requirement changes in the future, and we may want to support more than just two
+sources for vulnerability data.
+
+The focus is on CVEs and RHSAs, RHEAs, and RHBAs. This document will not consider other types of advisories such as
+Ubuntu's USNs.
 
 The current API looks like the following:
 
@@ -56,7 +64,7 @@ message VulnerabilityReport {
 
 ## Decision
 
-The VulnerabilityReport API will be extended to support more than one CVSS message. This will be done as follows:
+The VulnerabilityReport API will be extended as follows:
 
 ```
 message VulnerabilityReport {
@@ -69,6 +77,12 @@ message VulnerabilityReport {
       SEVERITY_CRITICAL = 4;
     }
     message CVSS {
+      enum Source {
+        SOURCE_UNKNOWN = 0;
+        SOURCE_RED_HAT = 1;
+        SOURCE_OSV = 2;
+        SOURCE_NVD = 3;
+      }
       message V2 {
         float base_score = 1;
         string vector = 2;
@@ -77,6 +91,7 @@ message VulnerabilityReport {
         float base_score = 1;
         string vector = 2;
       }
+      Source source = 3; <-- New field.
       V2 v2 = 1;
       V3 v3 = 2;
     }
@@ -84,20 +99,23 @@ message VulnerabilityReport {
     string severity = 6;
     ...
     CVSS cvss = 12;
-    CVSS nvd_cvss = 13; <-- New field.
+    repeated CVSS cvss_metrics = 13; <-- New field.
   }
   ...
 }
 ```
 
-Currently, there is only a need to have CVSS scores from the vendor (if available) and NVD (if available), no more.
-Making this explicit, then, makes it easy and clear to users to find each scores and choose between the two.
+There will be a new type plus two new fields added:
 
-Another option is to provide a more generic solution. One way to do this would be to update `CVSS cvss = 12` to 
-`repeated CVSS cvss = 12` (note: the [proto3 spec](https://protobuf.dev/programming-guides/proto3/#updating) indicates this is compatible).
-Doing it this way gives us a more generic way of supporting multiple CVSS scores vs adding a new `nvd_cvss` field,
-and it may certainly be the way to go in the future should we want to support a variety of score sources; however,
-there is no need for a generic solution at this time, and adding the new field make it very easy to choose between the two options.
+* `CVSS.Source`
+  * This specifies the supported CVSS metrics data sources.
+* `CVSS.source`
+  * This specifies the source of the particular CVSS metrics.
+* `cvss_metrics`
+  * This is a list of each unique CVSS metric based on the source.
+
+The original `cvss` field will remain and will continue to represent the Scanner's preferred CVSS score.
+This is currently the score from the vulnerability's original data source, if available, otherwise NVD.
 
 ### Handling RHSA/RHBA/RHEA
 
@@ -111,11 +129,20 @@ The [`claircore.Vulnerability.Severity`](https://github.com/quay/claircore/blob/
 
 `severity=<severity>&cvss3_score=<score3>&cvss3_vector=<vector3>cvss2_score=<score2>&cvss2_vector=<vector2>`
 
-This URL encoding will be extended to include `cve=<CVE ID>`. 
-By doing this, Scanner V4 has the ability to relate the RHSA back to the CVE which has the highest score and search NVD for that CVE's score.
+This URL encoding will be extended to include `cve=<CVE ID>`.
 
 ## Consequences
 
-NVD only tracks CVEs, while Scanner V4 shows a variety of advisories (CVE, RHSA/RHBA/RHEA, ALAS, etc).
-
-The current plan is only to support CVEs as well as RHSA/RHBA/RHEA.
+* Creating an `enum` for `Source` instead of just using a `string` ensures consistency and limits mistakes which may be made
+with misspelled or differently spelled strings.
+* Encoding the RHSA/RHEA/RHBA's related CVE allows Scanner V4 to relate the advisory back to the CVE which has the highest score and search NVD for that CVE's score.
+* Other type of advisories like ALAS and USN will not have a score from NVD.
+* OSV.dev sometimes does not related non-CVEs (like GHSAs) back to CVEs. When this happens, we cannot determine the CVSS score from NVD.
+* protobufs do not support enums as key types, so we cannot do something like `map<Source, CVSS> cvss_metrics = 13`.
+  * We could just use a `string`, but then we run into the same potential pitfalls mentioned previously.
+* Keeping `cvss` as-is allows for easy access to Scanner's preferred CVSS score.
+* Extending the `severity` field for Red Hat advisories means we further diverge away from ClairCore's Red Hat updater.
+  * There are two major efforts related to this, which are currently being worked on by the Clair team:
+    * Adoption of CSAF/VEX files instead of OVAL
+    * Return CVE-centric reports rather than the current advisory-centric report.
+  * We will have to re-evaluate our custom updater as these are being developed and completed.

--- a/scanner/decisions/0009-nvd-cvss-scores.md
+++ b/scanner/decisions/0009-nvd-cvss-scores.md
@@ -1,6 +1,6 @@
-# 0008 - NVD CVSS Scores
+# 0009 - NVD CVSS Scores
 
-- **Author(s):** Ross Tannenbaum
+- **Author(s):** Ross Tannenbaum and Yi Li
 - **Created:** [2024-04-11 Thurs]
 
 ## Status
@@ -10,7 +10,7 @@ Status: Accepted.
 ## Context
 
 Users who require FedRAMP compliance [must be able see NVD's CVSS scores associated with each CVE](https://www.fedramp.gov/assets/resources/documents/CSP_Vulnerability_Scanning_Requirements.pdf).
-Note: NVD tracks CVEs, so all of tis data is CVE-based.
+Note: NVD tracks CVEs, so all of its data is CVE-based.
 
 Currently, Scanner V4 provides a single CVSS score and severity, which is preferably from the vendor.
 In reality, the CVSS scores that are shown are from NVD except in the following cases:
@@ -77,12 +77,6 @@ message VulnerabilityReport {
       SEVERITY_CRITICAL = 4;
     }
     message CVSS {
-      enum Source {
-        SOURCE_UNKNOWN = 0;
-        SOURCE_RED_HAT = 1;
-        SOURCE_OSV = 2;
-        SOURCE_NVD = 3;
-      }
       message V2 {
         float base_score = 1;
         string vector = 2;
@@ -91,9 +85,10 @@ message VulnerabilityReport {
         float base_score = 1;
         string vector = 2;
       }
-      Source source = 3; <-- New field.
       V2 v2 = 1;
       V3 v3 = 2;
+      string updater = 3; <-- New field.
+      string cvss_url = 4; <-- New field, cvss source URL
     }
     ...
     string severity = 6;
@@ -107,10 +102,8 @@ message VulnerabilityReport {
 
 There will be a new type plus two new fields added:
 
-* `CVSS.Source`
-  * This specifies the supported CVSS metrics data sources.
-* `CVSS.source`
-  * This specifies the source of the particular CVSS metrics.
+* `CVSS.updater`
+  * This specifies the source of the particular CVSS metrics. The value will be the name of the scanner updater, indicating the data source from which the updater is fetching vulnerabilities.
 * `cvss_metrics`
   * This is a list of each unique CVSS metric based on the source.
 

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -1,4 +1,4 @@
-# 0009 - NVD CVSS Scores
+# 0010 - NVD CVSS Scores
 
 - **Author(s):** Ross Tannenbaum and Yi Li
 - **Created:** [2024-04-11 Thurs]
@@ -77,7 +77,7 @@ message VulnerabilityReport {
       SEVERITY_CRITICAL = 4;
     }
     message CVSS {
-      enum Source {
+      enum Source { <-- New field
         SOURCE_UNKNOWN = 0;
         SOURCE_RED_HAT = 1;
         SOURCE_OSV = 2;
@@ -108,10 +108,10 @@ message VulnerabilityReport {
 
 There will be a new type plus two new fields added:
 
-* `CVSS.Source`
-  * This specifies the supported CVSS metrics data sources.
-* `CVSS.source`
-  * This specifies the source of the particular CVSS metrics.
+* **enum** `CVSS.Source`
+  * This is the **enum** that specifies the supported CVSS metrics data sources.
+* **field** `CVSS.source`
+  * This **field** specifies the source of the particular CVSS metrics.
 * `CVSS.url`
   * This specifies the CVSS score source URL, aiding both API and UI users in tracking the origin of this metric.
 * `cvss_metrics`

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -99,7 +99,7 @@ message VulnerabilityReport {
     ...
     string severity = 6;
     ...
-    CVSS cvss = 12;
+    CVSS cvss = 12 [deprecated = true];
     repeated CVSS cvss_metrics = 13; <-- New field.
   }
   ...
@@ -117,8 +117,8 @@ There will be a new type plus two new fields added:
 * `cvss_metrics`
   * This is a list of each unique CVSS metric based on the source.
 
-The original `cvss` field will remain and will continue to represent the Scanner's preferred CVSS score.
-This is currently the score from the vulnerability's original data source, if available, otherwise NVD.
+The original cvss field will remain for backward compatibility, as it represents the Scanner's preferred CVSS score, typically derived from the vulnerability's original data source if available, or from the NVD otherwise. 
+However, this field will be deprecated because the repeated CVSS cvss_metrics field can now include CVSS scores from all data sources, making it more comprehensive.
 
 **JSON example**:
 

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -182,7 +182,7 @@ This URL encoding will be extended to include `cve=<CVE ID>`.
 * Creating an `enum` for `Source` instead of just using a `string` ensures consistency and limits mistakes which may be made
 * `repeated CVSS` field `cvss_metrics` will always include CVSS metrics from all data sources, including the Scanner's preferred CVSS metric.
   * This approach simplifies data querying and filtering, as `cvss_metrics` will be the sole field used for filtering data or making policies.
-* OSV.dev sometimes does not related non-CVEs (like GHSAs) back to CVEs. When this happens, we cannot determine the CVSS score from NVD.
+* OSV.dev sometimes does not relate non-CVEs (like GHSAs) back to CVEs. When this happens, we cannot determine the CVSS score from NVD.
 * protobufs do not support enums as key types, so we cannot do something like `map<Source, CVSS> cvss_metrics = 13`.
   * We could just use a `string`, but then we run into the same potential pitfalls mentioned previously.
 * Keeping `cvss` as-is allows for easy access to Scanner's preferred CVSS score.

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -123,7 +123,7 @@ However, this field will be deprecated because the repeated CVSS cvss_metrics fi
 **JSON example**:
 
 
-```sh
+```json
 "9216828": {
 	"id": "9216828",
 	"name": "CVE-2023-48231",
@@ -139,26 +139,27 @@ However, this field will be deprecated because the repeated CVSS cvss_metrics fi
 		"v3": {
 			"base_score": 4.3,
 			"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
-			},
-		"url":"https://access.redhat.com/security/cve/CVE-2023-48231"
 		},
-	"cvss_metrics": [{
-		"source": "SOURCE_RED_HAT",
-		"v3": {
-			"base_score": 4.3,
-			"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+		"url": "https://access.redhat.com/security/cve/CVE-2023-48231"
+	},
+	"cvss_metrics": [
+		{
+			"source": "SOURCE_RED_HAT",
+			"v3": {
+				"base_score": 4.3,
+				"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
 			},
-		"url":"https://access.redhat.com/security/cve/CVE-2023-48231"
-		},{
-		"source": "SOURCE_NVD",
-		"v3": {
-			"base_score": 4.3,
-			"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+			"url": "https://access.redhat.com/security/cve/CVE-2023-48231"
+		}, {
+			"source": "SOURCE_NVD",
+			"v3": {
+				"base_score": 4.3,
+				"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
 			},
-		"url":"https://nvd.nist.gov/vuln/detail/CVE-2023-48231"
-		}]
+			"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48231"
+		}
+	]
 }
-```
 ### Handling RHSA/RHBA/RHEA
 
 Without loss of generality, RHSA/RHBA/RHEA will just be referred to as the more well-known RHSA variant of the three.

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -162,7 +162,6 @@ Similarly, the link field will also be remained for backward compatibility but w
 		}
 	]
 }
-### Handling RHSA/RHBA/RHEA
 
 Without loss of generality, RHSA/RHBA/RHEA will just be referred to as the more well-known RHSA variant of the three.
 

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -97,6 +97,7 @@ message VulnerabilityReport {
       string url = 4;    <-- New field
     }
     ...
+    string link = 5 [deprecated = true];
     string severity = 6;
     ...
     CVSS cvss = 12 [deprecated = true];
@@ -117,8 +118,9 @@ There will be a new type plus two new fields added:
 * `cvss_metrics`
   * This is a list of each unique CVSS metric based on the source.
 
-The original cvss field will remain for backward compatibility, as it represents the Scanner's preferred CVSS score, typically derived from the vulnerability's original data source if available, or from the NVD otherwise. 
-However, this field will be deprecated because the repeated CVSS cvss_metrics field can now include CVSS scores from all data sources, making it more comprehensive.
+The original `cvss` field will remain for backward compatibility, as it represents the Scanner's preferred CVSS score, typically derived from the vulnerability's original data source if available, or from the NVD otherwise. 
+However, this field will be deprecated because the `repeated CVSS cvss_metrics` field can now include CVSS scores from all data sources, making it more comprehensive.
+Similarly, the link field will also be remained for backward compatibility but will be deprecated in favor of the new url field, which is associated with the data source of each CVSS metric.
 
 **JSON example**:
 

--- a/scanner/decisions/0010-nvd-cvss-scores.md
+++ b/scanner/decisions/0010-nvd-cvss-scores.md
@@ -162,6 +162,9 @@ Similarly, the link field will also be remained for backward compatibility but w
 		}
 	]
 }
+```
+
+### Handling RHSA/RHBA/RHEA
 
 Without loss of generality, RHSA/RHBA/RHEA will just be referred to as the more well-known RHSA variant of the three.
 


### PR DESCRIPTION
## Description

There is a desire to show both vendor-specific CVSS score as well as NVD's score. This PR adds the ADR for updating Scanner's API for this purpose.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

Just a document

## Testing Performed

### Here I tell how I validated my change

no

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
