### PR TITLE
ROX-23767: silent operator make

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -699,7 +699,7 @@ jobs:
         run: |
           release_tag=$(make tag)
           if [[ ${{ matrix.image }} =~ "operator" ]]; then
-            release_tag=$(make -C operator tag)
+            release_tag=$(make -C operator --silent tag)
           fi
           roxctl image scan --retries=10 --retry-delay=15 --force --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \


### PR DESCRIPTION
## Description

Make `make` silent because otherwise the `Entering directory` is logged to stdout (not stderr...) and gets assigned to the variable value.

```
❯ make -C operator tag
make: Entering directory '/Users/stephan/go/src/github.com/stackrox/stackrox/operator'
4.4.0-555-g44426a701b
make: Leaving directory '/Users/stephan/go/src/github.com/stackrox/stackrox/operator'
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

This should now make it green finally, see https://github.com/stackrox/stackrox/actions/runs/8888325330.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
