### PR TITLE
chore(test): Check all CO resources are in the AvailabilityChecker

### DIFF
--- a/pkg/complianceoperator/api.go
+++ b/pkg/complianceoperator/api.go
@@ -64,7 +64,7 @@ var (
 		Group:   GetGroupVersion().Group,
 		Version: GetGroupVersion().Version,
 	})
-	Remediation = registerAPIResource(v1.APIResource{
+	ComplianceRemediation = registerAPIResource(v1.APIResource{
 		Name:    "complianceremediations",
 		Kind:    "ComplianceRemediation",
 		Group:   GetGroupVersion().Group,

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -101,6 +101,7 @@ func (k *listenerImpl) handleAllEvents() {
 			}
 		}
 	}
+	// Any informer created in the following block should be added to the coAvailabilityChecker
 	if coAvailabilityChecker.Available(k.client) {
 		log.Info("initializing compliance operator informers")
 		crdSharedInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(k.client.Dynamic(), noResyncPeriod)
@@ -113,7 +114,7 @@ func (k *listenerImpl) handleAllEvents() {
 		complianceScanInformer = crdSharedInformerFactory.ForResource(complianceoperator.ComplianceScan.GroupVersionResource()).Informer()
 		complianceTailoredProfileInformer = crdSharedInformerFactory.ForResource(complianceoperator.TailoredProfile.GroupVersionResource()).Informer()
 		complianceSuiteInformer = crdSharedInformerFactory.ForResource(complianceoperator.ComplianceSuite.GroupVersionResource()).Informer()
-		complianceRemediationInformer = crdSharedInformerFactory.ForResource(complianceoperator.Remediation.GroupVersionResource()).Informer()
+		complianceRemediationInformer = crdSharedInformerFactory.ForResource(complianceoperator.ComplianceRemediation.GroupVersionResource()).Informer()
 		// Override the crdHandlerFn to only handle when the resources become unavailable
 		crdHandlerFn = func(status *watcher.Status) {
 			if !status.Available {

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker.go
@@ -35,7 +35,7 @@ func NewComplianceOperatorAvailabilityChecker() *availabilityChecker {
 		complianceoperator.ComplianceSuite,
 		complianceoperator.ComplianceCheckResult,
 		complianceoperator.TailoredProfile,
-		complianceoperator.Remediation,
+		complianceoperator.ComplianceRemediation,
 	}
 	return &availabilityChecker{
 		gv:        complianceoperator.GetGroupVersion(),

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
@@ -28,12 +28,12 @@ func TestAllCOResourcesAreAddedToTheAvailabilityChecker(t *testing.T) {
 
 	resFinder := &resourcesFinder{}
 	ast.Walk(resFinder, file)
+	require.NotEmpty(t, resFinder.resources)
 
 	var notFound []string
 finderLoop:
 	for _, resource := range resFinder.resources {
 		for _, acResource := range ac.resources {
-			log.Info(acResource.Kind)
 			if acResource.Kind == resource {
 				continue finderLoop
 			}

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
@@ -46,7 +46,7 @@ finderLoop:
 		notFound = append(notFound, resource)
 	}
 
-	assert.Empty(t, notFound, "Please add the missing types to the resources field in the availability checker ot the whileList in this test if they should not be used in the availability checker")
+	assert.Empty(t, notFound, "Please add the missing types to the resources field in the availability checker to the whilelist in this test if they should not be used in the availability checker")
 }
 
 type resourcesFinder struct {

--- a/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
+++ b/sensor/kubernetes/listener/watcher/complianceoperator/availabilitychecker_test.go
@@ -1,0 +1,74 @@
+package complianceoperator
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllCOResourcesAreAddedToTheAvailabilityChecker(t *testing.T) {
+	ac := NewComplianceOperatorAvailabilityChecker()
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path.Join(pwd, "../../../../../pkg/complianceoperator/api.go"), nil, 0)
+	require.NoError(t, err)
+
+	whileList := []string{
+		"groupVersion",
+		"requiredAPIResources",
+	}
+
+	resFinder := &resourcesFinder{}
+	ast.Walk(resFinder, file)
+
+	var notFound []string
+finderLoop:
+	for _, resource := range resFinder.resources {
+		for _, acResource := range ac.resources {
+			log.Info(acResource.Kind)
+			if acResource.Kind == resource {
+				continue finderLoop
+			}
+		}
+		for _, whileListed := range whileList {
+			if whileListed == resource {
+				continue finderLoop
+			}
+		}
+		notFound = append(notFound, resource)
+	}
+
+	assert.Empty(t, notFound, "Please add the missing types to the resources field in the availability checker ot the whileList in this test if they should not be used in the availability checker")
+}
+
+type resourcesFinder struct {
+	resources []string
+}
+
+func (f *resourcesFinder) Visit(n ast.Node) ast.Visitor {
+	switch n := n.(type) {
+	case *ast.Package:
+		return f
+	case *ast.File:
+		return f
+	case *ast.GenDecl:
+		if n.Tok == token.VAR {
+			return f
+		}
+	case *ast.ValueSpec:
+		// This should never happen
+		if len(n.Names) < 1 {
+			return nil
+		}
+		f.resources = append(f.resources, n.Names[0].Name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Adds a test to check whether all the Compliance Operator resources are added to the AvailabilityChecker.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] The unit tests should pass
- [x] Tampering with the `whiteList` or the `resources` field should make this test fail

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
