### PR TITLE
ROX-23911: Add node components table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -16,19 +16,20 @@ import {
     getHighestVulnerabilitySeverity,
 } from '../../utils/vulnerabilityUtils';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
-import NodeComponentsTable from '../components/NodeComponentsTable';
+import NodeComponentsTable, {
+    NodeComponent,
+    nodeComponentFragment,
+} from '../components/NodeComponentsTable';
 
 export const nodeVulnerabilityFragment = gql`
+    ${nodeComponentFragment}
     fragment NodeVulnerabilityFragment on NodeVulnerability {
         cve
         summary
         cvss
         scoreVersion
         nodeComponents(query: $query) {
-            name
-            source
-            operatingSystem
-            version
+            ...NodeComponentFragment
             nodeVulnerabilities(query: $query) {
                 severity
                 isFixable
@@ -43,17 +44,13 @@ export type NodeVulnerability = {
     summary: string;
     cvss: number;
     scoreVersion: string;
-    nodeComponents: {
-        name: string;
-        source: string;
-        operatingSystem: string;
-        version: string;
+    nodeComponents: (NodeComponent & {
         nodeVulnerabilities: {
             severity: string;
             isFixable: boolean;
             fixedByVersion: string;
         }[];
-    }[];
+    })[];
 };
 
 export type CVEsTableProps = {
@@ -129,7 +126,7 @@ function CVEsTable({ tableState }: CVEsTableProps) {
                                     <Td />
                                     <Td colSpan={COL_SPAN - 1}>
                                         <ExpandableRowContent>
-                                            <NodeComponentsTable />
+                                            <NodeComponentsTable data={nodeComponents} />
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -10,7 +10,7 @@ export const nodeMetadataFragment = gql`
     fragment NodeMetadata on Node {
         id
         name
-        operatingSystem
+        osImage
         kubeletVersion
         kernelVersion
         scanTime
@@ -20,7 +20,7 @@ export const nodeMetadataFragment = gql`
 export type NodeMetadata = {
     id: string;
     name: string;
-    operatingSystem: string;
+    osImage: string;
     kubeletVersion: string;
     kernelVersion: string;
     scanTime?: string;
@@ -48,7 +48,7 @@ function NodePageHeader({ data }: NodePageHeaderProps) {
                 {data.name}
             </Title>
             <LabelGroup numLabels={numLabels}>
-                <Label>OS: {data.operatingSystem}</Label>
+                <Label>OS: {data.osImage}</Label>
                 <Label>Kubelet: {data.kubeletVersion}</Label>
                 <Label>Kernel version: {data.kernelVersion}</Label>
                 {data.scanTime && <Label>Scan time: {getDateTime(data.scanTime)}</Label>}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -19,7 +19,6 @@ function mockNodeVulnerability(fields) {
 function mockNodeComponent(fields) {
     return {
         name: 'podman',
-        operatingSystem: 'rhcos:4.15',
         version: '3:4.4.1-21.rhaos4.15.el9.x86_64',
         fixedIn: '',
         source: 'INFRASTRUCTURE',
@@ -36,7 +35,7 @@ function mockNode(fields) {
         cluster: {
             name: 'test-cluster',
         },
-        operatingSystem: 'linux',
+        osImage: 'RHEL',
         ...fields,
     };
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -29,7 +29,7 @@ export const affectedNodeFragment = gql`
     fragment AffectedNode on Node {
         id
         name
-        operatingSystem
+        osImage
         cluster {
             name
         }
@@ -50,7 +50,7 @@ export const affectedNodeFragment = gql`
 export type AffectedNode = {
     id: string;
     name: string;
-    operatingSystem: string;
+    osImage: string;
     cluster: {
         name: string;
     };
@@ -141,7 +141,9 @@ function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
                                     <Td dataLabel="Cluster">
                                         <Truncate position="middle" content={node.cluster.name} />
                                     </Td>
-                                    <Td dataLabel="Operating system">{node.operatingSystem}</Td>
+                                    <Td dataLabel="Operating system">
+                                        <Truncate position="middle" content={node.osImage} />
+                                    </Td>
                                     <Td dataLabel="Affected components">
                                         {nodeComponents.length === 1
                                             ? nodeComponents[0].name

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -19,9 +19,13 @@ import {
     getHighestCvssScore,
 } from '../../utils/vulnerabilityUtils';
 
-import NodeComponentsTable from '../components/NodeComponentsTable';
+import NodeComponentsTable, {
+    NodeComponent,
+    nodeComponentFragment,
+} from '../components/NodeComponentsTable';
 
 export const affectedNodeFragment = gql`
+    ${nodeComponentFragment}
     fragment AffectedNode on Node {
         id
         name
@@ -30,9 +34,7 @@ export const affectedNodeFragment = gql`
             name
         }
         nodeComponents {
-            name
-            version
-            source
+            ...NodeComponentFragment
             nodeVulnerabilities {
                 vulnerabilityId: id
                 cve
@@ -52,10 +54,7 @@ export type AffectedNode = {
     cluster: {
         name: string;
     };
-    nodeComponents: {
-        name: string;
-        version: string;
-        source: string;
+    nodeComponents: (NodeComponent & {
         nodeVulnerabilities: {
             vulnerabilityId: string;
             cve: string;
@@ -64,7 +63,7 @@ export type AffectedNode = {
             cvss: number;
             scoreVersion: string;
         }[];
-    }[];
+    })[];
 };
 
 export type AffectedNodesTableProps = {
@@ -153,7 +152,7 @@ function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
                                     <Td />
                                     <Td colSpan={colSpan - 1}>
                                         <ExpandableRowContent>
-                                            <NodeComponentsTable />
+                                            <NodeComponentsTable data={nodeComponents} />
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import NodeComponentsTable from './NodeComponentsTable';
+
+const mockData = [
+    {
+        name: 'podman',
+        operatingSystem: 'rhel',
+        source: 'INFRASTRUCTURE',
+    },
+    {
+        name: 'cri-o',
+        operatingSystem: 'Ubuntu',
+        source: 'KUBELET',
+    },
+    {
+        name: 'kernel',
+        operatingSystem: 'Debian',
+        source: 'INFRASTRUCTURE',
+    },
+];
+
+function setup(data) {
+    cy.mount(<NodeComponentsTable data={data} />);
+}
+
+describe(Cypress.spec.relative, () => {
+    describe('client side sorting of the table', () => {
+        it('should sort by the component name', () => {
+            setup(mockData);
+
+            const componentCell = 'td[data-label="Component"]';
+
+            // Test that the default sort is by name descending
+            cy.get(componentCell).eq(0).should('have.text', 'cri-o');
+            cy.get(componentCell).eq(1).should('have.text', 'kernel');
+            cy.get(componentCell).eq(2).should('have.text', 'podman');
+
+            // Click the component header to sort by name ascending
+            cy.get('th:contains("Component")').click();
+            cy.get(componentCell).eq(0).should('have.text', 'podman');
+            cy.get(componentCell).eq(1).should('have.text', 'kernel');
+            cy.get(componentCell).eq(2).should('have.text', 'cri-o');
+
+            // Click the component header to sort by name descending
+            cy.get('th:contains("Component")').click();
+            cy.get(componentCell).eq(0).should('have.text', 'cri-o');
+            cy.get(componentCell).eq(1).should('have.text', 'kernel');
+            cy.get(componentCell).eq(2).should('have.text', 'podman');
+        });
+
+        it('should sort by the type', () => {
+            setup(mockData);
+
+            const typeCell = 'td[data-label="Type"]';
+
+            // Since this column is not the default sort, the starting sort will be descending
+            // Click the type header to sort by type descending
+            cy.get('th:contains("Type")').click();
+            cy.get(typeCell).eq(0).should('have.text', 'KUBELET');
+            cy.get(typeCell).eq(1).should('have.text', 'INFRASTRUCTURE');
+            cy.get(typeCell).eq(2).should('have.text', 'INFRASTRUCTURE');
+
+            // Click the type header to sort by type ascending
+            cy.get('th:contains("Type")').click();
+            cy.get(typeCell).eq(0).should('have.text', 'INFRASTRUCTURE');
+            cy.get(typeCell).eq(1).should('have.text', 'INFRASTRUCTURE');
+            cy.get(typeCell).eq(2).should('have.text', 'KUBELET');
+        });
+
+        it('should sort by the operating system', () => {
+            setup(mockData);
+
+            const osCell = 'td[data-label="Operating system"]';
+
+            // Since this column is not the default sort, the starting sort will be descending
+            // Click the operating system header to sort by operating system descending
+            cy.get('th:contains("Operating system")').click();
+            cy.get(osCell).eq(0).should('have.text', 'Ubuntu');
+            cy.get(osCell).eq(1).should('have.text', 'rhel');
+            cy.get(osCell).eq(2).should('have.text', 'Debian');
+
+            // Click the operating system header to sort by operating system ascending
+            cy.get('th:contains("Operating system")').click();
+            cy.get(osCell).eq(0).should('have.text', 'Debian');
+            cy.get(osCell).eq(1).should('have.text', 'rhel');
+            cy.get(osCell).eq(2).should('have.text', 'Ubuntu');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
@@ -5,17 +5,14 @@ import NodeComponentsTable from './NodeComponentsTable';
 const mockData = [
     {
         name: 'podman',
-        operatingSystem: 'rhel',
         source: 'INFRASTRUCTURE',
     },
     {
         name: 'cri-o',
-        operatingSystem: 'Ubuntu',
         source: 'KUBELET',
     },
     {
         name: 'kernel',
-        operatingSystem: 'Debian',
         source: 'INFRASTRUCTURE',
     },
 ];
@@ -66,25 +63,6 @@ describe(Cypress.spec.relative, () => {
             cy.get(typeCell).eq(0).should('have.text', 'INFRASTRUCTURE');
             cy.get(typeCell).eq(1).should('have.text', 'INFRASTRUCTURE');
             cy.get(typeCell).eq(2).should('have.text', 'KUBELET');
-        });
-
-        it('should sort by the operating system', () => {
-            setup(mockData);
-
-            const osCell = 'td[data-label="Operating system"]';
-
-            // Since this column is not the default sort, the starting sort will be descending
-            // Click the operating system header to sort by operating system descending
-            cy.get('th:contains("Operating system")').click();
-            cy.get(osCell).eq(0).should('have.text', 'Ubuntu');
-            cy.get(osCell).eq(1).should('have.text', 'rhel');
-            cy.get(osCell).eq(2).should('have.text', 'Debian');
-
-            // Click the operating system header to sort by operating system ascending
-            cy.get('th:contains("Operating system")').click();
-            cy.get(osCell).eq(0).should('have.text', 'Debian');
-            cy.get(osCell).eq(1).should('have.text', 'rhel');
-            cy.get(osCell).eq(2).should('have.text', 'Ubuntu');
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -1,11 +1,91 @@
 import React from 'react';
+import { gql } from '@apollo/client';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import sortBy from 'lodash/sortBy';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type NodeComponentsTableProps = {};
+import useTableSort from 'hooks/patternfly/useTableSort';
+import { ApiSortOption } from 'types/search';
+import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 
-// eslint-disable-next-line no-empty-pattern
-function NodeComponentsTable({}: NodeComponentsTableProps) {
-    return <div>NodeComponentsTable - TODO</div>;
+function sortTableData(tableData: NodeComponent[], sortOption: ApiSortOption): NodeComponent[] {
+    const sortedRows = sortBy(tableData, (row) => {
+        switch (sortOption.field) {
+            case 'Component':
+                return row.name?.toLowerCase();
+            case 'Type':
+                return row.source?.toLowerCase();
+            case 'Operating system':
+                return row.operatingSystem?.toLowerCase();
+            default:
+                return '';
+        }
+    });
+    if (sortOption.reversed) {
+        sortedRows.reverse();
+    }
+    return sortedRows;
+}
+
+export const nodeComponentFragment = gql`
+    fragment NodeComponentFragment on NodeComponent {
+        name
+        source
+        operatingSystem
+        version
+        fixedIn
+    }
+`;
+
+export type NodeComponent = {
+    name: string;
+    source: string;
+    operatingSystem: string;
+    version: string;
+    fixedIn: string;
+};
+
+const sortFields = ['Component', 'Type', 'Operating system'];
+const defaultSortOption = { field: 'Component', direction: 'asc' } as const;
+
+export type NodeComponentsTableProps = {
+    data: NodeComponent[];
+};
+
+function NodeComponentsTable({ data }: NodeComponentsTableProps) {
+    const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
+    const sortedData = sortTableData(data, sortOption);
+
+    // Logically should not occur, but prevents rendering an empty table if it does
+    if (data.length === 0) {
+        return null;
+    }
+
+    return (
+        <Table style={{ border: '1px solid var(--pf-v5-c-table--BorderColor)' }}>
+            <Thead noWrap>
+                <Tr>
+                    <Th sort={getSortParams('Component')}>Component</Th>
+                    <Th sort={getSortParams('Type')}>Type</Th>
+                    <Th sort={getSortParams('Operating system')}>Operating system</Th>
+                    <Th>Version</Th>
+                    <Th>Fixed in</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {sortedData.map(({ name, source, operatingSystem, version, fixedIn }) => (
+                    <Tr key={name}>
+                        <Td dataLabel="Component">{name}</Td>
+                        <Td dataLabel="Type">{source}</Td>
+                        <Td dataLabel="Operating system">{operatingSystem}</Td>
+                        <Td dataLabel="Version">{version}</Td>
+                        <Td dataLabel="Fixed in">
+                            {fixedIn || <VulnerabilityFixableIconText isFixable={false} />}
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </Table>
+    );
 }
 
 export default NodeComponentsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -14,8 +14,6 @@ function sortTableData(tableData: NodeComponent[], sortOption: ApiSortOption): N
                 return row.name?.toLowerCase();
             case 'Type':
                 return row.source?.toLowerCase();
-            case 'Operating system':
-                return row.operatingSystem?.toLowerCase();
             default:
                 return '';
         }
@@ -30,7 +28,6 @@ export const nodeComponentFragment = gql`
     fragment NodeComponentFragment on NodeComponent {
         name
         source
-        operatingSystem
         version
         fixedIn
     }
@@ -39,12 +36,11 @@ export const nodeComponentFragment = gql`
 export type NodeComponent = {
     name: string;
     source: string;
-    operatingSystem: string;
     version: string;
     fixedIn: string;
 };
 
-const sortFields = ['Component', 'Type', 'Operating system'];
+const sortFields = ['Component', 'Type'];
 const defaultSortOption = { field: 'Component', direction: 'asc' } as const;
 
 export type NodeComponentsTableProps = {
@@ -66,17 +62,15 @@ function NodeComponentsTable({ data }: NodeComponentsTableProps) {
                 <Tr>
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th sort={getSortParams('Type')}>Type</Th>
-                    <Th sort={getSortParams('Operating system')}>Operating system</Th>
                     <Th>Version</Th>
                     <Th>Fixed in</Th>
                 </Tr>
             </Thead>
             <Tbody>
-                {sortedData.map(({ name, source, operatingSystem, version, fixedIn }) => (
+                {sortedData.map(({ name, source, version, fixedIn }) => (
                     <Tr key={name}>
                         <Td dataLabel="Component">{name}</Td>
                         <Td dataLabel="Type">{source}</Td>
-                        <Td dataLabel="Operating system">{operatingSystem}</Td>
                         <Td dataLabel="Version">{version}</Td>
                         <Td dataLabel="Fixed in">
                             {fixedIn || <VulnerabilityFixableIconText isFixable={false} />}


### PR DESCRIPTION
## Description

Adds the nested table of node components to both of the Node CVE single pages: CVE and Node.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Node CVE single page and expand table rows to view the table (mocked data):
![image](https://github.com/stackrox/stackrox/assets/1292638/c4d86ecc-7613-4e3d-a589-cbfff8a4bfe6)

Visit a Node single page and expand table rows to view the table (mocked data):
![image](https://github.com/stackrox/stackrox/assets/1292638/202e0ebe-7016-44d2-8932-901a4c057f2d)

Table sorting tested via included component tests
![image](https://github.com/stackrox/stackrox/assets/1292638/2f7b9ddb-0d7b-4a34-a519-b9ac35055d36)
