### PR TITLE
Jv poc service sends config to sensor

### DIFF
--- a/central/runtimeconfiguration/service/service.go
+++ b/central/runtimeconfiguration/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	datastore "github.com/stackrox/rox/central/runtimeconfiguration/datastore"
+	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
 )
@@ -17,8 +18,9 @@ type Service interface {
 }
 
 // New returns a new Service instance using the given DataStore.
-func New(store datastore.DataStore) Service {
+func New(store datastore.DataStore, connManager connection.Manager) Service {
 	return &serviceImpl{
-		dataStore: store,
+		dataStore:   store,
+		connManager: connManager,
 	}
 }

--- a/central/runtimeconfiguration/service/service_impl.go
+++ b/central/runtimeconfiguration/service/service_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -83,11 +84,61 @@ func (s *serviceImpl) PostCollectorRuntimeConfiguration(
 ) (*v1.Empty, error) {
 
 	log.Infof("request.CollectorRuntimeConfiguration= %+v", request.CollectorRuntimeConfiguration)
-	err := s.dataStore.SetRuntimeConfiguration(ctx, request.CollectorRuntimeConfiguration)
+	// err := s.dataStore.SetRuntimeConfiguration(ctx, request.CollectorRuntimeConfiguration)
+
+	// msg := &central.MsgToSensor{
+	//	Msg: &central.MsgToSensor_RuntimeFilteringConfiguration{
+	//		RuntimeFilteringConfiguration: request.CollectorRuntimeConfiguration,
+	//	},
+	//}
+
+	runtimeFilterRule := storage.RuntimeFilter_RuntimeFilterRule{
+		ResourceCollectionId: "abcd",
+		Status:               "off",
+	}
+
+	rules := []*storage.RuntimeFilter_RuntimeFilterRule{&runtimeFilterRule}
+
+	runtimeFilter := storage.RuntimeFilter{
+		Feature:       storage.RuntimeFilterFeatures_PROCESSES,
+		DefaultStatus: "on",
+		Rules:         rules,
+	}
+
+	resourceSelector := storage.ResourceSelector{
+		Rules: []*storage.SelectorRule{
+			{
+				FieldName: "Namespace",
+				Operator:  storage.BooleanOperator_OR,
+				Values: []*storage.RuleValue{
+					{
+						Value:     "webapp",
+						MatchType: storage.MatchType_EXACT,
+					},
+				},
+			},
+		},
+	}
+
+	resourceSelectors := []*storage.ResourceSelector{&resourceSelector}
+
+	resourceCollection := storage.ResourceCollection{
+		Id:                "abcd",
+		Name:              "Fake collection",
+		ResourceSelectors: resourceSelectors,
+	}
+
+	runtimeFilters := []*storage.RuntimeFilter{&runtimeFilter}
+	resourceCollections := []*storage.ResourceCollection{&resourceCollection}
+
+	collectorRuntimeConfiguration := &storage.RuntimeFilteringConfiguration{
+		RuntimeFilters:      runtimeFilters,
+		ResourceCollections: resourceCollections,
+	}
 
 	msg := &central.MsgToSensor{
 		Msg: &central.MsgToSensor_RuntimeFilteringConfiguration{
-			RuntimeFilteringConfiguration: request.CollectorRuntimeConfiguration,
+			RuntimeFilteringConfiguration: collectorRuntimeConfiguration,
 		},
 	}
 

--- a/central/runtimeconfiguration/service/service_impl.go
+++ b/central/runtimeconfiguration/service/service_impl.go
@@ -148,5 +148,5 @@ func (s *serviceImpl) PostCollectorRuntimeConfiguration(
 		return nil, err2
 	}
 
-	return &v1.Empty{}, err
+	return &v1.Empty{}, err2
 }

--- a/central/runtimeconfiguration/service/service_impl.go
+++ b/central/runtimeconfiguration/service/service_impl.go
@@ -4,12 +4,10 @@ import (
 	"context"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	deleConnection "github.com/stackrox/rox/central/delegatedregistryconfig/util/connection"
 	datastore "github.com/stackrox/rox/central/runtimeconfiguration/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	// "github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"

--- a/central/runtimeconfiguration/service/service_impl.go
+++ b/central/runtimeconfiguration/service/service_impl.go
@@ -64,23 +64,6 @@ func (s *serviceImpl) GetCollectorRuntimeConfiguration(
 	return &getCollectorRuntimeConfigurationResponse, err
 }
 
-func (s *serviceImpl) broadcast(ctx context.Context, msg *central.MsgToSensor) error {
-	log.Info("In broadcast")
-	for _, conn := range s.connManager.GetActiveConnections() {
-		log.Info("About to check ValidForDelegation")
-		if !deleConnection.ValidForDelegation(conn) {
-			continue
-		}
-
-		log.Info("About to InjectMessage")
-		err := conn.InjectMessage(ctx, msg)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (s *serviceImpl) PostCollectorRuntimeConfiguration(
 	ctx context.Context,
 	request *v1.PostCollectorRuntimeConfigurationRequest,
@@ -96,62 +79,6 @@ func (s *serviceImpl) PostCollectorRuntimeConfiguration(
 	}
 
 	s.connManager.BroadcastMessage(msg)
-
-	// runtimeFilterRule := storage.RuntimeFilter_RuntimeFilterRule{
-	//	ResourceCollectionId: "abcd",
-	//	Status:               "off",
-	//}
-
-	// rules := []*storage.RuntimeFilter_RuntimeFilterRule{&runtimeFilterRule}
-
-	// runtimeFilter := storage.RuntimeFilter{
-	//	Feature:       storage.RuntimeFilterFeatures_PROCESSES,
-	//	DefaultStatus: "on",
-	//	Rules:         rules,
-	//}
-
-	// resourceSelector := storage.ResourceSelector{
-	//	Rules: []*storage.SelectorRule{
-	//		{
-	//			FieldName: "Namespace",
-	//			Operator:  storage.BooleanOperator_OR,
-	//			Values: []*storage.RuleValue{
-	//				{
-	//					Value:     "webapp",
-	//					MatchType: storage.MatchType_EXACT,
-	//				},
-	//			},
-	//		},
-	//	},
-	//}
-
-	// resourceSelectors := []*storage.ResourceSelector{&resourceSelector}
-
-	// resourceCollection := storage.ResourceCollection{
-	//	Id:                "abcd",
-	//	Name:              "Fake collection",
-	//	ResourceSelectors: resourceSelectors,
-	//}
-
-	// runtimeFilters := []*storage.RuntimeFilter{&runtimeFilter}
-	// resourceCollections := []*storage.ResourceCollection{&resourceCollection}
-
-	// collectorRuntimeConfiguration := &storage.RuntimeFilteringConfiguration{
-	//	RuntimeFilters:      runtimeFilters,
-	//	ResourceCollections: resourceCollections,
-	//}
-
-	// msg := &central.MsgToSensor{
-	//	Msg: &central.MsgToSensor_RuntimeFilteringConfiguration{
-	//		RuntimeFilteringConfiguration: collectorRuntimeConfiguration,
-	//	},
-	//}
-
-	err2 := s.broadcast(ctx, msg)
-
-	if err2 != nil {
-		return nil, err2
-	}
 
 	return &v1.Empty{}, err
 }

--- a/central/runtimeconfiguration/service/singleton.go
+++ b/central/runtimeconfiguration/service/singleton.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	datastore "github.com/stackrox/rox/central/runtimeconfiguration/datastore"
+	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -12,7 +13,9 @@ var (
 )
 
 func initialize() {
-	as = New(datastore.Singleton())
+	as = New(datastore.Singleton(),
+		connection.ManagerSingleton(),
+	)
 }
 
 // Singleton provides the instance of the Service interface to register.

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -59,6 +59,8 @@ func (p *eventPipeline) ProcessMessage(msg *central.MsgToSensor) error {
 		return p.processReprocessDeployment(msg.GetReprocessDeployment())
 	case msg.GetInvalidateImageCache() != nil:
 		return p.processInvalidateImageCache(msg.GetInvalidateImageCache())
+	case msg.GetRuntimeFilteringConfiguration() != nil:
+		return p.processRuntimeFilterConfiguration(msg.GetRuntimeFilteringConfiguration())
 	}
 	return nil
 }
@@ -242,5 +244,11 @@ func (p *eventPipeline) processInvalidateImageCache(req *central.InvalidateImage
 		component.WithSkipResolving())
 	msg.Context = p.getCurrentContext()
 	p.resolver.Send(msg)
+	return nil
+}
+
+func (p *eventPipeline) processRuntimeFilterConfiguration(req *storage.RuntimeFilteringConfiguration) error {
+	log.Infof("In processRuntimeFilterConfiguration msg is %+v", req)
+
 	return nil
 }


### PR DESCRIPTION
## Description

When the collector runtime configuration is sent to the API, it is sent onto Sensor.

## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

I deployed that branch and ran
```
kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &
```
I obtained the token and entered it into Postman. I sent the request to https://localhost:8000/v1/collector_runtime_configuration using POST with the following in the body
```
{
  "collectorRuntimeConfiguration": {
    "runtimeFilters": [
      {
        "feature": "EXTERNAL_IPS",
        "defaultStatus": "off"
      },
      {
        "feature": "PROCESSES",
        "defaultStatus": "on"
      },
      {
        "feature": "NETWORK_CONNECTIONS",
        "defaultStatus": "on"
      },
      {
        "feature": "LISTENING_ENDPOINTS",
        "defaultStatus": "on"
      }
    ],
    "resourceCollections": [
      {
        "id": "b703d50e-b003-4a6a-bf1b-7ab36c9af184",
        "name": "cluster-1",
        "resourceSelectors": [
          {
            "rules": [
              {
                "fieldName": "Cluster",
                "operator": "OR",
                "values": [
                  {
                    "matchType": "EXACT",
                    "value": "cluster-1"
                  }
                ]
              }
            ]
          }
        ]
      }
    ]
  }
}
```
Checked the sensor log
```
kubernetes/eventpipeline: 2024/04/20 19:00:30.280365 pipeline_impl.go:251: Info: In processRuntimeFilterConfiguration msg is runtime_filters:<default_status:"off" > runtime_filters:<feature:PROCESSES default_status:"on" > runtime_filters:<feature:NETWORK_CONNECTIONS default_status:"on" > runtime_filters:<feature:LISTENING_ENDPOINTS default_status:"on" > resource_collections:<id:"b703d50e-b003-4a6a-bf1b-7ab36c9af184" name:"cluster-1" resource_selectors:<rules:<field_name:"Cluster" values:<value:"cluster-1" > > > >
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
