### PR TITLE
feat(listener): Shutdown shared informers synchronously

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -82,16 +82,25 @@ func managedFieldsTransformer(obj interface{}) (interface{}, error) {
 func (k *listenerImpl) handleAllEvents() {
 	defer k.mayCreateHandlers.Signal()
 	sif := informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
+	concurrency.WithLock(&k.sifLock, func() {
+		k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, sif)
+	})
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory
 	if k.client.OpenshiftApps() != nil {
 		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), noResyncPeriod)
+		concurrency.WithLock(&k.sifLock, func() {
+			k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osAppsFactory)
+		})
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
 	if k.client.OpenshiftRoute() != nil {
 		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), noResyncPeriod)
+		concurrency.WithLock(&k.sifLock, func() {
+			k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osRouteFactory)
+		})
 	}
 
 	// We want creates to be treated as updates while existing objects are loaded.
@@ -104,7 +113,11 @@ func (k *listenerImpl) handleAllEvents() {
 	var crdSharedInformerFactory dynamicinformer.DynamicSharedInformerFactory
 	var complianceResultInformer, complianceProfileInformer, complianceTailoredProfileInformer, complianceScanSettingBindingsInformer, complianceRuleInformer, complianceScanInformer, complianceSuiteInformer, complianceRemediationInformer cache.SharedIndexInformer
 	var profileLister cache.GenericLister
-	crdWatcher := crd.NewCRDWatcher(&k.stopSig, dynamicinformer.NewDynamicSharedInformerFactory(k.client.Dynamic(), noResyncPeriod))
+	dynamicSif := dynamicinformer.NewDynamicSharedInformerFactory(k.client.Dynamic(), noResyncPeriod)
+	concurrency.WithLock(&k.sifLock, func() {
+		k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, dynamicSif)
+	})
+	crdWatcher := crd.NewCRDWatcher(&k.stopSig, dynamicSif)
 	coAvailabilityChecker := complianceOperatorAvailabilityChecker.NewComplianceOperatorAvailabilityChecker()
 	if err := coAvailabilityChecker.AppendToCRDWatcher(crdWatcher); err != nil {
 		log.Errorf("Unable to add the Resource to the CRD Watcher: %v", err)
@@ -128,6 +141,9 @@ func (k *listenerImpl) handleAllEvents() {
 	if coAvailabilityChecker.Available(k.client) {
 		log.Info("initializing compliance operator informers")
 		crdSharedInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(k.client.Dynamic(), noResyncPeriod)
+		concurrency.WithLock(&k.sifLock, func() {
+			k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, crdSharedInformerFactory)
+		})
 		complianceResultInformer = crdSharedInformerFactory.ForResource(complianceoperator.ComplianceCheckResult.GroupVersionResource()).Informer()
 		complianceProfileInformer = crdSharedInformerFactory.ForResource(complianceoperator.Profile.GroupVersionResource()).Informer()
 		profileLister = crdSharedInformerFactory.ForResource(complianceoperator.Profile.GroupVersionResource()).Lister()
@@ -198,6 +214,9 @@ func (k *listenerImpl) handleAllEvents() {
 			log.Errorf("Checking API resources for group %q: %v", osConfigGroupVersion, err)
 		} else {
 			osConfigFactory = osConfigExtVersions.NewSharedInformerFactory(k.client.OpenshiftConfig(), noResyncPeriod)
+			concurrency.WithLock(&k.sifLock, func() {
+				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osConfigFactory)
+			})
 
 			if listenerUtils.ResourceExists(resourceList, osClusterOperatorsResourceName, osConfigGroupVersion) {
 				log.Infof("Initializing %q informer", osClusterOperatorsResourceName)
@@ -224,6 +243,9 @@ func (k *listenerImpl) handleAllEvents() {
 			log.Errorf("Checking API resources for group %q: %v", osOperatorAlphaGroupVersion, err)
 		} else {
 			osOperatorFactory = osOperatorExtVersions.NewSharedInformerFactory(k.client.OpenshiftOperator(), noResyncPeriod)
+			concurrency.WithLock(&k.sifLock, func() {
+				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osOperatorFactory)
+			})
 
 			if listenerUtils.ResourceExists(resourceList, osImageContentSourcePoliciesResourceName, osOperatorAlphaGroupVersion) {
 				log.Infof("Initializing %q informer", osImageContentSourcePoliciesResourceName)


### PR DESCRIPTION
## Description

Sensor does not wait for the informers to be stopped before attempting to create them again, it simply triggers a stop signal that should (eventually) stop them. This could make [this function](https://github.com/stackrox/stackrox/blob/1652234a402221333b96505cda5cbb192aed230a/sensor/kubernetes/listener/resource_event_handler.go#L387) to fail if the informers are not fully stopped before starting them again. This PR aims to add a shutdown logic and waits for the informers to be fully stopped.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] Manually tested sensor connection/reconnections to central. This should trigger the stopping/starting logic of informers and observe no panics occur.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
