### PR TITLE
ROX-23200: comments on query performance

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -31,6 +31,10 @@ const (
 	getAllOrphanedNodes = `SELECT id FROM nodes WHERE NOT EXISTS
 		(SELECT 1 FROM clusters WHERE nodes.clusterid = clusters.Id)`
 
+	// deleteOrphanedProcesses select all process_indicators without
+	// associated deployments or pods. It does not scale for big deployments with million of rows
+	// in the table. If it fails repeatedly the postgres DB resources need to be reviewed,
+	// PostgresDefaultStatementTimeout increased, and a manual clean-up might be needed.
 	deleteOrphanedProcesses = `WITH orphan_proc AS 
 		(SELECT id FROM process_indicators pi WHERE NOT EXISTS 
 		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) 

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -3,7 +3,9 @@ package env
 import "time"
 
 var (
-	// PostgresDefaultStatementTimeout sets the default timeout for Postgres statements
+	// PostgresDefaultStatementTimeout sets the default timeout for Postgres statements. This does not
+	// set the statement_timeout, usually configured in the central-external-db configmap. Statement
+	// will fail after either of each is exceeded.
 	PostgresDefaultStatementTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_TIMEOUT", 60*time.Second)
 
 	// PostgresDefaultCursorTimeout sets the default timeout for Postgres cursor statements


### PR DESCRIPTION
## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
