### PR TITLE
ROX-22389: Do not query with an empty namespace

### DIFF
--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -205,9 +205,10 @@ func checkWriteAccess(client kubernetes.Interface) error {
 
 func (u *updaterImpl) searchComplianceOperatorDeployment() (*appsv1.Deployment, error) {
 	// Use cached namespace, if compliance operator deployment was not found search again in all namespaces.
-	complianceOperator, err := u.getComplianceOperatorDeployment(u.complianceOperatorNS)
-	if complianceOperator != nil {
-		return complianceOperator, err
+	if u.complianceOperatorNS != "" {
+		if complianceOperator, err := u.getComplianceOperatorDeployment(u.complianceOperatorNS); err == nil {
+			return complianceOperator, nil
+		}
 	}
 
 	// List all namespaces to begin the lookup for compliance operator.


### PR DESCRIPTION
## Description

If the cached namespace is empty do not query in that namespace and instead try to find the CO deployment in all namespaces. Checking for the deployment to not be `nil` is not enough to make sure the call to `Get` was successful, `Get` could return a non-nil deployment even if the call failed. Check for `err == nil` instead.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Manual test
    - Install ACS (with logs level Debug)
    - Check in logs the CO info reports an error
    - Install CO
    - Check in logs the CO info is successful
    - Creating a ScanConfig from the UI should succeed

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
