### PR TITLE
ROX-23767: increase retry time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -653,6 +653,7 @@ jobs:
       id-token: write
       security-events: write
     strategy:
+      fail-fast: false
       matrix:
         image:
           [
@@ -694,7 +695,7 @@ jobs:
       - name: Scan images for vulnerabilities
         run: |
           release_tag=$(make tag)
-          roxctl image scan --output=sarif \
+          roxctl image scan --retries=10 --retry-delay=15 --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif
 


### PR DESCRIPTION
## Description

Currently the image scan may fail with

```
[getting metadata from registry: "rhacs-eng": failed to get the manifest digest: Head "https://quay.io/v2/rhacs-eng/collector-slim/manifests/4.4.x-541-gbf46aba436": http: non-successful response (status=404 body="")
```

Increase the `roxctl` retry time to make sure the images are actually available during scanning.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

retried workflow and it succeeded after images was there.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
