### PR TITLE
ROX-23079: Add details tab to cluster page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -108,7 +108,7 @@ function NodePage() {
                         tabIndex={0}
                     >
                         {activeTabKey === vulnTabKey && <NodePageVulnerabilities nodeId={nodeId} />}
-                        {activeTabKey === detailTabKey && <NodePageDetails />}
+                        {activeTabKey === detailTabKey && <NodePageDetails nodeId={nodeId} />}
                     </PageSection>
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
@@ -1,18 +1,127 @@
+/* eslint-disable no-nested-ternary */
 import React from 'react';
-import { PageSection, Text } from '@patternfly/react-core';
+import {
+    Bullseye,
+    Card,
+    CardBody,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    PageSection,
+    Spinner,
+    Text,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type NodePageDetailsProps = {};
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import { getDateTime } from 'utils/dateUtils';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import ExpandableLabelSection from '../../components/ExpandableLabelSection';
+import useNodeExtendedDetails from './useNodeExtendedDetails';
 
-// eslint-disable-next-line no-empty-pattern
-function NodePageDetails({}: NodePageDetailsProps) {
+export type NodePageDetailsProps = {
+    nodeId: string;
+};
+
+function NodePageDetails({ nodeId }: NodePageDetailsProps) {
+    const { data, loading, error } = useNodeExtendedDetails(nodeId);
+
     return (
         <>
             <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
                 <Text>View details about this node</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
-                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">Details</div>
+                <Card>
+                    <CardBody>
+                        {error ? (
+                            <Bullseye>
+                                <EmptyStateTemplate
+                                    title={getAxiosErrorMessage(error)}
+                                    headingLevel="h2"
+                                    icon={ExclamationCircleIcon}
+                                    iconClassName="pf-v5-u-danger-color-100"
+                                />
+                            </Bullseye>
+                        ) : loading ? (
+                            <Bullseye>
+                                <Spinner size="xl" />
+                            </Bullseye>
+                        ) : (
+                            data && (
+                                <Flex
+                                    direction={{ default: 'column' }}
+                                    spaceItems={{ default: 'spaceItemsXl' }}
+                                >
+                                    <DescriptionList
+                                        columnModifier={{ default: '1Col', lg: '2Col' }}
+                                    >
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Cluster</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {data.node.cluster.name}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        {data.node.containerRuntimeVersion && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Container runtime
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {data.node.containerRuntimeVersion}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        {data.node.joinedAt && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Join time</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {getDateTime(data.node.joinedAt)}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        {data.node.scanTime && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Scan time</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {getDateTime(data.node.scanTime)}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        {data.node.kernelVersion && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Kernel version
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {data.node.kernelVersion}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        {data.node.kubeletVersion && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Kubelet</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {data.node.kubeletVersion}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                    </DescriptionList>
+                                    <ExpandableLabelSection
+                                        toggleText="Labels"
+                                        labels={data.node.labels}
+                                    />
+                                    <ExpandableLabelSection
+                                        toggleText="Annotations"
+                                        labels={data.node.annotations}
+                                    />
+                                </Flex>
+                            )
+                        )}
+                    </CardBody>
+                </Card>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
@@ -39,11 +39,13 @@ function NodePageDetails({ nodeId }: NodePageDetailsProps) {
                         {error ? (
                             <Bullseye>
                                 <EmptyStateTemplate
-                                    title={getAxiosErrorMessage(error)}
+                                    title="There was an error loading the node details"
                                     headingLevel="h2"
                                     icon={ExclamationCircleIcon}
                                     iconClassName="pf-v5-u-danger-color-100"
-                                />
+                                >
+                                    {getAxiosErrorMessage(error)}
+                                </EmptyStateTemplate>
                             </Bullseye>
                         ) : loading ? (
                             <Bullseye>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeExtendedDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeExtendedDetails.ts
@@ -1,0 +1,58 @@
+import { gql, useQuery } from '@apollo/client';
+
+const nodeExtendedDetailsQuery = gql`
+    query getNodeExtendedDetails($id: ID!) {
+        node(id: $id) {
+            id
+            cluster {
+                name
+            }
+            containerRuntimeVersion
+            joinedAt
+            scanTime
+            kernelVersion
+            kubeletVersion
+            labels {
+                key
+                value
+            }
+            annotations {
+                key
+                value
+            }
+        }
+    }
+`;
+
+export type NodeExtendedDetails = {
+    id: string;
+    cluster: {
+        name: string;
+    };
+    containerRuntimeVersion: string;
+    joinedAt?: string; // iso8601
+    scanTime?: string; // iso8601
+    kernelVersion: string;
+    kubeletVersion: string;
+    labels: {
+        key: string;
+        value: string;
+    }[];
+    annotations: {
+        key: string;
+        value: string;
+    }[];
+};
+
+export default function useNodeExtendedDetails(nodeId: string) {
+    return useQuery<
+        {
+            node: NodeExtendedDetails;
+        },
+        {
+            id: string;
+        }
+    >(nodeExtendedDetailsQuery, {
+        variables: { id: nodeId },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -113,7 +113,9 @@ function ClusterPage() {
                         {activeTabKey === vulnTabKey && (
                             <ClusterPageVulnerabilities clusterId={clusterId} />
                         )}
-                        {activeTabKey === detailTabKey && <ClusterPageDetails />}
+                        {activeTabKey === detailTabKey && (
+                            <ClusterPageDetails clusterId={clusterId} />
+                        )}
                     </PageSection>
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -1,18 +1,119 @@
+/* eslint-disable no-nested-ternary */
 import React from 'react';
-import { PageSection, Text } from '@patternfly/react-core';
+import {
+    Bullseye,
+    Card,
+    CardBody,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    PageSection,
+    Spinner,
+    Text,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type ClusterPageDetailsProps = {};
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import { getDateTime } from 'utils/dateUtils';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-// eslint-disable-next-line no-empty-pattern
-function ClusterPageDetails({}: ClusterPageDetailsProps) {
+import ExpandableLabelSection from '../../components/ExpandableLabelSection';
+import useClusterExtendedDetails from './useClusterExtendedDetails';
+import { displayClusterType } from '../utils/stringUtils';
+
+export type ClusterPageDetailsProps = {
+    clusterId: string;
+};
+
+function ClusterPageDetails({ clusterId }: ClusterPageDetailsProps) {
+    const { data, loading, error } = useClusterExtendedDetails(clusterId);
+
     return (
         <>
             <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-u-px-xl">
                 <Text>View details about this cluster</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
-                <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100">Details</div>
+                <Card>
+                    <CardBody>
+                        {error ? (
+                            <Bullseye>
+                                <EmptyStateTemplate
+                                    title="There was an error loading the cluster details"
+                                    headingLevel="h2"
+                                    icon={ExclamationCircleIcon}
+                                    iconClassName="pf-v5-u-danger-color-100"
+                                >
+                                    {getAxiosErrorMessage(error)}
+                                </EmptyStateTemplate>
+                            </Bullseye>
+                        ) : loading ? (
+                            <Bullseye>
+                                <Spinner size="xl" />
+                            </Bullseye>
+                        ) : (
+                            data && (
+                                <Flex
+                                    direction={{ default: 'column' }}
+                                    spaceItems={{ default: 'spaceItemsXl' }}
+                                >
+                                    <DescriptionList columnModifier={{ default: '1Col' }}>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Cluster type</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {displayClusterType(data.cluster.type)}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        {/*
+                                        {data.cluster.cloudProvider && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Cloud provider
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {data.cluster.cloudProvider}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        */}
+                                        {data.cluster.status?.orchestratorMetadata?.buildDate && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Build date
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {getDateTime(
+                                                        data.cluster.status.orchestratorMetadata
+                                                            .buildDate
+                                                    )}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                        {data.cluster.status?.orchestratorMetadata?.version && (
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    K8s version
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {
+                                                        data.cluster.status.orchestratorMetadata
+                                                            .version
+                                                    }
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        )}
+                                    </DescriptionList>
+                                    <ExpandableLabelSection
+                                        toggleText="Labels"
+                                        labels={data.cluster.labels}
+                                    />
+                                </Flex>
+                            )
+                        )}
+                    </CardBody>
+                </Card>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
@@ -1,0 +1,53 @@
+import { gql, useQuery } from '@apollo/client';
+import { ClusterType } from 'types/cluster.proto';
+
+const clusterExtendedDetailsQuery = gql`
+    query getClusterExtendedDetails($id: ID!) {
+        cluster(id: $id) {
+            id
+            status {
+                orchestratorMetadata {
+                    version
+                    buildDate
+                }
+            }
+            type
+            # TODO - Need to add the following fields to the query
+            # cloudProvider
+            labels {
+                key
+                value
+            }
+        }
+    }
+`;
+
+export type ClusterExtendedDetails = {
+    id: string;
+    status?: {
+        orchestratorMetadata?: {
+            version: string;
+            buildDate: string;
+        };
+    };
+    type: ClusterType;
+    // TODO - Need to add the following fields to the type
+    // cloudProvider: string;
+    labels: {
+        key: string;
+        value: string;
+    }[];
+};
+
+export default function useClusterExtendedDetails(clusterId: string) {
+    return useQuery<
+        {
+            cluster: ClusterExtendedDetails;
+        },
+        {
+            id: string;
+        }
+    >(clusterExtendedDetailsQuery, {
+        variables: { id: clusterId },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import {
+    ExpandableSection,
+    Badge,
+    Flex,
+    DataList,
+    DataListCell,
+    DataListItem,
+    DataListItemCells,
+    DataListItemRow,
+} from '@patternfly/react-core';
+
+export type ExpandableLabelSectionProps = {
+    toggleText: string;
+    labels: {
+        key: string;
+        value: string;
+    }[];
+};
+
+function ExpandableLabelSection({ toggleText, labels }: ExpandableLabelSectionProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
+        setIsExpanded(isExpanded);
+    };
+
+    return (
+        <ExpandableSection
+            toggleContent={
+                <Flex
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                >
+                    <span>{toggleText}</span>
+                    <Badge isRead>{labels.length}</Badge>
+                </Flex>
+            }
+            onToggle={onToggle}
+            isExpanded={isExpanded}
+        >
+            <DataList aria-label={toggleText} isCompact>
+                {labels.map(({ key, value }) => (
+                    <DataListItem key={key}>
+                        <DataListItemRow>
+                            <DataListItemCells
+                                dataListCells={[
+                                    <DataListCell isFilled={false} key={key}>
+                                        {key} : {value}
+                                    </DataListCell>,
+                                ]}
+                            />
+                        </DataListItemRow>
+                    </DataListItem>
+                ))}
+            </DataList>
+        </ExpandableSection>
+    );
+}
+
+export default ExpandableLabelSection;


### PR DESCRIPTION
## Description

As titled

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a cluster single page and click the details tab.

Loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/6f2b29ec-fb61-4c67-b9ee-dbb451b7b470)

Error:
![image](https://github.com/stackrox/stackrox/assets/1292638/2b6286ba-8b53-4071-8580-1979a7c5431f)

Success:
![image](https://github.com/stackrox/stackrox/assets/1292638/a9b33e4b-bb2d-4966-9f59-8ad18f71fdc7)

Test expand/collapse labels:
![image](https://github.com/stackrox/stackrox/assets/1292638/9f9c1039-c729-4ff6-851d-323f05cfc7ea)

