### PR TITLE
feat(tooling): Improve proto tooling

### DIFF
--- a/pkg/postgres/pool_impl.go
+++ b/pkg/postgres/pool_impl.go
@@ -35,6 +35,7 @@ func ParseConfig(source string) (*Config, error) {
 }
 
 // Connect wraps pgxpool.Connect
+// Example source postgres://jack:secret@pg.example.com:5432/mydb
 func Connect(ctx context.Context, sourceWithDatabase string) (*db, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, 10*time.Second)
 	defer cancel()

--- a/pkg/stringutils/default.go
+++ b/pkg/stringutils/default.go
@@ -2,7 +2,6 @@ package stringutils
 
 import (
 	"regexp"
-	"strings"
 )
 
 // OrDefault returns the string if it's not empty, or the default.
@@ -26,10 +25,3 @@ var (
 	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
 )
-
-// ToSnakeCase converts a string from camel case to snake case
-func ToSnakeCase(str string) string {
-	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
-	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-	return strings.ToLower(snake)
-}

--- a/pkg/stringutils/default.go
+++ b/pkg/stringutils/default.go
@@ -1,5 +1,10 @@
 package stringutils
 
+import (
+	"regexp"
+	"strings"
+)
+
 // OrDefault returns the string if it's not empty, or the default.
 func OrDefault(s, defaultString string) string {
 	if s != "" {
@@ -15,4 +20,16 @@ func PointerOrDefault(s *string, defaultString string) string {
 	}
 
 	return OrDefault(*s, defaultString)
+}
+
+var (
+	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
+)
+
+// ToSnakeCase converts a string from camel case to snake case
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
 }

--- a/pkg/stringutils/default.go
+++ b/pkg/stringutils/default.go
@@ -1,9 +1,5 @@
 package stringutils
 
