### PR TITLE
fix(proto): clone instead of copy

### DIFF
--- a/pkg/registries/docker/metadata_v1.go
+++ b/pkg/registries/docker/metadata_v1.go
@@ -61,7 +61,7 @@ func convertImageToDockerFileLine(img *v1.Image) *storage.ImageLayer {
 
 func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, ref string) (*storage.ImageMetadata, error) {
 	// Get the latest layer and author
-	var latest storage.ImageLayer
+	var latest *storage.ImageLayer
 	var layers []*storage.ImageLayer
 	labels := make(map[string]string)
 	for i := len(manifest.History) - 1; i > -1; i-- {
@@ -71,8 +71,8 @@ func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, 
 			return nil, errors.Wrap(err, "Failed unmarshalling v1 capability")
 		}
 		layer := convertImageToDockerFileLine(&v1Image)
-		if protocompat.CompareTimestamps(layer.Created, latest.Created) == 1 {
-			latest = *layer
+		if protocompat.CompareTimestamps(layer.Created, latest.GetCreated()) == 1 {
+			latest = layer
 		}
 		layers = append(layers, layer)
 		// Last label takes precedence and there seems to be a separate image object per layer
@@ -94,8 +94,8 @@ func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, 
 	return &storage.ImageMetadata{
 		V1: &storage.V1Metadata{
 			Digest:  ref,
-			Created: latest.Created,
-			Author:  latest.Author,
+			Created: latest.GetCreated(),
+			Author:  latest.GetAuthor(),
 			Layers:  layers,
 			Labels:  labels,
 		},

--- a/sensor/common/admissioncontroller/settings_manager_impl.go
+++ b/sensor/common/admissioncontroller/settings_manager_impl.go
@@ -43,7 +43,7 @@ func NewSettingsManager(deployments store.DeploymentStore, pods store.PodStore) 
 func (p *settingsManager) newSettingsNoLock() *sensor.AdmissionControlSettings {
 	settings := &sensor.AdmissionControlSettings{}
 	if p.currSettings != nil {
-		*settings = *p.currSettings
+		settings = p.currSettings.Clone()
 	}
 	settings.ClusterId = clusterid.Get()
 	settings.CentralEndpoint = p.centralEndpoint


### PR DESCRIPTION
## Description

New version of protobuf puts a mutex into a message. This causes copying mutex which could lead to race condition.

```go
pkg/registries/docker/metadata_v1.go:75:13: copylocks: assignment copies lock value to latest: github.com/stackrox/rox/generated/storage.ImageLayer contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
			latest = *layer
			         ^
pkg/booleanpolicy/augmentedobjs/construct.go:197:9: copylocks: assignment copies lock value to img: github.com/stackrox/rox/generated/storage.Image contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
	img := *image
	       ^
sensor/common/admissioncontroller/settings_manager_impl.go:46:15: copylocks: assignment copies lock value to *settings: github.com/stackrox/rox/generated/internalapi/sensor.AdmissionControlSettings contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
		*settings = *p.currSettings
		            ^
```

https://github.com/stackrox/stackrox/actions/runs/8483665309/job/23245169186#step:9:31

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
