### PR TITLE
ROX-23624: PF5 style fixes follow up

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -376,7 +376,7 @@ export function revokeAuthProvidersIntegrationInTable(integrationType, integrati
     getTableRowActionButtonByName(integrationName).click();
     interactAndWaitForResponses(() => {
         cy.get('button:contains("Delete Integration")').click(); // row actions
-        cy.get('button:contains("Delete")').click(); // confirmation modal
+        cy.get('.pf-v5-c-modal-box__footer button:contains("Delete")').click(); // confirmation modal
     }, routeMatcherMap);
 }
 

--- a/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
@@ -11,7 +11,7 @@ function TabNavSubHeader({ description, actions }: TabNavSubHeaderProps) {
         <PageSection variant="light" className="pf-v5-u-py-0">
             <Toolbar inset={{ default: 'insetNone' }}>
                 <ToolbarContent>
-                    <ToolbarItem>
+                    <ToolbarItem alignSelf="center">
                         <div className="pf-v5-u-font-size-sm">{description}</div>
                     </ToolbarItem>
                     <ToolbarItem align={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.css
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.css
@@ -138,7 +138,7 @@ table .pf-v5-c-dropdown__toggle.pf-m-plain svg {
 /*
  * Allow pop-up selects to scroll when customer has more roles than can be shown by height of screen
  */
- .pf-v5-c-select__menu {
+ #defaultRole.pf-v5-c-select__menu {
     max-height: calc(100vh - (3 * var(--pf-v5-c-page__header--MinHeight)));
     overflow: scroll;
 }

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -437,7 +437,7 @@ function AuthProviderForm({
                                 <FormHelperText>
                                     <HelperText>
                                         <HelperTextItem variant={nameValidated}>
-                                            {errors.name || ''}
+                                            {errors.name ? errors.name : ''}
                                         </HelperTextItem>
                                     </HelperText>
                                 </FormHelperText>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
@@ -122,7 +122,9 @@ function ConfigurationFormFields({
                                             showIssuerError ? ValidatedOptions.error : 'default'
                                         }
                                     >
-                                        {configErrors?.issuer || (
+                                        {showIssuerError ? (
+                                            configErrors?.issuer
+                                        ) : (
                                             <span className="pf-v5-u-font-size-sm">
                                                 for example,{' '}
                                                 <kbd className="pf-v5-u-font-size-xs">
@@ -154,7 +156,7 @@ function ConfigurationFormFields({
                                             showClientIdError ? ValidatedOptions.error : 'default'
                                         }
                                     >
-                                        {configErrors?.client_id || ''}
+                                        {showClientIdError ? configErrors?.client_id : ''}
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
@@ -212,7 +214,9 @@ function ConfigurationFormFields({
                                             showIssuerError ? ValidatedOptions.error : 'default'
                                         }
                                     >
-                                        {configErrors?.issuer || (
+                                        {showIssuerError ? (
+                                            configErrors?.issuer
+                                        ) : (
                                             <span className="pf-v5-u-font-size-sm">
                                                 for example,{' '}
                                                 <kbd className="pf-v5-u-font-size-xs">
@@ -244,7 +248,7 @@ function ConfigurationFormFields({
                                             showClientIdError ? ValidatedOptions.error : 'default'
                                         }
                                     >
-                                        {configErrors?.client_id || ''}
+                                        {showClientIdError ? configErrors?.client_id : ''}
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>
@@ -291,7 +295,9 @@ function ConfigurationFormFields({
                                                 : 'default'
                                         }
                                     >
-                                        {configErrors?.client_secret || (
+                                        {showClientSecretError ? (
+                                            configErrors?.client_secret
+                                        ) : (
                                             <span className="pf-v5-u-font-size-sm">
                                                 {clientSecretHelperText}
                                             </span>
@@ -383,7 +389,9 @@ function ConfigurationFormFields({
                                             showSpIssuerError ? ValidatedOptions.error : 'default'
                                         }
                                     >
-                                        {configErrors?.sp_issuer || (
+                                        {showSpIssuerError ? (
+                                            configErrors?.sp_issuer
+                                        ) : (
                                             <span className="pf-v5-u-font-size-sm">
                                                 for example,{' '}
                                                 <kbd className="pf-v5-u-font-size-xs">
@@ -448,7 +456,9 @@ function ConfigurationFormFields({
                                                         : 'default'
                                                 }
                                             >
-                                                {configErrors?.idp_metadata_url || (
+                                                {showIdpMetadataUrlError ? (
+                                                    configErrors?.idp_metadata_url
+                                                ) : (
                                                     <span className="pf-v5-u-font-size-sm">
                                                         for example,{' '}
                                                         <kbd className="pf-v5-u-font-size-xs">
@@ -492,7 +502,9 @@ function ConfigurationFormFields({
                                                         : 'default'
                                                 }
                                             >
-                                                {configErrors?.idp_issuer || (
+                                                {showIdpIssuerError ? (
+                                                    configErrors?.idp_issuer
+                                                ) : (
                                                     <span className="pf-v5-u-font-size-sm">
                                                         for example,{' '}
                                                         <kbd className="pf-v5-u-font-size-xs">
@@ -537,7 +549,9 @@ function ConfigurationFormFields({
                                                         : 'default'
                                                 }
                                             >
-                                                {configErrors?.idp_sso_url || (
+                                                {showIdpSsoUrlError ? (
+                                                    configErrors?.idp_sso_url
+                                                ) : (
                                                     <span className="pf-v5-u-font-size-sm">
                                                         for example,{' '}
                                                         <kbd className="pf-v5-u-font-size-xs">
@@ -609,7 +623,9 @@ function ConfigurationFormFields({
                                                         : 'default'
                                                 }
                                             >
-                                                {configErrors?.idp_cert_pem || ''}
+                                                {showIdpCertPemError
+                                                    ? configErrors?.idp_cert_pem
+                                                    : ''}
                                             </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
@@ -658,7 +674,7 @@ function ConfigurationFormFields({
                                         showUserPkiKeysError ? ValidatedOptions.error : 'default'
                                     }
                                 >
-                                    {configErrors?.keys || ''}
+                                    {showUserPkiKeysError ? configErrors?.keys : ''}
                                 </HelperTextItem>
                             </HelperText>
                         </FormHelperText>
@@ -683,7 +699,9 @@ function ConfigurationFormFields({
                                 <HelperTextItem
                                     variant={showAudienceError ? ValidatedOptions.error : 'default'}
                                 >
-                                    {configErrors?.audience || (
+                                    {showAudienceError ? (
+                                        configErrors?.audience
+                                    ) : (
                                         <span className="pf-v5-u-font-size-sm">
                                             for example,{' '}
                                             <kbd className="pf-v5-u-font-size-xs">

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -136,7 +136,9 @@ function ListeningEndpointsPage() {
             <PageTitle title="Listening Endpoints" />
             <PageSection variant="light">
                 <Title headingLevel="h1">Listening endpoints</Title>
-                <Text>Audit listening endpoints of deployments in your clusters</Text>
+                <Text className="pf-v5-u-pt-xs">
+                    Audit listening endpoints of deployments in your clusters
+                </Text>
             </PageSection>
             <Divider component="div" />
             <PageSection

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusPill.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusPill.tsx
@@ -14,7 +14,7 @@ function ClusterStatusPill({ healthStatus }: ClusterStatusPillProps): ReactEleme
     const scannerHealthStatus = healthStatus?.scannerHealthStatus || 'UNINITIALIZED';
 
     return (
-        <div className="border inline rounded-full decoration-clone leading-looser text-sm py-1">
+        <div className="border inline rounded-full decoration-clone leading-looser text-sm py-1 word-break">
             <div className="inline border-r pl-2 pr-3 w-full whitespace-nowrap">
                 <CollectorStatus healthStatus={healthStatus} isList />
             </div>

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -58,19 +58,21 @@ function DeploymentSkeleton() {
 
 function DeploymentResult({ deployment }: { deployment: ListDeployment }) {
     return (
-        <Flex>
-            <FlexItem>
-                <ResourceIcon kind="Deployment" />
-            </FlexItem>
-            <FlexItem>
-                <div>{deployment.name}</div>
-                <span className="pf-v5-u-color-300 pf-v5-u-font-size-xs">
-                    In &quot;{deployment.cluster} / {deployment.namespace}
-                    &quot;
-                </span>
-            </FlexItem>
-            <Divider className="pf-v5-u-mt-md" />
-        </Flex>
+        <>
+            <Flex>
+                <FlexItem>
+                    <ResourceIcon kind="Deployment" />
+                </FlexItem>
+                <FlexItem>
+                    <div>{deployment.name}</div>
+                    <span className="pf-v5-u-color-300 pf-v5-u-font-size-xs">
+                        In &quot;{deployment.cluster} / {deployment.namespace}
+                        &quot;
+                    </span>
+                </FlexItem>
+            </Flex>
+            <Divider className="pf-v5-u-mt-sm" />
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
@@ -65,7 +65,6 @@ function NumericSetting({
                         <TextInput
                             id={`${fieldId}.numDays`}
                             type="number"
-                            style={{ width: '100px' }}
                             value={value}
                             onChange={(e) => handleChange(e)}
                             isDisabled={!isSettingEnabled || isDisabled}
@@ -73,11 +72,15 @@ function NumericSetting({
                         />
                         <span>days</span>
                     </Flex>
-                    <FormHelperText>
-                        <HelperText>
-                            <HelperTextItem variant={validated}>{helperTextInvalid}</HelperTextItem>
-                        </HelperText>
-                    </FormHelperText>
+                    {helperTextInvalid && (
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem variant={validated}>
+                                    {helperTextInvalid}
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    )}
                 </FormGroup>
             </GridItem>
             <GridItem span={4} md={8} xl={9}>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -298,7 +298,7 @@ function NetworkGraphPage() {
                     data-testid="network-graph-selector-bar"
                 >
                     <ToolbarContent>
-                        <ToolbarGroup variant="filter-group">
+                        <ToolbarGroup variant="filter-group" className="pf-v5-u-align-self-center">
                             <Title headingLevel="h1" className="pf-v5-u-screen-reader">
                                 Network Graph
                             </Title>
@@ -380,7 +380,10 @@ function NetworkGraphPage() {
                                         />
                                     </ToolbarItem>
                                 </ToolbarGroup>
-                                <ToolbarGroup align={{ default: 'alignRight' }}>
+                                <ToolbarGroup
+                                    align={{ default: 'alignRight' }}
+                                    className="pf-v5-u-align-self-center"
+                                >
                                     <Divider
                                         component="div"
                                         orientation={{ default: 'vertical' }}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -43,36 +43,34 @@ function NetworkBreadcrumbs({
     };
 
     return (
-        <>
-            <Breadcrumb>
-                <BreadcrumbItem isDropdown>
-                    <ClusterSelector
-                        clusters={clusters}
-                        selectedClusterName={selectedCluster?.name ?? ''}
-                        searchFilter={searchFilter}
-                        setSearchFilter={onChange}
-                    />
-                </BreadcrumbItem>
-                <BreadcrumbItem isDropdown>
-                    <NamespaceSelector
-                        namespaces={namespaces}
-                        selectedNamespaces={selectedNamespaces}
-                        selectedDeployments={selectedDeployments}
-                        deploymentsByNamespace={deploymentsByNamespace}
-                        searchFilter={searchFilter}
-                        setSearchFilter={onChange}
-                    />
-                </BreadcrumbItem>
-                <BreadcrumbItem isDropdown>
-                    <DeploymentSelector
-                        deploymentsByNamespace={deploymentsByNamespace}
-                        selectedDeployments={selectedDeployments}
-                        searchFilter={searchFilter}
-                        setSearchFilter={onChange}
-                    />
-                </BreadcrumbItem>
-            </Breadcrumb>
-        </>
+        <Breadcrumb>
+            <BreadcrumbItem isDropdown>
+                <ClusterSelector
+                    clusters={clusters}
+                    selectedClusterName={selectedCluster?.name ?? ''}
+                    searchFilter={searchFilter}
+                    setSearchFilter={onChange}
+                />
+            </BreadcrumbItem>
+            <BreadcrumbItem isDropdown>
+                <NamespaceSelector
+                    namespaces={namespaces}
+                    selectedNamespaces={selectedNamespaces}
+                    selectedDeployments={selectedDeployments}
+                    deploymentsByNamespace={deploymentsByNamespace}
+                    searchFilter={searchFilter}
+                    setSearchFilter={onChange}
+                />
+            </BreadcrumbItem>
+            <BreadcrumbItem isDropdown>
+                <DeploymentSelector
+                    deploymentsByNamespace={deploymentsByNamespace}
+                    selectedDeployments={selectedDeployments}
+                    searchFilter={searchFilter}
+                    setSearchFilter={onChange}
+                />
+            </BreadcrumbItem>
+        </Breadcrumb>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
@@ -12,13 +12,19 @@ export type ComponentLocationProps = {
 function ComponentLocation({ location, source }: ComponentLocationProps) {
     return (
         <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
-            <Truncate content={location || 'N/A'} position="middle" />
-            {source === 'OS' && location === '' && (
-                <Tooltip content="Location is unavailable for operating system packages">
-                    <Icon>
-                        <InfoCircleIcon color="var(--pf-v5-global--info-color--100)" />
-                    </Icon>
-                </Tooltip>
+            {location ? (
+                <Truncate content={location} position="middle" />
+            ) : (
+                <>
+                    <span>N/A</span>
+                    {source === 'OS' && (
+                        <Tooltip content="Location is unavailable for operating system packages">
+                            <Icon>
+                                <InfoCircleIcon color="var(--pf-v5-global--info-color--100)" />
+                            </Icon>
+                        </Tooltip>
+                    )}
+                </>
             )}
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
@@ -63,11 +63,7 @@ function SeverityCountLabels({
                     icon={<CriticalIcon color={critical ? undefined : noViolationsColor} />}
                 >
                     <span className={getClassNameForCount(critical)}>
-                        {!critical && critical !== 0 ? (
-                            <EllipsisHIcon className="pf-v5-u-my-xs" />
-                        ) : (
-                            critical
-                        )}
+                        {!critical && critical !== 0 ? <EllipsisHIcon /> : critical}
                     </span>
                 </Label>
             </Tooltip>
@@ -78,11 +74,7 @@ function SeverityCountLabels({
                     icon={<ImportantIcon color={important ? undefined : noViolationsColor} />}
                 >
                     <span className={getClassNameForCount(important)}>
-                        {!important && important !== 0 ? (
-                            <EllipsisHIcon className="pf-v5-u-my-xs" />
-                        ) : (
-                            important
-                        )}
+                        {!important && important !== 0 ? <EllipsisHIcon /> : important}
                     </span>
                 </Label>
             </Tooltip>
@@ -93,11 +85,7 @@ function SeverityCountLabels({
                     icon={<ModerateIcon color={moderate ? undefined : noViolationsColor} />}
                 >
                     <span className={getClassNameForCount(moderate)}>
-                        {!moderate && moderate !== 0 ? (
-                            <EllipsisHIcon className="pf-v5-u-my-xs" />
-                        ) : (
-                            moderate
-                        )}
+                        {!moderate && moderate !== 0 ? <EllipsisHIcon /> : moderate}
                     </span>
                 </Label>
             </Tooltip>
@@ -108,7 +96,7 @@ function SeverityCountLabels({
                     icon={<LowIcon color={low ? undefined : noViolationsColor} />}
                 >
                     <span className={getClassNameForCount(low)}>
-                        {!low && low !== 0 ? <EllipsisHIcon className="pf-v5-u-my-xs" /> : low}
+                        {!low && low !== 0 ? <EllipsisHIcon /> : low}
                     </span>
                 </Label>
             </Tooltip>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -29,8 +29,10 @@ body {
 }
 
 /* overrides the default link styling in Tailwind (`inherit`) with PF's default blue */
-.pf-v5-c-page__main-section a {
-    color: var(--pf-v5-global--link--Color);
+.pf-v5-c-modal-box a, .pf-v5-c-page__main-section a {
+    color: var(--pf-v5-global--link--Color) !important;
+    -webkit-text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
+    text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
 }
 
 .pf-v5-c-page__sidebar {
@@ -155,6 +157,11 @@ body {
 /* Overrides Tailwind bolding of PF ToggleGroup buttons */
 .pf-v5-c-toggle-group__button {
     font-weight: var(--pf-v5-global--FontWeight--normal);
+}
+
+/* Overridding Tailwind dropdown arrow */
+select {
+    background-image: none;
 }
 
 /* override PatternFly DescriptionList horizontal variant to allow long keys and values to wrap */

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -29,7 +29,7 @@ body {
 }
 
 /* overrides the default link styling in Tailwind (`inherit`) with PF's default blue */
-.pf-v5-c-modal-box a, .pf-v5-c-page__main-section a {
+.pf-v5-c-modal-box a, .pf-v5-c-page__main-section a:not(.pf-v5-c-button) {
     color: var(--pf-v5-global--link--Color) !important;
     -webkit-text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
     text-decoration: var(--pf-v5-global--link--TextDecoration) !important;


### PR DESCRIPTION
Addressing follow up style regressions in this PR. 

1) Network graph: Last update time block/breadcrumb is not vertically centered in toolbar

Before: 
<img width="601" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/6d208e50-ec8d-48d0-8db6-6b45a1df2bf7">
<img width="408" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/54690d2f-03a9-49d7-8f62-fc461b44750b">

After:
<img width="605" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/52c85f87-9fb5-420d-8f9b-1202f1bd6059">
<img width="438" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/9b66a0d6-09ae-457d-8bd4-3db5e74a84b1">

2) VM 2.0 - Workload CVEs: Severity count spacing is incorrect

Before:
<img width="217" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/c695a516-ad1b-4836-a67e-54987c9e04c3">

After:
<img width="209" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/59a3c301-9e4f-4f29-86ef-af3baa098908">

3) VM 2.0 - Exception Mgmt: The request name link doesn’t show an underline when you hover over it

Before:
<img width="192" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/842a9972-180b-4387-b0a3-8cc5cf092295">

After:
<img width="173" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/24fa8767-2394-40c9-9bc9-98a001c8e8f3">

4) Clusters: Classic StackRox-style pills in Cluster Status column no longer wrap

Before:
<img width="360" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/d2dcdc92-73fb-43ad-ae48-9cee75467a28">

After:
<img width="467" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/72296bd9-f62b-4c42-a4a4-b669c23c3ab3">

5) Policy Mgmt: Spacing is odd in the header above the table

Before: 
<img width="205" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/dbec3802-e403-49a5-9c6a-c0da7771c0df">

After:
<img width="337" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/77841525-7dbe-482c-8eae-b266fd6c166e">

6) Collections: Deployment preview sidebar search button is always enabled, even when no text is present:
Unfixed because this is the expected behavior according to `SearchInput` component in PF5 documentation (https://www.patternfly.org/components/search-input)

7) Collections: Vertical spacing of deployment previews is uneven:

Before: 
<img width="346" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/fc845671-4ee9-4e18-b3ab-c398e0ef6418">

After:
<img width="421" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/0c821647-52bc-4575-8bac-339ed55831b5">

(the default margin for `Divider` components shrunk from `md` to `sm` so I adjusted accordingly

8) Integrations: Dropdown styling looks awkward

Before:
<img width="912" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/7a67a1e4-c5c2-470c-ae3a-9d1d17699756">

After:
<img width="901" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/6e50450b-751b-4b90-aaab-5f6b9d8834df">

9) Exception Configuration: The inputs looked a bit off

Before: 
<img width="456" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/15179499-29dc-49f6-92b7-872de2c4b936">

After: 
<img width="437" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/7757460a-94a6-4622-828d-ff4998750957">

Left the input to be extended because of awkwardness w helper text:

PF4:
<img width="446" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/abc490ae-553f-4771-9d09-d94e9506e252">

PF5:
<img width="436" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/9b74f820-afeb-4023-b4e0-d2ca738d187f">

10) Access control: Helper texts doesn’t appear to be working as intended on auth providers creation form. Displays helper text for all fields after any single field is changed/blurred

Before: 
<img width="645" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/d46de640-6b1d-4abf-829a-bcb008a6b261">

After: 
<img width="1180" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/9f10cd27-a019-461d-b8b0-3e13b61af914">

11) Access control: Invite users modal link has no styling in the alert when there is no configured auth provider.

Before: 
<img width="611" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/bb9b2025-7429-4d26-aa5f-84a8d4d3975d">

After:
<img width="556" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/2c267395-5b1f-4625-97cc-f76b179248da">
