### PR TITLE
fix: resource updates should trigger deploy time enforcements

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -232,6 +232,7 @@ func (d *detectorImpl) serializeDeployTimeOutput() {
 				if !isMostRecentUpdate {
 					continue
 				}
+				d.enforcer.ProcessAlertResults(result.action, storage.LifecycleStage_DEPLOY, alertResults)
 			}
 			select {
 			case <-d.serializerStopper.Flow().StopRequested():

--- a/sensor/common/enforcer/enforcer_test.go
+++ b/sensor/common/enforcer/enforcer_test.go
@@ -102,7 +102,15 @@ func TestProcessAlertResults(t *testing.T) {
 			alerts: []alertEnforcementPair{
 				{
 					alert:       alert1,
-					enforcement: storage.EnforcementAction_KILL_POD_ENFORCEMENT,
+					enforcement: storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+				},
+			},
+			expectedEnforcements: []*central.SensorEnforcement{
+				{
+					Enforcement: storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+					Resource: &central.SensorEnforcement_Deployment{
+						Deployment: generateDeploymentEnforcement(alert1),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Deploy time violations are currently only enforced _once_ either by the admission controller or the sensor (when scaling down). While this works in most cases, it won't work in case a deployment has a violation after it's already been deployed (e.g. when a policy changes or metadata about the image changes, like a new vulnerability arises).

The current behavior for an enforce policy is that a violation will be created which references that the image has been scaled to 0:
![Screenshot 2024-04-25 at 18 13 08](https://github.com/stackrox/stackrox/assets/89904305/2a669a2e-4399-4502-a16c-e9b1ea21575f)

However, this is not the case. At the current time, the enforcement is only done on `CREATE` actions, however when deployments are reassessed (which happens either during the reprocessing loop or when policy criteria are being updated) we pass `UPDATE`.

This PR fixes this behavior according to the violation: in case a violation is found _after_ the deployment has already been deployed, it will now correctly trigger an enforcement and scale the deployment to 0.
This also fixes another issue which would be that in case of a policy violations _during_ the deployment of a failing deployment and the deployment being scaled to 0 one could simply re-scale it afterwards, which would be an `UPDATE` event, which would be skipped by the enforcement.

_Note: I'll also make sure to create an e2e tests, either within this PR or as a follow-up._

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
