### PR TITLE
ROX-23970: Process ComplianceOperator controls

### DIFF
--- a/central/convert/internaltov2storage/compliance_rule.go
+++ b/central/convert/internaltov2storage/compliance_rule.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	standardsKey = "policies.open-cluster-management.io/standards"
-
+	standardsKey          = "policies.open-cluster-management.io/standards"
 	controlAnnotationBase = "control.compliance.openshift.io/"
 )
 
@@ -46,10 +45,15 @@ func ComplianceOperatorRule(sensorData *central.ComplianceOperatorRuleV2, cluste
 	standards := strings.Split(sensorData.GetAnnotations()[standardsKey], ",")
 	controls := make([]*storage.RuleControls, 0, len(standards))
 	for _, standard := range standards {
-		controls = append(controls, &storage.RuleControls{
-			Standard: standard,
-			Controls: strings.Split(sensorData.GetAnnotations()[controlAnnotationBase+standard], ";"),
-		})
+		controlAnnotationValues := strings.Split(sensorData.GetAnnotations()[controlAnnotationBase+standard], ";")
+
+		// Add a control entry for each Control + Standard. This data is intentionally denormalized for easier querying.
+		for _, controlValue := range controlAnnotationValues {
+			controls = append(controls, &storage.RuleControls{
+				Standard: standard,
+				Control:  controlValue,
+			})
+		}
 	}
 
 	parentRule := sensorData.GetAnnotations()[v1alpha1.RuleIDAnnotationKey]

--- a/central/convert/testutils/compliance_rules.go
+++ b/central/convert/testutils/compliance_rules.go
@@ -71,11 +71,19 @@ func GetRuleV2Storage(_ *testing.T) *storage.ComplianceOperatorRuleV2 {
 	controls := []*storage.RuleControls{
 		{
 			Standard: "NERC-CIP",
-			Controls: []string{"CIP-003-8 R6", "CIP-004-6 R3", "CIP-007-3 R6.1"},
+			Control:  "CIP-003-8 R6",
+		},
+		{
+			Standard: "NERC-CIP",
+			Control:  "CIP-004-6 R3",
+		},
+		{
+			Standard: "NERC-CIP",
+			Control:  "CIP-007-3 R6.1",
 		},
 		{
 			Standard: "PCI-DSS",
-			Controls: []string{"Req-2.2"},
+			Control:  "Req-2.2",
 		},
 	}
 	return &storage.ComplianceOperatorRuleV2{


### PR DESCRIPTION
## Description

Process compliance operator controls and persist them into the Central database. 
Each Control is associated with a standard and persisted denormalized.

This results in following structure:

| RuleID | Standard | Control |
|--------|----------|---------|
| uuid-1 | OCP-CIS  | 1.2.1   |
| uuid-1 | OCP_CIS  | 1.2.2   |
| uuid-1 | OCP_CIS  | 1.2.3   |



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - Run Sensor in a cluster with CO installed imports control data
 - Upgrade test case
   - Install StackRox, install CO + run scan, upgrade StackRox 
   - Should not duplicate results without controls 
   - Mapping controls to standard should be correct

**Before State**
![Screenshot from 2024-05-06 11-09-39](https://github.com/stackrox/stackrox/assets/9550466/f424fa83-e818-40ad-8e04-d771db19fee7)

**After State**
![Screenshot from 2024-05-06 11-13-42](https://github.com/stackrox/stackrox/assets/9550466/11de771f-aabf-4372-b3dd-7d72fb1f52e1)

