### PR TITLE
fix(proto): Remove usage of internal gogoproto generated fields

### DIFF
--- a/central/summary/service/service_impl_test.go
+++ b/central/summary/service/service_impl_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -15,14 +14,14 @@ func TestSummaryTypeToResourceMap(t *testing.T) {
 	summaryCountsRespType := reflect.TypeOf(v1.SummaryCountsResponse{})
 
 	for i := 0; i < summaryCountsRespType.NumField(); i++ {
-		name := summaryCountsRespType.Field(i).Name
+		field := summaryCountsRespType.Field(i)
 		// This ignores hidden metadata fields in the proto.
-		if strings.HasPrefix(name, "XXX_") {
+		if field.Tag.Get("protobuf") == "" {
 			continue
 		}
-		_, ok := summaryTypeToResourceMetadata[name]
+		_, ok := summaryTypeToResourceMetadata[field.Name]
 		// This is a programming error. If you see this, add the new summarized type you've added to the
 		// summaryTypeToResource map!
-		assert.True(t, ok, "Please add type %s to the summaryTypeToResource map used by the authorizer", name)
+		assert.True(t, ok, "Please add type %s to the summaryTypeToResource map used by the authorizer", field.Name)
 	}
 }


### PR DESCRIPTION
## Description

Fix the test to use common struct field tags instead of custom generator internal fields.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI only, since test is changed

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
