### PR TITLE
ROX-23069: Add sorting to Platform CVE single page table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -5,11 +5,19 @@ import { Truncate } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { TableUIState } from 'utils/getTableUIState';
 import { ClusterType } from 'types/cluster.proto';
 
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 import { displayClusterType } from '../utils/stringUtils';
+
+export const sortFields = {
+    Cluster: 'Cluster',
+    ClusterType: 'Cluster Type',
+    ClusterKubernetesVersion: 'Cluster Kubernetes Version',
+} as const;
+export const defaultSortOption = { field: 'Cluster', direction: 'asc' } as const;
 
 export const affectedClusterFragment = gql`
     fragment AffectedClusterFragment on Cluster {
@@ -37,9 +45,10 @@ export type AffectedCluster = {
 
 export type AffectedClustersTableProps = {
     tableState: TableUIState<AffectedCluster>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function AffectedClustersTable({ tableState }: AffectedClustersTableProps) {
+function AffectedClustersTable({ tableState, getSortParams }: AffectedClustersTableProps) {
     return (
         <Table
             borders={tableState.type === 'COMPLETE'}
@@ -50,9 +59,11 @@ function AffectedClustersTable({ tableState }: AffectedClustersTableProps) {
         >
             <Thead noWrap>
                 <Tr>
-                    <Th>Cluster</Th>
-                    <Th>Cluster type</Th>
-                    <Th>Kubernetes version</Th>
+                    <Th sort={getSortParams(sortFields.Cluster)}>Cluster</Th>
+                    <Th sort={getSortParams(sortFields.ClusterType)}>Cluster type</Th>
+                    <Th sort={getSortParams(sortFields.ClusterKubernetesVersion)}>
+                        Kubernetes version
+                    </Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -26,11 +26,12 @@ import {
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import useURLSort from 'hooks/useURLSort';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import CvePageHeader from '../../components/CvePageHeader';
 import { getOverviewPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
 import useAffectedClusters from './useAffectedClusters';
-import AffectedClustersTable from './AffectedClustersTable';
+import AffectedClustersTable, { sortFields, defaultSortOption } from './AffectedClustersTable';
 import usePlatformCveMetadata from './usePlatformCveMetadata';
 import ClustersByTypeSummaryCard from './ClustersByTypeSummaryCard';
 import AffectedClustersSummaryCard from './AffectedClustersSummaryCard';
@@ -54,11 +55,17 @@ function PlatformCvePage() {
     });
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: Object.values(sortFields),
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
 
     const { affectedClustersRequest, clusterData, clusterCount } = useAffectedClusters(
         query,
         page,
-        perPage
+        perPage,
+        sortOption
     );
     const metadataRequest = usePlatformCveMetadata(cveId, query, page, perPage);
     const cveName = metadataRequest.data?.platformCVE?.cve;
@@ -140,7 +147,7 @@ function PlatformCvePage() {
                             />
                         </SplitItem>
                     </Split>
-                    <AffectedClustersTable tableState={tableState} />
+                    <AffectedClustersTable tableState={tableState} getSortParams={getSortParams} />
                 </div>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
@@ -1,4 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
+import { ApiSortOption } from 'types/search';
+import { Pagination } from 'services/types';
 import { AffectedCluster, affectedClusterFragment } from './AffectedClustersTable';
 
 const affectedClustersQuery = gql`
@@ -11,7 +13,12 @@ const affectedClustersQuery = gql`
     }
 `;
 
-export default function useAffectedClusters(query: string, page: number, perPage: number) {
+export default function useAffectedClusters(
+    query: string,
+    page: number,
+    perPage: number,
+    sortOption: ApiSortOption
+) {
     const affectedClustersRequest = useQuery<
         {
             clusterCount: number;
@@ -19,7 +26,7 @@ export default function useAffectedClusters(query: string, page: number, perPage
         },
         {
             query: string;
-            pagination: { limit: number; offset: number };
+            pagination: Pagination;
         }
     >(affectedClustersQuery, {
         variables: {
@@ -27,6 +34,7 @@ export default function useAffectedClusters(query: string, page: number, perPage
             pagination: {
                 limit: perPage,
                 offset: (page - 1) * perPage,
+                sortOption,
             },
         },
     });


### PR DESCRIPTION
## Description

Adds sorting to the Platform CVE single page's table.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load a Platform CVE single page and verify that the default sort is by cluster name, ascending alphabetical order. (There is only one record on my system, so we can verify the correct parameters are passed via the query and visible in the URL.)
![image](https://github.com/stackrox/stackrox/assets/1292638/fdfff5eb-2c3d-473a-be56-2e54a016cc55)
Verify "Cluster" sort descending.
![image](https://github.com/stackrox/stackrox/assets/1292638/80924eba-6233-4ea8-b862-9a4624042d2a)
Verify "Cluster Type" sort descending.
![image](https://github.com/stackrox/stackrox/assets/1292638/8493ce27-9761-4607-9ece-73834a28afd8)
Verify "Cluster Type" sort ascending.
![image](https://github.com/stackrox/stackrox/assets/1292638/76a1e093-c7c0-4d14-a872-aefc2abd7e56)
Verify "Cluster Kubernetes Version" sort descending.
![image](https://github.com/stackrox/stackrox/assets/1292638/7275581a-ecf6-42dd-b291-eb1a05fe088f)
Verify "Cluster Kubernetes Version" sort ascending.
![image](https://github.com/stackrox/stackrox/assets/1292638/4eeade1d-8322-44de-8602-d3fbac6f9dbb)

