### PR TITLE
ROX-23153: Return accumulated count in e2e test when parsed int is NaN

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -64,7 +64,7 @@ describe('Workload CVE Image Single page', () => {
         ).then(($severityTotals) => {
             const severityTotal = $severityTotals.toArray().reduce((acc, $el) => {
                 const count = acc + parseInt($el.innerText.replace(/\D/g, ''), 10);
-                return Number.isNaN(count) ? 0 : count;
+                return Number.isNaN(count) ? acc : count;
             }, 0);
             const plural = severityTotal === 1 ? '' : 's';
             cy.get(`*:contains(${severityTotal} result${plural} found)`);


### PR DESCRIPTION
## Description

Fixes a e2e test flake after the PF5 merge.

The test is a consistency check that verifies the total of all CVEs by severity is equal to the total number of results found for an image:
![image](https://github.com/stackrox/stackrox/assets/1292638/d490fd2f-c728-455a-923a-21de49982551)

The flake would occur when any of "Important", "Moderate", or "Low" CVE counts is equal to zero. This is due to the test code incorrectly returning `0` instead of the currently accumulated count when parsing the text results in `NaN`. Note that this doesn't happen when there are only zero "Critical" CVEs, as that is the first entry parsed and the accumulated value would be equal to `0`!

This is an intermittent error because the image chosen is non-determinisitc and will depend on the underlying platform as well as the currently detected CVEs for that image.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress runs with 
1. mocked data reproducing the error 
2. unmocked data verifying success
