### PR TITLE
ROX-23661: Net graph internal entity patch

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -224,7 +224,7 @@ function NetworkGraphPage() {
 
                     Then iterate through the invalid entity nodes:
 
-                        If there is an existing INTERNET entity type in the nodes, set the `entity` 
+                        If there is an existing INTERNET entity type in the nodes, set the `entity`
                             field of each invalid node to the saved INTERNET entity.
 
                         If there is no INTERNET entity type in the nodes, we convert the entity type to `INTERNET`


### PR DESCRIPTION
## Description

Fixes a crash and rendering error in the Network Graph when using `central` version < 4.4.0 but a `sensor` version >= 4.4.0.

The crash is due to an internal entity node with type `5` being saved in central and passed to the UI. In 4.4.0 this value would be passed to the UI as the enum value `INTERNAL_ENTITIES`. Regardless, the UI in 4.3.x does not know how to handle either type and ignores it. The side effect of ignoring this entity is that there are edge connections in the graph where the target node does not exist, causing the error.

The fix is to convert entities of type `5` to `INTERNET`, which is incorrect, but consistent with the behavior expected in all versions of ACS <= 4.4

**Note that this PR is specifically targets to `release-4.3` and should not be merged to `master`.**

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Reproduction before the fix:

Deploy stackrox 4.3.x on GKE and then set the sensor image to be version 4.4.x:
```sh
$ kubectl -n stackrox set image deploy/sensor sensor=quay.io/stackrox-io/main:4.4.0

$ kubectl -n stackrox describe deploy {central,sensor} | grep -B 1 Image
   central:
    Image:      quay.io/stackrox-io/main:4.3.5
--
   sensor:
    Image:       quay.io/stackrox-io/main:4.4.0
```

Generate internal traffic by using the application, and then visit the network graph, selecting `stackrox` as the namespace. The Network Graph will be empty. You can see in the console the invalid entity type `5` which represents the sensor 4.4.x `INTERNAL` type that is not understood by central 4.3.x.
![image](https://github.com/stackrox/stackrox/assets/1292638/228e3e1a-22ca-437f-92fa-a3655a58c601)

Behavior after the fix:

Notice the ID of the highlighted "External Entities" node in the URL. This matches the static ID (starting with `afa`) of "INTERNET" when returned over the API. If this node type exists in the current view, it will be reused for invalid nodes.
![image](https://github.com/stackrox/stackrox/assets/1292638/1f2c6407-1ffc-4ecc-89ad-9e758051d1e9)

Change the filter so that the only deployment in scope is a node that has a connection to an internal entity (`type === 5`) and view the behavior. Notice the ID in the URL is now the static ID (starting with `ada`) of "INTERNAL_ENTITIES", as there is no preexisting "INTERNET" node in the response. Since the true `INTERNET` entity does not exist in the response, we repurpose the `5` entity as the `INTERNET` entity for invalid nodes.
![image](https://github.com/stackrox/stackrox/assets/1292638/5e966ae9-aea4-43c8-bf6d-ce7f778b9ffa)

