### PR TITLE
ROX-23508: Adding text input and select for advanced filters

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CheckboxSelect.tsx
@@ -35,10 +35,11 @@ function CheckboxSelect({
         _event: React.MouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
-        if (selection.includes(value as string)) {
+        // @TODO: Consider what to do if the value is an invalid value
+        if (selection.includes(String(value))) {
             onChange(selection.filter((id) => id !== value));
         } else {
-            onChange([...selection, value as string]);
+            onChange([...selection, String(value)]);
         }
     };
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CheckboxSelect.tsx
@@ -1,0 +1,74 @@
+import React, { ReactElement } from 'react';
+import {
+    Select,
+    SelectOption,
+    SelectList,
+    MenuToggle,
+    MenuToggleElement,
+    Badge,
+} from '@patternfly/react-core';
+
+type CheckboxSelectProps = {
+    selection: string[];
+    onChange: (value: string[]) => void;
+    children: ReactElement<typeof SelectOption> | ReactElement<typeof SelectOption>[];
+    isDisabled?: boolean;
+    ariaLabelMenu?: string;
+    toggleLabel?: string;
+};
+
+function CheckboxSelect({
+    selection,
+    onChange,
+    children,
+    isDisabled = false,
+    ariaLabelMenu,
+    toggleLabel,
+}: CheckboxSelectProps) {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const onToggleClick = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const onSelect = (
+        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        value: string | number | undefined
+    ) => {
+        if (selection.includes(value as string)) {
+            onChange(selection.filter((id) => id !== value));
+        } else {
+            onChange([...selection, value as string]);
+        }
+    };
+
+    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+            aria-label={toggleLabel}
+            ref={toggleRef}
+            onClick={onToggleClick}
+            isExpanded={isOpen}
+            isDisabled={isDisabled}
+        >
+            {toggleLabel}
+            {selection && selection.length > 0 && <Badge isRead>{selection.length}</Badge>}
+        </MenuToggle>
+    );
+
+    return (
+        <Select
+            role="menu"
+            aria-label={ariaLabelMenu}
+            isOpen={isOpen}
+            selected={selection}
+            onSelect={onSelect}
+            onOpenChange={(nextOpen: boolean) => setIsOpen(nextOpen)}
+            toggle={toggle}
+            shouldFocusToggleOnSelect
+        >
+            <SelectList>{children}</SelectList>
+        </Select>
+    );
+}
+
+export default CheckboxSelect;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundFilterInputField.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-// @TODO: Fill this out
-function CompoundFilterInputField() {
-    return <div />;
-}
-
-export default CompoundFilterInputField;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -177,8 +177,13 @@ describe(Cypress.spec.relative, () => {
         const nodeComponenSourceSelectItems =
             'div[aria-label="Filter by source select menu"] ul li';
 
-        cy.get(nodeComponenSourceSelectItems).should('have.length', 2);
-        cy.get(nodeComponenSourceSelectItems).eq(0).should('have.text', 'GO');
-        cy.get(nodeComponenSourceSelectItems).eq(1).should('have.text', 'OS');
+        cy.get(nodeComponenSourceSelectItems).should('have.length', 7);
+        cy.get(nodeComponenSourceSelectItems).eq(0).should('have.text', 'OS');
+        cy.get(nodeComponenSourceSelectItems).eq(1).should('have.text', 'Python');
+        cy.get(nodeComponenSourceSelectItems).eq(2).should('have.text', 'Java');
+        cy.get(nodeComponenSourceSelectItems).eq(3).should('have.text', 'Ruby');
+        cy.get(nodeComponenSourceSelectItems).eq(4).should('have.text', 'Node js');
+        cy.get(nodeComponenSourceSelectItems).eq(5).should('have.text', 'Dotnet Core Runtime');
+        cy.get(nodeComponenSourceSelectItems).eq(6).should('have.text', 'Infrastructure');
     });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -7,6 +7,7 @@ import {
     clusterSearchFilterConfig,
     deploymentSearchFilterConfig,
     imageSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
 } from '../types';
 
 const selectors = {
@@ -15,10 +16,15 @@ const selectors = {
     entitySelectItem: (text) => `${selectors.entitySelectItems} button:contains(${text})`,
     attributeSelectToggle: 'button[aria-label="compound search filter attribute selector toggle"]',
     attributeSelectItems: 'div[aria-label="compound search filter attribute selector menu"] ul li',
+    attributeSelectItem: (text) => `${selectors.attributeSelectItems} button:contains(${text})`,
 };
 
 function Wrapper({ config }) {
-    return <CompoundSearchFilter config={config} />;
+    return (
+        <div className="pf-v5-u-p-md">
+            <CompoundSearchFilter config={config} />
+        </div>
+    );
 }
 
 function setup(config) {
@@ -131,5 +137,47 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.attributeSelectItems).eq(0).should('have.text', 'Name');
         cy.get(selectors.attributeSelectItems).eq(1).should('have.text', 'Label');
         cy.get(selectors.attributeSelectItems).eq(2).should('have.text', 'Annotation');
+    });
+
+    it('should display the text input for the image tag search filter', () => {
+        const config = {
+            Image: imageSearchFilterConfig,
+            NodeComponent: nodeComponentSearchFilterConfig,
+        };
+
+        setup(config);
+
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
+
+        cy.get(selectors.attributeSelectToggle).click();
+        cy.get(selectors.attributeSelectItem('Tag')).click();
+
+        cy.get('input[aria-label="Filter results by image tag"]').should('exist');
+    });
+
+    it('should display the select input for the node component source search filter', () => {
+        const config = {
+            Image: imageSearchFilterConfig,
+            NodeComponent: nodeComponentSearchFilterConfig,
+        };
+
+        setup(config);
+
+        cy.get(selectors.entitySelectToggle).click();
+        cy.get(selectors.entitySelectItem('Node Component')).click();
+
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
+
+        cy.get(selectors.attributeSelectToggle).click();
+        cy.get(selectors.attributeSelectItem('Source')).click();
+
+        cy.get('button[aria-label="Filter by source"]').click();
+
+        const nodeComponenSourceSelectItems =
+            'div[aria-label="Filter by source select menu"] ul li';
+
+        cy.get(nodeComponenSourceSelectItems).should('have.length', 2);
+        cy.get(nodeComponenSourceSelectItems).eq(0).should('have.text', 'GO');
+        cy.get(nodeComponenSourceSelectItems).eq(1).should('have.text', 'OS');
     });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -6,6 +6,7 @@ import CompoundSearchFilter from './CompoundSearchFilter';
 import {
     clusterSearchFilterConfig,
     deploymentSearchFilterConfig,
+    imageComponentSearchFilterConfig,
     imageSearchFilterConfig,
     nodeComponentSearchFilterConfig,
 } from '../types';
