### PR TITLE
ROX-23574: Allow soft-restart of Sensor connection

### DIFF
--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -1,46 +1,22 @@
 package internalmessage
 
 import (
-	"context"
 	"sync"
 
 	"github.com/pkg/errors"
 )
 
 const (
-	SensorMessageSoftRestart = iota
+	SensorMessageSoftRestart = "SensorMessage_SoftRestart"
 )
 
 // SensorInternalMessageCallback is the callback used by subscribers.
-type SensorInternalMessageCallback func(message *SensorInternalMessage)
-
-// SensorInternalMessage is the message data structure used by publishers and subscribers to exchange messages.
-type SensorInternalMessage struct {
-	Kind     int
-	Text     string
-	Validity context.Context
-}
-
-// IsExpired is a helper function that checks if the context already expired without blocking.
-// If the context isn't set this function will always return false.
-func (im *SensorInternalMessage) IsExpired() bool {
-
-	if im.Validity == nil {
-		return false
-	}
-
-	select {
-	case <-im.Validity.Done():
-		return true
-	default:
-		return false
-	}
-}
+type SensorInternalMessageCallback func(message SensorInternalMessage)
 
 // NewMessageSubscriber creates a MessageSubscriber.
 func NewMessageSubscriber() *MessageSubscriber {
 	return &MessageSubscriber{
-		subscribers: map[int][]SensorInternalMessageCallback{
+		subscribers: map[string][]SensorInternalMessageCallback{
 			SensorMessageSoftRestart: {},
 		},
 		lock: &sync.RWMutex{},
@@ -50,25 +26,25 @@ func NewMessageSubscriber() *MessageSubscriber {
 // MessageSubscriber is a lightweight PubSub-like component that can be used to register callbacks and publish
 // messages.
 type MessageSubscriber struct {
-	subscribers map[int][]SensorInternalMessageCallback
+	subscribers map[string][]SensorInternalMessageCallback
 	lock        *sync.RWMutex
 }
 
 // Publish a message to all subscribers.
-func (m *MessageSubscriber) Publish(msg *SensorInternalMessage) error {
+func (m *MessageSubscriber) Publish(msg SensorInternalMessage) error {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	if arr, ok := m.subscribers[msg.Kind]; ok {
+	if arr, ok := m.subscribers[msg.Kind()]; ok {
 		for _, subCallback := range arr {
 			go subCallback(msg)
 		}
 		return nil
 	}
-	return errors.Errorf("message type %d not found: %v", msg.Kind, msg)
+	return errors.Errorf("message type %d not found: %v", msg.Kind(), msg)
 }
 
 // Subscribe registers a callback based on a message kind.
-func (m *MessageSubscriber) Subscribe(kind int, handler SensorInternalMessageCallback) error {
+func (m *MessageSubscriber) Subscribe(kind string, handler SensorInternalMessageCallback) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	if arr, ok := m.subscribers[kind]; ok {

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -1,0 +1,80 @@
+package internalmessage
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	SensorMessageSoftRestart = iota
+)
+
+// SensorInternalMessageCallback is the callback used by subscribers.
+type SensorInternalMessageCallback func(message *SensorInternalMessage)
+
+// SensorInternalMessage is the message data structure used by publishers and subscribers to exchange messages.
+type SensorInternalMessage struct {
+	Kind     int
+	Text     string
+	Validity context.Context
+}
+
+// IsExpired is a helper function that checks if the context already expired without blocking.
+// If the context isn't set this function will always return false.
+func (im *SensorInternalMessage) IsExpired() bool {
+
+	if im.Validity == nil {
+		return false
+	}
+
+	select {
+	case <-im.Validity.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// NewMessageSubscriber creates a MessageSubscriber.
+func NewMessageSubscriber() *MessageSubscriber {
+	return &MessageSubscriber{
+		subscribers: map[int][]SensorInternalMessageCallback{
+			SensorMessageSoftRestart: {},
+		},
+		lock: &sync.RWMutex{},
+	}
+}
+
+// MessageSubscriber is a lightweight PubSub-like component that can be used to register callbacks and publish
+// messages.
+type MessageSubscriber struct {
+	subscribers map[int][]SensorInternalMessageCallback
+	lock        *sync.RWMutex
+}
+
+// Publish a message to all subscribers.
+func (m *MessageSubscriber) Publish(msg *SensorInternalMessage) error {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if arr, ok := m.subscribers[msg.Kind]; ok {
+		for _, subCallback := range arr {
+			go subCallback(msg)
+		}
+		return nil
+	}
+	return errors.Errorf("message type %d not found: %v", msg.Kind, msg)
+}
+
+// Subscribe registers a callback based on a message kind.
+func (m *MessageSubscriber) Subscribe(kind int, handler SensorInternalMessageCallback) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if arr, ok := m.subscribers[kind]; ok {
+		arr = append(arr, handler)
+		m.subscribers[kind] = arr
+		return nil
+	}
+	return errors.Errorf("message type %d not found", kind)
+}

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
+	// SensorMessageSoftRestart is a message kind where components require sensor-central connection to restart.
 	SensorMessageSoftRestart = "SensorMessage_SoftRestart"
 )
 
 // SensorInternalMessageCallback is the callback used by subscribers.
-type SensorInternalMessageCallback func(message SensorInternalMessage)
+type SensorInternalMessageCallback func(message *SensorInternalMessage)
 
 // NewMessageSubscriber creates a MessageSubscriber.
 func NewMessageSubscriber() *MessageSubscriber {
@@ -31,16 +32,16 @@ type MessageSubscriber struct {
 }
 
 // Publish a message to all subscribers.
-func (m *MessageSubscriber) Publish(msg SensorInternalMessage) error {
+func (m *MessageSubscriber) Publish(msg *SensorInternalMessage) error {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	if arr, ok := m.subscribers[msg.Kind()]; ok {
+	if arr, ok := m.subscribers[msg.Kind]; ok {
 		for _, subCallback := range arr {
 			go subCallback(msg)
 		}
 		return nil
 	}
-	return errors.Errorf("message type %d not found: %v", msg.Kind(), msg)
+	return errors.Errorf("message type %s not found: %v", msg.Kind, msg)
 }
 
 // Subscribe registers a callback based on a message kind.
@@ -52,5 +53,5 @@ func (m *MessageSubscriber) Subscribe(kind string, handler SensorInternalMessage
 		m.subscribers[kind] = arr
 		return nil
 	}
-	return errors.Errorf("message type %d not found", kind)
+	return errors.Errorf("message type %s not found", kind)
 }

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -1,9 +1,8 @@
 package internalmessage
 
 import (
-	"sync"
-
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (

--- a/sensor/common/internalmessage/message.go
+++ b/sensor/common/internalmessage/message.go
@@ -1,11 +1,13 @@
 package internalmessage
 
-import "context"
+import (
+	"github.com/stackrox/rox/pkg/concurrency"
+)
 
 // SensorInternalMessage is the implementation data structure for text based internal messages.
 type SensorInternalMessage struct {
 	Kind     string
-	Validity context.Context
+	Validity concurrency.Waitable
 	Text     string
 }
 

--- a/sensor/common/internalmessage/message.go
+++ b/sensor/common/internalmessage/message.go
@@ -1,0 +1,37 @@
+package internalmessage
+
+import "context"
+
+// SensorInternalMessage is the interface of messages used by publishers and subscribers to exchange messages.
+type SensorInternalMessage interface {
+	Kind() string
+	IsExpired() bool
+}
+
+// SensorInternalTextMessage is the implementation data structure for text based internal messages.
+type SensorInternalTextMessage struct {
+	kind     string
+	validity context.Context
+
+	Text string
+}
+
+func (im *SensorInternalTextMessage) Kind() string {
+	return im.kind
+}
+
+// IsExpired is a helper function that checks if the context already expired without blocking.
+// If the context isn't set this function will always return false.
+func (im *SensorInternalTextMessage) IsExpired() bool {
+
+	if im.validity == nil {
+		return false
+	}
+
+	select {
+	case <-im.validity.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/sensor/common/internalmessage/message.go
+++ b/sensor/common/internalmessage/message.go
@@ -2,34 +2,23 @@ package internalmessage
 
 import "context"
 
-// SensorInternalMessage is the interface of messages used by publishers and subscribers to exchange messages.
-type SensorInternalMessage interface {
-	Kind() string
-	IsExpired() bool
-}
-
-// SensorInternalTextMessage is the implementation data structure for text based internal messages.
-type SensorInternalTextMessage struct {
-	kind     string
-	validity context.Context
-
-	Text string
-}
-
-func (im *SensorInternalTextMessage) Kind() string {
-	return im.kind
+// SensorInternalMessage is the implementation data structure for text based internal messages.
+type SensorInternalMessage struct {
+	Kind     string
+	Validity context.Context
+	Text     string
 }
 
 // IsExpired is a helper function that checks if the context already expired without blocking.
 // If the context isn't set this function will always return false.
-func (im *SensorInternalTextMessage) IsExpired() bool {
+func (im *SensorInternalMessage) IsExpired() bool {
 
-	if im.validity == nil {
+	if im.Validity == nil {
 		return false
 	}
 
 	select {
-	case <-im.validity.Done():
+	case <-im.Validity.Done():
 		return true
 	default:
 		return false

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -52,6 +52,7 @@ type centralCommunicationImpl struct {
 }
 
 var (
+	errForcedConnectionRestart       = errors.New("forced connection restart")
 	errCantReconcile                 = errors.New("unable to reconcile")
 	errLargePayload                  = errors.Wrap(errCantReconcile, "deduper payload too large")
 	errTimeoutWaitingForDeduperState = errors.Wrap(errCantReconcile, "timeout reached while waiting for the DeduperState")

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -441,9 +441,8 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// suddenly broke.
 		centralCommunication := NewCentralCommunication(s.reconnect.Load(), s.reconcile.Load(), s.components...)
 		syncDone := concurrency.NewSignal()
-		concurrency.WithLock1(s.centralCommunicationLock, func() bool {
+		concurrency.WithLock(s.centralCommunicationLock, func() {
 			s.centralCommunication = centralCommunication
-			return true
 		})
 		centralCommunication.Start(central.NewSensorServiceClient(s.centralConnection), centralReachable, &syncDone, s.configHandler, s.detector)
 		go s.notifySyncDone(&syncDone, centralCommunication)

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -272,14 +272,8 @@ func (s *Sensor) Start() {
 	okSig := s.centralConnectionFactory.OkSignal()
 	errSig := s.centralConnectionFactory.StopSignal()
 
-	err = s.pubSub.Subscribe(internalmessage.SensorMessageSoftRestart, func(message internalmessage.SensorInternalMessage) {
+	err = s.pubSub.Subscribe(internalmessage.SensorMessageSoftRestart, func(message *internalmessage.SensorInternalMessage) {
 		if message.IsExpired() {
-			return
-		}
-
-		v, ok := (message).(*internalmessage.SensorInternalTextMessage)
-		if !ok {
-			log.Warnf("Soft restart message has wrong type")
 			return
 		}
 
@@ -289,7 +283,7 @@ func (s *Sensor) Start() {
 			log.Warnf("Sensor connection was not yet established when internal message for connection restart was received. Skipping soft restart")
 			return
 		}
-		s.centralCommunication.Stop(errors.Wrap(errForcedConnectionRestart, v.Text))
+		s.centralCommunication.Stop(errors.Wrap(errForcedConnectionRestart, message.Text))
 	})
 
 	if err != nil {

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
@@ -31,7 +32,7 @@ import (
 // This component introduces a new type of component to sensor:
 // - The event pipeline is a sensor component. That means, it can send messages to the gRPC stream via the .ResponseC function.
 // - Pipeline components are sub-components inside the event pipeline that process a kubernetes event from start to finish (listener, resolver and output are all pipeline components)
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int, pubSub *internalmessage.MessageSubscriber) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	depResolver := resolver.New(outputQueue, storeProvider, queueSize)
 	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider)
@@ -49,5 +50,6 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		detector:    detector,
 		reprocessor: reprocessor,
 		offlineMode: offlineMode,
+		pubSub:      pubSub,
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -30,6 +31,7 @@ type eventPipeline struct {
 	reprocessor reprocessor.Handler
 
 	offlineMode *atomic.Bool
+	pubSub      *internalmessage.MessageSubscriber
 
 	eventsC chan *message.ExpiringMessage
 	stopper concurrency.Stopper

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/image"
 	"github.com/stackrox/rox/sensor/common/installmethod"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager"
 	"github.com/stackrox/rox/sensor/common/networkflow/service"
@@ -117,9 +118,11 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	localScan := scan.NewLocalScan(storeProvider.Registries(), storeProvider.RegistryMirrors())
 	delegatedRegistryHandler := delegatedregistry.NewHandler(storeProvider.Registries(), localScan)
 
+	pubSub := internalmessage.NewMessageSubscriber()
+
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, storeProvider.Deployments(), storeProvider.ServiceAccounts(), imageCache, auditLogEventsInput, auditLogCollectionManager, storeProvider.NetworkPolicies(), storeProvider.Registries(), localScan)
 	reprocessorHandler := reprocessor.NewHandler(admCtrlSettingsMgr, policyDetector, imageCache)
-	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, reprocessorHandler, k8sNodeName.Setting(), cfg.traceWriter, storeProvider, cfg.eventPipelineQueueSize)
+	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, reprocessorHandler, k8sNodeName.Setting(), cfg.traceWriter, storeProvider, cfg.eventPipelineQueueSize, pubSub)
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors())
@@ -206,6 +209,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		policyDetector,
 		imageService,
 		cfg.centralConnFactory,
+		pubSub,
 		components...,
 	)
 


### PR DESCRIPTION
## Description

Components can request connection to restart. 

This is required due to dynamic starting of compliance operator listeners. By restarting the connection Sensor will run reconciliation again.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Example changes made to event pipeline:
```go
 func (p *eventPipeline) Start() error {
+       go func() {
+               for {
+                       <-time.After(10 * time.Second)
+                       if err := p.pubSub.Publish(&internalmessage.SensorInternalMessage{
+                               Kind:     internalmessage.SensorMessageSoftRestart,
+                               Text:     "just messing with the connection",
+                               Validity: p.getCurrentContext(),
+                       }); err != nil {
+                               log.Errorf("failed to publish restart message: %s", err)
+                       }
+               }
+       }()
```

This makes the connection restart every 10 seconds
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
