### PR TITLE
chore(scanner): log when registry does not support Range header

### DIFF
--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -345,7 +345,7 @@ func getLayerRequest(ctx context.Context, httpClient *http.Client, imgRef name.R
 	}
 	utils.IgnoreError(res.Body.Close)
 	if res.StatusCode != http.StatusPartialContent {
-		zlog.Warn(ctx).
+		zlog.Debug(ctx).
 			Int("status_code", res.StatusCode).
 			Int("len", int(res.ContentLength)).
 			Str("url", u.String()).

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -275,7 +275,7 @@ func (i *localIndexer) IndexContainerImage(
 			return nil, fmt.Errorf("getting layer digests: %w", err)
 		}
 		// TODO Check for non-retryable errors (permission denied, etc.) to report properly.
-		layerReq, err := getLayerRequest(httpClient, imgRef, layerDigest)
+		layerReq, err := getLayerRequest(ctx, httpClient, imgRef, layerDigest)
 		if err != nil {
 			return nil, fmt.Errorf("getting layer request URL and headers (digest: %q): %w",
 				layerDigest.String(), err)
@@ -322,7 +322,7 @@ func getLayerDigests(layer v1.Layer) (ccd claircore.Digest, ld v1.Hash, err erro
 // getLayerRequest sends a partial request to retrieve the layer from the
 // registry and return the request object containing relevant information to
 // populate a container image manifest.
-func getLayerRequest(httpClient *http.Client, imgRef name.Reference, layerDigest v1.Hash) (*http.Request, error) {
+func getLayerRequest(ctx context.Context, httpClient *http.Client, imgRef name.Reference, layerDigest v1.Hash) (*http.Request, error) {
 	imgRepo := imgRef.Context()
 	registryURL := url.URL{
 		Scheme: imgRepo.Scheme(),
@@ -344,6 +344,13 @@ func getLayerRequest(httpClient *http.Client, imgRef name.Reference, layerDigest
 		return nil, err
 	}
 	utils.IgnoreError(res.Body.Close)
+	if res.StatusCode != http.StatusPartialContent {
+		zlog.Warn(ctx).
+			Int("status_code", res.StatusCode).
+			Int("len", int(res.ContentLength)).
+			Str("url", u.String()).
+			Msg("server might not support requests with Range HTTP header")
+	}
 	return res.Request, nil
 }
 


### PR DESCRIPTION
## Description

This is inspired by https://github.com/quay/clair/pull/2031. Ideally we should have a better way to track this, but for now, we can at least add a log to let us know if the `Range` query was respected. Ideally, it is, and we only pull layer contents once; however, it is possible not all registries support this.

To avoid potential log spam, the log is a debug log

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
