### PR TITLE
ROX-22475: add `--fail` flag to `roxctl image scan`

### DIFF
--- a/roxctl/image/scan/cve.go
+++ b/roxctl/image/scan/cve.go
@@ -46,6 +46,14 @@ type cveJSONResult struct {
 	Result cveJSONStructure `json:"result"`
 }
 
+func (c *cveJSONResult) CountVulnerabilities() int {
+	return c.Result.Summary[totalVulnerabilitiesMapKey]
+}
+
+func (c *cveJSONResult) CountComponents() int {
+	return c.Result.Summary[totalComponentsMapKey]
+}
+
 type cveJSONStructure struct {
 	Summary         map[string]int         `json:"summary"`
 	Vulnerabilities []cveVulnerabilityJSON `json:"vulnerabilities,omitempty"`

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -141,7 +141,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		importantCVESeverity.String(),
 		criticalCVESeverity.String(),
 	}, "List of severities to include in the output. Use this to filter for specific severities")
-	c.Flags().BoolVarP(&imageScanCmd.failOnFinding, "fail", "F", false, "Fail if vulnerabilities have been found")
+	c.Flags().BoolVarP(&imageScanCmd.failOnFinding, "fail", "", false, "Fail if vulnerabilities have been found")
 
 	// Deprecated flag
 	// TODO(ROX-8303): Remove this once we have fully deprecated the old output format and are sure we do not break existing customer scripts
@@ -246,7 +246,7 @@ func (i *imageScanCommand) Scan() error {
 		retry.Tries(i.retryCount+1),
 		retry.OnlyRetryableErrors(),
 		retry.OnFailedAttempts(func(err error) {
-			failedAttempts += 1
+			failedAttempts++
 			i.env.Logger().ErrfLn("Scanning image failed: %v. Retrying after %v seconds...", err, i.retryDelay)
 			time.Sleep(time.Duration(i.retryDelay) * time.Second)
 		}),

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -141,6 +141,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		importantCVESeverity.String(),
 		criticalCVESeverity.String(),
 	}, "List of severities to include in the output. Use this to filter for specific severities")
+	c.Flags().BoolVarP(&imageScanCmd.failOnFinding, "fail", "F", false, "Fail if vulnerabilities have been found")
 
 	// Deprecated flag
 	// TODO(ROX-8303): Remove this once we have fully deprecated the old output format and are sure we do not break existing customer scripts
@@ -165,6 +166,7 @@ type imageScanCommand struct {
 	timeout        time.Duration
 	cluster        string
 	severities     []string
+	failOnFinding  bool
 
 	// injected or constructed values
 	env                environment.Environment
@@ -217,8 +219,12 @@ func (i *imageScanCommand) Validate() error {
 		}
 	}
 