@@ -155,16 +156,16 @@ describe(Cypress.spec.relative, () => {
         cy.get('input[aria-label="Filter results by image tag"]').should('exist');
     });
 
-    it('should display the select input for the node component source search filter', () => {
+    it('should display the select input for the image component source search filter', () => {
         const config = {
             Image: imageSearchFilterConfig,
-            NodeComponent: nodeComponentSearchFilterConfig,
+            ImageComponent: imageComponentSearchFilterConfig,
         };
 
         setup(config);
 
         cy.get(selectors.entitySelectToggle).click();
-        cy.get(selectors.entitySelectItem('Node Component')).click();
+        cy.get(selectors.entitySelectItem('Image Component')).click();
 
         cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Flex } from '@patternfly/react-core';
+import { Split } from '@patternfly/react-core';
 
 import {
     CompoundSearchFilterConfig,
@@ -10,6 +10,7 @@ import { getDefaultAttribute, getDefaultEntity } from '../utils/utils';
 
 import EntitySelector, { SelectedEntity } from './EntitySelector';
 import AttributeSelector, { SelectedAttribute } from './AttributeSelector';
+import CompoundSearchFilterInputField, { InputFieldValue } from './CompoundSearchFilterInputField';
 
 export type CompoundSearchFilterProps = {
     config: Partial<CompoundSearchFilterConfig>;
@@ -40,6 +41,8 @@ function CompoundSearchFilter({
         return getDefaultAttribute(defaultEntity, config);
     });
 
+    const [inputValue, setInputValue] = useState<InputFieldValue>('');
+
     useEffect(() => {
         if (defaultEntity) {
             setSelectedEntity(defaultEntity);
@@ -53,7 +56,7 @@ function CompoundSearchFilter({
     }, [defaultAttribute]);
 
     return (
-        <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+        <Split>
             <EntitySelector
                 selectedEntity={selectedEntity}
                 onChange={(value) => {
@@ -63,16 +66,34 @@ function CompoundSearchFilter({
                         config
                     );
                     setSelectedAttribute(defaultAttribute);
+                    setInputValue('');
                 }}
                 config={config}
             />
             <AttributeSelector
                 selectedEntity={selectedEntity}
                 selectedAttribute={selectedAttribute}
-                onChange={(value) => setSelectedAttribute(value as SearchFilterAttributeName)}
+                onChange={(value) => {
+                    setSelectedAttribute(value as SearchFilterAttributeName);
+                    setInputValue('');
+                }}
                 config={config}
             />
-        </Flex>
+            <CompoundSearchFilterInputField
+                selectedEntity={selectedEntity}
+                selectedAttribute={selectedAttribute}
+                value={inputValue}
+                onChange={(value) => {
+                    setInputValue(value);
+                }}
+                onSearch={(value) => {
+                    // @TODO: Add search filter value to URL search
+                    // eslint-disable-next-line no-alert
+                    alert(value);
+                }}
+                config={config}
+            />
+        </Split>
     );
 }
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -29,6 +29,13 @@ function isSelectType(
     return attributeObject.inputType === 'select';
 }
 
+function ensureStringArray(value: InputFieldValue): string[] {
+    if (value === undefined || typeof value === 'number' || typeof value === 'string') {
+        return [];
+    }
+    return value;
+}
+
 function CompoundSearchFilterInputField({
     selectedEntity,
     selectedAttribute,
@@ -63,7 +70,7 @@ function CompoundSearchFilterInputField({
     }
     if (isSelectType(attributeObject)) {
         const attributeLabel = attributeObject.displayName.toLowerCase();
-        const selection = value as string[];
+        const selection = ensureStringArray(value);
         const selectOptions = attributeObject.inputProps.options;
 
         return (
@@ -81,10 +88,10 @@ function CompoundSearchFilterInputField({
                         return (
                             <SelectOption
                                 hasCheckbox
-                                value={option}
-                                isSelected={selection.includes(option)}
+                                value={option.value}
+                                isSelected={selection.includes(option.value)}
                             >
-                                {option}
+                                {option.label}
                             </SelectOption>
                         );
                     })

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+import { SearchInput, SelectOption } from '@patternfly/react-core';
+import { SelectedEntity } from './EntitySelector';
+import { SelectedAttribute } from './AttributeSelector';
+import {
+    CompoundSearchFilterConfig,
+    SearchFilterAttribute,
+    SelectSearchFilterAttribute,
+} from '../types';
+
+import CheckboxSelect from './CheckboxSelect';
+
+export type InputFieldValue = string | number | undefined | string[];
+export type InputFieldOnChange = (value: InputFieldValue) => void;
+
+export type CompoundSearchFilterInputFieldProps = {
+    selectedEntity: SelectedEntity;
+    selectedAttribute: SelectedAttribute;
+    value: InputFieldValue;
+    onSearch: InputFieldOnChange;
+    onChange: InputFieldOnChange;
+    config: Partial<CompoundSearchFilterConfig>;
+};
+
+function isSelectType(
+    attributeObject: SearchFilterAttribute
+): attributeObject is SelectSearchFilterAttribute {
+    return attributeObject.inputType === 'select';
+}
+
+function CompoundSearchFilterInputField({
+    selectedEntity,
+    selectedAttribute,
+    value,
+    onSearch,
+    onChange,
+    config,
+}: CompoundSearchFilterInputFieldProps) {
+    if (!selectedEntity || !selectedAttribute) {
+        return null;
+    }
+
+    const attributeObject: SearchFilterAttribute =
+        config[selectedEntity]?.attributes[selectedAttribute];
+
+    if (!attributeObject) {
+        return null;
+    }
+
+    if (attributeObject.inputType === 'text') {
+        const textLabel = `Filter results by ${attributeObject.filterChipLabel.toLowerCase()}`;
+        return (
+            <SearchInput
+                aria-label={textLabel}
+                placeholder={textLabel}
+                value={value as string}
+                onChange={(_event, _value) => onChange(_value)}
+                onSearch={(_event, _value) => onSearch(_value)}
+                onClear={() => onChange('')}
+            />
+        );
+    }
+    if (isSelectType(attributeObject)) {
+        const attributeLabel = attributeObject.displayName.toLowerCase();
+        const selection = value as string[];
+        const selectOptions = attributeObject.inputProps.options;
+
+        return (
+            <CheckboxSelect
+                selection={selection}
+                onChange={(value) => {
+                    onChange(value);
+                    onSearch(value);
+                }}
+                ariaLabelMenu={`Filter by ${attributeLabel} select menu`}
+                toggleLabel={`Filter by ${attributeLabel}`}
+            >
+                {selectOptions.length !== 0 ? (
+                    selectOptions.map((option) => {
+                        return (
+                            <SelectOption
+                                hasCheckbox
+                                value={option}
+                                isSelected={selection.includes(option)}
+                            >
+                                {option}
+                            </SelectOption>
+                        );
+                    })
+                ) : (
+                    <SelectOption isDisabled>No options available</SelectOption>
+                )}
+            </CheckboxSelect>
+        );
+    }
+    return <div />;
+}
+
+export default CompoundSearchFilterInputField;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
@@ -25,17 +25,20 @@ function EntitySelector({ selectedEntity, onChange, config }: EntitySelectorProp
         return null;
     }
 
+    const displayName = selectedEntity ? config[selectedEntity]?.displayName : undefined;
+
     return (
         <SimpleSelect
-            value={selectedEntity}
+            value={displayName}
             onChange={onChange}
             ariaLabelMenu="compound search filter entity selector menu"
             ariaLabelToggle="compound search filter entity selector toggle"
         >
             {entities.map((entity) => {
+                const displayName = config[entity]?.displayName;
                 return (
                     <SelectOption key={entity} value={entity}>
-                        {entity}
+                        {displayName}
                     </SelectOption>
                 );
             })}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
+import { sourceTypeLabels, sourceTypes } from 'types/image.proto';
 import { ValueOf } from 'utils/type.utils';
 
 export type SearchFilterConfig = {
@@ -17,7 +18,7 @@ export type BaseSearchFilterAttribute = {
 export interface SelectSearchFilterAttribute extends BaseSearchFilterAttribute {
     inputType: 'select';
     inputProps: {
-        options: string[];
+        options: { label: string; value: string }[];
     };
 }
 
@@ -88,8 +89,7 @@ export type ImageSearchFilterConfig = {
 
 export type ImageAttribute = keyof ImageSearchFilterConfig['attributes'];
 
-export type ImageAttributeInputType =
-    ImageSearchFilterConfig['attributes'][keyof ImageSearchFilterConfig['attributes']]['inputType'];
+export type ImageAttributeInputType = ValueOf<ImageSearchFilterConfig['attributes']>['inputType'];
 
 // Deployment search filter
 
@@ -126,8 +126,9 @@ export type DeploymentSearchFilterConfig = {
 
 export type DeploymentAttribute = keyof DeploymentSearchFilterConfig['attributes'];
 
-export type DeploymentAttributeInputType =
-    DeploymentSearchFilterConfig['attributes'][keyof DeploymentSearchFilterConfig['attributes']]['inputType'];
+export type DeploymentAttributeInputType = ValueOf<
+    DeploymentSearchFilterConfig['attributes']
+>['inputType'];
 
 // Namespace search filter
 
@@ -164,8 +165,9 @@ export type NamespaceSearchFilterConfig = {
 
 export type NamespaceAttribute = keyof NamespaceSearchFilterConfig['attributes'];
 
-export type NamespaceAttributeInputType =
-    NamespaceSearchFilterConfig['attributes'][keyof NamespaceSearchFilterConfig['attributes']]['inputType'];
+export type NamespaceAttributeInputType = ValueOf<
+    NamespaceSearchFilterConfig['attributes']
+>['inputType'];
 
 // Cluster search filter
 
@@ -202,8 +204,9 @@ export type ClusterSearchFilterConfig = {
 
 export type ClusterAttribute = keyof ClusterSearchFilterConfig['attributes'];
 
-export type ClusterAttributeInputType =
-    ClusterSearchFilterConfig['attributes'][keyof ClusterSearchFilterConfig['attributes']]['inputType'];
+export type ClusterAttributeInputType = ValueOf<
+    ClusterSearchFilterConfig['attributes']
+>['inputType'];
 
 // Node search filter
 
@@ -264,8 +267,7 @@ export type NodeSearchFilterConfig = {
 
 export type NodeAttribute = keyof NodeSearchFilterConfig['attributes'];
 
-export type NodeAttributeInputType =
-    NodeSearchFilterConfig['attributes'][keyof NodeSearchFilterConfig['attributes']]['inputType'];
+export type NodeAttributeInputType = ValueOf<NodeSearchFilterConfig['attributes']>['inputType'];
 
 // Image CVE search filter
 
@@ -297,7 +299,7 @@ export const imageCVESearchFilterConfig = {
             searchTerm: 'CVE Type',
             inputType: 'select',
             inputProps: {
-                options: [],
+                options: [{ label: 'Image CVE', value: 'IMAGE_CVE' }],
             },
         },
     },
@@ -311,8 +313,9 @@ export type ImageCVESearchFilterConfig = {
 
 export type ImageCVEAttribute = keyof ImageCVESearchFilterConfig['attributes'];
 
-export type ImageCVEAttributeInputType =
-    ImageCVESearchFilterConfig['attributes'][keyof ImageCVESearchFilterConfig['attributes']]['inputType'];
+export type ImageCVEAttributeInputType = ValueOf<
+    ImageCVESearchFilterConfig['attributes']
+>['inputType'];
 
 // Node CVE search filter
 
@@ -345,7 +348,10 @@ export const nodeCVESearchFilterConfig = {
             searchTerm: 'CVE Snoozed',
             inputType: 'select',
             inputProps: {
-                options: ['True', 'False'],
+                options: [
+                    { label: 'True', value: 'True' },
+                    { label: 'False', value: 'False' },
+                ],
             },
         },
     },
@@ -359,8 +365,9 @@ export type NodeCVESearchFilterConfig = {
 
 export type NodeCVEAttribute = keyof NodeCVESearchFilterConfig['attributes'];
 
-export type NodeCVEAttributeInputType =
-    NodeCVESearchFilterConfig['attributes'][keyof NodeCVESearchFilterConfig['attributes']]['inputType'];
+export type NodeCVEAttributeInputType = ValueOf<
+    NodeCVESearchFilterConfig['attributes']
+>['inputType'];
 
 // Platform CVE search filter
 
@@ -392,7 +399,10 @@ export const platformCVESearchFilterConfig = {
             searchTerm: 'CVE Snoozed',
             inputType: 'select',
             inputProps: {
-                options: ['True', 'False'],
+                options: [
+                    { label: 'True', value: 'True' },
+                    { label: 'False', value: 'False' },
+                ],
             },
         },
         Type: {
@@ -401,8 +411,11 @@ export const platformCVESearchFilterConfig = {
             searchTerm: 'CVE Type',
             inputType: 'select',
             inputProps: {
-                // @TODO: Need to add the possible options for this
-                options: [],
+                options: [
+                    { label: 'K8s CVE', value: 'K8S_CVE' },
+                    { label: 'Istio CVE', value: 'ISTIO_CVE' },
+                    { label: 'Openshift CVE', value: 'OPENSHIFT_CVE' },
+                ],
             },
         },
     },
@@ -416,8 +429,9 @@ export type PlatformCVESearchFilterConfig = {
 
 export type PlatformCVEAttribute = keyof PlatformCVESearchFilterConfig['attributes'];
 
-export type PlatformCVEAttributeInputType =
-    PlatformCVESearchFilterConfig['attributes'][keyof PlatformCVESearchFilterConfig['attributes']]['inputType'];
+export type PlatformCVEAttributeInputType = ValueOf<
+    PlatformCVESearchFilterConfig['attributes']
+>['inputType'];
 
 // Image Component search filter
 
@@ -437,8 +451,9 @@ export const imageComponentSearchFilterConfig = {
             searchTerm: 'Component Source',
             inputType: 'select',
             inputProps: {
-                // @TODO: Need to add the possible options for this
-                options: [],
+                options: sourceTypes.map((sourceType) => {
+                    return { label: sourceTypeLabels[sourceType], value: sourceType };
+                }),
             },
         },
         Version: {
@@ -458,8 +473,9 @@ export type ImageComponentSearchFilterConfig = {
 
 export type ImageComponentAttribute = keyof ImageComponentSearchFilterConfig['attributes'];
 
-export type ImageComponentAttributeInputType =
-    ImageComponentSearchFilterConfig['attributes'][keyof ImageComponentSearchFilterConfig['attributes']]['inputType'];
+export type ImageComponentAttributeInputType = ValueOf<
+    ImageComponentSearchFilterConfig['attributes']
+>['inputType'];
 
 // Node Component search filter
 
@@ -472,15 +488,6 @@ export const nodeComponentSearchFilterConfig = {
             filterChipLabel: 'Node Component Name',
             searchTerm: 'Component',
             inputType: 'autocomplete',
-        },
-        Source: {
-            displayName: 'Source',
-            filterChipLabel: 'Node Component Source',
-            searchTerm: 'Component Source',
-            inputType: 'select',
-            inputProps: {
-                options: ['GO', 'OS'],
-            },
         },
         Version: {
             displayName: 'Version',
@@ -499,8 +506,9 @@ export type NodeComponentSearchFilterConfig = {
 
 export type NodeComponentAttribute = keyof NodeComponentSearchFilterConfig['attributes'];
 
-export type NodeComponentAttributeInputType =
-    NodeComponentSearchFilterConfig['attributes'][keyof NodeComponentSearchFilterConfig['attributes']]['inputType'];
+export type NodeComponentAttributeInputType = ValueOf<
+    NodeComponentSearchFilterConfig['attributes']
+>['inputType'];
 
 // Compound search filter config
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
 import { ValueOf } from 'utils/type.utils';
 
 export type SearchFilterConfig = {
@@ -6,12 +7,21 @@ export type SearchFilterConfig = {
     attributes: Record<string, SearchFilterAttribute>;
 };
 
-export type SearchFilterAttribute = {
+export type BaseSearchFilterAttribute = {
     displayName: string;
     filterChipLabel: string;
     searchTerm: string;
-    inputType: string;
+    inputType: SearchFilterAttributeInputType;
 };
+
+export interface SelectSearchFilterAttribute extends BaseSearchFilterAttribute {
+    inputType: 'select';
+    inputProps: {
+        options: string[];
+    };
+}
+
+export type SearchFilterAttribute = BaseSearchFilterAttribute | SelectSearchFilterAttribute;
 
 // Image search filter
 
@@ -78,6 +88,9 @@ export type ImageSearchFilterConfig = {
 
 export type ImageAttribute = keyof ImageSearchFilterConfig['attributes'];
 
+export type ImageAttributeInputType =
+    ImageSearchFilterConfig['attributes'][keyof ImageSearchFilterConfig['attributes']]['inputType'];
+
 // Deployment search filter
 
 export const deploymentSearchFilterConfig = {
@@ -112,6 +125,9 @@ export type DeploymentSearchFilterConfig = {
 };
 
 export type DeploymentAttribute = keyof DeploymentSearchFilterConfig['attributes'];
+
+export type DeploymentAttributeInputType =
+    DeploymentSearchFilterConfig['attributes'][keyof DeploymentSearchFilterConfig['attributes']]['inputType'];
 
 // Namespace search filter
 
@@ -148,6 +164,9 @@ export type NamespaceSearchFilterConfig = {
 
 export type NamespaceAttribute = keyof NamespaceSearchFilterConfig['attributes'];
 
+export type NamespaceAttributeInputType =
+    NamespaceSearchFilterConfig['attributes'][keyof NamespaceSearchFilterConfig['attributes']]['inputType'];
+
 // Cluster search filter
 
 export const clusterSearchFilterConfig = {
@@ -182,6 +201,9 @@ export type ClusterSearchFilterConfig = {
 };
 
 export type ClusterAttribute = keyof ClusterSearchFilterConfig['attributes'];
+
+export type ClusterAttributeInputType =
+    ClusterSearchFilterConfig['attributes'][keyof ClusterSearchFilterConfig['attributes']]['inputType'];
 
 // Node search filter
 
@@ -242,6 +264,9 @@ export type NodeSearchFilterConfig = {
 
 export type NodeAttribute = keyof NodeSearchFilterConfig['attributes'];
 
+export type NodeAttributeInputType =
+    NodeSearchFilterConfig['attributes'][keyof NodeSearchFilterConfig['attributes']]['inputType'];
+
 // Image CVE search filter
 
 export const imageCVESearchFilterConfig = {
@@ -271,6 +296,9 @@ export const imageCVESearchFilterConfig = {
             filterChipLabel: 'Image CVE Type',
             searchTerm: 'CVE Type',
             inputType: 'select',
+            inputProps: {
+                options: [],
+            },
         },
     },
 } as const;
@@ -282,6 +310,9 @@ export type ImageCVESearchFilterConfig = {
 };
 
 export type ImageCVEAttribute = keyof ImageCVESearchFilterConfig['attributes'];
+
+export type ImageCVEAttributeInputType =
+    ImageCVESearchFilterConfig['attributes'][keyof ImageCVESearchFilterConfig['attributes']]['inputType'];
 
 // Node CVE search filter
 
@@ -313,6 +344,9 @@ export const nodeCVESearchFilterConfig = {
             filterChipLabel: 'Node CVE Snoozed',
             searchTerm: 'CVE Snoozed',
             inputType: 'select',
+            inputProps: {
+                options: ['True', 'False'],
+            },
         },
     },
 } as const;
@@ -324,6 +358,9 @@ export type NodeCVESearchFilterConfig = {
 };
 
 export type NodeCVEAttribute = keyof NodeCVESearchFilterConfig['attributes'];
+
+export type NodeCVEAttributeInputType =
+    NodeCVESearchFilterConfig['attributes'][keyof NodeCVESearchFilterConfig['attributes']]['inputType'];
 
 // Platform CVE search filter
 
@@ -354,12 +391,19 @@ export const platformCVESearchFilterConfig = {
             filterChipLabel: 'Platform CVE Snoozed',
             searchTerm: 'CVE Snoozed',
             inputType: 'select',
+            inputProps: {
+                options: ['True', 'False'],
+            },
         },
         Type: {
             displayName: 'Type',
             filterChipLabel: 'Platform CVE Type',
             searchTerm: 'CVE Type',
             inputType: 'select',
+            inputProps: {
+                // @TODO: Need to add the possible options for this
+                options: [],
+            },
         },
     },
 } as const;
@@ -371,6 +415,9 @@ export type PlatformCVESearchFilterConfig = {
 };
 
 export type PlatformCVEAttribute = keyof PlatformCVESearchFilterConfig['attributes'];
+
+export type PlatformCVEAttributeInputType =
+    PlatformCVESearchFilterConfig['attributes'][keyof PlatformCVESearchFilterConfig['attributes']]['inputType'];
 
 // Image Component search filter
 
@@ -389,6 +436,10 @@ export const imageComponentSearchFilterConfig = {
             filterChipLabel: 'Image Component Source',
             searchTerm: 'Component Source',
             inputType: 'select',
+            inputProps: {
+                // @TODO: Need to add the possible options for this
+                options: [],
+            },
         },
         Version: {
             displayName: 'Version',
@@ -407,6 +458,9 @@ export type ImageComponentSearchFilterConfig = {
 
 export type ImageComponentAttribute = keyof ImageComponentSearchFilterConfig['attributes'];
 
+export type ImageComponentAttributeInputType =
+    ImageComponentSearchFilterConfig['attributes'][keyof ImageComponentSearchFilterConfig['attributes']]['inputType'];
+
 // Node Component search filter
 
 export const nodeComponentSearchFilterConfig = {
@@ -424,6 +478,9 @@ export const nodeComponentSearchFilterConfig = {
             filterChipLabel: 'Node Component Source',
             searchTerm: 'Component Source',
             inputType: 'select',
+            inputProps: {
+                options: ['GO', 'OS'],
+            },
         },
         Version: {
             displayName: 'Version',
@@ -441,6 +498,9 @@ export type NodeComponentSearchFilterConfig = {
 };
 
 export type NodeComponentAttribute = keyof NodeComponentSearchFilterConfig['attributes'];
+
+export type NodeComponentAttributeInputType =
+    NodeComponentSearchFilterConfig['attributes'][keyof NodeComponentSearchFilterConfig['attributes']]['inputType'];
 
 // Compound search filter config
 
@@ -485,3 +545,13 @@ export type SearchFilterAttributeName =
     | NodeCVEAttribute
     | PlatformCVEAttribute
     | ImageComponentAttribute;
+
+export type SearchFilterAttributeInputType =
+    | ImageAttributeInputType
+    | DeploymentAttributeInputType
+    | ClusterAttributeInputType
+    | NodeAttributeInputType
+    | ImageCVEAttributeInputType
+    | NodeCVEAttributeInputType
+    | PlatformCVEAttributeInputType
+    | ImageComponentAttributeInputType;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -55,6 +55,9 @@ describe('utils', () => {
                     filterChipLabel: 'Image CVE Type',
                     searchTerm: 'CVE Type',
                     inputType: 'select',
+                    inputProps: {
+                        options: [{ label: 'Image CVE', value: 'IMAGE_CVE' }],
+                    },
                 },
             ]);
         });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 import sortBy from 'lodash/sortBy';
 import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
+import { SourceType } from 'types/image.proto';
 import { ApiSortOption } from 'types/search';
 
 export type ImageMetadataContext = {
@@ -38,17 +39,6 @@ export const imageMetadataContextFragment = gql`
         }
     }
 `;
-
-// This is a general type that isn't specific to this component, so should be moved elsewhere if
-// there is a more appropriate location. (top level ./types/ directory?)
-export type SourceType =
-    | 'OS'
-    | 'PYTHON'
-    | 'JAVA'
-    | 'RUBY'
-    | 'NODEJS'
-    | 'DOTNETCORERUNTIME'
-    | 'INFRASTRUCTURE';
 
 // TODO Enforce a non-empty imageVulnerabilities array at a higher level?
 export type ComponentVulnerabilityBase = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Flex, Icon, Tooltip, Truncate } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
-import { SourceType } from '../Tables/table.utils';
+import { SourceType } from 'types/image.proto';
 
 export type ComponentLocationProps = {
     location: string;

--- a/ui/apps/platform/src/types/image.proto.ts
+++ b/ui/apps/platform/src/types/image.proto.ts
@@ -19,3 +19,25 @@ export type ListImage = {
 export type WatchedImage = {
     name: string;
 };
+
+export const sourceTypes = [
+    'OS',
+    'PYTHON',
+    'JAVA',
+    'RUBY',
+    'NODEJS',
+    'DOTNETCORERUNTIME',
+    'INFRASTRUCTURE',
+] as const;
+
+export const sourceTypeLabels: Record<SourceType, string> = {
+    OS: 'OS',
+    PYTHON: 'Python',
+    JAVA: 'Java',
+    RUBY: 'Ruby',
+    NODEJS: 'Node js',
+    DOTNETCORERUNTIME: 'Dotnet Core Runtime',
+    INFRASTRUCTURE: 'Infrastructure',
+};
+
+export type SourceType = (typeof sourceTypes)[number];


### PR DESCRIPTION
## Description

This PR adds different search filter inputs to the compound filter. We begin by adding the `text` and `select` inputs.

<img width="1552" alt="Screenshot 2024-05-14 at 10 17 39 PM" src="https://github.com/stackrox/stackrox/assets/4805485/5eb8b240-b86f-495c-a16b-6133c994e952">
<img width="1552" alt="Screenshot 2024-05-14 at 10 18 40 PM" src="https://github.com/stackrox/stackrox/assets/4805485/25c1b479-5216-467d-8360-31a443aeadae">
