### PR TITLE
ROX-23625: Replace assertion about page address in clipboard

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -60,7 +60,7 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
- * @returns {Cypress.Chainable | never[]}
+ * @returns {Cypress.Chainable<Interception[] | Interception>}
  */
 export function waitForResponses(routeMatcherMap, waitOptions = {}) {
     if (routeMatcherMap) {
@@ -69,7 +69,7 @@ export function waitForResponses(routeMatcherMap, waitOptions = {}) {
         return cy.wait(aliases, waitOptions);
     }
 
-    return [];
+    return cy.wrap([]);
 }
 
 /**
@@ -79,7 +79,6 @@ export function waitForResponses(routeMatcherMap, waitOptions = {}) {
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
- * @returns {Cypress.Chainable | never[]}
  */
 export function interactAndWaitForResponses(
     interactionCallback,

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
@@ -7,7 +7,6 @@ import {
     verifySelectedCvesInModal,
     visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
-import { selectors as workloadCVESelectors } from '../workloadCves/WorkloadCves.selectors';
 
 const basePath = '/main/vulnerabilities/exception-management';
 export const pendingRequestsPath = `${basePath}/pending-requests`;
@@ -44,6 +43,23 @@ export function visitDeniedRequestsTab() {
     visitExceptionManagementTab(deniedRequestsPath);
 }
 
+function assertClipboardWriteAndVisitRequestPage(id) {
+    cy.location().then(({ origin }) => {
+        const url = `${origin}/main/vulnerabilities/exception-management/requests/${id}`;
+
+        // To prevent permission or timing problems, do not actually write to clipboard.
+        cy.window()
+            .its('navigator.clipboard')
+            .then((clipboard) => {
+                cy.stub(clipboard, 'writeText').as('writeText');
+            });
+        cy.get('button[aria-label="Copy"]').click();
+        cy.get('@writeText').should('have.been.calledOnceWith', `${url}`);
+
+        visit(url);
+    });
+}
+
 export function deferAndVisitRequestDetails({
     comment,
     expiry,
@@ -58,30 +74,24 @@ export function deferAndVisitRequestDetails({
     // defer a single cve
     selectSingleCveForException('DEFERRAL').then((cveName) => {
         verifySelectedCvesInModal([cveName]);
+
         fillAndSubmitExceptionForm({
             comment,
             expiryLabel: expiry,
-        });
-        verifyExceptionConfirmationDetails({
-            expectedAction: 'Deferral',
-            cves: [cveName],
-            scope,
-            expiry,
-        });
-        cy.get(workloadCVESelectors.copyToClipboardButton).click();
-        cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
-        // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
-        cy.window()
-            .then((win) => {
-                return win.navigator.clipboard.readText();
-            })
-            .then((url) => {
-                visit(url);
+        }).then(({ response }) => {
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'Deferral',
+                cves: [cveName],
+                scope,
+                expiry,
             });
+
+            // Response is source of truth for exceptipn id.
+            assertClipboardWriteAndVisitRequestPage(response?.body?.exception?.id);
+        });
     });
 }
 
-// @TODO: We could possibly just use a single function for deferral/false positive
 export function markFalsePositiveAndVisitRequestDetails({
     comment,
     scope,
@@ -94,22 +104,16 @@ export function markFalsePositiveAndVisitRequestDetails({
     // mark a single cve as false positive
     selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
         verifySelectedCvesInModal([cveName]);
-        fillAndSubmitExceptionForm({ comment });
-        verifyExceptionConfirmationDetails({
-            expectedAction: 'False positive',
-            cves: [cveName],
-            scope,
-        });
-        cy.get(workloadCVESelectors.copyToClipboardButton).click();
-        cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
-        // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
-        cy.window()
-            .then((win) => {
-                return win.navigator.clipboard.readText();
-            })
-            .then((url) => {
-                visit(url);
+        fillAndSubmitExceptionForm({ comment }).then(({ response }) => {
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'False positive',
+                cves: [cveName],
+                scope,
             });
+
+            // Response is source of truth for exceptipn id.
+            assertClipboardWriteAndVisitRequestPage(response?.body?.exception?.id);
+        });
     });
 }
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
@@ -54,7 +54,7 @@ function assertClipboardWriteAndVisitRequestPage(id) {
                 cy.stub(clipboard, 'writeText').as('writeText');
             });
         cy.get('button[aria-label="Copy"]').click();
-        cy.get('@writeText').should('have.been.calledOnceWith', `${url}`);
+        cy.get('@writeText').should('have.been.calledOnceWith', url);
 
         visit(url);
     });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
@@ -3,9 +3,11 @@ import { hasFeatureFlag } from '../../../helpers/features';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import { deferAndVisitRequestDetails, approveRequest } from './ExceptionManagement.helpers';
 
-const comment = 'Defer me';
-const expiry = 'When all CVEs are fixable';
-const scope = 'All images';
+const deferralProps = {
+    comment: 'Defer me',
+    expiry: 'When all CVEs are fixable',
+    scope: 'All images',
+};
 
 describe('Exception Management Request Details Page', () => {
     withAuth();
@@ -25,11 +27,6 @@ describe('Exception Management Request Details Page', () => {
             hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
         ) {
             cancelAllCveExceptions();
-            deferAndVisitRequestDetails({
-                comment,
-                expiry,
-                scope,
-            });
         }
     });
 
@@ -43,6 +40,7 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to approve a request if approval permissions are granted', () => {
+        deferAndVisitRequestDetails(deferralProps);
         approveRequest();
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
@@ -3,9 +3,11 @@ import { hasFeatureFlag } from '../../../helpers/features';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import { deferAndVisitRequestDetails, denyRequest } from './ExceptionManagement.helpers';
 
-const comment = 'Defer me';
-const expiry = 'When all CVEs are fixable';
-const scope = 'All images';
+const deferralProps = {
+    comment: 'Defer me',
+    expiry: 'When all CVEs are fixable',
+    scope: 'All images',
+};
 
 describe('Exception Management Request Details Page', () => {
     withAuth();
@@ -25,11 +27,6 @@ describe('Exception Management Request Details Page', () => {
             hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
         ) {
             cancelAllCveExceptions();
-            deferAndVisitRequestDetails({
-                comment,
-                expiry,
-                scope,
-            });
         }
     });
 
@@ -43,12 +40,14 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to deny a request if approval permissions are granted', () => {
+        deferAndVisitRequestDetails(deferralProps);
         denyRequest();
         // should not be able to cancel a denied request
         cy.get('button:contains("Cancel request")').should('not.exist');
     });
 
     it('should be able to see how many CVEs will be affected by a denial', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get('table tbody tr:not(".pf-v5-c-table__expandable-row")').then((rows) => {
             const numCVEs = rows.length;
             cy.get('button:contains("Deny request")').click();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
@@ -1,23 +1,16 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
-import {
-    cancelAllCveExceptions,
-    fillAndSubmitExceptionForm,
-    selectSingleCveForException,
-    verifyExceptionConfirmationDetails,
-    verifySelectedCvesInModal,
-    visitWorkloadCveOverview,
-} from '../workloadCves/WorkloadCves.helpers';
-import { selectors as workloadCVESelectors } from '../workloadCves/WorkloadCves.selectors';
+import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
+import { deferAndVisitRequestDetails } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
-import { visit } from '../../../helpers/visit';
 
-const deferralComment = 'Defer me';
-const deferralExpiry = 'When all CVEs are fixable';
-const deferralScope = 'All images';
+const deferralProps = {
+    comment: 'Defer me',
+    expiry: 'When all CVEs are fixable',
+    scope: 'All images',
+};
 
-// TODO: reenable and make beforeEach hook more robust https://issues.redhat.com/browse/ROX-23625
-describe.skip('Exception Management Request Details Page', () => {
+describe('Exception Management Request Details Page', () => {
     withAuth();
 
     before(function () {
@@ -38,35 +31,6 @@ describe.skip('Exception Management Request Details Page', () => {
         }
     });
 
-    beforeEach(() => {
-        visitWorkloadCveOverview();
-
-        // defer a single cve
-        selectSingleCveForException('DEFERRAL').then((cveName) => {
-            verifySelectedCvesInModal([cveName]);
-            fillAndSubmitExceptionForm({
-                comment: deferralComment,
-                expiryLabel: deferralExpiry,
-            });
-            verifyExceptionConfirmationDetails({
-                expectedAction: 'Deferral',
-                cves: [cveName],
-                scope: deferralScope,
-                expiry: deferralExpiry,
-            });
-            cy.get(workloadCVESelectors.copyToClipboardButton).click();
-            cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
-            // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
-            cy.window()
-                .then((win) => {
-                    return win.navigator.clipboard.readText();
-                })
-                .then((url) => {
-                    visit(url);
-                });
-        });
-    });
-
     after(() => {
         if (
             hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') &&
@@ -77,6 +41,7 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to sort on the "CVE" column', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get(selectors.tableSortColumn('CVE')).should('have.attr', 'aria-sort', 'none');
         cy.get(selectors.tableColumnSortButton('CVE')).click();
         cy.location('search').should('contain', 'sortOption[field]=CVE&sortOption[direction]=desc');
@@ -87,6 +52,7 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to sort on the "CVSS" column', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get(selectors.tableSortColumn('CVSS')).should('have.attr', 'aria-sort', 'descending');
         cy.get(selectors.tableColumnSortButton('CVSS')).click();
         cy.location('search').should(
@@ -103,6 +69,7 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to sort on the "Affected images" column', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get(selectors.tableSortColumn('Affected images')).should(
             'have.attr',
             'aria-sort',
@@ -131,6 +98,7 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to sort on the "First discovered" column', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get(selectors.tableSortColumn('First discovered')).should(
             'have.attr',
             'aria-sort',
@@ -159,6 +127,7 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to navigate to the Workload CVEs CVE Details page by clicking on the "CVE" link', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get('table td[data-label="CVE"] a')
             .invoke('text')
             .then((cveName) => {
@@ -173,12 +142,13 @@ describe.skip('Exception Management Request Details Page', () => {
     });
 
     it('should be able to view comments for a request', () => {
+        deferAndVisitRequestDetails(deferralProps);
         cy.get('button:contains("1 comment")').click();
 
         // modal should be opened
         cy.get('div[role="dialog"]').should('exist');
 
         // comment should exist
-        cy.get(`div:contains("${deferralComment}")`).should('exist');
+        cy.get(`div:contains("${deferralProps.comment}")`).should('exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
@@ -7,9 +7,11 @@ import {
 } from '../workloadCves/WorkloadCves.helpers';
 import { deferAndVisitRequestDetails } from './ExceptionManagement.helpers';
 
-const comment = 'Defer me';
-const expiry = 'When any CVE is fixable';
-const scope = 'All images';
+const deferralProps = {
+    comment: 'Defer me',
+    expiry: 'When any CVE is fixable',
+    scope: 'All images',
+};
 
 describe('Exception Management Request Details Page', () => {
     withAuth();
@@ -29,11 +31,6 @@ describe('Exception Management Request Details Page', () => {
             hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
         ) {
             cancelAllCveExceptions();
-            deferAndVisitRequestDetails({
-                comment,
-                expiry,
-                scope,
-            });
         }
     });
 
@@ -47,6 +44,8 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to update a pending request', () => {
+        deferAndVisitRequestDetails(deferralProps);
+
         const newExpiry = 'When all CVEs are fixable';
         const newComment = 'Updated';
 
@@ -63,7 +62,7 @@ describe('Exception Management Request Details Page', () => {
         cy.get('dl.vulnerability-exception-request-overview')
             .contains('dt', 'Latest comment')
             .next('dd')
-            .should('contain.text', comment);
+            .should('contain.text', deferralProps.comment);
 
         cy.wait('@getAffectedImagesCount');
         cy.wait('@getImageCVEList');
@@ -71,10 +70,13 @@ describe('Exception Management Request Details Page', () => {
         // update deferral
         cy.get('button:contains("Update request")').click();
         cy.get('div[role="dialog"]').should('exist');
-        fillAndSubmitExceptionForm({
-            comment: newComment,
-            expiryLabel: newExpiry,
-        });
+        fillAndSubmitExceptionForm(
+            {
+                comment: newComment,
+                expiryLabel: newExpiry,
+            },
+            'PATCH'
+        );
 
         cy.get('button:contains("Close")').click();
         cy.get('div[role="dialog"]').should('not.exist');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -67,8 +67,6 @@ export const selectors = {
     markCveFalsePositiveModal: '*[role="dialog"]:contains("Request false positive for")',
     exceptionOptionsTab: 'button[role="tab"]:contains("Options")',
     cveSelectionTab: 'button[role="tab"]:contains("CVE selections")',
-    copyToClipboardButton: 'button[aria-label="Copy"]',
-    copyToClipboardTooltipText: 'div[role="tooltip"]',
 
     // Watched image selectors
     watchedImageLabel: `.pf-v5-c-label:contains("${watchedImageLabelText}")`,


### PR DESCRIPTION
## Description

### Problems

Intermittent failures of integration tests during and after PatternFly 5 upgrade in #10401

Exception Management - Approved Deferrals Table should be able to navigate to the Request Details page by clicking on the request name

> Timed out retrying after 4000ms: Expected to find element: `div[role="tooltip"]`, but never found it.

Exception Management Request Details Page "before each" hook for "should be able to deny a request if approval permissions are granted": "before each" hook

> Timed out retrying after 4000ms: Expected to find element: `div[role="tooltip"]`, but never found it.

> Because this error occurred during a `before each` hook we are skipping the remaining tests in the current suite

### Analysis

Assertions about **Copied** tooltip:
* failure in tests: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts#L72
* failure in tests: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts#L104
* failure in `beforeEach` blocks: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts#L58

The code in `beforeEach` block is same as `deferAndVisitRequestDetails` heler function.

Thank you David Vail for observation that tooltip might not appear in a minority of cases since PatternFly 5 upgrade.

### Solution

Gleb Bahmutov describes an alternative to stub the `clipboard.write` method call:
https://glebbahmutov.com/blog/spy-on-clipboard-copy/

1. Replace assertion about **Copied** tooltip:
    * Use `id` from response as source of truth.
    * Replace actual write with stub that asserts expected content.
2. Replace `beforeEach` block, in which an intermittent failure affects not just one test, but all tests in file.
    * Call `deferAndVisitRequestDetails` function at the beginning of each test that needs it as initialization.

### Changes

1. cypress/helpers/request.js
    * Make `returns` type more specific in JSDoc comment for `waitForResponses` function.
    * Add `cy.wrap` for `[]` so it is chainable, which solves special case of `never[]` type which causes unnecessary type problem for callers. 
2. Move `deferAndVisitRequestDetails` function from `beforeEach` block into tests:
    * vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
    * vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
    * vulnerabilities/exceptionManagement/requestDetails.test.ts
    * vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
        Also add `PATCH` arg to `fillAndSubmitExceptionForm` function call.
3. vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
    * Factor out `assertClipboardWriteAndVisitRequestPage` function, which given `id` argument from response, asserts clipboard write via stub.
    * Get `id` from response in `deferAndVisitRequestDetails` and `markFalsePositiveAndVisitRequestDetails` functions.
4. vulnerabilities/workloadCves/WorkloadCves.helpers.js
    * Wait for requests in `cancelAllCveExceptions` function.
    * Return interception from `fillAndSubmitExceptionForm` function.
    * Assert `header` in `verifyExceptionConfirmationDetails` function.
5. vulnerabilities/workloadCves/WorkloadCves.selectors.js
    * Encapsulate selectors used only in helper functions.

### Residue

Refactor to reduce relative imports between sibling subfolders.
* Add cypress/integration/vulnerabilities/vulnerabilities.helpers.js file.
* Encapsulate selectors which tests do not need for assertions.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/vulnerabilities/workload-cves and defer a vulnerability via row action
    * POST /v2/vulnerability-exceptions/deferral has response which includes `id` and `name` properties.
2. Click copy button and see `role="tooltip"` attribute of transient `div` element at end of document body.

### Integration testing

Before `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_VULN_MGMT_WORKLOAD_CVES=true
export CYPRESS_ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL=true
```

1. `yarn cypress-open` in ui/apps/platform
    * vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
    * vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
    * vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
    * vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
    * vulnerabilities/exceptionManagement/deniedRequestsTable.test.ts
    * vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
    * vulnerabilities/exceptionManagement/general.test.ts 1
    * vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts 5
    * vulnerabilities/exceptionManagement/requestDetails.test.ts
    * vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
    * vulnerabilities/workloadCves/cveListExceptionFlow.test.js
    * vulnerabilities/workloadCves/deploymentSingle.test.js
    * vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
    * vulnerabilities/workloadCves/imageCveSingle.test.js
    * vulnerabilities/workloadCves/imageSingle.test.js
    * vulnerabilities/workloadCves/workloadCveOverviewPage.test.js