### PR TITLE
ROX-23067: platform CVE summary cards

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersSummaryCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
+
+export type AffectedClustersSummaryCardProps = {
+    affectedClusterCount: number;
+    totalClusterCount: number;
+};
+
+function AffectedClustersSummaryCard({
+    affectedClusterCount,
+    totalClusterCount,
+}: AffectedClustersSummaryCardProps) {
+    return (
+        <Card isCompact isFlat isFullHeight>
+            <CardTitle>Affected clusters</CardTitle>
+            <CardBody>
+                <Grid>
+                    <GridItem span={12} className="pf-v5-u-pt-sm">
+                        {affectedClusterCount} / {totalClusterCount} affected clusters
+                    </GridItem>
+                </Grid>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default AffectedClustersSummaryCard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+import { Card, CardTitle, CardBody, Grid, GridItem } from '@patternfly/react-core';
+
+export const clustersByTypeFragment = gql`
+    fragment ClustersByType on PlatformCVECore {
+        clusterCountByType {
+            generic
+            kubernetes
+            openshift
+            openshift4
+        }
+    }
+`;
+
+export type ClustersByType = {
+    clusterCountByType: {
+        generic: number;
+        kubernetes: number;
+        openshift: number;
+        openshift4: number;
+    };
+};
+
+export type ClustersByTypeSummaryCardProps = {
+    clusterCounts: ClustersByType['clusterCountByType'];
+};
+
+function ClustersByTypeSummaryCard({ clusterCounts }: ClustersByTypeSummaryCardProps) {
+    const { generic, kubernetes, openshift, openshift4 } = clusterCounts;
+    return (
+        <Card isCompact isFlat isFullHeight>
+            <CardTitle>Clusters by type</CardTitle>
+            <CardBody>
+                <Grid>
+                    {generic > 0 && (
+                        <GridItem span={12} className="pf-v5-u-pt-xs">
+                            {generic} Generic
+                        </GridItem>
+                    )}
+                    {kubernetes > 0 && (
+                        <GridItem span={12} className="pf-v5-u-pt-xs">
+                            {kubernetes} Kubernetes
+                        </GridItem>
+                    )}
+                    {openshift + openshift4 > 0 && (
+                        <GridItem span={12} className="pf-v5-u-pt-xs">
+                            {openshift + openshift4} OpenShift
+                        </GridItem>
+                    )}
+                </Grid>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ClustersByTypeSummaryCard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
     PageSection,
     Breadcrumb,
@@ -6,8 +6,6 @@ import {
     BreadcrumbItem,
     Skeleton,
     Alert,
-    Grid,
-    GridItem,
     Gallery,
     GalleryItem,
 } from '@patternfly/react-core';
@@ -21,7 +19,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import CvePageHeader from '../../components/CvePageHeader';
 import {
     getOverviewPagePath,
     getRegexScopedQueryString,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
@@ -1,0 +1,52 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { getPaginationParams } from 'utils/searchUtils';
+
+import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+
+const platformCveMetadataQuery = gql`
+    ${clustersByTypeFragment}
+    query getPlatformCVEMetadata($cve: String!, $query: String!) {
+        totalClusterCount: clusterCount
+        clusterCount(query: $query)
+        platformCVE(cve: $cve, subfieldScopeQuery: $query) {
+            cve
+            distroTuples {
+                link
+                summary
+                operatingSystem
+            }
+            firstDiscoveredInSystem
+            ...ClustersByType
+        }
+    }
+`;
+
+export type PlatformCveMetadata = {
+    cve: string;
+    distroTuples: {
+        link: string;
+        summary: string;
+        operatingSystem: string;
+    }[];
+    firstDiscoveredInSystem: string;
+};
+
+export default function usePlatformCveMetadata(
+    cve: string,
+    query: string,
+    page: number,
+    perPage: number
+) {
+    return useQuery<{
+        totalClusterCount: number;
+        clusterCount: number;
+        platformCVE: PlatformCveMetadata & ClustersByType;
+    }>(platformCveMetadataQuery, {
+        variables: {
+            cve,
+            query,
+            pagination: getPaginationParams(page, perPage),
+        },
+    });
+}


### PR DESCRIPTION
## Description

Adds the metadata request for the Platform CVE page and corresponding summary cards.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a platform CVE page:

Loading state:
![image](https://github.com/stackrox/stackrox/assets/1292638/1d28866e-e875-4bbf-acb9-5b0fc8a267a8)

Error state:
![image](https://github.com/stackrox/stackrox/assets/1292638/8e2a2bd1-83c6-47e6-95bf-806ffefd3496)

Success (generic should not occur, but I am accounting for it in the payload)
![image](https://github.com/stackrox/stackrox/assets/1292638/bce0fd42-e58a-4b8c-a876-83689ca4731f)
