### PR TITLE
chore(reports): Add close delimiter for Email MIME boundary

### DIFF
--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -3,10 +3,13 @@ package email
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,6 +51,108 @@ func TestEmailMsgWithAttachment(t *testing.T) {
 
 	assert.Contains(t, msgStr, base64.StdEncoding.EncodeToString(attachBuf.Bytes()))
 	assert.Contains(t, msgStr, "<div>\r\nHow you doin'?\r\n</div>\r\n")
+
+	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedFinalBoundary, lastBoundary)
+	}
+}
+
+func obtainLastAndExpectedBoundaryString(msgStr string) (string, string, error) {
+	// Obtain boundary to verify the close delimiter
+	regex := regexp.MustCompile(` boundary="([^"]+)"`)
+	match := regex.FindString(msgStr)
+	if match == "" {
+		return "", "", errors.New("boundary not found in the message")
+	}
+	splitResults := strings.Split(match, "=")
+	boundaryValue := strings.Trim(splitResults[1], `"`)
+	expectedFinalBoundary := fmt.Sprintf("--%s--", boundaryValue)
+
+	lines := strings.Split(msgStr, "\n")
+	if len(lines) < 2 {
+		return "", "", errors.New("message too short to have a final boundary")
+	}
+	lastBoundary := strings.TrimSpace(lines[len(lines)-2])
+
+	return lastBoundary, expectedFinalBoundary, nil
+}
+
+func TestEmailMsgWithMultipleAttachments(t *testing.T) {
+	var attachBuf bytes.Buffer
+
+	content := make([]byte, 200)
+	_, err := rand.Read(content)
+	assert.NoError(t, err)
+
+	msg := &Message{
+		To:      []string{"foo@stackrox.com", "bar@stackrox.com"},
+		From:    "xyz@stackrox.com",
+		Subject: "Test Email",
+		Body:    "How you doin'?",
+		Attachments: map[string][]byte{
+			"attachment1.zip": attachBuf.Bytes(),
+			"attachment2.zip": attachBuf.Bytes(),
+		},
+		EmbedLogo: true,
+	}
+
+	msgBytes := msg.Bytes()
+	msgStr := string(msgBytes)
+
+	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
+	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
+	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
+	assert.Contains(t, msgStr, "Content-Type: application/zip\r\n")
+	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
+	assert.Contains(t, msgStr, "Content-Disposition: attachment; filename=attachment1.zip\r\n")
+	assert.Contains(t, msgStr, "Content-Disposition: attachment; filename=attachment2.zip\r\n")
+
+	assert.Contains(t, msgStr, "Content-Type: image/png; name=logo.png\r\n")
+	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
+	assert.Contains(t, msgStr, "Content-Disposition: inline; filename=logo.png\r\n")
+	assert.Contains(t, msgStr, "Content-ID: <logo.png>\r\n")
+	assert.Contains(t, msgStr, "X-Attachment-Id: logo.png\r\n")
+
+	assert.Contains(t, msgStr, base64.StdEncoding.EncodeToString(attachBuf.Bytes()))
+	assert.Contains(t, msgStr, "<div>\r\nHow you doin'?\r\n</div>\r\n")
+
+	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedFinalBoundary, lastBoundary)
+	}
+}
+
+func TestEmailMsgNoAttachmentsWithLogo(t *testing.T) {
+	msg := &Message{
+		To:        []string{"foo@stackrox.com", "bar@stackrox.com"},
+		From:      "xyz@stackrox.com",
+		Subject:   "Test Email",
+		Body:      "How you doin'?",
+		EmbedLogo: true,
+	}
+
+	msgBytes := msg.Bytes()
+	msgStr := string(msgBytes)
+
+	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
+	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
+	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
+	assert.Contains(t, msgStr, "Content-Type: text/html; charset=\"utf-8\"\r\n\r\n")
+	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
+	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
+	assert.NotContains(t, msgStr, "Content-Type: application/zip\r\n")
+	assert.NotContains(t, msgStr, "Content-Disposition: attachment;")
+
+	assert.Contains(t, msgStr, "How you doin'?\r\n")
+
+	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedFinalBoundary, lastBoundary)
+	}
 }
 
 func TestEmailMsgNoAttachments(t *testing.T) {


### PR DESCRIPTION
## Description

Added closing delimiter `--` for the last iteration in `email.go` for Email MIME. Update unit tests in `email_test.go` to verify the final closing boundary has the following structure: `--boundaryValue--`. Introduce function `obtainLastAndExpectedBoundaryString` to obtain last and expected boundary for tests. Introduce a unit test `TestEmailMsgWithMultipleAttachments` with multiple attachments. Introduce a unit test `TestEmailMsgNoAttachmentsWithLogo` without attachments, but with logo.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Modified the unit test `TestEmailMsgWithAttachment` in `central/notifiers/email/email_test.go` which checks for the close delimiter via `assert.Equal(t, expectedFinalBoundary, lastBoundary)`. Add the check for the tests `TestEmailMsgWithMultipleAttachments` and `TestEmailMsgNoAttachmentsWithLogo` as well. The unit tests pass:
```sh
go test -v ./central/notifiers/email                 
=== RUN   TestEmailMsgWithAttachment
--- PASS: TestEmailMsgWithAttachment (0.00s)
=== RUN   TestEmailMsgWithMultipleAttachments
--- PASS: TestEmailMsgWithMultipleAttachments (0.00s)
=== RUN   TestEmailMsgNoAttachmentsWithLogo
--- PASS: TestEmailMsgNoAttachmentsWithLogo (0.00s)
=== RUN   TestEmailMsgNoAttachments
--- PASS: TestEmailMsgNoAttachments (0.00s)
...
PASS
ok  	github.com/stackrox/rox/central/notifiers/email
```
