### PR TITLE
ROX-23632: Use image SHA in name when tag does not exist

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -65,7 +65,9 @@ function ImageResourceTable({ data, getSortParams }: ImageResourceTableProps) {
                         }}
                     >
                         <Tr>
-                            <Td>{name ? <ImageNameLink id={id} name={name} /> : 'NAME UNKNOWN'}</Td>
+                            <Td width={50}>
+                                {name ? <ImageNameLink id={id} name={name} /> : 'NAME UNKNOWN'}
+                            </Td>
                             {/* Given that this is in the context of a deployment, when would `deploymentCount` ever be less than zero? */}
                             <Td>{deploymentCount > 0 ? 'Active' : 'Inactive'}</Td>
                             <Td>{operatingSystem}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -40,6 +40,7 @@ import ImageDetailBadges, {
 } from '../components/ImageDetailBadges';
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import { getImageBaseNameDisplay } from '../utils/images';
 
 const workloadCveOverviewImagePath = getOverviewPagePath('Workload', {
     vulnerabilityState: 'OBSERVED',
@@ -86,9 +87,11 @@ function ImagePage() {
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     const imageData = data && data.image;
-    const imageName = imageData?.name
-        ? `${imageData.name.registry}/${imageData.name.remote}:${imageData.name.tag}`
-        : 'NAME UNKNOWN';
+    const imageName = imageData?.name;
+    const imageDisplayName =
+        imageData && imageName
+            ? `${imageName.registry}/${getImageBaseNameDisplay(imageData.id, imageName)}`
+            : 'NAME UNKNOWN';
     const scanMessage = getImageScanMessage(imageData?.notes || [], imageData?.scanNotes || []);
 
     let mainContent: ReactNode | null = null;
@@ -117,7 +120,7 @@ function ImagePage() {
                             alignItems={{ default: 'alignItemsFlexStart' }}
                         >
                             <Title headingLevel="h1" className="pf-v5-u-m-0">
-                                {imageName}
+                                {imageDisplayName}
                             </Title>
                             {sha && (
                                 <ClipboardCopy
@@ -202,7 +205,7 @@ function ImagePage() {
 
     return (
         <>
-            <PageTitle title={`Workload CVEs - Image ${imageData ? imageName : ''}`} />
+            <PageTitle title={`Workload CVEs - Image ${imageData ? imageDisplayName : ''}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={workloadCveOverviewImagePath}>
@@ -211,7 +214,7 @@ function ImagePage() {
                     {!error && (
                         <BreadcrumbItem isActive>
                             {imageData ? (
-                                imageName
+                                imageDisplayName
                             ) : (
                                 <Skeleton screenreaderText="Loading image name" width="200px" />
                             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -4,6 +4,7 @@ import { Button, Flex, FlexItem, Tooltip, Truncate } from '@patternfly/react-cor
 import { OutlinedCopyIcon } from '@patternfly/react-icons';
 
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
+import { getImageBaseNameDisplay } from '../utils/images';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 export type ImageNameLinkProps = {
@@ -20,11 +21,14 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
     const vulnerabilityState = useVulnerabilityState();
     const [copyIconTooltip, setCopyIconTooltip] = useState('Copy image name');
 
-    const { registry, remote, tag } = name;
+    const { registry } = name;
+
+    // If tag is not provided, use the image hash (id) full the full image name
+    const baseName = getImageBaseNameDisplay(id, name);
 
     function copyImageName() {
         navigator?.clipboard
-            ?.writeText(`${registry}/${remote}:${tag}`)
+            ?.writeText(`${registry}/${baseName}`)
             .then(() => setCopyIconTooltip('Copied!'))
             .catch(() => {}); /* Nothing to do */
     }
@@ -38,7 +42,7 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
         >
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
                 <Link to={getWorkloadEntityPagePath('Image', id, vulnerabilityState)}>
-                    <Truncate position="middle" content={`${remote}:${tag}`} />
+                    <Truncate position="middle" content={baseName} />
                 </Link>{' '}
                 <span className="pf-v5-u-color-200 pf-v5-u-font-size-sm">in {registry}</span>
                 <div>{children}</div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/images.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/images.test.ts
@@ -1,0 +1,25 @@
+import { getImageBaseNameDisplay } from './images';
+
+describe('image utils', () => {
+    describe('getImageBaseNameDisplay', () => {
+        it('should return remote:tag when tag is provided', () => {
+            const id = 'id';
+            const name = {
+                remote: 'remote',
+                registry: 'registry',
+                tag: 'tag',
+            };
+            expect(getImageBaseNameDisplay(id, name)).toEqual('remote:tag');
+        });
+
+        it('should return remote@id when tag is not provided', () => {
+            const id = 'id';
+            const name = {
+                remote: 'remote',
+                registry: 'registry',
+                tag: '',
+            };
+            expect(getImageBaseNameDisplay(id, name)).toEqual('remote@id');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/images.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/images.ts
@@ -1,0 +1,13 @@
+/**
+ *  Get the display name of an image based on the presence of a tag
+ */
+export function getImageBaseNameDisplay(
+    id: string,
+    imageName: {
+        remote: string;
+        tag: string;
+    }
+) {
+    const { remote, tag } = imageName;
+    return tag ? `${remote}:${tag}` : `${remote}@${id}`;
+}


### PR DESCRIPTION
## Description

Fixes image name display issue in cases where an image does not have a tag. This will display either:
- registry/remote:tag
- registry/remote@sha
depending on the presence of a non-empty tag field for an image name in the Workload CVEs section.

Prior to this change, images without a tag simply displayed a trailing `:` character.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Workload CVEs and view the images tab.

Image names contain either a tag:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e4f7f37-c0a9-4c5a-ab92-9fae0018cf15)
or a digest:
![image](https://github.com/stackrox/stackrox/assets/1292638/8ea22751-57d0-4000-92b0-1927f4e7c106)

Manually verify that the copy button functionality also copies the correct full name.

Note that images that have no tag still do not have a menu option to "Watch image".

Verify tag/hash behavior in a CVE single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/194f0e90-0c5f-4748-ae87-3482a999cfce)
![image](https://github.com/stackrox/stackrox/assets/1292638/71b235b6-6c8c-449a-b736-682b350753c6)

Verify behavior in Deployment page -> Details tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/a99bc7a6-dd41-48e3-a5bf-79170b9b3eae)
![image](https://github.com/stackrox/stackrox/assets/1292638/28b31dfc-a0c0-4c90-8bb0-ae95847fb844)


Verify the behavior in the header of an Image single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/a0503d86-02b6-4887-9e58-11e5238952b2)
