### PR TITLE
ROX-22019: Cleanup usage of XXX_OneofWrappers internal func

### DIFF
--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -451,13 +451,11 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 		case reflect.Float32, reflect.Float64:
 			schema.AddFieldWithType(field, postgres.Numeric, opts)
 		case reflect.Interface:
-			// If it is a oneof then call XXX_OneofWrappers to get the types.
-			// The return values is a slice of interfaces that are nil type pointers
 			if structField.Tag.Get("protobuf_oneof") == "" {
 				panic("non-oneof interface is not handled")
 			}
 
-			oneOfFieldTypes := protocompat.GetOneOfFieldTypes(original, i)
+			oneOfFieldTypes := protocompat.GetOneOfTypesByFieldIndex(original, i)
 			for _, oneOfFieldType := range oneOfFieldTypes {
 				handleStruct(ctx, schema, oneOfFieldType.Elem())
 			}

--- a/pkg/protocompat/oneof.go
+++ b/pkg/protocompat/oneof.go
@@ -8,7 +8,15 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func GetOneOfFieldTypes(msgType reflect.Type, fieldIndex int) []reflect.Type {
+func oneOfFieldTypeSorter(a reflect.Type, b reflect.Type) int {
+	if a.Kind() != reflect.Ptr || b.Kind() != reflect.Ptr {
+		return 0
+	}
+
+	return strings.Compare(a.Elem().Name(), b.Elem().Name())
+}
+
+func GetOneOfTypesByFieldIndex(msgType reflect.Type, fieldIndex int) []reflect.Type {
 	oneOfFieldTypes := make([]reflect.Type, 0)
 
 	structProps := proto.GetProperties(msgType)
@@ -24,13 +32,24 @@ func GetOneOfFieldTypes(msgType reflect.Type, fieldIndex int) []reflect.Type {
 		oneOfFieldTypes = append(oneOfFieldTypes, oneOfField.Type)
 	}
 
-	slices.SortFunc(oneOfFieldTypes, func(a reflect.Type, b reflect.Type) int {
-		if a.Kind() != reflect.Ptr || b.Kind() != reflect.Ptr {
-			return 0
+	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeSorter)
+
+	return oneOfFieldTypes
+}
+
+func GetOneOfTypesByInterface(msgType reflect.Type, oneOfInterfaceType reflect.Type) []reflect.Type {
+	oneOfFieldTypes := make([]reflect.Type, 0)
+
+	structProps := proto.GetProperties(msgType)
+	for _, oneOfField := range structProps.OneofTypes {
+		if !oneOfField.Type.Implements(oneOfInterfaceType) {
+			continue
 		}
 
-		return strings.Compare(a.Elem().Name(), b.Elem().Name())
-	})
+		oneOfFieldTypes = append(oneOfFieldTypes, oneOfField.Type)
+	}
+
+	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeSorter)
 
 	return oneOfFieldTypes
 }

--- a/pkg/protocompat/oneof.go
+++ b/pkg/protocompat/oneof.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func oneOfFieldTypeSorter(a reflect.Type, b reflect.Type) int {
+func oneOfFieldTypeCmp(a reflect.Type, b reflect.Type) int {
 	if a.Kind() != reflect.Ptr || b.Kind() != reflect.Ptr {
 		return 0
 	}
@@ -32,7 +32,7 @@ func GetOneOfTypesByFieldIndex(msgType reflect.Type, fieldIndex int) []reflect.T
 		oneOfFieldTypes = append(oneOfFieldTypes, oneOfField.Type)
 	}
 
-	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeSorter)
+	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeCmp)
 
 	return oneOfFieldTypes
 }
@@ -49,7 +49,7 @@ func GetOneOfTypesByInterface(msgType reflect.Type, oneOfInterfaceType reflect.T
 		oneOfFieldTypes = append(oneOfFieldTypes, oneOfField.Type)
 	}
 
-	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeSorter)
+	slices.SortFunc(oneOfFieldTypes, oneOfFieldTypeCmp)
 
 	return oneOfFieldTypes
 }

--- a/pkg/search/walker.go
+++ b/pkg/search/walker.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoreflect"
 	"github.com/stackrox/rox/pkg/search/enumregistry"
 	"github.com/stackrox/rox/pkg/stringutils"
@@ -106,34 +107,12 @@ func (s *searchWalker) handleStruct(prefix string, original reflect.Type) {
 			s.fields[FieldLabel(fieldName)] = searchField
 			continue
 		}
-		// If it is a oneof then call XXX_OneofWrappers to get the types.
-		// The return values is a slice of interfaces that are nil type pointers
+		// For oneof fields, get the types and return values as a slice of
+		// interfaces that are nil type pointers.
 		if field.Tag.Get("protobuf_oneof") != "" {
-			ptrToOriginal := reflect.PtrTo(original)
-
-			methodName := fmt.Sprintf("Get%s", field.Name)
-			oneofGetter, ok := ptrToOriginal.MethodByName(methodName)
-			if !ok {
-				panic("didn't find oneof function, did the naming change?")
-			}
-			oneofInterfaces := oneofGetter.Func.Call([]reflect.Value{reflect.New(original)})
-			if len(oneofInterfaces) != 1 {
-				panic(fmt.Sprintf("found %d interfaces returned from oneof getter", len(oneofInterfaces)))
-			}
-
-			oneofInterface := oneofInterfaces[0].Type()
-
-			method, ok := ptrToOriginal.MethodByName("XXX_OneofWrappers")
-			if !ok {
-				panic(fmt.Sprintf("XXX_OneofWrappers should exist for all protobuf oneofs, not found for %s", original.Name()))
-			}
-			out := method.Func.Call([]reflect.Value{reflect.New(original)})
-			actualOneOfFields := out[0].Interface().([]interface{})
-			for _, f := range actualOneOfFields {
-				typ := reflect.TypeOf(f)
-				if typ.Implements(oneofInterface) {
-					s.walkRecursive(fullPath, typ)
-				}
+			oneOfFieldTypes := protocompat.GetOneOfTypesByFieldIndex(original, i)
+			for _, oneOfFieldType := range oneOfFieldTypes {
+				s.walkRecursive(fullPath, oneOfFieldType)
 			}
 			continue
 		}


### PR DESCRIPTION
## Description

This PR cleans up usage of internal `XXX_OneofWrappers` function.

Made changes:
- added function (with tests) to get oneof types by interface
- refactor function name use to get oneof type by field index
- remove all usages of `XXX_OneofWrappers`
- adjust comments and clean them up too

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

- Introduced unit test
- CI run

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
