### PR TITLE
ROX-23788: Reconcile ScanConfigs in sensor

### DIFF
--- a/sensor/debugger/message/fake.go
+++ b/sensor/debugger/message/fake.go
@@ -7,13 +7,16 @@ import (
 )
 
 // SensorHello returns a fake SensorHello message
-func SensorHello(clusterID string) *central.MsgToSensor {
+func SensorHello(clusterID string, centralCaps ...string) *central.MsgToSensor {
+	if len(centralCaps) == 0 {
+		centralCaps = []string{centralsensor.SendDeduperStateOnReconnect}
+	}
 	return &central.MsgToSensor{
 		Msg: &central.MsgToSensor_Hello{
 			Hello: &central.CentralHello{
 				ClusterId:        clusterID,
 				CertBundle:       map[string]string{},
-				Capabilities:     []string{centralsensor.SendDeduperStateOnReconnect},
+				Capabilities:     centralCaps,
 				SendDeduperState: true,
 			},
 		},

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -27,12 +27,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var (
-	annotation = map[string]string{
-		"owner": "sensor",
-	}
-)
-
 type handlerImpl struct {
 	client                 dynamic.Interface
 	complianceOperatorInfo StatusInfo
@@ -210,13 +204,11 @@ func (m *handlerImpl) processScheduledScanRequest(requestID string, request *cen
 
 func (m *handlerImpl) createScanResources(requestID string, ns string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) bool {
 	scanSetting, err := runtimeObjToUnstructured(convertCentralRequestToScanSetting(ns, request, cron))
-	scanSetting.SetAnnotations(annotation)
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
 	scanSettingBinding, err := runtimeObjToUnstructured(convertCentralRequestToScanSettingBinding(ns, request, ""))
-	scanSettingBinding.SetAnnotations(annotation)
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -82,11 +82,12 @@ func (m *handlerImpl) Stop(_ error) {
 func (m *handlerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
 	switch e {
-	case common.SensorComponentEventCentralReachable:
+	case common.SensorComponentEventSyncFinished:
 		m.restartSignal.Reset()
 		go m.isComplianceReady()
 	case common.SensorComponentEventOfflineMode:
 		m.restartSignal.Signal()
+		m.complianceIsReady.Reset()
 	}
 }
 

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+var (
+	annotation = map[string]string{
+		"owner": "sensor",
+	}
+)
+
 type handlerImpl struct {
 	client                 dynamic.Interface
 	complianceOperatorInfo StatusInfo
@@ -173,11 +179,13 @@ func (m *handlerImpl) processScheduledScanRequest(requestID string, request *cen
 
 func (m *handlerImpl) createScanResources(requestID string, ns string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) bool {
 	scanSetting, err := runtimeObjToUnstructured(convertCentralRequestToScanSetting(ns, request, cron))
+	scanSetting.SetAnnotations(annotation)
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
 	scanSettingBinding, err := runtimeObjToUnstructured(convertCentralRequestToScanSettingBinding(ns, request))
+	scanSettingBinding.SetAnnotations(annotation)
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/complianceoperator"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
@@ -48,7 +49,8 @@ func (s *HandlerTestSuite) SetupSuite() {
 func (s *HandlerTestSuite) SetupTest() {
 	s.client = fake.NewSimpleDynamicClient(runtime.NewScheme(), &v1alpha1.ScanSettingBinding{TypeMeta: v1.TypeMeta{Kind: "ScanSetting", APIVersion: complianceoperator.GetGroupVersion().String()}})
 	s.statusInfo = mocks.NewMockStatusInfo(gomock.NewController(s.T()))
-	s.requestHandler = NewRequestHandler(s.client, s.statusInfo)
+	readySignal := concurrency.NewSignal()
+	s.requestHandler = NewRequestHandler(s.client, s.statusInfo, &readySignal)
 	s.Require().NoError(s.requestHandler.Start())
 }
 

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -78,6 +78,8 @@ func (u *updaterImpl) Notify(e common.SensorComponentEvent) {
 			return
 		}
 		u.updateTicker.Stop()
+	case common.SensorComponentEventOfflineMode:
+		u.isReady.Reset()
 	}
 }
 
@@ -119,6 +121,8 @@ func (u *updaterImpl) collectInfoAndSendResponse() bool {
 	u.complianceOperatorNS = info.GetNamespace()
 	if info.GetIsInstalled() {
 		u.isReady.Signal()
+	} else {
+		u.isReady.Reset()
 	}
 
 	msg := &central.MsgFromSensor{

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -39,6 +39,8 @@ func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration, r
 	}
 	updateTicker := time.NewTicker(updateInterval)
 	updateTicker.Stop()
+	// We start the signal untriggered
+	readySignal.Reset()
 	return &updaterImpl{
 		client:               client,
 		updateInterval:       updateInterval,

--- a/sensor/kubernetes/complianceoperator/updater_test.go
+++ b/sensor/kubernetes/complianceoperator/updater_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/complianceoperator"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
@@ -267,7 +268,8 @@ func getKeys(m map[string]bool) []string {
 
 func (s *UpdaterTestSuite) getInfo(times int, updateInterval time.Duration) *central.ComplianceOperatorInfo {
 	timer := time.NewTimer(responseTimeout)
-	updater := NewInfoUpdater(s.client, updateInterval)
+	readySignal := concurrency.NewSignal()
+	updater := NewInfoUpdater(s.client, updateInterval, &readySignal)
 
 	updater.Notify(common.SensorComponentEventSyncFinished)
 	err := updater.Start()

--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -34,7 +34,7 @@ func validateScanName(req scanNameGetter) error {
 	return nil
 }
 
-func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) runtime.Object { // *v1alpha1.ScanSetting {
+func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) runtime.Object {
 	return &v1alpha1.ScanSetting{
 		TypeMeta: v1.TypeMeta{
 			Kind:       complianceoperator.ScanSetting.Kind,
@@ -63,7 +63,7 @@ func convertCentralRequestToScanSetting(namespace string, request *central.Apply
 	}
 }
 
-func convertCentralRequestToScanSettingBinding(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, _ string) runtime.Object { // *v1alpha1.ScanSettingBinding {
+func convertCentralRequestToScanSettingBinding(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, _ string) runtime.Object {
 	profileRefs := make([]v1alpha1.NamedObjectReference, 0, len(request.GetProfiles()))
 	for _, profile := range request.GetProfiles() {
 		profileRefs = append(profileRefs, v1alpha1.NamedObjectReference{

--- a/sensor/tests/complianceoperator/sync_test.go
+++ b/sensor/tests/complianceoperator/sync_test.go
@@ -3,7 +3,6 @@ package complianceoperator
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -88,10 +87,6 @@ func Test_ComplianceOperatorScanConfigSync(t *testing.T) {
 	require.NoError(t, err)
 
 	c.RunTest(t, helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, _ map[string]k8s.Object) {
-		// Wait for the sync
-		tc.WaitForSyncEvent(t, 30*time.Second)
-		tc.GetFakeCentral().ClearReceivedBuffer()
-
 		ctx := context.Background()
 		// Create the Compliance Operator CRDs
 		deleteCRDsFn, err := tc.ApplyWithManifestDir(context.Background(), "../../../tests/complianceoperator/crds", "*")
@@ -122,9 +117,6 @@ func Test_ComplianceOperatorScanConfigSync(t *testing.T) {
 
 		// Restart connection
 		tc.RestartFakeCentralConnection(centralCaps...)
-		// Wait for the sync
-		tc.WaitForSyncEvent(t, 30*time.Second)
-		tc.GetFakeCentral().ClearReceivedBuffer()
 
 		// Send a SyncScanConfigs Message
 		tc.GetFakeCentral().StubMessage(createSyncScanConfigsMessage(updatedTestScanConfig, testScanConfig2))
@@ -143,9 +135,6 @@ func Test_ComplianceOperatorScanConfigSync(t *testing.T) {
 
 		// Restart connection
 		tc.RestartFakeCentralConnection(centralCaps...)
-		// Wait for the sync
-		tc.WaitForSyncEvent(t, 30*time.Second)
-		tc.GetFakeCentral().ClearReceivedBuffer()
 
 		// Send a SyncScanConfigs Message
 		tc.GetFakeCentral().StubMessage(createSyncScanConfigsMessage())
@@ -154,7 +143,6 @@ func Test_ComplianceOperatorScanConfigSync(t *testing.T) {
 		tc.AssertResourceDoesNotExist(ctx, t, testScanConfig.GetUpdateScan().GetScanSettings().GetScanName(), coNamespace, complianceoperator.ScanSettingBinding.APIResource)
 		tc.AssertResourceDoesNotExist(ctx, t, testScanConfig2.GetUpdateScan().GetScanSettings().GetScanName(), coNamespace, complianceoperator.ScanSetting.APIResource)
 		tc.AssertResourceDoesNotExist(ctx, t, testScanConfig2.GetUpdateScan().GetScanSettings().GetScanName(), coNamespace, complianceoperator.ScanSettingBinding.APIResource)
-		t.Log("Test_ComplianceOperatorScanConfigSync assertions finished")
 	}))
 }
 

--- a/sensor/tests/complianceoperator/sync_test.go
+++ b/sensor/tests/complianceoperator/sync_test.go
@@ -1,0 +1,188 @@
+package complianceoperator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/complianceoperator"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/tests/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+)
+
+const (
+	coNamespace = "openshift-compliance"
+)
+
+var (
+	coDeployment = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "co-deployment.yaml", Name: "compliance-operator"}
+
+	testScanConfig = &central.ApplyComplianceScanConfigRequest{
+		ScanRequest: &central.ApplyComplianceScanConfigRequest_UpdateScan{
+			UpdateScan: &central.ApplyComplianceScanConfigRequest_UpdateScheduledScan{
+				ScanSettings: &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
+					ScanName: "test",
+					Profiles: []string{"ocp4-cis"},
+				},
+				Cron: "0 1 * * *",
+			},
+		},
+	}
+	updatedTestScanConfig = &central.ApplyComplianceScanConfigRequest{
+		ScanRequest: &central.ApplyComplianceScanConfigRequest_UpdateScan{
+			UpdateScan: &central.ApplyComplianceScanConfigRequest_UpdateScheduledScan{
+				ScanSettings: &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
+					ScanName: "test",
+					Profiles: []string{"ocp4-cis", "ocp4-cis-node"},
+				},
+				Cron: "0 2 * * *",
+			},
+		},
+	}
+	testScanConfig2 = &central.ApplyComplianceScanConfigRequest{
+		ScanRequest: &central.ApplyComplianceScanConfigRequest_UpdateScan{
+			UpdateScan: &central.ApplyComplianceScanConfigRequest_UpdateScheduledScan{
+				ScanSettings: &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
+					ScanName: "test-2",
+					Profiles: []string{"ocp4-moderate"},
+				},
+				Cron: "0 1 * * *",
+			},
+		},
+	}
+)
+
+func Test_ComplianceOperatorScanConfigSync(t *testing.T) {
+	t.Setenv(env.ConnectionRetryInitialInterval.EnvVar(), "1s")
+	t.Setenv(env.ConnectionRetryMaxInterval.EnvVar(), "2s")
+	t.Setenv(features.ComplianceEnhancements.EnvVar(), "true")
+
+	centralCaps := []string{
+		centralsensor.SendDeduperStateOnReconnect,
+		centralsensor.ComplianceV2Integrations,
+	}
+	c, err := helper.NewContextWithConfig(t, helper.Config{
+		CentralCaps:           centralCaps,
+		InitialSystemPolicies: nil,
+		CertFilePath:          "../../../tools/local-sensor/certs/",
+	})
+	t.Cleanup(c.Stop)
+
+	require.NoError(t, err)
+
+	c.RunTest(t, helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, _ map[string]k8s.Object) {
+		// Wait for the sync
+		tc.WaitForSyncEvent(t, 10*time.Second)
+		tc.GetFakeCentral().ClearReceivedBuffer()
+		ctx := context.Background()
+		// Create the Compliance Operator CRDs
+		deleteCRDsFn, err := tc.ApplyWithManifestDir(context.Background(), "../../../tests/complianceoperator/crds", "*")
+		t.Cleanup(func() {
+			// Deleting the namespace should take care of all the resources created in this test
+			utils.IgnoreError(deleteCRDsFn)
+		})
+
+		require.NoError(t, err)
+
+		// Create a fake Compliance Operator Deployment
+		coDep := &appsv1.Deployment{}
+		_, err = tc.ApplyResourceAndWait(ctx, t, coNamespace, &coDeployment, coDep, nil)
+
+		require.NoError(t, err)
+
+		// Wait for the sync
+		tc.WaitForSyncEvent(t, 10*time.Second)
+		tc.GetFakeCentral().ClearReceivedBuffer()
+
+		// Send a SyncScanConfigs Message
+		tc.GetFakeCentral().StubMessage(createSyncScanConfigsMessage(testScanConfig))
+
+		// Assert the resources are created
+		scanSetting := tc.AssertResourceDoesExist(ctx, t, "test", coNamespace, complianceoperator.ScanSetting.APIResource)
+		scanSettingBinding := tc.AssertResourceDoesExist(ctx, t, "test", coNamespace, complianceoperator.ScanSettingBinding.APIResource)
+
+		assertScanSetting(t, testScanConfig, scanSetting)
+		assertScanSettingBinding(t, testScanConfig, scanSettingBinding)
+
+		// Restart connection
+		tc.RestartFakeCentralConnection(centralCaps...)
+
+		// Wait for the sync
+		tc.WaitForSyncEvent(t, 30*time.Second)
+		tc.GetFakeCentral().ClearReceivedBuffer()
+
+		// Send a SyncScanConfigs Message
+		tc.GetFakeCentral().StubMessage(createSyncScanConfigsMessage(updatedTestScanConfig, testScanConfig2))
+
+		time.Sleep(30 * time.Second)
+
+		scanSetting = tc.AssertResourceDoesExist(ctx, t, "test", coNamespace, complianceoperator.ScanSetting.APIResource)
+		scanSettingBinding = tc.AssertResourceDoesExist(ctx, t, "test", coNamespace, complianceoperator.ScanSettingBinding.APIResource)
+
+		assertScanSetting(t, updatedTestScanConfig, scanSetting)
+		assertScanSettingBinding(t, updatedTestScanConfig, scanSettingBinding)
+
+		scanSetting = tc.AssertResourceDoesExist(ctx, t, "test-2", coNamespace, complianceoperator.ScanSetting.APIResource)
+		scanSettingBinding = tc.AssertResourceDoesExist(ctx, t, "test-2", coNamespace, complianceoperator.ScanSettingBinding.APIResource)
+
+		assertScanSetting(t, testScanConfig2, scanSetting)
+		assertScanSettingBinding(t, testScanConfig2, scanSettingBinding)
+
+		// Restart connection
+		tc.RestartFakeCentralConnection(centralCaps...)
+
+		// Wait for the sync
+		tc.WaitForSyncEvent(t, 30*time.Second)
+		tc.GetFakeCentral().ClearReceivedBuffer()
+
+		// Send a SyncScanConfigs Message
+		tc.GetFakeCentral().StubMessage(createSyncScanConfigsMessage())
+
+		tc.AssertResourceDoesNotExist(ctx, t, "test", coNamespace, complianceoperator.ScanSetting.APIResource)
+		tc.AssertResourceDoesNotExist(ctx, t, "test", coNamespace, complianceoperator.ScanSettingBinding.APIResource)
+		tc.AssertResourceDoesNotExist(ctx, t, "test-2", coNamespace, complianceoperator.ScanSetting.APIResource)
+		tc.AssertResourceDoesNotExist(ctx, t, "test-2", coNamespace, complianceoperator.ScanSettingBinding.APIResource)
+	}))
+}
+
+func createSyncScanConfigsMessage(scanConfigs ...*central.ApplyComplianceScanConfigRequest) *central.MsgToSensor {
+	return &central.MsgToSensor{
+		Msg: &central.MsgToSensor_ComplianceRequest{
+			ComplianceRequest: &central.ComplianceRequest{
+				Request: &central.ComplianceRequest_SyncScanConfigs{
+					SyncScanConfigs: &central.SyncComplianceScanConfigRequest{
+						ScanConfigs: scanConfigs,
+					},
+				},
+			},
+		},
+	}
+}
+func assertScanSetting(t *testing.T, expected *central.ApplyComplianceScanConfigRequest, actual *unstructured.Unstructured) {
+	require.NotNil(t, actual)
+	var scanSetting v1alpha1.ScanSetting
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(actual.Object, &scanSetting))
+	assert.Equal(t, expected.GetUpdateScan().GetScanSettings().GetScanName(), scanSetting.GetName())
+	assert.Equal(t, expected.GetUpdateScan().GetCron(), scanSetting.ComplianceSuiteSettings.Schedule)
+}
+
+func assertScanSettingBinding(t *testing.T, expected *central.ApplyComplianceScanConfigRequest, actual *unstructured.Unstructured) {
+	require.NotNil(t, actual)
+	var scanSettingBinding v1alpha1.ScanSettingBinding
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(actual.Object, &scanSettingBinding))
+	assert.Equal(t, expected.GetUpdateScan().GetScanSettings().GetScanName(), scanSettingBinding.GetName())
+	for _, profile := range scanSettingBinding.Profiles {
+		assert.Contains(t, expected.GetUpdateScan().GetScanSettings().GetProfiles(), profile.Name)
+	}
+}

--- a/sensor/tests/complianceoperator/yaml/co-deployment.yaml
+++ b/sensor/tests/complianceoperator/yaml/co-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compliance-operator
+  labels:
+    owner: compliance-operator.1.4.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      owner: compliance-operator.1.4.0
+  template:
+    metadata:
+      labels:
+        owner: compliance-operator.1.4.0
+    spec:
+      containers:
+      - name: compliance-operator
+        image: busybox
+        command:
+          - tail
+          - -f
+          - /dev/null

--- a/sensor/tests/helper/k8s.go
+++ b/sensor/tests/helper/k8s.go
@@ -2,15 +2,64 @@ package helper
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/stackrox/rox/pkg/containerid"
 	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	kubeAPIErr "k8s.io/apimachinery/pkg/api/errors"
+	apiMetaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
+
+func getGVR(api apiMetaV1.APIResource) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    api.Group,
+		Version:  api.Version,
+		Resource: api.Name,
+	}
+}
+
+// AssertResourceDoesExist asserts whether the given resource exits in the cluster
+func (c *TestContext) AssertResourceDoesExist(ctx context.Context, t *testing.T, resourceName string, namespace string, api apiMetaV1.APIResource) *unstructured.Unstructured {
+	client, err := dynamic.NewForConfig(c.r.GetConfig())
+	require.NoError(t, err)
+
+	var cli dynamic.ResourceInterface
+	var obj *unstructured.Unstructured
+	require.Eventually(t, func() bool {
+		cli = client.Resource(getGVR(api))
+		if namespace != "" {
+			cli = client.Resource(getGVR(api)).Namespace(namespace)
+		}
+		obj, err = cli.Get(ctx, resourceName, apiMetaV1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 10*time.Millisecond)
+	return obj
+}
+
+// AssertResourceDoesNotExist asserts whether the given resource does not exit in the cluster
+func (c *TestContext) AssertResourceDoesNotExist(ctx context.Context, t *testing.T, resourceName string, namespace string, api apiMetaV1.APIResource) {
+	client, err := dynamic.NewForConfig(c.r.GetConfig())
+	require.NoError(t, err)
+
+	var cli dynamic.ResourceInterface
+	require.Eventually(t, func() bool {
+		cli = client.Resource(getGVR(api))
+		if namespace != "" {
+			cli = client.Resource(getGVR(api)).Namespace(namespace)
+		}
+		_, err = cli.Get(ctx, resourceName, apiMetaV1.GetOptions{})
+		return err != nil && kubeAPIErr.IsNotFound(err)
+	}, 120*time.Second, 10*time.Millisecond)
+}
 
 // GetContainerIdsFromPod retrieves the container ids from a given pod.
 func (c *TestContext) GetContainerIdsFromPod(ctx context.Context, obj k8s.Object) []string {


### PR DESCRIPTION
## Description

Reconcile ScanConfigs. On sensor-central connection startup the ScanConfigs known by central will be sent to sensor. Upon receiving them, sensor will reconcile any resources (created by ACS) in the cluster.

- ~Depends on #11239~

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] New integration test pass

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
