### PR TITLE
fix: metadata should be re-fetched if disregarding cached values

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -339,7 +339,8 @@ func (e *enricherImpl) enrichWithMetadata(ctx context.Context, enrichmentContext
 		return false, nil
 	}
 
-	if enrichmentContext.FetchOpt != ForceRefetch {
+	if !enrichmentContext.FetchOpt.forceRefetchCachedValues() &&
+		enrichmentContext.FetchOpt != UseImageNamesRefetchCachedValues {
 		// The metadata in the cache is always up-to-date with respect to the current metadataVersion
 		if metadataValue := e.metadataCache.Get(getRef(image)); metadataValue != nil {
 			e.metrics.IncrementMetadataCacheHit()

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -304,6 +304,26 @@ func TestEnricherFlow(t *testing.T) {
 			},
 		},
 		{
+			name: " data in both caches but force refetch use names",
+			ctx: EnrichmentContext{
+				FetchOpt: UseImageNamesRefetchCachedValues,
+			},
+			inMetadataCache: true,
+			image: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+			},
+			fsr: newFakeRegistryScanner(opts{
+				requestedMetadata: true,
+				requestedScan:     true,
+			}),
+			result: EnrichmentResult{
+				ImageUpdated: true,
+				ScanResult:   ScanSucceeded,
+			},
+		},
+		{
 			name: "data in both caches but force refetch scans only",
 			ctx: EnrichmentContext{
 				FetchOpt: ForceRefetchScansOnly,


### PR DESCRIPTION
## Description

Fix a case where mistakenly the metadata was taken from the cache instead of correctly ignore when scanning images via roxctl with the `--force` option.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI for the added unit test.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
