### PR TITLE
ROX-23034: Add affected node table to CVE single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -1,0 +1,284 @@
+import React from 'react';
+
+import ComponentTestProviders from 'test-utils/ComponentProviders';
+import AffectedNodesTable from './AffectedNodesTable';
+
+function mockNodeVulnerability(fields) {
+    return {
+        vulnerabilityId: '',
+        cve: '',
+        severity: 'MODERATE_VULNERABILITY_SEVERITY',
+        isFixable: false,
+        cvss: 2.5,
+        scoreVersion: 'V3',
+        fixedByVersion: '',
+        ...fields,
+    };
+}
+
+function mockNodeComponent(fields) {
+    return {
+        name: 'podman',
+        operatingSystem: 'rhcos:4.15',
+        version: '3:4.4.1-21.rhaos4.15.el9.x86_64',
+        fixedIn: '',
+        source: 'INFRASTRUCTURE',
+        nodeVulnerabilities: [mockNodeVulnerability()],
+        ...fields,
+    };
+}
+
+function mockNode(fields) {
+    return {
+        id: '',
+        name: 'node name',
+        nodeComponents: [mockNodeComponent()],
+        cluster: {
+            name: 'test-cluster',
+        },
+        operatingSystem: 'linux',
+        ...fields,
+    };
+}
+
+function setup(tableState) {
+    cy.mount(
+        <ComponentTestProviders>
+            <AffectedNodesTable tableState={tableState} />
+        </ComponentTestProviders>
+    );
+}
+
+describe(Cypress.spec.relative, () => {
+    describe('when the table is in a non-success state', () => {
+        it('should render a spinner when loading', () => {
+            setup({ type: 'LOADING' });
+
+            cy.findByRole('progressbar');
+        });
+
+        it('should render an error message when errored', () => {
+            setup({ type: 'ERROR', error: new Error('An error from Cypress') });
+
+            cy.findByText('An error from Cypress');
+            cy.findByText('An error has occurred. Try clearing any filters or refreshing the page');
+        });
+
+        it('should render a message when no data is available', () => {
+            setup({ type: 'EMPTY' });
+
+            cy.findByText('No results found');
+            cy.findByText('No nodes are detected to have been reported for this CVE');
+        });
+
+        it('should render a message when a filter results in no data', () => {
+            setup({ type: 'FILTERED_EMPTY' });
+
+            cy.findByText('No results found');
+            cy.findByRole('button', { name: 'Clear filters' });
+        });
+    });
+
+    describe('when the table is in a success state', () => {
+        it('should render the correct number of rows', () => {
+            const nodes = [
+                mockNode({ id: `${1}`, name: `${1}-name` }),
+                mockNode({ id: `${2}`, name: `${2}-name` }),
+                mockNode({ id: `${3}`, name: `${3}-name` }),
+                mockNode({ id: `${4}`, name: `${4}-name` }),
+            ];
+            const rowCount = nodes.length;
+            const headerCount = 1;
+
+            setup({ type: 'COMPLETE', data: nodes });
+
+            cy.findAllByRole('row').should('have.length', headerCount + rowCount);
+        });
+
+        it('should correctly render the severity of a node with multiple components affected', () => {
+            let id = 0;
+            // Accepts an array of arrays of severities, where the outer array represents the components
+            // and the inner array represents the severities of vulnerabilities for that component
+            function createNodeWithComponentSeverities(severityGroups) {
+                id += 1;
+                return mockNode({
+                    id,
+                    nodeComponents: severityGroups.map((severities) =>
+                        mockNodeComponent({
+                            nodeVulnerabilities: severities.map((severity) =>
+                                mockNodeVulnerability({ severity })
+                            ),
+                        })
+                    ),
+                });
+            }
+
+            // Create nodes with mixed severities across affected components
+            const lowSeverityNode = createNodeWithComponentSeverities([
+                ['LOW_VULNERABILITY_SEVERITY'],
+            ]);
+            const moderateSeverityNode = createNodeWithComponentSeverities([
+                ['LOW_VULNERABILITY_SEVERITY'],
+                ['BOGUS_VALUE'],
+                [
+                    'LOW_VULNERABILITY_SEVERITY',
+                    'MODERATE_VULNERABILITY_SEVERITY',
+                    'LOW_VULNERABILITY_SEVERITY',
+                ],
+            ]);
+            const importantSeverityNode = createNodeWithComponentSeverities([
+                [
+                    'MODERATE_VULNERABILITY_SEVERITY',
+                    'IMPORTANT_VULNERABILITY_SEVERITY',
+                    'IMPORTANT_VULNERABILITY_SEVERITY',
+                    'BOGUS_VALUE',
+                ],
+                ['MODERATE_VULNERABILITY_SEVERITY', 'MODERATE_VULNERABILITY_SEVERITY'],
+            ]);
+            const criticalSeverityNode = createNodeWithComponentSeverities([
+                [
+                    'UNKNOWN_VULNERABILITY_SEVERITY',
+                    'LOW_VULNERABILITY_SEVERITY',
+                    'BOGUS_VALUE',
+                    'CRITICAL_VULNERABILITY_SEVERITY',
+                    'BOGUS_VALUE',
+                    'MODERATE_VULNERABILITY_SEVERITY',
+                    'IMPORTANT_VULNERABILITY_SEVERITY',
+                ],
+            ]);
+
+            const nodes = [
+                lowSeverityNode,
+                moderateSeverityNode,
+                importantSeverityNode,
+                criticalSeverityNode,
+            ];
+
+            setup({ type: 'COMPLETE', data: nodes });
+
+            // Avoid the 0th row which is the header, and then check that the top severity is rendered correctly
+            // for each row
+            [
+                { rowIndex: 1, expectedSeverity: 'Low' },
+                { rowIndex: 2, expectedSeverity: 'Moderate' },
+                { rowIndex: 3, expectedSeverity: 'Important' },
+                { rowIndex: 4, expectedSeverity: 'Critical' },
+            ].forEach(({ rowIndex, expectedSeverity }) => {
+                cy.findAllByRole('row')
+                    .eq(rowIndex)
+                    .within(() => {
+                        cy.get(`td[data-label="CVE severity"]:contains("${expectedSeverity}")`);
+                    });
+            });
+        });
+
+        it('should correctly render the fixability of a node with multiple components affected', () => {
+            let id = 0;
+            function createNodeWithComponentFixedIn(fixedByGroups) {
+                id += 1;
+                return mockNode({
+                    id,
+                    nodeComponents: fixedByGroups.map((fixedByVersions) =>
+                        mockNodeComponent({
+                            nodeVulnerabilities: fixedByVersions.map((fixedByVersion) =>
+                                mockNodeVulnerability({ fixedByVersion })
+                            ),
+                        })
+                    ),
+                });
+            }
+
+            const fixedByVersion = '3:4.4.1-21.rhaos4.15.el9.x86_64';
+            const notFixedInVersion = '';
+
+            // Create nodes with mixed fixability across affected components
+            const nodes = [
+                createNodeWithComponentFixedIn([[fixedByVersion]]),
+                createNodeWithComponentFixedIn([[notFixedInVersion]]),
+                createNodeWithComponentFixedIn([[fixedByVersion, notFixedInVersion]]),
+                createNodeWithComponentFixedIn([[fixedByVersion], [notFixedInVersion]]),
+            ];
+
+            setup({ type: 'COMPLETE', data: nodes });
+
+            // Avoid the 0th row which is the header, and then check that the fixability is rendered correctly
+            // for each row. If any vulnerability for any component is fixable, the node should render fixable.
+            [
+                { rowIndex: 1, expectedFixability: 'Fixable' },
+                { rowIndex: 2, expectedFixability: 'Not fixable' },
+                { rowIndex: 3, expectedFixability: 'Fixable' },
+                { rowIndex: 4, expectedFixability: 'Fixable' },
+            ].forEach(({ rowIndex, expectedFixability }) => {
+                cy.findAllByRole('row')
+                    .eq(rowIndex)
+                    .within(() => {
+                        cy.get(`td[data-label="CVE status"]:contains("${expectedFixability}")`);
+                    });
+            });
+        });
+
+        it('should render the highest CVSS score of all matching component vulnerabilities', () => {
+            let id = 0;
+            function createNodeWithComponentCvss(cvssGroups) {
+                id += 1;
+                return mockNode({
+                    id,
+                    nodeComponents: cvssGroups.map((cvssGroup) =>
+                        mockNodeComponent({
+                            nodeVulnerabilities: cvssGroup.map(mockNodeVulnerability),
+                        })
+                    ),
+                });
+            }
+
+            const nodes = [
+                createNodeWithComponentCvss([
+                    [{ cvss: 2.0, scoreVersion: 'V3' }],
+                    [
+                        { cvss: 1.0, scoreVersion: 'V3' },
+                        { cvss: 1.0, scoreVersion: 'V2' },
+                    ],
+                ]),
+                createNodeWithComponentCvss([
+                    [
+                        { cvss: 3.0, scoreVersion: 'V3' },
+                        { cvss: 4.0, scoreVersion: 'V2' },
+                    ],
+                ]),
+                createNodeWithComponentCvss([
+                    [
+                        { cvss: 5.0, scoreVersion: 'V2' },
+                        { cvss: 6.0, scoreVersion: 'V3' },
+                        { cvss: 7.0, scoreVersion: 'V2' },
+                    ],
+                    [
+                        { cvss: 6.0, scoreVersion: 'V3' },
+                        { cvss: 2.0, scoreVersion: 'V2' },
+                    ],
+                ]),
+            ];
+
+            setup({ type: 'COMPLETE', data: nodes });
+
+            // Avoid the 0th row which is the header, and then check that the highest CVSS score is rendered correctly
+            // for each row
+            [
+                { rowIndex: 1, expectedCVSS: '2.0', expectedVersion: 'V3' },
+                { rowIndex: 2, expectedCVSS: '4.0', expectedVersion: 'V2' },
+                { rowIndex: 3, expectedCVSS: '7.0', expectedVersion: 'V2' },
+            ].forEach(({ rowIndex, expectedCVSS, expectedVersion }) => {
+                cy.findAllByRole('row')
+                    .eq(rowIndex)
+                    .within(() => {
+                        cy.get(
+                            `td[data-label="CVSS score"]:contains("${expectedCVSS} (${expectedVersion})")`
+                        );
+                    });
+            });
+        });
+
+        it('should allow expanding and collapsing the nested component table', () => {
+            // TODO: Implement this test
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { Truncate, pluralize } from '@patternfly/react-core';
+import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { gql } from '@apollo/client';
+import { Link } from 'react-router-dom';
+
+import {
+    TbodyLoading,
+    TbodyError,
+    TbodyEmpty,
+    TbodyFilteredEmpty,
+} from 'Components/TableStateTemplates';
+import { TableUIState } from 'utils/getTableUIState';
+
+import useSet from 'hooks/useSet';
+import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
+import { severityRankings } from 'constants/vulnerabilities';
+import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
+import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
+
+import CvssFormatted from '../../components/CvssFormatted';
+import { getNodeEntityPagePath } from '../../utils/searchUtils';
+import NodeComponentsTable from './NodeComponentsTable';
+
+export const affectedNodeFragment = gql`
+    fragment AffectedNode on Node {
+        id
+        name
+        operatingSystem
+        cluster {
+            name
+        }
+        nodeComponents {
+            name
+            version
+            source
+            nodeVulnerabilities {
+                vulnerabilityId: id
+                cve
+                severity
+                fixedByVersion
+                cvss
+                scoreVersion
+            }
+        }
+    }
+`;
+
+export type AffectedNode = {
+    id: string;
+    name: string;
+    operatingSystem: string;
+    cluster: {
+        name: string;
+    };
+    nodeComponents: {
+        name: string;
+        version: string;
+        source: string;
+        nodeVulnerabilities: {
+            vulnerabilityId: string;
+            cve: string;
+            severity: string;
+            fixedByVersion: string;
+            cvss: number;
+            scoreVersion: string;
+        }[];
+    }[];
+};
+
+type NodeVulnerabilities = AffectedNode['nodeComponents'][0]['nodeVulnerabilities'];
+
+function getHighestVulnerabilitySeverity(vulns: NodeVulnerabilities): VulnerabilitySeverity {
+    let topSeverity: VulnerabilitySeverity = 'UNKNOWN_VULNERABILITY_SEVERITY';
+    vulns.forEach(({ severity }) => {
+        if (
+            isVulnerabilitySeverity(severity) &&
+            severityRankings[severity] > severityRankings[topSeverity]
+        ) {
+            topSeverity = severity;
+        }
+    });
+    return topSeverity;
+}
+
+function getAnyVulnerabilityIsFixable(vulns: NodeVulnerabilities): boolean {
+    return vulns.some((vuln) => vuln.fixedByVersion !== '');
+}
+
+function getHighestCvssScore(vulns: NodeVulnerabilities): {
+    cvss: number;
+    scoreVersion: string;
+} {
+    let topCvss = 0;
+    let topScoreVersion = 'N/A';
+    vulns.forEach(({ cvss, scoreVersion }) => {
+        if (cvss > topCvss) {
+            topCvss = cvss;
+            topScoreVersion = scoreVersion;
+        }
+    });
+    return { cvss: topCvss, scoreVersion: topScoreVersion };
+}
+
+export type AffectedNodesTableProps = {
+    tableState: TableUIState<AffectedNode>;
+};
+
+// TODO Add filter icon to dynamic table columns
+function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
+    const colSpan = 8;
+    const expandedRowSet = useSet<string>();
+
+    return (
+        <Table
+            borders={tableState.type === 'COMPLETE'}
+            variant="compact"
+            role="region"
+            aria-live="polite"
+            aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
+        >
+            <Thead noWrap>
+                <Tr>
+                    <Th aria-label="Expand row" />
+                    <Th>Node</Th>
+                    <Th>CVE severity</Th>
+                    <Th>CVE status</Th>
+                    <Th>CVSS score</Th>
+                    <Th>Cluster</Th>
+                    <Th>Operating system</Th>
+                    <Th>Affected components</Th>
+                </Tr>
+            </Thead>
+            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
+            {tableState.type === 'ERROR' && (
+                <TbodyError colSpan={colSpan} error={tableState.error} />
+            )}
+            {tableState.type === 'EMPTY' && (
+                <TbodyEmpty
+                    colSpan={colSpan}
+                    message="No nodes are detected to have been reported for this CVE"
+                />
+            )}
+            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
+            {tableState.type === 'COMPLETE' &&
+                tableState.data.map((node, rowIndex) => {
+                    const { id, name, nodeComponents } = node;
+                    const isExpanded = expandedRowSet.has(id);
+
+                    const vulns = nodeComponents.flatMap(
+                        ({ nodeVulnerabilities }) => nodeVulnerabilities
+                    );
+                    const topSeverity = getHighestVulnerabilitySeverity(vulns);
+                    const isFixable = getAnyVulnerabilityIsFixable(vulns);
+                    const { cvss, scoreVersion } = getHighestCvssScore(vulns);
+
+                    return (
+                        <Tbody key={id} isExpanded={isExpanded}>
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(id),
+                                    }}
+                                />
+
+                                <Td dataLabel="Node">
+                                    <Link to={getNodeEntityPagePath('Node', id)}>
+                                        <Truncate position="middle" content={name} />
+                                    </Link>
+                                </Td>
+                                <Td dataLabel="CVE severity" modifier="nowrap">
+                                    <VulnerabilitySeverityIconText severity={topSeverity} />
+                                </Td>
+                                <Td dataLabel="CVE status" modifier="nowrap">
+                                    <VulnerabilityFixableIconText isFixable={isFixable} />
+                                </Td>
+                                <Td dataLabel="CVSS score" modifier="nowrap">
+                                    <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
+                                </Td>
+                                <Td dataLabel="Cluster">
+                                    <Truncate position="middle" content={node.cluster.name} />
+                                </Td>
+                                <Td dataLabel="Operating system">{node.operatingSystem}</Td>
+                                <Td dataLabel="Affected components">
+                                    {nodeComponents.length === 1
+                                        ? nodeComponents[0].name
+                                        : pluralize(nodeComponents.length, 'component')}
+                                </Td>
+                            </Tr>
+                            <Tr isExpanded={isExpanded}>
+                                <Td />
+                                <Td colSpan={colSpan - 1}>
+                                    <ExpandableRowContent>
+                                        <NodeComponentsTable />
+                                    </ExpandableRowContent>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                })}
+        </Table>
+    );
+}
+
+export default AffectedNodesTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeComponentsTable.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NodeComponentsTableProps = {};
+
+// eslint-disable-next-line no-empty-pattern
+function NodeComponentsTable({}: NodeComponentsTableProps) {
+    return <div>NodeComponentsTable - TODO</div>;
+}
+
+export default NodeComponentsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,20 +1,49 @@
 import React, { useEffect, useState } from 'react';
+import { gql, useQuery } from '@apollo/client';
 import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 
-import { getOverviewPagePath } from '../../utils/searchUtils';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import { getTableUIState } from 'utils/getTableUIState';
+import {
+    getOverviewPagePath,
+    getRegexScopedQueryString,
+    parseWorkloadQuerySearchFilter,
+} from '../../utils/searchUtils';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import AffectedNodesTable, { AffectedNode, affectedNodeFragment } from './AffectedNodesTable';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Node', {
     entityTab: 'CVE',
 });
 
+const affectedNodesQuery = gql`
+    ${affectedNodeFragment}
+    query getAffectedNodes($query: String, $pagination: Pagination) {
+        nodes(query: $query, pagination: $pagination) {
+            ...AffectedNode
+        }
+    }
+`;
+
 function NodeCvePage() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { searchFilter } = useURLSearch();
+    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+
+    // We needs to scope all queries to the *exact* CVE name so that we don't accidentally get
+    // data that matches a prefix of the CVE name in the nested fields
     const { cveId } = useParams() as { cveId: string };
+    const exactCveIdSearchRegex = `^${cveId}$`;
+    const query = getRegexScopedQueryString({
+        ...querySearchFilter,
+        CVE: [exactCveIdSearchRegex],
+    });
+
+    const { page, perPage } = useURLPagination(20);
 
     const [nodeCveMetadata, setNodeCveMetadata] = useState<CveMetadata>();
     const nodeCveName = nodeCveMetadata?.cve;
@@ -36,6 +65,33 @@ function NodeCvePage() {
         }, 1500);
     }, [cveId]);
 
