### PR TITLE
fix(CI): better cancelation support

### DIFF
--- a/.openshift-ci/end.sh
+++ b/.openshift-ci/end.sh
@@ -36,7 +36,7 @@ determine_an_overall_job_outcome() {
     # Determine a useful overall job outcome based on outcomes shared from prior
     # steps. A default outcome of canceled is assumed for a step with an
     # undefined value. This handles steps that are canceled by openshift-ci and
-    # that do not terminate within the termination grace period where the
+    # that do not terminate within the termination grace period. In these cases
     # SHARED_DIR state is not propagated.
 
     combined="${CREATE_CLUSTER_OUTCOME:-${OUTCOME_CANCELED}}-${JOB_DISPATCH_OUTCOME:-${OUTCOME_CANCELED}}-${DESTROY_CLUSTER_OUTCOME:-${OUTCOME_CANCELED}}"
@@ -45,7 +45,7 @@ determine_an_overall_job_outcome() {
     info "${combined}"
 
     case "${combined}" in
-        "${OUTCOME_CANCELED}-${OUTCOME_CANCELED}"-*)
+        "${OUTCOME_CANCELED}"-*-*)
             # The job was interrupted before cluster create could complete.
             # Cluster destroy might still pass, fail or be canceled.
             outcome="${OUTCOME_CANCELED}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -54,6 +54,8 @@ ci_exit_trap() {
 
     if [[ "${exit_code}" == "0" ]]; then
         set_ci_shared_export JOB_DISPATCH_OUTCOME "${OUTCOME_PASSED}"
+    elif [[ "${exit_code}" == "130" ]]; then
+        set_ci_shared_export JOB_DISPATCH_OUTCOME "${OUTCOME_CANCELED}"
     else
         set_ci_shared_export JOB_DISPATCH_OUTCOME "${OUTCOME_FAILED}"
     fi


### PR DESCRIPTION
## Description

For job metrics it was originally determined that canceled openshift-ci jobs did not propagate data saved by the terminated step to `SHARED_DIR` for use in future steps. Based on results however it appears that this is only the case when a terminated step does not exit before the openshift-ci grace period ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/10836/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1783457015998189568)). Currently, steps that exit before the termination grace period propagate a failed value for `JOB_DISPATCH_OUTCOME` which results in an incorrect overall job outcome record of failed ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/10713/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1781241655144222720)).

This change uses the fact that terminated steps receive an exit code of 130 to the general exit handler. This is used to propagate a canceled outcome for the step. An assumption of canceled continues to be used to handle the case where the test does not exit before the grace period.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] cancel a job with a commit - the BQ job record outcome should be canceled.
- [x] let a job continue to completion - the BQ job record outcome should be passed|failed.

https://lookerstudio.google.com/s/mvDkZdp0NN8. There is an outstanding issue with GKE based jobs that will record a failure if the cancel occurs during cluster create. That will be fixed as a side effect of ROX-23480.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
