### PR TITLE
fix(ui): Fix a handful of minor visual issues in VM 2.0

### DIFF
--- a/ui/apps/platform/src/Components/DynamicIcon.tsx
+++ b/ui/apps/platform/src/Components/DynamicIcon.tsx
@@ -18,7 +18,7 @@ export function DynamicColumnIcon() {
 export function DynamicTableLabel() {
     return (
         <Tooltip content="You are viewing a filtered set of table rows. Column values may also be changed to match the applied filters.">
-            <Label color="blue" icon={<DynamicIcon />}>
+            <Label color="blue" icon={<DynamicIcon />} isCompact>
                 Filtered view
             </Label>
         </Tooltip>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -23,7 +23,7 @@ import { gql, useQuery } from '@apollo/client';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { getTableUIState } from 'utils/getTableUIState';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
@@ -125,8 +125,7 @@ function NamespaceViewPage() {
                 ...defaultSearchFilters,
             }),
             pagination: {
-                limit: perPage,
-                offset: page - 1,
+                ...getPaginationParams(page, perPage),
                 sortOption,
             },
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -111,36 +111,38 @@ function CVEsTableContainer({
                 isFiltered={isFiltered}
             >
                 {canSelectRows && (
-                    <ToolbarItem align={{ default: 'alignRight' }}>
-                        <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
-                            <DropdownItem
-                                key="bulk-defer-cve"
-                                component="button"
-                                onClick={() =>
-                                    showModal({
-                                        type: 'DEFERRAL',
-                                        cves: Array.from(selectedCves.values()),
-                                    })
-                                }
-                            >
-                                Defer CVEs
-                            </DropdownItem>
-                            <DropdownItem
-                                key="bulk-mark-false-positive"
-                                component="button"
-                                onClick={() =>
-                                    showModal({
-                                        type: 'FALSE_POSITIVE',
-                                        cves: Array.from(selectedCves.values()),
-                                    })
-                                }
-                            >
-                                Mark as false positives
-                            </DropdownItem>
-                        </BulkActionsDropdown>
-                    </ToolbarItem>
+                    <>
+                        <ToolbarItem align={{ default: 'alignRight' }}>
+                            <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                                <DropdownItem
+                                    key="bulk-defer-cve"
+                                    component="button"
+                                    onClick={() =>
+                                        showModal({
+                                            type: 'DEFERRAL',
+                                            cves: Array.from(selectedCves.values()),
+                                        })
+                                    }
+                                >
+                                    Defer CVEs
+                                </DropdownItem>
+                                <DropdownItem
+                                    key="bulk-mark-false-positive"
+                                    component="button"
+                                    onClick={() =>
+                                        showModal({
+                                            type: 'FALSE_POSITIVE',
+                                            cves: Array.from(selectedCves.values()),
+                                        })
+                                    }
+                                >
+                                    Mark as false positives
+                                </DropdownItem>
+                            </BulkActionsDropdown>
+                        </ToolbarItem>
+                        <ToolbarItem align={{ default: 'alignRight' }} variant="separator" />
+                    </>
                 )}
-                <ToolbarItem align={{ default: 'alignRight' }} variant="separator" />
             </TableEntityToolbar>
             <Divider component="div" />
             {loading && !tableData && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.css
@@ -1,0 +1,8 @@
+/*
+  Each child label is wrapped in a Tooltip, which as of PF5 has the style `display: contents;` applied
+  in a way that can not be overridden via props. This prevents us from rendering the children with
+  any sort of layout, so we need to override the display property here.
+*/
+.severity-count-labels > div {
+  display: inline !important;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
@@ -7,6 +7,8 @@ import { noViolationsClassName, noViolationsColor } from 'constants/severityColo
 
 import { VulnerabilitySeverityLabel } from '../types';
 
+import './SeverityCountLabels.css';
+
 type SeverityCountLabelsProps = {
     criticalCount: number;
     importantCount: number;
@@ -55,7 +57,11 @@ function SeverityCountLabels({
     const low = isLowHidden ? undefined : lowCount;
 
     return (
-        <Flex spaceItems={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+        <Flex
+            className="severity-count-labels"
+            spaceItems={{ default: 'spaceItemsSm' }}
+            flexWrap={{ default: 'nowrap' }}
+        >
             <Tooltip content={getTooltipContent('critical', critical, entity)}>
                 <Label
                     aria-label={getTooltipContent('critical', critical, entity)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
@@ -43,7 +43,7 @@ function TableEntityToolbar({
                 <ToolbarContent>
                     <ToolbarItem>{entityToggleGroup}</ToolbarItem>
                     {isFiltered && (
-                        <ToolbarItem>
+                        <ToolbarItem alignSelf="center">
                             <DynamicTableLabel />
                         </ToolbarItem>
                     )}


### PR DESCRIPTION
## Description

Fixes assorted minor visual issues in VM 2.0. Descriptions in testing section below.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. The `<Divider>` element to the right of the Bulk Actions dropdown was not within the conditionally rendered block, so it previously would show up in Deferred and False Positive tabs:
![image](https://github.com/stackrox/stackrox/assets/1292638/aa3e34b7-9f0a-42eb-aeeb-8c01cddf7153)
![image](https://github.com/stackrox/stackrox/assets/1292638/ed33fdb7-b254-432a-b3b7-8117642a564c)


2. Fixes the spacing between severity count labels that was a regression after upgrading to PF5:
![image](https://github.com/stackrox/stackrox/assets/1292638/18017cc9-de68-4960-b6cb-8d0fc00d9b81)

3. Changes the "Filtered view" label to the compact variant to match the mocks, and fixes the vertical centering:
![image](https://github.com/stackrox/stackrox/assets/1292638/b09711a5-0aaf-4e30-94da-87c3059b05d3)

4. Fixes the pagination offset in the namespace view that previously would only increment the offset by `1` on each page:
![image](https://github.com/stackrox/stackrox/assets/1292638/92f3d38e-2007-4c9b-9db8-bc998de07def)
![image](https://github.com/stackrox/stackrox/assets/1292638/776f0479-0957-4397-aa02-9bbc747a6ba4)


