### PR TITLE
ROX-24073: Use GOTOOLCHAIN local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,7 @@ deps: $(shell find $(BASE_DIR) -name "go.sum")
 	$(SILENT)test -z $(GOMOCK_REFLECT_DIRS) || { echo "Found leftover gomock directories. Please remove them and rerun make deps!"; echo $(GOMOCK_REFLECT_DIRS); exit 1; }
 	$(SILENT)go mod tidy
 ifdef CI
+	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "gotoolchain does not match with installed Go version" ; exit 1 ; }
 	$(SILENT)git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 	go mod verify
 endif

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ deps: $(shell find $(BASE_DIR) -name "go.sum")
 	$(SILENT)test -z $(GOMOCK_REFLECT_DIRS) || { echo "Found leftover gomock directories. Please remove them and rerun make deps!"; echo $(GOMOCK_REFLECT_DIRS); exit 1; }
 	$(SILENT)go mod tidy
 ifdef CI
-	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "gotoolchain does not match with installed Go version" ; exit 1 ; }
+	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "Go toolchain does not match with installed Go version. This is a compatibility check that prevents breaking downstream builds. If you really need to update the toolchain version, ask in #forum-acs-golang" ; exit 1 ; }
 	$(SILENT)git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 	go mod verify
 endif


### PR DESCRIPTION
## Description

> [When GOTOOLCHAIN is set to local, the go command always runs the bundled Go toolchain.](https://go.dev/doc/toolchain#:~:text=When%20GOTOOLCHAIN%20is%20set%20to%20local%2C%20the%20go%20command%20always%20runs%20the%20bundled%20Go%20toolchain.)

[Discussion](https://redhat-internal.slack.com/archives/C02CFR7GQUS/p1714740069768599)

- https://github.com/dependabot/dependabot-core/issues/9422

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```go
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) go get -u k8s.io/api
go: k8s.io/api@v0.30.0 requires go >= 1.22.0; switching to go1.22.3
go: upgraded go 1.21 => 1.22.0
go: upgraded toolchain go1.21.9 => go1.22.3
go: upgraded k8s.io/api v0.29.3 => v0.30.0
go: upgraded k8s.io/apimachinery v0.29.3 => v0.30.0
go: upgraded k8s.io/kube-openapi v0.0.0-20240105020646-a37d4de58910 => v0.0.0-20240228011516-70dd3763d340
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) ✗ go mod tidy
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) ✗ git add .
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) ✗ git ci --amend
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) ✗ git ci -m "WIP"
[ROX-24073-Use-GOTOOLCHAIN-local 1ddbab3882] WIP
 2 files changed, 11 insertions(+), 11 deletions(-)
➜  stackrox git:(ROX-24073-Use-GOTOOLCHAIN-local) CI=true make deps --always-make -j 8
+ go/src/github.com/stackrox/stackrox/scanner/tools/go.sum
+ go/src/github.com/stackrox/stackrox/tools/check-workflow-run/go.sum
+ go/src/github.com/stackrox/stackrox/tools/linters/go.sum
+ go/src/github.com/stackrox/stackrox/tools/proto/go.sum
+ go/src/github.com/stackrox/stackrox/tools/test/go.sum
+ go/src/github.com/stackrox/stackrox/go.sum
+ go/src/github.com/stackrox/stackrox/operator/tools/yq/go.sum
+ go/src/github.com/stackrox/stackrox/operator/tools/operator-sdk/go.sum
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/tools/test/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/tools/test/go.sum] Error 1
make: *** Waiting for unfinished jobs....
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/operator/tools/operator-sdk/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/operator/tools/operator-sdk/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/tools/check-workflow-run/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/tools/check-workflow-run/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/scanner/tools/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/scanner/tools/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/tools/proto/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/tools/proto/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/operator/tools/yq/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/operator/tools/yq/go.sum] Error 1
go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
gotoolchain does not match with installed Go version
Makefile:346: recipe for target 'go/src/github.com/stackrox/stackrox/tools/linters/go.sum' failed
make: *** [go/src/github.com/stackrox/stackrox/tools/linters/go.sum] Error 1
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
