### PR TITLE
ROX-23852: add filtering for severity in image scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 - ROX-18689: ACS will qualify the registry (and path) of images from the container runtime when env var `ROX_UNQUALIFIED_SEARCH_REGISTRIES` is set to `true` on both Central and Sensor.
   - This enables support for CRI-O's unqualified search registries and short name aliases ([more info](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)).
+- ROX-23852: `roxctl image scan` now has the option to filter by vulnerability severities using the `--severity` flag.
 
 ### Removed Features
 

--- a/roxctl/image/scan/cve.go
+++ b/roxctl/image/scan/cve.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -63,15 +64,16 @@ type cveVulnerabilityJSON struct {
 // all relevant information regarding components and CVEs and a summary of all found CVE by
 // severity
 // NOTE: The returned *cveJSONResult CAN be passed to json.Marshal
-func newCVESummaryForPrinting(scanResults *storage.ImageScan) *cveJSONResult {
+func newCVESummaryForPrinting(scanResults *storage.ImageScan, severities []string) *cveJSONResult {
 	var vulnerabilitiesJSON []cveVulnerabilityJSON
 	components := sortComponentsByName(scanResults.GetComponents())
 	vulnSummaryMap := createNumOfVulnerabilitiesBySeverityMap()
+	severitiesToInclude := createSeveritiesToInclude(severities)
 	uniqueCVEs := set.NewStringSet()
 
 	for _, comp := range components {
 		vulns := comp.GetVulns()
-		vulnsJSON := getVulnerabilityJSON(vulns, comp, vulnSummaryMap, uniqueCVEs)
+		vulnsJSON := getVulnerabilityJSON(vulns, comp, vulnSummaryMap, uniqueCVEs, severitiesToInclude)
 		if len(vulnsJSON) != 0 {
 			vulnerabilitiesJSON = append(vulnerabilitiesJSON, vulnsJSON...)
 			vulnSummaryMap[totalComponentsMapKey]++
@@ -87,13 +89,18 @@ func newCVESummaryForPrinting(scanResults *storage.ImageScan) *cveJSONResult {
 }
 
 func getVulnerabilityJSON(vulnerabilities []*storage.EmbeddedVulnerability, comp *storage.EmbeddedImageScanComponent,
-	numOfVulnsBySeverity map[string]int, uniqueCVEs set.StringSet) []cveVulnerabilityJSON {
+	numOfVulnsBySeverity map[string]int, uniqueCVEs set.StringSet,
+	severitiesToInclude []cveSeverity) []cveVulnerabilityJSON {
 	// sort vulnerabilities by severity
 	vulnerabilities = sortVulnerabilitiesForSeverity(vulnerabilities)
 
 	vulnerabilitiesJSON := make([]cveVulnerabilityJSON, 0, len(vulnerabilities))
 	for _, vulnerability := range vulnerabilities {
 		severity := cveSeverityFromVulnerabilitySeverity(vulnerability.GetSeverity())
+		if !slices.Contains(severitiesToInclude, severity) {
+			continue
+		}
+
 		vulnJSON := cveVulnerabilityJSON{
 			CveID:                 vulnerability.GetCve(),
 			CveSeverity:           severity.String(),
@@ -147,4 +154,12 @@ func createNumOfVulnerabilitiesBySeverityMap() map[string]int {
 	m[totalVulnerabilitiesMapKey] = 0
 	m[totalComponentsMapKey] = 0
 	return m
+}
+
+func createSeveritiesToInclude(severities []string) []cveSeverity {
+	severitiesToInclude := make([]cveSeverity, 0, len(severities))
+	for _, severity := range severities {
+		severitiesToInclude = append(severitiesToInclude, cveSeverityFromString(severity))
+	}
+	return severitiesToInclude
 }

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -221,6 +221,7 @@ func (i *imageScanCommand) Validate() error {
 		moderateCVESeverity.String(), importantCVESeverity.String(), criticalCVESeverity.String()}
 
 	for _, severity := range i.severities {
+		severity := strings.ToUpper(severity)
 		if !slices.Contains(validSeverities, severity) {
 			return errox.InvalidArgs.Newf("invalid severity %q used. Choose one of [%s]", severity,
 				strings.Join(validSeverities, ", "))

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -3,6 +3,8 @@ package scan
 import (
 	"context"
 	"io"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -133,6 +135,12 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().IntVarP(&imageScanCmd.retryDelay, "retry-delay", "d", 3, "Set time to wait between retries in seconds")
 	c.Flags().IntVarP(&imageScanCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error")
 	c.Flags().StringVar(&imageScanCmd.cluster, "cluster", "", "Cluster name or ID to delegate image scan to")
+	c.Flags().StringSliceVar(&imageScanCmd.severities, "severity", []string{
+		lowCVESeverity.String(),
+		moderateCVESeverity.String(),
+		importantCVESeverity.String(),
+		criticalCVESeverity.String(),
+	}, "List of severities to include in the output. Use this to filter for specific severities")
 
 	// Deprecated flag
 	// TODO(ROX-8303): Remove this once we have fully deprecated the old output format and are sure we do not break existing customer scripts
@@ -156,6 +164,7 @@ type imageScanCommand struct {
 	retryCount     int
 	timeout        time.Duration
 	cluster        string
+	severities     []string
 
 	// injected or constructed values
 	env                environment.Environment
@@ -207,6 +216,17 @@ func (i *imageScanCommand) Validate() error {
 				"only specify json or csv", i.format)
 		}
 	}
+
+	validSeverities := []string{lowCVESeverity.String(),
+		moderateCVESeverity.String(), importantCVESeverity.String(), criticalCVESeverity.String()}
+
+	for _, severity := range i.severities {
+		if !slices.Contains(validSeverities, severity) {
+			return errox.InvalidArgs.Newf("invalid severity %q used. Choose one of [%s]", severity,
+				strings.Join(validSeverities, ", "))
+		}
+	}
+
 	return nil
 }
 
@@ -268,7 +288,7 @@ func (i *imageScanCommand) printImageResult(imageResult *storage.Image) error {
 		return legacyPrintFormat(imageResult, i.format, i.env.InputOutput().Out(), i.env.Logger())
 	}
 
-	cveSummary := newCVESummaryForPrinting(imageResult.GetScan())
+	cveSummary := newCVESummaryForPrinting(imageResult.GetScan(), i.severities)
 
 	if !i.standardizedFormat {
 		printCVESummary(i.image, cveSummary.Result.Summary, i.env.Logger())

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -264,6 +264,8 @@ func (s *imageScanTestSuite) SetupTest() {
 		retryDelay: 3,
 		retryCount: 3,
 		timeout:    1 * time.Minute,
+		severities: []string{lowCVESeverity.String(), moderateCVESeverity.String(), importantCVESeverity.String(),
+			criticalCVESeverity.String()},
 	}
 }
 


### PR DESCRIPTION
## Description

Adds the `--severity` flag to the `roxctl image scan` command to filter CVE severities with it.

By default, all severities are taken into account.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Some manual tests:
```
roxctl image scan --image=quay.io/stackrox-io/roxctl:4.4.1 -o table
Scan results for image: quay.io/stackrox-io/roxctl:4.4.1
(TOTAL-COMPONENTS: 2, TOTAL-VULNERABILITIES: 2, LOW: 1, MODERATE: 1, IMPORTANT: 0, CRITICAL: 0)

+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
|        COMPONENT         |       VERSION        |      CVE       | SEVERITY |                                 LINK                                 |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
| github.com/docker/docker | v24.0.7+incompatible | CVE-2024-24557 | MODERATE | https://github.com/moby/moby/security/advisories/GHSA-xw73-rw38-6vjc |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
|     helm.sh/helm/v3      |       v3.14.2        | CVE-2019-25210 |   LOW    |           https://nvd.nist.gov/vuln/detail/CVE-2019-25210            |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
WARN:	A total of 2 unique vulnerabilities were found in 2 components
```

```
roxctl image scan --image=quay.io/stackrox-io/roxctl:4.4.1 -o table --severity MODERATE,IMPORTANT
Scan results for image: quay.io/stackrox-io/roxctl:4.4.1
(TOTAL-COMPONENTS: 1, TOTAL-VULNERABILITIES: 1, LOW: 0, MODERATE: 1, IMPORTANT: 0, CRITICAL: 0)

+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
|        COMPONENT         |       VERSION        |      CVE       | SEVERITY |                                 LINK                                 |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
| github.com/docker/docker | v24.0.7+incompatible | CVE-2024-24557 | MODERATE | https://github.com/moby/moby/security/advisories/GHSA-xw73-rw38-6vjc |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
WARN:	A total of 1 unique vulnerabilities were found in 1 components
```

```
roxctl image scan --image=quay.io/stackrox-io/roxctl:4.4.1 -o table --severity MODERATE --severity IMPORTANT
Scan results for image: quay.io/stackrox-io/roxctl:4.4.1
(TOTAL-COMPONENTS: 1, TOTAL-VULNERABILITIES: 1, LOW: 0, MODERATE: 1, IMPORTANT: 0, CRITICAL: 0)

+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
|        COMPONENT         |       VERSION        |      CVE       | SEVERITY |                                 LINK                                 |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
| github.com/docker/docker | v24.0.7+incompatible | CVE-2024-24557 | MODERATE | https://github.com/moby/moby/security/advisories/GHSA-xw73-rw38-6vjc |
+--------------------------+----------------------+----------------+----------+----------------------------------------------------------------------+
WARN:	A total of 1 unique vulnerabilities were found in 1 components
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
