### PR TITLE
ROX-22797: Add pagination to list policies endpoint

### DIFF
--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -44,6 +44,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/predicate/basematchers"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
@@ -86,6 +87,7 @@ const (
 	uncategorizedCategory = `Uncategorized`
 	dryRunParallelism     = 8
 	identityUIDKey        = "identityUID"
+	maxPoliciesReturned   = 1000
 )
 
 var (
@@ -176,23 +178,24 @@ func convertPoliciesToListPolicies(policies []*storage.Policy) []*storage.ListPo
 // ListPolicies retrieves all policies in ListPolicy form according to the request.
 func (s *serviceImpl) ListPolicies(ctx context.Context, request *v1.RawQuery) (*v1.ListPoliciesResponse, error) {
 	resp := new(v1.ListPoliciesResponse)
-	if request.GetQuery() == "" {
-		policies, err := s.policies.GetAllPolicies(ctx)
-		if err != nil {
-			return nil, err
-		}
-		resp.Policies = convertPoliciesToListPolicies(policies)
-	} else {
-		parsedQuery, err := search.ParseQuery(request.GetQuery())
-		if err != nil {
-			return nil, errors.Wrap(errox.InvalidArgs, err.Error())
-		}
-		policies, err := s.policies.SearchRawPolicies(ctx, parsedQuery)
-		if err != nil {
-			return nil, err
-		}
-		resp.Policies = convertPoliciesToListPolicies(policies)
+	parsedQuery, err := search.ParseQuery(request.GetQuery(), search.MatchAllIfEmpty())
+	if err != nil {
+		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
+	// Fill in pagination.
+	pagination := request.GetPagination()
+	if request.GetPagination() == nil {
+		pagination = &v1.Pagination{
+			Limit: maxPoliciesReturned,
+		}
+	}
+	paginated.FillPagination(parsedQuery, pagination, maxPoliciesReturned)
+
+	policies, err := s.policies.SearchRawPolicies(ctx, parsedQuery)
+	if err != nil {
+		return nil, err
+	}
+	resp.Policies = convertPoliciesToListPolicies(policies)
 
 	return resp, nil
 }

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
+	"github.com/stackrox/rox/pkg/fixtures"
 	mitreMocks "github.com/stackrox/rox/pkg/mitre/datastore/mocks"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/search"
@@ -223,6 +225,86 @@ func (s *PolicyServiceTestSuite) TestDryRunRuntime() {
 	resp, err := s.tested.DryRunPolicy(ctx, runtimePolicy)
 	s.Nil(err)
 	s.Nil(resp.GetAlerts())
+}
+
+func (s *PolicyServiceTestSuite) TestListPoliciesHandlesQueryAndPagination() {
+	ctx := context.Background()
+	basePolicy := fixtures.GetPolicy()
+	policies := make([]*storage.Policy, 4)
+	for i := 0; i < 4; i++ {
+		p := basePolicy.Clone()
+		p.Id = fmt.Sprintf("policy-%d", i)
+		policies = append(policies, p)
+	}
+	listPolicies := convertPoliciesToListPolicies(policies)
+	policyDisabledBaseQuery := &v1.Query_BaseQuery{
+		BaseQuery: &v1.BaseQuery{
+			Query: &v1.BaseQuery_MatchFieldQuery{
+				MatchFieldQuery: &v1.MatchFieldQuery{Field: search.Disabled.String(), Value: "false"},
+			},
+		},
+	}
+
+	cases := []struct {
+		name          string
+		request       *v1.RawQuery
+		expectedQuery *v1.Query
+	}{
+		{
+			name:          "Empty query, get all policies",
+			request:       &v1.RawQuery{},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: maxPoliciesReturned, Offset: 0}},
+		},
+		{
+			name:          "Empty query, paginate",
+			request:       &v1.RawQuery{Pagination: &v1.Pagination{Limit: 2}},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: 2, Offset: 0}},
+		},
+		{
+			name:          "Empty query, paginate and offset",
+			request:       &v1.RawQuery{Pagination: &v1.Pagination{Limit: 20, Offset: 4}},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: 20, Offset: 4}},
+		},
+		{
+			name:    "Non-empty query gets parsed properly",
+			request: &v1.RawQuery{Query: search.NewQueryBuilder().AddBools(search.Disabled, false).Query()},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: maxPoliciesReturned, Offset: 0},
+			},
+		},
+		{
+			name: "Non-empty query gets parsed properly, paginate",
+			request: &v1.RawQuery{
+				Query:      search.NewQueryBuilder().AddBools(search.Disabled, false).Query(),
+				Pagination: &v1.Pagination{Limit: 2},
+			},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: 2, Offset: 0},
+			},
+		},
+		{
+			name: "Non-empty query gets parsed properly, limit pagination to max and offset",
+			request: &v1.RawQuery{
+				Query:      search.NewQueryBuilder().AddBools(search.Disabled, false).Query(),
+				Pagination: &v1.Pagination{Limit: 2000, Offset: 50},
+			},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: 1000, Offset: 50},
+			},
+		},
+	}
+	for _, c := range cases {
+		s.T().Run(c.name, func(t *testing.T) {
+			s.policies.EXPECT().SearchRawPolicies(ctx, c.expectedQuery).Return(policies, nil).Times(1)
+			resp, err := s.tested.ListPolicies(ctx, c.request)
+			s.NoError(err)
+			s.NotNil(resp)
+			protoassert.SlicesEqual(s.T(), listPolicies, resp.Policies)
+		})
+	}
 }
 
 func (s *PolicyServiceTestSuite) TestImportPolicy() {

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -114,8 +114,8 @@ func (ds *datastoreImpl) SetPolicyCategoriesForPolicy(ctx context.Context, polic
 }
 
 func (ds *datastoreImpl) GetPolicyCategoriesForPolicy(ctx context.Context, policyID string) ([]*storage.PolicyCategory, error) {
-	ds.categoryMutex.RLock()
-	defer ds.categoryMutex.RUnlock()
+	//ds.categoryMutex.RLock()
+	//defer ds.categoryMutex.RUnlock()
 
 	return ds.SearchRawPolicyCategories(ctx, searchPkg.NewQueryBuilder().AddStrings(searchPkg.PolicyID, policyID).ProtoQuery())
 }

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -36,7 +36,7 @@ type datastoreImpl struct {
 	storage              store.Store
 	searcher             search.Searcher
 	policyCategoryEdgeDS datastore.DataStore
-	categoryMutex        sync.Mutex
+	categoryMutex        sync.RWMutex
 
 	categoryNameIDMap map[string]string
 }
@@ -114,8 +114,8 @@ func (ds *datastoreImpl) SetPolicyCategoriesForPolicy(ctx context.Context, polic
 }
 
 func (ds *datastoreImpl) GetPolicyCategoriesForPolicy(ctx context.Context, policyID string) ([]*storage.PolicyCategory, error) {
-	ds.categoryMutex.Lock()
-	defer ds.categoryMutex.Unlock()
+	ds.categoryMutex.RLock()
+	defer ds.categoryMutex.RUnlock()
 
 	return ds.SearchRawPolicyCategories(ctx, searchPkg.NewQueryBuilder().AddStrings(searchPkg.PolicyID, policyID).ProtoQuery())
 }

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -36,7 +36,7 @@ type datastoreImpl struct {
 	storage              store.Store
 	searcher             search.Searcher
 	policyCategoryEdgeDS datastore.DataStore
-	categoryMutex        sync.RWMutex
+	categoryMutex        sync.Mutex
 
 	categoryNameIDMap map[string]string
 }
@@ -114,8 +114,8 @@ func (ds *datastoreImpl) SetPolicyCategoriesForPolicy(ctx context.Context, polic
 }
 
 func (ds *datastoreImpl) GetPolicyCategoriesForPolicy(ctx context.Context, policyID string) ([]*storage.PolicyCategory, error) {
-	//ds.categoryMutex.RLock()
-	//defer ds.categoryMutex.RUnlock()
+	ds.categoryMutex.Lock()
+	defer ds.categoryMutex.Unlock()
 
 	return ds.SearchRawPolicyCategories(ctx, searchPkg.NewQueryBuilder().AddStrings(searchPkg.PolicyID, policyID).ProtoQuery())
 }


### PR DESCRIPTION
This PR adds pagination to list policies api. This changes has been tested manually and verified that pagination works in policies
GET https://localhost:8000/v1/policies?query=&pagination.offset=0&pagination.limit=10
response attached
[Untitled.txt](https://github.com/user-attachments/files/16149692/Untitled.txt)
