### PR TITLE
chore: do not batch telemetry events

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -79,6 +79,11 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	}
 
 	return &phonehome.Config{
+			// Segment does not respect the processing order of events in a
+			// batch. Setting BatchSize to 1, instead of default 250, may reduce
+			// the number of (none) values, appearing on Amplitude charts, by
+			// introducing a slight delay between consequent events.
+			BatchSize:    1,
 			ClientID:     centralID,
 			ClientName:   "Central",
 			GroupType:    "Tenant",

--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -1,0 +1,15 @@
+package centralclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetInstanceConfig(t *testing.T) {
+	cfg, props, err := getInstanceConfig()
+	// Telemetry should be disabled in test environment.
+	assert.Nil(t, cfg)
+	assert.Nil(t, props)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
## Description

Segment does not respect the processing order of events in a batch, which causes out-of-order processing by the analytics platform.

This PR disables batching, as per Segment support recommendation. The hope is to reduce the number of `(none)` values.

A disadvantage is that central will communicate more often, making calls per event. A possible advantage is that central events will be better correlated in time with related UI events.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Run the central in local, enable telemetry, check that the events appear immediately, with no batching.

`roxctl central whoami` command issued two events with the following timestamp:
```json
  "properties": {
    "Code": 0,
    "Method": "/v1.AuthService/GetAuthStatus",
    "Path": "/v1.AuthService/GetAuthStatus",
    "User-Agent": "roxctl/4.4.x-426-g0732d30c78 (linux; amd64) grpc-go/1.61.1"
  },
  "receivedAt": "2024-04-18T16:57:01.018Z",
  "sentAt": "2024-04-18T16:57:01.001Z",
  "timestamp": "2024-04-18T16:57:01.017Z",
```
```json
  "properties": {
    "Code": 0,
    "Method": "/v1.RoleService/GetMyPermissions",
    "Path": "/v1.RoleService/GetMyPermissions",
    "User-Agent": "roxctl/4.4.x-426-g0732d30c78 (linux; amd64) grpc-go/1.61.1"
  },
  "receivedAt": "2024-04-18T16:57:01.157Z",
  "sentAt": "2024-04-18T16:57:01.141Z",
  "timestamp": "2024-04-18T16:57:01.157Z",
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
