### PR TITLE
fix(imageintegrations): report 0 by default in telemetry

### DIFF
--- a/central/imageintegration/datastore/telemetry.go
+++ b/central/imageintegration/datastore/telemetry.go
@@ -38,8 +38,24 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		return len(integrations), nil
 	})
 
-	totalCount := map[string]int{}
-	stsCount := map[string]int{}
+	totalCount := map[string]int{
+		types.ArtifactoryType:      0,
+		types.ArtifactRegistryType: 0,
+		types.AzureType:            0,
+		types.DockerType:           0,
+		types.ECRType:              0,
+		types.GoogleType:           0,
+		types.IBMType:              0,
+		types.NexusType:            0,
+		types.QuayType:             0,
+		types.RedHatType:           0,
+	}
+	stsCount := map[string]int{
+		types.ArtifactRegistryType: 0,
+		types.AzureType:            0,
+		types.ECRType:              0,
+		types.GoogleType:           0,
+	}
 
 	for _, ii := range integrations {
 		iiType := ii.GetType()


### PR DESCRIPTION
## Description

Report 0 by default for image integrations to allow for better rendering in our telemetry charts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
