### PR TITLE
fix(CI): Try to reduce notifier e2e-test flake

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -344,7 +344,7 @@ export function deleteIntegrationInTable(integrationSource, integrationType, int
         cy.get(
             `tr:contains("${integrationName}") button[role="menuitem"]:contains("Delete Integration")`
         ).click(); // TODO Title Case
-        cy.get('button:contains("Delete")').click(); // confirmation modal
+        cy.get('.pf-v5-c-modal-box__footer button:contains("Delete")').click(); // confirmation modal
     }, routeMatcherMap);
 }
 


### PR DESCRIPTION
## Description

A lot of the noise from ui-e2e-tests this afternoon is coming from randoms flakes, always at the end of a different Integration test, where Cypress is finding exact 2 buttons with the text "Delete" in it
```
cy.get('button:contains("Delete")').click(); // confirmation modal
```

and the failure is always
```
{`cy.click()` can only be called on a single element. Your subject contained 2 elements. Pass `{ multiple: true }` if you want to serially click each element.
```

Since it is a test helper, simply adding that property would kill the noise, but perhaps we can find why it thinks there are two buttons?

For now, this PR scopes the helper to the Delete Confirmation modal's footer, where the button we want resides.

(I considered that PF 5 could be doing an unnecessary re-render under some circumstances, but then I'd expect it to say "node has become detached from the DOM", instead of "there are 2 of them...".)

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

### Here I tell how I validated my change

- All these still pass locally
- CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
