### PR TITLE
chore(signatures): refactor existing abstractions

### DIFF
--- a/pkg/signatures/cosign_sig_fetcher.go
+++ b/pkg/signatures/cosign_sig_fetcher.go
@@ -28,16 +28,16 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type cosignPublicKeySignatureFetcher struct {
+type cosignSignatureFetcher struct {
 	// registryRateLimiter is a rate limiter for parallel calls to the registry. This will avoid reaching out to the
 	// registry too many times leading to 429 errors.
 	registryRateLimiter *rate.Limiter
 }
 
-var _ SignatureFetcher = (*cosignPublicKeySignatureFetcher)(nil)
+var _ SignatureFetcher = (*cosignSignatureFetcher)(nil)
 
-func newCosignPublicKeySignatureFetcher() *cosignPublicKeySignatureFetcher {
-	return &cosignPublicKeySignatureFetcher{
+func newCosignSignatureFetcher() *cosignSignatureFetcher {
+	return &cosignSignatureFetcher{
 		registryRateLimiter: rate.NewLimiter(rate.Every(50*time.Millisecond), 1),
 	}
 }
@@ -55,7 +55,7 @@ func init() {
 // The signature associated with the image will be fetched from the given registry.
 // It will return the storage.ImageSignature and an error that indicated whether the fetching should be retried or not.
 // NOTE: No error will be returned when the image has no signature available. All occurring errors will be logged.
-func (c *cosignPublicKeySignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
+func (c *cosignSignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
 	fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error) {
 	// Short-circuit for images that do not have V2 metadata associated with them. These would be older images manifest
 	// schemes that are not supported by cosign, like the docker v1 manifest.

--- a/pkg/signatures/cosign_sig_fetcher_test.go
+++ b/pkg/signatures/cosign_sig_fetcher_test.go
@@ -116,7 +116,7 @@ func uploadSignatureForImage(imgRef string, b64Sig string, sigPayload []byte) er
 	return nil
 }
 
-func TestPublicKey_FetchSignature_Success(t *testing.T) {
+func TestCosignSignatureFetcher_FetchSignature_Success(t *testing.T) {
 	registryServer, imgRef, err := registryServerWithImage("nginx")
 	require.NoError(t, err, "setting up registry")
 	defer registryServer.Close()
@@ -157,7 +157,7 @@ func TestPublicKey_FetchSignature_Success(t *testing.T) {
 		},
 	}
 
-	f := newCosignPublicKeySignatureFetcher()
+	f := newCosignSignatureFetcher()
 	mockConfig := &registryTypes.Config{
 		Username: "",
 		Password: "",
@@ -170,12 +170,12 @@ func TestPublicKey_FetchSignature_Success(t *testing.T) {
 	assert.Equal(t, expectedSignatures, res)
 }
 
-func TestPublicKey_FetchSignature_Failure(t *testing.T) {
+func TestCosignSignatureFetcher_FetchSignature_Failure(t *testing.T) {
 	registryServer, _, err := registryServerWithImage("nginx")
 	require.NoError(t, err, "setting up registry")
 	defer registryServer.Close()
 
-	f := newCosignPublicKeySignatureFetcher()
+	f := newCosignSignatureFetcher()
 
 	cimg, err := imgUtils.GenerateImageFromString("nginx")
 	require.NoError(t, err, "creating test image")
@@ -190,7 +190,7 @@ func TestPublicKey_FetchSignature_Failure(t *testing.T) {
 	assert.False(t, retry.IsRetryable(err))
 }
 
-func TestPublicKey_FetchSignature_NoSignature(t *testing.T) {
+func TestCosignSignatureFetcher_FetchSignature_NoSignature(t *testing.T) {
 	registryServer, imgRef, err := registryServerWithImage("nginx")
 	require.NoError(t, err, "setting up registry")
 	defer registryServer.Close()
@@ -199,7 +199,7 @@ func TestPublicKey_FetchSignature_NoSignature(t *testing.T) {
 	require.NoError(t, err, "creating test image")
 	img := types.ToImage(cimg)
 
-	f := newCosignPublicKeySignatureFetcher()
+	f := newCosignSignatureFetcher()
 	reg := &mockRegistry{cfg: &registryTypes.Config{}}
 
 	require.NoError(t, err)

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -37,21 +37,21 @@ var (
 	errCorruptedSignature    = errox.InvariantViolation.New("corrupted signature")
 )
 
-type cosignPublicKeyVerifier struct {
+type cosignSignatureVerifier struct {
 	parsedPublicKeys []crypto.PublicKey
 }
 
-var _ SignatureVerifier = (*cosignPublicKeyVerifier)(nil)
+var _ SignatureVerifier = (*cosignSignatureVerifier)(nil)
 
 // IsValidPublicKeyPEMBlock is a helper function which checks whether public key PEM block was successfully decoded.
 func IsValidPublicKeyPEMBlock(keyBlock *pem.Block, rest []byte) bool {
 	return keyBlock != nil && keyBlock.Type == publicKeyType && len(rest) == 0
 }
 
-// newCosignPublicKeyVerifier creates a public key verifier with the given Cosign configuration. The provided public keys
+// newCosignSignatureVerifier creates a public key verifier with the given Cosign configuration. The provided public keys
 // MUST be valid PEM encoded ones.
 // It will return an error if the provided public keys could not be parsed.
-func newCosignPublicKeyVerifier(config *storage.CosignPublicKeyVerification) (*cosignPublicKeyVerifier, error) {
+func newCosignSignatureVerifier(config *storage.CosignPublicKeyVerification) (*cosignSignatureVerifier, error) {
 	publicKeys := config.GetPublicKeys()
 	parsedKeys := make([]crypto.PublicKey, 0, len(publicKeys))
 	for _, publicKey := range publicKeys {
@@ -68,13 +68,13 @@ func newCosignPublicKeyVerifier(config *storage.CosignPublicKeyVerification) (*c
 		parsedKeys = append(parsedKeys, parsedKey)
 	}
 
-	return &cosignPublicKeyVerifier{parsedPublicKeys: parsedKeys}, nil
+	return &cosignSignatureVerifier{parsedPublicKeys: parsedKeys}, nil
 }
 
 // VerifySignature implements the SignatureVerifier interface.
 // The signature of the image will be verified using cosign. It will include the verification via public key
 // as well as the claim verification of the payload of the signature.
-func (c *cosignPublicKeyVerifier) VerifySignature(ctx context.Context,
+func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 	image *storage.Image) (storage.ImageSignatureVerificationResult_Status, []string, error) {
 	// Short circuit if we do not have any public keys configured to verify against.
 	if len(c.parsedPublicKeys) == 0 {

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewPublicKeyVerifier(t *testing.T) {
+func TestNewCosignSignatureVerifier(t *testing.T) {
 	cases := map[string]struct {
 		pemEncKey string
 		fail      bool
@@ -43,7 +43,7 @@ func TestNewPublicKeyVerifier(t *testing.T) {
 					},
 				},
 			}
-			verifier, err := newCosignPublicKeyVerifier(config)
+			verifier, err := newCosignSignatureVerifier(config)
 			if c.fail {
 				assert.Error(t, err)
 				assert.Nil(t, verifier)
@@ -56,7 +56,7 @@ func TestNewPublicKeyVerifier(t *testing.T) {
 	}
 }
 
-func TestPublicKeyVerifier_VerifySignature_Success(t *testing.T) {
+func TestCosignSignatureVerifier_VerifySignature_Success(t *testing.T) {
 	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
 		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE04soAoNygRhaytCtygPcwsP+6Ein\n" +
 		"YoDv/BJx1T9WmtsANh2HplRR66Fbm+3OjFuah2IhFufPhDl6a85I3ymVYw==\n" +
@@ -70,10 +70,10 @@ func TestPublicKeyVerifier_VerifySignature_Success(t *testing.T) {
 	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
 		"bfd5c4c20a2fa2aaa7ede3"
 
-	pubKeyVerifier, err := newCosignPublicKeyVerifier(&storage.CosignPublicKeyVerification{
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
-				Name:            "cosignPublicKeyVerifier",
+				Name:            "cosignSignatureVerifier",
 				PublicKeyPemEnc: pemPublicKey,
 			},
 		},
@@ -92,7 +92,7 @@ func TestPublicKeyVerifier_VerifySignature_Success(t *testing.T) {
 		"image full name should match verified image reference")
 }
 
-func TestPublicKeyVerifier_VerifySignature_Multiple_Names(t *testing.T) {
+func TestCosignSignatureVerifier_VerifySignature_Multiple_Names(t *testing.T) {
 	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
 		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE04soAoNygRhaytCtygPcwsP+6Ein\n" +
 		"YoDv/BJx1T9WmtsANh2HplRR66Fbm+3OjFuah2IhFufPhDl6a85I3ymVYw==\n" +
@@ -106,10 +106,10 @@ func TestPublicKeyVerifier_VerifySignature_Multiple_Names(t *testing.T) {
 	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
 		"bfd5c4c20a2fa2aaa7ede3"
 
-	pubKeyVerifier, err := newCosignPublicKeyVerifier(&storage.CosignPublicKeyVerification{
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
-				Name:            "cosignPublicKeyVerifier",
+				Name:            "cosignSignatureVerifier",
 				PublicKeyPemEnc: pemPublicKey,
 			},
 		},
@@ -139,7 +139,7 @@ func TestPublicKeyVerifier_VerifySignature_Multiple_Names(t *testing.T) {
 		"verified image references should not contain image name %s", secondImageName.GetFullName())
 }
 
-func TestPublicKeyVerifier_VerifySignature_Failure(t *testing.T) {
+func TestCosignSignatureVerifier_VerifySignature_Failure(t *testing.T) {
 	const pemNonMatchingPubKey = "-----BEGIN PUBLIC KEY-----\n" +
 		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWi3tSxvBH7S/WUmv408nKPxNSJx6\n" +
 		"+w7c9FtFSk6coxx2VUbPy/X3US3cXfk/zVA+G7NbXGBYhAGaOsps5ZKjkQ==\n" +
@@ -153,7 +153,7 @@ func TestPublicKeyVerifier_VerifySignature_Failure(t *testing.T) {
 	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
 		"bfd5c4c20a2fa2aaa7ede3"
 
-	pubKeyVerifier, err := newCosignPublicKeyVerifier(&storage.CosignPublicKeyVerification{
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "Non matching key",
@@ -164,14 +164,14 @@ func TestPublicKeyVerifier_VerifySignature_Failure(t *testing.T) {
 
 	require.NoError(t, err, "creating public key verifier")
 
-	emptyPubKeyVerifier, err := newCosignPublicKeyVerifier(&storage.CosignPublicKeyVerification{})
+	emptyPubKeyVerifier, err := newCosignSignatureVerifier(&storage.CosignPublicKeyVerification{})
 	require.NoError(t, err, "creating empty public key verifier")
 
 	img, err := generateImageWithCosignSignature(imgString, b64Signature, b64SignaturePayload)
 	require.NoError(t, err, "creating image with signature")
 
 	cases := map[string]struct {
-		verifier *cosignPublicKeyVerifier
+		verifier *cosignSignatureVerifier
 		img      *storage.Image
 		err      error
 		status   storage.ImageSignatureVerificationResult_Status

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/protoutils"
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/retry"
 )
@@ -32,50 +32,50 @@ type SignatureFetcher interface {
 
 // NewSignatureVerifier creates a new signature verifier capable of verifying signatures against the provided config.
 func NewSignatureVerifier(config *storage.CosignPublicKeyVerification) (SignatureVerifier, error) {
-	return newCosignPublicKeyVerifier(config)
+	return newCosignSignatureVerifier(config)
 }
 
 // NewSignatureFetcher creates a new signature fetcher capable of fetching a specific signature format for an image.
 // Currently, only cosign public key signatures are supported.
 func NewSignatureFetcher() SignatureFetcher {
-	return newCosignPublicKeySignatureFetcher()
+	return newCosignSignatureFetcher()
 }
 
 // VerifyAgainstSignatureIntegration is a wrapper that will verify an image signature with SignatureVerifier's created
 // based off of the configuration within the storage.SignatureIntegration.
 // NOTE: No error will be returned if the SignatureVerifier's creation failed or the signature verification itself
-// failed. A log entry will be created for a failing creation, and the verification status can be must be checked within
-// the storage.ImageSignatureVerificationResult.
+// failed, the status can be checked in the verification result.
 func VerifyAgainstSignatureIntegration(ctx context.Context, integration *storage.SignatureIntegration,
-	image *storage.Image) []*storage.ImageSignatureVerificationResult {
-	verifiers := createVerifiersFromIntegration(integration)
-	var results []*storage.ImageSignatureVerificationResult
-	for _, verifier := range verifiers {
-		res, verifiedImageReferences, err := verifier.VerifySignature(ctx, image)
-
-		verificationResult := &storage.ImageSignatureVerificationResult{
-			VerificationTime:        protoconv.ConvertTimeToTimestamp(time.Now()),
-			VerifierId:              integration.GetId(),
-			Status:                  res,
-			VerifiedImageReferences: verifiedImageReferences,
+	image *storage.Image) *storage.ImageSignatureVerificationResult {
+	verifier, err := createVerifierFromSignatureIntegration(integration)
+	if err != nil {
+		return &storage.ImageSignatureVerificationResult{
+			VerificationTime: protoconv.ConvertTimeToTimestamp(time.Now()),
+			VerifierId:       integration.GetId(),
+			Status:           storage.ImageSignatureVerificationResult_GENERIC_ERROR,
+			Description:      err.Error(),
 		}
-		// We do not currently support specifying which specific method within an image signature integration should
-		// be successful. Hence, short-circuit on the first successfully verified signature within an image signature
-		// integration.
-		if res == storage.ImageSignatureVerificationResult_VERIFIED {
-			return []*storage.ImageSignatureVerificationResult{
-				verificationResult,
-			}
-		}
-		// Right now, we will duplicate the verification result for each SignatureVerifier contained within an image
-		// signature, ensuring all errors are properly returned to the caller.
-		if err != nil {
-			verificationResult.Description = err.Error()
-		}
-
-		results = append(results, verificationResult)
 	}
-	return results
+	res, verifiedImageReferences, err := verifier.VerifySignature(ctx, image)
+
+	verificationResult := &storage.ImageSignatureVerificationResult{
+		VerificationTime:        protoconv.ConvertTimeToTimestamp(time.Now()),
+		VerifierId:              integration.GetId(),
+		Status:                  res,
+		VerifiedImageReferences: verifiedImageReferences,
+	}
+	// We do not currently support specifying which specific method within an image signature integration should
+	// be successful. Hence, short-circuit on the first successfully verified signature within an image signature
+	// integration.
+	if res == storage.ImageSignatureVerificationResult_VERIFIED {
+		return verificationResult
+	}
+	// Right now, we will duplicate the verification result for each SignatureVerifier contained within an image
+	// signature, ensuring all errors are properly returned to the caller.
+	if err != nil {
+		verificationResult.Description = err.Error()
+	}
+	return verificationResult
 }
 
 // VerifyAgainstSignatureIntegrations is a wrapper that will verify an image signature against a list of
@@ -93,26 +93,19 @@ func VerifyAgainstSignatureIntegrations(ctx context.Context, integrations []*sto
 	var results []*storage.ImageSignatureVerificationResult
 	for _, integration := range integrations {
 		verificationResults := VerifyAgainstSignatureIntegration(ctx, integration, image)
-		results = append(results, verificationResults...)
+		results = append(results, verificationResults)
 	}
 	return results
 }
 
-func createVerifiersFromIntegration(integration *storage.SignatureIntegration) []SignatureVerifier {
-	verifiers := make([]SignatureVerifier, 0)
-
-	// This method will later be extended with other verification methods.
-	if integration.GetCosign() != nil {
-		verifier, err := NewSignatureVerifier(integration.GetCosign())
-		if err != nil {
-			log.Errorf("Error during creation of the signature verifier for signature integration %q: %v",
-				integration.GetId(), err)
-		} else {
-			verifiers = append(verifiers, verifier)
-		}
+func createVerifierFromSignatureIntegration(integration *storage.SignatureIntegration) (SignatureVerifier, error) {
+	verifier, err := NewSignatureVerifier(integration.GetCosign())
+	if err != nil {
+		log.Errorf("Error during creation of the signature verifier for signature integration %q: %v",
+			integration.GetId(), err)
+		return nil, err
 	}
-
-	return verifiers
+	return verifier, nil
 }
 
 // FetchImageSignaturesWithRetries will try and fetch signatures for the given image from the given registry and return them.
@@ -150,19 +143,9 @@ func fetchAndAppendSignatures(ctx context.Context, fetcher SignatureFetcher, ima
 	}
 
 	for _, sig := range sigs {
-		// TODO(ROX-9688): Replace with generated generic contains function.
-		if !containsSignature(sig, fetchedSignatures) {
+		if !protoutils.SliceContains(sig, fetchedSignatures) {
 			fetchedSignatures = append(fetchedSignatures, sig)
 		}
 	}
 	return fetchedSignatures, nil
-}
-
-func containsSignature(sig *storage.Signature, sigs []*storage.Signature) bool {
-	for _, s := range sigs {
-		if protocompat.Equal(sig, s) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/signatures/factory_test.go
+++ b/pkg/signatures/factory_test.go
@@ -58,7 +58,7 @@ func TestVerifyAgainstSignatureIntegration(t *testing.T) {
 
 	cases := map[string]struct {
 		integration        *storage.SignatureIntegration
-		results            []storage.ImageSignatureVerificationResult
+		result             *storage.ImageSignatureVerificationResult
 		verifiedReferences []string
 	}{
 		"successful verification": {
@@ -66,12 +66,10 @@ func TestVerifyAgainstSignatureIntegration(t *testing.T) {
 				Id:     "successful",
 				Cosign: successfulCosignConfig,
 			},
-			results: []storage.ImageSignatureVerificationResult{
-				{
-					VerifierId:              "successful",
-					Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
-					VerifiedImageReferences: []string{imgString},
-				},
+			result: &storage.ImageSignatureVerificationResult{
+				VerifierId:              "successful",
+				Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+				VerifiedImageReferences: []string{imgString},
 			},
 		},
 		"failing verification": {
@@ -79,26 +77,21 @@ func TestVerifyAgainstSignatureIntegration(t *testing.T) {
 				Id:     "failure",
 				Cosign: failingCosignConfig,
 			},
-			results: []storage.ImageSignatureVerificationResult{
-				{
-					VerifierId:  "failure",
-					Status:      storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
-					Description: "1 error occurred:",
-				},
+			result: &storage.ImageSignatureVerificationResult{
+				VerifierId:  "failure",
+				Status:      storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
+				Description: "1 error occurred:",
 			},
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			results := VerifyAgainstSignatureIntegration(context.Background(), c.integration, testImg)
-			require.Len(t, results, len(c.results))
-			for i, res := range c.results {
-				assert.Equal(t, res.VerifierId, results[i].VerifierId)
-				assert.Equal(t, res.Status, results[i].Status)
-				assert.Contains(t, results[i].Description, res.Description)
-				assert.ElementsMatch(t, results[i].VerifiedImageReferences, res.VerifiedImageReferences)
-			}
+			result := VerifyAgainstSignatureIntegration(context.Background(), c.integration, testImg)
+			assert.Equal(t, c.result.VerifierId, result.VerifierId)
+			assert.Equal(t, c.result.Status, result.Status)
+			assert.Contains(t, result.Description, c.result.Description)
+			assert.ElementsMatch(t, c.result.VerifiedImageReferences, result.VerifiedImageReferences)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The previously existing signature fetcher / verifier abstractions were too tightly cut: we initially had plans to also add things like GPG signature fetcher / verifier. However, since this plan has been
cut _and_ in case of extending cosign signature verification support, it doesn't make sense to abstract in the way of `public key, certificate, rekor` if the fetching and verification mechanism will be the same just depending on the
input given by the signature integration.

Also cleaned up a couple of the factory functions for simplification.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
