### PR TITLE
chore(roxvet): replace sort functions with slices equivalents

### DIFF
--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"slices"
 	"sort"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -144,7 +145,7 @@ func (s *serviceImpl) ListAvailableProviderTypes(_ context.Context, _ *v1.Empty)
 		}
 
 		attributes := factory.GetSuggestedAttributes()
-		sort.Strings(attributes)
+		slices.Sort(attributes)
 		supportedTypes = append(supportedTypes, &v1.AvailableProviderTypesResponse_AuthProviderType{
 			Type:                typ,
 			SuggestedAttributes: attributes,

--- a/central/deployment/datastore/search_comparison_test.go
+++ b/central/deployment/datastore/search_comparison_test.go
@@ -4,7 +4,7 @@ package datastore
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"testing"
 
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
@@ -60,14 +60,14 @@ func compareResults(t *testing.T, matches bool, predResult *search.Result, searc
 
 	if matches && len(searchResults) > 0 {
 		for k := range predResult.Matches {
-			sort.Strings(predResult.Matches[k])
+			slices.Sort(predResult.Matches[k])
 			newImageKey, ok := imageKeyMap[k]
 			// If the key exists
 			if ok {
-				sort.Strings(searchResults[0].Matches[newImageKey])
+				slices.Sort(searchResults[0].Matches[newImageKey])
 				assert.Equal(t, predResult.Matches[k], searchResults[0].Matches[newImageKey])
 			} else {
-				sort.Strings(searchResults[0].Matches[k])
+				slices.Sort(searchResults[0].Matches[k])
 				assert.Equal(t, predResult.Matches[k], searchResults[0].Matches[k])
 			}
 		}

--- a/central/deployment/service/service_impl.go
+++ b/central/deployment/service/service_impl.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"math"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -268,10 +268,10 @@ func labelsMapFromSearchResults(results []search.Result) (map[string]*v1.Deploym
 		keyValuesMap[k] = &v1.DeploymentLabelsResponse_LabelValues{
 			Values: valSet.AsSlice(),
 		}
-		sort.Strings(keyValuesMap[k].Values)
+		slices.Sort(keyValuesMap[k].Values)
 	}
 	values = globalValueSet.AsSlice()
-	sort.Strings(values)
+	slices.Sort(values)
 
 	return keyValuesMap, values
 }

--- a/central/networkgraph/service/masker.go
+++ b/central/networkgraph/service/masker.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
@@ -45,7 +45,7 @@ func (m *flowGraphMasker) RegisterDeploymentForMasking(deployment *storage.ListD
 
 func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 	orderedNamespaceNamesToMask := m.namespaceNamesToMask.AsSlice()
-	sort.Strings(orderedNamespaceNamesToMask)
+	slices.Sort(orderedNamespaceNamesToMask)
 	for ix, ns := range orderedNamespaceNamesToMask {
 		maskedNS := fmt.Sprintf("%s #%d", MaskedNamespaceName, ix+1)
 		m.realToMaskedNamespace[ns] = maskedNS
@@ -55,7 +55,7 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 	for deploymentID := range m.deploymentsToMask {
 		orderedDeploymentIDsToMask = append(orderedDeploymentIDsToMask, deploymentID)
 	}
-	sort.Strings(orderedDeploymentIDsToMask)
+	slices.Sort(orderedDeploymentIDsToMask)
 	for ix, deploymentID := range orderedDeploymentIDsToMask {
 		origDeployment := m.deploymentsToMask[deploymentID]
 		maskedDeploymentName := fmt.Sprintf("%s #%d", MaskedDeploymentName, ix+1)

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -417,8 +417,8 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 		"baz/depF <- foo/depB",
 		"mycluster__net1 <- foo/depA",
 	}
-	sort.Strings(expected)
-	sort.Strings(flowStrings)
+	slices.Sort(expected)
+	slices.Sort(flowStrings)
 	s.Equal(expected, flowStrings)
 }
 
@@ -774,7 +774,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 		"baz/depF <- foo/depB",
 		"mycluster__net1 <- foo/depA",
 	}
-	sort.Strings(expected)
+	slices.Sort(expected)
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.TestScopeCheckerCoreFromFullScopeMap(s.T(),
@@ -842,7 +842,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 		}
 	}
 
-	sort.Strings(flowStrings)
+	slices.Sort(flowStrings)
 	s.Equal(expected, flowStrings)
 
 	// Second run, change only the order of the elements in SearchListDeployments
@@ -882,7 +882,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 			flowStringsSecondPass = append(flowStringsSecondPass, flowAsString(src, dst))
 		}
 	}
