### PR TITLE
fix(test): Install CO before stackrox

### DIFF
--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -28,8 +28,9 @@ test_ui_e2e() {
     remove_existing_stackrox_resources
     setup_default_TLS_certs
 
-    deploy_stackrox
+    # deploy the optional components before stackrox
     deploy_optional_e2e_components
+    deploy_stackrox
 
     run_ui_e2e_tests
 }


### PR DESCRIPTION
## Description

Install CO before stackrox in the UI tests to avoid problems with CO not being ready on time.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] UI test steps should be happy

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
