### PR TITLE
fix(CI): link to build status for missing image failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          source './scripts/ci/lib.sh'
+          source './scripts/ci/li.sh'
 
           matrix='{ "pre_build_go_binaries": { "name":[], "arch":[] }, "build_and_push_main": { "name":[], "arch":[] }, "push_main_multiarch_manifests": { "name":[] } }'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          source './scripts/ci/li.sh'
+          source './scripts/ci/lib.sh'
 
           matrix='{ "pre_build_go_binaries": { "name":[], "arch":[] }, "build_and_push_main": { "name":[], "arch":[] }, "push_main_multiarch_manifests": { "name":[] } }'
 

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -11,6 +11,7 @@ make_test_bin() {
 
     make cli_host-arch upgrader
     make cli-install
+    (cd ./tools/check-workflow-run && go install .)
 }
 
 make_test_bin "$*"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -515,8 +515,6 @@ poll_for_system_test_images() {
     local commit_sha
     commit_sha="$(get_commit_sha)"
 
-    (cd ./tools/check-workflow-run && go install .) || true
-
     while true; do
         local all_exist=true
         for image in "${reqd_images[@]}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -529,11 +529,13 @@ poll_for_system_test_images() {
         done
 
         {
+            echo
             info "Workflow status for build.yaml:"
             check-workflow-run \
               --workflow=build.yaml \
               --head-SHA="${commit_sha}"
 
+            echo
             info "Workflow status for scanner-build.yaml:"
             check-workflow-run \
               --workflow=scanner-build.yaml \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -567,13 +567,13 @@ check_build_workflows() {
 
     {
         echo
-        info "Workflow status for build.yaml:"
+        info "GitHub Actions workflow status for build.yaml:"
         check-workflow-run \
             --workflow=build.yaml \
             --head-SHA="${commit_sha}"
 
         echo
-        info "Workflow status for scanner-build.yaml:"
+        info "GitHub Actions workflow status for scanner-build.yaml:"
         check-workflow-run \
             --workflow=scanner-build.yaml \
             --head-SHA="${commit_sha}"

--- a/scripts/ci/test_state.sh
+++ b/scripts/ci/test_state.sh
@@ -3,4 +3,5 @@
 # State files used to track test progress across script invocations.
 
 export STATE_IMAGES_AVAILABLE="${SHARED_DIR:-/tmp}/stackrox_ci_state_images_available"
+export STATE_BUILD_WORKFLOW="${SHARED_DIR:-/tmp}/stackrox_ci_state_build_workflow"
 export STATE_DEPLOYED="${SHARED_DIR:-/tmp}/stackrox_ci_state_deployed"

--- a/scripts/ci/test_state.sh
+++ b/scripts/ci/test_state.sh
@@ -3,5 +3,5 @@
 # State files used to track test progress across script invocations.
 
 export STATE_IMAGES_AVAILABLE="${SHARED_DIR:-/tmp}/stackrox_ci_state_images_available"
-export STATE_BUILD_WORKFLOW="${SHARED_DIR:-/tmp}/stackrox_ci_state_build_workflow"
+export STATE_BUILD_RESULTS="${SHARED_DIR:-/tmp}/stackrox_ci_state_build_results"
 export STATE_DEPLOYED="${SHARED_DIR:-/tmp}/stackrox_ci_state_deployed"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1148,8 +1148,14 @@ handle_e2e_progress_failures() {
         save_junit_success "${images_available[@]}" || true
         check_deployment=true
     else
-        save_junit_failure "${images_available[@]}" \
-            "Did the images build OK? If yes then the poll_for_system_test_images() timeout might need to be increased."
+        local build_results="state unknown"
+        if [[ -f "${STATE_BUILD_WORKFLOW}" ]]; then
+            build_results="$(cat "${STATE_BUILD_WORKFLOW}")"
+        fi
+        save_junit_failure "${images_available[@]}" << __EO_BUILD_RESULTS__
+Check the build workflow runs:
+${build_results}
+__EO_BUILD_RESULTS__
     fi
 
     if $check_deployment; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1148,9 +1148,9 @@ handle_e2e_progress_failures() {
         save_junit_success "${images_available[@]}"
         check_deployment=true
     else
-        local build_results="state unknown"
-        if [[ -f "${STATE_BUILD_WORKFLOW}" ]]; then
-            build_results="$(cat "${STATE_BUILD_WORKFLOW}")"
+        local build_results="build results are unknown"
+        if [[ -f "${STATE_BUILD_RESULTS}" ]]; then
+            build_results="$(cat "${STATE_BUILD_RESULTS}")"
         fi
         read -r -d '' build_details <<- _EO_DETAILS_ || true
 Check the build workflow runs:

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1139,7 +1139,7 @@ db_backup_and_restore_test() {
 handle_e2e_progress_failures() {
     info "Checking for progress events"
 
-    local images_available=("Image_Availability" "Are the required images available?")
+    local images_available=("Image_Availability" "Were the required images built successfully by github actions?")
     local stackrox_deployed=("Stackrox_Deployment" "Was Stackrox deployed to the cluster?")
 
     local check_deployment=false

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1139,7 +1139,7 @@ db_backup_and_restore_test() {
 handle_e2e_progress_failures() {
     info "Checking for progress events"
 
-    local images_available=("Image_Availability" "Were the required images built successfully by github actions?")
+    local images_available=("Image_Availability" "Were the required images built successfully by GitHub Actions?")
     local stackrox_deployed=("Stackrox_Deployment" "Was Stackrox deployed to the cluster?")
 
     local check_deployment=false
@@ -1153,7 +1153,7 @@ handle_e2e_progress_failures() {
             build_results="$(cat "${STATE_BUILD_RESULTS}")"
         fi
         read -r -d '' build_details <<- _EO_DETAILS_ || true
-Check the build workflow runs:
+Check the build workflow runs on GitHub:
 ${build_results}
 _EO_DETAILS_
         save_junit_failure "${images_available[@]}" "${build_details}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1145,27 +1145,28 @@ handle_e2e_progress_failures() {
     local check_deployment=false
 
     if [[ -f "${STATE_IMAGES_AVAILABLE}" ]]; then
-        save_junit_success "${images_available[@]}" || true
+        save_junit_success "${images_available[@]}"
         check_deployment=true
     else
         local build_results="state unknown"
         if [[ -f "${STATE_BUILD_WORKFLOW}" ]]; then
             build_results="$(cat "${STATE_BUILD_WORKFLOW}")"
         fi
-        save_junit_failure "${images_available[@]}" << __EO_BUILD_RESULTS__
+        read -r -d '' build_details <<- _EO_DETAILS_ || true
 Check the build workflow runs:
 ${build_results}
-__EO_BUILD_RESULTS__
+_EO_DETAILS_
+        save_junit_failure "${images_available[@]}" "${build_details}"
     fi
 
     if $check_deployment; then
         if [[ -f "${STATE_DEPLOYED}" ]]; then
-            save_junit_success "${stackrox_deployed[@]}" || true
+            save_junit_success "${stackrox_deployed[@]}"
         else
-            save_junit_failure "${stackrox_deployed[@]}" "Check the build log" || true
+            save_junit_failure "${stackrox_deployed[@]}" "Check the build log"
         fi
     else
-        save_junit_skipped "${stackrox_deployed[@]}" || true
+        save_junit_skipped "${stackrox_deployed[@]}"
     fi
 }
 

--- a/tools/check-workflow-run/go.mod
+++ b/tools/check-workflow-run/go.mod
@@ -4,7 +4,6 @@ go 1.21.7
 
 require (
 	github.com/google/go-github/v61 v61.0.0
-	github.com/spf13/pflag v1.0.5
 )
 
 require github.com/google/go-querystring v1.1.0 // indirect

--- a/tools/check-workflow-run/go.mod
+++ b/tools/check-workflow-run/go.mod
@@ -1,0 +1,10 @@
+module github.com/stackrox/stackrox/tools/check-workflow-run
+
+go 1.21.7
+
+require (
+	github.com/google/go-github/v61 v61.0.0
+	github.com/spf13/pflag v1.0.5
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/tools/check-workflow-run/go.sum
+++ b/tools/check-workflow-run/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools/check-workflow-run/main.go
+++ b/tools/check-workflow-run/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	conclusion := lastRun.GetConclusion()
 	if *generateProwError && conclusion != "" && conclusion != "success" {
-		fmt.Println("ERROR: this workflow did not complete successfully")
+		fmt.Printf("ERROR: %s did not complete successfully\n", *workflowFileName)
 	}
 
 	fmt.Printf("status: %v\nconclusion: %v\nURL: %v\n",

--- a/tools/check-workflow-run/main.go
+++ b/tools/check-workflow-run/main.go
@@ -26,7 +26,8 @@ func main() {
 	}
 
 	client := github.NewClient(nil)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute())
+	defer cancel()
 
 	runs, _, err := client.Actions.ListWorkflowRunsByFileName(
 		ctx, "stackrox", "stackrox", *workflowFileName,
@@ -48,7 +49,7 @@ func main() {
 
 	conclusion := lastRun.GetConclusion()
 	if *generateProwError && conclusion != "" && conclusion != "success" {
-		fmt.Printf("ERROR: %s did not complete successfully\n", *workflowFileName)
+		fmt.Printf("ERROR: GitHub Actions workflow %s did not complete successfully\n", *workflowFileName)
 	}
 
 	fmt.Printf("status: %v\nconclusion: %v\nURL: %v\n",

--- a/tools/check-workflow-run/main.go
+++ b/tools/check-workflow-run/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	headSHA          = flag.String("head-SHA", "", "the SHA for the workflow run")
-	workflowFileName = flag.String("workflow", "build.yaml", "the workflow of interest")
+	headSHA           = flag.String("head-SHA", "", "the SHA for the workflow run")
+	workflowFileName  = flag.String("workflow", "build.yaml", "the workflow of interest")
+	generateProwError = flag.Bool("prow-error", true, "generate output that will stand out in prow")
 )
 
 // lookup useful information for a github action workflows most recent run
@@ -45,6 +46,11 @@ func main() {
 
 	lastRun := runs.WorkflowRuns[*runs.TotalCount-1]
 
+	conclusion := lastRun.GetConclusion()
+	if *generateProwError && conclusion != "" && conclusion != "success" {
+		fmt.Println("ERROR: this workflow did not complete successfully")
+	}
+
 	fmt.Printf("status: %v\nconclusion: %v\nURL: %v\n",
-		lastRun.GetStatus(), lastRun.GetConclusion(), lastRun.GetHTMLURL())
+		lastRun.GetStatus(), conclusion, lastRun.GetHTMLURL())
 }

--- a/tools/check-workflow-run/main.go
+++ b/tools/check-workflow-run/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/go-github/v61/github"
+	flag "github.com/spf13/pflag"
+)
+
+var (
+	headSHA          = flag.String("head-SHA", "", "the SHA for the workflow run")
+	workflowFileName = flag.String("workflow", "build.yaml", "the workflow of interest")
+)
+
+// lookup useful information for a github action workflows most recent run
+// relating to a SHA.
+func main() {
+	flag.Parse()
+
+	if *headSHA == "" {
+		fmt.Println("--head-SHA is required")
+		os.Exit(2)
+	}
+
+	client := github.NewClient(nil)
+	ctx := context.Background()
+
+	runs, _, err := client.Actions.ListWorkflowRunsByFileName(
+		ctx, "stackrox", "stackrox", *workflowFileName,
+		&github.ListWorkflowRunsOptions{
+			HeadSHA: *headSHA,
+		},
+	)
+	if err != nil {
+		fmt.Println("Cannot list workflow runs", err)
+		os.Exit(2)
+	}
+
+	if *runs.TotalCount == 0 {
+		fmt.Println("no runs")
+		os.Exit(1)
+	}
+
+	lastRun := runs.WorkflowRuns[*runs.TotalCount-1]
+
+	fmt.Printf("status: %v\nconclusion: %v\nURL: %v\n",
+		lastRun.GetStatus(), lastRun.GetConclusion(), lastRun.GetHTMLURL())
+}

--- a/tools/check-workflow-run/main.go
+++ b/tools/check-workflow-run/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/go-github/v61/github"
-	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -26,7 +27,7 @@ func main() {
 	}
 
 	client := github.NewClient(nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	runs, _, err := client.Actions.ListWorkflowRunsByFileName(


### PR DESCRIPTION
## Description

It is not clear to all users of stackrox CI that `Image_Availability` job failures are typically due to build failures in github actions. This PR improves the situation somewhat given the constraints of the openshift CI results UI.

It:
- Explicitly mentions github actions in the junit failure
- Checks the status of the GHA build workflows to include in the junit failure body and highlight in the prow UI. This is imperfect as different jobs require different workflows or parts of workflow to generate the images they need. I'll leave perfection to the next PR.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

A forced build failure results in:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/10773/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1781001763793408000
![Screenshot_2024-04-18_11-43-09](https://github.com/stackrox/stackrox/assets/64558589/cc84c1b4-0be3-4789-bbe9-1be4239eebc5)

The body has the details (but not clickable :( ):
![Screenshot_2024-04-18_11-51-59](https://github.com/stackrox/stackrox/assets/64558589/3064cc96-5792-4bcd-9df2-8664d18c1084)

Prow `ERROR:` highlighting does draw attention to the failed build and the link is clickable!

![Screenshot_2024-04-18_11-42-24](https://github.com/stackrox/stackrox/assets/64558589/81d63e02-9feb-4daf-8aa4-0ea75db663db)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
