### PR TITLE
ROX-24103: Adds the Risk Priority column to image and deployment lists

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -34,6 +34,7 @@ export const deploymentListQuery = gql`
                     total
                 }
             }
+            priority
             clusterName
             namespace
             imageCount(query: $query)
@@ -51,6 +52,7 @@ export type Deployment = {
         moderate: { total: number };
         low: { total: number };
     };
+    priority: number;
     clusterName: string;
     namespace: string;
     imageCount: number;
@@ -77,6 +79,7 @@ function DeploymentsTable({
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>
+                    <Th sort={getSortParams('Deployment Risk Priority')}>Risk priority</Th>
                     <TooltipTh tooltip="CVEs by severity across this deployment">
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}
@@ -96,6 +99,7 @@ function DeploymentsTable({
                     id,
                     name,
                     imageCVECountBySeverity,
+                    priority,
                     clusterName,
                     namespace,
                     imageCount,
@@ -123,6 +127,12 @@ function DeploymentsTable({
                                     >
                                         <Truncate position="middle" content={name} />
                                     </Link>
+                                </Td>
+                                <Td
+                                    dataLabel="Risk priority"
+                                    className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
+                                >
+                                    {priority}
                                 </Td>
                                 <Td>
                                     <SeverityCountLabels

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -38,6 +38,7 @@ export const imageListQuery = gql`
                     total
                 }
             }
+            priority
             operatingSystem
             deploymentCount(query: $query)
             watchStatus
@@ -66,6 +67,7 @@ type Image = {
         moderate: { total: number };
         low: { total: number };
     };
+    priority: number;
     operatingSystem: string;
     deploymentCount: number;
     watchStatus: WatchStatus;
@@ -98,7 +100,7 @@ function ImagesTable({
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableProps) {
-    const colSpan = hasWriteAccessForWatchedImage ? 7 : 6;
+    const colSpan = hasWriteAccessForWatchedImage ? 8 : 7;
 
     return (
         <Table borders={false} variant="compact">
@@ -106,6 +108,7 @@ function ImagesTable({
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Image')}>Image</Th>
+                    <Th sort={getSortParams('Image Risk Priority')}>Risk priority</Th>
                     <TooltipTh tooltip="CVEs by severity across this image">
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}
@@ -126,6 +129,7 @@ function ImagesTable({
                     id,
                     name,
                     imageCVECountBySeverity,
+                    priority,
                     operatingSystem,
                     deploymentCount,
                     metadata,
@@ -175,6 +179,12 @@ function ImagesTable({
                                     ) : (
                                         'Image name not available'
                                     )}
+                                </Td>
+                                <Td
+                                    dataLabel="Risk priority"
+                                    className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
+                                >
+                                    {priority}
                                 </Td>
                                 <Td dataLabel="CVEs by severity">
                                     <SeverityCountLabels

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -26,9 +26,15 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): string[] {
         case 'CVE':
             return ['CVE', 'CVSS', 'Image Sha', 'CVE Created Time'];
         case 'Image':
-            return ['Image', 'Image OS', 'Image created time', 'Image scan time'];
+            return [
+                'Image',
+                'Image Risk Priority',
+                'Image OS',
+                'Image created time',
+                'Image scan time',
+            ];
         case 'Deployment':
-            return ['Deployment', 'Cluster', 'Namespace', 'Created'];
+            return ['Deployment', 'Deployment Risk Priority', 'Cluster', 'Namespace', 'Created'];
         default:
             return ensureExhaustive(entityTab);
     }
@@ -44,9 +50,9 @@ export function getDefaultWorkloadSortOption(entityTab: WorkloadEntityTab): Sort
         case 'CVE':
             return { field: 'CVSS', aggregateBy: aggregateByCVSS, direction: 'desc' };
         case 'Deployment':
-            return { field: 'Deployment', direction: 'asc' };
+            return { field: 'Deployment Risk Priority', direction: 'asc' };
         case 'Image':
-            return { field: 'Image', direction: 'desc' };
+            return { field: 'Image Risk Priority', direction: 'asc' };
         default:
             return ensureExhaustive(entityTab);
     }


### PR DESCRIPTION
## Description

As titled, the return of the risk `priority` column in order to allow better prioritization of the Image and Deployment lists until we can get Olympic style sorting of the severity columns.

Also makes this column the default sort for each of the two tables.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Workload CVEs and view the image table:
![image](https://github.com/stackrox/stackrox/assets/1292638/d7d73a47-7f71-4041-9c9c-caa271031902)

Sort risk:
![image](https://github.com/stackrox/stackrox/assets/1292638/e51c8e36-6e37-44d8-b17b-db41df8529aa)

Visit Workload CVEs and view the deployment table:
![image](https://github.com/stackrox/stackrox/assets/1292638/25ad37f5-48dd-442c-94f6-d8403758221c)

Sort risk:
![image](https://github.com/stackrox/stackrox/assets/1292638/17726e4b-9a1d-46d1-af80-a7e456288589)

Simulate a large number for Risk to ensure the centered layout looks good:
![image](https://github.com/stackrox/stackrox/assets/1292638/3627ee43-117f-41b4-bc03-00c88991fb37)
