### PR TITLE
ROX-23637: add custom execution environment string to User-Agent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -683,8 +683,6 @@ jobs:
           roxctl version
 
       - name: Scan images
-        env:
-          ROX_EXECUTION_ENV: stackrox workflow
         run: |
           ./release/scripts/scan-images-with-roxctl.sh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -683,6 +683,8 @@ jobs:
           roxctl version
 
       - name: Scan images
+        env:
+          ROX_EXECUTION_ENV: stackrox workflow
         run: |
           ./release/scripts/scan-images-with-roxctl.sh
 

--- a/pkg/clientconn/useragent.go
+++ b/pkg/clientconn/useragent.go
@@ -32,9 +32,10 @@ func init() {
 func SetUserAgent(agent string) {
 	var ci string
 	if v, ok := os.LookupEnv("CI"); ok {
-		if v == "" {
-			ci = " CI"
-		} else if value, err := strconv.ParseBool(v); err == nil && value {
+		// Do not set CI if CI=false.
+		if value, err := strconv.ParseBool(v); err == nil && !value {
+			ci = ""
+		} else {
 			ci = " CI"
 		}
 	}

--- a/pkg/clientconn/useragent.go
+++ b/pkg/clientconn/useragent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/version"
 )
@@ -33,7 +34,11 @@ func SetUserAgent(agent string) {
 	if testutils.IsRunningInCI() {
 		ci = " CI"
 	}
-	userAgent = fmt.Sprintf("%s/%s (%s; %s)%s", agent, version.GetMainVersion(), runtime.GOOS, runtime.GOARCH, ci)
+	execEnv := env.ExecutionEnvironment.Setting()
+	if execEnv != "" {
+		execEnv = fmt.Sprintf(" (%s)", execEnv)
+	}
+	userAgent = fmt.Sprintf("%s/%s (%s; %s)%s%s", agent, version.GetMainVersion(), runtime.GOOS, runtime.GOARCH, ci, execEnv)
 }
 
 // GetUserAgent returns the previously calculated value, which has to be set

--- a/pkg/clientconn/useragent.go
+++ b/pkg/clientconn/useragent.go
@@ -2,10 +2,9 @@ package clientconn
 
 import (
 	"fmt"
-	"os"
 	"runtime"
-	"strconv"
 
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/version"
 )
 
@@ -31,13 +30,8 @@ func init() {
 // e.g. grpc-go/1.50.1.
 func SetUserAgent(agent string) {
 	var ci string
-	if v, ok := os.LookupEnv("CI"); ok {
-		// Do not set CI if CI=false.
-		if value, err := strconv.ParseBool(v); err == nil && !value {
-			ci = ""
-		} else {
-			ci = " CI"
-		}
+	if testutils.IsRunningInCI() {
+		ci = " CI"
 	}
 	userAgent = fmt.Sprintf("%s/%s (%s; %s)%s", agent, version.GetMainVersion(), runtime.GOOS, runtime.GOARCH, ci)
 }

--- a/pkg/clientconn/useragent_test.go
+++ b/pkg/clientconn/useragent_test.go
@@ -4,18 +4,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetUserAgent(t *testing.T) {
 	ua := GetUserAgent()
 	assert.True(t, strings.HasPrefix(ua, "StackRox/"))
-	assert.NotContains(t, ua, "CI")
+	assert.Equal(t, testutils.IsRunningInCI(), strings.Contains(ua, "CI"))
 
 	SetUserAgent("abc")
 	ua = GetUserAgent()
 	assert.True(t, strings.HasPrefix(ua, "abc/"))
-	assert.NotContains(t, ua, "CI")
+	assert.Equal(t, testutils.IsRunningInCI(), strings.Contains(ua, "CI"))
 
 	for ci, expected := range map[string]bool{
 		"yes":   true,
@@ -28,6 +29,6 @@ func TestSetUserAgent(t *testing.T) {
 		t.Setenv("CI", ci)
 		SetUserAgent("test")
 		ua = GetUserAgent()
-		assert.Equal(t, expected, strings.Contains(ua, " CI"))
+		assert.Equal(t, expected, strings.Contains(ua, " CI"), ci)
 	}
 }

--- a/pkg/clientconn/useragent_test.go
+++ b/pkg/clientconn/useragent_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,11 +13,14 @@ func TestSetUserAgent(t *testing.T) {
 	ua := GetUserAgent()
 	assert.True(t, strings.HasPrefix(ua, "StackRox/"))
 	assert.Equal(t, testutils.IsRunningInCI(), strings.Contains(ua, "CI"))
+	assert.NotContains(t, ua, "()")
 
+	t.Setenv(env.ExecutionEnvironment.EnvVar(), "test")
 	SetUserAgent("abc")
 	ua = GetUserAgent()
 	assert.True(t, strings.HasPrefix(ua, "abc/"))
 	assert.Equal(t, testutils.IsRunningInCI(), strings.Contains(ua, "CI"))
+	assert.Contains(t, ua, "(test)")
 
 	for ci, expected := range map[string]bool{
 		"yes":   true,

--- a/pkg/clientconn/useragent_test.go
+++ b/pkg/clientconn/useragent_test.go
@@ -1,0 +1,33 @@
+package clientconn
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetUserAgent(t *testing.T) {
+	ua := GetUserAgent()
+	assert.True(t, strings.HasPrefix(ua, "StackRox/"))
+	assert.NotContains(t, ua, "CI")
+
+	SetUserAgent("abc")
+	ua = GetUserAgent()
+	assert.True(t, strings.HasPrefix(ua, "abc/"))
+	assert.NotContains(t, ua, "CI")
+
+	for ci, expected := range map[string]bool{
+		"yes":   true,
+		"no":    true,
+		"true":  true,
+		"":      true,
+		"false": false,
+		"False": false,
+	} {
+		t.Setenv("CI", ci)
+		SetUserAgent("test")
+		ua = GetUserAgent()
+		assert.Equal(t, expected, strings.Contains(ua, " CI"))
+	}
+}

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -17,4 +17,8 @@ var (
 
 	// TelemetryStorageKey can be empty to disable telemetry collection.
 	TelemetryStorageKey = RegisterSetting("ROX_TELEMETRY_STORAGE_KEY_V1", AllowEmpty())
+
+	// ExecutionEnvironment specifies the context of the roxctl run. For example: "GHA" or "Tekton".
+	// The value will be added to the User-Agent string.
+	ExecutionEnvironment = RegisterSetting("ROX_EXECUTION_ENV", AllowEmpty())
 )

--- a/pkg/testutils/ci.go
+++ b/pkg/testutils/ci.go
@@ -12,6 +12,6 @@ func IsRunningInCI() bool {
 		return false
 	}
 
-	b, _ := strconv.ParseBool(v)
-	return b
+	b, err := strconv.ParseBool(v)
+	return err != nil || b
 }


### PR DESCRIPTION
Allow the roxctl caller to add a custom environment label to the User-Agent string. This can be useful in identification of GHA and Tekton tasks usage.