### PR TITLE
fix(CI): give the CI user access to EKS clusters

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -40,3 +40,13 @@ if [[ "${JOB_NAME:-}" =~ ocp-4-.*-perf-scale- ]]; then
     set_ci_shared_export WORKER_NODE_COUNT 9
     set_ci_shared_export WORKER_NODE_TYPE n1-standard-8
 fi
+
+if [[ "${JOB_NAME:-}" =~ -eks- ]]; then
+    info "Provide access for the CI user to EKS"
+    # shellcheck disable=SC2034
+    AWS_ACCESS_KEY_ID="$(cat /tmp/vault/stackrox-stackrox-e2e-tests/AWS_ACCESS_KEY_ID)"
+    # shellcheck disable=SC2034
+    AWS_SECRET_ACCESS_KEY="$(cat /tmp/vault/stackrox-stackrox-e2e-tests/AWS_SECRET_ACCESS_KEY)"
+    aws sts get-caller-identity | jq -r '.Arn'
+    set_ci_shared_export USER_ARNS "$(aws sts get-caller-identity | jq -r '.Arn')"
+fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1056,6 +1056,15 @@ openshift_ci_e2e_mods() {
         # shellcheck disable=SC1090
         source "$envfile"
     fi
+
+    if [[ "${JOB_NAME:-}" =~ -eks- ]]; then
+        # Explicitly set AWS creds from the stackrox-stackrox-e2e-tests vault to
+        # override any from other vaults e.g. automation-flavors.
+        AWS_ACCESS_KEY_ID="$(cat /tmp/vault/stackrox-stackrox-e2e-tests/AWS_ACCESS_KEY_ID)"
+        AWS_SECRET_ACCESS_KEY="$(cat /tmp/vault/stackrox-stackrox-e2e-tests/AWS_SECRET_ACCESS_KEY)"
+        export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+        aws sts get-caller-identity | jq -r '.Arn'
+    fi
 }
 
 operator_e2e_test_setup() {


### PR DESCRIPTION
## Description

The AWS user in the CI context is different from the provisioning (create step) user. This PR gives the CI user access to the cluster. 

https://github.com/stackrox/automation-iac/pull/90 is also required.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

/test eks-qa-e2e-tests

```
>>> Add user ARNs to aws-auth
User: arn:aws:iam::XXXXXXXXXXXX:user/automation/stackrox-ci-general-test-user
configmap/aws-auth patched
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