-import (
-	"regexp"
-)
-
 // OrDefault returns the string if it's not empty, or the default.
 func OrDefault(s, defaultString string) string {
 	if s != "" {
@@ -20,8 +16,3 @@ func PointerOrDefault(s *string, defaultString string) string {
 
 	return OrDefault(*s, defaultString)
 }
-
-var (
-	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
-)

--- a/tools/deserialize-proto/README.md
+++ b/tools/deserialize-proto/README.md
@@ -15,8 +15,20 @@ $ pbpaste | go run ./tools/deserialize-proto --type storage.IntegrationHealth
 ```
 
 ```sh
-# If you have a central database running locally
+# Read from stdin with a local database
 $ psql -U postgres -h localhost -d central_data -t \
   -c 'SELECT serialized FROM integration_healths' | \
-  go run ./tools/deserialize-proto --type storage.IntegrationHealth
+  go run ./tools/deserialize-proto --type storage.IntegrationHealth --stdin
+
+# Connect automatically to a local database and print all entries.
+$ go run tools/deserialize-proto/main.go --type storage.Policy
+
+# Print entry by id.
+$ go run tools/deserialize-proto/main.go --type storage.Policy --id <UUID>
+
+# Connect to a configured database and run a custom where clause.
+$ go run tools/deserialize-proto/main.go --type storage.Policy --where "name='OpenShift: Central Admin Secret Accessed'"
+
+# Connect to a configured database.
+$ POSTGRES_PASSWORD=password USER=postgres POSTGRES_PORT=5432 POSTGRES_HOST=localhost go run tools/deserialize-proto/main.go --type storage.Policy
 ```

--- a/tools/deserialize-proto/main.go
+++ b/tools/deserialize-proto/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -15,6 +16,9 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	flag "github.com/spf13/pflag"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/stringutils"
+	"github.com/stackrox/rox/pkg/utils"
 
 	// This will register all proto types in the package,
 	// making it possible to retrieve the message type by name.
@@ -23,6 +27,9 @@ import (
 
 var (
 	protobufType = flag.String("type", "", "name of protobuf, e.g., storage.Alert")
+	id           = flag.String("id", "", "id of the object to query")
+	whereClause  = flag.String("where-clause", "", "additional where clause for the objects to query")
+	fromStdin    = flag.Bool("from-stdin", false, "reads serialized protos from stdin")
 
 	errUnqoting  = errors.New("failed to unquote the serialized text")
 	errDecoding  = errors.New("failed decoding the hex value of the text")
@@ -42,12 +49,55 @@ func main() {
 	}
 	msg := reflect.New(mt.Elem()).Interface().(proto.Message)
 
-	if err := printProtoMessages(os.Stdin, os.Stdout, msg); err != nil {
-		log.Fatalf("Error while printing proto messages: %v", err)
+	// reads the serialized protos directly from stdin
+	if *fromStdin {
+		utils.Should(printProtoMessagesFromStdin(os.Stdin, os.Stdout, msg))
+		return
+	}
+
+	// reads directly from the database.
+	readFromDatabase(msg)
+}
+
+// Detect database directly from provided proto. Add id or optional where clauses to the SQL query.
+func readFromDatabase(msg proto.Message) {
+
+	db, err := postgres.Connect(context.TODO(), "postgres://postgres:password@localhost:5432/central")
+	utils.Should(err)
+
+	tableName, _ := strings.CutPrefix(stringutils.ToSnakeCase(*protobufType), "storage._")
+
+	query := fmt.Sprintf("SELECT serialized FROM %s", tableName)
+	if *id != "" && *whereClause == "" {
+		query = fmt.Sprintf("%s WHERE id = '%s'", query, *id)
+	} else {
+		query = fmt.Sprintf("%s WHERE id = '%s' AND %s", query, *id, *whereClause)
+	}
+
+	rows, err := db.Query(context.TODO(), query)
+	if err != nil {
+		fmt.Println("SQL QUERY: ", query)
+		utils.Should(err)
+	}
+
+	for rows.Next() {
+		value, err := rows.Values()
+		utils.Should(err)
+
+		if err := proto.Unmarshal(value[0].([]byte), msg); err != nil {
+			utils.Should(err)
+		}
+
+		m := jsonpb.Marshaler{Indent: "  "}
+		json, err := m.MarshalToString(msg)
+		if err != nil {
+			utils.Should(err)
+		}
+		fmt.Println(json)
 	}
 }
 
-func printProtoMessages(in io.Reader, out io.Writer, msg proto.Message) error {
+func printProtoMessagesFromStdin(in io.Reader, out io.Writer, msg proto.Message) error {
 	reader := bufio.NewScanner(in)
 
 	for reader.Scan() {

--- a/tools/deserialize-proto/main.go
+++ b/tools/deserialize-proto/main.go
@@ -34,6 +34,7 @@ var (
 	id           = flag.String("id", "", "id of the object to query")
 	whereClause  = flag.String("where", "", "additional where clause for the objects to query")
 	fromStdin    = flag.Bool("stdin", false, "reads serialized protos from stdin")
+	debug        = flag.Bool("debug", false, "enable debug logging")
 
 	errUnqoting  = errors.New("failed to unquote the serialized text")
 	errDecoding  = errors.New("failed decoding the hex value of the text")
@@ -67,7 +68,10 @@ func main() {
 func readFromDatabase(msg proto.Message) {
 	dbName := env.GetString("POSTGRES_DATABASE", "central")
 	connectionString := conn.GetConnectionStringWithDatabaseName(&testing.T{}, dbName)
-	fmt.Println("Connecting to database: ", connectionString)
+
+	if *debug {
+		fmt.Println("Connecting to database: ", connectionString)
+	}
 
 	db, err := postgres.Connect(context.TODO(), connectionString)
 	utils.Should(err)
@@ -83,7 +87,9 @@ func readFromDatabase(msg proto.Message) {
 		log.Fatalf("cannot provide both id and where clause")
 	}
 
-	fmt.Printf("Run query: %s", query)
+	if *debug {
+		fmt.Printf("Run query: %s", query)
+	}
 
 	rows, err := db.Query(context.TODO(), query)
 	if err != nil {

--- a/tools/deserialize-proto/main_test.go
+++ b/tools/deserialize-proto/main_test.go
@@ -84,7 +84,7 @@ func TestPrintProtoMessages(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tmpOut := &bytes.Buffer{}
-			err := printProtoMessages(tc.in, tmpOut, tc.msg)
+			err := printProtoMessagesFromStdin(tc.in, tmpOut, tc.msg)
 			if tc.err != nil {
 				assert.ErrorIs(t, err, tc.err)
 			} else {


### PR DESCRIPTION
## Description

Improve proto tooling to automatically resolve a proto to the configure database.

Changelist:

 - to read from stdin added  `--stdin` flag (breaking change)
 - automatically resolve proto `storage.XYZ` to its table name
 - automatically connect to the database, configure it like a testing databases
 - added `--id` flag to easily provide an id
 - added `--where` to add where clauses to the query
 - added `--debug` flag

This allows to easily run a database locally or port-forwarded, connect to it and print a de-serialized proto for a table entry.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

 - tested documented queries locally from `README.md`