### PR TITLE
ROX-23767: scan after main manifests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -646,6 +646,7 @@ jobs:
     if: github.event_name == 'push'
     needs:
       - build-and-push-main
+      - push-main-manifests
     name: Check images for vulnerabilities
     runs-on: ubuntu-latest
     permissions:
@@ -661,7 +662,8 @@ jobs:
             "collector",
             "collector-slim",
             "main",
-            "roxctl",
+            # TODO(stehessel): re-enable roxctl scanning after #10928 has been released.
+            # "roxctl",
             "scanner",
             "scanner-db",
             "scanner-db-slim",
@@ -695,6 +697,9 @@ jobs:
       - name: Scan images for vulnerabilities
         run: |
           release_tag=$(make tag)
+          if [[ ${{ matrix.image }} =~ "operator" ]]; then
+            release_tag=$(make -C operator tag)
+          fi
           roxctl image scan --retries=10 --retry-delay=15 --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -646,6 +646,7 @@ jobs:
     if: github.event_name == 'push'
     needs:
       - build-and-push-main
+      - build-and-push-operator
       - push-main-manifests
     name: Check images for vulnerabilities
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -662,7 +662,7 @@ jobs:
             "collector",
             "collector-slim",
             "main",
-            # TODO(stehessel): re-enable roxctl scanning after #10928 has been released.
+            # TODO(ROX-23940): re-enable roxctl scanning after #10928 has been released.
             # "roxctl",
             "scanner",
             "scanner-db",
@@ -700,7 +700,7 @@ jobs:
           if [[ ${{ matrix.image }} =~ "operator" ]]; then
             release_tag=$(make -C operator tag)
           fi
-          roxctl image scan --retries=10 --retry-delay=15 --output=sarif \
+          roxctl image scan --retries=10 --retry-delay=15 --force --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif
 


### PR DESCRIPTION
## Description

A couple more fixes to the roxctl check in the build pipeline.

* Unfortunately my last attempt in #10918 alone was not sufficient. The reason is that some of the images are only pushed in the `push-main-manifests` step.
* I also disabled the `roxctl` job temporarily due to the bug discovered in #10928 (roxctl fails if no vulnerabilities are found). `roxctl` image currently has no vulnerabilities.
* The `stackrox-operator` image uses a slightly different format. We need to use `make -C operator tag` here.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested re-running the failed jobs *after* `push-main-manifests` was done. See https://github.com/stackrox/stackrox/actions/runs/8884874794/job/24396114650 for that run.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
