### PR TITLE
ROX-23998: Adding check details page breadcrumbs

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -1,29 +1,31 @@
 import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
-import { Button, PageSection } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom';
 
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { complianceEnhancedCoveragePath } from 'routePaths';
 
-function CheckDetailsPage() {
-    const history = useHistory();
-    const { profileName } = useParams();
+function CheckDetails() {
+    const { checkName, profileName } = useParams();
+
+    const complianceCoverageChecksURL = `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks`;
+
     return (
         <>
-            <PageSection variant="light">
-                <div>CheckDetailsPage</div>
-                <Button
-                    onClick={() => {
-                        history.push(
-                            `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks`
-                        );
-                    }}
-                    variant="primary"
-                >
-                    Go to all checks (ProfileChecksPage)
-                </Button>
+            <PageTitle title="Compliance coverage - Check" />
+            <PageSection variant="light" className="pf-v5-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItem>Compliance coverage</BreadcrumbItem>
+                    <BreadcrumbItemLink to={complianceCoverageChecksURL}>
+                        {profileName}
+                    </BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>{checkName}</BreadcrumbItem>
+                </Breadcrumb>
             </PageSection>
+            <Divider component="div" />
         </>
     );
 }
 
-export default CheckDetailsPage;
+export default CheckDetails;


### PR DESCRIPTION
## Description

This PR adds the breadcrumbs to the `CheckDetailsPage` component

<img width="1436" alt="Screenshot 2024-05-08 at 12 58 26 PM" src="https://github.com/stackrox/stackrox/assets/4805485/1df30d33-3d04-4f34-889c-f1b36db7a38e">

Note: For now I put `Compliance coverage` as the first breadcrumb. I need clarity on what we want to do there (cc: @bradr5 )