### PR TITLE
ROX-23820: Add ability to snooze node cves in VM 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -45,7 +45,7 @@ function PlatformCvesOverviewPage() {
     const querySearchFilter = searchFilter;
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
-    const isViewingSnoozedCves = querySearchFilter['CVE Snoozed'] === 'true';
+    const isViewingSnoozedCves = querySearchFilter['CVE Snoozed']?.[0] === 'true';
     const hasLegacySnoozeAbility = useHasLegacySnoozeAbility();
     const selectedCves = useMap<string, { cve: string }>();
     const { snoozeModalOptions, setSnoozeModalOptions, snoozeActionCreator } = useSnoozeCveModal();


### PR DESCRIPTION
## Description

Adds the ability to snooze/unsnooze Node CVEs via the UI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

This PR uses code common with Platform CVEs, so the implementation and UX is nearly identical. Re-use testing steps in:
1. https://github.com/stackrox/stackrox/pull/11041 to validate that permissions and feature flags correctly gate the row action and bulk dropdown functionality
2. https://github.com/stackrox/stackrox/pull/11040 to validate the snooze and unsnooze workflows for single and multiple CVEs

For further verification, the following screenshots show that requests when using the testing steps above are sent under the `nodecves` endpoint instead of the `clustercves` endpoint used in Platform CVEs:

Snooze single
![image](https://github.com/stackrox/stackrox/assets/1292638/2f755738-859b-4555-8aa5-4fdac0cc0b80)
Snooze multiple
![image](https://github.com/stackrox/stackrox/assets/1292638/495bcc70-25c4-447a-a8ad-94c3251f96d3)
Unsnooze single
![image](https://github.com/stackrox/stackrox/assets/1292638/a467b454-50dd-4e76-9b8f-9c7e28c855d1)
Unsnooze multiple
![image](https://github.com/stackrox/stackrox/assets/1292638/2c17dec1-7721-4f75-be41-9d54b90ee867)