-	sort.Strings(flowStringsSecondPass)
+	slices.Sort(flowStringsSecondPass)
 	s.Equal(expected, flowStringsSecondPass)
 }
 
@@ -1140,8 +1140,8 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 		es2ID.String() + " <- bar/depD",
 		es3ID.String() + " <- bar/depD",
 	}
-	sort.Strings(expected)
-	sort.Strings(flowStrings)
+	slices.Sort(expected)
+	slices.Sort(flowStrings)
 	s.Equal(expected, flowStrings)
 }
 

--- a/central/networkpolicies/graph/diff.go
+++ b/central/networkpolicies/graph/diff.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"slices"
-	"sort"
 
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -15,7 +14,7 @@ func getAdjacentNodeIDs(adjacencies map[string]*v1.NetworkEdgePropertiesBundle) 
 	for id := range adjacencies {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	slices.Sort(ids)
 	return ids
 }
 
@@ -29,7 +28,7 @@ func adjacentNodeIDsToMap(adjacencies []string) map[string]*v1.NetworkEdgeProper
 
 func getPolicyIDs(node *v1.NetworkNode) []string {
 	result := slices.Clone(node.GetPolicyIds())
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }
 

--- a/central/networkpolicies/graph/diff_test.go
+++ b/central/networkpolicies/graph/diff_test.go
@@ -23,7 +23,7 @@ type nodeSpecMap map[string]nodeSpec
 
 func sortedIDs(ids []string) []string {
 	result := slices.Clone(ids)
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }
 

