### PR TITLE
ROX-23639: track central download API

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -91,7 +91,7 @@ spec:
           value: {{ ._rox.central.telemetry.storage.key | quote }}
         {{- end }}
         - name: ROX_TELEMETRY_API_WHITELIST
-          value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
+          value: "/api/splunk/ta/*,/v1/auth/m2m/exchange,/api/cli/download/*"
         {{- /* Otherwise... */}}
         {{- else }}
         {{- /* ... if telemetry.enabled is false, configure the key to disable

--- a/operator/tests/central/central-misc/080-assert-non-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-non-openshift.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
             - name: ROX_TELEMETRY_API_WHITELIST
-              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
+              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange,/api/cli/download/*"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_INSTALL_METHOD

--- a/operator/tests/central/central-misc/080-assert-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-openshift.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
             - name: ROX_TELEMETRY_API_WHITELIST
-              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange"
+              value: "/api/splunk/ta/*,/v1/auth/m2m/exchange,/api/cli/download/*"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH


### PR DESCRIPTION
## Description

Start tracking the download API calls for roxctl.

This will give us insight in a) the general amount of downloads we see from Central and b) with the introduction of a custom user-agent for the roxctl-installer action it will also give us insights into the usage of the action itself and for which OS roxctl is mostly used.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI pass.

Manual testing to see that the API calls are received in telemetry:

Taking the sample action run [here](https://github.com/dhaus67/test-repo/actions/runs/8956167238) which does:
- central login
- roxctl install
- run roxctl

We receive the following within amplitude:

_An event for the exchange API call from the central login action:_
```json
  "event_properties": {
    "Code": 200,
    "Method": "POST",
    "Path": "/v1/auth/m2m/exchange",
    "User-Agent": "Rox Central/4.4.x-585-geb72ca7260 (linux; amd64) grpc-go/1.61.1 central-login-GHA"
  }
```

_An event for the roxctl download from Central:_
```json
  "event_properties": {
    "Code": 200,
    "Method": "GET",
    "Path": "/roxctl-linux-amd64",
    "User-Agent": "roxctl-installer-GHA"
  }
```

_An event for the roxctl command being executed:_
```json
  "event_properties": {
    "Code": 0,
    "Method": "/v1.RoleService/GetMyPermissions",
    "Path": "/v1.RoleService/GetMyPermissions",
    "User-Agent": "roxctl/4.4.x-585-geb72ca7260 (linux; amd64) CI grpc-go/1.61.1"
  }
```

These datapoints should be enough to create dashboards for us to collect some data.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
