### PR TITLE
ROX-23847: Attempt at reducing lock contention in network entities datastore

### DIFF
--- a/central/networkgraph/entity/datastore/internal/store/mocks/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/mocks/store.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -154,4 +155,18 @@ func (m *MockEntityStore) Walk(ctx context.Context, fn func(*storage.NetworkEnti
 func (mr *MockEntityStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockEntityStore)(nil).Walk), ctx, fn)
+}
+
+// WalkByQuery mocks base method.
+func (m *MockEntityStore) WalkByQuery(ctx context.Context, query *v1.Query, fn func(*storage.NetworkEntity) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WalkByQuery", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkByQuery indicates an expected call of WalkByQuery.
+func (mr *MockEntityStoreMockRecorder) WalkByQuery(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkByQuery", reflect.TypeOf((*MockEntityStore)(nil).WalkByQuery), ctx, query, fn)
 }

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -21,4 +22,5 @@ type EntityStore interface {
 	DeleteMany(ctx context.Context, ids []string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.NetworkEntity) error) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkEntity) error) error
 }


### PR DESCRIPTION
## Description

When a cluster is deleted, it calls `DeleteExternalNetworkEntitiesForCluster` in networkEntity's in a go routine. When multiple clusters are deleted, there are multiple routines calling `DeleteExternalNetworkEntitiesForCluster`. This function acquires lock on `netEntityLock` and walks through all the network entities. This can be slow and cause other routines to timeout waiting on `netEntityLock` . This is probably causing "TestClusterDeletion" failures in CI because that test creates 58083 network entities. This is an attempt at a quick fix to filter out some of the entities before walking through them to reduce contention. A more complete solution would be to make `clusterID` searchable in `NetworkEntity` proto but that would require migration and thus more time to fix.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Passing CI is enough 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
