### PR TITLE
fix(test): Ensure that timer is not zero in Test_CreateDeleteCRD

### DIFF
--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
@@ -69,7 +69,7 @@ func newFakeCRD(name string) *unstructured.Unstructured {
 
 func (s *watcherSuite) createWithRandomTicker(names ...string) {
 	go func() {
-		ticker := time.NewTicker(time.Duration(rand.Intn(100)) * time.Millisecond)
+		ticker := time.NewTicker(time.Duration(rand.Intn(90)+10) * time.Millisecond)
 		for _, name := range names {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
## Description

This PR should fix some unexpected test failures for the `Test_CreateDeleteCRD` test.

1% (in theory 😄 ) of our unit test runs are failing with the following error:
```
2024-04-24T17:39:23.2786934Z panic: non-positive interval for NewTicker
2024-04-24T17:39:23.2787381Z 
2024-04-24T17:39:23.2787555Z goroutine 24 [running]:
2024-04-24T17:39:23.2788006Z time.NewTicker(0x0)
2024-04-24T17:39:23.2788477Z 	/usr/local/go/src/time/tick.go:22 +0x1c8
2024-04-24T17:39:23.2789744Z github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd.(*watcherSuite).createWithRandomTicker.func1()
2024-04-24T17:39:23.2791476Z 	/__w/stackrox/stackrox/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go:72 +0x5b
2024-04-24T17:39:23.2793465Z created by github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd.(*watcherSuite).createWithRandomTicker in goroutine 23
2024-04-24T17:39:23.2795507Z 	/__w/stackrox/stackrox/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go:71 +0x118
2024-04-24T17:39:23.2796884Z FAIL	github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd	0.344s
```

The problem is that the used function for random **non-negative** numbers `rand.Intn` can return `0`. But `time.NewTicker` will panic if a **non-positive** number is provided. Provided change should ensure that the number is always `>0`.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Checked on Go Playground:
https://go.dev/play/p/aqi6LIso2he

And CI tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
