### PR TITLE
chore(ui): Split up compliance results service

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
@@ -5,7 +5,7 @@ import useRestQuery from 'hooks/useRestQuery';
 import {
     getComplianceProfilesStats,
     ListComplianceProfileScanStatsResponse,
-} from 'services/ComplianceResultsService';
+} from 'services/ComplianceResultsStatsService';
 
 type ComplianceProfilesContextValue = {
     profileScanStats: ListComplianceProfileScanStatsResponse;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -13,9 +13,9 @@ import {
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { ComplianceCheckResultStatusCount } from 'services/ComplianceResultsService';
-import { getTableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { ComplianceCheckResultStatusCount } from 'services/ComplianceCommon';
+import { getTableUIState } from 'utils/getTableUIState';
 
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -15,7 +15,7 @@ import {
     ComplianceCheckStatus,
     ComplianceCheckStatusCount,
     ComplianceCheckStatusEnum,
-} from 'services/ComplianceResultsService';
+} from 'services/ComplianceCommon';
 
 // Thresholds for compliance status
 const DANGER_THRESHOLD = 50;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CheckStatusModal.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CheckStatusModal.tsx
@@ -19,7 +19,8 @@ import {
 } from '@patternfly/react-core';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
-import { ComplianceCheckResult, ComplianceCheckStatus } from 'services/ComplianceResultsService';
+import { ComplianceCheckStatus } from 'services/ComplianceCommon';
+import { ComplianceCheckResult } from 'services/ComplianceResultsService';
 
 import { getClusterResultsStatusObject } from '../compliance.coverage.utils';
 

--- a/ui/apps/platform/src/services/ComplianceCommon.ts
+++ b/ui/apps/platform/src/services/ComplianceCommon.ts
@@ -1,1 +1,38 @@
 export const complianceV2Url = '/v2/compliance';
+
+export const ComplianceCheckStatusEnum = {
+    UNSET_CHECK_STATUS: 'UNSET_CHECK_STATUS',
+    PASS: 'PASS',
+    FAIL: 'FAIL',
+    ERROR: 'ERROR',
+    INFO: 'INFO',
+    MANUAL: 'MANUAL',
+    NOT_APPLICABLE: 'NOT_APPLICABLE',
+    INCONSISTENT: 'INCONSISTENT',
+} as const;
+
+export type ComplianceCheckStatus =
+    (typeof ComplianceCheckStatusEnum)[keyof typeof ComplianceCheckStatusEnum];
+
+export type ComplianceScanCluster = {
+    clusterId: string;
+    clusterName: string;
+};
+
+export type ComplianceCheckStatusCount = {
+    count: number;
+    status: ComplianceCheckStatus;
+};
+
+export type ComplianceCheckResultStatusCount = {
+    checkName: string;
+    rationale: string;
+    ruleName: string;
+    checkStats: ComplianceCheckStatusCount[];
+};
+
+export type ListComplianceProfileResults = {
+    profileResults: ComplianceCheckResultStatusCount[];
+    profileName: string;
+    totalCount: number;
+};

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,27 +1,13 @@
 import axios from 'services/instance';
 
-import { complianceV2Url } from './ComplianceCommon';
+import {
+    ComplianceCheckStatus,
+    ComplianceScanCluster,
+    complianceV2Url,
+    ListComplianceProfileResults,
+} from './ComplianceCommon';
 
 const complianceResultsBaseUrl = `${complianceV2Url}/scan`;
-
-export const ComplianceCheckStatusEnum = {
-    UNSET_CHECK_STATUS: 'UNSET_CHECK_STATUS',
-    PASS: 'PASS',
-    FAIL: 'FAIL',
-    ERROR: 'ERROR',
-    INFO: 'INFO',
-    MANUAL: 'MANUAL',
-    NOT_APPLICABLE: 'NOT_APPLICABLE',
-    INCONSISTENT: 'INCONSISTENT',
-} as const;
-
-export type ComplianceCheckStatus =
-    (typeof ComplianceCheckStatusEnum)[keyof typeof ComplianceCheckStatusEnum];
-
-type ComplianceScanCluster = {
-    clusterId: string;
-    clusterName: string;
-};
 
 export type ClusterCheckStatus = {
     cluster: ComplianceScanCluster;
@@ -42,44 +28,6 @@ export type ComplianceCheckResult = {
     valuesUsed: string[];
     warnings: string[];
 };
-export type ComplianceCheckStatusCount = {
-    count: number;
-    status: ComplianceCheckStatus;
-};
-
-type ComplianceProfileScanStats = {
-    checkStats: ComplianceCheckStatusCount[];
-    profileName: string;
-    title: string;
-    version: string;
-};
-
-export type ListComplianceProfileScanStatsResponse = {
-    scanStats: ComplianceProfileScanStats[];
-    totalCount: number;
-};
-
-export type ComplianceCheckResultStatusCount = {
-    checkName: string;
-    rationale: string;
-    ruleName: string;
-    checkStats: ComplianceCheckStatusCount[];
-};
-
-type ListComplianceProfileResults = {
-    profileResults: ComplianceCheckResultStatusCount[];
-    profileName: string;
-    totalCount: number;
-};
-
-/**
- * Fetches the scan stats grouped by profile.
- */
-export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanStatsResponse> {
-    return axios
-        .get<ListComplianceProfileScanStatsResponse>(`${complianceResultsBaseUrl}/stats/profiles`)
-        .then((response) => response.data);
-}
 
 /**
  * Fetches the profile check results.
@@ -89,7 +37,7 @@ export function getComplianceProfileResults(
 ): Promise<ListComplianceProfileResults> {
     return axios
         .get<ListComplianceProfileResults>(
-            `${complianceResultsBaseUrl}/profile/results/${profileName}`
+            `${complianceResultsBaseUrl}/results/profiles/${profileName}/checks`
         )
         .then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -1,0 +1,24 @@
+import axios from 'services/instance';
+
+import { ComplianceCheckStatusCount, complianceV2Url } from './ComplianceCommon';
+
+type ComplianceProfileScanStats = {
+    checkStats: ComplianceCheckStatusCount[];
+    profileName: string;
+    title: string;
+    version: string;
+};
+
+export type ListComplianceProfileScanStatsResponse = {
+    scanStats: ComplianceProfileScanStats[];
+    totalCount: number;
+};
+
+/**
+ * Fetches the scan stats grouped by profile.
+ */
+export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanStatsResponse> {
+    return axios
+        .get<ListComplianceProfileScanStatsResponse>(`${complianceV2Url}/scan/stats/profiles`)
+        .then((response) => response.data);
+}


### PR DESCRIPTION
## Description

The backend recently divided the compliance results service into two parts: one for stats and the other for results. This change aligns UI services with the backend proto counterpart.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually tested endpoints to ensure they still work
