### PR TITLE
chore(e2e): Update cypress 13.9.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -135,7 +135,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "autoprefixer": "^10.2.5",
-        "cypress": "^13.7.3",
+        "cypress": "^13.9.0",
         "eslint": "^8.56.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-cypress": "^2.15.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6471,10 +6471,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^13.7.3:
-  version "13.7.3"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.7.3.tgz#3e7dcd32e007676a6c8e972293c50d6ef329d991"
-  integrity sha512-uoecY6FTCAuIEqLUYkTrxamDBjMHTYak/1O7jtgwboHiTnS1NaMOoR08KcTrbRZFCBvYOiS4tEkQRmsV+xcrag==
+cypress@^13.9.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.9.0.tgz#b529cfa8f8c39ba163ed0501a25bb5b09c143652"
+  integrity sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

https://docs.cypress.io/guides/references/changelog#13-9-0

* We now pass the same default Chromium flags to Electron as we do to Chrome.
* Updated electron from 27.1.3 to 27.3.10 to address CVE-2024-3156

https://docs.cypress.io/guides/references/changelog#13-8-1

* Fixed a regression introduced in 13.6.0 where Cypress would occasionally exit with status code 1, even when a test run was successful, due to an unhandled WebSocket exception
* Updated zod from 3.20.3 to 3.22.5

https://docs.cypress.io/guides/references/changelog#13-8-0

* Added support for webpack-dev-server v5 to cypress/webpack-dev-server.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn` in ui
2. `yarn start` in ui

### Regression testing

Prerequisite for integeration testing:

```sh
export CYPRESS_ROX_COMPLIANCE_ENHANCEMENTS=true
```

1. `yarn cypress-open` in ui/apps/platform

### Component testing

* apps/platform/src/Containers/Dashboard/Widgets/AgingImages.cy.js
* apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.cy.js
* apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.cy.js
* apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.cy.js
* apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.cy.js
* apps/platform/src/Containers/Dashboard/ScopeBar.cy.jsx

### Integration testing

* compliance-enhanced/complianceEnhancedScanConfigs.test.js