### PR TITLE
ROX-23042: Add node list table to CVE overview page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -1,10 +1,77 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Truncate } from '@patternfly/react-core';
+import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { gql, useQuery } from '@apollo/client';
 
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import DateDistance from 'Components/DateDistance';
+import { DynamicColumnIcon } from 'Components/DynamicIcon';
+import {
+    TbodyLoading,
+    TbodyError,
+    TbodyEmpty,
+    TbodyFilteredEmpty,
+} from 'Components/TableStateTemplates';
+import { getTableUIState } from 'utils/getTableUIState';
 import useURLPagination from 'hooks/useURLPagination';
 
-import { QuerySearchFilter } from '../../types';
+import { vulnerabilitySeverityLabels } from 'messages/common';
+import SeverityCountLabels from '../../components/SeverityCountLabels';
+import { getNodeEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
+import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
+
+const nodeListQuery = gql`
+    query getNodes($query: String, $pagination: Pagination) {
+        nodes(query: $query, pagination: $pagination) {
+            id
+            name
+            nodeCVECountBySeverity {
+                critical {
+                    total
+                }
+                important {
+                    total
+                }
+                moderate {
+                    total
+                }
+                low {
+                    total
+                }
+            }
+            cluster {
+                name
+            }
+            operatingSystem
+            scanTime
+        }
+    }
+`;
+
+// TODO - Verify these types once the BE is implemented
+type Node = {
+    id: string;
+    name: string;
+    nodeCVECountBySeverity: {
+        critical: {
+            total: number;
+        };
+        important: {
+            total: number;
+        };
+        moderate: {
+            total: number;
+        };
+        low: {
+            total: number;
+        };
+    };
+    cluster: {
+        name: string;
+    };
+    operatingSystem: string;
+    scanTime: string;
+};
 
 export type NodesTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -12,37 +79,96 @@ export type NodesTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
 };
 
