### PR TITLE
Create PoC v2, focusing on minimal dependencies

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -305,7 +305,13 @@ func (c *gRPCScanner) IndexAndScanNode(ctx context.Context) (*v4.VulnerabilityRe
 	if err != nil {
 		return nil, fmt.Errorf("creating node index report: %w", err)
 	}
-	return c.getVulnerabilitiesForManifest(ctx, nr.GetHashId(), nil)
+	rc := &v4.Contents{
+		Packages:      nr.GetContents().GetPackages(),
+		Distributions: nr.GetContents().GetDistributions(),
+		Repositories:  nr.GetContents().GetRepositories(),
+		Environments:  nr.GetContents().GetEnvironments(),
+	}
+	return c.getVulnerabilities(ctx, "/v4/containerimage/"+nr.GetHashId(), rc)
 }
 
 func getImageManifestID(ref name.Digest) string {

--- a/scanner/cmd/nodescanner/main.go
+++ b/scanner/cmd/nodescanner/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/rhel"
+	rpm2 "github.com/quay/claircore/rpm"
+	"github.com/quay/zlog"
+)
+
+func main() {
+	h := getRandomSHA256()
+	c := http.DefaultClient
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, "manifest_id", h)
+
+	// construct a layer
+	zlog.Info(ctx).Msgf("Realizing mount path: %s", "/tmp/rhcos")
+	nodeFS := os.DirFS("/tmp/rhcos")
+	l := claircore.Layer{}
+	err := l.InitROFS(ctx, nodeFS)
+	if err != nil {
+		panic(err)
+	}
+
+	// repository scanner
+	sc := rhel.RepositoryScanner{}
+	config := rhel.RepositoryScannerConfig{
+		DisableAPI:         false,
+		API:                "https://catalog.redhat.com/api/containers/",
+		Repo2CPEMappingURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
+		Timeout:            10 * time.Second,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&config); err != nil {
+		panic(err)
+	}
+	if err := sc.Configure(ctx, json.NewDecoder(&buf).Decode, c); err != nil {
+		panic(err)
+	}
+
+	reps, err := sc.Scan(ctx, &l)
+	if err != nil {
+		panic(err)
+	}
+	if reps != nil {
+		zlog.Info(ctx).Msgf("Num repositories found: %v", len(reps))
+	}
+	for i, r := range reps {
+		r.ID = fmt.Sprintf("%d", i)
+	}
+
+	// package scanner
+	rpm := rpm2.Scanner{}
+	pck, err := rpm.Scan(ctx, &l)
+	if err != nil {
+		panic(err)
+	}
+	if pck != nil {
+		zlog.Info(ctx).Msgf("Num packages found: %v", len(pck))
+	}
+	for i, p := range pck {
+		p.ID = fmt.Sprintf("%d", i)
+	}
+
+	// coalesce
+	la := &indexer.LayerArtifacts{
+		Hash: claircore.MustParseDigest(`sha256:` + h),
+	}
+	la.Repos = append(la.Repos, reps...)
+	la.Pkgs = append(la.Pkgs, pck...)
+	artifacts := []*indexer.LayerArtifacts{la}
+	coal := new(rhel.Coalescer)
+
+	ir, err := coal.Coalesce(ctx, artifacts)
+	if err != nil {
+		panic(err)
+	}
+	// to json
+	reportJSON, err := json.MarshalIndent(ir, "", "  ")
+	fmt.Println(string(reportJSON))
+}
+
+func getRandomSHA256() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}

--- a/scanner/indexer/node.go
+++ b/scanner/indexer/node.go
@@ -1,25 +1,24 @@
 package indexer
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"time"
 
-	"errors"
-
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/quay/claircore"
-	ccpostgres "github.com/quay/claircore/datastore/postgres"
 	ccindexer "github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/libindex"
-	"github.com/quay/claircore/pkg/ctxlock"
+	"github.com/quay/claircore/indexer/controller"
+	"github.com/quay/claircore/rhel"
+	rpm2 "github.com/quay/claircore/rpm"
 	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/scanner/config"
-	"github.com/stackrox/rox/scanner/datastore/postgres"
-	"github.com/stackrox/rox/scanner/internal/httputil"
 )
 
 // NodeIndexer represents a node indexer.
