### PR TITLE
ROX-23691: Profile check results table

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -5,6 +5,12 @@ import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 import { complianceEnhancedCoveragePath } from 'routePaths';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import {
+    coverageCheckDetailsPath,
+    coverageClusterDetailsPath,
+    coverageProfileChecksPath,
+    coverageProfileClustersPath,
+} from './compliance.coverage.routes';
 import CheckDetailsPage from './CheckDetailsPage';
 import ClusterDetailsPage from './ClusterDetailsPage';
 import ComplianceProfilesProvider, {
@@ -47,26 +53,10 @@ function CoverageContent() {
 
     return (
         <Switch>
-            <Route
-                exact
-                path={`${complianceEnhancedCoveragePath}/profiles/:profileName/checks`}
-                component={ProfileChecksPage}
-            />
-            <Route
-                exact
-                path={`${complianceEnhancedCoveragePath}/profiles/:profileName/clusters`}
-                component={ProfileClustersPage}
-            />
-            <Route
-                exact
-                path={`${complianceEnhancedCoveragePath}/profiles/:profileName/checks/:checkName`}
-                component={CheckDetailsPage}
-            />
-            <Route
-                exact
-                path={`${complianceEnhancedCoveragePath}/profiles/:profileName/clusters/:clusterName`}
-                component={ClusterDetailsPage}
-            />
+            <Route exact path={coverageProfileChecksPath} component={ProfileChecksPage} />
+            <Route exact path={coverageProfileClustersPath} component={ProfileClustersPage} />
+            <Route exact path={coverageCheckDetailsPath} component={CheckDetailsPage} />
+            <Route exact path={coverageClusterDetailsPath} component={ClusterDetailsPage} />
             <Route
                 exact
                 path={[

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { PageSection, Text, Title } from '@patternfly/react-core';
 
-import PageTitle from 'Components/PageTitle';
-
 function CoveragesPageHeader() {
     return (
         <>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -6,7 +6,6 @@ import PageTitle from 'Components/PageTitle';
 function CoveragesPageHeader() {
     return (
         <>
-            <PageTitle title="Compliance coverage" />
             <PageSection component="div" variant="light">
                 <Title headingLevel="h1">Compliance coverage</Title>
                 <Text>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,15 +1,22 @@
-import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
-import { Button, PageSection } from '@patternfly/react-core';
+import React, { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { Divider, PageSection, Title } from '@patternfly/react-core';
 
-import { complianceEnhancedCoveragePath } from 'routePaths';
+import useRestQuery from 'hooks/useRestQuery';
+import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 
 import CoveragesToggleGroup from './CoveragesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
+import ProfileChecksTable from './ProfileChecksTable';
 
 function ProfileChecksPage() {
-    const history = useHistory();
     const { profileName } = useParams();
+
+    const fetchProfileChecks = useCallback(
+        () => getComplianceProfileResults(profileName),
+        [profileName]
+    );
+    const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
     return (
         <>
@@ -17,28 +24,17 @@ function ProfileChecksPage() {
             <PageSection>
                 <CoveragesToggleGroup tableView="checks" />
             </PageSection>
-            <PageSection variant="light">
-                <div>ProfileChecksPage</div>
-                <Button
-                    onClick={() => {
-                        history.push(
-                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/clusters`
-                        );
-                    }}
-                    variant="primary"
-                >
-                    Go to all clusters (ProfileClustersPage)
-                </Button>
-                <Button
-                    onClick={() => {
-                        history.push(
-                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks/test`
-                        );
-                    }}
-                    variant="primary"
-                >
-                    Go to single check (CheckDetailsPage)
-                </Button>
+            <PageSection variant="default">
+                <PageSection variant="light">
+                    <Title headingLevel="h2">Profile results</Title>
+                    <Divider />
+                    <ProfileChecksTable
+                        isLoading={isLoading}
+                        error={error}
+                        profileChecks={profileChecks?.profileResults ?? []}
+                        profileName={profileName}
+                    />
+                </PageSection>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -27,7 +27,7 @@ function ProfileChecksPage() {
                 <CoveragesToggleGroup tableView="checks" />
             </PageSection>
             <PageSection variant="default">
-                <PageSection variant="light">
+                <PageSection variant="light" component="div">
                     <Title headingLevel="h2">Profile results</Title>
                     <Divider />
                     <ProfileChecksTable

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -5,6 +5,7 @@ import { Divider, PageSection, Title } from '@patternfly/react-core';
 import useRestQuery from 'hooks/useRestQuery';
 import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 
+import PageTitle from 'Components/PageTitle';
 import CoveragesToggleGroup from './CoveragesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
@@ -20,6 +21,7 @@ function ProfileChecksPage() {
 
     return (
         <>
+            <PageTitle title="Compliance coverage - Profile checks" />
             <CoveragesPageHeader />
             <PageSection>
                 <CoveragesToggleGroup tableView="checks" />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.css
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.css
@@ -1,0 +1,5 @@
+.truncate-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -18,7 +18,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
-import CoverageTableViewToggleGroup from './components/CoverageTableViewToggle';
+import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
 import {
     calculateCompliancePercentage,
@@ -53,7 +53,7 @@ function ProfileChecksTable({
             <Toolbar>
                 <ToolbarContent>
                     <ToolbarItem>
-                        <CoverageTableViewToggleGroup activeToggle="checks" />
+                        <ProfilesTableToggleGroup activeToggle="checks" />
                     </ToolbarItem>
                 </ToolbarContent>
             </Toolbar>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { generatePath, Link } from 'react-router-dom';
+import {
+    Divider,
+    Progress,
+    ProgressMeasureLocation,
+    Text,
+    TextVariants,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    Tooltip,
+} from '@patternfly/react-core';
+import { Table, TableText, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import { ComplianceCheckResultStatusCount } from 'services/ComplianceResultsService';
+import { getTableUIState } from 'utils/getTableUIState';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+
+import { coverageCheckDetailsPath } from './compliance.coverage.routes';
+import CoverageTableViewToggleGroup from './components/CoverageTableViewToggle';
+import StatusCountIcon from './components/StatusCountIcon';
+import {
+    calculateCompliancePercentage,
+    getCompliancePfClassName,
+    getStatusCounts,
+} from './compliance.coverage.utils';
+
+export type ProfileChecksTableProps = {
+    isLoading: boolean;
+    error: Error | undefined;
+    profileChecks: ComplianceCheckResultStatusCount[];
+    profileName: string;
+};
+
+function ProfileChecksTable({
+    isLoading,
+    error,
+    profileChecks,
+    profileName,
+}: ProfileChecksTableProps) {
+    const tableState = getTableUIState({
+        isLoading,
+        data: profileChecks,
+        error,
+        searchFilter: {},
+    });
+
+    return (
+        <>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <CoverageTableViewToggleGroup activeToggle="checks" />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            <Divider />
+            <Table>
+                <Thead>
+                    <Tr>
+                        <Th width={50}>Check</Th>
+                        <Th modifier="fitContent">Controls</Th>
+                        <Th modifier="fitContent">Fail status</Th>
+                        <Th modifier="fitContent">Pass status</Th>
+                        <Th modifier="fitContent">Other status</Th>
+                        <Th width={40}>Compliance</Th>
+                    </Tr>
+                </Thead>
+                <TbodyUnified
+                    tableState={tableState}
+                    colSpan={6}
+                    errorProps={{
+                        title: 'There was an error loading profile checks',
+                    }}
+                    emptyProps={{
+                        message: 'No results found',
+                    }}
+                    filteredEmptyProps={{
+                        title: 'No checks found',
+                        message: 'Clear all filters and try again',
+                    }}
+                    renderer={({ data }) => (
+                        <Tbody>
+                            {data.map((check) => {
+                                const { checkName, rationale, checkStats } = check;
+                                const { passCount, failCount, otherCount, totalCount } =
+                                    getStatusCounts(checkStats);
+                                const passPercentage = calculateCompliancePercentage(
+                                    passCount,
+                                    totalCount
+                                );
+                                return (
+                                    <Tr key={checkName}>
+                                        <Td dataLabel="Check">
+                                            <TableText wrapModifier="wrap">
+                                                <Link
+                                                    to={generatePath(coverageCheckDetailsPath, {
+                                                        checkName,
+                                                        profileName,
+                                                    })}
+                                                >
+                                                    {checkName}
+                                                </Link>
+                                            </TableText>
+                                            <TableText wrapModifier="truncate">
+                                                <Text
+                                                    component={TextVariants.small}
+                                                    className="pf-v5-u-color-200"
+                                                >
+                                                    {rationale}
+                                                </Text>
+                                            </TableText>
+                                        </Td>
+                                        <Td dataLabel="Controls" modifier="fitContent">
+                                            placeholder
+                                        </Td>
+                                        <Td dataLabel="Fail status" modifier="fitContent">
+                                            <StatusCountIcon
+                                                text="cluster"
+                                                status="fail"
+                                                count={failCount}
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Pass status" modifier="fitContent">
+                                            <StatusCountIcon
+                                                text="cluster"
+                                                status="pass"
+                                                count={passCount}
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Other status" modifier="fitContent">
+                                            <StatusCountIcon
+                                                text="cluster"
+                                                status="other"
+                                                count={otherCount}
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Compliance">
+                                            <Progress
+                                                id={`progress-bar-${checkName}`}
+                                                value={passPercentage}
+                                                measureLocation={ProgressMeasureLocation.outside}
+                                                className={getCompliancePfClassName(passPercentage)}
+                                                aria-label={`${checkName} compliance percentage`}
+                                            />
+                                            <Tooltip
+                                                content={
+                                                    <div>
+                                                        {`${passCount} / ${totalCount} clusters are passing this check`}
+                                                    </div>
+                                                }
+                                                triggerRef={() =>
+                                                    document.getElementById(
+                                                        `progress-bar-${checkName}`
+                                                    ) as HTMLButtonElement
+                                                }
+                                            />
+                                        </Td>
+                                    </Tr>
+                                );
+                            })}
+                        </Tbody>
+                    )}
+                />
+            </Table>
+        </>
+    );
+}
+
+export default ProfileChecksTable;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -11,7 +11,7 @@ import {
     ToolbarItem,
     Tooltip,
 } from '@patternfly/react-core';
-import { Table, TableText, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ComplianceCheckResultStatusCount } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
@@ -25,6 +25,8 @@ import {
     getCompliancePfClassName,
     getStatusCounts,
 } from './compliance.coverage.utils';
+
+import './ProfileChecksTable.css';
 
 export type ProfileChecksTableProps = {
     isLoading: boolean;
@@ -59,7 +61,7 @@ function ProfileChecksTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th width={50}>Check</Th>
+                        <Th width={60}>Check</Th>
                         <Th modifier="fitContent">Controls</Th>
                         <Th modifier="fitContent">Fail status</Th>
                         <Th modifier="fitContent">Pass status</Th>
@@ -90,27 +92,32 @@ function ProfileChecksTable({
                                     passCount,
                                     totalCount
                                 );
+                                const progressBarId = `progress-bar-${checkName}`;
+
                                 return (
                                     <Tr key={checkName}>
                                         <Td dataLabel="Check">
-                                            <TableText wrapModifier="wrap">
-                                                <Link
-                                                    to={generatePath(coverageCheckDetailsPath, {
-                                                        checkName,
-                                                        profileName,
-                                                    })}
-                                                >
-                                                    {checkName}
-                                                </Link>
-                                            </TableText>
-                                            <TableText wrapModifier="truncate">
+                                            <Link
+                                                to={generatePath(coverageCheckDetailsPath, {
+                                                    checkName,
+                                                    profileName,
+                                                })}
+                                            >
+                                                {checkName}
+                                            </Link>
+                                            {/*
+                                                grid display is required to prevent the cell from
+                                                expanding to the text length. The Truncate PF component
+                                                is not used here because it displays a tooltip on hover
+                                            */}
+                                            <div style={{ display: 'grid' }}>
                                                 <Text
                                                     component={TextVariants.small}
-                                                    className="pf-v5-u-color-200"
+                                                    className="pf-v5-u-color-200 truncate-text"
                                                 >
                                                     {rationale}
                                                 </Text>
-                                            </TableText>
+                                            </div>
                                         </Td>
                                         <Td dataLabel="Controls" modifier="fitContent">
                                             placeholder
@@ -138,7 +145,7 @@ function ProfileChecksTable({
                                         </Td>
                                         <Td dataLabel="Compliance">
                                             <Progress
-                                                id={`progress-bar-${checkName}`}
+                                                id={progressBarId}
                                                 value={passPercentage}
                                                 measureLocation={ProgressMeasureLocation.outside}
                                                 className={getCompliancePfClassName(passPercentage)}
@@ -152,7 +159,7 @@ function ProfileChecksTable({
                                                 }
                                                 triggerRef={() =>
                                                     document.getElementById(
-                                                        `progress-bar-${checkName}`
+                                                        progressBarId
                                                     ) as HTMLButtonElement
                                                 }
                                             />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.routes.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.routes.ts
@@ -1,0 +1,6 @@
+import { complianceEnhancedCoveragePath } from 'routePaths';
+
+export const coverageProfileChecksPath = `${complianceEnhancedCoveragePath}/profiles/:profileName/checks`;
+export const coverageProfileClustersPath = `${complianceEnhancedCoveragePath}/profiles/:profileName/clusters`;
+export const coverageCheckDetailsPath = `${coverageProfileChecksPath}/:checkName`;
+export const coverageClusterDetailsPath = `${coverageProfileClustersPath}/:clusterName`;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CoverageTableViewToggle.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CoverageTableViewToggle.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+
+import { complianceEnhancedCoveragePath } from 'routePaths';
+
+export type CoverageTableViewToggleGroupProps = {
+    activeToggle: 'checks' | 'clusters';
+};
+
+function CoverageTableViewToggleGroup({ activeToggle }: CoverageTableViewToggleGroupProps) {
+    const { profileName } = useParams();
+    const history = useHistory();
+
+    const handleToggleChange = (resultsView) => {
+        history.push(`${complianceEnhancedCoveragePath}/profiles/${profileName}/${resultsView}`);
+    };
+
+    return (
+        <ToggleGroup aria-label="Toggle for coverage view">
+            <ToggleGroupItem
+                text="Checks"
+                buttonId="compliance-clusters-toggle-group"
+                isSelected={activeToggle === 'checks'}
+                onChange={() => handleToggleChange('checks')}
+            />
+            <ToggleGroupItem
+                text="Clusters"
+                buttonId="compliance-clusters-toggle-group"
+                isSelected={activeToggle === 'clusters'}
+                onChange={() => handleToggleChange('clusters')}
+            />
+        </ToggleGroup>
+    );
+}
+
+export default CoverageTableViewToggleGroup;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -4,11 +4,11 @@ import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import { complianceEnhancedCoveragePath } from 'routePaths';
 
-export type CoverageTableViewToggleGroupProps = {
+export type ProfilesTableToggleGroupProps = {
     activeToggle: 'checks' | 'clusters';
 };
 
-function CoverageTableViewToggleGroup({ activeToggle }: CoverageTableViewToggleGroupProps) {
+function ProfilesTableToggleGroup({ activeToggle }: ProfilesTableToggleGroupProps) {
     const { profileName } = useParams();
     const history = useHistory();
 
@@ -34,4 +34,4 @@ function CoverageTableViewToggleGroup({ activeToggle }: CoverageTableViewToggleG
     );
 }
 
-export default CoverageTableViewToggleGroup;
+export default ProfilesTableToggleGroup;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -19,7 +19,7 @@ function getStatusIcon(status, count) {
                 color = 'var(--pf-v5-global--danger-color--100)';
                 break;
             case 'pass':
-                color = 'var(--pf-v5-global--success-color--100)';
+                color = 'var(--pf-v5-global--primary-color--100)';
                 break;
             case 'other':
                 color = 'var(--pf-v5-global--disabled-color--100)';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -5,13 +5,15 @@ import pluralize from 'pluralize';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 
+type Status = 'pass' | 'fail' | 'other';
+
 type StatusCountIconProps = {
     text: string;
-    status: 'pass' | 'fail' | 'other';
+    status: Status;
     count: number;
 };
 
-function getStatusIcon(status, count) {
+function getStatusIcon(status: Status, count: number) {
     let color = 'var(--pf-v5-global--disabled-color--100)';
     if (count > 0) {
         switch (status) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Icon } from '@patternfly/react-core';
+import { BarsIcon, CheckCircleIcon, SecurityIcon } from '@patternfly/react-icons';
+import pluralize from 'pluralize';
+
+import IconText from 'Components/PatternFly/IconText/IconText';
+
+type StatusCountIconProps = {
+    text: string;
+    status: 'pass' | 'fail' | 'other';
+    count: number;
+};
+
+function getStatusIcon(status, count) {
+    let color = 'var(--pf-v5-global--disabled-color--100)';
+    if (count > 0) {
+        switch (status) {
+            case 'fail':
+                color = 'var(--pf-v5-global--danger-color--100)';
+                break;
+            case 'pass':
+                color = 'var(--pf-v5-global--success-color--100)';
+                break;
+            case 'other':
+                color = 'var(--pf-v5-global--disabled-color--100)';
+                break;
+            default:
+                break;
+        }
+    }
+
+    switch (status) {
+        case 'fail':
+            return <SecurityIcon color={color} />;
+        case 'pass':
+            return <CheckCircleIcon color={color} />;
+        case 'other':
+            return <BarsIcon color={color} />;
+        default:
+            return null;
+    }
+}
+
+function StatusCountIcon({ text, status, count }: StatusCountIconProps) {
+    const icon = <Icon>{getStatusIcon(status, count)}</Icon>;
+
+    return <IconText icon={icon} text={`${count} ${pluralize(text, count)}`} />;
+}
+
+export default StatusCountIcon;

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -59,11 +59,37 @@ export type ListComplianceProfileScanStatsResponse = {
     totalCount: number;
 };
 
+export type ComplianceCheckResultStatusCount = {
+    checkName: string;
+    rationale: string;
+    ruleName: string;
+    checkStats: ComplianceCheckStatusCount[];
+};
+
+type ListComplianceProfileResults = {
+    profileResults: ComplianceCheckResultStatusCount[];
+    profileName: string;
+    totalCount: number;
+};
+
 /**
  * Fetches the scan stats grouped by profile.
  */
 export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanStatsResponse> {
     return axios
         .get<ListComplianceProfileScanStatsResponse>(`${complianceResultsBaseUrl}/stats/profiles`)
+        .then((response) => response.data);
+}
+
+/**
+ * Fetches the profile check results.
+ */
+export function getComplianceProfileResults(
+    profileName: string
+): Promise<ListComplianceProfileResults> {
+    return axios
+        .get<ListComplianceProfileResults>(
+            `${complianceResultsBaseUrl}/profile/results/${profileName}`
+        )
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

Creates a table to display a single profiles check results

Notable changes:

- All coverage routes have been pulled into their own file for reusability - `compliance.coverage.routes.ts`
- Taking advantage of the newly created `getTableUIState` utility for table state 
- Added a placeholder for the benchmark controls column since that info is not available yet
- `CoverageTableViewToggle` component created for going between `ProfileChecksPage` and `ProfileClustersPage`
- `StatusCountIcon` component created for displaying status counts with their respective icon. Intended to also be used in `ProfileClustersPage` and `ProfileClusterDetails`
- Sorting, pagination, filtering will come later

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

wip

![Screenshot 2024-05-08 at 11 41 23 AM](https://github.com/stackrox/stackrox/assets/61400697/45c9a819-1b02-490c-9572-333eeb9520d0)

