### PR TITLE
ROX-23759: skip fetching signatures with no signature integrations

### DIFF
--- a/central/reprocessor/mocks/reprocessor.go
+++ b/central/reprocessor/mocks/reprocessor.go
@@ -55,15 +55,15 @@ func (mr *MockLoopMockRecorder) ReprocessRiskForDeployments(deploymentIDs ...any
 }
 
 // ReprocessSignatureVerifications mocks base method.
-func (m *MockLoop) ReprocessSignatureVerifications() {
+func (m *MockLoop) ReprocessSignatureVerifications(firstIntegration bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReprocessSignatureVerifications")
+	m.ctrl.Call(m, "ReprocessSignatureVerifications", firstIntegration)
 }
 
 // ReprocessSignatureVerifications indicates an expected call of ReprocessSignatureVerifications.
-func (mr *MockLoopMockRecorder) ReprocessSignatureVerifications() *gomock.Call {
+func (mr *MockLoopMockRecorder) ReprocessSignatureVerifications(firstIntegration any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReprocessSignatureVerifications", reflect.TypeOf((*MockLoop)(nil).ReprocessSignatureVerifications))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReprocessSignatureVerifications", reflect.TypeOf((*MockLoop)(nil).ReprocessSignatureVerifications), firstIntegration)
 }
 
 // ShortCircuit mocks base method.

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -212,9 +212,8 @@ func (l *loopImpl) ReprocessSignatureVerifications(firstIntegration bool) {
 	// Signal that we should reprocess signature verifications for all images. This will only trigger a reprocess with
 	// refetch of signature verification results.
 	// If the signal is already triggered, then the current signal is effectively deduped.
-	l.signatureVerificationSig.Signal()
-
 	l.firstSignatureIntegration.Set(firstIntegration)
+	l.signatureVerificationSig.Signal()
 }
 
 func (l *loopImpl) sendDeployments(deploymentIDs []string) {

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -734,6 +734,18 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 		return false, nil
 	}
 
+	// Fetch signature integrations from the data store.
+	sigIntegrations, err := e.signatureIntegrationGetter(sac.WithAllAccess(ctx))
+	if err != nil {
+		return false, errors.Wrap(err, "fetching signature integrations")
+	}
+
+	// Short-circuit if no integrations are available.
+	if len(sigIntegrations) == 0 {
+		// Contrary to the signature verification step we will retain existing signatures.
+		return false, nil
+	}
+
 	imgName := img.GetName().GetFullName()
 
 	if err := e.checkRegistryForImage(img); err != nil {

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -894,8 +894,9 @@ func TestEnrichWithSignature_Success(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := enricherImpl{
-				integrations:     integrationsSetMock,
-				signatureFetcher: c.sigFetcher,
+				integrations:               integrationsSetMock,
+				signatureFetcher:           c.sigFetcher,
+				signatureIntegrationGetter: fakeSignatureIntegrationGetter("test", false),
 			}
 			updated, err := e.enrichWithSignature(emptyCtx, c.ctx, c.img)
 			assert.NoError(t, err)
@@ -948,7 +949,8 @@ func TestEnrichWithSignature_Failures(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := enricherImpl{
-				integrations: c.integrationSet,
+				integrations:               c.integrationSet,
+				signatureIntegrationGetter: fakeSignatureIntegrationGetter("test", false),
 			}
 			updated, err := e.enrichWithSignature(emptyCtx,
 				EnrichmentContext{FetchOpt: ForceRefetchSignaturesOnly}, c.img)


### PR DESCRIPTION
## Description

In case no signature integration exist for verification, let's skip fetching signatures for the time being.

This won't really have any impact on the feature itself, since the reprocessing loop will short-circuit and force fetching sigs + verifying them once a signature integration is added.

This optimization only applies to the Central part of enrichment, since we do not sync signature integrations with Sensor and thus have to eagerly fetch signatures even if we don't need them (for the time being at least).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI + added unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
