### PR TITLE
feat(collector): add runtime configuration feature flag

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -132,6 +132,12 @@ collector:
   hostAliases: null # [dict]
   disableSELinuxOptions: null # bool
   seLinuxOptionsType: null # string
+  containerd:
+    enabled: null # bool
+  crio:
+    enabled: null # bool
+  runtime_config:
+    enabled: null # bool
 auditLogs:
   disableCollection: null # bool
 customize:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -107,6 +107,14 @@ collector:
   nodescanningEndpoint: "127.0.0.1:8444"
   tolerations:
   - operator: "Exists"
+  [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
+  containerd:
+    enabled: {{ eq ._rox.env.openshift 0 }}
+  crio:
+    enabled: {{ ne ._rox.env.openshift 0 }}
+  runtime_config:
+    enabled: true
+  [<- end >]
 
 auditLogs:
   disableCollection: {{ ne ._rox.env.openshift 4 }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -68,6 +68,10 @@ spec:
           value: {{ ._rox.sensor.endpoint }}
         - name: SNI_HOSTNAME
           value: "sensor.stackrox.svc"
+        [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
+        - name: ROX_COLLECTOR_RUNTIME_FILTERS_ENABLED
+          value: "{{ ._rox.collector.runtime_config.enabled }}"
+        [<- end >]
         {{- include "srox.envVars" (list . "daemonset" "collector" "collector") | nindent 8 }}
         resources:
           {{- ._rox.collector._resources | nindent 10 }}
@@ -103,6 +107,18 @@ spec:
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
+        [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
+        {{- if ._rox.collector.containerd.enabled }}
+        - mountPath: /host/run/containerd/containerd.sock
+          name: containerd-sock
+          mountPropagation: HostToContainer
+        {{- end }}
+        {{- if ._rox.collector.crio.enabled }}
+        - mountPath: /host/run/crio/crio.sock
+          name: crio-sock
+          mountPropagation: HostToContainer
+        {{- end }}
+        [<- end >]
       {{- end }}
       - command:
         - stackrox/compliance
@@ -232,3 +248,15 @@ spec:
       - name: cache-volume
         emptyDir:
           sizeLimit: 200Mi
+      [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
+      {{- if ._rox.collector.containerd.enabled }}
+      - name: containerd-sock
+        hostPath:
+          path: /run/containerd/containerd.sock
+      {{- end }}
+      {{- if ._rox.collector.crio.enabled }}
+      - name: crio-sock
+        hostPath:
+          path: /run/crio/crio.sock
+      {{- end }}
+      [<- end >]

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -119,4 +119,7 @@ var (
 	// DelegateWatchedImageReprocessing when set to true reprocessing of watched images may be delegated to secured clusters based
 	// on the delegated scanning config.
 	DelegateWatchedImageReprocessing = registerFeature("Enables delegating scans for watched images during reprocessing", "ROX_DELEGATE_WATCHED_IMAGE_REPROCESSING", true)
+
+	// CollectorRuntimeConfig enables filtering of runtime events.
+	CollectorRuntimeConfig = registerFeature("Enable collector runtime configuration", "ROX_COLLECTOR_RUNTIME_CONFIG", false)
 )


### PR DESCRIPTION
## Description

This PR adds the `ROX_RUNTIME_FILTERS`  feature flag, the proper name for this is still being discussed but updating shouldn't be too much trouble, so I'm erring on the side of moving things forward. The collector version is also updated to one that can actually use the flag and the helm charts are updated so collector can access the CRI sockets for it to be able to grab the container metadata it needs.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Used roxctl to generate helm charts with and without the feature flag, deployed secured-cluster-servcives with both sets of charts and verified everything worked as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