-	validSeverities := []string{lowCVESeverity.String(),
-		moderateCVESeverity.String(), importantCVESeverity.String(), criticalCVESeverity.String()}
+	validSeverities := []string{
+		lowCVESeverity.String(),
+		moderateCVESeverity.String(),
+		importantCVESeverity.String(),
+		criticalCVESeverity.String(),
+	}
 
 	for _, severity := range i.severities {
 		severity := strings.ToUpper(severity)
@@ -233,18 +239,23 @@ func (i *imageScanCommand) Validate() error {
 
 // Scan will execute the image scan with retry functionality
 func (i *imageScanCommand) Scan() error {
+	var failedAttempts int
 	err := retry.WithRetry(func() error {
 		return i.scanImage()
 	},
 		retry.Tries(i.retryCount+1),
 		retry.OnlyRetryableErrors(),
 		retry.OnFailedAttempts(func(err error) {
+			failedAttempts += 1
 			i.env.Logger().ErrfLn("Scanning image failed: %v. Retrying after %v seconds...", err, i.retryDelay)
 			time.Sleep(time.Duration(i.retryDelay) * time.Second)
 		}),
 	)
 	if err != nil {
-		return errors.Wrapf(err, "scanning image failed after %d retries", i.retryCount)
+		if failedAttempts > 0 {
+			return errors.Wrapf(err, "image scan failed after %d retries", failedAttempts)
+		}
+		return errors.Wrap(err, "image scan failed")
 	}
 	return nil
 }
@@ -300,9 +311,11 @@ func (i *imageScanCommand) printImageResult(imageResult *storage.Image) error {
 	}
 
 	if !i.standardizedFormat {
-		printCVEWarning(cveSummary.Result.Summary[totalVulnerabilitiesMapKey],
-			cveSummary.Result.Summary[totalComponentsMapKey],
-			i.env.Logger())
+		printCVEWarning(cveSummary.CountVulnerabilities(), cveSummary.CountComponents(), i.env.Logger())
+	}
+
+	if cveCount := cveSummary.CountVulnerabilities(); i.failOnFinding && cveCount > 0 {
+		return newErrVulnerabilityFound(cveCount)
 	}
 	return nil
 }

--- a/roxctl/image/scan/scan_errors.go
+++ b/roxctl/image/scan/scan_errors.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -10,5 +12,5 @@ var errVulnerabilityFound = errors.New("vulnerabilities found")
 // newErrVulnerabilityFound creates an errVulnerabilityFound with the number of vulnerabilities
 // in the explanation.
 func newErrVulnerabilityFound(num int) error {
-	return errors.WithMessagef(errVulnerabilityFound, "found %d vulnerabilities", num)
+	return fmt.Errorf("%w: %d vulnerabilities", errVulnerabilityFound, num)
 }

--- a/roxctl/image/scan/scan_errors.go
+++ b/roxctl/image/scan/scan_errors.go
@@ -1,0 +1,14 @@
+package scan
+
+import (
+	"github.com/pkg/errors"
+)
+
+// errVulnerabilityFound occurs if an image scan reveals at least one vulnerability.
+var errVulnerabilityFound = errors.New("vulnerabilities found")
+
+// newErrVulnerabilityFound creates an errVulnerabilityFound with the number of vulnerabilities
+// in the explanation.
+func newErrVulnerabilityFound(num int) error {
+	return errors.WithMessagef(errVulnerabilityFound, "found %d vulnerabilities", num)
+}

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -264,8 +264,12 @@ func (s *imageScanTestSuite) SetupTest() {
 		retryDelay: 3,
 		retryCount: 3,
 		timeout:    1 * time.Minute,
-		severities: []string{lowCVESeverity.String(), moderateCVESeverity.String(), importantCVESeverity.String(),
-			criticalCVESeverity.String()},
+		severities: []string{
+			lowCVESeverity.String(),
+			moderateCVESeverity.String(),
+			importantCVESeverity.String(),
+			criticalCVESeverity.String(),
+		},
 	}
 }
 
