### PR TITLE
fix(sarif): nil array should not have placeholder value

### DIFF
--- a/pkg/gjson/slices.go
+++ b/pkg/gjson/slices.go
@@ -49,5 +49,10 @@ func getStringsFromGJSONResult(results []gjson.Result) []string {
 			return true
 		})
 	}
+	// If we only have a single result _and_ that result is null, return a nil array.
+	if len(results) == 1 && results[0].Type == gjson.Null {
+		return nil
+	}
+
 	return stringResults
 }

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -195,15 +195,9 @@ func sarifEntriesFromJSONObject(jsonObject interface{}, pathExpressions map[stri
 		return nil, err
 	}
 	data := sliceMapper.CreateSlices()
-
-	numberOfValues := len(data[SarifRuleJSONPathExpressionKey])
-	for key, values := range data {
-		// "-" is used as an empty replacement value in case values are missing in an array for GJSON. Hence, ignore
-		// all values which may not match the number of expected values iff the array contains the replacement value.
-		if len(values) != numberOfValues && !slices.Equal(values, []string{"-"}) {
-			return nil, errox.InvalidArgs.Newf("the amount of values retrieved from JSON path expressions "+
-				"should be %d, but got %d for key %s", numberOfValues, len(values), key)
-		}
+	numberOfValues, err := validateDataEntries(data)
+	if err != nil {
+		return nil, err
 	}
 
 	sarifEntries := make([]sarifEntry, 0, numberOfValues)
@@ -219,6 +213,19 @@ func sarifEntriesFromJSONObject(jsonObject interface{}, pathExpressions map[stri
 		sarifEntries = append(sarifEntries, entry)
 	}
 	return sarifEntries, nil
+}
+
+func validateDataEntries(entries map[string][]string) (int, error) {
+	numberOfValues := len(entries[SarifRuleJSONPathExpressionKey])
+	for key, values := range entries {
+		// "-" is used as an empty replacement value in case values are missing in an array for GJSON. Hence, ignore
+		// all values which may not match the number of expected values iff the array contains the replacement value.
+		if len(values) != numberOfValues && !slices.Equal(values, []string{"-"}) {
+			return -1, errox.InvalidArgs.Newf("the amount of values retrieved from JSON path expressions "+
+				"should be %d, but got %d for key %s", numberOfValues, len(values), key)
+		}
+	}
+	return numberOfValues, nil
 }
 
 // All our supported severities. We have different severities for policy violations and CVE violations, and the sarif

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -83,9 +83,9 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 }
 
 func TestSarifPrinter_Print_EmptyViolations(t *testing.T) {
-	obj := &testObject{Violations: []violation{}}
+	obj := &testObject{Violations: nil}
 	expressions := map[string]string{
-		SarifRuleJSONPathExpressionKey:     "violations.#.id",
+		SarifRuleJSONPathExpressionKey:     "{violations.#.id}.@text",
 		SarifHelpJSONPathExpressionKey:     "violations.#.reason",
 		SarifSeverityJSONPathExpressionKey: "violations.#.severity",
 	}


### PR DESCRIPTION
## Description

This is a follow-up from #10150 where we fixed an issue with the SARIF report generation when an empty value in the form of the replacement string was given.

In the case of all arrays being nil we receive from the JSON path expressions (e.g. when violations during image scan are nil) then we previously had for the result and help text an empty array with the `-` value in it.

This lead to the report being failed to generated.

Now the logic of the slice mapper, which will retrieve data from the JSON path expression, has changed: in case we receive a nil array in a GJSON result, we will just return nil.
This fixes the report generation for SARIF.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI (changed the unit test to have the same JSON path expression as the image scan call)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