--- a/central/networkpolicies/graph/evaluator_test.go
+++ b/central/networkpolicies/graph/evaluator_test.go
@@ -3,7 +3,7 @@ package graph
 import (
 	"bytes"
 	"context"
-	"sort"
+	"slices"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -704,7 +704,7 @@ func flattenEdges(edges ...[]testEdge) []testEdge {
 }
 
 func mockNode(node string, namespace string, internetAccess, nonIsolatedIngress, nonIsolatedEgress bool, queryMatch bool, policies ...string) *v1.NetworkNode {
-	sort.Strings(policies)
+	slices.Sort(policies)
 	return &v1.NetworkNode{
 		Entity: &storage.NetworkEntityInfo{
 			Type: storage.NetworkEntityInfo_DEPLOYMENT,

--- a/central/networkpolicies/graph/graph_builder.go
+++ b/central/networkpolicies/graph/graph_builder.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strings"
 
@@ -373,7 +374,7 @@ func (b *graphBuilder) forEachNetworkPolicy(netPols []*storage.NetworkPolicy, do
 
 func (b *graphBuilder) PostProcess() {
 	for _, d := range b.allDeployments {
-		sort.Strings(d.applyingPoliciesIDs)
+		slices.Sort(d.applyingPoliciesIDs)
 		for _, e := range d.ingressEdges {
 			e.ports.normalizeInPlace()
 		}

--- a/central/notifiers/cscc/convert.go
+++ b/central/notifiers/cscc/convert.go
@@ -3,7 +3,7 @@ package cscc
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -165,7 +165,7 @@ func convertAlertDescription(alert *storage.Alert) string {
 	for v := range distinct {
 		distinctSlice = append(distinctSlice, v)
 	}
-	sort.Strings(distinctSlice)
+	slices.Sort(distinctSlice)
 	return strings.Join(distinctSlice, " ")
 }
 

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -545,7 +545,7 @@ func (s *serviceImpl) GetPolicyCategories(ctx context.Context, _ *v1.Empty) (*v1
 
 	response := new(v1.PolicyCategoriesResponse)
 	response.Categories = categorySet.AsSlice()
-	sort.Strings(response.Categories)
+	slices.Sort(response.Categories)
 
 	return response, nil
 }

--- a/central/scanner/handler.go
+++ b/central/scanner/handler.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/distribution/reference"
 	"github.com/pkg/errors"
@@ -48,7 +48,7 @@ func validateParamsAndNormalizeClusterType(p *apiparams.Scanner) (storage.Cluste
 				validClusterTypes = append(validClusterTypes, clusterString)
 			}
 		}
-		sort.Strings(validClusterTypes)
+		slices.Sort(validClusterTypes)
 		errorList.AddStringf("invalid cluster type: %q; valid options are %+v", p.ClusterType, validClusterTypes)
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -3,7 +3,7 @@ package extensions
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -328,7 +328,7 @@ func (r *reconcilePVCExtensionRun) getUniqueOwnedPVCForCurrentTarget() (*corev1.
 	}
 	if len(pvcList) > 1 {
 		names := sliceutils.Map(pvcList, (*corev1.PersistentVolumeClaim).GetName)
-		sort.Strings(names)
+		slices.Sort(names)
 
 		return nil, errors.Wrapf(errMultipleOwnedPVCs,
 			"multiple owned PVCs were found for %s, please remove not used ones or delete their OwnerReferences. Found PVCs: %s", r.target, strings.Join(names, ", "))

--- a/pkg/booleanpolicy/violationmessages/printer/process.go
+++ b/pkg/booleanpolicy/violationmessages/printer/process.go
@@ -2,7 +2,7 @@ package printer
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -29,7 +29,7 @@ func UpdateProcessAlertViolationMessage(v *storage.Alert_ProcessViolation) {
 	var sb strings.Builder
 
 	paths := pathSet.AsSlice()
-	sort.Strings(paths)
+	slices.Sort(paths)
 	switch numPaths := pathSet.Cardinality(); {
 	case numPaths == 1:
 		fmt.Fprintf(&sb, "Binary '%s'", paths[0])

--- a/pkg/booleanpolicy/violationmessages/printer/util.go
+++ b/pkg/booleanpolicy/violationmessages/printer/util.go
@@ -2,7 +2,7 @@ package printer
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -35,7 +35,7 @@ func (t *templateCache) Set(tpl string, tmpl *template.Template) {
 }
 
 func stringSliceToSortedSentence(s []string) string {
-	sort.Strings(s)
+	slices.Sort(s)
 	return stringSliceToSentence(s)
 }
 

--- a/pkg/compliance/checks/kubernetes/kubelet_command.go
+++ b/pkg/compliance/checks/kubernetes/kubelet_command.go
@@ -1,7 +1,7 @@
 package kubernetes
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/compliance/checks/common"
@@ -156,7 +156,7 @@ func tlsCipherSuites(config *standards.KubeletConfiguration) []*storage.Complian
 		}
 	}
 	if len(unexpectedCiphers) != 0 {
-		sort.Strings(unexpectedCiphers)
+		slices.Sort(unexpectedCiphers)
 		return common.FailListf("TLSCipherSuites contains unexpected ciphers: %q", unexpectedCiphers)
 	}
 	return common.PassListf("TLSCipherSuites contains only %q", config.TLSCipherSuites)

--- a/pkg/gjson/modifiers.go
+++ b/pkg/gjson/modifiers.go
@@ -3,7 +3,7 @@ package gjson
 import (
 	"encoding/json"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/stackrox/rox/pkg/utils"
@@ -149,7 +149,7 @@ func TextModifier() CustomModifier {
 		})
 		// Ensure we keep the same order for the texts we generated.
 		keys := maps.Keys(texts)
-		sort.Ints(keys)
+		slices.Sort(keys)
 		var result []string
 		for _, key := range keys {
 			result = append(result, modifier.trimSeparator(texts[key]))

--- a/pkg/postgres/schema/all.go
+++ b/pkg/postgres/schema/all.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -62,7 +62,7 @@ func getAllRegisteredTablesInOrder() []*registeredTable {
 	for table := range registeredTables {
 		tables = append(tables, table)
 	}
-	sort.Strings(tables)
+	slices.Sort(tables)
 
 	var rts []*registeredTable
 	for _, table := range tables {

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -212,6 +212,6 @@ func TestRenderSensorTLSSecretsOnly(t *testing.T) {
 		encounteredSecretNames = append(encounteredSecretNames, secret.Name)
 	}
 
-	sort.Strings(encounteredSecretNames)
+	slices.Sort(encounteredSecretNames)
 	assert.Equal(t, expectedSecrets, encounteredSecretNames)
 }

--- a/pkg/sac/resources/list_test.go
+++ b/pkg/sac/resources/list_test.go
@@ -1,7 +1,7 @@
 package resources
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,9 +12,5 @@ func TestList(t *testing.T) {
 
 	list := ListAll()
 	a.True(len(list) > 10)
-	asStrings := make([]string, 0, len(list))
-	for _, r := range list {
-		asStrings = append(asStrings, string(r))
-	}
-	a.True(sort.StringsAreSorted(asStrings))
+	a.True(slices.IsSorted(list))
 }

--- a/pkg/search/postgres/query/map_query.go
+++ b/pkg/search/postgres/query/map_query.go
@@ -3,7 +3,7 @@ package pgsearch
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/stackrox/rox/pkg/search"
@@ -130,7 +130,7 @@ func newMapQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 			}
 			out = append(out, fmt.Sprintf("%s=%s", k, v))
 		}
-		sort.Strings(out)
+		slices.Sort(out)
 		return out
 	}), nil
 }

--- a/pkg/search/query_builder.go
+++ b/pkg/search/query_builder.go
@@ -3,7 +3,7 @@ package search
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -456,7 +456,7 @@ func (qb *QueryBuilder) Query() string {
 	for k, values := range qb.fieldsToValues {
 		pairs = append(pairs, fmt.Sprintf("%s:%s", k, strings.Join(values, ",")))
 	}
-	sort.Strings(pairs)
+	slices.Sort(pairs)
 	return strings.Join(pairs, "+")
 }
 

--- a/pkg/set/frozen_set_test.go
+++ b/pkg/set/frozen_set_test.go
@@ -24,7 +24,7 @@ func assertFrozenSetContainsExactly(t *testing.T, fs FrozenStringSet, elements .
 	}
 	a.ElementsMatch(fs.AsSlice(), elements)
 
-	sort.Strings(elements)
+	slices.Sort(elements)
 	a.Equal(elements, fs.AsSortedSlice(func(i, j string) bool {
 		return i < j
 	}))

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -24,7 +24,7 @@ func assertSetContainsExactly(t *testing.T, set StringSet, elements ...string) {
 	}
 	a.ElementsMatch(set.AsSlice(), elements)
 
-	sort.Strings(elements)
+	slices.Sort(elements)
 	a.Equal(elements, set.AsSortedSlice(func(i, j string) bool {
 		return i < j
 	}))

--- a/pkg/sliceutils/string.go
+++ b/pkg/sliceutils/string.go
@@ -2,7 +2,7 @@ package sliceutils
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 )
 
 // StringSlice returns a sorted string slice from the given T.
@@ -12,7 +12,7 @@ func StringSlice[T fmt.Stringer](in ...T) []string {
 		res = append(res, i.String())
 	}
 
-	sort.Strings(res)
+	slices.Sort(res)
 	return res
 }
 

--- a/roxctl/central/whoami/whoami.go
+++ b/roxctl/central/whoami/whoami.go
@@ -2,7 +2,7 @@ package whoami
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -71,7 +71,7 @@ func (cmd *centralWhoAmICommand) whoami() error {
 	for resource := range resourceToAccess {
 		resources = append(resources, resource)
 	}
-	sort.Strings(resources)
+	slices.Sort(resources)
 
 	cmd.env.Logger().PrintfLn(`UserID:
 	%s

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -253,7 +253,7 @@ func (a *authProviderCmd) Construct(cmd *cobra.Command) error {
 func (a *authProviderCmd) Validate(providerType string) error {
 	requiredAttributes := make([]declarativeconfig.RequiredAttribute, 0, len(a.requiredAttributes))
 	keys := maps.Keys(a.requiredAttributes)
-	sort.Strings(keys)
+	slices.Sort(keys)
 	for _, key := range keys {
 		requiredAttributes = append(requiredAttributes, declarativeconfig.RequiredAttribute{
 			AttributeKey:   key,
@@ -290,7 +290,7 @@ func (a *authProviderCmd) Validate(providerType string) error {
 	case "oidc":
 		claimMappings := make([]declarativeconfig.ClaimMapping, 0, len(a.claimMapping))
 		paths := maps.Keys(a.claimMapping)
-		sort.Strings(paths)
+		slices.Sort(paths)
 		for _, path := range paths {
 			claimMappings = append(claimMappings, declarativeconfig.ClaimMapping{
 				Path: path,

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"sort"
+	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -180,12 +180,12 @@ func (n *notifierCmd) construct(cmd *cobra.Command) error {
 
 	if anyFlagChanged(n.genericFlagSet) {
 		keys := maps.Keys(n.gcHeaders)
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{Key: k, Value: n.gcHeaders[k]})
 		}
 		keys = maps.Keys(n.gcExtraFields)
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{Key: k, Value: n.gcExtraFields[k]})
 		}
@@ -200,7 +200,7 @@ func (n *notifierCmd) construct(cmd *cobra.Command) error {
 
 	if anyFlagChanged(n.splunkFlagSet) {
 		keys := maps.Keys(n.scSourceTypes)
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{Key: k, Value: n.scSourceTypes[k]})
 		}

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -81,7 +81,7 @@ func (p *permissionSetCmd) Validate() error {
 
 	// Keep an alphabetic order within the resources.
 	resources := maps.Keys(accessMap)
-	sort.Strings(resources)
+	slices.Sort(resources)
 
 	// TODO(ROX-16330): Resources are currently defined within central/role/resources, and hence cannot be reused here yet.
 	// There are plans to move the resource definition to a shared place however, in which case we can reuse them here.

--- a/roxctl/helm/internal/common/chartnames.go
+++ b/roxctl/helm/internal/common/chartnames.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/stackrox/rox/image"
@@ -27,7 +27,7 @@ const (
 
 // MakePrettyChartNameList forms a pretty printed string listing multiple chart names.
 func MakePrettyChartNameList(chartNames ...string) string {
-	sort.Strings(chartNames)
+	slices.Sort(chartNames)
 	return strings.Join(chartNames, " | ")
 }
 

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -415,7 +415,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 			Strs("cve", ts).
 			Msg("found CVEs")
 
-		sort.Strings(ts)
+		slices.Sort(ts)
 		cveKey := strings.Join(ts, "_")
 		rec, ok := erCache[cveKey]
 		if !ok {

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -3,7 +3,7 @@ package clusterstatus
 import (
 	"context"
 	"encoding/json"
-	"sort"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -289,7 +289,7 @@ func (u *updaterImpl) getAPIVersions() []string {
 	}
 
 	apiVersions := metav1.ExtractGroupVersions(groupList)
-	sort.Strings(apiVersions)
+	slices.Sort(apiVersions)
 	return apiVersions
 }
 

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -2,7 +2,7 @@ package resources
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -102,8 +102,8 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsWithServiceAccount() {
 
 			ids := s.deploymentStore.FindDeploymentIDsWithServiceAccount(testCase.queryNs, testCase.querySa)
 			s.Require().Len(ids, len(testCase.expectedIDs), "FindDeploymentIDsWithServiceAccount returned incorrect number of elements")
-			sort.Strings(testCase.expectedIDs)
-			sort.Strings(ids)
+			slices.Sort(testCase.expectedIDs)
+			slices.Sort(ids)
 			s.Equal(testCase.expectedIDs, ids)
 		})
 	}

--- a/tests/graphql_sorting_test.go
+++ b/tests/graphql_sorting_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -35,7 +36,7 @@ func getDeploymentsWithSortOption(t *testing.T, field string, reversed bool) []*
 
 func testDeploymentSorting(t *testing.T, field string, extractor func(d *storage.Deployment) string) {
 	sorted := sliceutils.Map(getDeploymentsWithSortOption(t, field, false), extractor)
-	assert.True(t, sort.StringsAreSorted(sorted), "field %s not sorted in response (got %v)", field, sorted)
+	assert.True(t, slices.IsSorted(sorted), "field %s not sorted in response (got %v)", field, sorted)
 
 	sortedReverse := sliceutils.Map(getDeploymentsWithSortOption(t, field, true), extractor)
 	assert.True(t, sort.SliceIsSorted(sortedReverse, func(i, j int) bool {

--- a/tools/generate-helpers/notifier/main.go
+++ b/tools/generate-helpers/notifier/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 
 	. "github.com/dave/jennifer/jen"
 	"github.com/spf13/cobra"
@@ -64,7 +64,7 @@ func generate(props *operations.GeneratorProperties, methods []string) error {
 
 func generateFunctions(props *operations.GeneratorProperties, methods []string) (signatures []Code, variables []Code, implementations []Code) {
 	// Generate code in a deterministic order so the style checker doesn't complain about stale generated code
-	sort.Strings(methods)
+	slices.Sort(methods)
 	for _, method := range methods {
 		newSignatures, newVariables, newImplementations := operations.GenerateSignaturesAndImplementations(method, props)
 		signatures = append(signatures, newSignatures...)

--- a/tools/roxvet/analyzers/sortslices/analyzer.go
+++ b/tools/roxvet/analyzers/sortslices/analyzer.go
@@ -1,0 +1,57 @@
+package sortslices
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+const doc = `check for usages of "sort" funcs which should be replaced with equivalent "slices" funcs`
+
+// slicesFuncs maps the sort functions to the slices equivalent.
+//
+// Note: sort.IsSorted, sort.Sort, and sort.Stable are not considered, as they take in a sort.Interface which
+// may not necessarily be a slice. Perhaps the usage of these functions should be audited and considered for
+// replacement. The functions sort.Slice and sort.SliceStable should also be considered.
+var slicesFuncs = map[string]string{
+	`sort.Float64s`:          `slices.Sort`,
+	`sort.Float64sAreSorted`: `slices.IsSorted`,
+	`sort.Ints`:              `slices.Sort`,
+	`sort.IntsAreSorted`:     `slices.IsSorted`,
+	`sort.Strings`:           `slices.Sort`,
+	`sort.StringsAreSorted`:  `slices.IsSorted`,
+}
+
+// Analyzer is the analyzer.
+var Analyzer = &analysis.Analyzer{
+	Name:     "sortslices",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.CallExpr)(nil)}
+	inspectResult.Preorder(nodeFilter, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+		fn, ok := typeutil.Callee(pass.TypesInfo, call).(*types.Func)
+		if !ok {
+			return
+		}
+		slicesFunc, ok := slicesFuncs[fn.FullName()]
+		if !ok {
+			return
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:     n.Pos(),
+			Message: fmt.Sprintf("Use %s instead of %s, as it is more efficient/ergonomic (https://pkg.go.dev/slices).", slicesFunc, fn.FullName()),
+		})
+	})
+	return nil, nil
+}

--- a/tools/roxvet/roxvet.go
+++ b/tools/roxvet/roxvet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoclone"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoptrs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/regexes"
+	"github.com/stackrox/rox/tools/roxvet/analyzers/sortslices"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/storeinterface"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/structuredlogs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/uncheckederrors"
@@ -40,5 +41,6 @@ func main() {
 		structuredlogs.Analyzer,
 		migrationreferencedschema.Analyzer,
 		undeferredmutexunlocks.Analyzer,
+		sortslices.Analyzer,
 	)
 }


### PR DESCRIPTION
## Description

Related to https://github.com/stackrox/stackrox/issues/10966.

go1.21 introduced the [`slices` package](https://pkg.go.dev/slices) which offers nice utility functions related to slices.

It comes with sorting functions which we should use instead of the older, `sort` package for slices. The documentation for go1.21 for these functions suggests using the `slices` package for better efficiency and ergonomics. In go1.22, some of the implementations were even replaced with the `slices` equivalents.

This PR replaces these `sort` functions with the `slices` equivalents and also introduces a new `roxvet` step to ensure devs do not use the older functions anymore.

Note the following are not covered at this time:

* sort.IsSorted
* sort.Slice
* sort.SliceStable
* sort.Sort
* sort.Stable

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

The new `roxvet` steps checks for these functions. I used this to find all usages of these old functions.

`make roxvet`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
