### PR TITLE
feat(scanner): updater: Publish multi-bundle vulns

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -53,23 +53,18 @@ jobs:
         name: updater
         path: /usr/local/bin
 
-    - name: Run updater
-      if: >
-        github.event_name == 'schedule' ||
-        (github.event_name == 'pull_request' &&
-         !contains(github.event.pull_request.labels.*.name, 'scanner-split-vulns'))
+    - name: Set updater
       run: |
         chmod +x /usr/local/bin/updater
+        mkdir vulns
+
+    - name: Run updater (single bundle)
+      run: |
         updater export vulns
 
-    - name: Run updater with split vulns
-      if: >
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'scanner-split-vulns')
+    - name: Run updater (multi bundle)
       run: |
-        chmod +x /usr/local/bin/updater
         updater export --split bundles
-        mkdir vulns
         zip vulns/vulnerabilities.zip bundles/*.json.zst
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -85,20 +85,20 @@ jobs:
         go build -trimpath -o bin/updater ./cmd/updater
         go clean -cache -modcache
 
-        # TODO(ROX-23684): Ensure previous release versions can coexist with
-        #                  muti-bundle command line arguments.
-        ./bin/updater -output-dir=${{ env.ROX_PRODUCT_VERSION }}
+        mkdir ${{ env.ROX_PRODUCT_VERSION }}
 
-        # The vulnerability file created by older versions can remain the name
-        # vulns.json.zst in the GCS bucket.
-        #
-        # TODO(ROX-22285): Remove after 4.4
-        for file in output.json.{zst,ztd}; do
-          if [ -f "${{ env.ROX_PRODUCT_VERSION }}/${file}" ]; then
-            mv "${{ env.ROX_PRODUCT_VERSION }}/${file}" "${{ env.ROX_PRODUCT_VERSION }}/vulns.json.zst"
-            break
-          fi
-        done
+        # Run updater per release/product version.
+        case "${{ env.ROX_PRODUCT_VERSION }}" in
+        4.4.*)
+            ./bin/updater -output-dir="${{ env.ROX_PRODUCT_VERSION }}"
+            ;;
+        *)
+            ./bin/updater export --split bundles
+            zip ${{ env.ROX_PRODUCT_VERSION }}/vulnerabilities.zip bundles/*.json.zst
+            ;;
+        esac
+
+        # Upload all bundles.
         gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
 
   send-notification:


### PR DESCRIPTION
## Description

This will publish multi-bundle vulns in addition to existing single-bundle vulns. The release workflow was updated to continue publishing single-bundle vunls for `4.4.*` releases and switching to multi-bundle for newer releases.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Run workflows based on this PR's branch:

- Release workflow: https://github.com/stackrox/stackrox/actions/runs/9008637193
- Dev workflow: https://github.com/stackrox/stackrox/actions/runs/9024320501

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
