### PR TITLE
chore: telemetry: allow custom key for release versions

### DIFF
--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -1,10 +1,9 @@
 package centralclient
 
 import (
-	"testing"
-
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/images/defaults"

--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -13,12 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetInstanceConfigInTest(t *testing.T) {
-	cfg, props, err := getInstanceConfig("id")
+func Test_getKey(t *testing.T) {
+	key, err := getKey()
 	// Telemetry should be disabled in test environment.
-	assert.Nil(t, cfg)
-	assert.Nil(t, props)
-	assert.Nil(t, err)
+	assert.Empty(t, key)
+	assert.NoError(t, err)
 }
 
 func TestInstanceConfig(t *testing.T) {
@@ -65,16 +64,16 @@ func TestInstanceConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv(env.TelemetryConfigURL.EnvVar(), test.configURL)
 			t.Setenv(env.TelemetryStorageKey.EnvVar(), test.key)
-
-			cfg, props, err := getInstanceConfig("test-id")
+			key, err := getKey()
 			assert.NoError(t, err)
 			if test.telemetryEnabled {
+				cfg, props := getInstanceConfig("test-id", key)
 				require.NotNil(t, cfg, "Telemetry must be enabled")
 				assert.Equal(t, test.expectedKey, cfg.StorageKey)
 				assert.Equal(t, "test-id", cfg.ClientID)
 				assert.Equal(t, devVersion, props["Central version"])
 			} else {
-				assert.Nil(t, cfg, "Telemetry must be disabled")
+				assert.Empty(t, key, "Telemetry must be disabled")
 			}
 		})
 	}

--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -3,13 +3,79 @@ package centralclient
 import (
 	"testing"
 
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGetInstanceConfig(t *testing.T) {
-	cfg, props, err := getInstanceConfig()
+func TestGetInstanceConfigInTest(t *testing.T) {
+	cfg, props, err := getInstanceConfig("id")
 	// Telemetry should be disabled in test environment.
 	assert.Nil(t, cfg)
 	assert.Nil(t, props)
 	assert.Nil(t, err)
+}
+
+func TestInstanceConfig(t *testing.T) {
+	const devVersion = "4.4.1-dev"
+	const remoteKey = "remotekey"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"storage_key_v1": "` + remoteKey + `" }`))
+	}))
+	defer server.Close()
+
+	testutils.SetMainVersion(t, devVersion)
+	t.Setenv(defaults.ImageFlavorEnvName, "opensource")
+
+	tests := map[string]struct {
+		configURL string
+		key       string
+
+		telemetryEnabled bool
+		expectedKey      string
+	}{
+		"no URL, with key": {
+			"", "whatever-key",
+			true, "whatever-key",
+		},
+		"hardcoded URL, with key": {
+			// non-release builds should provide the same key as in the remote
+			// config to make the remote key effective, otherwise the provided
+			// key is used instead.
+			"hardcoded", "not-equal-to-hardcoded",
+			true, "not-equal-to-hardcoded",
+		},
+		"custom URL, no key": {
+			server.URL, "",
+			false, "",
+		},
+		"custom URL, with matching key": {
+			server.URL, remoteKey,
+			true, remoteKey,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(env.TelemetryConfigURL.EnvVar(), test.configURL)
+			t.Setenv(env.TelemetryStorageKey.EnvVar(), test.key)
+
+			cfg, props, err := getInstanceConfig("test-id")
+			assert.NoError(t, err)
+			if test.telemetryEnabled {
+				require.NotNil(t, cfg, "Telemetry must be enabled")
+				assert.Equal(t, test.expectedKey, cfg.StorageKey)
+				assert.Equal(t, "test-id", cfg.ClientID)
+				assert.Equal(t, devVersion, props["Central version"])
+			} else {
+				assert.Nil(t, cfg, "Telemetry must be disabled")
+			}
+		})
+	}
 }

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -11,7 +11,9 @@ var (
 
 	// TelemetryConfigURL to retrieve the telemetry configuration from.
 	// TODO(ROX-17726): Set default URL for self-managed installations use.
-	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault("hardcoded"))
+	// AllowEmpty() allows for disabling the downloading, and for providing a
+	// custom key to release binary versions.
+	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", AllowEmpty(), WithDefault("hardcoded"))
 
 	// TelemetryFrequency is the frequency at which we will report telemetry.
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 10*time.Minute)

--- a/pkg/telemetry/phonehome/key_management.go
+++ b/pkg/telemetry/phonehome/key_management.go
@@ -71,7 +71,7 @@ func downloadConfig(u string) (*remoteConfig, error) {
 // We want to prevent accidental use of the production key, but still allow
 // developers to test the functionality. So download will only happen for
 // development installations if both a key and an URL are provided. For release
-// versions the key may be empty.
+// versions the key should be empty.
 // See unit tests for the examples.
 func toDownload(isRelease bool, key, cfgURL string) bool {
 	if cfgURL == "" {
@@ -81,7 +81,7 @@ func toDownload(isRelease bool, key, cfgURL string) bool {
 		// Development versions must provide a key on top of the URL.
 		return key != ""
 	}
-	return true
+	return key == ""
 }
 
 // useRemoteKey decides if the key from the downloaded configuration has to be


### PR DESCRIPTION
## Description

When configuring the telemetry key on a release central version, the current implementation ignores the provided value in favor of the hardcoded one.

This PR disables "downloading" of the hardcoded value if:
* a key is provided;
* the telemetry configuration URL is set to an empty value.

Tests have been added to cover some testable code paths.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
