### PR TITLE
ROX-23078: Add sorting to Cluster single page table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -11,6 +11,12 @@ import { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
 import { UseURLSortResult } from 'hooks/useURLSort';
+import {
+    CLUSTER_CVE_STATUS_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVE_TYPE_SORT_FIELD,
+    CVSS_SORT_FIELD,
+} from '../../utils/sortFields';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 
@@ -27,14 +33,14 @@ function displayCveType(cveType: string): string {
     }
 }
 
-export const sortFields = {
-    CVE: 'CVE',
-    CVEStatus: 'Cluster CVE Fixable',
-    CVEType: 'CVE Type',
-    CVSSScore: 'CVSS',
-};
+export const sortFields = [
+    CVE_SORT_FIELD,
+    CLUSTER_CVE_STATUS_SORT_FIELD,
+    CVE_TYPE_SORT_FIELD,
+    CVSS_SORT_FIELD,
+];
 
-export const defaultSortOption = { field: 'CVSS', direction: 'desc' } as const;
+export const defaultSortOption = { field: CVSS_SORT_FIELD, direction: 'desc' } as const;
 
 export const clusterVulnerabilityFragment = gql`
     fragment ClusterVulnerabilityFragment on ClusterVulnerability {
@@ -76,10 +82,10 @@ function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
             <Thead noWrap>
                 <Tr>
                     <Th aria-label="Expand row" />
-                    <Th sort={getSortParams(sortFields.CVE)}>CVE</Th>
-                    <Th sort={getSortParams(sortFields.CVEStatus)}>CVE status</Th>
-                    <Th sort={getSortParams(sortFields.CVEType)}>CVE type</Th>
-                    <Th sort={getSortParams(sortFields.CVSSScore)}>CVSS score</Th>
+                    <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
+                    <Th sort={getSortParams(CLUSTER_CVE_STATUS_SORT_FIELD)}>CVE status</Th>
+                    <Th sort={getSortParams(CVE_TYPE_SORT_FIELD)}>CVE type</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS score</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -10,6 +10,7 @@ import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/Vulnera
 import { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
+import { UseURLSortResult } from 'hooks/useURLSort';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 
@@ -25,6 +26,15 @@ function displayCveType(cveType: string): string {
             return cveType;
     }
 }
+
+export const sortFields = {
+    CVE: 'CVE',
+    CVEStatus: 'Cluster CVE Fixable',
+    CVEType: 'CVE Type',
+    CVSSScore: 'CVSS',
+};
+
+export const defaultSortOption = { field: 'CVSS', direction: 'desc' } as const;
 
 export const clusterVulnerabilityFragment = gql`
     fragment ClusterVulnerabilityFragment on ClusterVulnerability {
@@ -48,9 +58,10 @@ export type ClusterVulnerability = {
 
 export type CVEsTableProps = {
     tableState: TableUIState<ClusterVulnerability>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function CVEsTable({ tableState }: CVEsTableProps) {
+function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
     const COL_SPAN = 5;
     const expandedRowSet = useSet<string>();
 
@@ -65,10 +76,10 @@ function CVEsTable({ tableState }: CVEsTableProps) {
             <Thead noWrap>
                 <Tr>
                     <Th aria-label="Expand row" />
-                    <Th>CVE</Th>
-                    <Th>CVE status</Th>
-                    <Th>CVE type</Th>
-                    <Th>CVSS score</Th>
+                    <Th sort={getSortParams(sortFields.CVE)}>CVE</Th>
+                    <Th sort={getSortParams(sortFields.CVEStatus)}>CVE status</Th>
+                    <Th sort={getSortParams(sortFields.CVEType)}>CVE type</Th>
+                    <Th sort={getSortParams(sortFields.CVSSScore)}>CVSS score</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -40,7 +40,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: Object.values(sortFields),
+        sortFields,
         defaultSortOption,
         onSort: () => setPage(1),
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -17,13 +17,14 @@ import { getHasSearchApplied, getUrlQueryStringForSearchFilter } from 'utils/sea
 import { getTableUIState } from 'utils/getTableUIState';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
+import useURLSort from 'hooks/useURLSort';
 import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import { getHiddenStatuses } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import useClusterVulnerabilities from './useClusterVulnerabilities';
 import useClusterSummaryData from './useClusterSummaryData';
-import CVEsTable from './CVEsTable';
+import CVEsTable, { defaultSortOption, sortFields } from './CVEsTable';
 import PlatformCvesByStatusSummaryCard from './PlatformCvesByStatusSummaryCard';
 import PlatformCvesByTypeSummaryCard from './PlatformCvesByTypeSummaryCard';
 
@@ -38,8 +39,19 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: Object.values(sortFields),
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
 
-    const { data, loading, error } = useClusterVulnerabilities(clusterId, query, page, perPage);
+    const { data, loading, error } = useClusterVulnerabilities(
+        clusterId,
+        query,
+        page,
+        perPage,
+        sortOption
+    );
     const summaryRequest = useClusterSummaryData(clusterId, query);
 
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
@@ -108,7 +120,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                             />
                         </SplitItem>
                     </Split>
-                    <CVEsTable tableState={tableState} />
+                    <CVEsTable tableState={tableState} getSortParams={getSortParams} />
                 </div>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -42,7 +42,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,
-        onSort: () => setPage(1),
+        onSort: () => setPage(1, 'replace'),
     });
 
     const { data, loading, error } = useClusterVulnerabilities(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
@@ -2,6 +2,8 @@ import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
 
+import { Pagination } from 'services/types';
+import { ApiSortOption } from 'types/search';
 import { ClusterVulnerability, clusterVulnerabilityFragment } from './CVEsTable';
 
 const clusterVulnerabilitiesQuery = gql`
@@ -21,7 +23,8 @@ export default function useClusterVulnerabilities(
     id: string,
     query: string,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<
         {
@@ -33,13 +36,13 @@ export default function useClusterVulnerabilities(
         {
             id: string;
             query: string;
-            pagination: { limit: number; offset: number };
+            pagination: Pagination;
         }
     >(clusterVulnerabilitiesQuery, {
         variables: {
             id,
             query,
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -14,7 +14,7 @@ import { displayClusterType } from '../utils/stringUtils';
 
 export const sortFields = {
     Cluster: 'Cluster',
-    ClusterType: 'Cluster Type',
+    ClusterType: 'Cluster Platform Type',
     ClusterKubernetesVersion: 'Cluster Kubernetes Version',
 } as const;
 export const defaultSortOption = { field: 'Cluster', direction: 'asc' } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -9,15 +9,21 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { TableUIState } from 'utils/getTableUIState';
 import { ClusterType } from 'types/cluster.proto';
 
+import {
+    CLUSTER_KUBERNETES_VERSION_SORT_FIELD,
+    CLUSTER_SORT_FIELD,
+    CLUSTER_TYPE_SORT_FIELD,
+} from '../../utils/sortFields';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 import { displayClusterType } from '../utils/stringUtils';
 
-export const sortFields = {
-    Cluster: 'Cluster',
-    ClusterType: 'Cluster Platform Type',
-    ClusterKubernetesVersion: 'Cluster Kubernetes Version',
-} as const;
-export const defaultSortOption = { field: 'Cluster', direction: 'asc' } as const;
+export const sortFields = [
+    CLUSTER_SORT_FIELD,
+    CLUSTER_TYPE_SORT_FIELD,
+    CLUSTER_KUBERNETES_VERSION_SORT_FIELD,
+];
+
+export const defaultSortOption = { field: CLUSTER_SORT_FIELD, direction: 'asc' } as const;
 
 export const affectedClusterFragment = gql`
     fragment AffectedClusterFragment on Cluster {
@@ -59,9 +65,9 @@ function AffectedClustersTable({ tableState, getSortParams }: AffectedClustersTa
         >
             <Thead noWrap>
                 <Tr>
-                    <Th sort={getSortParams(sortFields.Cluster)}>Cluster</Th>
-                    <Th sort={getSortParams(sortFields.ClusterType)}>Cluster type</Th>
-                    <Th sort={getSortParams(sortFields.ClusterKubernetesVersion)}>
+                    <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
+                    <Th sort={getSortParams(CLUSTER_TYPE_SORT_FIELD)}>Cluster type</Th>
+                    <Th sort={getSortParams(CLUSTER_KUBERNETES_VERSION_SORT_FIELD)}>
                         Kubernetes version
                     </Th>
                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -56,7 +56,7 @@ function PlatformCvePage() {
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: Object.values(sortFields),
+        sortFields,
         defaultSortOption,
         onSort: () => setPage(1),
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -1,0 +1,10 @@
+// General CVE sort fields
+export const CVE_SORT_FIELD = 'CVE';
+export const CVSS_SORT_FIELD = 'CVSS';
+export const CVE_TYPE_SORT_FIELD = 'CVE Type';
+
+// Cluster sort fields
+export const CLUSTER_SORT_FIELD = 'Cluster';
+export const CLUSTER_CVE_STATUS_SORT_FIELD = 'Cluster CVE Fixable';
+export const CLUSTER_TYPE_SORT_FIELD = 'Cluster Platform Type';
+export const CLUSTER_KUBERNETES_VERSION_SORT_FIELD = 'Cluster Kubernetes Version';


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Cluster single page, and verify that the default sort is by CVSS, descending:
![image](https://github.com/stackrox/stackrox/assets/1292638/67d15361-8543-49b0-b7ce-e4cac60cf9e7)
Sort ascending:
![image](https://github.com/stackrox/stackrox/assets/1292638/247f78fb-6968-440d-8234-3ba037bae195)
CVE descending
![image](https://github.com/stackrox/stackrox/assets/1292638/7460573c-cf9a-45e2-be4a-de96c4786da2)
CVE ascending
![image](https://github.com/stackrox/stackrox/assets/1292638/ee160e1d-d362-4e01-b697-bad29cf71f9d)
CVE status descending
![image](https://github.com/stackrox/stackrox/assets/1292638/3e7a33a1-621f-40d8-ba81-0939cfc56ea5)
CVE status ascending
![image](https://github.com/stackrox/stackrox/assets/1292638/09bd5736-96b7-446b-8fc5-bf113d8123e1)
CVE type descending
![image](https://github.com/stackrox/stackrox/assets/1292638/992a7718-36bc-4f79-a91d-63466ac0bfb1)

CVE type ascending
![image](https://github.com/stackrox/stackrox/assets/1292638/a9b70946-a912-409b-b8dd-8528fea28b83)

