### PR TITLE
fix: close response body once done

### DIFF
--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -284,6 +284,7 @@ func (l *loginCommand) verifyLoginAuthProviders() error {
 	if err != nil {
 		return errors.Wrap(err, "requesting login auth providers")
 	}
+	defer utils.IgnoreError(resp.Body.Close)
 
 	var loginAuthProviders v1.GetLoginAuthProvidersResponse
 	if err := jsonpb.Unmarshal(resp.Body, &loginAuthProviders); err != nil {


### PR DESCRIPTION
## Description

I don't think this is a big deal since `roxctl` just runs a command and then terminates, but I figure it's good hygiene to close response bodies once done with them.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

no

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
