### PR TITLE
refactor: `requestinfo`

### DIFF
--- a/pkg/grpc/requestinfo/requestinfo.go
+++ b/pkg/grpc/requestinfo/requestinfo.go
@@ -163,18 +163,18 @@ func slimHTTPRequest(req *http.Request) *HTTPRequest {
 	}
 }
 
-// AnnotateMD builds a RequestInfo for a request coming in through the HTTP/1.1 gateway, and returns it in serialized
-// form as GRPC metadata.
-func (h *Handler) AnnotateMD(_ context.Context, req *http.Request) metadata.MD {
+func makeRequestInfo(req *http.Request) *RequestInfo {
 	tlsState := req.TLS
 
-	var ri RequestInfo
+	ri := &RequestInfo{
+		Hostname:    req.Host,
+		Metadata:    metadataFromHeader(req.Header),
+		HTTPRequest: slimHTTPRequest(req),
+		Source:      sourceFromRequest(req),
+	}
 
-	ri.HTTPRequest = slimHTTPRequest(req)
-
-	ri.Source = sourceFromRequest(req)
-
-	// X-Forwarded-Host takes precedence in case we are behind a proxy. `Hostname` should match what the client sees.
+	// X-Forwarded-Host takes precedence in case we are behind a proxy.
+	// `Hostname` should match what the client sees.
 	if fwdHost := req.Header.Get(forwardedHost); fwdHost != "" {
 		ri.Hostname = fwdHost
 	} else if tlsState != nil {
@@ -190,6 +190,14 @@ func (h *Handler) AnnotateMD(_ context.Context, req *http.Request) metadata.MD {
 	if tlsState != nil {
 		ri.VerifiedChains = ExtractCertInfoChains(tlsState.VerifiedChains)
 	}
+	return ri
+}
+
+// AnnotateMD builds a RequestInfo for a request coming in through the HTTP/1.1
+// gateway, and returns it in serialized form as GRPC metadata.
+// HTTP Request -> Metadata[RequestInfo]
+func (h *Handler) AnnotateMD(_ context.Context, req *http.Request) metadata.MD {
+	ri := makeRequestInfo(req)
 
 	// Encode to GOB.
 	var buf bytes.Buffer
@@ -222,6 +230,11 @@ func FromContext(ctx context.Context) RequestInfo {
 	return ri
 }
 
+func toContext(ctx context.Context, ri *RequestInfo) context.Context {
+	return context.WithValue(ctx, requestInfoKey{}, *ri)
+}
+
+// Metadata[RequestInfo] -> RequestInfo+Metadata
 func (h *Handler) extractFromMD(ctx context.Context) (*RequestInfo, error) {
 	md := metautils.ExtractIncoming(ctx)
 	riB64 := md.Get(requestInfoMDKey)
@@ -242,11 +255,12 @@ func (h *Handler) extractFromMD(ctx context.Context) (*RequestInfo, error) {
 	if err := gob.NewDecoder(bytes.NewReader(riRaw)).Decode(&reqInfo); err != nil {
 		return nil, errors.Wrap(err, "could not decode request info")
 	}
-
+	reqInfo.Metadata = metadata.MD(md)
 	return &reqInfo, nil
 }
 
 // UpdateContextForGRPC provides the context updater logic when used with GRPC interceptors.
+// Context[Metadata[RequestInfo]] -> Context[RequestInfo[Metadata]]
 func (h *Handler) UpdateContextForGRPC(ctx context.Context) (context.Context, error) {
 	ri, err := h.extractFromMD(ctx)
 	if err != nil {
@@ -260,6 +274,7 @@ func (h *Handler) UpdateContextForGRPC(ctx context.Context) (context.Context, er
 	if ri == nil {
 		ri = &RequestInfo{
 			ClientUsedTLS: tlsState != nil,
+			Metadata:      metadata.MD(metautils.ExtractIncoming(ctx)),
 		}
 	}
 
@@ -269,49 +284,26 @@ func (h *Handler) UpdateContextForGRPC(ctx context.Context) (context.Context, er
 		ri.VerifiedChains = ExtractCertInfoChains(tlsState.VerifiedChains)
 	}
 
-	ri.Metadata, _ = metadata.FromIncomingContext(ctx)
-	return context.WithValue(ctx, requestInfoKey{}, *ri), nil
+	return toContext(ctx, ri), nil
 }
 
 // HTTPIntercept provides a http interceptor logic for populating the context with the request info.
 func (h *Handler) HTTPIntercept(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		ri := &RequestInfo{
-			Hostname:    r.Host,
-			Metadata:    metadataFromHeader(r.Header),
-			HTTPRequest: slimHTTPRequest(r),
-			Source:      sourceFromRequest(r),
-		}
-		// X-Forwarded-Host takes precedence in case we are behind a proxy.
-		// `Hostname` should match what the client sees.
-		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
-			ri.Hostname = fwdHost
-		}
-		if fwdProto := r.Header.Get("X-Forwarded-Proto"); fwdProto != "" {
-			ri.ClientUsedTLS = fwdProto != "http"
-		} else {
-			ri.ClientUsedTLS = r.TLS != nil
-		}
-
-		if r.TLS != nil {
-			ri.VerifiedChains = ExtractCertInfoChains(r.TLS.VerifiedChains)
-		}
-		newCtx := context.WithValue(r.Context(), requestInfoKey{}, *ri)
-		logRequest(r)
+		ri := makeRequestInfo(r)
+		logRequest(r, ri)
+		newCtx := toContext(r.Context(), ri)
 		handler.ServeHTTP(w, r.WithContext(newCtx))
 	})
 }
 
-func logRequest(request *http.Request) {
+func logRequest(request *http.Request, ri *RequestInfo) {
 	if !networkLog || request == nil {
 		return
 	}
 
 	forwardedBy := stringutils.OrDefault(request.Header.Get(forwardedKey), "N/A")
 	xff := request.Header.Get(forwardedForKey)
-
-	source := sourceFromRequest(request)
 
 	var referer string
 	if request.Header.Get(refererKey) != "" {
@@ -324,7 +316,7 @@ func logRequest(request *http.Request) {
 
 	log.Infof(
 		"Source: %+v, Method: %s, User Agent: %s, Forwarded: %s, Destination Host: %s, Referer: %s, X-Forwarded-For: %s, URL: %s",
-		source, request.Method, request.Header.Get(userAgent), forwardedBy, destHost, referer, stringutils.OrDefault(xff, "N/A"), uri)
+		ri.Source, request.Method, request.Header.Get(userAgent), forwardedBy, destHost, referer, stringutils.OrDefault(xff, "N/A"), uri)
 }
 
 func sourceAddr(ctx context.Context) net.Addr {

--- a/pkg/grpc/requestinfo/requestinfo_test.go
+++ b/pkg/grpc/requestinfo/requestinfo_test.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	pb "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/netutil/pipeconn"
 	"github.com/stackrox/rox/pkg/testutils"
-
-	pb "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"

--- a/pkg/grpc/requestinfo/requestinfo_test.go
+++ b/pkg/grpc/requestinfo/requestinfo_test.go
@@ -1,0 +1,167 @@
+package requestinfo
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stackrox/rox/pkg/contextutil"
+	"github.com/stackrox/rox/pkg/netutil/pipeconn"
+	"github.com/stackrox/rox/pkg/testutils"
+
+	pb "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+var insecureTLSConfig = &tls.Config{InsecureSkipVerify: true}
+var insecureSkipVerify = credentials.NewTLS(insecureTLSConfig)
+
+func Test_PureHTTP(t *testing.T) {
+	handler := NewRequestInfoHandler()
+
+	var receivedRequest *http.Request
+	var receivedRI *RequestInfo
+
+	server := httptest.NewServer(handler.HTTPIntercept(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedRequest = r
+		ri := FromContext(r.Context())
+		receivedRI = &ri
+	})))
+	defer server.Close()
+
+	req, _ := http.NewRequest("GET", server.URL+"/v1/test", nil)
+	req.Header.Add("test-key", "test value")
+
+	client := http.Client{}
+	_, err := client.Do(req)
+	require.NoError(t, err)
+
+	require.NotNil(t, receivedRequest)
+	assert.Equal(t, req.Method, receivedRequest.Method)
+	assert.Equal(t, req.Header.Get("test-key"), receivedRequest.Header.Get("test-key"))
+	assert.Equal(t, "Go-http-client/1.1", receivedRequest.Header.Get("user-agent"))
+
+	require.NotNil(t, receivedRI)
+	assert.Equal(t, receivedRequest.Header, receivedRI.HTTPRequest.Headers)
+	assert.NotNil(t, receivedRI.Metadata)
+	assert.Equal(t, []string{"test value"}, receivedRI.Metadata.Get("test-key"))
+}
+
+type pingService struct {
+	pb.UnimplementedPingServiceServer
+	receivedRI *RequestInfo
+}
+
+func (s *pingService) Ping(ctx context.Context, in *pb.Empty) (*pb.PongMessage, error) {
+	ri := FromContext(ctx)
+	s.receivedRI = &ri
+	return &pb.PongMessage{Status: "pong"}, nil
+}
+
+func Test_PureGRPC(t *testing.T) {
+	handler := NewRequestInfoHandler()
+
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(
+		contextutil.UnaryServerInterceptor(handler.UpdateContextForGRPC)))
+
+	serviceInstance := &pingService{}
+	pb.RegisterPingServiceServer(grpcServer, serviceInstance)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(grpcServer.ServeHTTP))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	conn, err := grpc.Dial(server.Listener.Addr().String(),
+		grpc.WithTransportCredentials(insecureSkipVerify))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	c := pb.NewPingServiceClient(conn)
+	resp, err := c.Ping(context.Background(), &pb.Empty{})
+	require.NoError(t, err)
+	require.Equal(t, "pong", resp.Status)
+
+	receivedRI := serviceInstance.receivedRI
+	require.NotNil(t, receivedRI)
+	require.Nil(t, receivedRI.HTTPRequest)
+	assert.NotNil(t, receivedRI.Metadata)
+	assert.Equal(t, []string{"application/grpc"}, receivedRI.Metadata.Get("content-type"))
+	assert.Contains(t, receivedRI.Metadata.Get("user-agent")[0], "grpc-go/")
+}
+
+func Test_gRPCGateway(t *testing.T) {
+	handler := NewRequestInfoHandler()
+	serviceInstance := &pingService{}
+
+	cert := testutils.IssueSelfSignedCert(t, "*.example.com", "*.example.com")
+	creds := credentials.NewTLS(&tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{cert},
+	})
+
+	grpcServer := grpc.NewServer(grpc.Creds(creds),
+		grpc.UnaryInterceptor(contextutil.UnaryServerInterceptor(
+			handler.UpdateContextForGRPC)))
+	pb.RegisterPingServiceServer(grpcServer, serviceInstance)
+
+	lis, dialContext := pipeconn.NewPipeListener()
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	defer grpcServer.Stop()
+
+	gateway := runtime.NewServeMux(runtime.WithMetadata(handler.AnnotateMD))
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	err := pb.RegisterPingServiceHandlerFromEndpoint(ctx, gateway, lis.Addr().String(),
+		[]grpc.DialOption{
+			grpc.WithTransportCredentials(creds),
+			grpc.WithContextDialer(func(ctx context.Context, url string) (net.Conn, error) {
+				return dialContext(ctx)
+			}),
+			grpc.WithUserAgent("gateway agent"),
+		})
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(gateway)
+	server.TLS = insecureTLSConfig
+	server.StartTLS()
+	defer server.Close()
+
+	client := http.Client{Transport: &http.Transport{
+		TLSClientConfig:   insecureTLSConfig,
+		ForceAttemptHTTP2: true,
+	}}
+
+	req, _ := http.NewRequest("GET", server.URL+"/v1/ping", nil)
+	req.Header.Add("user-agent", "test agent")
+	req.Header.Add("test-key", "test value")
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	receivedRI := serviceInstance.receivedRI
+	require.NotNil(t, receivedRI)
+
+	require.NotNil(t, receivedRI.HTTPRequest)
+	assert.Equal(t, "test agent", receivedRI.HTTPRequest.Headers.Get("user-agent"))
+	assert.Equal(t, "test value", receivedRI.HTTPRequest.Headers.Get("test-key"))
+
+	assert.NotNil(t, receivedRI.Metadata)
+	assert.Equal(t, []string{"application/grpc"}, receivedRI.Metadata.Get("content-type"))
+	assert.Contains(t, receivedRI.Metadata.Get("user-agent")[0], "gateway agent")
+	prefixedUserAgentKey, _ := runtime.DefaultHeaderMatcher("user-agent")
+	assert.Contains(t, receivedRI.Metadata.Get(prefixedUserAgentKey)[0], "test agent")
+}

--- a/pkg/grpc/requestinfo/requestinfo_test.go
+++ b/pkg/grpc/requestinfo/requestinfo_test.go
@@ -68,7 +68,7 @@ func Test_PureGRPC(t *testing.T) {
 	conn, err := grpc.Dial(server.Listener.Addr().String(),
 		grpc.WithTransportCredentials(insecureSkipVerify))
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	c := pb.NewPingServiceClient(conn)
 	resp, err := c.Ping(context.Background(), &pb.Empty{})

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -59,8 +59,12 @@ func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string
 	// Use the wrapped HTTP request details if provided:
 	ri := requestinfo.FromContext(ctx)
 	if ri.HTTPRequest != nil && ri.HTTPRequest.URL != nil {
+		userAgentKey := "User-Agent"
+		if matchedKey, ok := runtime.DefaultHeaderMatcher(userAgentKey); ok {
+			userAgentKey = matchedKey
+		}
 		return &RequestParams{
-			UserAgent: getUserAgent(ri.Metadata.Get),
+			UserAgent: ri.HTTPRequest.Headers.Get(userAgentKey),
 			UserID:    id,
 			Method:    ri.HTTPRequest.Method,
 			Path:      ri.HTTPRequest.URL.Path,

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	erroxGRPC "github.com/stackrox/rox/pkg/errox/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
@@ -13,7 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
-const grpcGatewayUserAgentHeader = runtime.MetadataPrefix + "User-Agent"
+const userAgentKey = "User-Agent"
 
 func (cfg *Config) track(rp *RequestParams) {
 	cfg.interceptorsLock.RLock()
@@ -38,43 +37,38 @@ func (cfg *Config) track(rp *RequestParams) {
 	}
 }
 
-func getUserAgent[getter func(string) []string](headers getter) string {
-	// By default, all permanent HTTP headers in grpc-gateway are added grpcgateway- prefix:
-	// https://github.com/grpc-ecosystem/grpc-gateway/blob/8952e38d5addd28308e29c272c696a578aa8ace8/runtime/mux.go#L106-L114
-	// User-Agent header is occupied with internal grpc-go value:
-	// https://github.com/grpc/grpc-go/blob/0238b6e1cec37b55820b461d3d30652c54efe2c4/clientconn.go#L211-L215
-	userAgentValues := headers(grpcGatewayUserAgentHeader)
-	// If endpoint is accessed not via grpc-gateway, extract from User-Agent header.
-	// If endpoint is accessed via grpc-gateway, append grpc-go value to the resultinguser agent.
-	userAgentValues = append(userAgentValues, headers("User-Agent")...)
-	return strings.Join(userAgentValues, " ")
-}
-
 func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string, req any) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)
 	}
 
-	// Use the wrapped HTTP request details if provided:
 	ri := requestinfo.FromContext(ctx)
-	if ri.HTTPRequest != nil && ri.HTTPRequest.URL != nil {
-		userAgentKey := "User-Agent"
-		if matchedKey, ok := runtime.DefaultHeaderMatcher(userAgentKey); ok {
-			userAgentKey = matchedKey
+
+	// This is either the gRPC client or the grpc-gateway user agent:
+	grpcClientAgent := ri.Metadata.Get(userAgentKey)
+
+	// Use the wrapped HTTP request if provided by the grpc-gateway.
+	if ri.HTTPRequest != nil {
+		var path string
+		if ri.HTTPRequest.URL != nil {
+			path = ri.HTTPRequest.URL.Path
+		}
+		if clientAgent := ri.HTTPRequest.Headers.Get(userAgentKey); clientAgent != "" {
+			grpcClientAgent = append(grpcClientAgent, clientAgent)
 		}
 		return &RequestParams{
-			UserAgent: ri.HTTPRequest.Headers.Get(userAgentKey),
+			UserAgent: strings.Join(grpcClientAgent, " "),
 			UserID:    id,
 			Method:    ri.HTTPRequest.Method,
-			Path:      ri.HTTPRequest.URL.Path,
+			Path:      path,
 			Code:      grpcError.ErrToHTTPStatus(err),
 			GRPCReq:   req,
 		}
 	}
 
 	return &RequestParams{
-		UserAgent: getUserAgent(ri.Metadata.Get),
+		UserAgent: strings.Join(grpcClientAgent, " "),
 		UserID:    id,
 		Method:    grpcFullMethod,
 		Path:      grpcFullMethod,
@@ -90,7 +84,7 @@ func getHTTPRequestDetails(ctx context.Context, r *http.Request, status int) *Re
 	}
 
 	return &RequestParams{
-		UserAgent: getUserAgent(r.Header.Values),
+		UserAgent: r.Header.Get(userAgentKey),
 		UserID:    id,
 		Method:    r.Method,
 		Path:      r.URL.Path,

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -150,17 +150,18 @@ func (s *interceptorTestSuite) TestGrpcRequestInfo() {
 
 func (s *interceptorTestSuite) TestGrpcWithHTTPRequestInfo() {
 	req, _ := http.NewRequest("PATCH", "/wrapped/http", nil)
+	req.Header.Add("user-agent", "user")
 	rih := requestinfo.NewRequestInfoHandler()
 	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
 	md := rih.AnnotateMD(ctx, req)
-	md.Set("User-Agent", "test")
+	md.Set("User-Agent", "gateway")
 
 	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
 	s.NoError(err)
 
 	rp := getGRPCRequestDetails(ctx, err, "ignored grpc method", "request")
 	s.Equal(http.StatusOK, rp.Code)
-	s.Equal("test", rp.UserAgent)
+	s.Equal("gateway user", rp.UserAgent)
 	s.Nil(rp.UserID)
 	s.Equal("request", rp.GRPCReq)
 	s.Equal("/wrapped/http", rp.Path)


### PR DESCRIPTION
This is another try to refactor `requestinfo` after #10614.
The added tests exercise the three call flows:
* HTTP
* gRPC
* HTTP->gRPC gateway->gRPC