### PR TITLE
ROX-23039: Add pagination to Node CVE detail page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -43,6 +43,7 @@ import {
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
 import { getTableUIState } from '../../../utils/getTableUIState';
+import { DEFAULT_PAGE_SIZE } from '../constants';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -65,7 +66,7 @@ const defaultSortOption = {
 
 function ApprovedDeferrals() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -42,6 +42,7 @@ import {
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
 import { getTableUIState } from '../../../utils/getTableUIState';
+import { DEFAULT_PAGE_SIZE } from '../constants';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -58,7 +59,7 @@ const defaultSortOption = {
 
 function ApprovedFalsePositives() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -41,6 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { DEFAULT_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
@@ -64,7 +65,7 @@ const defaultSortOption = {
 
 function DeniedRequests() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -41,6 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { DEFAULT_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
@@ -64,7 +65,7 @@ const defaultSortOption = {
 
 function PendingApprovals() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../utils/sortUtils';
 import { CVEListQueryResult, cveListQuery } from '../../WorkloadCves/Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 
@@ -48,7 +49,7 @@ function RequestCVEsTable({
     expandedRowSet,
     vulnerabilityState,
 }: RequestCVEsTableProps) {
-    const { page, perPage, setPage } = useURLPagination(20);
+    const { page, perPage, setPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields: getWorkloadSortFields('CVE'),
         defaultSortOption: getDefaultWorkloadSortOption('CVE'),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -29,6 +29,7 @@ import {
     parseWorkloadQuerySearchFilter,
 } from '../../utils/searchUtils';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import AffectedNodesTable, { AffectedNode, affectedNodeFragment } from './AffectedNodesTable';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Node', {
@@ -57,7 +58,7 @@ function NodeCvePage() {
         CVE: [exactCveIdSearchRegex],
     });
 
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const [nodeCveMetadata, setNodeCveMetadata] = useState<CveMetadata>();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,6 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
-import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Divider,
+    Flex,
+    PageSection,
+    Pagination,
+    Skeleton,
+    Split,
+    SplitItem,
+    Title,
+    pluralize,
+} from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
 import PageTitle from 'Components/PageTitle';
@@ -9,6 +21,8 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getTableUIState } from 'utils/getTableUIState';
+import { getHasSearchApplied } from 'utils/searchUtils';
+import { DynamicTableLabel } from 'Components/DynamicIcon';
 import {
     getOverviewPagePath,
     getRegexScopedQueryString,
@@ -43,7 +57,8 @@ function NodeCvePage() {
         CVE: [exactCveIdSearchRegex],
     });
 
-    const { page, perPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const [nodeCveMetadata, setNodeCveMetadata] = useState<CveMetadata>();
     const nodeCveName = nodeCveMetadata?.cve;
@@ -84,6 +99,7 @@ function NodeCvePage() {
     });
 
     const nodeData = affectedNodesRequest.data?.nodes ?? affectedNodesRequest.previousData?.nodes;
+    const nodeCount = 50; // TODO
 
     const tableState = getTableUIState({
         isLoading: affectedNodesRequest.loading,
@@ -110,8 +126,32 @@ function NodeCvePage() {
                 <CvePageHeader data={nodeCveMetadata} />
             </PageSection>
             <Divider component="div" />
-            <PageSection className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1">
-                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-md">
+            <PageSection className="pf-v5-u-flex-grow-1">
+                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-lg">
+                    <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
+                        <SplitItem isFilled>
+                            <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                                <Title headingLevel="h2">
+                                    {pluralize(nodeCount, 'node')} affected
+                                </Title>
+                                {isFiltered && <DynamicTableLabel />}
+                            </Flex>
+                        </SplitItem>
+                        <SplitItem>
+                            <Pagination
+                                itemCount={nodeCount}
+                                perPage={perPage}
+                                page={page}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    if (nodeCount < (page - 1) * newPerPage) {
+                                        setPage(1);
+                                    }
+                                    setPerPage(newPerPage);
+                                }}
+                            />
+                        </SplitItem>
+                    </Split>
                     <AffectedNodesTable tableState={tableState} />
                 </div>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -21,6 +21,7 @@ import NodeCveFilterToolbar from '../components/NodeCveFilterToolbar';
 import { NODE_CVE_SEARCH_OPTION } from '../../searchOptions';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { nodeEntityTabValues } from '../../types';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 
 import CVEsTable from './CVEsTable';
 import NodesTable from './NodesTable';
@@ -30,7 +31,7 @@ const searchOptions = [NODE_CVE_SEARCH_OPTION];
 function NodeCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', nodeEntityTabValues);
     const { searchFilter } = useURLSearch();
-    const pagination = useURLPagination(20);
+    const pagination = useURLPagination(DEFAULT_PAGE_SIZE);
 
     // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
     const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -16,6 +16,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { platformEntityTabValues } from '../../types';
@@ -26,7 +27,7 @@ import CVEsTable from './CVEsTable';
 function PlatformCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
     const { searchFilter } = useURLSearch();
-    const pagination = useURLPagination(20);
+    const pagination = useURLPagination(DEFAULT_PAGE_SIZE);
 
     // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
     const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -26,6 +26,7 @@ import DeploymentPageHeader, {
 } from './DeploymentPageHeader';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import { detailsTabValues } from '../../types';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import DeploymentPageResources from './DeploymentPageResources';
 import DeploymentPageVulnerabilities from './DeploymentPageVulnerabilities';
 import DeploymentPageDetails from './DeploymentPageDetails';
@@ -48,7 +49,7 @@ function DeploymentPage() {
     const { deploymentId } = useParams() as { deploymentId: string };
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
-    const pagination = useURLPagination(20);
+    const pagination = useURLPagination(DEFAULT_PAGE_SIZE);
 
     const metadataRequest = useQuery<{ deployment: DeploymentMetadata | null }, { id: string }>(
         deploymentMetadataQuery,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -39,6 +39,7 @@ import ImageDetailBadges, {
     imageDetailsFragment,
 } from '../components/ImageDetailBadges';
 import getImageScanMessage from '../utils/getImageScanMessage';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 
 const workloadCveOverviewImagePath = getOverviewPagePath('Workload', {
     vulnerabilityState: 'OBSERVED',
@@ -82,7 +83,7 @@ function ImagePage() {
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
     const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
 
-    const pagination = useURLPagination(20);
+    const pagination = useURLPagination(DEFAULT_PAGE_SIZE);
 
     const imageData = data && data.image;
     const imageName = imageData?.name

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../utils/searchUtils';
 import { getDefaultWorkloadSortOption } from '../../utils/sortUtils';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 
 import WorkloadCveFilterToolbar from '../components/WorkloadCveFilterToolbar';
 import AffectedImagesTable, {
@@ -191,7 +192,7 @@ function ImageCvePage() {
         },
         currentVulnerabilityState
     );
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
 
     const [entityTab] = useURLStringUnion('entityTab', imageCveEntities);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -41,6 +41,7 @@ import PageTitle from 'Components/PageTitle';
 import FilterAutocompleteSelect from 'Containers/Vulnerabilities/components/FilterAutocomplete';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import KeyValueListModal from 'Components/KeyValueListModal';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import DeploymentFilterLink from './DeploymentFilterLink';
 
 type Namespace = {
@@ -97,7 +98,7 @@ const pollInterval = 30000;
 
 function NamespaceViewPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -46,6 +46,8 @@ import {
     parseWorkloadQuerySearchFilter,
     getVulnStateScopedQueryString,
 } from '../../utils/searchUtils';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
+
 import CVEsTableContainer from './CVEsTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
 import ImagesTableContainer, { imageListQuery } from './ImagesTableContainer';
@@ -152,7 +154,7 @@ function WorkloadCvesOverviewPage() {
     // as a fallback
     const localStorageValue = isFixabilityFiltersEnabled ? storedValue : defaultStorage;
 
-    const pagination = useURLPagination(20);
+    const pagination = useURLPagination(DEFAULT_PAGE_SIZE);
 
     const sort = useURLSort({
         sortFields: getWorkloadSortFields(activeEntityTabKey),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/constants.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PAGE_SIZE = 20;


### PR DESCRIPTION
## Description

Adds pagination component to Node CVE detail page.

Node counts and node data are simulation, this is specifically for the Pagination component and interaction with the URL parameters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Node CVE page and see the pagination component:
![image](https://github.com/stackrox/stackrox/assets/1292638/3a5192f3-243d-46b4-b574-22e8751cfd46)

Page over, and the URL is updated (data is still simulated though):
![image](https://github.com/stackrox/stackrox/assets/1292638/cd03d1a9-b627-428c-8df9-06c27ae5a773)

Change the perPage:
![image](https://github.com/stackrox/stackrox/assets/1292638/725ac6a5-78f7-4bdd-afc4-7ed6df67dd19)

Goto end of pages:
![image](https://github.com/stackrox/stackrox/assets/1292638/b3429643-b0fa-4ef2-8a15-1f7f2bbe730f)