@@ -34,120 +33,143 @@ type NodeIndexer interface {
 }
 
 type localNodeIndexer struct {
-	libIndex          *libindex.Libindex
-	pool              *pgxpool.Pool
-	root              string // do we need u?
-	getIndexerTimeout time.Duration
+	client http.Client
 }
 
 // NewNodeIndexer creates a new node indexer
 func NewNodeIndexer(ctx context.Context, cfg config.NodeIndexerConfig) (NodeIndexer, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.NewNodeIndexer")
 
-	var success bool
-
-	pool, err := postgres.Connect(ctx, cfg.Database.ConnString, "libindexNodeIndex")
-	if err != nil {
-		return nil, fmt.Errorf("connecting to postgres for nodeindexer: %w", err)
-	}
-	defer func() {
-		if !success {
-			pool.Close()
-		}
-	}()
-
-	store, err := ccpostgres.InitPostgresIndexerStore(ctx, pool, true)
-	if err != nil {
-		return nil, fmt.Errorf("initializing postgres indexer store: %w", err)
-	}
-	defer func() {
-		if !success {
-			_ = store.Close(ctx)
-		}
-	}()
-
-	locker, err := ctxlock.New(ctx, pool)
-	if err != nil {
-		return nil, fmt.Errorf("creating indexer postgres locker: %w", err)
-	}
-	defer func() {
-		if !success {
-			_ = locker.Close(ctx)
-		}
-	}()
-
-	root, err := os.MkdirTemp("", "scanner-fetcharena-*")
-	if err != nil {
-		return nil, fmt.Errorf("creating indexer root directory: %w", err)
-	}
-	defer func() {
-		if !success {
-			_ = os.RemoveAll(root)
-		}
-	}()
-
 	// Note: http.DefaultTransport has already been modified to handle configured proxies.
 	// See scanner/cmd/scanner/main.go.
-	t, err := httputil.TransportMux(http.DefaultTransport, httputil.WithDenyStackRoxServices(!cfg.StackRoxServices))
-	if err != nil {
-		return nil, fmt.Errorf("creating HTTP transport: %w", err)
-	}
-	client := &http.Client{
-		Transport: t,
-	}
+	//t, err := httputil.TransportMux(http.DefaultTransport, httputil.WithDenyStackRoxServices(!cfg.StackRoxServices))
+	//if err != nil {
+	//	return nil, fmt.Errorf("creating HTTP transport: %w", err)
+	//}
+	//client := &http.Client{
+	//	Transport: t,
+	//}
 
-	indexer, err := newNodeLibindex(ctx, cfg, client, root, store, locker)
-	if err != nil {
-		return nil, err
-	}
-
-	success = true
-	return &localNodeIndexer{
-		libIndex:          indexer,
-		pool:              pool,
-		root:              root,
-		getIndexerTimeout: time.Duration(1 * time.Second),
-	}, nil
-}
-
-func newNodeLibindex(ctx context.Context, _ config.NodeIndexerConfig, client *http.Client, _ string, store ccindexer.Store, locker *ctxlock.Locker) (*libindex.Libindex, error) {
-	opts := libindex.Options{
-		Store:                store,
-		Locker:               locker,
-		ScanLockRetry:        libindex.DefaultScanLockRetry,
-		FetchArena:           libindex.NewRemoteFetchArena(client, ""), // FIXME: Unused, but required
-		LayerScanConcurrency: 1,
-		NoLayerValidation:    true,
-		ControllerFactory:    nil, // TODO: We could go for a custom factory here as well
-		Ecosystems:           ecosystems(ctx),
-		ScannerConfig: struct {
-			Package, Dist, Repo, File map[string]func(interface{}) error
-		}{},
-		Resolvers: nil,
-	}
-
-	zlog.Info(ctx).Msgf("Setting mount host path to %s", env.NodeScanningV4HostPath.Setting())
-	indexer, err := libindex.NewNodeScan(ctx, &opts, client, env.NodeScanningV4HostPath.Setting())
-	if err != nil {
-		return nil, fmt.Errorf("creating libindex: %w", err)
-	}
-
-	return indexer, nil
+	return &localNodeIndexer{}, nil
 }
 
 // IndexNode indexes a live fs.FS at the container mountpoint given in the basePath.
 func (l *localNodeIndexer) IndexNode(ctx context.Context) (*claircore.IndexReport, error) {
-	return l.libIndex.IndexNode(ctx)
+	report := &claircore.IndexReport{
+		Packages:      map[string]*claircore.Package{},
+		Environments:  map[string][]*claircore.Environment{},
+		Distributions: map[string]*claircore.Distribution{},
+		Repositories:  map[string]*claircore.Repository{},
+		Files:         map[string]claircore.File{},
+	}
+
+	h := getRandomSHA256()
+	ch, err := claircore.ParseDigest(`sha256:` + h)
+	if err != nil {
+		return nil, err
+	}
+	report.Hash = ch
+
+	ctx = context.WithValue(ctx, "manifest_id", h)
+
+	layer, err := constructLayer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reps, err := runRepositoryScanner(ctx, layer)
+	if err != nil {
+		return nil, err
+	}
+
+	// package scanner
+	rpm := rpm2.Scanner{}
+	pck, err := rpm.Scan(ctx, layer)
+	if err != nil {
+		return nil, err
+	}
+	if pck != nil {
+		zlog.Info(ctx).Msgf("Num packages found: %v", len(pck))
+	}
+	for i, p := range pck {
+		p.ID = fmt.Sprintf("%d", i)
+	}
+
+	// coalesce
+	la := &ccindexer.LayerArtifacts{
+		Hash: claircore.MustParseDigest(`sha256:` + h),
+	}
+	la.Repos = append(la.Repos, reps...)
+	la.Pkgs = append(la.Pkgs, pck...)
+	artifacts := []*ccindexer.LayerArtifacts{la}
+	coal := new(rhel.Coalescer)
+
+	ir, err := coal.Coalesce(ctx, artifacts)
+	if err != nil {
+		panic(err)
+	}
+	report = controller.MergeSR(report, []*claircore.IndexReport{ir})
+	report.Success = true
+	report.State = controller.IndexFinished.String()
+
+	return report, nil
 }
 
 // Close closes the NodeIndexer.
 func (l *localNodeIndexer) Close(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/nodeindexer.Close")
-	err := errors.Join(l.libIndex.Close(ctx)) // , os.RemoveAll(l.root)) // FIXME: Close fs.FS here!
-	return err
+	return nil
 }
 
 // Ready check function.
 func (l *localNodeIndexer) Ready(_ context.Context) error {
 	return nil
+}
+
+func runRepositoryScanner(ctx context.Context, l *claircore.Layer) ([]*claircore.Repository, error) {
+	c := http.DefaultClient
+	sc := rhel.RepositoryScanner{}
+	config := rhel.RepositoryScannerConfig{
+		DisableAPI:         false,
+		API:                "https://catalog.redhat.com/api/containers/",
+		Repo2CPEMappingURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
+		Timeout:            10 * time.Second,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&config); err != nil {
+		return nil, err
+	}
+	if err := sc.Configure(ctx, json.NewDecoder(&buf).Decode, c); err != nil {
+		return nil, err
+	}
+
+	reps, err := sc.Scan(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+	if reps != nil {
+		zlog.Info(ctx).Msgf("Num repositories found: %v", len(reps))
+	}
+	for i, r := range reps {
+		r.ID = fmt.Sprintf("%d", i)
+	}
+	return reps, nil
+}
+
+func getRandomSHA256() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+func constructLayer(ctx context.Context) (*claircore.Layer, error) {
+	hostPath := env.NodeScanningV4HostPath.Setting()
+	zlog.Info(ctx).Msgf("Realizing mount path: %s", hostPath)
+	nodeFS := os.DirFS(hostPath)
+	l := claircore.Layer{}
+	err := l.InitROFS(ctx, nodeFS)
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
 }

--- a/scanner/services/nodeindexer.go
+++ b/scanner/services/nodeindexer.go
@@ -1,14 +1,27 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
+	"github.com/quay/claircore"
+	indexer2 "github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/indexer/controller"
+	"github.com/quay/claircore/rhel"
+	rpm2 "github.com/quay/claircore/rpm"
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/mappers"
@@ -31,7 +44,8 @@ func NewNodeIndexerService(indexer indexer.NodeIndexer) *nodeIndexerService {
 
 // CreateNodeIndexReport is the endpoint to create a new report for the node it runs on.
 func (s *nodeIndexerService) CreateNodeIndexReport(ctx context.Context, _ *v4.CreateNodeIndexReportRequest) (*v4.IndexReport, error) {
-	clairReport, err := s.nodeIndexer.IndexNode(ctx)
+	// clairReport, err := s.nodeIndexer.IndexNode(ctx)
+	clairReport, err := createNodeIndexReport(ctx)
 	if err != nil {
 		zlog.Error(ctx).Err(err).Msg("nodeIndexer.IndexNode failed")
 		return nil, err
@@ -71,4 +85,114 @@ func (s *nodeIndexerService) RegisterServiceServer(server *grpc.Server) {
 func (s *nodeIndexerService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
 	// Currently we do not set up gRPC gateway for the indexer.
 	return nil
+}
+
+func createNodeIndexReport(ctx context.Context) (*claircore.IndexReport, error) {
+	report := &claircore.IndexReport{
+		Packages:      map[string]*claircore.Package{},
+		Environments:  map[string][]*claircore.Environment{},
+		Distributions: map[string]*claircore.Distribution{},
+		Repositories:  map[string]*claircore.Repository{},
+		Files:         map[string]claircore.File{},
+	}
+
+	h := getRandomSHA256()
+	ch, err := claircore.ParseDigest(`sha256:` + h)
+	if err != nil {
+		return nil, err
+	}
+	report.Hash = ch
+
+	ctx = context.WithValue(ctx, "manifest_id", h)
+
+	l, err := constructLayer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reps, err := runRepositoryScanner(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+
+	// package scanner
+	rpm := rpm2.Scanner{}
+	pck, err := rpm.Scan(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+	if pck != nil {
+		zlog.Info(ctx).Msgf("Num packages found: %v", len(pck))
+	}
+	for i, p := range pck {
+		p.ID = fmt.Sprintf("%d", i)
+	}
+
+	// coalesce
+	la := &indexer2.LayerArtifacts{
+		Hash: claircore.MustParseDigest(`sha256:` + h),
+	}
+	la.Repos = append(la.Repos, reps...)
+	la.Pkgs = append(la.Pkgs, pck...)
+	artifacts := []*indexer2.LayerArtifacts{la}
+	coal := new(rhel.Coalescer)
+
+	ir, err := coal.Coalesce(ctx, artifacts)
+	if err != nil {
+		panic(err)
+	}
+	report = controller.MergeSR(report, []*claircore.IndexReport{ir})
+	report.Success = true
+	report.State = controller.IndexFinished.String()
+
+	return report, nil
+}
+
+func runRepositoryScanner(ctx context.Context, l *claircore.Layer) ([]*claircore.Repository, error) {
+	c := http.DefaultClient
+	sc := rhel.RepositoryScanner{}
+	config := rhel.RepositoryScannerConfig{
+		DisableAPI:         false,
+		API:                "https://catalog.redhat.com/api/containers/",
+		Repo2CPEMappingURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
+		Timeout:            10 * time.Second,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&config); err != nil {
+		return nil, err
+	}
+	if err := sc.Configure(ctx, json.NewDecoder(&buf).Decode, c); err != nil {
+		return nil, err
+	}
+
+	reps, err := sc.Scan(ctx, l)
+	if err != nil {
+		return nil, err
+	}
+	if reps != nil {
+		zlog.Info(ctx).Msgf("Num repositories found: %v", len(reps))
+	}
+	for i, r := range reps {
+		r.ID = fmt.Sprintf("%d", i)
+	}
+	return reps, nil
+}
+
+func getRandomSHA256() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+func constructLayer(ctx context.Context) (*claircore.Layer, error) {
+	hostPath := env.NodeScanningV4HostPath.Setting()
+	zlog.Info(ctx).Msgf("Realizing mount path: %s", hostPath)
+	nodeFS := os.DirFS(hostPath)
+	l := claircore.Layer{}
+	err := l.InitROFS(ctx, nodeFS)
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
 }

--- a/scanner/services/nodeindexer.go
+++ b/scanner/services/nodeindexer.go
@@ -1,27 +1,14 @@
 package services
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
-	"github.com/quay/claircore"
-	indexer2 "github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/indexer/controller"
-	"github.com/quay/claircore/rhel"
-	rpm2 "github.com/quay/claircore/rpm"
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/buildinfo"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/mappers"
@@ -44,8 +31,8 @@ func NewNodeIndexerService(indexer indexer.NodeIndexer) *nodeIndexerService {
 
 // CreateNodeIndexReport is the endpoint to create a new report for the node it runs on.
 func (s *nodeIndexerService) CreateNodeIndexReport(ctx context.Context, _ *v4.CreateNodeIndexReportRequest) (*v4.IndexReport, error) {
-	// clairReport, err := s.nodeIndexer.IndexNode(ctx)
-	clairReport, err := createNodeIndexReport(ctx)
+	clairReport, err := s.nodeIndexer.IndexNode(ctx)
+	//clairReport, err := createNodeIndexReport(ctx)
 	if err != nil {
 		zlog.Error(ctx).Err(err).Msg("nodeIndexer.IndexNode failed")
 		return nil, err
@@ -85,114 +72,4 @@ func (s *nodeIndexerService) RegisterServiceServer(server *grpc.Server) {
 func (s *nodeIndexerService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
 	// Currently we do not set up gRPC gateway for the indexer.
 	return nil
-}
-
-func createNodeIndexReport(ctx context.Context) (*claircore.IndexReport, error) {
-	report := &claircore.IndexReport{
-		Packages:      map[string]*claircore.Package{},
-		Environments:  map[string][]*claircore.Environment{},
-		Distributions: map[string]*claircore.Distribution{},
-		Repositories:  map[string]*claircore.Repository{},
-		Files:         map[string]claircore.File{},
-	}
-
-	h := getRandomSHA256()
-	ch, err := claircore.ParseDigest(`sha256:` + h)
-	if err != nil {
-		return nil, err
-	}
-	report.Hash = ch
-
-	ctx = context.WithValue(ctx, "manifest_id", h)
-
-	l, err := constructLayer(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	reps, err := runRepositoryScanner(ctx, l)
-	if err != nil {
-		return nil, err
-	}
-
-	// package scanner
-	rpm := rpm2.Scanner{}
-	pck, err := rpm.Scan(ctx, l)
-	if err != nil {
-		return nil, err
-	}
-	if pck != nil {
-		zlog.Info(ctx).Msgf("Num packages found: %v", len(pck))
-	}
-	for i, p := range pck {
-		p.ID = fmt.Sprintf("%d", i)
-	}
-
-	// coalesce
-	la := &indexer2.LayerArtifacts{
-		Hash: claircore.MustParseDigest(`sha256:` + h),
-	}
-	la.Repos = append(la.Repos, reps...)
-	la.Pkgs = append(la.Pkgs, pck...)
-	artifacts := []*indexer2.LayerArtifacts{la}
-	coal := new(rhel.Coalescer)
-
-	ir, err := coal.Coalesce(ctx, artifacts)
-	if err != nil {
-		panic(err)
-	}
-	report = controller.MergeSR(report, []*claircore.IndexReport{ir})
-	report.Success = true
-	report.State = controller.IndexFinished.String()
-
-	return report, nil
-}
-
-func runRepositoryScanner(ctx context.Context, l *claircore.Layer) ([]*claircore.Repository, error) {
-	c := http.DefaultClient
-	sc := rhel.RepositoryScanner{}
-	config := rhel.RepositoryScannerConfig{
-		DisableAPI:         false,
-		API:                "https://catalog.redhat.com/api/containers/",
-		Repo2CPEMappingURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
-		Timeout:            10 * time.Second,
-	}
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(&config); err != nil {
-		return nil, err
-	}
-	if err := sc.Configure(ctx, json.NewDecoder(&buf).Decode, c); err != nil {
-		return nil, err
-	}
-
-	reps, err := sc.Scan(ctx, l)
-	if err != nil {
-		return nil, err
-	}
-	if reps != nil {
-		zlog.Info(ctx).Msgf("Num repositories found: %v", len(reps))
-	}
-	for i, r := range reps {
-		r.ID = fmt.Sprintf("%d", i)
-	}
-	return reps, nil
-}
-
-func getRandomSHA256() string {
-	data := make([]byte, 10)
-	rand.Read(data)
-	return fmt.Sprintf("%x", sha256.Sum256(data))
-}
-
-func constructLayer(ctx context.Context) (*claircore.Layer, error) {
-	hostPath := env.NodeScanningV4HostPath.Setting()
-	zlog.Info(ctx).Msgf("Realizing mount path: %s", hostPath)
-	nodeFS := os.DirFS(hostPath)
-	l := claircore.Layer{}
-	err := l.InitROFS(ctx, nodeFS)
-	if err != nil {
-		return nil, err
-	}
-	return &l, nil
 }


### PR DESCRIPTION
PoC code - do not merge!

A second version of the PoC, focusing on minimizing dependencies into ClairCore.
Instead of running a custom controller, we skip the DB and local storage/dedup and directly generate the report in memory.