-function NodesTable({
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    querySearchFilter,
-    isFiltered,
-    pagination,
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-}: NodesTableProps) {
-    // TODO - Placeholders for query results
-    const data = [];
-    const previousData = undefined;
-    const error: Error | undefined = undefined;
-    const loading = false;
+function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTableProps) {
+    const { page, perPage } = pagination;
+    const { data, previousData, loading, error } = useQuery<{ nodes: Node[] }>(nodeListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
 
     const tableData = data ?? previousData;
+    const tableState = getTableUIState({
+        isLoading: loading,
+        data: tableData?.nodes,
+        error,
+        searchFilter: querySearchFilter,
+    });
+    const colSpan = 5;
+
+    const filteredSeverities = querySearchFilter.SEVERITY?.map(
+        (s) => vulnerabilitySeverityLabels[s]
+    ).filter(isVulnerabilitySeverityLabel);
 
     return (
-        <>
-            {loading && !tableData && (
-                <Bullseye>
-                    <Spinner />
-                </Bullseye>
+        <Table
+            borders={tableState.type === 'COMPLETE'}
+            variant="compact"
+            role="region"
+            aria-live="polite"
+            aria-busy={loading ? 'true' : 'false'}
+        >
+            <Thead noWrap>
+                <Tr>
+                    <Th>Node</Th>
+                    <Th>
+                        CVEs by severity
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th>Cluster</Th>
+                    <Th>Operating system</Th>
+                    <Th>Scan time</Th>
+                </Tr>
+            </Thead>
+            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
+            {tableState.type === 'ERROR' && (
+                <TbodyError colSpan={colSpan} error={tableState.error} />
             )}
-            {error && (
-                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            {tableState.type === 'EMPTY' && (
+                <TbodyEmpty
+                    colSpan={colSpan}
+                    message="No CVEs have been reported for your scanned nodes"
+                />
             )}
-            {!error && tableData && (
-                <div role="region" aria-live="polite" aria-busy={loading ? 'true' : 'false'}>
-                    Table goes here
-                </div>
-            )}
-        </>
+            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
+            {tableState.type === 'COMPLETE' &&
+                tableState.data.map((node) => {
+                    const { id, name, nodeCVECountBySeverity, cluster, operatingSystem, scanTime } =
+                        node;
+                    const { critical, important, moderate, low } = nodeCVECountBySeverity;
+                    return (
+                        <Tr key={node.id}>
+                            <Td dataLabel="Node" modifier="nowrap">
+                                <Link to={getNodeEntityPagePath('Node', id)}>
+                                    <Truncate position="middle" content={name} />
+                                </Link>
+                            </Td>
+                            <Td dataLabel="CVEs by severity">
+                                <SeverityCountLabels
+                                    criticalCount={critical.total}
+                                    importantCount={important.total}
+                                    moderateCount={moderate.total}
+                                    lowCount={low.total}
+                                    filteredSeverities={filteredSeverities}
+                                />
+                            </Td>
+                            <Td dataLabel="Cluster" modifier="nowrap">
+                                <Truncate position="middle" content={cluster.name} />
+                            </Td>
+                            <Td dataLabel="Operating system" modifier="nowrap">
+                                {operatingSystem}
+                            </Td>
+                            <Td dataLabel="Scan time">
+                                <DateDistance date={scanTime} />
+                            </Td>
+                        </Tr>
+                    );
+                })}
+        </Table>
     );
 }
 

--- a/ui/apps/platform/src/messages/common.ts
+++ b/ui/apps/platform/src/messages/common.ts
@@ -1,5 +1,4 @@
 import { AccessControlEntityType, RbacConfigType } from 'constants/entityTypes';
-import { VulnerabilitySeverity } from 'types/cve.proto';
 import {
     EnforcementAction,
     LifecycleStage,
@@ -14,13 +13,13 @@ export const severityLabels: Record<PolicySeverity, string> = Object.freeze({
     LOW_SEVERITY: 'Low',
 });
 
-export const vulnerabilitySeverityLabels: Record<VulnerabilitySeverity, string> = Object.freeze({
+export const vulnerabilitySeverityLabels = {
     CRITICAL_VULNERABILITY_SEVERITY: 'Critical',
     IMPORTANT_VULNERABILITY_SEVERITY: 'Important',
     MODERATE_VULNERABILITY_SEVERITY: 'Moderate',
     LOW_VULNERABILITY_SEVERITY: 'Low',
     UNKNOWN_VULNERABILITY_SEVERITY: 'Unknown',
-});
+} as const;
 
 export const clusterTypeLabels = Object.freeze({
     KUBERNETES_CLUSTER: 'Kubernetes Clusters',


### PR DESCRIPTION
## Description

Adds the nodes table to the Node CVE overview page.

This PR relies on simulated data until the BE queries are in place.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the Node CVE page:
![image](https://github.com/stackrox/stackrox/assets/1292638/f7a74e81-c650-4d16-affe-564f192f7831)

Click the Nodes tab:

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad9b8624-d4a5-4448-a3ca-434f3263090c)

Error:
![image](https://github.com/stackrox/stackrox/assets/1292638/a8d79db0-bf3d-486e-908d-0d92992b601f)

Empty no filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad1e5d11-aa16-438a-9377-c478c4d3bf70)

Empty with filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/0b2fb1f7-1462-4e2c-aba5-06411b6e6e32)

Success:
![image](https://github.com/stackrox/stackrox/assets/1292638/59adaa3a-96c8-44f3-8f2f-b575cc3d7f6a)

Clicking a Node link takes you to the node detail page:
![image](https://github.com/stackrox/stackrox/assets/1292638/b89e5405-6bc5-4676-8027-a7994b28c0a5)

Table view with a severity filter applied:
![image](https://github.com/stackrox/stackrox/assets/1292638/b0621a18-5111-4860-97fd-89c2548b3bcb)

