### PR TITLE
chore(ui): Abstract out summary card layout and logic

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import {
-    Alert,
     Breadcrumb,
     BreadcrumbItem,
     Divider,
     Flex,
-    Grid,
-    GridItem,
     PageSection,
     Pagination,
     Skeleton,
@@ -24,8 +21,11 @@ import useURLSearch from 'hooks/useURLSearch';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import {
+    SummaryCardLayout,
+    SummaryCard,
+} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import {
     getHiddenSeverities,
@@ -91,55 +91,33 @@ function NodeCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-v5-u-flex-grow-1">
-                <div className="pf-v5-u-background-color-100 pf-v5-u-p-lg">
-                    {metadataRequest.error && (
-                        <Alert
-                            title="There was an error loading the summary data for this deployment"
-                            isInline
-                            variant="danger"
-                        >
-                            {getAxiosErrorMessage(metadataRequest.error)}
-                        </Alert>
-                    )}
-                    {metadataRequest.loading && (
-                        <Grid hasGutter>
-                            <GridItem sm={12} md={6} xl2={4}>
-                                <Skeleton
-                                    style={{ height: '120px' }}
-                                    screenreaderText="Loading affected nodes summary"
-                                />
-                            </GridItem>
-                            <GridItem sm={12} md={6} xl2={4}>
-                                <Skeleton
-                                    style={{ height: '120px' }}
-                                    screenreaderText="Loading affected nodes by CVE severity summary"
-                                />
-                            </GridItem>
-                        </Grid>
-                    )}
-                    {metadataRequest.data && (
-                        <Grid hasGutter>
-                            <GridItem sm={12} md={6} xl2={4}>
-                                <AffectedNodesSummaryCard
-                                    affectedNodeCount={nodeCount}
-                                    totalNodeCount={metadataRequest.data.totalNodeCount}
-                                    operatingSystemCount={
-                                        metadataRequest.data.nodeCVE.distroTuples.length
-                                    }
-                                />
-                            </GridItem>
-                            <GridItem sm={12} md={6} xl2={4}>
-                                <BySeveritySummaryCard
-                                    title="Nodes by severity"
-                                    severityCounts={
-                                        metadataRequest.data.nodeCVE.nodeCountBySeverity
-                                    }
-                                    hiddenSeverities={hiddenSeverities}
-                                />
-                            </GridItem>
-                        </Grid>
-                    )}
-                </div>
+                <SummaryCardLayout
+                    error={metadataRequest.error}
+                    isLoading={metadataRequest.loading}
+                >
+                    <SummaryCard
+                        data={metadataRequest.data}
+                        loadingText="Loading affected nodes summary"
+                        renderer={({ data }) => (
+                            <AffectedNodesSummaryCard
+                                affectedNodeCount={nodeCount}
+                                totalNodeCount={data.totalNodeCount}
+                                operatingSystemCount={data.nodeCVE.distroTuples.length}
+                            />
+                        )}
+                    />
+                    <SummaryCard
+                        data={metadataRequest.data}
+                        loadingText="Loading affected nodes by CVE severity summary"
+                        renderer={({ data }) => (
+                            <BySeveritySummaryCard
+                                title="Nodes by severity"
+                                severityCounts={data.nodeCVE.nodeCountBySeverity}
+                                hiddenSeverities={hiddenSeverities}
+                            />
+                        )}
+                    />
+                </SummaryCardLayout>
                 <Divider component="div" />
                 <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-lg">
                     <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-    PageSection,
-    Breadcrumb,
-    Divider,
-    BreadcrumbItem,
-    Skeleton,
-    Alert,
-    Gallery,
-    GalleryItem,
-} from '@patternfly/react-core';
+import { PageSection, Breadcrumb, Divider, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
 import PageTitle from 'Components/PageTitle';
@@ -18,7 +9,10 @@ import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getTableUIState } from 'utils/getTableUIState';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import {
+    SummaryCardLayout,
+    SummaryCard,
+} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import CvePageHeader from '../../components/CvePageHeader';
 import {
     getOverviewPagePath,
@@ -81,62 +75,30 @@ function PlatformCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-v5-u-flex-grow-1">
-                <div className="pf-v5-u-background-color-100 pf-v5-u-p-lg">
-                    {metadataRequest.error && (
-                        <Alert
-                            title="There was an error loading the summary data for this deployment"
-                            isInline
-                            variant="danger"
-                        >
-                            {getAxiosErrorMessage(metadataRequest.error)}
-                        </Alert>
-                    )}
-                    {metadataRequest.loading && (
-                        <Gallery
-                            hasGutter
-                            minWidths={{
-                                // Enforce a 1/3 size, taking into account the GridGap
-                                default: 'calc(33.3% - var(--pf-v5-l-gallery--m-gutter--GridGap))',
-                            }}
-                        >
-                            <GalleryItem>
-                                <Skeleton
-                                    style={{ height: '120px' }}
-                                    screenreaderText="Loading affected nodes summary"
-                                />
-                            </GalleryItem>
-                            <GalleryItem>
-                                <Skeleton
-                                    style={{ height: '120px' }}
-                                    screenreaderText="Loading affected nodes by CVE severity summary"
-                                />
-                            </GalleryItem>
-                        </Gallery>
-                    )}
-                    {metadataRequest.data && (
-                        <Gallery
-                            hasGutter
-                            minWidths={{
-                                // Enforce a 1/3 size, taking into account the GridGap
-                                default: 'calc(33.3% - var(--pf-v5-l-gallery--m-gutter--GridGap))',
-                            }}
-                        >
-                            <GalleryItem>
-                                <AffectedClustersSummaryCard
-                                    affectedClusterCount={metadataRequest.data.clusterCount}
-                                    totalClusterCount={metadataRequest.data.totalClusterCount}
-                                />
-                            </GalleryItem>
-                            <GalleryItem>
-                                <ClustersByTypeSummaryCard
-                                    clusterCounts={
-                                        metadataRequest.data.platformCVE.clusterCountByType
-                                    }
-                                />
-                            </GalleryItem>
-                        </Gallery>
-                    )}
-                </div>
+                <SummaryCardLayout
+                    error={metadataRequest.error}
+                    isLoading={metadataRequest.loading}
+                >
+                    <SummaryCard
+                        data={metadataRequest.data}
+                        loadingText="Loading affected nodes summary"
+                        renderer={({ data }) => (
+                            <AffectedClustersSummaryCard
+                                affectedClusterCount={data.clusterCount}
+                                totalClusterCount={data.totalClusterCount}
+                            />
+                        )}
+                    />
+                    <SummaryCard
+                        data={metadataRequest.data}
+                        loadingText="Loading affected nodes by CVE severity summary"
+                        renderer={({ data }) => (
+                            <ClustersByTypeSummaryCard
+                                clusterCounts={data.platformCVE.clusterCountByType}
+                            />
+                        )}
+                    />
+                </SummaryCardLayout>
                 <Divider component="div" />
                 <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1 pf-v5-u-p-lg">
                     <AffectedClustersTable tableState={tableState} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import {
-    Alert,
     Bullseye,
     Divider,
     Flex,
-    Grid,
-    GridItem,
     PageSection,
     Pagination,
     pluralize,
-    Skeleton,
     Spinner,
     Split,
     SplitItem,
@@ -23,11 +19,14 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied } from 'utils/searchUtils';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
+import {
+    SummaryCardLayout,
+    SummaryCard,
+} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import {
     SearchOption,
     COMPONENT_SEARCH_OPTION,
@@ -210,47 +209,32 @@ function DeploymentPageVulnerabilities({
                         onFilterChange={() => setPage(1)}
                     />
                 </div>
-                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">
-                    <div className="pf-v5-u-px-lg pf-v5-u-pb-lg">
-                        {summaryRequest.error && (
-                            <Alert
-                                title="There was an error loading the summary data for this deployment"
-                                isInline
-                                variant="danger"
-                            >
-                                {getAxiosErrorMessage(summaryRequest.error)}
-                            </Alert>
-                        )}
-                        {summaryRequest.loading && !summaryData && (
-                            <Skeleton
-                                style={{ height: '120px' }}
-                                screenreaderText="Loading deployment summary data"
+                <SummaryCardLayout error={summaryRequest.error} isLoading={summaryRequest.loading}>
+                    <SummaryCard
+                        data={summaryData?.deployment}
+                        loadingText="Loading deployment summary data"
+                        renderer={({ data }) => (
+                            <BySeveritySummaryCard
+                                title="CVEs by severity"
+                                severityCounts={data.imageCVECountBySeverity}
+                                hiddenSeverities={hiddenSeverities}
                             />
                         )}
-                        {!summaryRequest.error && summaryData && summaryData.deployment && (
-                            <Grid hasGutter>
-                                <GridItem sm={12} md={6} xl2={4}>
-                                    <BySeveritySummaryCard
-                                        title="CVEs by severity"
-                                        severityCounts={
-                                            summaryData.deployment.imageCVECountBySeverity
-                                        }
-                                        hiddenSeverities={hiddenSeverities}
-                                    />
-                                </GridItem>
-                                <GridItem sm={12} md={6} xl2={4}>
-                                    <CvesByStatusSummaryCard
-                                        cveStatusCounts={
-                                            summaryData.deployment.imageCVECountBySeverity
-                                        }
-                                        hiddenStatuses={hiddenStatuses}
-                                        isBusy={summaryRequest.loading}
-                                    />
-                                </GridItem>
-                            </Grid>
+                    />
+                    <SummaryCard
+                        data={summaryData?.deployment}
+                        loadingText="Loading deployment summary data"
+                        renderer={({ data }) => (
+                            <CvesByStatusSummaryCard
+                                cveStatusCounts={data.imageCVECountBySeverity}
+                                hiddenStatuses={hiddenStatuses}
+                                isBusy={summaryRequest.loading}
+                            />
                         )}
-                    </div>
-                    <Divider />
+                    />
+                </SummaryCardLayout>
+                <Divider />
+                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">
                     <div className="pf-v5-u-p-lg">
                         <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
                             <SplitItem isFilled>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -3,8 +3,6 @@ import {
     Bullseye,
     Divider,
     Flex,
-    Grid,
-    GridItem,
     PageSection,
     Pagination,
     pluralize,
@@ -30,6 +28,10 @@ import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
+import {
+    SummaryCardLayout,
+    SummaryCard,
+} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import {
     SearchOption,
     IMAGE_CVE_SEARCH_OPTION,
@@ -201,24 +203,30 @@ function ImagePageVulnerabilities({
 
         mainContent = (
             <>
-                <div className="pf-v5-u-px-lg pf-v5-u-pb-lg">
-                    <Grid hasGutter>
-                        <GridItem sm={12} md={6} xl2={4}>
+                <SummaryCardLayout error={error} isLoading={loading}>
+                    <SummaryCard
+                        data={vulnerabilityData.image}
+                        loadingText="Loading image vulnerability summary"
+                        renderer={({ data }) => (
                             <BySeveritySummaryCard
                                 title="CVEs by severity"
-                                severityCounts={vulnCounter}
+                                severityCounts={data.imageCVECountBySeverity}
                                 hiddenSeverities={hiddenSeverities}
                             />
-                        </GridItem>
-                        <GridItem sm={12} md={6} xl2={4}>
+                        )}
+                    />
+                    <SummaryCard
+                        data={vulnerabilityData.image}
+                        loadingText="Loading image vulnerability summary"
+                        renderer={({ data }) => (
                             <CvesByStatusSummaryCard
-                                cveStatusCounts={vulnerabilityData.image.imageCVECountBySeverity}
+                                cveStatusCounts={data.imageCVECountBySeverity}
                                 hiddenStatuses={hiddenStatuses}
                                 isBusy={loading}
                             />
-                        </GridItem>
-                    </Grid>
-                </div>
+                        )}
+                    />
+                </SummaryCardLayout>
                 <Divider />
                 <div className="pf-v5-u-p-lg">
                     <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import {
-    Alert,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
     Divider,
     Flex,
-    Grid,
-    GridItem,
     PageSection,
     Pagination,
     Skeleton,
@@ -26,7 +23,6 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { Pagination as PaginationParam } from 'services/types';
 
@@ -34,6 +30,10 @@ import { VulnerabilitySeverity } from 'types/cve.proto';
 import useAnalytics, { WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED } from 'hooks/useAnalytics';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
+import {
+    SummaryCardLayout,
+    SummaryCard,
+} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import {
     SearchOption,
     IMAGE_SEARCH_OPTION,
@@ -387,44 +387,33 @@ function ImageCvePage() {
                             onFilterChange={() => setPage(1)}
                         />
                     </div>
-                    <div className="pf-v5-u-px-lg pf-v5-u-pb-lg">
-                        {summaryRequest.error && (
-                            <Alert
-                                title="There was an error loading the summary data for this CVE"
-                                isInline
-                                variant="danger"
-                            >
-                                {getAxiosErrorMessage(summaryRequest.error)}
-                            </Alert>
-                        )}
-                        {summaryRequest.loading && !summaryRequest.data && (
-                            <Skeleton
-                                style={{ height: '120px' }}
-                                screenreaderText="Loading image cve summary data"
-                            />
-                        )}
-                        {!summaryRequest.error && summaryRequest.data && (
-                            <Grid hasGutter>
-                                <GridItem sm={12} md={6} xl2={4}>
-                                    <AffectedImages
-                                        className="pf-v5-u-h-100"
-                                        affectedImageCount={severitySummary.affectedImageCount}
-                                        totalImagesCount={summaryRequest.data.totalImageCount}
-                                    />
-                                </GridItem>
-                                <GridItem sm={12} md={6} xl2={4}>
-                                    <BySeveritySummaryCard
-                                        className="pf-v5-u-h-100"
-                                        title="Images by severity"
-                                        severityCounts={
-                                            severitySummary.affectedImageCountBySeverity
-                                        }
-                                        hiddenSeverities={hiddenSeverities}
-                                    />
-                                </GridItem>
-                            </Grid>
-                        )}
-                    </div>
+                    <SummaryCardLayout
+                        error={summaryRequest.error}
+                        isLoading={summaryRequest.loading}
+                    >
+                        <SummaryCard
+                            data={summaryRequest.data}
+                            loadingText="Loading image CVE summary data"
+                            renderer={({ data }) => (
+                                <AffectedImages
+                                    className="pf-v5-u-h-100"
+                                    affectedImageCount={severitySummary.affectedImageCount}
+                                    totalImagesCount={data.totalImageCount}
+                                />
+                            )}
+                        />
+                        <SummaryCard
+                            data={severitySummary}
+                            loadingText="Loading image CVE summary data"
+                            renderer={({ data }) => (
+                                <BySeveritySummaryCard
+                                    title="Images by severity"
+                                    severityCounts={data.affectedImageCountBySeverity}
+                                    hiddenSeverities={hiddenSeverities}
+                                />
+                            )}
+                        />
+                    </SummaryCardLayout>
                 </div>
                 <Divider />
                 <div className="pf-v5-u-background-color-100 pf-v5-u-flex-grow-1">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.cy.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { SummaryCard, SummaryCardLayout } from './SummaryCardLayout';
+
+describe(Cypress.spec.relative, () => {
+    it('should render an error alert if an error is provided', () => {
+        cy.mount(
+            <SummaryCardLayout
+                errorAlertTitle="This is an error in a test"
+                error={new Error('An error occurred')}
+                isLoading={true}
+            >
+                <SummaryCard
+                    loadingText="Loading..."
+                    data={{ key: 'does not render' }}
+                    renderer={({ data }) => <div>{data.key}</div>}
+                />
+            </SummaryCardLayout>
+        );
+
+        cy.findByText('Danger alert:').should('exist');
+        cy.findByText('This is an error in a test').should('exist');
+        cy.findByText('An error occurred').should('exist');
+        cy.findByText('Loading...').should('not.exist');
+        cy.findByText('does not render').should('not.exist');
+    });
+
+    it('should render a loading skeleton instead of content when in a loading state', () => {
+        cy.mount(
+            <SummaryCardLayout isLoading={true}>
+                <SummaryCard
+                    loadingText="Loading..."
+                    data={{ key: 'does not render' }}
+                    renderer={({ data }) => <div>{data.key}</div>}
+                />
+            </SummaryCardLayout>
+        );
+
+        cy.findByText('Danger alert:').should('not.exist');
+        cy.findByText('Loading...').should('exist');
+        cy.findByText('does not render').should('not.exist');
+    });
+
+    it('should render a loading skeleton if data is not provided', () => {
+        cy.mount(
+            <SummaryCardLayout isLoading={false}>
+                <SummaryCard
+                    loadingText="Loading..."
+                    data={null}
+                    renderer={({ data }) => <div>{data.key}</div>}
+                />
+            </SummaryCardLayout>
+        );
+
+        cy.findByText('Danger alert:').should('not.exist');
+        cy.findByText('Loading...').should('exist');
+        cy.findByText('does not render').should('not.exist');
+    });
+
+    it('should render the provided data', () => {
+        cy.mount(
+            <SummaryCardLayout isLoading={false}>
+                <SummaryCard
+                    loadingText="Loading..."
+                    data={{ key: 'does render' }}
+                    renderer={({ data }) => <div>{data.key}</div>}
+                />
+            </SummaryCardLayout>
+        );
+
+        cy.findByText('Danger alert:').should('not.exist');
+        cy.findByText('Loading...').should('not.exist');
+        cy.findByText('does render').should('exist');
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
@@ -38,7 +38,7 @@ const fullWidth = '100%';
 export type SummaryCardLayoutProps = {
     error: unknown;
     isLoading: boolean;
-    children: [React.ReactElement, ...React.ReactElement[]];
+    children: React.ReactNode;
     errorAlertTitle?: string;
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Alert, Gallery, GalleryItem, Skeleton } from '@patternfly/react-core';
+
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+const LoadingContext = React.createContext<{ isLoading: boolean }>({
+    isLoading: false,
+});
+
+export type SummaryCardProps<T> = {
+    data: T;
+    loadingText: string;
+    renderer: ({ data }: { data: NonNullable<T> }) => React.ReactNode;
+};
+
+/**
+ * Component that handles rendering of individual summary cards. This will get the loading state
+ * from the parent context and render a skeleton if the data is not yet available.
+ */
+export function SummaryCard<T>({ loadingText, renderer, data }: SummaryCardProps<T>) {
+    const { isLoading } = React.useContext(LoadingContext);
+    return (
+        <GalleryItem>
+            {isLoading || !data ? (
+                <Skeleton height="100%" screenreaderText={loadingText} />
+            ) : (
+                renderer({ data })
+            )}
+        </GalleryItem>
+    );
+}
+
+// Responsive widths for the summary cards, taking into account the gutter spacing
+const oneThirdWidth = 'calc(33.3% - var(--pf-v5-global--gutter))';
+const oneHalfWidth = 'calc(50% - var(--pf-v5-global--gutter))';
+const fullWidth = '100%';
+
+export type SummaryCardLayoutProps = {
+    error: unknown;
+    isLoading: boolean;
+    children: [React.ReactElement, ...React.ReactElement[]];
+    errorAlertTitle?: string;
+};
+
+/**
+ * Component that encapsulates the layout for Vulnerability Management summary cards. This includes
+ * handling of loading and error states, and providing non-nullable data to the summary cards.
+ */
+export function SummaryCardLayout({
+    error,
+    isLoading,
+    children,
+    errorAlertTitle = 'There was an error loading the summary data for this entity',
+}: SummaryCardLayoutProps) {
+    return (
+        <LoadingContext.Provider value={{ isLoading }}>
+            <div className="pf-v5-u-background-color-100 pf-v5-u-p-lg">
+                {error ? (
+                    <Alert title={errorAlertTitle} isInline variant="danger">
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                ) : (
+                    <Gallery
+                        hasGutter
+                        style={{ minHeight: '120px' }}
+                        minWidths={{ '2xl': oneThirdWidth, md: oneHalfWidth, sm: fullWidth }}
+                    >
+                        {children}
+                    </Gallery>
+                )}
+            </div>
+        </LoadingContext.Provider>
+    );
+}


### PR DESCRIPTION
## Description

Extracts the layout and logic for summary cards across VM 2.0.

- Removes duplication of `error`/`loading`/`data` checking logic
- Reduces layout duplication switching between `Skeleton` components and rendered data during loading states
- Makes the `isLoading` behavior consistent throughout VM 2.0 (previously we would display stale data when the request was refetched)
- Switches from `Grid` to `Gallery` based layout to ensure we have matching heights of all cards, regardless of content, without explicit height setting
- Avoids null checks on `data` at the call site by encapsulating this in a render prop
- Tests 🎉 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of all VM 2.0 pages with summary cards to ensure the data still loads and displays correctly.

Component tests to validate behavior of the generic component.

Here is a side-by-side of the old components with the new component. The new component is the top set of summary cards:

https://github.com/stackrox/stackrox/assets/1292638/8b073043-d646-4dc1-8630-7e1eb884898a



