### PR TITLE
ROX-23767: fail on high severity vulns

### DIFF
--- a/.github/workflows/check-image-vulnerabilities.yml
+++ b/.github/workflows/check-image-vulnerabilities.yml
@@ -32,6 +32,7 @@ jobs:
       # Needed for stackrox/central-login to create the JWT token.
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         image:
           [
@@ -74,3 +75,16 @@ jobs:
             echo '```'
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if critical or important vulnerabilities have been found
+        run: |
+          RESULT=$(roxctl image scan --output=json \
+            --image="quay.io/rhacs-eng/${{ matrix.image }}:${{ inputs.version }}")
+          CRITICAL_CNT=$(jq ".result.summary.CRITICAL" <<< "$RESULT")
+          IMPORTANT_CNT=$(jq ".result.summary.IMPORTANT" <<< "$RESULT")
+          if (( CRITICAL_CNT + IMPORTANT_CNT > 0 )); then
+            echo "Found $CRITICAL_CNT critical vulnerabilities."
+            echo "Found $IMPORTANT_CNT important vulnerabilities."
+            echo "Check the workflow summary for a detailed list of the vulnerabilities."
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Make sure that the release vulnerability check fails if either a `Critical` or `Important` vulnerability has been found. Unfortunately we cannot pass such an error condition to `roxctl` today, so we have to scan again with `json` output and then do some `jq` parsing. Note that the image scan is cached by Central, so there is no performance penalty for scanning twice.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

See example run https://github.com/stackrox/stackrox/actions/runs/8837151755.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
