### PR TITLE
ROX-23032: Add node cves list table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -1,10 +1,85 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Text } from '@patternfly/react-core';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { gql, useQuery } from '@apollo/client';
 
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import {
+    TbodyLoading,
+    TbodyError,
+    TbodyEmpty,
+    TbodyFilteredEmpty,
+} from 'Components/TableStateTemplates';
+import useSet from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
+import { getTableUIState } from 'utils/getTableUIState';
 
+import DateDistance from '../../components/DateDistance';
+import { getNodeEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
+import TooltipTh from '../../WorkloadCves/components/TooltipTh';
+import { DynamicColumnIcon } from '../../components/DynamicIcon';
+import PartialCVEDataAlert from '../../WorkloadCves/components/PartialCVEDataAlert';
+import CvssFormatted from '../../components/CvssFormatted';
+import { getScoreVersionsForTopCVSS, sortCveDistroList } from '../../utils/sortUtils';
+import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { QuerySearchFilter } from '../../types';
+
+const cvesListQuery = gql`
+    query getNodeCVEs($query: String, $pagination: Pagination) {
+        nodeCVEs(query: $query, pagination: $pagination) {
+            cve
+            nodeCountBySeverity {
+                critical {
+                    total
+                }
+                important {
+                    total
+                }
+                moderate {
+                    total
+                }
+                low {
+                    total
+                }
+            }
+            topCVSS
+            affectedNodeCount
+            firstDiscoveredInSystem
+            distroTuples {
+                summary
+                operatingSystem
+                cvss
+                scoreVersion
+            }
+        }
+    }
+`;
+
+const totalNodeCountQuery = gql`
+    query getTotalNodeCount {
+        nodeCount
+    }
+`;
+
+// TODO Need to verify these types with the BE implementation
+export type NodeCVE = {
+    cve: string;
+    nodeCountBySeverity: {
+        critical: { total: number };
+        important: { total: number };
+        moderate: { total: number };
+        low: { total: number };
+    };
+    topCVSS: number;
+    affectedNodeCount: number;
+    firstDiscoveredInSystem: string;
+    distroTuples: {
+        summary: string;
+        operatingSystem: string;
+        cvss: number;
+        scoreVersion: string;
+    }[];
+};
 
 export type CVEsTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -12,37 +87,144 @@ export type CVEsTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
 };
 
