### PR TITLE
chore(test): Check that SensorEvent was added as a deduper key

### DIFF
--- a/pkg/deduperkey/key_test.go
+++ b/pkg/deduperkey/key_test.go
@@ -130,6 +130,7 @@ func withKey(resource any, id string) Key {
 var allSensorEventTypes []string
 
 var whitelist = []string{
+	"SensorEvent",
 	"SensorEvent_SensorHash",
 	"SensorEvent_Synced",
 	"SensorEvent_ReprocessDeployment",
@@ -137,7 +138,7 @@ var whitelist = []string{
 	"SensorEvent_ResourcesSynced",
 }
 
-func TestAllSensorEventsWereAdded(t *testing.T) {
+func TestAllSensorEventsWereAddedToDeduper(t *testing.T) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Add test to check that SensorEvent was added as a deduper key

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI