### PR TITLE
chore(ui): Refactor Node/Platform CVE tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -68,7 +68,7 @@ describe(Cypress.spec.relative, () => {
             setup({ type: 'EMPTY' });
 
             cy.findByText('No results found');
-            cy.findByText('No nodes are detected to have been reported for this CVE');
+            cy.findByText('There are no nodes that are affected by this CVE');
         });
 
         it('should render a message when a filter results in no data', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -130,7 +130,7 @@ function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
                 tableState={tableState}
                 colSpan={colSpan}
                 emptyProps={{
-                    message: 'No nodes are detected to have been reported for this CVE',
+                    message: 'There are no nodes that are affected by this CVE',
                 }}
                 renderer={({ data }) =>
                     data.map((node, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -4,12 +4,6 @@ import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternf
 import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
-import {
-    TbodyLoading,
-    TbodyError,
-    TbodyEmpty,
-    TbodyFilteredEmpty,
-} from 'Components/TableStateTemplates';
 import { TableUIState } from 'utils/getTableUIState';
 
 import useSet from 'hooks/useSet';
@@ -19,6 +13,7 @@ import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/Vulner
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 
 import CvssFormatted from 'Components/CvssFormatted';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import NodeComponentsTable from './NodeComponentsTable';
 
@@ -131,75 +126,72 @@ function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
                     <Th>Affected components</Th>
                 </Tr>
             </Thead>
-            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
-            {tableState.type === 'ERROR' && (
-                <TbodyError colSpan={colSpan} error={tableState.error} />
-            )}
-            {tableState.type === 'EMPTY' && (
-                <TbodyEmpty
-                    colSpan={colSpan}
-                    message="No nodes are detected to have been reported for this CVE"
-                />
-            )}
-            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
-            {tableState.type === 'COMPLETE' &&
-                tableState.data.map((node, rowIndex) => {
-                    const { id, name, nodeComponents } = node;
-                    const isExpanded = expandedRowSet.has(id);
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={colSpan}
+                emptyProps={{
+                    message: 'No nodes are detected to have been reported for this CVE',
+                }}
+                renderer={({ data }) =>
+                    data.map((node, rowIndex) => {
+                        const { id, name, nodeComponents } = node;
+                        const isExpanded = expandedRowSet.has(id);
 
-                    const vulns = nodeComponents.flatMap(
-                        ({ nodeVulnerabilities }) => nodeVulnerabilities
-                    );
-                    const topSeverity = getHighestVulnerabilitySeverity(vulns);
-                    const isFixable = getAnyVulnerabilityIsFixable(vulns);
-                    const { cvss, scoreVersion } = getHighestCvssScore(vulns);
+                        const vulns = nodeComponents.flatMap(
+                            ({ nodeVulnerabilities }) => nodeVulnerabilities
+                        );
+                        const topSeverity = getHighestVulnerabilitySeverity(vulns);
+                        const isFixable = getAnyVulnerabilityIsFixable(vulns);
+                        const { cvss, scoreVersion } = getHighestCvssScore(vulns);
 
-                    return (
-                        <Tbody key={id} isExpanded={isExpanded}>
-                            <Tr>
-                                <Td
-                                    expand={{
-                                        rowIndex,
-                                        isExpanded,
-                                        onToggle: () => expandedRowSet.toggle(id),
-                                    }}
-                                />
+                        return (
+                            <Tbody key={id} isExpanded={isExpanded}>
+                                <Tr>
+                                    <Td
+                                        expand={{
+                                            rowIndex,
+                                            isExpanded,
+                                            onToggle: () => expandedRowSet.toggle(id),
+                                        }}
+                                    />
 
-                                <Td dataLabel="Node">
-                                    <Link to={getNodeEntityPagePath('Node', id)}>
-                                        <Truncate position="middle" content={name} />
-                                    </Link>
-                                </Td>
-                                <Td dataLabel="CVE severity" modifier="nowrap">
-                                    <VulnerabilitySeverityIconText severity={topSeverity} />
-                                </Td>
-                                <Td dataLabel="CVE status" modifier="nowrap">
-                                    <VulnerabilityFixableIconText isFixable={isFixable} />
-                                </Td>
-                                <Td dataLabel="CVSS score" modifier="nowrap">
-                                    <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
-                                </Td>
-                                <Td dataLabel="Cluster">
-                                    <Truncate position="middle" content={node.cluster.name} />
-                                </Td>
-                                <Td dataLabel="Operating system">{node.operatingSystem}</Td>
-                                <Td dataLabel="Affected components">
-                                    {nodeComponents.length === 1
-                                        ? nodeComponents[0].name
-                                        : pluralize(nodeComponents.length, 'component')}
-                                </Td>
-                            </Tr>
-                            <Tr isExpanded={isExpanded}>
-                                <Td />
-                                <Td colSpan={colSpan - 1}>
-                                    <ExpandableRowContent>
-                                        <NodeComponentsTable />
-                                    </ExpandableRowContent>
-                                </Td>
-                            </Tr>
-                        </Tbody>
-                    );
-                })}
+                                    <Td dataLabel="Node">
+                                        <Link to={getNodeEntityPagePath('Node', id)}>
+                                            <Truncate position="middle" content={name} />
+                                        </Link>
+                                    </Td>
+                                    <Td dataLabel="CVE severity" modifier="nowrap">
+                                        <VulnerabilitySeverityIconText severity={topSeverity} />
+                                    </Td>
+                                    <Td dataLabel="CVE status" modifier="nowrap">
+                                        <VulnerabilityFixableIconText isFixable={isFixable} />
+                                    </Td>
+                                    <Td dataLabel="CVSS score" modifier="nowrap">
+                                        <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
+                                    </Td>
+                                    <Td dataLabel="Cluster">
+                                        <Truncate position="middle" content={node.cluster.name} />
+                                    </Td>
+                                    <Td dataLabel="Operating system">{node.operatingSystem}</Td>
+                                    <Td dataLabel="Affected components">
+                                        {nodeComponents.length === 1
+                                            ? nodeComponents[0].name
+                                            : pluralize(nodeComponents.length, 'component')}
+                                    </Td>
+                                </Tr>
+                                <Tr isExpanded={isExpanded}>
+                                    <Td />
+                                    <Td colSpan={colSpan - 1}>
+                                        <ExpandableRowContent>
+                                            <NodeComponentsTable />
+                                        </ExpandableRowContent>
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
+                }
+            />
         </Table>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -40,9 +40,7 @@ import AffectedNodesSummaryCard from './AffectedNodesSummaryCard';
 import useAffectedNodes from './useAffectedNodes';
 import useNodeCveMetadata from './useNodeCveMetadata';
 
-const workloadCveOverviewCvePath = getOverviewPagePath('Node', {
-    entityTab: 'CVE',
-});
+const nodeCveOverviewCvePath = getOverviewPagePath('Node', { entityTab: 'CVE' });
 
 function NodeCvePage() {
     const { searchFilter } = useURLSearch();
@@ -79,9 +77,7 @@ function NodeCvePage() {
             <PageTitle title={`Node CVEs - NodeCVE ${nodeCveName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
-                        Node CVEs
-                    </BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={nodeCveOverviewCvePath}>Node CVEs</BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {nodeCveName ?? (
                             <Skeleton screenreaderText="Loading CVE name" width="200px" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Text } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { gql, useQuery } from '@apollo/client';
 
-import {
-    TbodyLoading,
-    TbodyError,
-    TbodyEmpty,
-    TbodyFilteredEmpty,
-} from 'Components/TableStateTemplates';
 import useSet from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
 import { getTableUIState } from 'utils/getTableUIState';
@@ -18,68 +11,14 @@ import TooltipTh from 'Components/TooltipTh';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
-import { getNodeEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import PartialCVEDataAlert from '../../WorkloadCves/components/PartialCVEDataAlert';
 import { getScoreVersionsForTopCVSS, sortCveDistroList } from '../../utils/sortUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { QuerySearchFilter } from '../../types';
-
-const cvesListQuery = gql`
-    query getNodeCVEs($query: String, $pagination: Pagination) {
-        nodeCVEs(query: $query, pagination: $pagination) {
-            cve
-            nodeCountBySeverity {
-                critical {
-                    total
-                }
-                important {
-                    total
-                }
-                moderate {
-                    total
-                }
-                low {
-                    total
-                }
-            }
-            topCVSS
-            affectedNodeCount
-            firstDiscoveredInSystem
-            distroTuples {
-                summary
-                operatingSystem
-                cvss
-                scoreVersion
-            }
-        }
-    }
-`;
-
-const totalNodeCountQuery = gql`
-    query getTotalNodeCount {
-        nodeCount
-    }
-`;
-
-// TODO Need to verify these types with the BE implementation
-export type NodeCVE = {
-    cve: string;
-    nodeCountBySeverity: {
-        critical: { total: number };
-        important: { total: number };
-        moderate: { total: number };
-        low: { total: number };
-    };
-    topCVSS: number;
-    affectedNodeCount: number;
-    firstDiscoveredInSystem: string;
-    distroTuples: {
-        summary: string;
-        operatingSystem: string;
-        cvss: number;
-        scoreVersion: string;
-    }[];
-};
+import useNodeCves from './useNodeCves';
+import useTotalNodeCount from './useTotalNodeCount';
 
 export type CVEsTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -89,27 +28,9 @@ export type CVEsTableProps = {
 
 function CVEsTable({ querySearchFilter, isFiltered, pagination }: CVEsTableProps) {
     const { page, perPage } = pagination;
-    const { data, previousData, loading, error } = useQuery<
-        { nodeCVEs: NodeCVE[] },
-        {
-            query: string;
-            pagination: {
-                offset: number;
-                limit: number;
-            };
-        }
-    >(cvesListQuery, {
-        variables: {
-            query: getRegexScopedQueryString(querySearchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-            },
-        },
-    });
 
-    const totalNodeCountRequest = useQuery<{ nodeCount: number }>(totalNodeCountQuery);
-    const totalNodeCount = totalNodeCountRequest.data?.nodeCount ?? 0;
+    const { data, previousData, loading, error } = useNodeCves(querySearchFilter, page, perPage);
+    const totalNodeCount = useTotalNodeCount();
 
     const tableData = data ?? previousData;
     const tableState = getTableUIState({
@@ -146,84 +67,85 @@ function CVEsTable({ querySearchFilter, isFiltered, pagination }: CVEsTableProps
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
-            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
-            {tableState.type === 'ERROR' && (
-                <TbodyError colSpan={colSpan} error={tableState.error} />
-            )}
-            {tableState.type === 'EMPTY' && (
-                <TbodyEmpty
-                    colSpan={colSpan}
-                    message="No Platform CVEs have been reported for your secured clusters"
-                />
-            )}
-            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
-            {tableState.type === 'COMPLETE' &&
-                tableState.data.map((nodeCve, rowIndex) => {
-                    const {
-                        cve,
-                        nodeCountBySeverity: { critical, important, moderate, low },
-                        distroTuples,
-                        topCVSS,
-                        affectedNodeCount,
-                        firstDiscoveredInSystem,
-                    } = nodeCve;
-                    const isExpanded = expandedRowSet.has(cve);
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={colSpan}
+                emptyProps={{
+                    message: 'No Platform CVEs have been reported for your secured clusters',
+                }}
+                renderer={({ data }) =>
+                    data.map((nodeCve, rowIndex) => {
+                        const {
+                            cve,
+                            nodeCountBySeverity: { critical, important, moderate, low },
+                            distroTuples,
+                            topCVSS,
+                            affectedNodeCount,
+                            firstDiscoveredInSystem,
+                        } = nodeCve;
+                        const isExpanded = expandedRowSet.has(cve);
 
-                    const prioritizedDistros = sortCveDistroList(distroTuples);
-                    const summary =
-                        prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
-                    const scoreVersions = getScoreVersionsForTopCVSS(topCVSS, distroTuples);
+                        const prioritizedDistros = sortCveDistroList(distroTuples);
+                        const summary =
+                            prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
+                        const scoreVersions = getScoreVersionsForTopCVSS(topCVSS, distroTuples);
 
-                    return (
-                        <Tbody key={cve} isExpanded={isExpanded}>
-                            <Tr>
-                                <Td
-                                    expand={{
-                                        rowIndex,
-                                        isExpanded,
-                                        onToggle: () => expandedRowSet.toggle(cve),
-                                    }}
-                                />
-                                <Td dataLabel="CVE" modifier="nowrap">
-                                    <Link to={getNodeEntityPagePath('CVE', cve)}>{cve}</Link>
-                                </Td>
-                                <Td dataLabel="Nodes by severity">
-                                    <SeverityCountLabels
-                                        criticalCount={critical.total}
-                                        importantCount={important.total}
-                                        moderateCount={moderate.total}
-                                        lowCount={low.total}
-                                        // TODO - Add filtered severities once filter toolbar is in place
+                        return (
+                            <Tbody key={cve} isExpanded={isExpanded}>
+                                <Tr>
+                                    <Td
+                                        expand={{
+                                            rowIndex,
+                                            isExpanded,
+                                            onToggle: () => expandedRowSet.toggle(cve),
+                                        }}
                                     />
-                                </Td>
-                                <Td dataLabel="Top CVSS">
-                                    <CvssFormatted
-                                        cvss={topCVSS}
-                                        scoreVersion={
-                                            scoreVersions.length > 0
-                                                ? scoreVersions.join('/')
-                                                : undefined
-                                        }
-                                    />
-                                </Td>
-                                <Td dataLabel="Affected nodes">
-                                    {affectedNodeCount} / {totalNodeCount} affected nodes
-                                </Td>
-                                <Td dataLabel="First discovered">
-                                    <DateDistance date={firstDiscoveredInSystem} />
-                                </Td>
-                            </Tr>
-                            <Tr isExpanded={isExpanded}>
-                                <Td />
-                                <Td colSpan={colSpan - 1}>
-                                    <ExpandableRowContent>
-                                        {summary ? <Text>{summary}</Text> : <PartialCVEDataAlert />}
-                                    </ExpandableRowContent>
-                                </Td>
-                            </Tr>
-                        </Tbody>
-                    );
-                })}
+                                    <Td dataLabel="CVE" modifier="nowrap">
+                                        <Link to={getNodeEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    </Td>
+                                    <Td dataLabel="Nodes by severity">
+                                        <SeverityCountLabels
+                                            criticalCount={critical.total}
+                                            importantCount={important.total}
+                                            moderateCount={moderate.total}
+                                            lowCount={low.total}
+                                            // TODO - Add filtered severities once filter toolbar is in place
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Top CVSS">
+                                        <CvssFormatted
+                                            cvss={topCVSS}
+                                            scoreVersion={
+                                                scoreVersions.length > 0
+                                                    ? scoreVersions.join('/')
+                                                    : undefined
+                                            }
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Affected nodes">
+                                        {affectedNodeCount} / {totalNodeCount} affected nodes
+                                    </Td>
+                                    <Td dataLabel="First discovered">
+                                        <DateDistance date={firstDiscoveredInSystem} />
+                                    </Td>
+                                </Tr>
+                                <Tr isExpanded={isExpanded}>
+                                    <Td />
+                                    <Td colSpan={colSpan - 1}>
+                                        <ExpandableRowContent>
+                                            {summary ? (
+                                                <Text>{summary}</Text>
+                                            ) : (
+                                                <PartialCVEDataAlert />
+                                            )}
+                                        </ExpandableRowContent>
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
+                }
+            />
         </Table>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -71,7 +71,7 @@ function CVEsTable({ querySearchFilter, isFiltered, pagination }: CVEsTableProps
                 tableState={tableState}
                 colSpan={colSpan}
                 emptyProps={{
-                    message: 'No Platform CVEs have been reported for your secured clusters',
+                    message: 'No CVEs have been detected for nodes across your secured clusters',
                 }}
                 renderer={({ data }) =>
                     data.map((nodeCve, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -74,7 +74,7 @@ function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTablePro
                         } = node;
                         const { critical, important, moderate, low } = nodeCVECountBySeverity;
                         return (
-                            <Tr key={node.id}>
+                            <Tr key={id}>
                                 <Td dataLabel="Node" modifier="nowrap">
                                     <Link to={getNodeEntityPagePath('Node', id)}>
                                         <Truncate position="middle" content={name} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -2,76 +2,18 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Truncate } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { gql, useQuery } from '@apollo/client';
 
 import DateDistance from 'Components/DateDistance';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
-import {
-    TbodyLoading,
-    TbodyError,
-    TbodyEmpty,
-    TbodyFilteredEmpty,
-} from 'Components/TableStateTemplates';
 import { getTableUIState } from 'utils/getTableUIState';
 import useURLPagination from 'hooks/useURLPagination';
 
 import { vulnerabilitySeverityLabels } from 'messages/common';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { getNodeEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
+import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
-
-const nodeListQuery = gql`
-    query getNodes($query: String, $pagination: Pagination) {
-        nodes(query: $query, pagination: $pagination) {
-            id
-            name
-            nodeCVECountBySeverity {
-                critical {
-                    total
-                }
-                important {
-                    total
-                }
-                moderate {
-                    total
-                }
-                low {
-                    total
-                }
-            }
-            cluster {
-                name
-            }
-            operatingSystem
-            scanTime
-        }
-    }
-`;
-
-// TODO - Verify these types once the BE is implemented
-type Node = {
-    id: string;
-    name: string;
-    nodeCVECountBySeverity: {
-        critical: {
-            total: number;
-        };
-        important: {
-            total: number;
-        };
-        moderate: {
-            total: number;
-        };
-        low: {
-            total: number;
-        };
-    };
-    cluster: {
-        name: string;
-    };
-    operatingSystem: string;
-    scanTime: string;
-};
+import useNodes from './useNodes';
 
 export type NodesTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -81,24 +23,16 @@ export type NodesTableProps = {
 
 function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTableProps) {
     const { page, perPage } = pagination;
-    const { data, previousData, loading, error } = useQuery<{ nodes: Node[] }>(nodeListQuery, {
-        variables: {
-            query: getRegexScopedQueryString(querySearchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-            },
-        },
-    });
 
+    const { data, previousData, loading, error } = useNodes(querySearchFilter, page, perPage);
     const tableData = data ?? previousData;
+
     const tableState = getTableUIState({
         isLoading: loading,
         data: tableData?.nodes,
         error,
         searchFilter: querySearchFilter,
     });
-    const colSpan = 5;
 
     const filteredSeverities = querySearchFilter.SEVERITY?.map(
         (s) => vulnerabilitySeverityLabels[s]
@@ -124,50 +58,51 @@ function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTablePro
                     <Th>Scan time</Th>
                 </Tr>
             </Thead>
-            {tableState.type === 'LOADING' && <TbodyLoading colSpan={colSpan} />}
-            {tableState.type === 'ERROR' && (
-                <TbodyError colSpan={colSpan} error={tableState.error} />
-            )}
-            {tableState.type === 'EMPTY' && (
-                <TbodyEmpty
-                    colSpan={colSpan}
-                    message="No CVEs have been reported for your scanned nodes"
-                />
-            )}
-            {tableState.type === 'FILTERED_EMPTY' && <TbodyFilteredEmpty colSpan={colSpan} />}
-            {tableState.type === 'COMPLETE' &&
-                tableState.data.map((node) => {
-                    const { id, name, nodeCVECountBySeverity, cluster, operatingSystem, scanTime } =
-                        node;
-                    const { critical, important, moderate, low } = nodeCVECountBySeverity;
-                    return (
-                        <Tr key={node.id}>
-                            <Td dataLabel="Node" modifier="nowrap">
-                                <Link to={getNodeEntityPagePath('Node', id)}>
-                                    <Truncate position="middle" content={name} />
-                                </Link>
-                            </Td>
-                            <Td dataLabel="CVEs by severity">
-                                <SeverityCountLabels
-                                    criticalCount={critical.total}
-                                    importantCount={important.total}
-                                    moderateCount={moderate.total}
-                                    lowCount={low.total}
-                                    filteredSeverities={filteredSeverities}
-                                />
-                            </Td>
-                            <Td dataLabel="Cluster" modifier="nowrap">
-                                <Truncate position="middle" content={cluster.name} />
-                            </Td>
-                            <Td dataLabel="Operating system" modifier="nowrap">
-                                {operatingSystem}
-                            </Td>
-                            <Td dataLabel="Scan time">
-                                <DateDistance date={scanTime} />
-                            </Td>
-                        </Tr>
-                    );
-                })}
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={5}
+                emptyProps={{ message: 'No CVEs have been reported for your scanned nodes' }}
+                renderer={({ data }) =>
+                    data.map((node) => {
+                        const {
+                            id,
+                            name,
+                            nodeCVECountBySeverity,
+                            cluster,
+                            operatingSystem,
+                            scanTime,
+                        } = node;
+                        const { critical, important, moderate, low } = nodeCVECountBySeverity;
+                        return (
+                            <Tr key={node.id}>
+                                <Td dataLabel="Node" modifier="nowrap">
+                                    <Link to={getNodeEntityPagePath('Node', id)}>
+                                        <Truncate position="middle" content={name} />
+                                    </Link>
+                                </Td>
+                                <Td dataLabel="CVEs by severity">
+                                    <SeverityCountLabels
+                                        criticalCount={critical.total}
+                                        importantCount={important.total}
+                                        moderateCount={moderate.total}
+                                        lowCount={low.total}
+                                        filteredSeverities={filteredSeverities}
+                                    />
+                                </Td>
+                                <Td dataLabel="Cluster" modifier="nowrap">
+                                    <Truncate position="middle" content={cluster.name} />
+                                </Td>
+                                <Td dataLabel="Operating system" modifier="nowrap">
+                                    {operatingSystem}
+                                </Td>
+                                <Td dataLabel="Scan time">
+                                    <DateDistance date={scanTime} />
+                                </Td>
+                            </Tr>
+                        );
+                    })
+                }
+            />
         </Table>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
+import { getPaginationParams } from 'utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -70,10 +71,7 @@ export default function useNodeCves(
     >(cvesListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-            },
+            pagination: getPaginationParams(page, perPage),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,0 +1,79 @@
+import { gql, useQuery } from '@apollo/client';
+import { QuerySearchFilter } from '../../types';
+import { getRegexScopedQueryString } from '../../utils/searchUtils';
+
+const cvesListQuery = gql`
+    query getNodeCVEs($query: String, $pagination: Pagination) {
+        nodeCVEs(query: $query, pagination: $pagination) {
+            cve
+            nodeCountBySeverity {
+                critical {
+                    total
+                }
+                important {
+                    total
+                }
+                moderate {
+                    total
+                }
+                low {
+                    total
+                }
+            }
+            topCVSS
+            affectedNodeCount
+            firstDiscoveredInSystem
+            distroTuples {
+                summary
+                operatingSystem
+                cvss
+                scoreVersion
+            }
+        }
+    }
+`;
+
+// TODO Need to verify these types with the BE implementation
+export type NodeCVE = {
+    cve: string;
+    nodeCountBySeverity: {
+        critical: { total: number };
+        important: { total: number };
+        moderate: { total: number };
+        low: { total: number };
+    };
+    topCVSS: number;
+    affectedNodeCount: number;
+    firstDiscoveredInSystem: string;
+    distroTuples: {
+        summary: string;
+        operatingSystem: string;
+        cvss: number;
+        scoreVersion: string;
+    }[];
+};
+
+export default function useNodeCves(
+    querySearchFilter: QuerySearchFilter,
+    page: number,
+    perPage: number
+) {
+    return useQuery<
+        { nodeCVEs: NodeCVE[] },
+        {
+            query: string;
+            pagination: {
+                offset: number;
+                limit: number;
+            };
+        }
+    >(cvesListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
+import { getPaginationParams } from 'utils/searchUtils';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 
@@ -63,10 +64,7 @@ export default function useNodes(
     return useQuery<{ nodes: Node[] }>(nodeListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-            },
+            pagination: getPaginationParams(page, perPage),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,0 +1,72 @@
+import { gql, useQuery } from '@apollo/client';
+import { getRegexScopedQueryString } from '../../utils/searchUtils';
+import { QuerySearchFilter } from '../../types';
+
+const nodeListQuery = gql`
+    query getNodes($query: String, $pagination: Pagination) {
+        nodes(query: $query, pagination: $pagination) {
+            id
+            name
+            nodeCVECountBySeverity {
+                critical {
+                    total
+                }
+                important {
+                    total
+                }
+                moderate {
+                    total
+                }
+                low {
+                    total
+                }
+            }
+            cluster {
+                name
+            }
+            operatingSystem
+            scanTime
+        }
+    }
+`;
+
+// TODO - Verify these types once the BE is implemented
+type Node = {
+    id: string;
+    name: string;
+    nodeCVECountBySeverity: {
+        critical: {
+            total: number;
+        };
+        important: {
+            total: number;
+        };
+        moderate: {
+            total: number;
+        };
+        low: {
+            total: number;
+        };
+    };
+    cluster: {
+        name: string;
+    };
+    operatingSystem: string;
+    scanTime: string;
+};
+
+export default function useNodes(
+    querySearchFilter: QuerySearchFilter,
+    page: number,
+    perPage: number
+) {
+    return useQuery<{ nodes: Node[] }>(nodeListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useTotalNodeCount.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useTotalNodeCount.ts
@@ -1,0 +1,13 @@
+import { gql, useQuery } from '@apollo/client';
+
+const totalNodeCountQuery = gql`
+    query getTotalNodeCount {
+        nodeCount
+    }
+`;
+
+export default function useTotalNodeCount() {
+    const totalNodeCountRequest = useQuery<{ nodeCount: number }>(totalNodeCountQuery);
+
+    return totalNodeCountRequest.data?.nodeCount ?? 0;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -80,7 +80,7 @@ function CVEsTable({ querySearchFilter, isFiltered, pagination }: CVEsTableProps
                 tableState={tableState}
                 colSpan={colSpan}
                 emptyProps={{
-                    message: 'No Platform CVEs have been reported for your secured clusters',
+                    message: 'No CVEs have been detected for your secured clusters',
                 }}
                 renderer={({ data }) =>
                     data.map((platformCve, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -1,0 +1,73 @@
+import { gql, useQuery } from '@apollo/client';
+import { QuerySearchFilter } from '../../types';
+import { getRegexScopedQueryString } from '../../utils/searchUtils';
+
+// TODO Validate types with BE implementation
+type PlatformCVE = {
+    cve: string;
+    isFixable: boolean;
+    cveType: string;
+    cvss: number;
+    scoreVersion: string;
+    distroTuples: {
+        summary: string;
+        operatingSystem: string;
+        cvss: number;
+        scoreVersion: string;
+    }[];
+    clusterCountByType: {
+        generic: number;
+        kubernetes: number;
+        openshift: number;
+        openshift4: number;
+    };
+};
+
+const cveListQuery = gql`
+    query getPlatformCves($query: String, $pagination: Pagination) {
+        platformCVEs(query: $query, pagination: $pagination) {
+            cve
+            isFixable
+            cveType
+            cvss
+            scoreVersion
+            distroTuples {
+                summary
+                operatingSystem
+            }
+            clusterCountByType {
+                generic
+                kubernetes
+                openshift
+                openshift4
+            }
+        }
+    }
+`;
+
+export default function usePlatformCves(
+    querySearchFilter: QuerySearchFilter,
+    page: number,
+    perPage: number
+) {
+    return useQuery<
+        {
+            platformCVEs: PlatformCVE[];
+        },
+        {
+            query: string;
+            pagination: {
+                offset: number;
+                limit: number;
+            };
+        }
+    >(cveListQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+            },
+        },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
+import { getPaginationParams } from 'utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -64,10 +65,7 @@ export default function usePlatformCves(
     >(cveListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-            },
+            pagination: getPaginationParams(page, perPage),
         },
     });
 }

--- a/ui/apps/platform/src/utils/searchUtils.test.js
+++ b/ui/apps/platform/src/utils/searchUtils.test.js
@@ -6,6 +6,7 @@ import {
     convertSortToRestFormat,
     searchOptionsToSearchFilter,
     getListQueryParams,
+    getPaginationParams,
     searchValueAsArray,
     convertToExactMatch,
 } from './searchUtils';
@@ -377,6 +378,18 @@ describe('searchUtils', () => {
                 const offset = parseInt(offsetParam, 10);
                 expect(offset % page).toBe(0);
             });
+        });
+    });
+
+    describe('getPaginationParams', () => {
+        it('should return an object with the offset and limit properties', () => {
+            expect(getPaginationParams(0, 20)).toEqual({ offset: 0, limit: 20 });
+        });
+
+        it('should calculate the offset based on the page number and page size', () => {
+            expect(getPaginationParams(1, 20)).toEqual({ offset: 0, limit: 20 });
+            expect(getPaginationParams(2, 20)).toEqual({ offset: 20, limit: 20 });
+            expect(getPaginationParams(3, 20)).toEqual({ offset: 40, limit: 20 });
         });
     });
 

--- a/ui/apps/platform/src/utils/searchUtils.test.js
+++ b/ui/apps/platform/src/utils/searchUtils.test.js
@@ -382,14 +382,12 @@ describe('searchUtils', () => {
     });
 
     describe('getPaginationParams', () => {
-        it('should return an object with the offset and limit properties', () => {
-            expect(getPaginationParams(0, 20)).toEqual({ offset: 0, limit: 20 });
-        });
-
         it('should calculate the offset based on the page number and page size', () => {
             expect(getPaginationParams(1, 20)).toEqual({ offset: 0, limit: 20 });
             expect(getPaginationParams(2, 20)).toEqual({ offset: 20, limit: 20 });
             expect(getPaginationParams(3, 20)).toEqual({ offset: 40, limit: 20 });
+            expect(getPaginationParams(4, 12)).toEqual({ offset: 36, limit: 12 });
+            expect(getPaginationParams(5, 1)).toEqual({ offset: 4, limit: 1 });
         });
     });
 

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -219,6 +219,20 @@ export function getListQueryParams(
 }
 
 /**
+ * Calculates the API pagination limit and offset parameters given the
+ * current page and number of items per page
+ */
+export function getPaginationParams(
+    page: number,
+    perPage: number
+): { offset: number; limit: number } {
+    return {
+        offset: (page - 1) * perPage,
+        limit: perPage,
+    };
+}
+
+/**
  * Coerces a search filter value obtained from the URL into an array of strings.
  *
  * Array values will be returned unchanged.


### PR DESCRIPTION
## Description

Refactors Node and Platform CVE pages for readability and consistency with recent merged pull requests.

1. Replaces manual table state logic throughout with `<TbodyUnified>` component that encapsulates this logic
2. Extracts `useQuery` calls, query definitions, and query request/response types to de-clutter the component in which they are used

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual smoke testing of existing Node and Platform CVE pages, ensuring that data loads correctly.
