### PR TITLE
fix: manually shallow clone instead of copy

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -194,7 +194,7 @@ func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.Augme
 		return pathutil.NewAugmentedObj(image), nil
 	}
 
-	img := image.Clone()
+	img := shallowCopyImage(image)
 
 	// When evaluating policies, the evaluator will stop when any of the objects within the path
 	// are nil and immediately return, not matching. Within the image signature criteria, we have
@@ -263,4 +263,26 @@ func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.Augme
 	}
 
 	return obj, nil
+}
+
+func shallowCopyImage(image *storage.Image) storage.Image {
+	return storage.Image{
+		Id:                        image.Id,
+		Name:                      image.Name,
+		Names:                     image.Names,
+		Metadata:                  image.Metadata,
+		Scan:                      image.Scan,
+		SignatureVerificationData: image.SignatureVerificationData,
+		Signature:                 image.Signature,
+		SetComponents:             image.SetComponents,
+		SetCves:                   image.SetCves,
+		SetFixable:                image.SetFixable,
+		LastUpdated:               image.LastUpdated,
+		NotPullable:               image.NotPullable,
+		IsClusterLocal:            image.IsClusterLocal,
+		Priority:                  image.Priority,
+		RiskScore:                 image.RiskScore,
+		SetTopCvss:                image.SetTopCvss,
+		Notes:                     image.Notes,
+	}
 }

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -265,8 +265,8 @@ func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.Augme
 	return obj, nil
 }
 
-func shallowCopyImage(image *storage.Image) storage.Image {
-	return storage.Image{
+func shallowCopyImage(image *storage.Image) *storage.Image {
+	return &storage.Image{
 		Id:                        image.Id,
 		Name:                      image.Name,
 		Names:                     image.Names,


### PR DESCRIPTION
## Description

Shallow clone image instead of copying to prevent issues after migration to v2 proto that has a mutex inside proto message.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
