### PR TITLE
feat(ui): Add queries for node and platform cve entity counts

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -25,6 +25,7 @@ import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import CVEsTable from './CVEsTable';
 import NodesTable from './NodesTable';
+import { useNodeCveEntityCounts } from './useNodeCveEntityCounts';
 
 const searchOptions = [NODE_CVE_SEARCH_OPTION];
 
@@ -42,10 +43,11 @@ function NodeCvesOverviewPage() {
         // TODO - set default sort here
     }
 
-    // TODO - needs to be connected to a query
+    const { data } = useNodeCveEntityCounts(querySearchFilter);
+
     const entityCounts = {
-        CVE: 0,
-        Node: 0,
+        CVE: data?.nodeCVECount ?? 0,
+        Node: data?.nodeCount ?? 0,
     };
 
     const filterToolbar = (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCveEntityCounts.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCveEntityCounts.ts
@@ -1,0 +1,27 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { QuerySearchFilter } from '../../types';
+import { getRegexScopedQueryString } from '../../utils/searchUtils';
+
+const entityCountsQuery = gql`
+    query getNodeCVEEntityCounts($query: String) {
+        nodeCVECount(query: $query)
+        nodeCount(query: $query)
+    }
+`;
+
+export function useNodeCveEntityCounts(querySearchFilter: QuerySearchFilter) {
+    return useQuery<
+        {
+            nodeCVECount: number;
+            nodeCount: number;
+        },
+        {
+            query: string;
+        }
+    >(entityCountsQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+        },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -52,6 +52,7 @@ type Node = {
     cluster: {
         name: string;
     };
+    // TODO Swap this to the osImage field
     operatingSystem: string;
     scanTime: string;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -23,6 +23,7 @@ import { platformEntityTabValues } from '../../types';
 
 import ClustersTable from './ClustersTable';
 import CVEsTable from './CVEsTable';
+import { usePlatformCveEntityCounts } from './usePlatformCveEntityCounts';
 
 function PlatformCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
@@ -38,10 +39,11 @@ function PlatformCvesOverviewPage() {
         // TODO - set default sort here
     }
 
-    // TODO - needs to be connected to a query
+    const { data } = usePlatformCveEntityCounts(querySearchFilter);
+
     const entityCounts = {
-        CVE: 0,
-        Cluster: 0,
+        CVE: data?.platformCVECount ?? 0,
+        Cluster: data?.clusterCount ?? 0,
     };
 
     const filterToolbar = <></>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCveEntityCounts.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCveEntityCounts.ts
@@ -1,0 +1,27 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { QuerySearchFilter } from '../../types';
+import { getRegexScopedQueryString } from '../../utils/searchUtils';
+
+const entityCountsQuery = gql`
+    query getPlatformCVEEntityCounts($query: String) {
+        platformCVECount(query: $query)
+        clusterCount(query: $query)
+    }
+`;
+
+export function usePlatformCveEntityCounts(querySearchFilter: QuerySearchFilter) {
+    return useQuery<
+        {
+            platformCVECount: number;
+            clusterCount: number;
+        },
+        {
+            query: string;
+        }
+    >(entityCountsQuery, {
+        variables: {
+            query: getRegexScopedQueryString(querySearchFilter),
+        },
+    });
+}


### PR DESCRIPTION
## Description

Adds queries to get the counts for entity buttons on the overview pages.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

**Note this is still mocked data**

Visit Platform CVEs and see that the entity counts load correctly:
![image](https://github.com/stackrox/stackrox/assets/1292638/b323ed12-54d7-42bb-a294-03c2cc289015)
![image](https://github.com/stackrox/stackrox/assets/1292638/80efe58c-595f-468a-8f1a-ee041b545f9d)

Visit Node CVEs and see that the entity counts load correctly:
![image](https://github.com/stackrox/stackrox/assets/1292638/9159874a-32f9-4332-aa8c-99abb27e529f)
![image](https://github.com/stackrox/stackrox/assets/1292638/be3f42cf-585f-48d8-944d-b8ad4eed6f04)