+    const affectedNodesRequest = useQuery<
+        {
+            nodes: AffectedNode[];
+        },
+        {
+            query: string;
+            pagination: { limit: number; offset: number };
+        }
+    >(affectedNodesQuery, {
+        variables: {
+            query,
+            pagination: {
+                limit: perPage,
+                offset: (page - 1) * perPage,
+            },
+        },
+    });
+
+    const nodeData = affectedNodesRequest.data?.nodes ?? affectedNodesRequest.previousData?.nodes;
+
+    const tableState = getTableUIState({
+        isLoading: affectedNodesRequest.loading,
+        error: affectedNodesRequest.error,
+        data: nodeData,
+        searchFilter: querySearchFilter,
+    });
+
     return (
         <>
             <PageTitle title={`Node CVEs - NodeCVE ${nodeCveName}`} />
@@ -55,7 +111,9 @@ function NodeCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1">
-                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1"></div>
+                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-md">
+                    <AffectedNodesTable tableState={tableState} />
+                </div>
             </PageSection>
         </>
     );


### PR DESCRIPTION
## Description

Adds the affected node table on the Node CVE single page.

_Note that the data is mocked until the query is fully implemented._

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Node CVE single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/e4af7549-1139-4428-af52-0e02987bcefd)

Table states and properties are tested via automated tests below.

Added component tests to validate table state and the more interesting properties of this table:
- Severity is the highest severity of all vulns in all components affected by the CVE
- CVE status is "Fixable" when _any_ of the vulns in any component has a non-empty fixedByVersion
- CVSS is the highest calculated CVSS of all vulns in all components affected by the CVE
![image](https://github.com/stackrox/stackrox/assets/1292638/7990fc97-5bcf-46fc-88eb-89f730b09a71)

