### PR TITLE
ROX-23953: Attempt Manifest Digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Adds a label `app.stackrox.io/managed-by: operator` to all helm chart resources and secrets created by the operator
 - ROX-22044: Scanner DB is now based on PostgreSQL 15 instead of 12.
   - No migration should be necessary, as the database is not persisted.
-- ROX-23953: Nexus and Red Hat registry integrations will now attempt to pull manifest digests by default. This can be disabled by setting env `ROX_ATTEMPT_MANIFEST_DIGEST` to `false`.
+- ROX-23953: Nexus and Red Hat registry integrations will now attempt to pull manifest digests by default (via a `HEAD` request to `/v2/<name>/manifests/<reference>`). This can be disabled by setting env `ROX_ATTEMPT_MANIFEST_DIGEST` to `false`.
   - This fixes one scenario that resulted in an `unsupported digest algorithm` error when using Scanner V4.
 
 ## [4.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Adds a label `app.stackrox.io/managed-by: operator` to all helm chart resources and secrets created by the operator
 - ROX-22044: Scanner DB is now based on PostgreSQL 15 instead of 12.
   - No migration should be necessary, as the database is not persisted.
+- ROX-23953: Nexus and Red Hat registry integrations will now attempt to pull manifest digests by default. This can be disabled by setting env `ROX_ATTEMPT_MANIFEST_DIGEST` to `false`.
+  - This fixes one scenario that resulted in an `unsupported digest algorithm` error when using Scanner V4.
 
 ## [4.4.0]
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -99,6 +99,11 @@ var (
 
 	// SensorAggregateDeploymentReferenceOptimization enables a performance improvement by aggregating deployment references when the same reference is queued for processing
 	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", true)
+
 	// ACSCSEmailNotifier enables support for the ACSCS email notifier integratioon
 	ACSCSEmailNotifier = registerFeature("Enable support for ACSCS Email notifier type", "ROX_ACSCS_EMAIL_NOTIFIER", false)
+
+	// AttemptManifestDigest enables attempting to pull manifest digests from registres that historically did not
+	// support it but now appear to (ie: Nexus and RHEL).
+	AttemptManifestDigest = registerFeature("", "ROX_ATTEMPT_MANIFEST_DIGEST", true)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -105,5 +105,5 @@ var (
 
 	// AttemptManifestDigest enables attempting to pull manifest digests from registres that historically did not
 	// support it but now appear to (ie: Nexus and RHEL).
-	AttemptManifestDigest = registerFeature("", "ROX_ATTEMPT_MANIFEST_DIGEST", true)
+	AttemptManifestDigest = registerFeature("Enables attempts to pull manifest digests for all registry integrations", "ROX_ATTEMPT_MANIFEST_DIGEST", true)
 )

--- a/pkg/registries/docker/registry_without_digest_call_test.go
+++ b/pkg/registries/docker/registry_without_digest_call_test.go
@@ -1,0 +1,82 @@
+package docker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/urlfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRegistry struct {
+	NumFailedHeadCalls int
+	NumAllowedCalls    int
+}
+
+func (f *fakeRegistry) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodHead {
+		http.Error(w, "", http.StatusMethodNotAllowed)
+		f.NumFailedHeadCalls++
+		return
+	}
+
+	f.NumAllowedCalls++
+}
+
+func TestMetadataFallback(t *testing.T) {
+	tcs := []struct {
+		desc           string
+		featureEnabled bool
+	}{
+		{"attempt manifest digest, fallback on error", true},
+		{"do not attempt manifest digest", false},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.AttemptManifestDigest, tc.featureEnabled)
+
+			fr := &fakeRegistry{}
+
+			s := httptest.NewServer(http.HandlerFunc(fr.HandlerFunc))
+			defer s.Close()
+
+			r, err := NewRegistryWithoutManifestCall(&storage.ImageIntegration{
+				IntegrationConfig: &storage.ImageIntegration_Docker{
+					Docker: &storage.DockerConfig{
+						Endpoint: s.URL,
+					},
+				},
+			}, true, nil)
+			require.NoError(t, err)
+
+			imgStr := fmt.Sprintf("%s/%s:%s", urlfmt.TrimHTTPPrefixes(s.URL), "repo/path", "tag")
+			cimg, err := utils.GenerateImageFromString(imgStr)
+			require.NoError(t, err)
+			img := types.ToImage(cimg)
+
+			_, err = r.Metadata(img)
+
+			// An overall error is expected because the 'fake registry' is returning garbage data.
+			assert.Error(t, err)
+
+			// Expect each of the handler functions to attempt a single call and fail.
+			assert.Equal(t, len(manifestFuncs), fr.NumAllowedCalls)
+
+			if tc.featureEnabled {
+				assert.Equal(t, 1, fr.NumFailedHeadCalls)
+			} else {
+				assert.Equal(t, 0, fr.NumFailedHeadCalls)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
## Description

Attempts to scan images from Nexus or Red Hat registries _may_ fail with `unsupported digest algorithm` errors when referenced by `tag` and Scanner V4 is active (not always, depends on multiple factors such as if a manifest list is present or not)

Scanner V4 requires a valid digest to scan an image (the "Stackrox Scanner" did not), a bug (arguably) has existed for some time where the image tag is set to the `Digest` field in image metadata ([here](https://github.com/stackrox/stackrox/blob/49a2532e939ab72c671bccf69026a71477a7e751/pkg/registries/docker/metadata_v2.go#L68-L70) and [here](https://github.com/stackrox/stackrox/blob/49a2532e939ab72c671bccf69026a71477a7e751/pkg/registries/docker/metadata_v2.go#L104-L106)) which is [later returned](https://github.com/stackrox/stackrox/blob/92215e774812bd11e77a31a5ad3084e1c9ec7152/pkg/images/utils/utils.go#L146-L152) as a digest triggering an [error here](https://github.com/stackrox/stackrox/blob/1a06186282a4958c8d8d4720e7002f9cfc13c7c4/pkg/scannerv4/util.go#L14).

This fix only addresses one scenario in which Nexus and Red Hat registries support a HEAD call to pull the manifest digest (historically this was not the case).  At the time this was tested, all versions of Nexus 3 and registry*.redhat.[com|io] supported this HEAD call.

The fix adds attempts to pull the digest directly via the HEAD call - if that fails it will fallback to processing each type of manifest one by one.  This fallback mechanism was kept in case there is a permutation/combination of network configuration, registry, version, config, etc. that triggers the historic failure conditions. 

On fallback the issue can re-surface, this PR is only part of a multi-faceted fix to the problem, additional changes are in progress that will modify the `docker-registry-client` to obtain the digest when possible via the `GET` calls per the [distribution spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md).

Should this encounter unforeseen issues, the new attempts can be disabled by setting env var `ROX_ATTEMPT_MANIFEST_DIGEST` to `false`.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- [X] Evaluated and added CHANGELOG entry if required
- [X] Determined and documented upgrade steps
- [X] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests added and manually tested on an OCP installation on infra with Scanner V4 enabled:

Without fix or with `ROX_ATTEMPT_MANIFEST_DIGEST=false`

```
$ roxctl image scan --image=registry.access.redhat.com/rhel7.1:7.1-24 --force

ERROR:	Scanning image failed: could not scan image: "registry.access.redhat.com/rhel7.1:7.1-24": rpc error: code = Internal desc = image enrichment error: error scanning image: registry.access.redhat.com/rhel7.1:7.1-24 error: scanning "registry.access.redhat.com/rhel7.1:7.1-24" with scanner "Scanner V4": creating digest reference: unsupported digest algorithm: 7.1-24. Retrying after 3 seconds...
```

With fix and `ROX_ATTEMPT_MANIFEST_DIGEST=true` (default):

```
$ roxctl image scan --image=registry.access.redhat.com/rhel7.1:7.1-24 --force

{
  "id": "sha256:9675a0cbb44ca8b2ef04f490ecd69242a60fdefdbca23881d66c3640c64ca37d",
  "name": {
    "registry": "registry.access.redhat.com",
    "remote": "rhel7.1",
    "tag": "7.1-24",
    "fullName": "registry.access.redhat.com/rhel7.1:7.1-24"
  },
...
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
