### PR TITLE
ROX-23630: indicator pruning

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -39,19 +39,6 @@ const (
 		(SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND 	
 		(signal_time < now() AT time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time IS NULL)`
 
-	// deleteOrphanedProcesses select all process_indicators without
-	// associated deployments or pods. It does not scale for big deployments with million of rows
-	// in the table. If it fails repeatedly the postgres DB resources need to be reviewed,
-	// PostgresDefaultStatementTimeout increased, and a manual clean-up might be needed.
-	deleteOrphanedProcesses = `WITH orphan_proc AS 
-		(SELECT id FROM process_indicators pi WHERE NOT EXISTS 
-		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) 
-		UNION 
-		SELECT id FROM process_indicators pi WHERE NOT EXISTS 
-		(SELECT 1 FROM pods WHERE pi.poduid = pods.Id)) 
-		delete FROM process_indicators pi USING orphan_proc op WHERE pi.id = op.id AND 	
-		(signal_time < now() AT time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time IS NULL)`
-
 	// (snapshots.reportstatus_runstate = 2 OR snapshots.reportstatus_runstate = 3 OR snapshots.reportstatus_runstate = 4)
 	// ...gives us the report jobs that are in final state.
 	//

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -31,12 +31,12 @@ const (
 	getAllOrphanedNodes = `SELECT id FROM nodes WHERE NOT EXISTS
 		(SELECT 1 FROM clusters WHERE nodes.clusterid = clusters.Id)`
 
-	getOrphanedProcessesByDeployment = `SELECT id FROM process_indicators pi WHERE NOT EXISTS 
-		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND 	
+	getOrphanedProcessesByDeployment = `SELECT id FROM process_indicators pi WHERE NOT EXISTS
+		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND
 		(signal_time < now() AT time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time IS NULL)`
 
-	getOrphanedProcessesByPod = `SELECT id FROM process_indicators pi WHERE NOT EXISTS 
-		(SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND 	
+	getOrphanedProcessesByPod = `SELECT id FROM process_indicators pi WHERE NOT EXISTS
+		(SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND
 		(signal_time < now() AT time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time IS NULL)`
 
 	// (snapshots.reportstatus_runstate = 2 OR snapshots.reportstatus_runstate = 3 OR snapshots.reportstatus_runstate = 4)

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -420,11 +420,6 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			idsByPod, err := GetOrphanedProcessIDsByPod(s.ctx, s.testDB.DB, orphanWindow)
 			s.NoError(err)
 			idsToDelete = append(idsToDelete, idsByPod...)
-
-			log.Infof(c.name)
-			log.Infof("%v by deployment", idsToDelete)
-			log.Infof("%v by pod", idsByPod)
-			log.Infof("%v by compact", slices.Compact(idsToDelete))
 			slices.Sort(idsToDelete)
 			s.Require().Equal(len(c.expectedDeletions), len(slices.Compact(idsToDelete)))
 

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -396,29 +396,29 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			s.testDB = pgtest.ForT(s.T())
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			s.Nil(err)
+			s.Require().NoError(err)
 			for _, deploymentID := range c.deployments.AsSlice() {
-				s.NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
+				s.Require().NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
 			podDS, err := podStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			s.Nil(err)
+			s.Require().NoError(err)
 			for _, podID := range c.pods.AsSlice() {
 				err := podDS.UpsertPod(s.ctx, &storage.Pod{Id: podID, ClusterId: fixtureconsts.Cluster1})
-				s.Nil(err)
+				s.Require().NoError(err)
 			}
 
 			processDatastore, err := processIndicatorDatastore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			s.Nil(err)
-			s.NoError(processDatastore.AddProcessIndicators(s.ctx, c.initialProcesses...))
+			s.Require().NoError(err)
+			s.Require().NoError(processDatastore.AddProcessIndicators(s.ctx, c.initialProcesses...))
 			countFromDB, err := processDatastore.Count(s.ctx, nil)
-			s.NoError(err)
-			s.Equal(len(c.initialProcesses), countFromDB)
+			s.Require().NoError(err)
+			s.Require().Equal(len(c.initialProcesses), countFromDB)
 
 			idsToDelete, err := GetOrphanedProcessIDsByDeployment(s.ctx, s.testDB.DB, orphanWindow)
-			s.NoError(err)
+			s.Require().NoError(err)
 			idsByPod, err := GetOrphanedProcessIDsByPod(s.ctx, s.testDB.DB, orphanWindow)
-			s.NoError(err)
+			s.Require().NoError(err)
 			idsToDelete = append(idsToDelete, idsByPod...)
 			slices.Sort(idsToDelete)
 			s.Require().Equal(len(c.expectedDeletions), len(slices.Compact(idsToDelete)))
@@ -428,14 +428,14 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			for _, process := range c.initialProcesses {
 				cleanupIDs = append(cleanupIDs, process.Id)
 			}
-			s.NoError(processDatastore.RemoveProcessIndicators(s.ctx, cleanupIDs))
+			s.Require().NoError(processDatastore.RemoveProcessIndicators(s.ctx, cleanupIDs))
 
 			for _, deploymentID := range c.deployments.AsSlice() {
-				s.NoError(deploymentDS.RemoveDeployment(s.ctx, fixtureconsts.Cluster1, deploymentID))
+				s.Require().NoError(deploymentDS.RemoveDeployment(s.ctx, fixtureconsts.Cluster1, deploymentID))
 			}
 
 			for _, podID := range c.pods.AsSlice() {
-				s.NoError(podDS.RemovePod(s.ctx, podID))
+				s.Require().NoError(podDS.RemovePod(s.ctx, podID))
 			}
 
 		})

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -421,7 +421,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			s.Require().NoError(err)
 			idsToDelete = append(idsToDelete, idsByPod...)
 			slices.Sort(idsToDelete)
-			s.Require().Equal(len(c.expectedDeletions), len(slices.Compact(idsToDelete)))
+			s.Require().ElementsMatch(c.expectedDeletions, slices.Compact(idsToDelete))
 
 			// Cleanup
 			var cleanupIDs []string

--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -33,6 +33,7 @@ type DataStore interface {
 	AddProcessIndicators(context.Context, ...*storage.ProcessIndicator) error
 	RemoveProcessIndicatorsByPod(ctx context.Context, id string) error
 	RemoveProcessIndicators(ctx context.Context, ids []string) error
+	PruneProcessIndicators(ctx context.Context, ids []string) (int, error)
 
 	WalkAll(ctx context.Context, fn func(pi *storage.ProcessIndicator) error) error
 

--- a/central/processindicator/datastore/mocks/datastore.go
+++ b/central/processindicator/datastore/mocks/datastore.go
@@ -109,6 +109,21 @@ func (mr *MockDataStoreMockRecorder) GetProcessIndicators(ctx, ids any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessIndicators", reflect.TypeOf((*MockDataStore)(nil).GetProcessIndicators), ctx, ids)
 }
 
+// PruneProcessIndicators mocks base method.
+func (m *MockDataStore) PruneProcessIndicators(ctx context.Context, ids []string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PruneProcessIndicators", ctx, ids)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PruneProcessIndicators indicates an expected call of PruneProcessIndicators.
+func (mr *MockDataStoreMockRecorder) PruneProcessIndicators(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneProcessIndicators", reflect.TypeOf((*MockDataStore)(nil).PruneProcessIndicators), ctx, ids)
+}
+
 // RemoveProcessIndicators mocks base method.
 func (m *MockDataStore) RemoveProcessIndicators(ctx context.Context, ids []string) error {
 	m.ctrl.T.Helper()

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -381,12 +381,10 @@ func (g *garbageCollectorImpl) removeOrphanedProcesses() {
 		return
 	}
 
-	prunedIndicatorCount, err := g.removeProcesses(processesToRemove, "deployment")
+	deploymentIndicatorCount, err := g.removeProcesses(processesToRemove, "deployment")
 	if err != nil {
 		log.Errorf("[Pruning] Error removing processes orphaned by deployment: %v", err)
 	}
-	log.Infof("[Pruning] Deleted %d orphaned processes",
-		prunedIndicatorCount)
 
 	processesToRemove, err = postgres.GetOrphanedProcessIDsByPod(pruningCtx, g.postgres, orphanWindow)
 	if err != nil {
@@ -394,14 +392,13 @@ func (g *garbageCollectorImpl) removeOrphanedProcesses() {
 		return
 	}
 
-	prunedIndicatorCount, err = g.removeProcesses(processesToRemove, "pod")
+	podIndicatorCount, err := g.removeProcesses(processesToRemove, "pod")
 	if err != nil {
 		log.Errorf("[Pruning] Error removing processes orphaned by pod: %v", err)
 	}
-	log.Infof("[Pruning] Deleted %d orphaned processes",
-		prunedIndicatorCount)
 
-	log.Info("[Process pruning] Pruning of orphaned processes complete")
+	log.Infof("[Pruning] Pruning of orphaned processes complete.  Pruned %d orphaned processes (%d orphaned by deployments and %d orphaned by pods)",
+		deploymentIndicatorCount+podIndicatorCount, deploymentIndicatorCount, podIndicatorCount)
 }
 
 func (g *garbageCollectorImpl) removeProcesses(processesToRemove []string, processParent string) (int, error) {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -373,8 +373,46 @@ func (g *garbageCollectorImpl) removeOrphanedProcesses() {
 
 	log.Info("[PLOP pruning by processes] Pruning of orphaned PLOPs by processes complete")
 
-	postgres.PruneOrphanedProcessIndicators(pruningCtx, g.postgres, orphanWindow)
+	// Prune processes in chunks.  First get the ones orphaned by deployments and then go back and
+	// do the same for those orphaned by pod
+	processesToRemove, err := postgres.GetOrphanedProcessIDsByDeployment(pruningCtx, g.postgres, orphanWindow)
+	if err != nil {
+		log.Errorf("Error finding processes orphaned by deployment: %v", err)
+		return
+	}
+
+	prunedIndicatorCount, err := g.removeProcesses(processesToRemove, "deployment")
+	if err != nil {
+		log.Errorf("Error removing processes orphaned by deployment: %v", err)
+	}
+	log.Infof("[Pruning] Deleted %d orphaned processes",
+		prunedIndicatorCount)
+
+	processesToRemove, err = postgres.GetOrphanedProcessIDsByPod(pruningCtx, g.postgres, orphanWindow)
+	if err != nil {
+		log.Errorf("Error finding processes orphaned by pod: %v", err)
+		return
+	}
+
+	prunedIndicatorCount, err = g.removeProcesses(processesToRemove, "pod")
+	if err != nil {
+		log.Errorf("Error removing processes orphaned by pod: %v", err)
+	}
+	log.Infof("[Pruning] Deleted %d orphaned processes",
+		prunedIndicatorCount)
+
 	log.Info("[Process pruning] Pruning of orphaned processes complete")
+}
+
+func (g *garbageCollectorImpl) removeProcesses(processesToRemove []string, processParent string) (int, error) {
+	if len(processesToRemove) == 0 {
+		log.Infof("[Pruning] Found no processes orphaned by %s...", processParent)
+		return 0, nil
+	}
+	log.Infof("[Pruning] Found %d orphaned processes (from formerly deleted %s). Deleting...",
+		len(processesToRemove), processParent)
+
+	return g.processes.PruneProcessIndicators(pruningCtx, processesToRemove)
 }
 
 func (g *garbageCollectorImpl) removeOrphanedProcessBaselines(deployments set.FrozenStringSet) {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -377,26 +377,26 @@ func (g *garbageCollectorImpl) removeOrphanedProcesses() {
 	// do the same for those orphaned by pod
 	processesToRemove, err := postgres.GetOrphanedProcessIDsByDeployment(pruningCtx, g.postgres, orphanWindow)
 	if err != nil {
-		log.Errorf("Error finding processes orphaned by deployment: %v", err)
+		log.Errorf("[Pruning] Error finding processes orphaned by deployment: %v", err)
 		return
 	}
 
 	prunedIndicatorCount, err := g.removeProcesses(processesToRemove, "deployment")
 	if err != nil {
-		log.Errorf("Error removing processes orphaned by deployment: %v", err)
+		log.Errorf("[Pruning] Error removing processes orphaned by deployment: %v", err)
 	}
 	log.Infof("[Pruning] Deleted %d orphaned processes",
 		prunedIndicatorCount)
 
 	processesToRemove, err = postgres.GetOrphanedProcessIDsByPod(pruningCtx, g.postgres, orphanWindow)
 	if err != nil {
-		log.Errorf("Error finding processes orphaned by pod: %v", err)
+		log.Errorf("[Pruning] Error finding processes orphaned by pod, could not prune process indicators: %v", err)
 		return
 	}
 
 	prunedIndicatorCount, err = g.removeProcesses(processesToRemove, "pod")
 	if err != nil {
-		log.Errorf("Error removing processes orphaned by pod: %v", err)
+		log.Errorf("[Pruning] Error removing processes orphaned by pod: %v", err)
 	}
 	log.Infof("[Pruning] Deleted %d orphaned processes",
 		prunedIndicatorCount)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1299,11 +1299,8 @@ func (s *PruningTestSuite) TestRemoveOrphanedProcesses() {
 			s.Nil(err)
 			s.NoError(actualProcessDatastore.AddProcessIndicators(s.ctx, c.initialProcesses...))
 
+			processes.EXPECT().PruneProcessIndicators(pruningCtx, c.expectedDeletions).AnyTimes()
 			gci.removeOrphanedProcesses()
-
-			countFromDB, err := actualProcessDatastore.Count(s.ctx, nil)
-			s.NoError(err)
-			s.Equal(len(c.initialProcesses)-len(c.expectedDeletions), countFromDB)
 
 			db.Teardown(t)
 		})


### PR DESCRIPTION
## Description

Indicator pruning has become all or nothing.  Additionally changes to `DeleteMany` made using that an all or nothing as one batch was used for all transactions.  This PR is meant to chunk the deletion of process indicators.

The idea is to get the indicators orphaned by deleted deployments and prune those indicators.
Then get the indicators orphaned by deleted pods and prune those indicators.

Additionally an error with a batch should not stop all pruning, we should just move on to the next batch.  If there are issues, any pruning we can successfully complete is less we have to prune later.  If we keep the all or nothing approach, if the database begins to have issues with pruning, the problem snowballs as each pruning interval we have to prune the failed intervals records plus all the new ones we need to prune.  This should help keep the database from falling markedly behind when pruning process indicators.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
