### PR TITLE
feat(scanner): Enable openshift metrics

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
@@ -63,4 +63,26 @@ spec:
   policyTypes:
   - Ingress
 {{- end }}
+{{- if ._rox.monitoring.openshift.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scanner-v4-indexer-monitoring-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-indexer-monitoring-tls") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "networkpolicy" "scanner-v4-indexer-monitoring-tls") | nindent 4 }}
+spec:
+  ingress:
+    - ports:
+      - port: 9091
+        protocol: TCP
+  podSelector:
+    matchLabels:
+      app: scanner-v4-indexer
+  policyTypes:
+    - Ingress
+{{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
@@ -47,4 +47,26 @@ spec:
   policyTypes:
   - Ingress
 {{- end }}
+{{- if ._rox.monitoring.openshift.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scanner-v4-matcher-monitoring-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-matcher-monitoring-tls") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "networkpolicy" "scanner-v4-matcher-monitoring-tls") | nindent 4 }}
+spec:
+  ingress:
+    - ports:
+      - port: 9091
+        protocol: TCP
+  podSelector:
+    matchLabels:
+      app: scanner-v4-matcher
+  policyTypes:
+    - Ingress
+{{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -61,12 +61,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-       {{- if ._rox.env.openshift }}
+        {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"
         {{- end }}
         - name: ROX_METRICS_PORT
           value: ":{{- ._rox.scannerV4.indexer.metricsPort -}}"
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - name: ROX_ENABLE_SECURE_METRICS
+          value: "true"
+        - name: ROX_SECURE_METRICS_PORT
+          value: ":9091"
+        {{- end }}
         {{- include "srox.envVars" (list . "deployment" "scanner-v4-indexer" "indexer") | nindent 8 }}
         resources:
           {{- ._rox.scannerV4.indexer._resources | nindent 10 }}
@@ -80,6 +86,10 @@ spec:
         - name: monitoring
           containerPort: {{ ._rox.scannerV4.indexer.metricsPort }}
         {{- end}}
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - containerPort: 9091
+          name: monitoring-tls
+        {{- end }}
         securityContext:
           capabilities:
             drop: ["NET_RAW"]
@@ -114,6 +124,11 @@ spec:
         - name: db-password
           mountPath: /run/secrets/stackrox.io/secrets
           readOnly: true
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - name: monitoring-tls
+          mountPath: /run/secrets/stackrox.io/monitoring-tls
+          readOnly: true
+        {{- end }}
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
       securityContext:
         runAsNonRoot: true
@@ -147,5 +162,10 @@ spec:
       - name: db-password
         secret:
           secretName: scanner-v4-db-password
+      {{- if ._rox.monitoring.openshift.enabled }}
+      - name: monitoring-tls
+        secret:
+          secretName: scanner-v4-indexer-monitoring-tls
+      {{- end }}
       {{- include "srox.injectedCABundleVolume" . | nindent 6 }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -68,6 +68,12 @@ spec:
         {{- end }}
         - name: ROX_METRICS_PORT
           value: ":{{- ._rox.scannerV4.matcher.metricsPort -}}"
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - name: ROX_ENABLE_SECURE_METRICS
+          value: "true"
+        - name: ROX_SECURE_METRICS_PORT
+          value: ":9091"
+        {{- end }}
         {{- include "srox.envVars" (list . "deployment" "scanner-v4-matcher" "matcher") | nindent 8 }}
         resources:
           {{- ._rox.scannerV4.matcher._resources | nindent 10 }}
@@ -80,6 +86,10 @@ spec:
         {{ if ._rox.scannerV4.exposeMonitoring -}}
         - name: monitoring
           containerPort: {{ ._rox.scannerV4.matcher.metricsPort }}
+        {{- end }}
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - containerPort: 9091
+          name: monitoring-tls
         {{- end }}
         securityContext:
           capabilities:
@@ -115,6 +125,11 @@ spec:
         - name: db-password
           mountPath: /run/secrets/stackrox.io/secrets
           readOnly: true
+        {{- if ._rox.monitoring.openshift.enabled }}
+        - name: monitoring-tls
+          mountPath: /run/secrets/stackrox.io/monitoring-tls
+          readOnly: true
+        {{- end }}
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
       securityContext:
         runAsNonRoot: true
@@ -144,5 +159,10 @@ spec:
       - name: db-password
         secret:
           secretName: scanner-v4-db-password
+      {{- if ._rox.monitoring.openshift.enabled }}
+      - name: monitoring-tls
+        secret:
+          secretName: scanner-v4-matcher-monitoring-tls
+      {{- end }}
       {{- include "srox.injectedCABundleVolume" . | nindent 6 }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-08-indexer-service.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-08-indexer-service.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- include "srox.labels" (list . "service" "scanner-v4-indexer") | nindent 4 }}
   annotations:
     {{- include "srox.annotations" (list . "service" "scanner-v4-indexer") | nindent 4 }}
+    {{- if ._rox.monitoring.openshift.enabled }}
+    service.beta.openshift.io/serving-cert-secret-name: scanner-v4-indexer-monitoring-tls
+    {{- end }}
 spec:
   selector:
     app: scanner-v4-indexer
@@ -22,10 +25,14 @@ spec:
     port: {{ ._rox.scannerV4.indexer.metricsPort }}
     targetPort: monitoring
   {{- end }}
+  {{- if ._rox.monitoring.openshift.enabled }}
+  - name: indexer-monitoring-tls
+    port: 9091
+    targetPort: monitoring-tls
+  {{- end }}
 
 {{- if ._rox.env.istio }}
 ---
-
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/image/templates/helm/shared/templates/02-scanner-v4-08-matcher-service.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-08-matcher-service.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- include "srox.labels" (list . "service" "scanner-v4-matcher") | nindent 4 }}
   annotations:
     {{- include "srox.annotations" (list . "service" "scanner-v4-matcher") | nindent 4 }}
+    {{- if ._rox.monitoring.openshift.enabled }}
+    service.beta.openshift.io/serving-cert-secret-name: scanner-v4-matcher-monitoring-tls
+    {{- end }}
 spec:
   selector:
     app: scanner-v4-matcher
@@ -22,10 +25,14 @@ spec:
     port: {{ ._rox.scannerV4.matcher.metricsPort }}
     targetPort: monitoring
   {{- end }}
+  {{ if ._rox.monitoring.openshift.enabled -}}
+  - name: matcher-monitoring-tls
+    port: 9091
+    targetPort: monitoring-tls
+  {{- end }}
 
 {{- if ._rox.env.istio }}
 ---
-
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/image/templates/helm/shared/templates/99-shared-openshift-monitoring.yaml.htpl
+++ b/image/templates/helm/shared/templates/99-shared-openshift-monitoring.yaml.htpl
@@ -1,0 +1,67 @@
+{{- include "srox.init" . -}}
+{{- if ._rox.monitoring.openshift.enabled -}}
+[<- if .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
+  {{- if (or ._rox.scannerV4._indexerEnabled ._rox.scannerV4._matcherEnabled) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "scanner-v4-monitor-{{ .Release.Namespace }}"
+  namespace: openshift-monitoring
+  labels:
+    {{- include "srox.labels" (list . "servicemonitor" (print "scanner-v4-monitor-" .Release.Namespace)) | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "servicemonitor" (print "scanner-v4-monitor-" .Release.Namespace)) | nindent 4 }}
+spec:
+  endpoints:
+    {{- if ._rox.scannerV4._indexerEnabled }}
+  - interval: 30s
+    path: metrics
+    port: indexer-monitoring-tls
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: "scanner-v4-indexer.{{ .Release.Namespace }}.svc"
+    {{- end }}
+    {{- if ._rox.scannerV4._matcherEnabled }}
+  - interval: 30s
+    path: metrics
+    port: matcher-monitoring-tls
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: "scanner-v4-matcher.{{ .Release.Namespace }}.svc"
+    {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: scanner-v4
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+---
+{{/* TODO(ROX-22188): Switch to a ClusterRoleBinding to avoid leaking to
+     kube-system namespace. */ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "rhacs-scanner-v4-auth-reader-{{ .Release.Namespace }}"
+  namespace: kube-system
+  labels:
+    {{- include "srox.labels" (list . "rolebinding" (print "rhacs-scanner-v4-auth-reader-" .Release.Namespace)) | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-scanner-v4-auth-reader-" .Release.Namespace)) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: scanner-v4
+    namespace: "{{ .Release.Namespace }}"
+  {{- end }}
+[<- end >]
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/_labels.tpl
+++ b/image/templates/helm/stackrox-central/templates/_labels.tpl
@@ -19,7 +19,7 @@
 {{ $_ = set $labels "app.kubernetes.io/instance" $.Release.Name }}
 {{ $_ = set $labels "app.kubernetes.io/version" $.Chart.AppVersion }}
 {{ $_ = set $labels "app.kubernetes.io/part-of" "stackrox-central-services" }}
-{{ $component := regexReplaceAll "^.*/\\d{2}-([a-z]+)-\\d{2}-[^/]+\\.yaml" $.Template.Name "${1}" }}
+{{ $component := regexReplaceAll "^.*/\\d{2}-([a-z0-9-]+)-\\d{2}-[^/]+\\.yaml" $.Template.Name "${1}" }}
 {{ if not (contains "/" $component) }}
   {{ $_ = set $labels "app.kubernetes.io/component" $component }}
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_labels.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_labels.tpl
@@ -19,7 +19,7 @@
 {{ $_ = set $labels "app.kubernetes.io/instance" $.Release.Name }}
 {{ $_ = set $labels "app.kubernetes.io/version" $.Chart.AppVersion }}
 {{ $_ = set $labels "app.kubernetes.io/part-of" "stackrox-secured-cluster-services" }}
-{{ $component := regexReplaceAll "^.*/(admission-control|collector|sensor)[^/]*\\.yaml" $.Template.Name "${1}" }}
+{{ $component := regexReplaceAll "^.*/(\\d{2}-)?(admission-control|collector|sensor|scanner-v4)[^/]*\\.yaml" $.Template.Name "${2}" }}
 {{ if not (contains "/" $component) }}
   {{ $_ = set $labels "app.kubernetes.io/component" $component }}
 {{ end }}

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -44,6 +44,69 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "When enabled with Scanner V4"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+    scannerV4:
+      disable: false
+  tests:
+    - name: "resources are created for prometheus-operator"
+      expect: |
+        .roles["central-prometheus-k8s"] | assertThat(. != null)
+        .rolebindings["central-prometheus-k8s"] | assertThat(. != null)
+        .rolebindings["rhacs-central-auth-reader-stackrox"] | assertThat(. != null)
+        .servicemonitors["central-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "monitoring-tls")
+          ]
+        .rolebindings["rhacs-scanner-v4-auth-reader-stackrox"] | assertThat(. != null)
+        .servicemonitors["scanner-v4-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[0].port == "indexer-monitoring-tls"),
+            assertThat(.spec.endpoints[1].port == "matcher-monitoring-tls")
+          ]
+
+    - name: "secure metrics endpoint is enabled"
+      expect: |
+        .deployments.central.spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_ENABLE_SECURE_METRICS") | assertThat(.value == "true")
+        .deployments.central.spec.template.spec.containers[0].ports[] |
+          select(.name == "monitoring-tls") | assertThat(.containerPort == 9091)
+        .deployments.central.spec.template.spec.containers[0].volumeMounts[] |
+          select(.name == "monitoring-tls") | assertThat(.mountPath == "/run/secrets/stackrox.io/monitoring-tls")
+        .services.central.spec.ports[] | select(.name == "monitoring-tls") | [
+            assertThat(.targetPort == "monitoring-tls"),
+            assertThat(.port == 9091)
+          ]
+        .networkpolicys["central-monitoring-tls"] | assertThat(. != null)
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_ENABLE_SECURE_METRICS") | assertThat(.value == "true")
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_SECURE_METRICS_PORT") | assertThat(.value == ":9091")
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].ports[] |
+          select(.name == "monitoring-tls") | assertThat(.containerPort == 9091)
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].volumeMounts[] |
+          select(.name == "monitoring-tls") | assertThat(.mountPath == "/run/secrets/stackrox.io/monitoring-tls")
+        .services["scanner-v4-indexer"].spec.ports[] | select(.name == "indexer-monitoring-tls") | [
+            assertThat(.targetPort == "monitoring-tls"),
+            assertThat(.port == 9091)
+          ]
+        .networkpolicys["scanner-v4-matcher-monitoring-tls"] | assertThat(. != null)
+        .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_ENABLE_SECURE_METRICS") | assertThat(.value == "true")
+        .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_SECURE_METRICS_PORT") | assertThat(.value == ":9091")
+        .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].ports[] |
+          select(.name == "monitoring-tls") | assertThat(.containerPort == 9091)
+        .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].volumeMounts[] |
+          select(.name == "monitoring-tls") | assertThat(.mountPath == "/run/secrets/stackrox.io/monitoring-tls")
+        .services["scanner-v4-matcher"].spec.ports[] | select(.name == "matcher-monitoring-tls") | [
+            assertThat(.targetPort == "monitoring-tls"),
+            assertThat(.port == 9091)
+          ]
+        .networkpolicys["scanner-v4-matcher-monitoring-tls"] | assertThat(. != null)
+
 - name: "When enabled via default value"
   set:
     env.openshift: 4

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -41,6 +41,55 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "When enabled with Scanner V4"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+    scannerV4:
+      disable: false
+  tests:
+    - name: "resources are created for prometheus-operator"
+      expect: |
+        .roles["secured-cluster-prometheus-k8s"] | assertThat(. != null)
+        .rolebindings["secured-cluster-prometheus-k8s"] | assertThat(. != null)
+        .rolebindings["rhacs-sensor-auth-reader-stackrox"] | assertThat(. != null)
+        .servicemonitors["sensor-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "monitoring-tls")
+          ]
+        .rolebindings["rhacs-scanner-v4-auth-reader-stackrox"] | assertThat(. != null)
+        .servicemonitors["scanner-v4-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "indexer-monitoring-tls")
+          ]
+
+    - name: "secure metrics endpoint is enabled"
+      expect: |
+        .deployments.sensor.spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_ENABLE_SECURE_METRICS") | assertThat(.value == "true")
+        .deployments.sensor.spec.template.spec.containers[0].ports[] |
+          select(.name == "monitoring-tls") | assertThat(.containerPort == 9091)
+        .deployments.sensor.spec.template.spec.containers[0].volumeMounts[] |
+          select(.name == "monitoring-tls") | assertThat(.mountPath == "/run/secrets/stackrox.io/monitoring-tls")
+        .services.sensor.spec.ports[] | select(.name == "monitoring-tls") | [
+            assertThat(.targetPort == "monitoring-tls"),
+            assertThat(.port == 9091)
+          ]
+        .networkpolicys["sensor-monitoring-tls"] | assertThat(. != null)
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_ENABLE_SECURE_METRICS") | assertThat(.value == "true")
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_SECURE_METRICS_PORT") | assertThat(.value == ":9091")
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].ports[] |
+          select(.name == "monitoring-tls") | assertThat(.containerPort == 9091)
+        .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].volumeMounts[] |
+          select(.name == "monitoring-tls") | assertThat(.mountPath == "/run/secrets/stackrox.io/monitoring-tls")
+        .services["scanner-v4-indexer"].spec.ports[] | select(.name == "indexer-monitoring-tls") | [
+            assertThat(.targetPort == "monitoring-tls"),
+            assertThat(.port == 9091)
+          ]
+        .networkpolicys["scanner-v4-indexer-monitoring-tls"] | assertThat(. != null)
+
 - name: "When enabled via default value"
   set:
     env.openshift: 4


### PR DESCRIPTION
## Description

This will change what is necessary to serve a secure metric endpoint based on Openshfit's service-serving certificates. It also enables metrics scrapping using a `ServiceMonitors` akin to Central and Sensor. But we use separate endpoints for matcher and indexer and match the service by component, which is "scanner-v4"--due to how the `_label` template parses it from the template filename. The ServiceMonitor seems to ignore services based on the service port existence. I noticed that from Central's SM.

I adopted ClusterRoles to access the monitoring secrets, so this also fixes ROX-22188.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I deployed these changes using Helm on a clean Openshift cluster:

1. Installing the central chart and secured cluster chart in the same namespace.
2. Central in one namespace and secured in another namespace.

Then I observed that:

1. Service Monitors are healthy, and the service monitor `scanner-v4-monitor-stackrox` has targets (in the UI "Observe / Targets") for each Matcher and Indexer pod.
2. I queried metrics for Matcher and Indexer in the Metric UI.

![image](https://github.com/stackrox/stackrox/assets/291493/62e868eb-99c7-4120-b550-dcc96243b38d)

![image](https://github.com/stackrox/stackrox/assets/291493/00118a2d-8860-42aa-90ca-be5162f5815b)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
