### PR TITLE
ROX-23308: fetch metrics from image prefetcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ $(call go-tool, PROTOLOCK_BIN, github.com/nilslice/protolock/cmd/protolock, tool
 $(call go-tool, GOVULNCHECK_BIN, golang.org/x/vuln/cmd/govulncheck, tools/linters)
 $(call go-tool, IMAGE_PREFETCHER_DEPLOY, github.com/stackrox/image-prefetcher/deploy, tools/test)
 
+IMAGE_PREFETCHER_DEPLOY_VERSION = $(shell go -C tools/test list -m -f '{{.Version}}' github.com/stackrox/image-prefetcher/deploy)
+
 ###########
 ## Style ##
 ###########
@@ -819,7 +821,7 @@ bootstrap_migration:
 
 .PHONY: image-prefetcher-start
 image-prefetcher-start: $(IMAGE_PREFETCHER_DEPLOY)
-	. scripts/ci/lib.sh; image_prefetcher_start stackrox-images $(IMAGE_PREFETCHER_DEPLOY)
+	. scripts/ci/lib.sh; image_prefetcher_start stackrox-images $(IMAGE_PREFETCHER_DEPLOY) $(IMAGE_PREFETCHER_DEPLOY_VERSION)
 
 .PHONY: image-prefetcher-await
 image-prefetcher-await:

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -6,5 +6,7 @@ toolchain go1.21.7
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
-	github.com/stackrox/image-prefetcher/deploy v0.1.0
+	github.com/stackrox/image-prefetcher/deploy v0.2.0
 )
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/tools/test/go.sum
+++ b/tools/test/go.sum
@@ -1,6 +1,7 @@
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
 github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
-github.com/stackrox/image-prefetcher/deploy v0.1.0 h1:BiTtiI6dOwLkjPf0NcRuS7M7DmbntQngupH1KdVRfe8=
-github.com/stackrox/image-prefetcher/deploy v0.1.0/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=
+github.com/stackrox/image-prefetcher/deploy v0.2.0 h1:8Mpkv9KoUy1L0QIymycgxOkGn77BsNwoQ5HVof4+SQY=
+github.com/stackrox/image-prefetcher/deploy v0.2.0/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=


### PR DESCRIPTION
## Description

This works, but requires a few more things before merge, see checklist.

One word regarding the false-positive GitGuardian check: it seems to be interpreting a `--secret=blah` flag as if `blah` is a secret string, while in fact in this case `blah` is just a name of a Kubernetes `Secret` resource! I was digging for at least 10 minutes on how to mark this as a false positive in the source code, but came back with nothing. Maybe we're doomed to click the false positive button 🤷🏻 

## Checklist
- [x] Get https://github.com/stackrox/automation-iac/pull/107 merged and the table updated
- [x] Get https://github.com/stackrox/image-prefetcher/pull/12 merged
- [x] Add `v0.2.0` and `deploy/v.0.2.0` tags to image prefetcher repo
- [x] Update `require` lines in `tools/test/go.mod` and the `$image_prefetcher_version` in `scripts/ci/lib.sh` to match
- [x] Run the batch import workflow
- [x] Make sure the data appears in the table
  ![image](https://github.com/stackrox/stackrox/assets/489420/b0162dff-b319-4800-b157-cf4ff2f82dc1)
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI (`*-operator-e2e-tests` jobs) should be enough, with additional manual inspection of loaded data as mentioned in the checklist above.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
