### PR TITLE
ROX-23068: Add cluster list to Platform CVE detail page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -79,7 +79,9 @@ function NodeCvePage() {
             <PageTitle title={`Node CVEs - NodeCVE ${nodeCveName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
+                        Node CVEs
+                    </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {nodeCveName ?? (
                             <Skeleton screenreaderText="Loading CVE name" width="200px" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -8,25 +8,11 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useURLPagination from 'hooks/useURLPagination';
 import { ClusterType } from 'types/cluster.proto';
 import { getTableUIState } from 'utils/getTableUIState';
-import { ensureExhaustive } from 'utils/type.utils';
 
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import { getPlatformEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
-
-function displayClusterType(type: ClusterType): string {
-    switch (type) {
-        case 'GENERIC_CLUSTER':
-            return 'Generic';
-        case 'KUBERNETES_CLUSTER':
-            return 'Kubernetes';
-        case 'OPENSHIFT_CLUSTER':
-        case 'OPENSHIFT4_CLUSTER':
-            return 'OCP';
-        default:
-            return ensureExhaustive(type);
-    }
-}
+import { displayClusterType } from '../utils/stringUtils';
 
 const clusterListQuery = gql`
     query getPlatformClusters($query: String, $pagination: Pagination) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { gql } from '@apollo/client';
+import { Truncate } from '@patternfly/react-core';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { TableUIState } from 'utils/getTableUIState';
+import { ClusterType } from 'types/cluster.proto';
+
+import { getPlatformEntityPagePath } from '../../utils/searchUtils';
+import { displayClusterType } from '../utils/stringUtils';
+
+export const affectedClusterFragment = gql`
+    fragment AffectedClusterFragment on Cluster {
+        id
+        name
+        type
+        status {
+            orchestratorMetadata {
+                version
+            }
+        }
+    }
+`;
+
+export type AffectedCluster = {
+    id: string;
+    name: string;
+    type: ClusterType;
+    status?: {
+        orchestratorMetadata?: {
+            version: string;
+        };
+    };
+};
+
+export type AffectedClustersTableProps = {
+    tableState: TableUIState<AffectedCluster>;
+};
+
+function AffectedClustersTable({ tableState }: AffectedClustersTableProps) {
+    return (
+        <Table
+            borders={tableState.type === 'COMPLETE'}
+            variant="compact"
+            role="region"
+            aria-live="polite"
+            aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
+        >
+            <Thead noWrap>
+                <Tr>
+                    <Th>Cluster</Th>
+                    <Th>Cluster type</Th>
+                    <Th>Kubernetes version</Th>
+                </Tr>
+            </Thead>
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={3}
+                emptyProps={{ message: 'No clusters have been reported for this CVE' }}
+                renderer={({ data }) => (
+                    <Tbody>
+                        {data.map(({ id, name, type, status }) => (
+                            <Tr key={id}>
+                                <Td dataLabel="Cluster">
+                                    <Link to={getPlatformEntityPagePath('Cluster', id)}>
+                                        <Truncate position="middle" content={name} />
+                                    </Link>
+                                </Td>
+                                <Td dataLabel="Cluster type" modifier="nowrap">
+                                    {displayClusterType(type)}
+                                </Td>
+                                <Td dataLabel="Kubernetes version" modifier="nowrap">
+                                    {status?.orchestratorMetadata?.version ?? 'Unavailable'}
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                )}
+            />
+        </Table>
+    );
+}
+
+export default AffectedClustersTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -5,16 +5,39 @@ import { useParams } from 'react-router-dom';
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 
-import { getOverviewPagePath } from '../../utils/searchUtils';
+import { DEFAULT_PAGE_SIZE } from 'Components/Table';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import { getTableUIState } from 'utils/getTableUIState';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import {
+    getOverviewPagePath,
+    getRegexScopedQueryString,
+    parseWorkloadQuerySearchFilter,
+} from '../../utils/searchUtils';
+import useAffectedClusters from './useAffectedClusters';
+import AffectedClustersTable from './AffectedClustersTable';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Platform', {
     entityTab: 'CVE',
 });
 
 function PlatformCvePage() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { searchFilter } = useURLSearch();
+    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+
+    // We need to scope all queries to the *exact* CVE name so that we don't accidentally get
+    // data that matches a prefix of the CVE name in the nested fields
     const { cveId } = useParams() as { cveId: string };
+    const exactCveIdSearchRegex = `^${cveId}$`;
+    const query = getRegexScopedQueryString({
+        ...querySearchFilter,
+        CVE: [exactCveIdSearchRegex],
+    });
+
+    const { page, perPage } = useURLPagination(DEFAULT_PAGE_SIZE);
+
+    const { affectedClustersRequest, clusterData } = useAffectedClusters(query, page, perPage);
 
     const [platformCveMetadata, setPlatformCveMetadata] = useState<CveMetadata>();
     const cveName = platformCveMetadata?.cve;
@@ -36,12 +59,21 @@ function PlatformCvePage() {
         }, 1500);
     }, [cveId]);
 
