### PR TITLE
ROX-23929: Factor out email notifier from vulnerability reporting

### DIFF
--- a/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierForm.tsx
+++ b/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierForm.tsx
@@ -1,15 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-void */
 import React, { ReactElement, useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Checkbox,
-    Form,
-    PageSection,
-    TextInput,
-    Popover,
-} from '@patternfly/react-core';
+import { Alert, Checkbox, Form, PageSection, Popover, TextInput } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import { HelpIcon } from '@patternfly/react-icons';
 import { FormikErrors, FormikTouched } from 'formik';
@@ -34,7 +25,7 @@ const startTLSAuthMethods = [
     },
 ];
 
-export type EmailIntegrationFormProps = {
+export type EmailNotifierFormProps = {
     values: EmailIntegrationFormValues;
     setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
     handleBlur: (e: React.FocusEvent<any, Element>) => void;
@@ -42,23 +33,23 @@ export type EmailIntegrationFormProps = {
     touched: FormikTouched<any>;
 };
 
-function EmailIntegrationForm({
+function EmailNotifierForm({
     values,
     setFieldValue,
     handleBlur,
     errors,
     touched,
-}: EmailIntegrationFormProps): ReactElement {
+}: EmailNotifierFormProps): ReactElement {
     const [storedUsername, setStoredUsername] = useState('');
     const { allowUnauthenticatedSmtp } = values.notifier.email;
     function onChange(value, event) {
-        return void setFieldValue(event.target.id, value);
+        setFieldValue(event.target.id, value);
     }
 
     function updateStartTLSAuthMethodOnChange(value, event) {
-        void setFieldValue(event.target.id, value);
+        setFieldValue(event.target.id, value);
         if (value === false && values.notifier.email.startTLSAuthMethod !== 'DISABLED') {
-            void setFieldValue('notifier.email.startTLSAuthMethod', 'DISABLED');
+            setFieldValue('notifier.email.startTLSAuthMethod', 'DISABLED');
         }
     }
 
@@ -145,7 +136,7 @@ function EmailIntegrationForm({
                                 <Alert
                                     className="pf-v5-u-mt-md"
                                     title="Security Warning"
-                                    variant={AlertVariant.warning}
+                                    variant="warning"
                                     isInline
                                 >
                                     <p>
@@ -309,4 +300,4 @@ function EmailIntegrationForm({
     );
 }
 
-export default EmailIntegrationForm;
+export default EmailNotifierForm;

--- a/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierModal.tsx
+++ b/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Modal, ModalVariant, Title, TitleSizes } from '@patternfly/react-core';
+import { Flex, Modal, Title } from '@patternfly/react-core';
 
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
@@ -11,7 +11,7 @@ import {
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import useFormModal from 'hooks/patternfly/useFormModal';
 import { createIntegration } from 'services/IntegrationsService';
-import EmailIntegrationForm from './EmailIntegrationForm';
+import EmailNotifierForm from './EmailNotifierForm';
 
 export type EmailNotifierFormModalProps = {
     isOpen: boolean;
@@ -19,7 +19,7 @@ export type EmailNotifierFormModalProps = {
     onToggleEmailNotifierModal: () => void;
 };
 
-function EmailNotifierFormModal({
+function EmailNotifierModal({
     isOpen,
     updateNotifierList,
     onToggleEmailNotifierModal,
@@ -52,12 +52,12 @@ function EmailNotifierFormModal({
     const descriptionText = 'Configure the setting for a new email notifier integration.';
 
     const header = (
-        <>
-            <Title id="custom-header-label" headingLevel="h1" size={TitleSizes.xl}>
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+            <Title id="custom-header-label" headingLevel="h1">
                 {title}
             </Title>
-            <p className="pf-v5-u-pt-sm">{descriptionText}</p>
-        </>
+            <p>{descriptionText}</p>
+        </Flex>
     );
 
     const { values, touched, errors, isSubmitting, dirty, isValid, setFieldValue, handleBlur } =
@@ -66,7 +66,7 @@ function EmailNotifierFormModal({
     return (
         <Modal
             aria-label="Create new email notifier"
-            variant={ModalVariant.medium}
+            variant="medium"
             header={header}
             isOpen={isOpen}
             onClose={onHandleCancel}
@@ -83,7 +83,7 @@ function EmailNotifierFormModal({
             ]}
         >
             <FormMessage message={message} />
-            <EmailIntegrationForm
+            <EmailNotifierForm
                 values={values}
                 setFieldValue={setFieldValue}
                 handleBlur={handleBlur}
@@ -94,4 +94,4 @@ function EmailNotifierFormModal({
     );
 }
 
-export default EmailNotifierFormModal;
+export default EmailNotifierModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/NotifierSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/NotifierSelection.tsx
@@ -5,14 +5,12 @@ import { FormikProps } from 'formik';
 import isEqual from 'lodash/isEqual';
 import resolvePath from 'object-resolve-path';
 
+import EmailNotifierModal from 'Components/EmailNotifier/EmailNotifierModal';
 import SelectSingle from 'Components/SelectSingle';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { fetchIntegration } from 'services/IntegrationsService';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { ReportFormValues } from './useReportFormValues';
-
-// eslint-disable-next-line import/no-named-as-default
-import EmailNotifierFormModal from './EmailNotifierFormModal';
 
 type ReportNotifier = {
     id: string;
@@ -174,7 +172,7 @@ function NotifierSelection({
                     Reset to default
                 </Button>
             )}
-            <EmailNotifierFormModal
+            <EmailNotifierModal
                 isOpen={isEmailNotifierModalOpen}
                 updateNotifierList={setLastAddedNotifier}
                 onToggleEmailNotifierModal={onToggleEmailNotifierModal}


### PR DESCRIPTION
## Description

Prerequisite to factor out delivery destinations from Vulnerability Reports to reuse in Compliance Reports.

Start with `EmailNotifierForm` and `EmailNotifierModal` because they do not import anything from src/Containers/Vulnerabilities/VulnerablityReporting folder.

### Changes

1. Move and rename EmailIntegrationForm.tsx as EmailNotifierForm.tsx
    * Delete ESLint disable comment and delete `void` from function calls: early work-around to obsolete typescript-eslint error.
    * Replace `variant={AlertVariant.warning}` with `variant="warning"` prop because enumerated string type is source of truth.
2. Move and rename EmailIntegrationFormModal.tsx as EmailNotifierModal.tsx
    * Delete `size={TitleSizes.xl}` prop that specifies 20px instead of PatternFly default size 24px.
3. Edit NotifierSelection.tsx
    * Change path to and name of `EmailNotifierModal` component.
    * Replace `className="pf-v5-u-pt-sm"` modifier prop with flex layout.
    * Replace `variant={ModalVariant.medium}` with `variant="medium"` prop because enumerated string type is source of truth.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -1 = 4633578 - 4633579
        total 12 = 11597125 - 11597113
    * `ls -al build/static/js/*.js | wc`
        files 0 = 174 - 174
3. `yarn start` in ui

### Manual testing

Prerequisite: create at least one collection.

Create e-mail notifiers on the fly.

1. Create a report and create email notifier
    * Verify payload and response of POST /v1/notifiers request
    * Verify review details.
    * Verify payload and response of POST /v2/reports/configurations request
3. Edit the first report and ditto items 2 and 3 above.

### Integration testing

Uh, oh! No tests. Yet.