### PR TITLE
fix(ROX-23214): overwrite image name only when not cached

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -217,6 +217,7 @@ func (e *enricherImpl) updateImageWithExistingImage(image *storage.Image, existi
 
 	e.useExistingSignature(image, existingImage, option)
 	e.useExistingSignatureVerificationData(image, existingImage, option, hasChangedNames)
+	e.useExistingImageName(image, existingImage, option)
 	return e.useExistingScan(image, existingImage, option)
 }
 
@@ -546,6 +547,13 @@ func (e *enricherImpl) useExistingSignatureVerificationData(img *storage.Image, 
 
 	if existingImg.GetSignatureVerificationData() != nil {
 		img.SignatureVerificationData = existingImg.GetSignatureVerificationData()
+	}
+}
+
+func (e *enricherImpl) useExistingImageName(img *storage.Image, existingImg *storage.Image, option FetchOption) {
+	// We only want to overwrite the top-level image name if we are ignoring cached values.
+	if !option.forceRefetchCachedValues() {
+		img.Name = existingImg.Name
 	}
 }
 

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -265,11 +265,13 @@ func TestEnricherFlow(t *testing.T) {
 			shortCircuitRegistry: false,
 			shortCircuitScanner:  true,
 			image: &storage.Image{
+				Id: "id",
+			},
+			imageGetter: imageGetterFromImage(&storage.Image{
 				Id:    "id",
 				Name:  &storage.ImageName{Registry: "reg"},
 				Names: []*storage.ImageName{{Registry: "reg"}},
-			},
-			imageGetter: imageGetterFromImage(&storage.Image{Id: "id", Scan: &storage.ImageScan{}}),
+				Scan:  &storage.ImageScan{}}),
 
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: false,


### PR DESCRIPTION
## Description

This fixes an issue in the current behavior of the image enricher where unconditionally the image name of the image to-enrich was used as the top-level image name, irrespective of whether one is retrieving cached values or not.

This leads to an issue where the to-be-enriched image has an invalid image reference (e.g. a name that isn't pointing to the correct image) but specified via digest. This would result
in an image being upserted which has a top level name which cannot be enriched but still all other valid cached fields like image scan, metadata, sigs etc.

The behavior has now changed to the following within this PR:
- instead of overwriting the image's top-level name with the to-be-enriched image name; this will now only be done when we use the force option; i.e. we disregard cached values.
This ensures that on cached runs (e.g. when using `roxctl image scan` without the `--force` flag, the image name will only be added to the `names` field and not as the new top-level image name.

In case the `force` option is used, we can safely overwrite the image since it will go through the whole enrichment workflow, either failing or succeeding for the given image name.

What hasn't been changed in this PR is what to do in principle when metadata fetching _but_ we shall use cached values. For the time being, this will only hit when images referenced by digest are being used and it's not possible to fetch metadata from them. For the time, after this PR, the "invalid" references will be added to the names list. Given that we do not show the list anywhere for the time being as well as it not having impact for enrichment, I chose to keep it as-is.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Manual tests in addition:

```bash
# Scan an arbitrary image via roxctl
roxctl image scan --image=docker.io/nginx:1.23

# Verify the stored image name
roxcurl https://$ROX_ENDPOINT/v1/images/sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf | jq -r .name
{
  "registry": "docker.io",
  "remote": "library/nginx",
  "tag": "1.23",
  "fullName": "docker.io/library/nginx:1.23"
}

# Scan an image with an invalid hostname but the same digest as the previously scanned image
roxctl image scan --image=custom.io/nginx@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf

# Verify the stored image name again, it should not be changed
roxcurl https://$ROX_ENDPOINT/v1/images/sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf | jq -r .name
{
  "registry": "docker.io",
  "remote": "library/nginx",
  "tag": "1.23",
  "fullName": "docker.io/library/nginx:1.23"
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
