### PR TITLE
test: stop moving failed batches to done location

### DIFF
--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -258,13 +258,13 @@ _save_metrics() {
 
 batch_load_test_metrics() {
     while _load_one_batch "${_TESTS_STORAGE_DIR}" "${_TESTS_TABLE_NAME}"; do
-        info "one tests batch loaded"
+        info "one tests batch processed"
     done
     while _load_one_batch "${_CENTRAL_STORAGE_DIR}" "${_CENTRAL_TABLE_NAME}"; do
-        info "one central batch loaded"
+        info "one central batch processed"
     done
     while _load_one_batch "${_IMAGE_PREFETCHES_STORAGE_DIR}" "${_IMAGE_PREFETCHES_TABLE_NAME}"; do
-        info "one image prefetches batch loaded"
+        info "one image prefetches batch processed"
     done
     info "done loading"
 }
@@ -296,13 +296,16 @@ _load_one_batch() {
     gsutil ls -l "${process_location}"
 
     info "Loading into BQ"
-    bq load \
+    if bq load \
         --skip_leading_rows=1 \
         --allow_quoted_newlines \
         "$table_name" "${process_location}/*"
-
-    info "Moving the processed batch to ${storage_done}"
-    gsutil -m mv "${process_location}" "${storage_done}/"
+    then
+        info "Moving the processed batch to ${storage_done}"
+        gsutil -m mv "${process_location}" "${storage_done}/"
+    else
+        info "ERROR processing the batch, leaving in ${process_location}"
+    fi
 
     return 0
 }


### PR DESCRIPTION
## Description

Since `bq` is running in a function in a `while` loop, `set -e` has no effect and does not stop execution.

This change explicitly tests the exit code and skips the move with a loud message easy to grep for.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Plan:
- [x] wait for the scheduled hourly workflow from `master` to finish
- [x] run a job that produces garbage CSV from https://github.com/stackrox/stackrox/pull/11175
- [x] run the [workflow](https://github.com/stackrox/stackrox/actions/runs/9170235609/job/25212114316) from this branch
- [x] verify effect:
```
INFO: Tue May 21 06:58:58 UTC 2024: Gathering a batch of image-prefetches-metrics to load
INFO: Tue May 21 06:58:59 UTC 2024: Found 1 metric(s) for this batch load
INFO: Tue May 21 06:58:59 UTC 2024: Moving the batch to gs://stackrox-ci-artifacts/image-prefetches-metrics/processing/2024-05-21-06-58-59.745974966
Copying gs://stackrox-ci-artifacts/image-prefetches-metrics/upload/bla [Content-Type=application/octet-stream]...
/ [0/1 files][    0.0 B/  160.0 B]   0% Done                                    
/ [1/1 files][  160.0 B/  160.0 B] 100% Done                                    
Operation completed over 1 objects/160.0 B.                                      
Removing gs://stackrox-ci-artifacts/image-prefetches-metrics/upload/bla...
       160  2024-05-21T06:59:00Z  gs://stackrox-ci-artifacts/image-prefetches-metrics/processing/2024-05-21-06-58-59.745974966/bla
TOTAL: 1 objects, 160 bytes (160 B)
INFO: Tue May 21 06:59:02 UTC 2024: Loading into BQ

Waiting on bqjob_r6b6ba4994a5ac148_0000018f99f2474d_1 ... (0s) Current status: RUNNING
                                                                                      
Waiting on bqjob_r6b6ba4994a5ac148_0000018f99f2474d_1 ... (0s) Current status: DONE   
BigQuery error in load operation: Error processing job 'acs-san-
stackroxci:bqjob_r6b6ba4994a5ac148_0000018f99f2474d_1': Error while reading
data, error message: CSV processing encountered too many errors, giving up.
Rows: 0; errors: 1; max bad: 0; error percent: 0
Failure details:
- gs://stackrox-ci-artifacts/image-prefetches-
metrics/processing/[202](https://github.com/stackrox/stackrox/actions/runs/9170235609/job/25212114316#step:4:203)4-05-21-06-58-59.745974966/bla: Error while
reading data, error message: CSV table references column position
10, but line contains only 1 columns.; line_number: 2
byte_offset_to_start_of_line: 80 column_index: 10 column_name:
"build_tag" column_type: STRING File: gs://stackrox-ci-
artifacts/image-prefetches-
metrics/processing/2024-05-21-06-58-59.745974966/bla
- You are loading data without specifying data format, data will be
treated as CSV format by default. If this is not what you mean,
please specify data format by --source_format.
INFO: Tue May 21 06:59:05 UTC 2024: ERROR processing the batch, leaving in gs://stackrox-ci-artifacts/image-prefetches-metrics/processing/2024-05-21-06-58-59.745974966
INFO: Tue May 21 06:59:05 UTC 2024: one image prefetches batch processed
INFO: Tue May 21 06:59:05 UTC 2024: Gathering a batch of image-prefetches-metrics to load
CommandException: One or more URLs matched no objects.
INFO: Tue May 21 06:59:06 UTC 2024: No metrics found to load
INFO: Tue May 21 06:59:06 UTC 2024: done loading
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
