### PR TITLE
fix: retest action

### DIFF
--- a/.github/workflows/retest_periodic.yml
+++ b/.github/workflows/retest_periodic.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Retest
       env:
         GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
-      run: cd tools/retest && go run main.go
+      run: cd tools/retest && go run ./...

--- a/.github/workflows/retest_periodic.yml
+++ b/.github/workflows/retest_periodic.yml
@@ -1,5 +1,6 @@
 name: Auto /retest
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
   - cron: 5 * * * *

--- a/.github/workflows/retest_periodic.yml
+++ b/.github/workflows/retest_periodic.yml
@@ -1,6 +1,5 @@
 name: Auto /retest
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
   - cron: 5 * * * *

--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -10,6 +10,11 @@ import (
 )
 
 func createComment(ctx context.Context, client *github.Client, prNumber int, comment string) {
+	if comment == "" {
+		log.Printf("#%d not commented", prNumber)
+		return
+	}
+	log.Printf("#%d will be commented with: %s", prNumber, comment)
 	issueComment := &github.IssueComment{
 		Body: &comment,
 	}

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -33,7 +33,7 @@ func run(ctx context.Context, client *github.Client) error {
 	log.Printf("Logged as %s: %s", user.GetLogin(), user.GetHTMLURL())
 
 	// TODO(janisz): handle pagination
-	search, _, err := client.Search.Issues(ctx, `repo:stackrox/stackrox label:auto-retest state:open type:pr status:failure`, nil)
+	search, _, err := client.Search.Issues(ctx, `repo:stackrox/stackrox label:auto-retest state:open type:pr`, nil)
 	if err != nil {
 		return fmt.Errorf("could not find issues: %w", err)
 	}
@@ -89,7 +89,6 @@ issues:
 		}
 		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
 		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatuses(statuses, userComments))
-		log.Printf("#%d will be commented with: %s", prNumber, strings.Join(newComments, ", "))
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
 	}
 	return nil

--- a/tools/retest/main_integration_test.go
+++ b/tools/retest/main_integration_test.go
@@ -44,7 +44,7 @@ func TestIntegration(t *testing.T) {
 		}
 
 		switch r.RequestURI {
-		case `/search/issues?q=repo%3Astackrox%2Fstackrox+label%3Aauto-retest+state%3Aopen+type%3Apr+status%3Afailure`:
+		case `/search/issues?q=repo%3Astackrox%2Fstackrox+label%3Aauto-retest+state%3Aopen+type%3Apr`:
 			_, err := w.Write([]byte(`
 {
   "total_count": 2,


### PR DESCRIPTION
## Description

Fixes:
- broken action that after splitting main.go needs to run `./...` 
- error on empty comment body when we do not want to comment
- search filters by failing statues which is ok for `retest` but not for `retest-times`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

https://github.com/stackrox/stackrox/actions/runs/8723885263/job/23933147486?pr=10788

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
