### PR TITLE
fix(reprocessor): reprocess all images with signatures

### DIFF
--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -5,17 +5,21 @@ package reprocessor
 import (
 	"context"
 	"testing"
+	"time"
 
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	imagePG "github.com/stackrox/rox/central/image/datastore/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/process/filter"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,4 +62,51 @@ func TestGetActiveImageIDs(t *testing.T) {
 	ids, err = loop.getActiveImageIDs()
 	require.NoError(t, err)
 	require.ElementsMatch(t, imageIDs, ids)
+}
+
+func TestImagesWithSignaturesQuery(t *testing.T) {
+	t.Parallel()
+
+	testCtx := sac.WithAllAccess(context.Background())
+
+	testingDB := pgtest.ForT(t)
+	pool := testingDB.DB
+	defer pool.Close()
+
+	imageDS := imageDatastore.NewWithPostgres(imagePG.New(pool, false,
+		concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
+
+	imgWithSignature := fixtures.GetImage()
+	imgWithoutSignature := fixtures.GetImageWithUniqueComponents(10)
+
+	oneHourAgo := time.Now().Add(-1 * time.Hour)
+	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
+	const imgWithSignatureID = "sha256:image-with-signature"
+	const imgWithoutSignatureID = "sha256:image-without-signature"
+
+	imgWithSignature.Id = imgWithSignatureID
+	imgWithSignature.Signature = &storage.ImageSignature{
+		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneHourAgo),
+	}
+	imgWithoutSignature.Id = imgWithoutSignatureID
+
+	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
+	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithoutSignature))
+
+	results, err := imageDS.Search(testCtx, imagesWithSignaturesQuery)
+	assert.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, results[0].ID, imgWithSignatureID)
+
+	imgWithSignature.Signature = &storage.ImageSignature{
+		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneMinuteAgo),
+	}
+	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
+
+	results, err = imageDS.Search(testCtx, imagesWithSignaturesQuery)
+	assert.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, results[0].ID, imgWithSignatureID)
 }


### PR DESCRIPTION
## Description

During a change to a signature integration (when the actual verification data changes such as the public key) we attempt to reprocess all images that already have signatures associated with them.

However, in case one of your images was not permitted on clusters due to a signature verification failure (e.g. due to enforcement by the admission controller) then this image previously would have been skipped.
The reason for this is that we only took images into account which had a related cluster with them.

The query has now been changed to take into account _all_ images irrespective of whether they are assigned to a cluster or not. While this will theoretically increase the size of the to-reprocess images, it will
have a better UX _and_ the changes to signature integrations aren't considered high-volume.

Additionally changed the query to use the `AddTimeRange` field in the query since this seemed more readable than the previous query field.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI; also added some test cases.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
