### PR TITLE
chore(ui): Update yup 1.4.0 dependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -88,7 +88,7 @@
         "store": "^2.0.12",
         "styled-components": "^5.3.1",
         "use-deep-compare-effect": "^1.8.1",
-        "yup": "^1.3.3"
+        "yup": "^1.4.0"
     },
     "scripts": {
         "clean": "rm -rf ./cypress/test-results",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18511,10 +18511,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-1.3.3.tgz#d2f6020ad1679754c5f8178a29243d5447dead04"
-  integrity sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==
+yup@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.4.0.tgz#898dcd660f9fb97c41f181839d3d65c3ee15a43e"
+  integrity sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==
   dependencies:
     property-expr "^2.0.5"
     tiny-case "^1.0.3"


### PR DESCRIPTION
## Description

Version 1.3.3 was published 5 months ago and 1.4.0 was published 2 months ago.

Update with 2 sprints before next release while we are paying close attention to validation in compliance wizard steps.

https://github.com/jquense/yup/blob/master/CHANGELOG.md#140-2024-03-06

* add optional message to `nonNullable` schema methods
* `string`: Create `.datetime()`

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn` in ui
2. `yarn build` in ui
3. `yarn lint` in ui/apps/platform
4. `yarn start` in ui

### Manual testing

Prerequisite: create at least one collection.

Create e-mail notifiers on the fly.

1. Visit /main/vulnerabilities/reports and test validation.
    * Does not display validation error if distribution lists is empty.
        Confirmed on staging, so investigate in vulnerability reports after we merge #11062

### Integration testing


Prerequisites:

```sh
export CYPRESS_ROX_CLOUD_SOURCES=true
export CYPRESS_ROX_AUTH_MACHINE_TO_MACHINE=true
```

1. `yarn cypress-open` in ui/apps/platform
    * integrations/apiTokens.test.js
    * integrations/cloudSourcesIntegrations.test.js
    * integrations/externalBackups.test.js
    * integrations/imageIntegrations.test.js
    * integrations/machineAccessConfigs.test.js
    * integrations/notifiers.test.js
    * integrations/signatureIntegrations.test.js