### PR TITLE
ROX-19974: Add trusted TLS certs for Sensor-Central HTTP connection

### DIFF
--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -1,19 +1,19 @@
 package scannerdefinitions
 
 import (
+	"crypto/x509"
 	"io"
 	"net/http"
 	"net/url"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralclient"
 	"google.golang.org/grpc/codes"
 )
 
@@ -32,8 +32,8 @@ type Handler struct {
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
-func NewDefinitionsHandler(centralEndpoint string) (*Handler, error) {
-	client, err := clientconn.NewHTTPClient(mtls.CentralSubject, centralEndpoint, 0)
+func NewDefinitionsHandler(centralEndpoint string, centralCertificates []*x509.Certificate) (*Handler, error) {
+	client, err := centralclient.AuthenticatedCentralHTTPClient(centralEndpoint, centralCertificates)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating central HTTP transport")
 	}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -2,6 +2,7 @@ package sensor
 
 import (
 	"context"
+	"crypto/x509"
 	"net/http"
 	"strconv"
 	"sync/atomic"
@@ -10,7 +11,6 @@ import (
 	"github.com/cenkalti/backoff/v3"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -24,7 +24,6 @@ import (
 	grpcUtil "github.com/stackrox/rox/pkg/grpc/util"
 	"github.com/stackrox/rox/pkg/kocache"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/probeupload"
 	"github.com/stackrox/rox/pkg/sync"
@@ -78,6 +77,7 @@ type Sensor struct {
 	centralCommunication     CentralCommunication
 	centralConnectionFactory centralclient.CentralConnectionFactory
 	centralCommunicationLock *sync.Mutex
+	certLoader               centralclient.CertLoader
 
 	stoppedSig concurrency.ErrorSignal
 
@@ -93,6 +93,7 @@ func NewSensor(
 	imageService image.Service,
 	centralConnectionFactory centralclient.CentralConnectionFactory,
 	pubSub *internalmessage.MessageSubscriber,
+	certLoader centralclient.CertLoader,
 	components ...common.SensorComponent,
 ) *Sensor {
 	return &Sensor{
@@ -106,6 +107,7 @@ func NewSensor(
 		components:    append(components, detector, configHandler), // Explicitly add the config handler
 
 		centralConnectionFactory: centralConnectionFactory,
+		certLoader:               certLoader,
 		centralConnection:        grpcUtil.NewLazyClientConn(),
 		centralCommunicationLock: &sync.Mutex{},
 
@@ -149,9 +151,9 @@ type offlineAwareProbeSource interface {
 	offlineAware
 }
 
-func createKOCacheSource(centralEndpoint string) (offlineAwareProbeSource, error) {
+func createKOCacheSource(centralEndpoint string, centralCerts []*x509.Certificate) (offlineAwareProbeSource, error) {
 	kernelObjsBaseURL := "/kernel-objects"
-	kernelObjsClient, err := clientconn.NewHTTPClient(mtls.CentralSubject, centralEndpoint, 0)
+	kernelObjsClient, err := centralclient.AuthenticatedCentralHTTPClient(centralEndpoint, centralCerts)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating central HTTP transport")
 	}
@@ -167,7 +169,10 @@ func (s *Sensor) Start() {
 		chaos.InitializeChaosConfiguration(context.Background())
 	}
 
-	go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection)
+	// reuse certificates between GRPC and HTTP clients for initial connection
+	centralCertificates := s.certLoader()
+
+	go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, centralclient.StaticCertLoader(centralCertificates))
 
 	for _, c := range s.components {
 		s.AddNotifiable(c)
@@ -196,7 +201,7 @@ func (s *Sensor) Start() {
 
 	customRoutes := []routes.CustomRoute{readinessRoute, legacyAdmissionControllerRoute}
 
-	koCacheSource, err := createKOCacheSource(s.centralEndpoint)
+	koCacheSource, err := createKOCacheSource(s.centralEndpoint, centralCertificates)
 	if err != nil {
 		utils.Should(errors.Wrap(err, "Failed to create kernel object download/caching layer"))
 	} else {
@@ -214,7 +219,7 @@ func (s *Sensor) Start() {
 
 	// Enable endpoint to retrieve vulnerability definitions if local image scanning is enabled.
 	if env.LocalImageScanningEnabled.BooleanSetting() {
-		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint)
+		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
 		if err != nil {
 			utils.Should(errors.Wrap(err, "Failed to create scanner definition route"))
 		}
@@ -313,8 +318,8 @@ func (s *Sensor) Start() {
 
 // newScannerDefinitionsRoute returns a custom route that serves scanner
 // definitions retrieved from Central.
-func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string) (*routes.CustomRoute, error) {
-	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint)
+func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCertificates []*x509.Certificate) (*routes.CustomRoute, error) {
+	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint, centralCertificates)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +437,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			s.changeState(common.SensorComponentEventCentralReachable)
 		case <-s.centralConnectionFactory.StopSignal().WaitC():
 			// Connection is still broken, report and try again
-			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection)
+			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
 			return wrapOrNewError(s.centralConnectionFactory.StopSignal().Err(), "connection couldn't be re-established")
 		}
 
@@ -472,7 +477,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			s.reconnect.Store(true)
 			// Trigger goroutine that will attempt the connection. s.centralConnectionFactory.*Signal() should be
 			// checked to probe connection state.
-			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection)
+			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
 			return wrapOrNewError(s.centralCommunication.Stopped().Err(), "communication stopped")
 		case <-s.stoppedSig.WaitC():
 			// This means sensor was signaled to finish, this error shouldn't be retried

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -42,7 +42,7 @@ func (f *fakeGRPCClient) OverwriteCentralConnection(newConn *grpc.ClientConn) {
 
 // SetCentralConnectionWithRetries is the implementation of the concurrent function SetCentralConnectionWithRetries
 // that sensor uses to set the gRPC connection to all its components. Present test version simply.
-func (f *fakeGRPCClient) SetCentralConnectionWithRetries(ptr *util.LazyClientConn) {
+func (f *fakeGRPCClient) SetCentralConnectionWithRetries(ptr *util.LazyClientConn, _ centralclient.CertLoader) {
 	f.connMtx.Lock()
 	defer f.connMtx.Unlock()
 	ptr.Set(f.conn)

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -53,14 +53,17 @@ func main() {
 		sharedClientInterface = client.MustCreateInterface()
 	}
 	clientconn.SetUserAgent(clientconn.Sensor)
-	centralConnFactory, err := centralclient.NewCentralConnectionFactory(env.CentralEndpoint.Setting())
+	centralClient, err := centralclient.NewClient(env.CentralEndpoint.Setting())
 	if err != nil {
-		utils.CrashOnError(errors.Wrapf(err, "sensor failed to start while initializing gRPC client to endpoint %s", env.CentralEndpoint.Setting()))
+		utils.CrashOnError(errors.Wrapf(err, "sensor failed to start while initializing central HTTP client for endpoint %s", env.CentralEndpoint.Setting()))
 	}
+	centralConnFactory := centralclient.NewCentralConnectionFactory(centralClient)
+	certLoader := centralclient.RemoteCertLoader(centralClient)
 
 	s, err := sensor.CreateSensor(sensor.ConfigWithDefaults().
 		WithK8sClient(sharedClientInterface).
 		WithCentralConnectionFactory(centralConnFactory).
+		WithCertLoader(certLoader).
 		WithWorkloadManager(workloadManager))
 	utils.CrashOnError(err)
 

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -16,6 +16,7 @@ import (
 type CreateOptions struct {
 	workloadManager                    *fake.WorkloadManager
 	centralConnFactory                 centralclient.CentralConnectionFactory
+	certLoader                         centralclient.CertLoader
 	localSensor                        bool
 	k8sClient                          client.Interface
 	traceWriter                        io.Writer
@@ -36,6 +37,7 @@ func ConfigWithDefaults() *CreateOptions {
 	return &CreateOptions{
 		workloadManager:                    nil,
 		centralConnFactory:                 nil,
+		certLoader:                         centralclient.EmptyCertLoader(),
 		k8sClient:                          nil,
 		localSensor:                        false,
 		traceWriter:                        nil,
@@ -65,6 +67,11 @@ func (cfg *CreateOptions) WithWorkloadManager(manager *fake.WorkloadManager) *Cr
 // Default: nil
 func (cfg *CreateOptions) WithCentralConnectionFactory(centralConnFactory centralclient.CentralConnectionFactory) *CreateOptions {
 	cfg.centralConnFactory = centralConnFactory
+	return cfg
+}
+
+func (cfg *CreateOptions) WithCertLoader(certLoader centralclient.CertLoader) *CreateOptions {
+	cfg.certLoader = certLoader
 	return cfg
 }
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -210,6 +210,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		imageService,
 		cfg.centralConnFactory,
 		pubSub,
+		cfg.certLoader,
 		components...,
 	)
 

--- a/sensor/tests/helper/http.go
+++ b/sensor/tests/helper/http.go
@@ -1,0 +1,81 @@
+package helper
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/initca"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func NewCentralHTTPTestServer(t *testing.T) *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/kernel-objects/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("probe"))
+	})
+	handler.HandleFunc("/api/extensions/scannerdefinitions", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("definitions"))
+	})
+
+	ca := generateAdditionalCA(t)
+	serverCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{issuedCertToTLSCertificate(t, serverCert)},
+	}
+	server.StartTLS()
+	return server
+}
+
+func generateAdditionalCA(t *testing.T) mtls.CA {
+	req := csr.CertificateRequest{
+		CN:         "localhost test certificate", // should NOT be StackRox CA Common Name
+		KeyRequest: csr.NewKeyRequest(),
+		Hosts:      []string{"localhost"},
+	}
+
+	caCert, _, caKey, err := initca.New(&req)
+	require.NoError(t, err)
+	ca, err := mtls.LoadCAForSigning(caCert, caKey)
+	require.NoError(t, err)
+	return ca
+}
+
+func NewHTTPTestClient(t *testing.T, serviceType storage.ServiceType) *http.Client {
+	issuedCert, err := mtls.IssueNewCert(
+		mtls.NewInitSubject(
+			centralsensor.RegisteredInitCertClusterID,
+			serviceType,
+			uuid.NewV4()))
+	require.NoError(t, err)
+	clientCert := issuedCertToTLSCertificate(t, issuedCert)
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{clientCert},
+		},
+	}
+
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+}
+
+func issuedCertToTLSCertificate(t *testing.T, collectorCert *mtls.IssuedCert) tls.Certificate {
+	clientCert, err := tls.X509KeyPair(collectorCert.CertPEM, collectorCert.KeyPEM)
+	require.NoError(t, err)
+	clientCert.Leaf = collectorCert.X509Cert
+	return clientCert
+}


### PR DESCRIPTION
## Description
This change adds trusted TLS certificates to HTTP connections in addition to gRPC, allowing you to connect to Central running behind a proxy/load balancer without configuring additional CA certificates.

There is functionality in sensor to allow loading and trusting a user's TLS certificate when Central is running behind a proxy or load balancer (see [ROX-5710](https://issues.redhat.com/browse/ROX-5710)).
This seems to work only for a persistent grpc connection, but not for proxying collector calls to load kernel modules from Central (see [ROX-19868](https://issues.redhat.com/browse/ROX-19868)).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Tested manually on an infra cluster.

#### Steps to reproduce
1. Install Central on an infra cluster. I used Stackrox operator v4.4.0
2. Create a re-encrypt route for Central exposure with ingress TLS certificate. Specify the Central CA certificate taken from `central-tls` secret in the route spec.
3. Configure additional CAs on **Central side** as described [here](https://docs.openshift.com/acs/4.4/configuration/add-trusted-ca.html). Take the ingress CA certificate as an additional CA:
```
oc -n openshift-ingress get secret router-certs-default -o json
```
5. Install the secured cluster on a dev cluster (colima) with helm:
Generate an Init bundle:
```
roxctl --insecure-skip-tls-verify --password $ROX_PASSWORD central init-bundles generate stackrox-init-bundle --endpoint=$REENCRYPT_ENDPOINT --output - > ~/tmp/2024-04-22/stackrox-init-bundle.yaml
```
Install the helm chart.
```
helm upgrade -i --namespace=stackrox --create-namespace stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services --version 400.4.0 --values ~/tmp/2024-04-22/stackrox-init-bundle.yaml --set clusterName="$CLUSTER_NAME" --set sensor.resources.requests.memory=500Mi --set sensor.resources.requests.cpu=500m --set sensor.resources.limits.memory=500Mi --set sensor.resources.limits.cpu=500m --set centralEndpoint="wss://$REENCRYPT_ENDPOINT" --set collector.forceCollectionMethod=true --set collector.collectionMethod=EBPF
```
**Note:**
* Force EBPF collection method to make collector-slim pull the kernel module through Sensor. 
* Connection through websocket was necessary to successfully establish connection through the re-encrypt endpoint. 


#### Results
###### Secured Cluster v4.4.0

Sensor logs:
```
pkg/probeupload: 2024/04/23 11:14:12.388163 server_handler.go:111: Error: error loading probe 2.9.0/collector-ebpf-6.5.0-15-generic.o.gz: making upstream request: Get "/kernel-objects/2.9.0/collector-ebpf-6.5.0-15-generic.o.gz": x509: certificate signed by unknown authority
```

Collector logs:
```
[INFO    2024/04/23 11:53:25] Candidate drivers:                                                                                                                                                                  
[INFO    2024/04/23 11:53:25] collector-ebpf-6.5.0-15-generic.o                                                                                                                                                   
[INFO    2024/04/23 11:53:25] Attempting to download collector-ebpf-6.5.0-15-generic.o                                                                                                                            
[INFO    2024/04/23 11:53:25] Attempting to download kernel object from https://sensor.stackrox.svc:443/kernel-objects/2.9.0/collector-ebpf-6.5.0-15-generic.o.gz                                                 
[WARNING 2024/04/23 11:53:25] [Throttled] Unexpected HTTP request failure (HTTP 500)                                                                                                                              
[WARNING 2024/04/23 11:53:35] [Throttled] Unexpected HTTP request failure (HTTP 500)                                                                                                                              
[WARNING 2024/04/23 11:53:45] [Throttled] Unexpected HTTP request failure (HTTP 500)
```

###### Secured Cluster v4.4.x-472-g785e7d3762

Sensor logs:
```
pkg/kocache: 2024/04/23 11:26:46.261285 source.go:64: Info: loading probe 2.9.0/collector-ebpf-6.5.0-15-generic.o.gz from upstream /kernel-objects   
```

Collector logs:
```
[INFO    2024/04/23 11:26:53] == Collector Startup Diagnostics: ==          [INFO    2024/04/23 11:26:53]  Connected to Sensor?       true              [INFO    2024/04/23 11:26:53]  Kernel driver candidates:                    [INFO    2024/04/23 11:26:53]    collector-ebpf-6.5.0-15-generic.o (available)                                                                 [INFO    2024/04/23 11:26:53]  Driver loaded into kernel: collector-ebpf-6.5.0-15-generic.o
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
