### PR TITLE
test: Fix awk syntax error.

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -481,7 +481,7 @@ poll_for_system_test_images() {
     local image_list
     image_list="$(mktemp)"
     populate_image_list "${image_list}"
-    info "Will poll for: $(awk 'print $1' "${image_list}")"
+    info "Will poll for: $(awk '{print $1}' "${image_list}")"
 
     local start_time
     start_time="$(date '+%s')"


### PR DESCRIPTION
## Description

Example:
```
INFO: Wed May 8 10:01:20 UTC 2024: Polling for images required for system tests
awk: cmd. line:1: print $1
awk: cmd. line:1: ^ syntax error
INFO: Wed May 8 10:01:20 UTC 2024: Will poll for:
```

Introduced in #10750 🤦🏻 

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] inspected logs from CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
