### PR TITLE
ROX-23308: Run image prefetcher before operator e2e tests.

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -160,6 +160,7 @@ class PostClusterTest(StoreArtifacts):
             "proxies",
             "squid",
             "kube-system",
+            "prefetch-images",
         ]
         self.openshift_namespaces = [
             "openshift-dns",

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ $(call go-tool, MOCKGEN_BIN, go.uber.org/mock/mockgen)
 $(call go-tool, GO_JUNIT_REPORT_BIN, github.com/jstemmer/go-junit-report/v2, tools/test)
 $(call go-tool, PROTOLOCK_BIN, github.com/nilslice/protolock/cmd/protolock, tools/linters)
 $(call go-tool, GOVULNCHECK_BIN, golang.org/x/vuln/cmd/govulncheck, tools/linters)
+$(call go-tool, IMAGE_PREFETCHER_DEPLOY, github.com/stackrox/image-prefetcher/deploy, tools/test)
 
 ###########
 ## Style ##
@@ -808,3 +809,11 @@ mitre:
 .PHONY: bootstrap_migration
 bootstrap_migration:
 	$(SILENT)if [[ "x${DESCRIPTION}" == "x" ]]; then echo "Please set a description for your migration in the DESCRIPTION environment variable"; else go run tools/generate-helpers/bootstrap-migration/main.go --root . --description "${DESCRIPTION}" ;fi
+
+.PHONY: image-prefetcher-start
+image-prefetcher-start: $(IMAGE_PREFETCHER_DEPLOY)
+	. scripts/ci/lib.sh; image_prefetcher_start stackrox-images $(IMAGE_PREFETCHER_DEPLOY)
+
+.PHONY: image-prefetcher-await
+image-prefetcher-await:
+	. scripts/ci/lib.sh; image_prefetcher_await stackrox-images

--- a/operator/tests/run.sh
+++ b/operator/tests/run.sh
@@ -22,6 +22,12 @@ _EO_KUTTL_HELP_
 
     local FAILED=0
 
+    info "Starting image pre-fetcher"
+    junit_wrap image-prefetcher-start \
+               "Start image pre-fetcher." \
+               "See log for error details." \
+               "make" "image-prefetcher-start"
+
     info "Fetching kuttl binary"
     junit_wrap fetch-kuttl \
                "Download kuttl binary." \
@@ -33,6 +39,12 @@ _EO_KUTTL_HELP_
                "Deploy previously released version of the operator." \
                "${kuttl_help}" \
                "make" "-C" "operator" "deploy-previous-via-olm"
+
+    info "Waiting image for pre-fetcher to complete"
+    junit_wrap image-prefetcher-await \
+               "Wait for image pre-fetcher to complete." \
+               "See log for error details." \
+               "make" "image-prefetcher-await"
 
     info "Executing operator upgrade test"
     junit_wrap test-upgrade \

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,5 +1,10 @@
 module github.com/stackrox/stackrox/tools/test
 
-go 1.18
+go 1.21
 
-require github.com/jstemmer/go-junit-report/v2 v2.1.0
+toolchain go1.21.7
+
+require (
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
+	github.com/stackrox/image-prefetcher/deploy v0.1.0
+)

--- a/tools/test/go.sum
+++ b/tools/test/go.sum
@@ -2,3 +2,5 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
 github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/stackrox/image-prefetcher/deploy v0.1.0 h1:BiTtiI6dOwLkjPf0NcRuS7M7DmbntQngupH1KdVRfe8=
+github.com/stackrox/image-prefetcher/deploy v0.1.0/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=

--- a/tools/test/tools-import.go
+++ b/tools/test/tools-import.go
@@ -9,4 +9,5 @@ package tools
 import (
 	// Tool dependencies, not used anywhere in the code.
 	_ "github.com/jstemmer/go-junit-report/v2"
+	_ "github.com/stackrox/image-prefetcher/deploy"
 )


### PR DESCRIPTION
## Description

This is just a first step, although already useful.

Two commits, reviewable separately:
- refactor generation of list of images that are expected for a CI job to avoid tricky substitutions
- start prefetching as early as possible, and then verify it completes right before upgrade step

Another improvement could be to start another instance that prefetches the base images (i.e. the ones from last release) since that can happen even before the build of the current commit completes. But that can be done later.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is enough.

Judging from the logs of a few jobs deploying the pre-fetcher added 7-18 seconds, and waiting for pulls to complete 1-4 seconds to the job runtime, but likely provided a moderate net speed-up, since non-prefetched stackrox image pulls was on the order of 20-40 seconds.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
