### PR TITLE
ROX-23060: Add cluster list table to Platform CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -1,10 +1,65 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { pluralize } from '@patternfly/react-core';
+import { Table, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
+import { gql, useQuery } from '@apollo/client';
 
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLPagination from 'hooks/useURLPagination';
+import { ClusterType } from 'types/cluster.proto';
+import {
+    TbodyLoading,
+    TbodyError,
+    TbodyEmpty,
+    TbodyFilteredEmpty,
+} from 'Components/TableStateTemplates';
+import { getTableUIState } from 'utils/getTableUIState';
+import { ensureExhaustive } from 'utils/type.utils';
 
+import { DynamicColumnIcon } from '../../components/DynamicIcon';
+import { getPlatformEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
+
+function displayClusterType(type: ClusterType): string {
+    switch (type) {
+        case 'GENERIC_CLUSTER':
+            return 'Generic';
+        case 'KUBERNETES_CLUSTER':
+            return 'Kubernetes';
+        case 'OPENSHIFT_CLUSTER':
+        case 'OPENSHIFT4_CLUSTER':
+            return 'OCP';
+        default:
+            return ensureExhaustive(type);
+    }
+}
+
+const clusterListQuery = gql`
+    query getPlatformClusters($query: String, $pagination: Pagination) {
+        clusters(query: $query, pagination: $pagination) {
+            id
+            name
+            clusterVulnerabilityCount(query: $query)
+            type
+            status {
+                orchestratorMetadata {
+                    version
+                }
+            }
+        }
+    }
+`;
+
+export type Cluster = {
+    id: string;
+    name: string;
+    clusterVulnerabilityCount: number;
+    type: ClusterType;
+    status?: {
+        orchestratorMetadata?: {
+            version: string;
+        };
+    };
+};
 
 export type ClustersTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -12,37 +67,81 @@ export type ClustersTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
 };
 
-function ClustersTable({
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    querySearchFilter,
-    isFiltered,
-    pagination,
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-}: ClustersTableProps) {
-    // TODO - Placeholders for query results
-    const data = [];
-    const previousData = undefined;
-    const error: Error | undefined = undefined;
-    const loading = false;
+function ClustersTable({ querySearchFilter, isFiltered, pagination }: ClustersTableProps) {
+    const { page, perPage } = pagination;
+    const { data, previousData, error, loading } = useQuery<
+        { clusters: Cluster[] },
+        {
+            query: string;
+            pagination: {
+                offset: number;
+                limit: number;
+            };
+        }
+    >(clusterListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
 
     const tableData = data ?? previousData;
 
+    const tableState = getTableUIState({
+        isLoading: loading,
+        data: tableData?.clusters,
+        error,
+        searchFilter: querySearchFilter,
+    });
+
+    const colSpan = 4;
+
     return (
-        <>
-            {loading && !tableData && (
-                <Bullseye>
-                    <Spinner />
-                </Bullseye>
+        <Table
+            borders={tableState.type === 'COMPLETE'}
+            variant="compact"
+            role="region"
+            aria-live="polite"
+            aria-busy={loading ? 'true' : 'false'}
+        >
+            <Thead noWrap>
+                <Tr>
+                    <Th>Cluster</Th>
+                    <Th>
+                        CVEs
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th>Cluster type</Th>
+                    <Th>Kubernetes version</Th>
+                </Tr>
+            </Thead>
+            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
+            {tableState.type === 'ERROR' && (
+                <TbodyError colSpan={colSpan} error={tableState.error} />
             )}
-            {error && (
-                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            {tableState.type === 'EMPTY' && (
+                <TbodyEmpty colSpan={colSpan} message="No secured clusters have been detected" />
             )}
-            {!error && tableData && (
-                <div role="region" aria-live="polite" aria-busy={loading ? 'true' : 'false'}>
-                    Cluster table goes here
-                </div>
-            )}
-        </>
+            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
+            {tableState.type === 'COMPLETE' &&
+                tableState.data.map(({ id, name, clusterVulnerabilityCount, type, status }) => (
+                    <Tbody key={id}>
+                        <Tr>
+                            <Td dataLabel="Cluster" modifier="nowrap">
+                                <Link to={getPlatformEntityPagePath('Cluster', id)}>{name}</Link>
+                            </Td>
+                            <Td dataLabel="CVEs">{pluralize(clusterVulnerabilityCount, 'CVE')}</Td>
+                            <Td dataLabel="Cluster type">{displayClusterType(type)}</Td>
+                            <Td dataLabel="Kubernetes version">
+                                {status?.orchestratorMetadata?.version ?? 'UNKNOWN'}
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                ))}
+        </Table>
     );
 }
 


### PR DESCRIPTION
## Description

Adds the cluster list to the Platform CVEs overview page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit platform CVEs and click the cluster tab:

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/4472e5f7-4ef5-429f-a4aa-8be9e3f1b85c)

Error:
![image](https://github.com/stackrox/stackrox/assets/1292638/3b77f5ee-9689-4c73-962c-ef64bac35d77)

Empty without filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/c727d7fd-13e2-4f49-b3a1-95509b1515bf)

Empty with filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/e1904c42-5f8b-46e3-9906-59fbaf7f1301)

Success:
![image](https://github.com/stackrox/stackrox/assets/1292638/c73dcd6b-7d28-442f-9c1d-722a1e5ddd62)

Clicking the link in the table takes you to the correct Cluster single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/a6acfdb0-93c1-4faf-9680-762eb49e5b7f)


