### PR TITLE
chore(ui): node cves table component refactor

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -1,30 +1,24 @@
 import React from 'react';
-import { Bullseye, Divider, Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLPagination from 'hooks/useURLPagination';
 
-import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import { QuerySearchFilter } from '../../types';
 
-export type CVEsTableContainerProps = {
-    filterToolbar: TableEntityToolbarProps['filterToolbar'];
-    entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
+export type CVEsTableProps = {
     querySearchFilter: QuerySearchFilter;
     isFiltered: boolean;
-    rowCount: number;
     pagination: ReturnType<typeof useURLPagination>;
 };
 
-function CVEsTableContainer({
-    filterToolbar,
-    entityToggleGroup,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+function CVEsTable({
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     querySearchFilter,
     isFiltered,
-    rowCount,
     pagination,
-}: CVEsTableContainerProps) {
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+}: CVEsTableProps) {
     // TODO - Placeholders for query results
     const data = [];
     const previousData = undefined;
@@ -35,14 +29,6 @@ function CVEsTableContainer({
 
     return (
         <>
-            <TableEntityToolbar
-                filterToolbar={filterToolbar}
-                entityToggleGroup={entityToggleGroup}
-                pagination={pagination}
-                tableRowCount={rowCount}
-                isFiltered={isFiltered}
-            />
-            <Divider component="div" />
             {loading && !tableData && (
                 <Bullseye>
                     <Spinner />
@@ -60,4 +46,4 @@ function CVEsTableContainer({
     );
 }
 
-export default CVEsTableContainer;
+export default CVEsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -15,14 +15,15 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
+import TableEntityToolbar from '../../components/TableEntityToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import NodeCveFilterToolbar from '../components/NodeCveFilterToolbar';
 import { NODE_CVE_SEARCH_OPTION } from '../../searchOptions';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { nodeEntityTabValues } from '../../types';
 
-import CVEsTableContainer from './CVEsTableContainer';
-import NodesTableContainer from './NodesTableContainer';
+import CVEsTable from './CVEsTable';
+import NodesTable from './NodesTable';
 
 const searchOptions = [NODE_CVE_SEARCH_OPTION];
 
@@ -78,23 +79,29 @@ function NodeCvesOverviewPage() {
                 <PageSection isCenterAligned>
                     <Card>
                         <CardBody>
+                            <TableEntityToolbar
+                                filterToolbar={filterToolbar}
+                                entityToggleGroup={entityToggleGroup}
+                                pagination={pagination}
+                                tableRowCount={
+                                    activeEntityTabKey === 'CVE'
+                                        ? entityCounts.CVE
+                                        : entityCounts.Node
+                                }
+                                isFiltered={isFiltered}
+                            />
+                            <Divider component="div" />
                             {activeEntityTabKey === 'CVE' && (
-                                <CVEsTableContainer
-                                    filterToolbar={filterToolbar}
-                                    entityToggleGroup={entityToggleGroup}
+                                <CVEsTable
                                     querySearchFilter={querySearchFilter}
                                     isFiltered={isFiltered}
-                                    rowCount={entityCounts.CVE}
                                     pagination={pagination}
                                 />
                             )}
                             {activeEntityTabKey === 'Node' && (
-                                <NodesTableContainer
-                                    filterToolbar={filterToolbar}
-                                    entityToggleGroup={entityToggleGroup}
+                                <NodesTable
                                     querySearchFilter={querySearchFilter}
                                     isFiltered={isFiltered}
-                                    rowCount={entityCounts.Node}
                                     pagination={pagination}
                                 />
                             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -1,30 +1,24 @@
 import React from 'react';
-import { Bullseye, Divider, Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLPagination from 'hooks/useURLPagination';
 
-import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import { QuerySearchFilter } from '../../types';
 
-export type NodesTableContainerProps = {
-    filterToolbar: TableEntityToolbarProps['filterToolbar'];
-    entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
+export type NodesTableProps = {
     querySearchFilter: QuerySearchFilter;
     isFiltered: boolean;
-    rowCount: number;
     pagination: ReturnType<typeof useURLPagination>;
 };
 
-function NodesTableContainer({
-    filterToolbar,
-    entityToggleGroup,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+function NodesTable({
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     querySearchFilter,
     isFiltered,
-    rowCount,
     pagination,
-}: NodesTableContainerProps) {
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+}: NodesTableProps) {
     // TODO - Placeholders for query results
     const data = [];
     const previousData = undefined;
@@ -35,14 +29,6 @@ function NodesTableContainer({
 
     return (
         <>
-            <TableEntityToolbar
-                filterToolbar={filterToolbar}
-                entityToggleGroup={entityToggleGroup}
-                pagination={pagination}
-                tableRowCount={rowCount}
-                isFiltered={isFiltered}
-            />
-            <Divider component="div" />
             {loading && !tableData && (
                 <Bullseye>
                     <Spinner />
@@ -60,4 +46,4 @@ function NodesTableContainer({
     );
 }
 
-export default NodesTableContainer;
+export default NodesTable;


### PR DESCRIPTION
## Description

Minor refactor that extracts `<TableEntityToolbar>` from the Node and NodeCVE tables to the parent component, as also done in Platform CVEs, in order to make follow up PRs smaller.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Minimal change - test that the WIP Node page still loads without error:
![image](https://github.com/stackrox/stackrox/assets/1292638/3643fa89-96f9-49ba-82cf-8409240da610)

