### PR TITLE
chore(qa-tests): remove ROX_POSTGRES_DATASTORE

### DIFF
--- a/qa-tests-backend/README.md
+++ b/qa-tests-backend/README.md
@@ -43,7 +43,7 @@ are inferred from the `deploy/{k8s,openshift}/central-deploy` directory.
   `GOOGLE_CREDENTIALS_GCR_SCANNER_V2`, `EMAIL_NOTIFIER_PASSWORD`,
   `MAILGUN_PASSWORD`, `JIRA_TOKEN`, `DTR_REGISTRY_PASSWORD`, `QUAY_PASSWORD`
   - Create a `qa-tests-backend/qa-test-settings.properties` file that contains environment variable assignments.
-  - Copy environment variable settings from the [StackRox 1Password Vault](https://stackrox.1password.com)
+  - Copy environment variable settings from [BitWarden](https://vault.bitwarden.com/#/vault?itemId=da41ea10-15fa-44e2-988e-af260101b26e)
 
 ### Custom configuration
 - If you have deployed the cluster differently or need to use a custom environment variable configuration:
@@ -54,10 +54,11 @@ are inferred from the `deploy/{k8s,openshift}/central-deploy` directory.
   - Environment Variables:
     - `CLUSTER`: Either `OPENSHIFT` or `K8S`
     - `API_HOSTNAME`: hostname central is running; default `localhost`
-    - `PORT`: central port; default `8000`
+    - `API_PORT`: central port; default `8000`
     - `ROX_USERNAME`: default `admin`
     - `ROX_PASSWORD`: default read from deploy dir based on specified `CLUSTER`
     - `KUBECONFIG`: kubeconfig file to use
+    - `POD_SECURITY_POLICIES`: set to `false` if the underlying kubernetes cluster does not support pod security policies
 
   - module : `qa-test-backend.test`
 - Save the configuration and run the test.

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -9,12 +9,8 @@ import spock.lang.Unroll
 
 @Tag("PZ")
 class AutocompleteTest extends BaseSpecification {
-    private static final SearchCategory VULNERABILITY_SEARCH_CATEGORY =
-        isPostgresRun() ?
-            SearchCategory.IMAGE_VULNERABILITIES :
-            SearchCategory.VULNERABILITIES
-
-    private static final String GROUP_AUTOCOMPLETE = isPostgresRun() ? "GROUP" : "group"
+    private static final SearchCategory VULNERABILITY_SEARCH_CATEGORY = SearchCategory.IMAGE_VULNERABILITIES
+    private static final String GROUP_AUTOCOMPLETE = "GROUP"
 
     @Tag("BAT")
     @Tag("COMPATIBILITY")

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -48,7 +48,9 @@ class BaseSpecification extends Specification {
 
     static final String RUN_ID
 
-    public static final String UNRESTRICTED_SCOPE_ID = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
+    public static final String UNRESTRICTED_SCOPE_ID = isPostgresRun() ?
+            "ffffffff-ffff-fff4-f5ff-ffffffffffff" :
+            "io.stackrox.authz.accessscope.unrestricted"
 
     static {
         String idStr

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -48,9 +48,7 @@ class BaseSpecification extends Specification {
 
     static final String RUN_ID
 
-    public static final String UNRESTRICTED_SCOPE_ID = isPostgresRun() ?
-        "ffffffff-ffff-fff4-f5ff-ffffffffffff" :
-        "io.stackrox.authz.accessscope.unrestricted"
+    public static final String UNRESTRICTED_SCOPE_ID = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
 
     static {
         String idStr
@@ -422,10 +420,6 @@ class BaseSpecification extends Specification {
                 "gcr-image-pull-secret",
                 Constants.ORCHESTRATOR_NAMESPACE)
         orchestrator.deleteSecret("gcr-image-pull-secret", Constants.ORCHESTRATOR_NAMESPACE)
-    }
-
-    static Boolean isPostgresRun() {
-        return Env.get("ROX_POSTGRES_DATASTORE", null) == "true"
     }
 
     static Boolean isRaceBuild() {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -422,6 +422,10 @@ class BaseSpecification extends Specification {
         orchestrator.deleteSecret("gcr-image-pull-secret", Constants.ORCHESTRATOR_NAMESPACE)
     }
 
+    static Boolean isPostgresRun() {
+        return Env.get("ROX_POSTGRES_DATASTORE", null) == "true"
+    }
+
     static Boolean isRaceBuild() {
         return Env.get("IS_RACE_BUILD", null) == "true" || Env.CI_JOB_NAME == "race-condition-qa-e2e-tests"
     }

--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -5,7 +5,6 @@ import static util.Helpers.withRetry
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 
 import objects.Deployment
-import util.Env
 
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -25,23 +24,16 @@ class GlobalSearch extends BaseSpecification {
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 30
 
     def setupSpec() {
-        if (Env.get("ROX_POSTGRES_DATASTORE", null) == "true") {
-            EXPECTED_DEPLOYMENT_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.CLUSTERS,
-                                              SearchServiceOuterClass.SearchCategory.NAMESPACES,
-                                              SearchServiceOuterClass.SearchCategory.IMAGES,
-                                              SearchServiceOuterClass.SearchCategory.DEPLOYMENTS,
-                                              SearchServiceOuterClass.SearchCategory.ALERTS)
-            EXPECTED_IMAGE_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.CLUSTERS,
-                                         SearchServiceOuterClass.SearchCategory.NAMESPACES,
-                                         SearchServiceOuterClass.SearchCategory.IMAGES,
-                                         SearchServiceOuterClass.SearchCategory.DEPLOYMENTS)
-        } else {
-            EXPECTED_DEPLOYMENT_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.IMAGES,
-                                              SearchServiceOuterClass.SearchCategory.DEPLOYMENTS,
-                                              SearchServiceOuterClass.SearchCategory.ALERTS)
-            EXPECTED_IMAGE_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.IMAGES,
-                                         SearchServiceOuterClass.SearchCategory.DEPLOYMENTS)
-        }
+        EXPECTED_DEPLOYMENT_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.CLUSTERS,
+                                          SearchServiceOuterClass.SearchCategory.NAMESPACES,
+                                          SearchServiceOuterClass.SearchCategory.IMAGES,
+                                          SearchServiceOuterClass.SearchCategory.DEPLOYMENTS,
+                                          SearchServiceOuterClass.SearchCategory.ALERTS)
+        EXPECTED_IMAGE_CATEGORIES.addAll(SearchServiceOuterClass.SearchCategory.CLUSTERS,
+                                     SearchServiceOuterClass.SearchCategory.NAMESPACES,
+                                     SearchServiceOuterClass.SearchCategory.IMAGES,
+                                     SearchServiceOuterClass.SearchCategory.DEPLOYMENTS)
+
         orchestrator.createDeployment(DEPLOYMENT)
         assert Services.waitForDeployment(DEPLOYMENT)
         // Wait for the latest tag violation since we try to search by it.

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -80,9 +80,7 @@ class SACTest extends BaseSpecification {
 
     static final private Integer WAIT_FOR_RISK_RETRIES =
             isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 80 : 50)
-    static final private String DENY_ALL = isPostgresRun() ?
-        "ffffffff-ffff-fff4-f5ff-fffffffffffe" :
-        'io.stackrox.authz.accessscope.denyall'
+    static final private String DENY_ALL = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
 
     @Shared
     private Map<String, RoleOuterClass.Access> allResourcesAccess

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -22,9 +22,15 @@ class UpgradesTest extends BaseSpecification {
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
 
-    private static final String VULNERABILITY_RESOURCE_TYPE = "nodeVulnerabilities"
+    private static final String VULNERABILITY_RESOURCE_TYPE =
+            isPostgresRun() ?
+                    "nodeVulnerabilities" :
+                    "vulnerabilities"
 
-    private static final String COMPONENT_RESOURCE_TYPE = "nodeComponents"
+    private static final String COMPONENT_RESOURCE_TYPE =
+            isPostgresRun() ?
+                    "nodeComponents" :
+                    "components"
 
     private static final COMPLIANCE_QUERY = """query getAggregatedResults(
         \$groupBy: [ComplianceAggregation_Scope!],

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -22,15 +22,9 @@ class UpgradesTest extends BaseSpecification {
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
 
-    private static final String VULNERABILITY_RESOURCE_TYPE =
-        isPostgresRun() ?
-            "nodeVulnerabilities" :
-            "vulnerabilities"
+    private static final String VULNERABILITY_RESOURCE_TYPE = "nodeVulnerabilities"
 
-    private static final String COMPONENT_RESOURCE_TYPE =
-        isPostgresRun() ?
-            "nodeComponents" :
-            "components"
+    private static final String COMPONENT_RESOURCE_TYPE = "nodeComponents"
 
     private static final COMPLIANCE_QUERY = """query getAggregatedResults(
         \$groupBy: [ComplianceAggregation_Scope!],

--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -66,22 +66,6 @@ class VulnMgmtSACTest extends BaseSpecification {
     }
     """
 
-    private static final GET_COMPONENTS_QUERY = """
-    query getComponents(\$query: String, \$pagination: Pagination)
-    {
-        results: components(query: \$query, pagination: \$pagination) {
-            ...componentFields
-            __typename
-        }
-        count: componentCount(query: \$query)
-    }
-
-    fragment componentFields on EmbeddedImageScanComponent {
-        name
-        version
-    }
-    """
-
     private static final GET_IMAGE_COMPONENTS_QUERY = """
     query getComponents(\$query: String, \$pagination: Pagination)
     {
@@ -167,19 +151,19 @@ class VulnMgmtSACTest extends BaseSpecification {
     }
 
     def getImageCVEQuery() {
-        return isPostgresRun() ? GET_IMAGE_CVES_QUERY : GET_CVES_QUERY
+        return GET_IMAGE_CVES_QUERY
     }
 
     def getNodeCVEQuery() {
-        return isPostgresRun() ? GET_NODE_CVES_QUERY : GET_CVES_QUERY
+        return GET_NODE_CVES_QUERY
     }
 
     def getImageComponentQuery() {
-        return isPostgresRun() ? GET_IMAGE_COMPONENTS_QUERY : GET_COMPONENTS_QUERY
+        return GET_IMAGE_COMPONENTS_QUERY
     }
 
     def getNodeComponentQuery() {
-        return isPostgresRun() ? GET_NODE_COMPONENTS_QUERY : GET_COMPONENTS_QUERY
+        return GET_NODE_COMPONENTS_QUERY
     }
 
     @Unroll
@@ -286,8 +270,8 @@ class VulnMgmtSACTest extends BaseSpecification {
         def imageComponentQuery = getImageComponentQuery()
         def nodeCveQuery = getNodeCVEQuery()
         def nodeComponentQuery = getNodeComponentQuery()
-        def imageBaseQuery = isPostgresRun() ? imageQuery : baseQuery
-        def nodeBaseQuery = isPostgresRun() ? nodeQuery : baseQuery
+        def imageBaseQuery = imageQuery
+        def nodeBaseQuery = nodeQuery
         def baseImageVulnCallResult = gqlService.Call(imageCveQuery, [query: imageBaseQuery])
         assert baseImageVulnCallResult.hasNoErrors()
         def baseImageComponentCallResult = gqlService.Call(imageComponentQuery, [query: imageBaseQuery])

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -22,7 +22,7 @@ class VulnMgmtTest extends BaseSpecification {
             "quay.io/rhacs-eng/qa:barchart-"+
             "-dockerup--ce6c28c63fa9a043214f4cccf036990dbd2bb0e47820af015de8dfb5dc68dd9a"
 
-    private static final EMBEDDED_IMAGE_POSTGRES_QUERY = """
+    private static final EMBEDDED_IMAGE_QUERY = """
     query getImage(\$id: ID!, \$query: String) {
       result: fullImage(id: \$id) {
         scan {
@@ -42,7 +42,7 @@ fragment cveFields on EmbeddedVulnerability {
 }
 """
 
-    private static final TOPLEVEL_IMAGE_POSTGRES_QUERY = """
+    private static final TOPLEVEL_IMAGE_QUERY = """
     query getImage(\$id: ID!, \$query: String) {
       result: image(id: \$id) {
         vulns: imageVulnerabilities(query: \$query) {
@@ -57,7 +57,7 @@ fragment cveFields on EmbeddedVulnerability {
     }
     """
 
-    private static final IMAGE_FIXABLE_CVE_POSTGRES_QUERY = """
+    private static final IMAGE_FIXABLE_CVE_QUERY = """
 query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
   result: image(id: \$id) {
     vulnerabilities: imageVulnerabilities(
@@ -77,7 +77,7 @@ fragment cveFields on ImageVulnerability {
 }
 """
 
-    private static final COMPONENT_FIXABLE_CVE_POSTGRES_QUERY = """
+    private static final COMPONENT_FIXABLE_CVE_QUERY = """
 query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
   result: imageComponent(id: \$id) {
     vulnerabilities: imageVulnerabilities(
@@ -98,7 +98,7 @@ fragment cveFields on ImageVulnerability {
 }
 """
 
-    private static final COMPONENT_SUBCVE_POSTGRES_QUERY = """
+    private static final COMPONENT_SUBCVE_QUERY = """
 query getComponentSubEntityCVE(\$id: ID!, \$query: String, \$scopeQuery: String) {
   result: imageComponent(id: \$id) {
     vulns: imageVulnerabilities(query: \$query, scopeQuery: \$scopeQuery) {
@@ -120,23 +120,23 @@ fragment cveFields on ImageVulnerability {
     }
 
     def getEmbeddedImageQuery() {
-        return EMBEDDED_IMAGE_POSTGRES_QUERY
+        return EMBEDDED_IMAGE_QUERY
     }
 
     def getTopLevelImageQuery() {
-        return TOPLEVEL_IMAGE_POSTGRES_QUERY
+        return TOPLEVEL_IMAGE_QUERY
     }
 
     def getImageFixableCVEQuery() {
-        return IMAGE_FIXABLE_CVE_POSTGRES_QUERY
+        return IMAGE_FIXABLE_CVE_QUERY
     }
 
     def getComponentFixableCVEQuery() {
-        return COMPONENT_FIXABLE_CVE_POSTGRES_QUERY
+        return COMPONENT_FIXABLE_CVE_QUERY
     }
 
     def getComponentSubCVEQuery() {
-        return COMPONENT_SUBCVE_POSTGRES_QUERY
+        return COMPONENT_SUBCVE_QUERY
     }
 
     def getRHELComponentID() {

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -22,26 +22,6 @@ class VulnMgmtTest extends BaseSpecification {
             "quay.io/rhacs-eng/qa:barchart-"+
             "-dockerup--ce6c28c63fa9a043214f4cccf036990dbd2bb0e47820af015de8dfb5dc68dd9a"
 
-    private static final EMBEDDED_IMAGE_QUERY = """
-    query getImage(\$id: ID!, \$query: String) {
-      result: image(id: \$id) {
-        scan {
-          components(query: \$query) {
-            vulns(query: \$query) {
-              ...cveFields
-            }
-          }
-        }
-      }
-    }
-
-fragment cveFields on EmbeddedVulnerability {
-  cve
-  cvss
-  severity
-}
-"""
-
     private static final EMBEDDED_IMAGE_POSTGRES_QUERY = """
     query getImage(\$id: ID!, \$query: String) {
       result: fullImage(id: \$id) {
@@ -62,21 +42,6 @@ fragment cveFields on EmbeddedVulnerability {
 }
 """
 
-    private static final TOPLEVEL_IMAGE_QUERY = """
-    query getImage(\$id: ID!, \$query: String) {
-      result: image(id: \$id) {
-        vulns(query: \$query) {
-          ...cveFields
-        }
-      }
-    }
-
-    fragment cveFields on EmbeddedVulnerability {
-      cvss
-      severity
-    }
-    """
-
     private static final TOPLEVEL_IMAGE_POSTGRES_QUERY = """
     query getImage(\$id: ID!, \$query: String) {
       result: image(id: \$id) {
@@ -91,27 +56,6 @@ fragment cveFields on EmbeddedVulnerability {
       severity
     }
     """
-
-    private static final IMAGE_FIXABLE_CVE_QUERY = """
-query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
-  result: image(id: \$id) {
-    vulnerabilities: vulns(
-      query: \$vulnQuery
-      scopeQuery: \$scopeQuery
-    ) {
-      ...cveFields
-      __typename
-    }
-    __typename
-  }
-}
-
-fragment cveFields on EmbeddedVulnerability {
-  cve
-  cvss
-  severity
-}
-"""
 
     private static final IMAGE_FIXABLE_CVE_POSTGRES_QUERY = """
 query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
@@ -133,27 +77,6 @@ fragment cveFields on ImageVulnerability {
 }
 """
 
-    private static final COMPONENT_FIXABLE_CVE_QUERY = """
-query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
-  result: component(id: \$id) {
-    vulnerabilities: vulns(
-      query: \$vulnQuery
-      scopeQuery: \$scopeQuery
-    ) {
-      ...cveFields
-      __typename
-    }
-    __typename
-  }
-}
-
-fragment cveFields on EmbeddedVulnerability {
-  cve
-  cvss
-  severity
-}
-"""
-
     private static final COMPONENT_FIXABLE_CVE_POSTGRES_QUERY = """
 query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: String) {
   result: imageComponent(id: \$id) {
@@ -170,22 +93,6 @@ query getFixableCvesForEntity(\$id: ID!, \$scopeQuery: String, \$vulnQuery: Stri
 
 fragment cveFields on ImageVulnerability {
   cve
-  cvss
-  severity
-}
-"""
-
-    private static final COMPONENT_SUBCVE_QUERY = """
-query getComponentSubEntityCVE(\$id: ID!, \$query: String, \$scopeQuery: String) {
-  result: component(id: \$id) {
-    vulns(query: \$query, scopeQuery: \$scopeQuery) {
-      ...cveFields
-    }
-    __typename
-  }
-}
-
-fragment cveFields on EmbeddedVulnerability {
   cvss
   severity
 }
@@ -213,35 +120,31 @@ fragment cveFields on ImageVulnerability {
     }
 
     def getEmbeddedImageQuery() {
-        return isPostgresRun() ? EMBEDDED_IMAGE_POSTGRES_QUERY : EMBEDDED_IMAGE_QUERY
+        return EMBEDDED_IMAGE_POSTGRES_QUERY
     }
 
     def getTopLevelImageQuery() {
-        return isPostgresRun() ? TOPLEVEL_IMAGE_POSTGRES_QUERY : TOPLEVEL_IMAGE_QUERY
+        return TOPLEVEL_IMAGE_POSTGRES_QUERY
     }
 
     def getImageFixableCVEQuery() {
-        return isPostgresRun() ? IMAGE_FIXABLE_CVE_POSTGRES_QUERY : IMAGE_FIXABLE_CVE_QUERY
+        return IMAGE_FIXABLE_CVE_POSTGRES_QUERY
     }
 
     def getComponentFixableCVEQuery() {
-        return isPostgresRun() ? COMPONENT_FIXABLE_CVE_POSTGRES_QUERY : COMPONENT_FIXABLE_CVE_QUERY
+        return COMPONENT_FIXABLE_CVE_POSTGRES_QUERY
     }
 
     def getComponentSubCVEQuery() {
-        return isPostgresRun() ? COMPONENT_SUBCVE_POSTGRES_QUERY : COMPONENT_SUBCVE_QUERY
+        return COMPONENT_SUBCVE_POSTGRES_QUERY
     }
 
     def getRHELComponentID() {
-        return isPostgresRun() ?
-            "ncurses-base#5.9-14.20130511.el7_4#centos:7" :
-            "bmN1cnNlcy1iYXNl:NS45LTE0LjIwMTMwNTExLmVsN180"
+        return "ncurses-base#5.9-14.20130511.el7_4#centos:7"
     }
 
     def getUbuntuComponentID() {
-        return isPostgresRun() ?
-            "ncurses#5.9+20140118-1ubuntu1#ubuntu:14.04" :
-            "bmN1cnNlcw:NS45KzIwMTQwMTE4LTF1YnVudHUx"
+        return "ncurses#5.9+20140118-1ubuntu1#ubuntu:14.04"
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -9,7 +9,6 @@ import services.CollectionsService
 import services.VulnReportService
 import util.MailServer
 
-import org.junit.Assume
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.IgnoreIf
@@ -67,10 +66,6 @@ class VulnReportingTest extends BaseSpecification {
     @Tag("BAT")
     def "Verify vulnerability generated using a collection sends an email with a valid report attachment"() {
         given:
-        "Central is using postgres"
-        Assume.assumeTrue(isPostgresRun())
-
-        and:
         "a an email notifier is configured"
         EmailNotifier notifier = new EmailNotifier("Vuln Reports Notifier",
                 mailServer.smtpUrl(),

--- a/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
@@ -59,39 +59,6 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         }
     }"""
 
-    private static final String GET_IMAGE_INFO_FROM_VULN_QUERY = """
-    query getCve(\$id: ID!) {
-        result: vulnerability(id: \$id) {
-        cve
-        cvss
-        scoreVersion
-        link
-        vectors {
-          __typename
-          ... on CVSSV2 {
-            impactScore
-            exploitabilityScore
-            vector
-          }
-          ... on CVSSV3 {
-            impactScore
-            exploitabilityScore
-            vector
-          }
-        }
-        summary
-        fixedByVersion
-        isFixable
-        lastScanned
-        componentCount
-        imageCount
-        deploymentCount
-        images {
-            id  name {fullName} scan {
-                scanTime
-            }}}
-    }"""
-
     private static final String GET_POSTGRES_IMAGE_INFO_FROM_VULN_QUERY = """
     query getCve(\$id: ID!) {
         result: imageVulnerability(id: \$id) {
@@ -197,8 +164,8 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
     private GraphQLService.Response waitForImagesTobeFetched(String cveId, String os,
      int retries = 30, int interval = 4) {
         Timer t = new Timer(retries, interval)
-        def objId = isPostgresRun() ? cveId + "#" + os : cveId
-        def graphQLQuery = isPostgresRun() ? GET_POSTGRES_IMAGE_INFO_FROM_VULN_QUERY : GET_IMAGE_INFO_FROM_VULN_QUERY
+        def objId = cveId + "#" + os
+        def graphQLQuery = GET_POSTGRES_IMAGE_INFO_FROM_VULN_QUERY
         while (t.IsValid()) {
             def result2Ret = gqlService.Call(graphQLQuery, [id: objId])
             assert result2Ret.getCode() == 200

--- a/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnScanWithGraphQLTest.groovy
@@ -59,7 +59,7 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
         }
     }"""
 
-    private static final String GET_POSTGRES_IMAGE_INFO_FROM_VULN_QUERY = """
+    private static final String GET_IMAGE_INFO_FROM_VULN_QUERY = """
     query getCve(\$id: ID!) {
         result: imageVulnerability(id: \$id) {
         cve
@@ -165,7 +165,7 @@ class VulnScanWithGraphQLTest extends BaseSpecification {
      int retries = 30, int interval = 4) {
         Timer t = new Timer(retries, interval)
         def objId = cveId + "#" + os
-        def graphQLQuery = GET_POSTGRES_IMAGE_INFO_FROM_VULN_QUERY
+        def graphQLQuery = GET_IMAGE_INFO_FROM_VULN_QUERY
         while (t.IsValid()) {
             def result2Ret = gqlService.Call(graphQLQuery, [id: objId])
             assert result2Ret.getCode() == 200


### PR DESCRIPTION
## Description

Removing the `ROX_POSTGRES_DATASTORE` environment variable from `qa-tests` as well as the `isPostgresRun()` and the different queries we had to use when we supported both rocksDB and postgres.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
