### PR TITLE
fix(build): make image on M3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,18 @@ ifeq ($(GOARCH),s390x)
 		--build-arg="RPMS_BASE_TAG=stream9"
 endif
 
-ifeq ($(UNAME_S),Darwin)
-BIND_GOCACHE ?= 0
-BIND_GOPATH ?= 0
-else
+# By default, assume we are going to use a bind mount volume instead of a standalone one.
 BIND_GOCACHE ?= 1
 BIND_GOPATH ?= 1
+
+# Only resort to local volumes on X86_64 Darwin, since on ARM Darwin the permissions of the
+# standalone volume will be mapped to root instead of the local user, making the build fail.
+# An alternative is to chown the directory of the standalone volume within the container.
+ifeq ($(UNAME_S),Darwin)
+ifneq ($(UNAME_M),arm64)
+BIND_GOCACHE ?= 0
+BIND_GOPATH ?= 0
+endif
 endif
 
 ifeq ($(BIND_GOCACHE),1)


### PR DESCRIPTION
## Description

When running the `make image` command on an M3 Mac, you get the following error:
```
failed to initialize build cache at /linux-gocache: mkdir /linux-gocache/00: permission denied
```
This happens during building the components (i.e. sensor central etc.) within the dockerized build.

On closer inspection, the mounted directory within the container has the permissions of the directory set to `root` instead of the UID of the user.

There were two options to fix this:
- when starting the container, make sure to chown the go cache directory to the UID within the container
- instead of using a standalone docker volume (i.e. one created by calling `docker volume create`) use a bind mount which preserves the UIDs on the directory

The latter seemed like the more fitting option. One thing to consider separately would be wether we can skip the standalone volume completely and move to the bind mount after the recent improvements to docker on darwin (the current build time on an M3 mac is a bit less than 5 minutes with cold caches).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- ran `make image` on a M3 mac.
- TODO @dhaus67: test other archs like M2/M1 macs + intel ones to be on the safe side.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
