### PR TITLE
ROX-23776: Replace DeliveryDestination with NotifierConfiguration

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/DeliveryDestinationsDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/DeliveryDestinationsDetails.tsx
@@ -36,7 +36,9 @@ function DeliveryDestinationsDetails({
     const deliveryDestinations =
         formValues.deliveryDestinations.length !== 0 ? (
             formValues.deliveryDestinations.map((deliveryDestination) => (
-                <li key={deliveryDestination.notifier?.id}>{deliveryDestination.notifier?.name}</li>
+                <li key={deliveryDestination.emailConfig.notifierId}>
+                    {deliveryDestination.notifierName}
+                </li>
             ))
         ) : (
             <li>None</li>
@@ -45,7 +47,7 @@ function DeliveryDestinationsDetails({
     const mailingLists =
         formValues.deliveryDestinations.length !== 0 ? (
             formValues.deliveryDestinations.map((deliveryDestination) => {
-                const emails = deliveryDestination?.mailingLists.join(', ');
+                const emails = deliveryDestination.emailConfig.mailingLists.join(', ');
                 return <li key={emails}>{emails}</li>;
             })
         ) : (
@@ -55,7 +57,8 @@ function DeliveryDestinationsDetails({
     const emailTemplates =
         formValues.deliveryDestinations.length !== 0 ? (
             formValues.deliveryDestinations.map((deliveryDestination, index) => {
-                const { customSubject, customBody } = deliveryDestination;
+                const { emailConfig } = deliveryDestination;
+                const { customSubject, customBody } = emailConfig;
                 const isDefaultEmailTemplateApplied = isDefaultEmailTemplate(
                     customSubject,
                     customBody

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -15,7 +15,6 @@ import { FormikProps } from 'formik';
 
 import {
     CVESDiscoveredSince,
-    DeliveryDestination,
     ReportFormValues,
 } from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 import { fixabilityLabels } from 'constants/reportConstants';
@@ -30,6 +29,7 @@ import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/Vulner
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { cloneDeep } from 'lodash';
 import { CollectionSlim } from 'services/CollectionsService';
+import { NotifierConfiguration } from 'services/ReportsService.types';
 import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormParams = {
@@ -218,11 +218,14 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                                 // since delivery destinations are required in this case, we will
                                 // automatically add to the array so the user doesn't need to do it
                                 // manually
-                                const newDeliveryDestination: DeliveryDestination = {
-                                    notifier: null,
-                                    mailingLists: [],
-                                    customSubject: '',
-                                    customBody: '',
+                                const newDeliveryDestination: NotifierConfiguration = {
+                                    emailConfig: {
+                                        notifierId: '',
+                                        mailingLists: [],
+                                        customSubject: '',
+                                        customBody: '',
+                                    },
+                                    notifierName: '',
                                 };
                                 modifiedFormValues.deliveryDestinations.push(
                                     newDeliveryDestination

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -3,7 +3,13 @@ import { FormikProps, useFormik } from 'formik';
 import * as yup from 'yup';
 
 import { VulnerabilitySeverity, vulnerabilitySeverities } from 'types/cve.proto';
-import { ImageType, IntervalType, imageTypes, intervalTypes } from 'services/ReportsService.types';
+import {
+    ImageType,
+    IntervalType,
+    NotifierConfiguration,
+    imageTypes,
+    intervalTypes,
+} from 'services/ReportsService.types';
 import {
     DayOfMonth,
     DayOfWeek,
@@ -14,7 +20,7 @@ import {
 export type ReportFormValues = {
     reportId: string;
     reportParameters: ReportParametersFormValues;
-    deliveryDestinations: DeliveryDestination[];
+    deliveryDestinations: NotifierConfiguration[];
     schedule: {
         intervalType: IntervalType | null;
         daysOfWeek: DayOfWeek[];
@@ -27,7 +33,7 @@ export type SetReportFormValues = (newFormValues: ReportFormValues) => void;
 export type FormFieldValue =
     | string
     | string[]
-    | DeliveryDestination[]
+    | NotifierConfiguration[]
     | Partial<Record<string, string | string[] | null>>;
 
 export type SetReportFormFieldValue = (fieldName: string, value: FormFieldValue) => void;
@@ -54,18 +60,6 @@ export type CVESDiscoveredSince = (typeof cvesDiscoveredSince)[number];
 export type CVESDiscoveredStartDate = string | undefined;
 
 export type ReportScope = {
-    id: string;
-    name: string;
-};
-
-export type DeliveryDestination = {
-    notifier: ReportNotifier | null;
-    mailingLists: string[];
-    customSubject: string;
-    customBody: string;
-};
-
-export type ReportNotifier = {
     id: string;
     name: string;
 };
@@ -138,19 +132,16 @@ const validationSchema = yup.object().shape({
         .array()
         .of(
             yup.object().shape({
-                notifier: yup
-                    .object()
-                    .nullable()
-                    .strict()
-                    .test('is-not-null', 'A notifier is required', (value) => {
-                        return value !== null && value !== undefined;
-                    }),
-                mailingLists: yup
-                    .array()
-                    .of(yup.string())
-                    .min(1, 'At least 1 delivery destination is required'),
-                customSubject: emailSubjectValidation,
-                customBody: emailBodyValidation,
+                emailConfig: yup.object().shape({
+                    notifierId: yup.string().required('A notifier is required'),
+                    mailingLists: yup
+                        .array()
+                        .of(yup.string())
+                        .min(1, 'At least 1 delivery destination is required'),
+                    customSubject: emailSubjectValidation,
+                    customBody: emailBodyValidation,
+                }),
+                notifierName: yup.string(),
             })
         )
         .strict()

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useEmailTemplateModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useEmailTemplateModal.ts
@@ -1,18 +1,18 @@
 import { Dispatch, SetStateAction, useState } from 'react';
-import { DeliveryDestination } from '../forms/useReportFormValues';
+import { NotifierConfiguration } from 'services/ReportsService.types';
 
 export type UseEmailTemplateModalResult = {
     isEmailTemplateModalOpen: boolean;
     closeEmailTemplateModal: () => void;
     selectedEmailSubject: string;
     selectedEmailBody: string;
-    selectedDeliveryDestination: DeliveryDestination | null;
-    setSelectedDeliveryDestination: Dispatch<SetStateAction<DeliveryDestination | null>>;
+    selectedDeliveryDestination: NotifierConfiguration | null;
+    setSelectedDeliveryDestination: Dispatch<SetStateAction<NotifierConfiguration | null>>;
 };
 
 function useEmailTemplateModal(): UseEmailTemplateModalResult {
     const [selectedDeliveryDestination, setSelectedDeliveryDestination] =
-        useState<DeliveryDestination | null>(null);
+        useState<NotifierConfiguration | null>(null);
 
     function closeEmailTemplateModal() {
         setSelectedDeliveryDestination(null);
@@ -21,8 +21,8 @@ function useEmailTemplateModal(): UseEmailTemplateModalResult {
     return {
         isEmailTemplateModalOpen: !!selectedDeliveryDestination,
         closeEmailTemplateModal,
-        selectedEmailSubject: selectedDeliveryDestination?.customSubject || '',
-        selectedEmailBody: selectedDeliveryDestination?.customBody || '',
+        selectedEmailSubject: selectedDeliveryDestination?.emailConfig?.customSubject ?? '',
+        selectedEmailBody: selectedDeliveryDestination?.emailConfig?.customBody ?? '',
         selectedDeliveryDestination,
         setSelectedDeliveryDestination,
     };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
@@ -12,7 +12,6 @@ import { getDate } from 'utils/dateUtils';
 import {
     CVESDiscoveredSince,
     CVESDiscoveredStartDate,
-    DeliveryDestination,
     ReportFormValues,
     ReportParametersFormValues,
 } from './forms/useReportFormValues';
@@ -81,17 +80,7 @@ export function getReportConfigurationFromFormValues(
         };
     }
 
-    const notifiers = deliveryDestinations.map((deliveryDestination) => {
-        return {
-            emailConfig: {
-                notifierId: deliveryDestination.notifier?.id || '',
-                mailingLists: deliveryDestination.mailingLists,
-                customSubject: deliveryDestination.customSubject,
-                customBody: deliveryDestination.customBody,
-            },
-            notifierName: deliveryDestination.notifier?.name || '',
-        };
-    });
+    const notifiers = deliveryDestinations;
 
     let schedule: Schedule | null;
     if (formSchedule.intervalType === 'WEEKLY') {
@@ -161,18 +150,7 @@ export function getReportFormValuesFromConfiguration(
         cvesDiscoveredSince = 'ALL_VULN';
     }
 
-    const deliveryDestinations = notifiers.map((notifier) => {
-        const deliveryDestination: DeliveryDestination = {
-            notifier: {
-                id: notifier.emailConfig.notifierId,
-                name: notifier.notifierName,
-            },
-            mailingLists: notifier.emailConfig.mailingLists,
-            customSubject: notifier.emailConfig.customSubject,
-            customBody: notifier.emailConfig.customBody,
-        };
-        return deliveryDestination;
-    });
+    const deliveryDestinations = notifiers;
 
     let formSchedule: ReportFormValues['schedule'];
     if (!schedule) {


### PR DESCRIPTION
## Description

### Problem

The frontend-only `DeliveryDestination` type:
* requires conversion functions
* hinders potential reuse of delivery destination components

### Analysis

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx#L61-L71

```ts
export type DeliveryDestination = {
    notifier: ReportNotifier | null;
    mailingLists: string[];
    customSubject: string;
    customBody: string;
};

export type ReportNotifier = {
    id: string;
    name: string;
};
```

The frontend-only type seems to be a compromise between:

Vulnerability Reports 1.0 which has `notifierId` but not name property:

https://github.com/stackrox/stackrox/blob/master/proto/storage/report_configuration.proto#L96-L101

Vulnerability Reports 2.0 which has notifier both `notifierId` and `notifierName` properties:

https://github.com/stackrox/stackrox/blob/master/proto/api/v2/report_service.proto#L98-L110

### Solution

To reduce the number of changed files, keep `deliveryDestinations` as property name in form props.

Import type from frontend service which corresponds to backend service:

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/services/ReportsService.types.ts#L42-L50

```ts
export type NotifierConfiguration = {
    emailConfig: {
        notifierId: string;
        mailingLists: string[];
        customSubject: string;
        customBody: string;
    };
    notifierName: string;
};
```

The most subtle changes are formik state:
* forms/NotifierSelection.tsx:
    * Add `emailConfig` to `fieldId` props.
    * Update `setFieldValue` in `onNotifierChange` function.
* forms/useReportFormValues.tsx: Update yup validation.

### Residue

1. Compliance Reports 2.0 plans to use the same type: as Brad suggested, import both type definitions so TypeScript compiler verifies that they are compatible.
2. Replace description list with table in DeliveryDestinationDetail.tsx file.
3. Despite formik validation, I did not notice a validation error for the field. Instead the wizard displayed a backend validation error after I clicked **Create**.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Type changes do not affect bundle size. Reduction from deletion of conversions between separate frontend and backend data structures more than balanced increase in updates to data structures.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4633083 - 4633083
        total -115 = 11551000 - 11551115
    * `ls -al build/static/js/*.js | wc`
        files 0 = 170 - 170
3. `yarn start` in ui

### Manual testing

Prerequisite: create at least one collection.

Create e-mail notifiers on the fly.

1. Create a report and circle back to change some choices.
    * Verify consistency of form and detail.
    * Verify payload and response of POST /v2/reports/configurations request
2. Clone the first report and ditto.
3. Edit the first report and ditto.
