### PR TITLE
chore: Make Scanner's `CGO_ENABLED` overriding as desired

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -24,7 +24,7 @@ ifeq ($(shell uname -s),Darwin)
 	HOST_OS := darwin
 endif
 
-CGO_ENABLED := 0
+CGO_ENABLED ?= 0
 GOOS := $(HOST_OS)
 
 GO_BUILD_FLAGS = CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH}

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /src
 
 RUN scripts/konflux/fail-build-if-git-is-dirty.sh
 
-RUN make -C scanner NODEPS=1 CGO_ENABLED=${CGO_ENABLED} image/scanner/bin/scanner copy-scripts
+RUN make -C scanner NODEPS=1 image/scanner/bin/scanner copy-scripts
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 


### PR DESCRIPTION
## Description

While going through Scanner Makefile I noticed an inconsistency.
`CGO_ENABLED` is declared with `:=` assignment.
https://github.com/stackrox/stackrox/blob/375158c88a64acffd237ff1dd78b395f12b5dbed/scanner/Makefile#L27

and in the [downstream Dockerfile](https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/blob/2fc0fe21cbcd4e4ee5646caf2f2bb9825c7dab6c/distgit/containers/rhacs-scanner-v4/Dockerfile.in#L6-18) it is defined **twice**.
First, as the environment variable
```Dockerfile
ENV CGO_ENABLED=1
```
Second, as the Makefile variable override
```Dockerfile
RUN make ... CGO_ENABLED=${CGO_ENABLED} ...
```
We copied the same pattern to `konflux.Dockerfile`.
https://github.com/stackrox/stackrox/blob/375158c88a64acffd237ff1dd78b395f12b5dbed/scanner/image/scanner/konflux.Dockerfile#L10
https://github.com/stackrox/stackrox/blob/375158c88a64acffd237ff1dd78b395f12b5dbed/scanner/image/scanner/konflux.Dockerfile#L22

The problem is that
```Dockerfile
ENV CGO_ENABLED=1
```
alone is not enough to set the value of a Makefile variable `CGO_ENABLED`. That is because of `:=` assignment (just `=` would give equivalent results).

**In order to use environment variable's value for `CGO_ENABLED`**, one either must not be assigned at all in the `Makefile`, or `?=` assignment must be used.

It can be simply illustrated by this:

```
$ cat Makefile
CGO_ENABLED := 0
FOO_ENABLED ?= 0

.PHONY: blah
blah:
	@echo "Cgo state is: $(CGO_ENABLED)"
	@echo "compare it to foo which is: $(FOO_ENABLED)"

$ make
Cgo state is: 0
compare it to foo which is: 0

$ CGO_ENABLED=500 FOO_ENABLED=500 make
Cgo state is: 0
compare it to foo which is: 500

$ make CGO_ENABLED=500 FOO_ENABLED=500     
Cgo state is: 500
compare it to foo which is: 500
```

In this change I switch from `:=` to `?=` in the Makefile and remove a redundant override from `konflux.Dockerfile`. Downstream Dockerfile needs to be adjusted subsequently.

Alternatively, we can retain `CGO_ENABLED := 0` and use makefile override `make VAR=value` (and not environment variable approach `VAR=value make`) in which case we must change `ENV CGO_ENABLED=1` to `ARG CGO_ENABLED=1` in the Dockerfile to stop misleading. Leaving this decision to you as a reviewer.

## Checklist
- [ ] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Will pull Konflux-built image and check `CGO_ENABLED` is `1` in the binary there with `go version -m <scanner-binary>`.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
