### PR TITLE
ROX-24122: Add graphQL prop for clusterAdmin in Service Accounts table

### DIFF
--- a/ui/apps/platform/src/queries/serviceAccount.js
+++ b/ui/apps/platform/src/queries/serviceAccount.js
@@ -13,6 +13,7 @@ export const SERVICE_ACCOUNT_FRAGMENT = gql`
         }
         clusterName
         clusterId
+        clusterAdmin
         deploymentCount
         deployments {
             id


### PR DESCRIPTION
## Description

USER PROBLEM

- Browse to the service accounts for the "cluster-admin" role: Choose Configuration Management from the left menu. Navigate to "Role Based Access Control" dropdown, choose Roles. Scroll down and click on "cluster-admin"
- "maximise" the window with the arrow-square control.
- Click on "service accounts" tab at the top
- Note that every service account has "Disabled" in the "Cluster Admin Role" column despite having "cluster-admin" in the "Role" column

CONDITIONS

- This particular page exhibits this issue, but other pages that show cluster-admin roles do not
- URL path is something like /main/configmanagement/role/{id}/serviceaccounts

ROOT CAUSE

it looks like the response to the network call to /api/graphql?opname=getRole_SERVICE_ACCOUNT does not include an attribute for the clusterAdmin and the UI seems to default to displaying "Disabled" when this attribute is not set


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

### Here I tell how I validated my change

- Validated that the field is now requested and comes back from the graphQL API call.
- (still need to validate with multiple services accounts, with some where `clusterAdmin` = `true`)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
