### PR TITLE
fix: Bump memory for `main` container builds in Konflux

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -81,10 +81,10 @@ spec:
       computeResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 7Gi
         requests:
           cpu: 4
-          memory: 6Gi
+          memory: 7Gi
   - pipelineTaskName: clamav-scan
     stepSpecs:
     # Provision more CPU to speed up ClamAV scan compared to the defaults.

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -79,10 +79,10 @@ spec:
       computeResources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 7Gi
         requests:
           cpu: 4
-          memory: 6Gi
+          memory: 7Gi
   - pipelineTaskName: clamav-scan
     stepSpecs:
     # Provision more CPU to speed up ClamAV scan compared to the defaults.


### PR DESCRIPTION
## Description

This is to address a failure during UI build
https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-push-dwflt

6Gi appears not enough occasionally, giving it +1 more.

## Checklist
- [x] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

None, just CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
