### PR TITLE
fix(fake-workloads): Add fake dynamic client

### DIFF
--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -237,15 +237,15 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		Platform:     "linux/amd64",
 	}
 	scheme := runtime.NewScheme()
+	gvr := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
 
 	w.client = &clientSetImpl{
 		kubernetes: w.fakeClient,
-		dynamic: fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
-			schema.GroupVersionResource{
-				Group:    "apiextensions.k8s.io",
-				Version:  "v1",
-				Resource: "customresourcedefinitions",
-			}: "CustomResourceDefinitionList"}),
+		dynamic:    fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{gvr: "CustomResourceDefinitionList"}),
 	}
 
 	go w.clearActions()


### PR DESCRIPTION
## Description

Fake workloads are failing because the dynamic client is not configured.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Running Sensor with fake workloads does not panic anymore.
- [x] The `gke-scale-tests` passes.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
