### PR TITLE
fix: hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ Then go to https://localhost:8000/ in your web browser.
 
 - **E2E Dev Docs**: Refer to [qa-tests-backend/README.md](./qa-tests-backend/README.md)
 
-- **Pull request guidelines**: [contributing.md](./github/contributing.md)
+- **Pull request guidelines**: [contributing.md](./.github/contributing.md)
 
-- **Go coding style guide**: [go-coding-style.md](./github/go-coding-style.md) 
+- **Go coding style guide**: [go-coding-style.md](./.github/go-coding-style.md) 
 
 ### Quickstart
 


### PR DESCRIPTION
## Description

The hyperlinks to `contributing.md` and `go-coding-style.md` are changed from `github/<filename>` to `.github/<filename>`. Those hyperlinks are now functional.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The files `contributing.md` and `go-coding-style.md` are located in `.github/` instead of `github/`
```sh
# ls .github/*.md
.github/api_guidelines.md        .github/contributing.md          .github/go-coding-style.md       .github/pull_request_template.md
```