### PR TITLE
compliance v2 coverage routing without context

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { Button, PageSection } from '@patternfly/react-core';
+
+import { complianceEnhancedCoveragePath } from 'routePaths';
+
+function CheckDetailsPage() {
+    const history = useHistory();
+    const { profileName } = useParams();
+    return (
+        <>
+            <PageSection variant="light">
+                <div>CheckDetailsPage</div>
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks`
+                        );
+                    }}
+                    variant="primary"
+                >
+                    Go to all checks (ProfileChecksPage)
+                </Button>
+            </PageSection>
+        </>
+    );
+}
+
+export default CheckDetailsPage;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useCallback } from 'react';
+
+import useRestQuery from 'hooks/useRestQuery';
+
+import {
+    getComplianceProfilesStats,
+    ListComplianceProfileScanStatsResponse,
+} from 'services/ComplianceResultsService';
+
+type ComplianceProfilesContextValue = {
+    profileScanStats: ListComplianceProfileScanStatsResponse | undefined;
+    isLoading: boolean;
+    error: Error | undefined;
+};
+
+export const ComplianceProfilesContext = createContext<ComplianceProfilesContextValue | null>(null);
+
+function ComplianceProfilesProvider({ children }: { children: React.ReactNode }) {
+    const fetchProfilesStats = useCallback(() => getComplianceProfilesStats(), []);
+    const { data: profileScanStats, loading: isLoading, error } = useRestQuery(fetchProfilesStats);
+
+    const contextValue: ComplianceProfilesContextValue = {
+        profileScanStats,
+        isLoading,
+        error,
+    };
+
+    return (
+        <ComplianceProfilesContext.Provider value={contextValue}>
+            {children}
+        </ComplianceProfilesContext.Provider>
+    );
+}
+
+export default ComplianceProfilesProvider;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { complianceEnhancedCoveragePath } from 'routePaths';
 
+import CheckDetailsPage from './CheckDetailsPage';
 import CoveragesPage from './CoveragesPage';
 
 function CoveragePage() {
@@ -13,9 +14,30 @@ function CoveragePage() {
 
     return (
         <Switch>
-            <Route exact path={complianceEnhancedCoveragePath}>
-                <CoveragesPage />
-            </Route>
+            <Route
+                exact
+                path={`${complianceEnhancedCoveragePath}/profiles/:profileName/checks/:checkName`}
+                component={CheckDetailsPage}
+            />
+            <Route
+                exact
+                path={[
+                    `${complianceEnhancedCoveragePath}/profiles`,
+                    `${complianceEnhancedCoveragePath}/profiles/:profileName/checks`,
+                    `${complianceEnhancedCoveragePath}/profiles/:profileName/clusters`,
+                ]}
+                component={CoveragesPage}
+            />
+            <Redirect
+                exact
+                from={`${complianceEnhancedCoveragePath}`}
+                to={`${complianceEnhancedCoveragePath}/profiles`}
+            />
+            <Redirect
+                exact
+                from={`${complianceEnhancedCoveragePath}/profiles/:profileName`}
+                to={`${complianceEnhancedCoveragePath}/profiles/:profileName/checks`}
+            />
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -1,7 +1,73 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
+import { Route, Switch, useHistory, useParams } from 'react-router-dom';
+import { Bullseye, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import useRestQuery from 'hooks/useRestQuery';
+import { complianceEnhancedCoveragePath } from 'routePaths';
+import { getComplianceProfilesStats } from 'services/ComplianceResultsService';
+
+import ProfileChecksPage from './ProfileChecksPage';
+import ProfileClustersPage from './ProfileClustersPage';
 
 function CoveragesPage() {
-    return <>Coverages Page</>;
+    const fetchProfilesStats = useCallback(() => getComplianceProfilesStats(), []);
+    const { data: profileScanStats, loading: isLoading, error } = useRestQuery(fetchProfilesStats);
+
+    const history = useHistory();
+    const { profileName } = useParams();
+
+    const { scanStats } = profileScanStats || {};
+
+    // redirect to the first profile if no profile is given
+    useEffect(() => {
+        if (scanStats && scanStats.length > 0 && !profileName) {
+            const firstProfileName = scanStats[0].profileName;
+            history.push(`${complianceEnhancedCoveragePath}/profiles/${firstProfileName}/checks`);
+        }
+    }, [isLoading, scanStats, profileName, history]);
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return <div>Error: {error.message}</div>;
+    }
+
+    if (!profileScanStats) {
+        return <div>No results</div>;
+    }
+
+    return (
+        <>
+            <PageTitle title="Compliance coverage" />
+            <PageSection component="div" variant="light">
+                <Title headingLevel="h1">Compliance coverage</Title>
+                <Text>
+                    Assess profile compliance for nodes and platform resources across clusters
+                </Text>
+            </PageSection>
+            <PageSection>
+                <Switch>
+                    <Route
+                        exact
+                        path={`${complianceEnhancedCoveragePath}/profiles/:profileName/checks`}
+                        render={() => <ProfileChecksPage profileScanStats={profileScanStats} />}
+                    />
+                    <Route
+                        exact
+                        path={`${complianceEnhancedCoveragePath}/profiles/:profileName/clusters`}
+                        render={() => <ProfileClustersPage profileScanStats={profileScanStats} />}
+                    />
+                </Switch>
+            </PageSection>
+        </>
+    );
 }
 
 export default CoveragesPage;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesToggleGroup.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+
+import { complianceEnhancedCoveragePath } from 'routePaths';
+import { ListComplianceProfileScanStatsResponse } from 'services/ComplianceResultsService';
+
+function CoveragesToggleGroup({
+    tableView,
+    profileScanStats,
+}: {
+    tableView: string;
+    profileScanStats: ListComplianceProfileScanStatsResponse;
+}) {
+    const { profileName } = useParams();
+    const history = useHistory();
+
+    const handleToggleChange = (selectedProfile) => {
+        history.push(`${complianceEnhancedCoveragePath}/profiles/${selectedProfile}/${tableView}`);
+    };
+    return (
+        <ToggleGroup aria-label="Toggle for selected profile view">
+            {profileScanStats &&
+                profileScanStats.scanStats.map((profile) => (
+                    <ToggleGroupItem
+                        key={profile.profileName}
+                        text={profile.profileName}
+                        buttonId="compliance-profiles-toggle-group"
+                        isSelected={profileName === profile.profileName}
+                        onChange={() => handleToggleChange(profile.profileName)}
+                    />
+                ))}
+        </ToggleGroup>
+    );
+}
+
+export default CoveragesToggleGroup;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { Button, PageSection } from '@patternfly/react-core';
+
+import { complianceEnhancedCoveragePath } from 'routePaths';
+import { ListComplianceProfileScanStatsResponse } from 'services/ComplianceResultsService';
+
+import CoveragesToggleGroup from './CoveragesToggleGroup';
+
+function ProfileChecksPage({
+    profileScanStats,
+}: {
+    profileScanStats: ListComplianceProfileScanStatsResponse;
+}) {
+    const history = useHistory();
+    const { profileName } = useParams();
+
+    const profileParamExists = profileScanStats.scanStats.some(
+        (profile) => profile.profileName === profileName
+    );
+
+    if (!profileParamExists) {
+        return <div>No results for {profileName}</div>;
+    }
+
+    return (
+        <>
+            <CoveragesToggleGroup tableView="checks" profileScanStats={profileScanStats} />
+            <PageSection variant="light">
+                <div>ProfileChecksPage</div>
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/clusters`
+                        );
+                    }}
+                    variant="primary"
+                >
+                    Go to all clusters (ProfileClustersPage)
+                </Button>
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks/test`
+                        );
+                    }}
+                    variant="primary"
+                >
+                    Go to single check (CheckDetailsPage)
+                </Button>
+            </PageSection>
+        </>
+    );
+}
+
+export default ProfileChecksPage;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { Button, PageSection } from '@patternfly/react-core';
+
+import { complianceEnhancedCoveragePath } from 'routePaths';
+import { ListComplianceProfileScanStatsResponse } from 'services/ComplianceResultsService';
+
+import CoveragesToggleGroup from './CoveragesToggleGroup';
+
+function ProfileClustersPage({
+    profileScanStats,
+}: {
+    profileScanStats: ListComplianceProfileScanStatsResponse;
+}) {
+    const history = useHistory();
+    const { profileName } = useParams();
+
+    const profileParamExists = profileScanStats.scanStats.some(
+        (profile) => profile.profileName === profileName
+    );
+
+    if (!profileParamExists) {
+        return <div>Profile {profileName} does have results</div>;
+    }
+
+    return (
+        <>
+            <CoveragesToggleGroup tableView="clusters" profileScanStats={profileScanStats} />
+            <PageSection variant="light">
+                <div>ProfileClustersPage</div>
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks`
+                        );
+                    }}
+                    variant="primary"
+                >
+                    Go to all checks (ProfileChecksPage)
+                </Button>
+            </PageSection>
+        </>
+    );
+}
+
+export default ProfileClustersPage;

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,6 +1,8 @@
-// import { complianceV2Url } from './ComplianceCommon';
+import axios from 'services/instance';
 
