### PR TITLE
chore(test): Do not dereference pointers in assertions

### DIFF
--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -215,7 +215,7 @@ func (s *alertDatastoreSACTestSuite) TestGetAlert() {
 			s.NoError(err1)
 			if c.ExpectedFound {
 				s.True(found1)
-				s.Equal(*alert1, *readAlert1)
+				s.Equal(alert1, readAlert1)
 			} else {
 				s.False(found1)
 				s.Nil(readAlert1)
@@ -224,7 +224,7 @@ func (s *alertDatastoreSACTestSuite) TestGetAlert() {
 			s.NoError(err2)
 			if c.ExpectedFound {
 				s.True(found2)
-				s.Equal(*alert2, *readAlert2)
+				s.Equal(alert2, readAlert2)
 			} else {
 				s.False(found2)
 				s.Nil(readAlert2)

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -271,7 +271,7 @@ func (s *clusterDatastoreSACSuite) TestGetCluster() {
 			if c.ExpectedFound {
 				s.True(found)
 				s.Require().NotNil(fetchedCluster)
-				s.Equal(*cluster, *fetchedCluster)
+				s.Equal(cluster, fetchedCluster)
 			} else {
 				s.False(found)
 				s.Nil(fetchedCluster)
@@ -646,17 +646,17 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
 			s.NoError(postUpdateErr)
 			s.True(postUpdateFound)
 			if c.ExpectError {
-				s.Equal(*oldSensorExpiry, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				s.Equal(*oldSensorCertNotBefore, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 				s.ErrorIs(updateErr, c.ExpectedError)
-				s.Equal(*oldSensorExpiry, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				s.Equal(*oldSensorCertNotBefore, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(oldSensorCertNotBefore, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 			} else {
-				s.Equal(*oldSensorExpiry, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				s.Equal(*oldSensorCertNotBefore, *preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 				s.NoError(updateErr)
-				s.Equal(*newSensorExpiry, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				s.Equal(*newSensorCertNotBefore, *postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(newSensorExpiry, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+				s.Equal(newSensorCertNotBefore, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 			}
 			// Revert to pre-test state
 			err := s.datastore.UpdateClusterCertExpiryStatus(globalReadWriteCtx, clusterID, oldCertExpiryStatus)
@@ -664,8 +664,8 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
 			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
 			s.Require().NoError(err)
 			s.Require().True(found)
-			s.Require().Equal(*oldSensorExpiry, *fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-			s.Require().Equal(*oldSensorCertNotBefore, *fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+			s.Require().Equal(oldSensorExpiry, fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
+			s.Require().Equal(oldSensorCertNotBefore, fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 		})
 	}
 }
@@ -725,19 +725,19 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterHealth() {
 			if c.ExpectError {
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
 				s.ErrorIs(updateErr, c.ExpectedError)
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
 			} else {
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				s.Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
 				s.NoError(updateErr)
 				s.Equal(newHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(newHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				s.Equal(*newHealthStatus.GetLastContact(), *postUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(newHealthStatus.GetLastContact(), postUpdateCluster.GetHealthStatus().GetLastContact())
 			}
 			// Revert to pre-test state
 			err := s.datastore.UpdateClusterHealth(globalReadWriteCtx, clusterID, oldHealthStatus)
@@ -747,7 +747,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterHealth() {
 			s.Require().True(found)
 			s.Require().Equal(oldHealthStatus.GetCollectorHealthStatus(), fetchedCluster.GetHealthStatus().GetCollectorHealthStatus())
 			s.Require().Equal(oldHealthStatus.GetOverallHealthStatus(), fetchedCluster.GetHealthStatus().GetOverallHealthStatus())
-			s.Require().Equal(*oldHealthStatus.GetLastContact(), *preUpdateCluster.GetHealthStatus().GetLastContact())
+			s.Require().Equal(oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
 		})
 	}
 }
@@ -954,29 +954,29 @@ func (s *clusterDatastoreSACSuite) TestUpdateAuditLogFileStates() {
 				s.Require().Equal(len(oldAuditLogFileState), len(preUpdateCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
-					s.Require().NotNil(*preUpdateCluster.GetAuditLogState()[k])
-					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Require().NotNil(preUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(oldAuditLogFileState[k].GetCollectLogsSince(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
 				}
 				s.ErrorIs(updateErr, c.ExpectedError)
 				s.Require().Equal(len(oldAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
-					s.Require().NotNil(*postUpdateCluster.GetAuditLogState()[k])
-					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Require().NotNil(postUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(oldAuditLogFileState[k].GetCollectLogsSince(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
 				}
 			} else {
 				s.Require().Equal(len(oldAuditLogFileState), len(preUpdateCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
-					s.Require().NotNil(*preUpdateCluster.GetAuditLogState()[k])
-					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Require().NotNil(preUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(oldAuditLogFileState[k].GetCollectLogsSince(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
 				}
 				s.NoError(updateErr)
 				s.Require().Equal(len(newAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
 				for k := range newAuditLogFileState {
 					s.Require().Equal(newAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
-					s.Require().NotNil(*postUpdateCluster.GetAuditLogState()[k])
-					s.Require().Equal(*newAuditLogFileState[k].GetCollectLogsSince(), *postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Require().NotNil(postUpdateCluster.GetAuditLogState()[k])
+					s.Require().Equal(newAuditLogFileState[k].GetCollectLogsSince(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
 				}
 				// Revert to pre-test state
 				err := s.datastore.UpdateAuditLogFileStates(globalReadWriteCtx, clusterID, oldAuditLogFileState)
@@ -987,8 +987,8 @@ func (s *clusterDatastoreSACSuite) TestUpdateAuditLogFileStates() {
 				s.Require().Equal(len(oldAuditLogFileState), len(fetchedCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), fetchedCluster.GetAuditLogState()[k].GetLastAuditId())
-					s.Require().NotNil(*fetchedCluster.GetAuditLogState()[k])
-					s.Require().Equal(*oldAuditLogFileState[k].GetCollectLogsSince(), *fetchedCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Require().NotNil(fetchedCluster.GetAuditLogState()[k])
+					s.Require().Equal(oldAuditLogFileState[k].GetCollectLogsSince(), fetchedCluster.GetAuditLogState()[k].GetCollectLogsSince())
 				}
 			}
 		})

--- a/central/namespace/datastore/datastore_sac_test.go
+++ b/central/namespace/datastore/datastore_sac_test.go
@@ -113,7 +113,7 @@ func (s *namespaceDatastoreSACSuite) TestGetNamespace() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.Require().True(found)
-				s.Equal(*namespace, *res)
+				s.Equal(namespace, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/node/datastore/datastore_sac_test.go
+++ b/central/node/datastore/datastore_sac_test.go
@@ -200,7 +200,7 @@ func (s *nodeDatastoreSACSuite) TestGetNode() {
 
 				// Priority can have updated value, and we want to ignore it.
 				fetchedNode.Priority = s.testNodes[nodeID].Priority
-				s.Equal(*s.testNodes[nodeID], *fetchedNode)
+				s.Equal(s.testNodes[nodeID], fetchedNode)
 			} else {
 				s.False(found)
 				s.Nil(fetchedNode)

--- a/central/pod/datastore/datastore_impl_real_test.go
+++ b/central/pod/datastore/datastore_impl_real_test.go
@@ -131,7 +131,7 @@ func (s *PodDatastoreSuite) TestRemovePod() {
 	// Verify that the correct listening endpoints have been deleted
 	s.Len(newPlops, 1)
 
-	s.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	s.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		PodId:         fixtureconsts.PodName2,
 		PodUid:        fixtureconsts.PodUID2,
 		DeploymentId:  fixtureconsts.Deployment1,
@@ -164,5 +164,5 @@ func (s *PodDatastoreSuite) TestRemovePod() {
 	indicatorsFromDB := s.getProcessIndicatorsFromDB()
 	s.Len(indicatorsFromDB, 1)
 
-	s.Equal(*indicatorsFromDB[0], *indicator3)
+	s.Equal(indicatorsFromDB[0], indicator3)
 }

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -110,7 +110,7 @@ func (s *podDatastoreSACSuite) TestGetPod() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*pod, *res)
+				s.Equal(pod, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/processbaseline/datastore/datastore_impl_test.go
+++ b/central/processbaseline/datastore/datastore_impl_test.go
@@ -319,7 +319,7 @@ func (suite *ProcessBaselineDataStoreTestSuite) TestIDToKeyConversion() {
 	resKey, err := IDToKey(id)
 	suite.NoError(err)
 	suite.NotNil(resKey)
-	suite.Equal(*key, *resKey)
+	suite.Equal(key, resKey)
 }
 
 func (suite *ProcessBaselineDataStoreTestSuite) TestBuildUnlockedProcessBaseline() {

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -162,7 +162,7 @@ func (s *processBaselineSACTestSuite) TestGetProcessBaseline() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.Require().True(found)
-				s.Equal(*processBaseline, *res)
+				s.Equal(processBaseline, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/processbaselineresults/datastore/datastore_sac_test.go
+++ b/central/processbaselineresults/datastore/datastore_sac_test.go
@@ -108,7 +108,7 @@ func (s *processBaselineResultsDatastoreSACSuite) TestGetBaselineResults() {
 			res, err := s.datastore.GetBaselineResults(ctx, processBaselineResult.GetDeploymentId())
 			if c.ExpectedFound {
 				s.NoError(err)
-				s.Equal(*processBaselineResult, *res)
+				s.Equal(processBaselineResult, res)
 			} else {
 				s.Require().Error(err)
 				s.ErrorIs(err, sac.ErrResourceAccessDenied)

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -115,7 +115,7 @@ func (s *processIndicatorDatastoreSACSuite) TestGetProcessIndicator() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*processIndicator, *res)
+				s.Equal(processIndicator, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -211,7 +211,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPAdd() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -330,7 +330,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPAddOpenTwice() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -453,7 +453,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPReopen() {
 
 	// The PLOP is reported since it is in the open state
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -675,7 +675,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPAddNoIndicator() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -910,7 +910,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPAddMultipleIndicators() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -1406,7 +1406,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPDeleteAndCreateDeployment() {
 
 	// It's open and included in the API response for the new deployment
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -1660,7 +1660,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPUpdatePodUidFromBlank() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		DeploymentId:  fixtureconsts.Deployment1,
@@ -1707,7 +1707,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPUpdatePodUidFromBlank() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -1964,7 +1964,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPUpdateClusterIdFromBlank() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,
@@ -2012,7 +2012,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPUpdateClusterIdFromBlank() {
 	suite.NoError(err)
 
 	suite.Len(newPlops, 1)
-	suite.Equal(*newPlops[0], storage.ProcessListeningOnPort{
+	suite.Equal(newPlops[0], &storage.ProcessListeningOnPort{
 		ContainerName: "test_container1",
 		PodId:         fixtureconsts.PodName1,
 		PodUid:        fixtureconsts.PodUID1,

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -112,7 +112,7 @@ func (s *k8sRoleSACSuite) TestGetRole() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*role, *res)
+				s.Equal(role, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -109,7 +109,7 @@ func (s *k8sRoleBindingSACSuite) TestGetRoleBinding() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*roleBinding, *res)
+				s.Equal(roleBinding, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -115,7 +115,7 @@ func (s *riskDatastoreSACSuite) TestGetRisk() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.Require().True(found)
-				s.Equal(*risk, *res)
+				s.Equal(risk, res)
 			} else {
 				s.False(found)
 				s.Nil(res)
@@ -146,7 +146,7 @@ func (s *riskDatastoreSACSuite) TestGetRiskForDeployment() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.Require().True(found)
-				s.Equal(*risk, *res)
+				s.Equal(risk, res)
 			} else {
 				s.False(found)
 				s.Nil(res)

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -111,7 +111,7 @@ func (s *secretDatastoreSACTestSuite) TestGetSecret() {
 			s.NoError(getErr)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*testSecret, *readSecret)
+				s.Equal(testSecret, readSecret)
 			} else {
 				s.False(found)
 				s.Nil(readSecret)

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -116,7 +116,7 @@ func (s *serviceAccountSACSuite) TestGetServiceAccount() {
 			s.Require().NoError(err)
 			if c.ExpectedFound {
 				s.True(found)
-				s.Equal(*account, *res)
+				s.Equal(account, res)
 			} else {
 				s.False(found)
 				s.Nil(res)


### PR DESCRIPTION
## Description

In some case, this can lead to copy of objects which hold locks.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
