### PR TITLE
ROX-24119: Configure node-inventory container to be privileged

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -172,6 +172,8 @@ spec:
             name: grpc
         resources:
           {{- ._rox.collector._nodeScanningResources | nindent 10 }}
+        securityContext:
+          privileged: true
         env:
         - name: ROX_NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Description

This should prevent the node-inventory container triggering SELinux violations on OpenShift with SELinux enabled.

This has already been tested [with an overlay](https://github.com/stackrox/acs-fleet-manager/pull/1799) in ACSCS in the integration environment.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Testing in ACSCS integration environment.
The [Grafana dashboard](https://grafana-route-rhacs-observability.apps.acs-int-us-01.isbr.p1.openshiftapps.com/d/4032f3c17643119901e107a0a1786d5b9e4c9565/rhacs-dataplane-cluster-metrics?orgId=1) shows no SELinux violations.