+    const tableState = getTableUIState({
+        isLoading: affectedClustersRequest.loading,
+        error: affectedClustersRequest.error,
+        data: clusterData,
+        searchFilter: querySearchFilter,
+    });
+
     return (
         <>
             <PageTitle title={`Platform CVEs - PlatformCVE ${cveName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
+                        Platform CVEs
+                    </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {cveName ?? <Skeleton screenreaderText="Loading CVE name" width="200px" />}
                     </BreadcrumbItem>
@@ -52,8 +84,10 @@ function PlatformCvePage() {
                 <CvePageHeader data={platformCveMetadata} />
             </PageSection>
             <Divider component="div" />
-            <PageSection className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1">
-                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1"></div>
+            <PageSection className="pf-v5-u-flex-grow-1">
+                <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-lg">
+                    <AffectedClustersTable tableState={tableState} />
+                </div>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
@@ -1,0 +1,38 @@
+import { gql, useQuery } from '@apollo/client';
+import { AffectedCluster, affectedClusterFragment } from './AffectedClustersTable';
+
+const affectedClustersQuery = gql`
+    ${affectedClusterFragment}
+    query getAffectedClusters($query: String, $pagination: Pagination) {
+        clusters(query: $query, pagination: $pagination) {
+            ...AffectedClusterFragment
+        }
+    }
+`;
+
+export default function useAffectedClusters(query: string, page: number, perPage: number) {
+    const affectedClustersRequest = useQuery<
+        {
+            clusters: AffectedCluster[];
+        },
+        {
+            query: string;
+            pagination: { limit: number; offset: number };
+        }
+    >(affectedClustersQuery, {
+        variables: {
+            query,
+            pagination: {
+                limit: perPage,
+                offset: (page - 1) * perPage,
+            },
+        },
+    });
+
+    return {
+        affectedClustersRequest,
+        clusterData:
+            affectedClustersRequest.data?.clusters ??
+            affectedClustersRequest.previousData?.clusters,
+    };
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
@@ -1,0 +1,16 @@
+import { ClusterType } from 'types/cluster.proto';
+import { ensureExhaustive } from 'utils/type.utils';
+
+export function displayClusterType(type: ClusterType): string {
+    switch (type) {
+        case 'GENERIC_CLUSTER':
+            return 'Generic';
+        case 'KUBERNETES_CLUSTER':
+            return 'Kubernetes';
+        case 'OPENSHIFT_CLUSTER':
+        case 'OPENSHIFT4_CLUSTER':
+            return 'OCP';
+        default:
+            return ensureExhaustive(type);
+    }
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -345,7 +345,9 @@ function ImageCvePage() {
             />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
+                        Workload CVEs
+                    </BreadcrumbItemLink>
                     {!metadataRequest.error && (
                         <BreadcrumbItem isActive>
                             {cveName ?? (


### PR DESCRIPTION
## Description

Title.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Platform CVEs, and click the link of a CVE to view the affected clusters list.

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/fdb8f453-6c89-4bf9-bae8-721311d5c067)

Error:
![image](https://github.com/stackrox/stackrox/assets/1292638/bdd9b10d-7ecc-44d2-a08e-b518d38f7e0c)

Empty (should never occur here though...):
![image](https://github.com/stackrox/stackrox/assets/1292638/d0258b23-3211-4cc5-8d95-34d6d15db033)

Filtered Empty:
![image](https://github.com/stackrox/stackrox/assets/1292638/54d3fc76-56b1-4b5f-a760-c55976142388)

Success:
![image](https://github.com/stackrox/stackrox/assets/1292638/b807c775-7dff-4b96-b332-e5485992205a)

Test clicking the cluster link:
![image](https://github.com/stackrox/stackrox/assets/1292638/4076b171-ceb5-4f96-834c-de4edf23ad90)

Test clicking the breadcrumb link in the header:
![image](https://github.com/stackrox/stackrox/assets/1292638/981bd7df-825e-459b-81ad-d268709c5861)