-// const complianceResultsBaseUrl = `${complianceV2Url}/scan`;
+import { complianceV2Url } from './ComplianceCommon';
+
+const complianceResultsBaseUrl = `${complianceV2Url}/scan`;
 
 export const ComplianceCheckStatusEnum = {
     UNSET_CHECK_STATUS: 'UNSET_CHECK_STATUS',
@@ -44,3 +46,24 @@ export type ComplianceCheckStatusCount = {
     count: number;
     status: ComplianceCheckStatus;
 };
+
+type ComplianceProfileScanStats = {
+    checkStats: ComplianceCheckStatusCount[];
+    profileName: string;
+    title: string;
+    version: string;
+};
+
+export type ListComplianceProfileScanStatsResponse = {
+    scanStats: ComplianceProfileScanStats[];
+    totalCount: number;
+};
+
+/**
+ * Fetches the scan stats grouped by profile.
+ */
+export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanStatsResponse> {
+    return axios
+        .get<ListComplianceProfileScanStatsResponse>(`${complianceResultsBaseUrl}/stats/profiles`)
+        .then((response) => response.data);
+}


### PR DESCRIPTION
Compliance coverage routing setup using a nested approach, without react context.

The reason for offering two approaches has to do with the difficulty around shared data between 4 pages:

- Profile check results
- Profile cluster results
- Benchmark control results (coming later)
- Benchmark cluster results (coming later)

In this option, all 4 result pages lead to the same shared component (`CoveragePage.tsx`). This component is responsible for fetching and managing the shared profile data. As well as rendering common UI. The specific results pages (i.e. `ProfileCheckResults.tsx`) will be conditionally rendered depending on the route.

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.