### PR TITLE
ROX-23818: Add CVE snoozed toggle option

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -19,11 +19,7 @@ import { getUrlQueryStringForSearchFilter, getHasSearchApplied } from 'utils/sea
 
 import BySeveritySummaryCard from 'Containers/Vulnerabilities/components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from 'Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard';
-import {
-    getHiddenSeverities,
-    getHiddenStatuses,
-    parseWorkloadQuerySearchFilter,
-} from '../../utils/searchUtils';
+import { getHiddenSeverities, getHiddenStatuses } from '../../utils/searchUtils';
 
 import CVEsTable from './CVEsTable';
 import useNodeVulnerabilities from './useNodeVulnerabilities';
@@ -37,7 +33,9 @@ export type NodePageVulnerabilitiesProps = {
 
 function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+
+    // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
+    const querySearchFilter = searchFilter;
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -31,7 +31,6 @@ import {
     getHiddenSeverities,
     getOverviewPagePath,
     getRegexScopedQueryString,
-    parseWorkloadQuerySearchFilter,
 } from '../../utils/searchUtils';
 import CvePageHeader from '../../components/CvePageHeader';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
@@ -44,7 +43,8 @@ const nodeCveOverviewCvePath = getOverviewPagePath('Node', { entityTab: 'CVE' })
 
 function NodeCvePage() {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
+    const querySearchFilter = searchFilter;
 
     // We need to scope all queries to the *exact* CVE name so that we don't accidentally get
     // data that matches a prefix of the CVE name in the nested fields

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -15,11 +15,11 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
+import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import TableEntityToolbar from '../../components/TableEntityToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import NodeCveFilterToolbar from '../components/NodeCveFilterToolbar';
-import { NODE_CVE_SEARCH_OPTION } from '../../searchOptions';
-import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
+import { NODE_CVE_SEARCH_OPTION, SNOOZED_NODE_CVE_SEARCH_OPTION } from '../../searchOptions';
 import { nodeEntityTabValues } from '../../types';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
@@ -27,15 +27,15 @@ import CVEsTable from './CVEsTable';
 import NodesTable from './NodesTable';
 import { useNodeCveEntityCounts } from './useNodeCveEntityCounts';
 
-const searchOptions = [NODE_CVE_SEARCH_OPTION];
+const searchOptions = [NODE_CVE_SEARCH_OPTION, SNOOZED_NODE_CVE_SEARCH_OPTION];
 
 function NodeCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', nodeEntityTabValues);
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const querySearchFilter = searchFilter;
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     function onEntityTabChange() {
@@ -73,9 +73,17 @@ function NodeCvesOverviewPage() {
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-row pf-v5-u-align-items-center"
                 variant="light"
             >
-                <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                    <Title headingLevel="h1">Node CVEs</Title>
-                    <FlexItem>Prioritize and manage scanned CVEs across nodes</FlexItem>
+                <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v5-u-flex-grow-1">
+                    <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
+                        <Title headingLevel="h1">Node CVEs</Title>
+                        <FlexItem>Prioritize and manage scanned CVEs across nodes</FlexItem>
+                    </Flex>
+                    <FlexItem>
+                        <SnoozeCveToggleButton
+                            searchFilter={querySearchFilter}
+                            setSearchFilter={setSearchFilter}
+                        />
+                    </FlexItem>
                 </Flex>
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeCveFilterToolbar.tsx
@@ -65,6 +65,10 @@ function NodeCveFilterToolbar({
             searchFilterName: 'CVE',
         },
         {
+            displayName: 'CVE Snoozed',
+            searchFilterName: 'CVE Snoozed',
+        },
+        {
             displayName: 'Severity',
             searchFilterName: 'SEVERITY',
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -18,7 +18,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
-import { getHiddenStatuses, parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
+import { getHiddenStatuses } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import useClusterVulnerabilities from './useClusterVulnerabilities';
@@ -33,7 +33,8 @@ export type ClusterPageVulnerabilitiesProps = {
 
 function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
+    const querySearchFilter = searchFilter;
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -20,9 +20,10 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
 import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+
+import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
-import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { platformEntityTabValues } from '../../types';
 import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 
@@ -32,11 +33,11 @@ import { usePlatformCveEntityCounts } from './usePlatformCveEntityCounts';
 
 function PlatformCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const querySearchFilter = searchFilter;
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const isViewingSnoozedCves = querySearchFilter['CVE Snoozed'] === 'true';
@@ -73,9 +74,17 @@ function PlatformCvesOverviewPage() {
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-row pf-v5-u-align-items-center"
                 variant="light"
             >
-                <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                    <Title headingLevel="h1">Platform CVEs</Title>
-                    <FlexItem>Prioritize and manage scanned CVEs across clusters</FlexItem>
+                <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v5-u-flex-grow-1">
+                    <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
+                        <Title headingLevel="h1">Platform CVEs</Title>
+                        <FlexItem>Prioritize and manage scanned CVEs across clusters</FlexItem>
+                    </Flex>
+                    <FlexItem>
+                        <SnoozeCveToggleButton
+                            searchFilter={querySearchFilter}
+                            setSearchFilter={setSearchFilter}
+                        />
+                    </FlexItem>
                 </Flex>
             </PageSection>
             <PageSection isCenterAligned isFilled>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -28,11 +28,7 @@ import { DynamicTableLabel } from 'Components/DynamicIcon';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import CvePageHeader from '../../components/CvePageHeader';
-import {
-    getOverviewPagePath,
-    getRegexScopedQueryString,
-    parseWorkloadQuerySearchFilter,
-} from '../../utils/searchUtils';
+import { getOverviewPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
 import useAffectedClusters from './useAffectedClusters';
 import AffectedClustersTable from './AffectedClustersTable';
 import usePlatformCveMetadata from './usePlatformCveMetadata';
@@ -45,7 +41,8 @@ const workloadCveOverviewCvePath = getOverviewPagePath('Platform', {
 
 function PlatformCvePage() {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
+    const querySearchFilter = searchFilter;
 
     // We need to scope all queries to the *exact* CVE name so that we don't accidentally get
     // data that matches a prefix of the CVE name in the nested fields

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import SnoozeCveToggleButton from './SnoozedCveToggleButton';
+
+function Wrapper({ startingSearchFilter = {} }) {
+    const [searchFilter, setSearchFilter] = useState(startingSearchFilter);
+
+    return (
+        <>
+            <div>
+                <h1>Filters</h1>
+                {Object.entries(searchFilter).map(([key, values]) => (
+                    <div key={key}>
+                        {key}:{values.join(',')}
+                    </div>
+                ))}
+            </div>
+            <SnoozeCveToggleButton searchFilter={searchFilter} setSearchFilter={setSearchFilter} />
+        </>
+    );
+}
+
+const snoozedFilterSelector =
+    'div:has(h1:contains("Filters")) div:contains("CVE Snoozed:true") div';
+
+const severityFilterSelector =
+    'div:has(h1:contains("Filters")) div:contains("Severity:Critical,Important") div';
+
+describe(Cypress.spec.relative, () => {
+    it('should manage the toggling of the snoozed CVE filter', () => {
+        cy.mount(<Wrapper />);
+
+        // Default is off
+        cy.get(snoozedFilterSelector).should('not.exist');
+
+        // Toggle on
+        cy.findByText('Show snoozed CVEs').click();
+        cy.get(snoozedFilterSelector).should('exist');
+
+        // Toggle off
+        cy.findByText('Show observed CVEs').click();
+        cy.get(snoozedFilterSelector).should('not.exist');
+    });
+
+    it('should not change the state of existing filters when toggling the snoozed CVE filter', () => {
+        cy.mount(<Wrapper startingSearchFilter={{ Severity: ['Critical', 'Important'] }} />);
+
+        // Default is off
+        cy.get(snoozedFilterSelector).should('not.exist');
+        cy.get(severityFilterSelector).should('exist');
+
+        // Toggle on
+        cy.findByText('Show snoozed CVEs').click();
+        cy.get(snoozedFilterSelector).should('exist');
+        cy.get(severityFilterSelector).should('exist');
+
+        // Toggle off
+        cy.findByText('Show observed CVEs').click();
+        cy.get(snoozedFilterSelector).should('not.exist');
+        cy.get(severityFilterSelector).should('exist');
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { SearchFilter } from 'types/search';
+
+export type SnoozeCveToggleButtonProps = {
+    searchFilter: SearchFilter;
+    setSearchFilter: (searchFilter: SearchFilter) => void;
+};
+
+function SnoozeCveToggleButton({ searchFilter, setSearchFilter }: SnoozeCveToggleButtonProps) {
+    const isSnoozeFilterActive = searchFilter['CVE Snoozed']?.[0] === 'true';
+    const buttonText = isSnoozeFilterActive ? 'Show observed CVEs' : 'Show snoozed CVEs';
+
+    function toggleSnoozeFilter() {
+        const nextFilter = { ...searchFilter };
+        if (isSnoozeFilterActive) {
+            delete nextFilter['CVE Snoozed'];
+        } else {
+            nextFilter['CVE Snoozed'] = ['true'];
+        }
+        setSearchFilter(nextFilter);
+    }
+
+    return (
+        <Button variant="secondary" onClick={toggleSnoozeFilter}>
+            {buttonText}
+        </Button>
+    );
+}
+
+export default SnoozeCveToggleButton;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
@@ -5,6 +5,7 @@ export type SearchOptionValue =
     | 'COMPONENT'
     | 'COMPONENT SOURCE'
     | 'CVE'
+    | 'CVE Snoozed'
     | 'DEPLOYMENT'
     | 'FIXABLE'
     | 'IMAGE'
@@ -50,6 +51,12 @@ export const IMAGE_CVE_SEARCH_OPTION = {
 export const NODE_CVE_SEARCH_OPTION = {
     label: 'CVE',
     value: 'CVE',
+    category: 'NODE_VULNERABILITIES',
+} as const;
+
+export const SNOOZED_NODE_CVE_SEARCH_OPTION = {
+    label: 'CVE Snoozed',
+    value: 'CVE Snoozed',
     category: 'NODE_VULNERABILITIES',
 } as const;
 


### PR DESCRIPTION
## Description

Adds the show/hide Snoozed CVEs option to Node and Platform CVE overview pages. Clicking on the button is a shortcut for applying the "CVE Snoozed: true" filter in the upcoming advanced filters toolbar.

This button enables the read-only support of the same legacy feature in VM 1.0 (the ability to _write_ snooze CVE requests will be gated behind a runtime feature flag).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Node CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/36629f46-63b6-4ce9-b80c-67ba865f0b9d)

Click the button in the top right, the button's text will change, a filter will be applied, and the network request will include this new filter:
<img width="1671" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/df0197b2-6096-4b3b-907b-10cd33616aaf">

Clicking the button again removes the filter:
<img width="1671" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/aee7b505-07c5-426f-9323-801647b8e1c6">

Visit Platform CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/696d1968-2558-4f71-9d5c-d2dd631fd8b6)

Click the button in the top right, the button's text will change, and the network request will include this new filter:
<img width="1671" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/89501d00-3a60-46e9-97c1-c930d77a6e5e">

Clicking the button again removes the filter:
<img width="1671" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/208cf66f-5a87-4119-999e-81e7d0200fb5">
