### PR TITLE
chore(resolver): Disable the aggregator queue

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -104,7 +104,7 @@ var (
 	ComplianceRemediationV2 = registerFeature("Enable Compliance Remediation feature", "ROX_COMPLIANCE_REMEDIATION", false)
 
 	// SensorAggregateDeploymentReferenceOptimization enables a performance improvement by aggregating deployment references when the same reference is queued for processing
-	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", true)
+	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", false)
 
 	// ACSCSEmailNotifier enables support for the ACSCS email notifier integratioon
 	ACSCSEmailNotifier = registerFeature("Enable support for ACSCS Email notifier type", "ROX_ACSCS_EMAIL_NOTIFIER", false)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
@@ -49,6 +50,7 @@ func (s *resolverSuite) TearDownTest() {
 }
 
 func (s *resolverSuite) SetupTest() {
+	s.T().Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(), "true")
 	s.mockCtrl = gomock.NewController(s.T())
 
 	s.mockOutput = mocks.NewMockOutputQueue(s.mockCtrl)


### PR DESCRIPTION
## Description

Disable the aggregator queue until we figure out why the SummaryTests are flaking.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI should be happy (SummaryTests at least 🙂 )

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