@@ -439,6 +443,8 @@ func (s *imageScanTestSuite) TestValidate() {
 
 type outputFormatTest struct {
 	components                   []*storage.EmbeddedImageScanComponent
+	failOnFinding                bool
+	error                        error
 	expectedOutput               string
 	expectedErrorOutput          string
 	expectedErrorOutputColorized string
@@ -448,6 +454,14 @@ func (s *imageScanTestSuite) TestScan_TableOutput() {
 	cases := map[string]outputFormatTest{
 		"should render default output with merged cells and additional verbose output": {
 			components:                   testComponents,
+			expectedOutput:               "testComponents.txt",
+			expectedErrorOutput:          "WARN:\tA total of 11 unique vulnerabilities were found in 5 components\n",
+			expectedErrorOutputColorized: "\x1b[95mWARN:\tA total of 11 unique vulnerabilities were found in 5 components\n\x1b[0m",
+		},
+		"should return a vulnerability found error": {
+			components:                   testComponents,
+			failOnFinding:                true,
+			error:                        errVulnerabilityFound,
 			expectedOutput:               "testComponents.txt",
 			expectedErrorOutput:          "WARN:\tA total of 11 unique vulnerabilities were found in 5 components\n",
 			expectedErrorOutputColorized: "\x1b[95mWARN:\tA total of 11 unique vulnerabilities were found in 5 components\n\x1b[0m",
@@ -471,6 +485,12 @@ func (s *imageScanTestSuite) TestScan_JSONOutput() {
 			components:     testComponents,
 			expectedOutput: "testComponents.json",
 		},
+		"should return a vulnerability found error": {
+			components:     testComponents,
+			failOnFinding:  true,
+			error:          errVulnerabilityFound,
+			expectedOutput: "testComponents.json",
+		},
 		"should print nothing with empty components in image scan": {
 			components:     nil,
 			expectedOutput: "empty.json",
@@ -489,6 +509,12 @@ func (s *imageScanTestSuite) TestScan_CSVOutput() {
 	cases := map[string]outputFormatTest{
 		"should render default output without additional verbose output": {
 			components:     testComponents,
+			expectedOutput: "testComponents.csv",
+		},
+		"should return a vulnerability found error": {
+			components:     testComponents,
+			failOnFinding:  true,
+			error:          errVulnerabilityFound,
 			expectedOutput: "testComponents.csv",
 		},
 		"should print only headers with empty components in image scan": {
@@ -539,7 +565,7 @@ func (s *imageScanTestSuite) runOutputTests(cases map[string]outputFormatTest, p
 			defer closeF()
 
 			err := imgScanCmd.Scan()
-			s.Require().NoError(err)
+			s.assertError(err, c)
 			expectedOutput, err := os.ReadFile(path.Join("testdata", c.expectedOutput))
 			s.Require().NoError(err)
 			s.Assert().Equal(string(expectedOutput), out.String())
@@ -555,12 +581,21 @@ func (s *imageScanTestSuite) runOutputTests(cases map[string]outputFormatTest, p
 			defer closeF()
 
 			err := imgScanCmd.Scan()
-			s.Require().NoError(err)
+			s.assertError(err, c)
 			expectedOutput, err := os.ReadFile(path.Join("testdata", colorTestPrefix+c.expectedOutput))
 			s.Require().NoError(err)
 			s.Assert().Equal(string(expectedOutput), out.String())
 			s.Assert().Equal(c.expectedErrorOutputColorized, errOut.String())
 		})
+	}
+}
+
+func (s *imageScanTestSuite) assertError(err error, c outputFormatTest) {
+	if c.failOnFinding {
+		s.Require().Error(err)
+		s.Assert().ErrorIs(err, c.error)
+	} else {
+		s.Require().NoError(err)
 	}
 }
 
@@ -572,6 +607,7 @@ func (s *imageScanTestSuite) createImgScanCmd(c outputFormatTest, printer printe
 	imgScanCmd.printer = printer
 	imgScanCmd.standardizedFormat = standardizedFormat
 	imgScanCmd.env, out, errOut = s.newTestMockEnvironmentWithConn(conn)
+	imgScanCmd.failOnFinding = c.failOnFinding
 	return out, errOut, closeF, imgScanCmd
 }
 

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -565,7 +565,7 @@ func (s *imageScanTestSuite) runOutputTests(cases map[string]outputFormatTest, p
 			defer closeF()
 
 			err := imgScanCmd.Scan()
-			s.assertError(err, c)
+			s.Assert().ErrorIs(err, c.error)
 			expectedOutput, err := os.ReadFile(path.Join("testdata", c.expectedOutput))
 			s.Require().NoError(err)
 			s.Assert().Equal(string(expectedOutput), out.String())
@@ -581,21 +581,12 @@ func (s *imageScanTestSuite) runOutputTests(cases map[string]outputFormatTest, p
 			defer closeF()
 
 			err := imgScanCmd.Scan()
-			s.assertError(err, c)
+			s.Assert().ErrorIs(err, c.error)
 			expectedOutput, err := os.ReadFile(path.Join("testdata", colorTestPrefix+c.expectedOutput))
 			s.Require().NoError(err)
 			s.Assert().Equal(string(expectedOutput), out.String())
 			s.Assert().Equal(c.expectedErrorOutputColorized, errOut.String())
 		})
-	}
-}
-
-func (s *imageScanTestSuite) assertError(err error, c outputFormatTest) {
-	if c.failOnFinding {
-		s.Require().Error(err)
-		s.Assert().ErrorIs(err, c.error)
-	} else {
-		s.Require().NoError(err)
 	}
 }
 


### PR DESCRIPTION
## Description

Add a new flag `--fail`, which if enabled, causes `roxctl image scan` to fail if vulnerabilities have been found. The number of vulnerabilities is indicated in the error message and `roxctl` exits with code 1. If no vulnerabilities are found, `roxctl` exits normally with code 0.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

see CI

```
roxctl image scan --fail --image=quay.io/rhacs-eng/main:4.4.1 -o table

WARN:	A total of 2 unique vulnerabilities were found in 2 components
ERROR:	image scan failed: vulnerabilities found: found 2 vulnerabilities
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
