### PR TITLE
feat(ui): Add platform CVE row actions

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { platformEntityTabValues } from '../../types';
-import useCanSnoozeCves from '../../hooks/useCanSnoozeCves';
+import useHasLegacySnoozeAbility from '../../hooks/useCanSnoozeCves';
 
 import ClustersTable from './ClustersTable';
 import CVEsTable from './CVEsTable';
@@ -40,7 +40,7 @@ function PlatformCvesOverviewPage() {
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const isViewingSnoozedCves = querySearchFilter['CVE Snoozed'] === 'true';
-    const canSnoozeCves = useCanSnoozeCves();
+    const canSnoozeCves = useHasLegacySnoozeAbility();
     const selectedCves = useMap<string, { cve: string }>();
 
     function onEntityTabChange() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -7,7 +7,9 @@ import {
     FlexItem,
     Card,
     CardBody,
+    ToolbarItem,
 } from '@patternfly/react-core';
+import { DropdownItem } from '@patternfly/react-core/deprecated';
 
 import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
@@ -16,10 +18,13 @@ import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
+import useMap from 'hooks/useMap';
+import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { platformEntityTabValues } from '../../types';
+import useCanSnoozeCves from '../../hooks/useCanSnoozeCves';
 
 import ClustersTable from './ClustersTable';
 import CVEsTable from './CVEsTable';
@@ -33,6 +38,10 @@ function PlatformCvesOverviewPage() {
     // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
     const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
+
+    const isViewingSnoozedCves = querySearchFilter['CVE Snoozed'] === 'true';
+    const canSnoozeCves = useCanSnoozeCves();
+    const selectedCves = useMap<string, { cve: string }>();
 
     function onEntityTabChange() {
         pagination.setPage(1);
@@ -82,13 +91,32 @@ function PlatformCvesOverviewPage() {
                                     : entityCounts.Cluster
                             }
                             isFiltered={isFiltered}
-                        />
+                        >
+                            {canSnoozeCves && (
+                                <ToolbarItem align={{ default: 'alignRight' }}>
+                                    <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                                        <DropdownItem
+                                            key="bulk-snooze-cve"
+                                            component="button"
+                                            onClick={() => {
+                                                // TODO
+                                            }}
+                                        >
+                                            {isViewingSnoozedCves ? 'Unsnooze CVEs' : 'Snooze CVEs'}
+                                        </DropdownItem>
+                                    </BulkActionsDropdown>
+                                </ToolbarItem>
+                            )}
+                        </TableEntityToolbar>
                         <Divider component="div" />
                         {activeEntityTabKey === 'CVE' && (
                             <CVEsTable
                                 querySearchFilter={querySearchFilter}
                                 isFiltered={isFiltered}
                                 pagination={pagination}
+                                selectedCves={selectedCves}
+                                canSelectRows={canSnoozeCves}
+                                createRowActions={() => []}
                             />
                         )}
                         {activeEntityTabKey === 'Cluster' && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { parseWorkloadQuerySearchFilter } from '../../utils/searchUtils';
 import { platformEntityTabValues } from '../../types';
-import useHasLegacySnoozeAbility from '../../hooks/useCanSnoozeCves';
+import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 
 import ClustersTable from './ClustersTable';
 import CVEsTable from './CVEsTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -40,7 +40,7 @@ function PlatformCvesOverviewPage() {
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const isViewingSnoozedCves = querySearchFilter['CVE Snoozed'] === 'true';
-    const canSnoozeCves = useHasLegacySnoozeAbility();
+    const hasLegacySnoozeAbility = useHasLegacySnoozeAbility();
     const selectedCves = useMap<string, { cve: string }>();
 
     function onEntityTabChange() {
@@ -92,7 +92,7 @@ function PlatformCvesOverviewPage() {
                             }
                             isFiltered={isFiltered}
                         >
-                            {canSnoozeCves && (
+                            {hasLegacySnoozeAbility && (
                                 <ToolbarItem align={{ default: 'alignRight' }}>
                                     <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
                                         <DropdownItem
@@ -115,7 +115,7 @@ function PlatformCvesOverviewPage() {
                                 isFiltered={isFiltered}
                                 pagination={pagination}
                                 selectedCves={selectedCves}
-                                canSelectRows={canSnoozeCves}
+                                canSelectRows={hasLegacySnoozeAbility}
                                 createRowActions={() => []}
                             />
                         )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -35,8 +35,8 @@ import {
 import EmptyTableResults from '../components/EmptyTableResults';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
-import CVESelectionTh from '../components/CVESelectionTh';
-import CVESelectionTd from '../components/CVESelectionTd';
+import CVESelectionTh from '../../components/CVESelectionTh';
+import CVESelectionTd from '../../components/CVESelectionTd';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -227,9 +227,11 @@ function CVEsTable({
                                     <CVESelectionTd
                                         selectedCves={selectedCves}
                                         rowIndex={rowIndex}
-                                        cve={cve}
-                                        summary={summary}
-                                        numAffectedImages={affectedImageCount}
+                                        item={{
+                                            cve,
+                                            summary,
+                                            numAffectedImages: affectedImageCount,
+                                        }}
                                     />
                                 )}
                                 <Td dataLabel="CVE" modifier="nowrap">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -34,8 +34,8 @@ import ImageComponentVulnerabilitiesTable, {
 import EmptyTableResults from '../components/EmptyTableResults';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
-import CVESelectionTh from '../components/CVESelectionTh';
-import CVESelectionTd from '../components/CVESelectionTd';
+import CVESelectionTh from '../../components/CVESelectionTh';
+import CVESelectionTd from '../../components/CVESelectionTd';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -162,9 +162,7 @@ function ImageVulnerabilitiesTable({
                                     <CVESelectionTd
                                         selectedCves={selectedCves}
                                         rowIndex={rowIndex}
-                                        cve={cve}
-                                        summary={summary}
-                                        numAffectedImages={1}
+                                        item={{ cve, summary, numAffectedImages: 1 }}
                                     />
                                 )}
                                 <Td dataLabel="CVE" modifier="nowrap">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
@@ -3,23 +3,18 @@ import { Td } from '@patternfly/react-table';
 
 import useMap from 'hooks/useMap';
 
-export type CVESelectionTdProps = {
-    selectedCves: ReturnType<
-        typeof useMap<string, { cve: string; summary: string; numAffectedImages: number }>
-    >;
+export type CVESelectionTdProps<T extends { cve: string }> = {
+    selectedCves: ReturnType<typeof useMap<string, T>>;
     rowIndex: number;
-    cve: string;
-    summary: string;
-    numAffectedImages: number;
+    item: T;
 };
 
-function CVESelectionTd({
+function CVESelectionTd<T extends { cve: string }>({
     selectedCves,
     rowIndex,
-    cve,
-    summary,
-    numAffectedImages,
-}: CVESelectionTdProps) {
+    item,
+}: CVESelectionTdProps<T>) {
+    const { cve } = item;
     return (
         <Td
             select={{
@@ -28,7 +23,7 @@ function CVESelectionTd({
                     if (selectedCves.has(cve)) {
                         selectedCves.remove(cve);
                     } else {
-                        selectedCves.set(cve, { cve, summary, numAffectedImages });
+                        selectedCves.set(cve, item);
                     }
                 },
                 isSelected: selectedCves.has(cve),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
@@ -4,13 +4,11 @@ import { Th } from '@patternfly/react-table';
 
 import useMap from 'hooks/useMap';
 
-export type CVESelectionThProps = {
-    selectedCves: ReturnType<
-        typeof useMap<string, { cve: string; summary: string; numAffectedImages: number }>
-    >;
+export type CVESelectionThProps<T extends { cve: string }> = {
+    selectedCves: ReturnType<typeof useMap<string, T>>;
 };
 
-function CVESelectionTh({ selectedCves }: CVESelectionThProps) {
+function CVESelectionTh<T extends { cve: string }>({ selectedCves }: CVESelectionThProps<T>) {
     return (
         <Th
             title={

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useCanSnoozeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useCanSnoozeCves.ts
@@ -1,0 +1,12 @@
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+
+export default function useCanSnoozeCves(): boolean {
+    const { hasReadWriteAccess } = usePermissions();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    return (
+        hasReadWriteAccess('VulnerabilityManagementApprovals') &&
+        isFeatureFlagEnabled('ROX_VULN_MGMT_LEGACY_SNOOZE')
+    );
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasLegacySnoozeAbility.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasLegacySnoozeAbility.ts
@@ -1,7 +1,7 @@
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 
-export default function useCanSnoozeCves(): boolean {
+export default function useHasLegacySnoozeAbility(): boolean {
     const { hasReadWriteAccess } = usePermissions();
     const { isFeatureFlagEnabled } = useFeatureFlags();
 


### PR DESCRIPTION
## Description

Adds row selection checkboxes and row actions to the Platform CVE table when the user has the ability to snooze/unsnooze CVEs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the Platform CVE page with a user with `VulnManagementApprovals` READ_WRITE access and the feature flag enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/05baf3d0-f349-45ba-bd03-3323035c22bb)

Test row selection and bulk dropdown:
![image](https://github.com/stackrox/stackrox/assets/1292638/cf32eb01-a9fa-44c2-a3e3-bb173f709a5e)

Test opening row actions (currently empty):
![image](https://github.com/stackrox/stackrox/assets/1292638/0ee028a7-b687-470f-9ed1-e34dc5fa7a7d)

Test the UI with the feature flag disabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/ea396e2f-9dcb-4771-b81f-69358f3259ea)

Test the UI with insufficient `VulnManagementApprovals` permissions:
![image](https://github.com/stackrox/stackrox/assets/1292638/8c6735a6-1a91-4674-a307-3693143e2fde)

Test Workload CVE selection after the component refactor:
![image](https://github.com/stackrox/stackrox/assets/1292638/97957649-d967-4373-bce6-c7293359fba3)
![image](https://github.com/stackrox/stackrox/assets/1292638/c7197d97-4f88-4791-9afd-d4f147f324b0)


