### PR TITLE
fix: do not copy image layer object

### DIFF
--- a/pkg/registries/docker/metadata_v1.go
+++ b/pkg/registries/docker/metadata_v1.go
@@ -61,7 +61,7 @@ func convertImageToDockerFileLine(img *v1.Image) *storage.ImageLayer {
 
 func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, ref string) (*storage.ImageMetadata, error) {
 	// Get the latest layer and author
-	var latest storage.ImageLayer
+	var latest *storage.ImageLayer
 	var layers []*storage.ImageLayer
 	labels := make(map[string]string)
 	for i := len(manifest.History) - 1; i > -1; i-- {
@@ -71,8 +71,8 @@ func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, 
 			return nil, errors.Wrap(err, "Failed unmarshalling v1 capability")
 		}
 		layer := convertImageToDockerFileLine(&v1Image)
-		if protocompat.CompareTimestamps(layer.Created, latest.Created) == 1 {
-			latest = *layer
+		if protocompat.CompareTimestamps(layer.Created, latest.GetCreated()) == 1 {
+			latest = layer
 		}
 		layers = append(layers, layer)
 		// Last label takes precedence and there seems to be a separate image object per layer
@@ -94,8 +94,8 @@ func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, 
 	return &storage.ImageMetadata{
 		V1: &storage.V1Metadata{
 			Digest:  ref,
-			Created: latest.Created,
-			Author:  latest.Author,
+			Created: latest.GetCreated(),
+			Author:  latest.GetAuthor(),
 			Layers:  layers,
 			Labels:  labels,
 		},


### PR DESCRIPTION
## Description

Messages in proto v2 contains a mutex co copying them like that may lead to races.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