-function CVEsTable({
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    querySearchFilter,
-    isFiltered,
-    pagination,
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-}: CVEsTableProps) {
-    // TODO - Placeholders for query results
-    const data = [];
-    const previousData = undefined;
-    const error: Error | undefined = undefined;
-    const loading = false;
+function CVEsTable({ querySearchFilter, isFiltered, pagination }: CVEsTableProps) {
+    const { page, perPage } = pagination;
+    const { data, previousData, loading, error } = useQuery<
+        { nodeCVEs: NodeCVE[] },
+        {
+            query: string;
+            pagination: {
+                offset: number;
+                limit: number;
+            };
+        }
+    >(cvesListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
+
+    const totalNodeCountRequest = useQuery<{ nodeCount: number }>(totalNodeCountQuery);
+    const totalNodeCount = totalNodeCountRequest.data?.nodeCount ?? 0;
 
     const tableData = data ?? previousData;
+    const tableState = getTableUIState({
+        isLoading: loading,
+        data: tableData?.nodeCVEs,
+        error,
+        searchFilter: querySearchFilter,
+    });
+
+    const expandedRowSet = useSet<string>();
+    const colSpan = 6;
 
     return (
-        <>
-            {loading && !tableData && (
-                <Bullseye>
-                    <Spinner />
-                </Bullseye>
+        <Table
+            borders={tableState.type === 'COMPLETE'}
+            variant="compact"
+            role="region"
+            aria-live="polite"
+            aria-busy={loading ? 'true' : 'false'}
+        >
+            <Thead noWrap>
+                <Tr>
+                    <Th aria-label="Expand row" />
+                    <Th>CVE</Th>
+                    <TooltipTh tooltip="The number of nodes affected by this CVE, grouped by the severity of the CVE on each node">
+                        Nodes by severity
+                        {isFiltered && <DynamicColumnIcon />}
+                    </TooltipTh>
+                    <Th>Top CVSS</Th>
+                    <TooltipTh tooltip="Ratio of the number of nodes affected by this CVE to the total number of nodes">
+                        Affected nodes
+                        {isFiltered && <DynamicColumnIcon />}
+                    </TooltipTh>
+                    <Th>First discovered</Th>
+                </Tr>
+            </Thead>
+            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
+            {tableState.type === 'ERROR' && (
+                <TbodyError colSpan={colSpan} error={tableState.error} />
             )}
-            {error && (
-                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            {tableState.type === 'EMPTY' && (
+                <TbodyEmpty
+                    colSpan={colSpan}
+                    message="No Platform CVEs have been reported for your secured clusters"
+                />
             )}
-            {!error && tableData && (
-                <div role="region" aria-live="polite" aria-busy={loading ? 'true' : 'false'}>
-                    Table goes here
-                </div>
-            )}
-        </>
+            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
+            {tableState.type === 'COMPLETE' &&
+                tableState.data.map((nodeCve, rowIndex) => {
+                    const {
+                        cve,
+                        nodeCountBySeverity: { critical, important, moderate, low },
+                        distroTuples,
+                        topCVSS,
+                        affectedNodeCount,
+                        firstDiscoveredInSystem,
+                    } = nodeCve;
+                    const isExpanded = expandedRowSet.has(cve);
+
+                    const prioritizedDistros = sortCveDistroList(distroTuples);
+                    const summary =
+                        prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
+                    const scoreVersions = getScoreVersionsForTopCVSS(topCVSS, distroTuples);
+
+                    return (
+                        <Tbody key={cve} isExpanded={isExpanded}>
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(cve),
+                                    }}
+                                />
+                                <Td dataLabel="CVE" modifier="nowrap">
+                                    <Link to={getNodeEntityPagePath('CVE', cve)}>{cve}</Link>
+                                </Td>
+                                <Td dataLabel="Nodes by severity">
+                                    <SeverityCountLabels
+                                        criticalCount={critical.total}
+                                        importantCount={important.total}
+                                        moderateCount={moderate.total}
+                                        lowCount={low.total}
+                                        // TODO - Add filtered severities once filter toolbar is in place
+                                    />
+                                </Td>
+                                <Td dataLabel="Top CVSS">
+                                    <CvssFormatted
+                                        cvss={topCVSS}
+                                        scoreVersion={
+                                            scoreVersions.length > 0
+                                                ? scoreVersions.join('/')
+                                                : undefined
+                                        }
+                                    />
+                                </Td>
+                                <Td dataLabel="Affected nodes">
+                                    {affectedNodeCount} / {totalNodeCount} affected nodes
+                                </Td>
+                                <Td dataLabel="First discovered">
+                                    <DateDistance date={firstDiscoveredInSystem} />
+                                </Td>
+                            </Tr>
+                            <Tr isExpanded={isExpanded}>
+                                <Td />
+                                <Td colSpan={colSpan - 1}>
+                                    <ExpandableRowContent>
+                                        {summary ? <Text>{summary}</Text> : <PartialCVEDataAlert />}
+                                    </ExpandableRowContent>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                })}
+        </Table>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.test.ts
@@ -1,4 +1,8 @@
-import { getPlatformEntityPagePath, getWorkloadEntityPagePath } from './searchUtils';
+import {
+    getNodeEntityPagePath,
+    getPlatformEntityPagePath,
+    getWorkloadEntityPagePath,
+} from './searchUtils';
 
 const workloadUrlBase = '/main/vulnerabilities/workload-cves';
 
@@ -90,6 +94,34 @@ describe('getPlatformEntityPagePath', () => {
             })
         ).toEqual(
             `${platformUrlBase}/clusters/cluster-123-456?s[SEVERITY][0]=CRITICAL&s[NAMESPACE][0]=stackrox`
+        );
+    });
+});
+
+const nodeUrlBase = '/main/vulnerabilities/node-cves';
+
+describe('getNodeEntityPagePath', () => {
+    it('should return the correct path for CVE entity', () => {
+        expect(getNodeEntityPagePath('CVE', 'CVE-123-456')).toEqual(
+            `${nodeUrlBase}/cves/CVE-123-456`
+        );
+
+        expect(
+            getNodeEntityPagePath('CVE', 'CVE-123-456', { s: { SEVERITY: ['CRITICAL'] } })
+        ).toEqual(`${nodeUrlBase}/cves/CVE-123-456?s[SEVERITY][0]=CRITICAL`);
+    });
+
+    it('should return the correct path for Node entity', () => {
+        expect(getNodeEntityPagePath('Node', 'node-123-456')).toEqual(
+            `${nodeUrlBase}/nodes/node-123-456`
+        );
+
+        expect(
+            getNodeEntityPagePath('Node', 'node-123-456', {
+                s: { SEVERITY: ['CRITICAL'], NAMESPACE: ['stackrox'] },
+            })
+        ).toEqual(
+            `${nodeUrlBase}/nodes/node-123-456?s[SEVERITY][0]=CRITICAL&s[NAMESPACE][0]=stackrox`
         );
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -93,6 +93,22 @@ export function getPlatformEntityPagePath(
     }
 }
 
+export function getNodeEntityPagePath(
+    nodeCveEntity: NodeEntityTab,
+    id: string,
+    queryOptions?: qs.ParsedQs
+): string {
+    const queryString = getQueryString(queryOptions);
+    switch (nodeCveEntity) {
+        case 'CVE':
+            return `${vulnerabilitiesNodeCvesPath}/cves/${id}${queryString}`;
+        case 'Node':
+            return `${vulnerabilitiesNodeCvesPath}/nodes/${id}${queryString}`;
+        default:
+            return ensureExhaustive(nodeCveEntity);
+    }
+}
+
 export function fixableStatusToFixability(fixableStatus: FixableStatus): 'true' | 'false' {
     return fixableStatus === 'Fixable' ? 'true' : 'false';
 }


### PR DESCRIPTION
## Description

Adds the Node CVE list table to the Node CVE overview page.

Note: This is currently using simulated data until the APIs are in place.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the Node overview page:

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/6bb77f16-3a84-4b4b-bb03-a1924340e983)

Error:
![image](https://github.com/stackrox/stackrox/assets/1292638/7888a6b5-13ab-4c64-b6ad-07bb7f73afbc)

Empty without filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/0c1e1af7-c806-4238-8122-214e2869ec9f)

Empty with filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/39404aeb-0771-4c81-a186-9822476a7121)

Success:
![image](https://github.com/stackrox/stackrox/assets/1292638/c0ef6218-fa6d-4676-9f3d-88d21deaf4f2)

Click a CVE link within the table and ensure it navigates to the correct page:
![image](https://github.com/stackrox/stackrox/assets/1292638/8c202cfe-e1e2-4ac5-b398-3f908c9046c6)

