### PR TITLE
fix: add gcloud retry in wif setup

### DIFF
--- a/qa-tests-backend/scripts/workload-identities/workload-identities.sh
+++ b/qa-tests-backend/scripts/workload-identities/workload-identities.sh
@@ -40,7 +40,8 @@ setup_gcp_workload_identities() {
     setup_gcp_variables
 
     # Connect the stackrox ci service account to the workload identity of Central.
-    gcloud iam service-accounts add-iam-policy-binding "${service_account}" \
+    retry 5 true \
+        gcloud iam service-accounts add-iam-policy-binding "${service_account}" \
         --member="principal://iam.googleapis.com/projects/${project}/locations/global/workloadIdentityPools/${cluster}/subject/${subject_central}" \
         --role=roles/iam.workloadIdentityUser
 
@@ -57,7 +58,8 @@ cleanup_gcp_workload_identities() {
     setup_gcp
     setup_gcp_variables
 
-    gcloud iam service-accounts remove-iam-policy-binding "${service_account}" \
+    retry 5 true \
+        gcloud iam service-accounts remove-iam-policy-binding "${service_account}" \
         --member="principal://iam.googleapis.com/projects/${project}/locations/global/workloadIdentityPools/${cluster}/subject/${subject_central}" \
         --role=roles/iam.workloadIdentityUser
 }


### PR DESCRIPTION
## Description

The `gcloud` calls may fail when race conditions are detected. See https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-15-merge-qa-e2e-tests/1780578263538601984 for an example.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
