### PR TITLE
ROX-23995: improve roxctl retries

### DIFF
--- a/pkg/retry/retryable.go
+++ b/pkg/retry/retryable.go
@@ -1,5 +1,7 @@
 package retry
 
+import "errors"
+
 // MakeRetryable is an explicit wrapper for errors you want to retry if you use the IsRetryable function with
 // the OnlyIf option.
 func MakeRetryable(e error) error {
@@ -15,6 +17,6 @@ type retryableError struct {
 
 // IsRetryable returns if the error is an instance of RetryableError
 func IsRetryable(e error) bool {
-	_, ir := e.(*retryableError)
-	return ir
+	var retryableError *retryableError
+	return errors.As(e, &retryableError)
 }

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -444,7 +444,7 @@ func (r *v2Restorer) resumeAfterError(ctx context.Context) (*http.Request, error
 		// Unavailable and DeadlineExceeded indicate transport failures & timeouts. All other errors (permissions etc.)
 		// are likely permanent.
 		if code := status.Convert(err).Code(); code == codes.Unavailable || code == codes.DeadlineExceeded {
-			err = retry.MakeRetryable(err)
+			err = common.MakeRetryable(err)
 		}
 		return nil, err
 	}

--- a/roxctl/common/errors.go
+++ b/roxctl/common/errors.go
@@ -1,6 +1,13 @@
 package common
 
-import "github.com/stackrox/rox/pkg/errox"
+import (
+	"slices"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/retry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 var (
 	// ErrInvalidCommandOption indicates bad options provided by the user
@@ -11,4 +18,33 @@ var (
 	ErrDeprecatedFlag = func(oldFlag, newFlag string) errox.Error {
 		return errox.InvalidArgs.Newf("specified deprecated flag %q and new flag %q at the same time", oldFlag, newFlag)
 	}
+
+	nonRetryCodes = []codes.Code{
+		codes.Unauthenticated,
+		codes.AlreadyExists,
+		codes.PermissionDenied,
+		codes.InvalidArgument,
+	}
 )
+
+// MakeRetryable makes an error retryable based on the error type.
+func MakeRetryable(err error) error {
+	// Specific sentinel errors shouldn't be retried.
+	if errox.IsAny(err, ErrInvalidCommandOption, errox.InvalidArgs, errox.NotAuthorized, errox.NoCredentials) {
+		return err
+	}
+
+	s, ok := status.FromError(err)
+	// Retry all errors that cannot be mapped to a GRPC code and aren't already explicitly skipped already.
+	if !ok {
+		return retry.MakeRetryable(err)
+	}
+
+	// Do not retry errors with specific GRPC codes such as unauthenticated etc.
+	if slices.Contains(nonRetryCodes, s.Code()) {
+		return err
+	}
+
+	// Mark all other errors as retryable.
+	return retry.MakeRetryable(err)
+}

--- a/roxctl/common/errors_test.go
+++ b/roxctl/common/errors_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/retry"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMakeRetryable(t *testing.T) {
+	cases := []struct {
+		err       error
+		retryable bool
+	}{
+		{
+			err: errox.InvalidArgs,
+		},
+		{
+			err: errox.NotAuthorized,
+		},
+		{
+			err: errox.NoCredentials,
+		},
+		{
+			err: ErrInvalidCommandOption,
+		},
+		{
+			err:       errox.ReferencedByAnotherObject,
+			retryable: true,
+		},
+		{
+			err:       errors.New("some error"),
+			retryable: true,
+		},
+		{
+			err: status.Error(codes.Unauthenticated, "some error"),
+		},
+		{
+			err: status.Error(codes.AlreadyExists, "some error"),
+		},
+
+		{
+			err: status.Error(codes.PermissionDenied, "some error"),
+		},
+		{
+			err: status.Error(codes.InvalidArgument, "some error"),
+		},
+		{
+			err:       status.Error(codes.DeadlineExceeded, "some error"),
+			retryable: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			err := MakeRetryable(c.err)
+			assert.Equal(t, c.retryable, retry.IsRetryable(err))
+		})
+	}
+}

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -264,7 +264,7 @@ func (i *imageScanCommand) Scan() error {
 func (i *imageScanCommand) scanImage() error {
 	imageResult, err := i.getImageResultFromService()
 	if err != nil {
-		return retry.MakeRetryable(err)
+		return errors.Wrap(common.MakeRetryable(err), "retrieving image scan result")
 	}
 
 	return i.printImageResult(imageResult)


### PR DESCRIPTION
## Description

The ticket originally was filed due to an error not being thrown when an invalid endpoint was used. Since we fixed that in 4.4.0, I used this opportunity to fix the retry logic within roxctl.

Previously we just retried every error, which is a bit awkward especially if we are dealing with invalid arguments, unauthenticated creds or missing permissions.

This has been now fixed and all places relying on our `retry` package have been refactored to accomodate this.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
