### PR TITLE
fix(ui): GitHub spelling in m2m ui

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/machineAccessConfigs.test.ts
+++ b/ui/apps/platform/cypress/integration/integrations/machineAccessConfigs.test.ts
@@ -37,12 +37,12 @@ describe('Machine Access Configs', () => {
             'Create configuration'
         );
 
-        // Check inital state.
+        // Check initial state.
         cy.get(selectors.buttons.save).should('be.disabled');
 
-        // Check that issuer is automatically determined when Github action type is selected.
+        // Check that issuer is automatically determined when GitHub action type is selected.
         getSelectButtonByLabel('Select configuration type').click();
-        getSelectOption('Github action').click();
+        getSelectOption('GitHub action').click();
         getInputByLabel('Issuer').should('be.disabled');
         getInputByLabel('Issuer').should(
             'contain.value',
@@ -61,7 +61,7 @@ describe('Machine Access Configs', () => {
 
         // Save integration.
         getSelectButtonByLabel('Select configuration type').click();
-        getSelectOption('Github action').click();
+        getSelectOption('GitHub action').click();
         getInputByLabel('Token lifetime').clear().type('3h20m');
 
         // Check that without rules it's not possible to save integration.
@@ -84,13 +84,13 @@ describe('Machine Access Configs', () => {
         saveCreatedIntegrationInForm(integrationSource, integrationType);
 
         // View it.
-        cy.get(`${selectors.tableRowNameLink}:contains("Github action")`).click();
+        cy.get(`${selectors.tableRowNameLink}:contains("GitHub action")`).click();
 
         clickIntegrationSourceLinkInForm(integrationSource, integrationType);
 
         // Delete it.
-        deleteIntegrationInTable(integrationSource, integrationType, 'Github action');
+        deleteIntegrationInTable(integrationSource, integrationType, 'GitHub action');
 
-        cy.get(`${selectors.tableRowNameLink}:contains("Github action")`).should('not.exist');
+        cy.get(`${selectors.tableRowNameLink}:contains("GitHub action")`).should('not.exist');
     });
 });

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -146,7 +146,7 @@ function MachineAccessIntegrationForm({
                                     Generic
                                 </SelectOption>
                                 <SelectOption key={'GITHUB_ACTIONS'} value={'GITHUB_ACTIONS'}>
-                                    Github action
+                                    GitHub action
                                 </SelectOption>
                             </SelectSingle>
                         </FormLabelGroup>

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -109,7 +109,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
                         return 'Generic';
                     }
                     if (type === 'GITHUB_ACTIONS') {
-                        return 'Github action';
+                        return 'GitHub action';
                     }
                     return 'Unknown';
                 },


### PR DESCRIPTION
## Description

Change spelling from `Github` -> `GitHub`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
