### PR TITLE
ROX-22019: Fix protobuf V2 copylock linter errors for enricher

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -180,7 +180,8 @@ func (e *enricherImpl) delegateEnrichImage(ctx context.Context, enrichCtx Enrich
 	}
 
 	// Copy the fields from scannedImage into image, EnrichImage expecting modification in place
-	*image = *scannedImage
+	image.Reset()
+	protocompat.Merge(image, scannedImage)
 
 	e.cvesSuppressor.EnrichImageWithSuppressedCVEs(image)
 	e.cvesSuppressorV2.EnrichImageWithSuppressedCVEs(image)

--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -65,3 +65,11 @@ type ClonedUnmarshaler[T any] interface {
 	proto.Unmarshaler
 	*T
 }
+
+// Merge merges src into dst.
+// Required and optional fields that are set in src will be set to that value in dst.
+// Elements of repeated fields will be appended.
+// Merge panics if src and dst are not the same type, or if dst is nil.
+func Merge(dst, src Message) {
+	proto.Merge(dst, src)
+}

--- a/pkg/protocompat/message_test.go
+++ b/pkg/protocompat/message_test.go
@@ -122,3 +122,22 @@ func TestUnmarshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, msg, decoded)
 }
+
+func TestMerge(t *testing.T) {
+	msgDst := &storage.NamespaceMetadata{
+		Id:          testconsts.NamespaceA,
+		ClusterName: "Cluster 1",
+	}
+
+	msgSrc := &storage.NamespaceMetadata{
+		Name:        "Namespace A",
+		ClusterName: "Cluster 2",
+	}
+
+	Merge(msgDst, msgSrc)
+
+	assert.Equal(t, testconsts.NamespaceA, msgDst.GetId())
+	assert.Equal(t, "Namespace A", msgDst.GetName())
+	assert.Equal(t, "Cluster 2", msgDst.GetClusterName())
+	assert.Equal(t, "", msgDst.GetClusterId())
+}


### PR DESCRIPTION
## Description

We have a PR that generates protobuf V2 structs. V2 includes locks in a struct, and we had a few linter failures:
https://github.com/stackrox/stackrox/actions/runs/8483665309/job/23245169186?pr=10333

In order to fix that we should avoid shallow struct copy and use provided functions and interfaces by protobuf framework in such cases.

This PR fixes one situation where structs are copied. It is a bit trickier problem because we are not able to use `Clone` because the caller expects object modification. We can not allocate a new object. That's why the `Merge` function is used.

The `Merge` function is a bit slower (`~20us`) than copying, but this section is not in the critical execution path. It will only be executed in situations where delegated scanning is triggered, and a call to the sensor is made.

**Benchmark**
```
BenchmarkPointer
BenchmarkPointer-12                  	125648763	         9.551 ns/op
..
BenchmarkMerge
BenchmarkMerge-12                    	   55508	     22230 ns/op
```

Additional benchmark info in: #10874 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Image build and CI tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
