### PR TITLE
chore(lint): remove deprecated golangci-lint configs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,25 @@
 run:
   timeout: 240m
-  skip-dirs:
-  - pkg/complianceoperator/api
-  - scanner/updater/rhel        # TODO(ROX-21539): Remove when CSAF/VEX arrives
   build-tags:
   - integration
   - sql_integration
   modules-download-mode: readonly
+  go: "1.21"
 
 output:
-  format: "junit-xml:report.xml,colored-line-number"
+  formats:
+    - format: colored-line-number
+    - format: junit-xml
+      path: report.xml
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
 
+  exclude-dirs:
+  - pkg/complianceoperator/api
+  - scanner/updater/rhel        # TODO(ROX-21539): Remove when CSAF/VEX arrives
   exclude-rules:
     - path: "(central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale)/"
       linters:
@@ -118,7 +122,6 @@ linters-settings:
     - 'os\.Stderr(# Disallowed output streams used\. Use environment\.InputOutput\(\).Out instead\.)?'
     - 'os\.Stdin(# Disallowed output streams used\. Use environment\.InputOutput\(\).Out instead\.)?'
   staticcheck:
-    go: "1.20"
     checks: [all,-ST1000,-ST1001,-ST1003,-ST1005,-SA1019,-SA4001,-ST1016]
   wrapcheck:
     ignoreSigRegexps:


### PR DESCRIPTION
## Description

When running golangci-lint locally with one of the latest versions, you will get complaints about a couple of fields being deprecated in the config:
```log
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`
WARN [config_reader] The configuration option `linters.staticcheck.go` is deprecated, please use global `run.go`
```

This PR fixes those occurrences and also bumps the go version to check against to 1.21.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
