### PR TITLE
chore(auth): add telemetry for m2m

### DIFF
--- a/central/auth/datastore/telemetry.go
+++ b/central/auth/datastore/telemetry.go
@@ -1,0 +1,48 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
+
+	props := make(map[string]any)
+
+	configs, err := Singleton().ListAuthM2MConfigs(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get machine-to-machine configurations")
+	}
+
+	_ = phonehome.AddTotal(ctx, props, "Machine-To-Machine Configurations", func(_ context.Context) (int, error) {
+		return len(configs), nil
+	})
+
+	countByType := map[string]int{
+		storage.AuthMachineToMachineConfig_GITHUB_ACTIONS.String(): 0,
+		storage.AuthMachineToMachineConfig_GENERIC.String():        0,
+	}
+
+	for _, config := range configs {
+		countByType[config.GetType().String()]++
+	}
+
+	for configType, count := range countByType {
+		props[fmt.Sprintf("Total %s Machine-to-Machine configurations",
+			cases.Title(language.English, cases.Compact).String(configType))] = count
+	}
+
+	return props, nil
+}

--- a/central/main.go
+++ b/central/main.go
@@ -20,6 +20,7 @@ import (
 	apiTokenExpiration "github.com/stackrox/rox/central/apitoken/expiration"
 	apiTokenService "github.com/stackrox/rox/central/apitoken/service"
 	"github.com/stackrox/rox/central/audit"
+	authDS "github.com/stackrox/rox/central/auth/datastore"
 	authService "github.com/stackrox/rox/central/auth/service"
 	"github.com/stackrox/rox/central/auth/userpass"
 	authProviderRegistry "github.com/stackrox/rox/central/authprovider/registry"
@@ -623,6 +624,7 @@ func startGRPCServer() {
 				gs.AddGatherer(externalbackupsDS.Gather)
 				gs.AddGatherer(imageintegrationsDS.Gather)
 				gs.AddGatherer(cloudSourcesDS.Gather(cloudSourcesDS.Singleton()))
+				gs.AddGatherer(authDS.Gather)
 			}
 		}
 	}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -91,7 +91,7 @@ spec:
           value: {{ ._rox.central.telemetry.storage.key | quote }}
         {{- end }}
         - name: ROX_TELEMETRY_API_WHITELIST
-          value: "/api/splunk/ta/*"
+          value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
         {{- /* Otherwise... */}}
         {{- else }}
         {{- /* ... if telemetry.enabled is false, configure the key to disable

--- a/operator/tests/central/central-misc/080-assert-non-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-non-openshift.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
             - name: ROX_TELEMETRY_API_WHITELIST
-              value: "/api/splunk/ta/*"
+              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_INSTALL_METHOD

--- a/operator/tests/central/central-misc/080-assert-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-openshift.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
             - name: ROX_TELEMETRY_API_WHITELIST
-              value: "/api/splunk/ta/*"
+              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH


### PR DESCRIPTION
## Description

Add telemetry information for machine-to-machine configurations as well as track the amount of `exchange` calls.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- manual test to observe that the API calls are correctly tracked in Segment + the total amount of machine-to-machine configs is there as well.

```json
{
...
    "Total Generic Machine-to-Machine configurations": 0,´
    "Total Github_actions Machine-to-Machine configurations": 0,
    "Total Machine-To-Machine Configurations": 0
}
```
When two distinct types are created:
```json
{
...
    "Total Generic Machine-to-Machine configurations": 1,
    "Total Github_actions Machine-to-Machine configurations": 1,
    "Total Machine-To-Machine Configurations": 2
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
