### PR TITLE
ROX-22019: Prepare graphql codegen for proto V2

### DIFF
--- a/central/graphql/generator/codegen/schema.go
+++ b/central/graphql/generator/codegen/schema.go
@@ -65,9 +65,6 @@ func makeSchemaEntries(data []typeData) []schemaEntry {
 }
 
 func schemaType(fd fieldData) string {
-	if strings.HasPrefix(fd.Name, "XXX_") {
-		return ""
-	}
 	if strings.ToLower(fd.Name) == "id" && fd.Type.Kind() == reflect.String {
 		return "ID!"
 	}

--- a/central/graphql/generator/codegen/typewalk.go
+++ b/central/graphql/generator/codegen/typewalk.go
@@ -123,7 +123,7 @@ func (ctx *walkState) walkType(typeDesc typeDescriptor) {
 }
 
 func (ctx *walkState) walkField(td *typeData, p reflect.Type, sf reflect.StructField) {
-	if len(sf.Name) > 4 && sf.Name[:4] == "XXX_" {
+	if protoreflect.IsInternalGeneratorField(sf) {
 		return
 	}
 	if strings.HasPrefix(sf.Name, "DEPRECATED") {

--- a/central/graphql/generator/codegen/typewalk.go
+++ b/central/graphql/generator/codegen/typewalk.go
@@ -129,7 +129,7 @@ func (ctx *walkState) walkField(td *typeData, p reflect.Type, sf reflect.StructF
 	if strings.HasPrefix(sf.Name, "DEPRECATED") {
 		return
 	}
-	ctx.typeQueue = append(ctx.typeQueue, typeDescriptor{ty: sf.Type})
+	ctx.typeQueue = append(ctx.typeQueue, typeDescriptor{ty: sf.Type, isInputType: td.IsInputType})
 	if !rejectedField(p, sf, ctx.skipFields) {
 		td.FieldData = append(td.FieldData, fieldData{
 			Name: sf.Name,

--- a/central/graphql/generator/codegen/typewalk.go
+++ b/central/graphql/generator/codegen/typewalk.go
@@ -123,7 +123,7 @@ func (ctx *walkState) walkType(typeDesc typeDescriptor) {
 }
 
 func (ctx *walkState) walkField(td *typeData, p reflect.Type, sf reflect.StructField) {
-	if protoreflect.IsInternalGeneratorField(sf) {
+	if !td.IsInputType && protoreflect.IsInternalGeneratorField(sf) {
 		return
 	}
 	if strings.HasPrefix(sf.Name, "DEPRECATED") {


### PR DESCRIPTION
## Description

This PR removes usage or `XXX_` fields in the GraphQL generator.

*Note for reviewers*
- check in `schemaType` looks redundant because all proto structs are populated by `walkField`.
- we are getting mix of proto structs and internal structs in `walkField` (list is in: `central/graphql/resolvers/gen/main.go`). The way to differentiate them is by `isInputType` properly.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Style checks because generated files will be different if a field is added/removed.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
