### PR TITLE
fix: nightly tag roxctl scan

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -684,6 +684,8 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Central login
         uses: stackrox/central-login@v1
         with:


### PR DESCRIPTION
## Description

The scan workflow currently fails to scan images for nightly branches. Central returns 404 errors upon scanning (see https://github.com/stackrox/stackrox/actions/runs/8916679405/job/24489250757). The issue seems to be that the image uploaded by the previous build step is tagged differently to the one being scanned.

We need to run the `handle-tagged-build` action, which sets the `BUILD_TAG` env variable. This then changes the behavior of `make tag`.

Before:
```
make tag

4.4.x-586-g6341b5717a
```

After:
```
export BUILD_TAG=4.4.x-nightly-20240502
make tag

4.4.x-nightly-20240502
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

see explanation above

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
