### PR TITLE
ROX-22019: Fix protobuf V2 copylock linter errors

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -194,7 +194,7 @@ func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.Augme
 		return pathutil.NewAugmentedObj(image), nil
 	}
 
-	img := *image
+	img := image.Clone()
 
 	// When evaluating policies, the evaluator will stop when any of the objects within the path
 	// are nil and immediately return, not matching. Within the image signature criteria, we have
@@ -209,7 +209,7 @@ func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.Augme
 		}
 	}
 
-	obj := pathutil.NewAugmentedObj(&img)
+	obj := pathutil.NewAugmentedObj(img)
 
 	// Since policies query for Dockerfile Line as a single compound field, we simulate it by creating a "composite"
 	// dockerfile line under each layer.

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -279,8 +279,7 @@ func (e *enricher) getImages(deployment *storage.Deployment) []*storage.Image {
 
 		// This will ensure that when we change the Name of the image
 		// that it will not cause a potential race condition
-		// cloning the full object is too expensive and also unnecessary
-		image := *imgResult.image
+		image := *imgResult.image.Clone()
 		// Overwrite the image Name as a workaround to the fact that we fetch the image by ID
 		// The ID may actually have many names that refer to it. e.g. busybox:latest and busybox:1.31 could have the
 		// exact same ID


### PR DESCRIPTION
## Description

We have a PR that generates protobuf V2 structs. V2 includes locks in a struct, and we had a few linter failures:
https://github.com/stackrox/stackrox/actions/runs/8483665309/job/23245169186?pr=10333

In order to fix that we should avoid shallow struct copy and use provided functions and interfaces by protobuf framework in such cases.

For these two identified cases, we can use `Clone`.

**Benchmark**

I did some benchmarking on my local machine:
```
BenchmarkPointer
BenchmarkPointer-12                  	125648763	         9.551 ns/op
BenchmarkCustomShallowCopy
BenchmarkCustomShallowCopy-12        	60597052	        20.10 ns/op
BenchmarkReflectionShallowCopy
BenchmarkReflectionShallowCopy-12    	  126420	      9274 ns/op
BenchmarkClone
BenchmarkClone-12                    	  674404	      1727 ns/op
```

* BenchmarkPointer (what we currently have):
```
img := &storage.Image{}
*img = *image`
```

* BenchmarkCustomShallowCopy (probably should be improved to avoid lock copy of sub-structs):
```
func customShallowCopy(dest *storage.Image, src *storage.Image) {
	dest.Id = src.Id
// ...
	dest.Notes = src.Notes
}
```

* BenchmarkReflectionShallowCopy (uses reflection and loops over fields):
```
// In benchmark test loop
		img := &storage.Image{}
		reflectionShallowCopy(img, image)
// ...

func reflectionShallowCopy(dst interface{}, src interface{}) {
 // ...
	for i := 0; i < srcType.NumField(); i++ {
		fieldName := srcType.Field(i).Name
		dstElemType.FieldByName(fieldName).Set(srcElemType.FieldByName(fieldName))
	}
}
```
A solution that uses a field index is faster: `~700 ns/op`. This solution could still suffer from lock copy. Similar to `BenchmarkCustomShallowCopy`.

* BenchmarkClone:
```
img := image.Clone()
```

**Conclusion**

The previous solution is fast (a few `ns`), and the solution with `Clone` takes `<2us`.

I think that execution paths are not so critical and that an increase of `2us` per image should not cause issues for users. Also, the solution with `Clone` is more straightforward, robust, and easier to maintain.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

- Benchmarking to decide on the solution
- Image build and CI tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
