### PR TITLE
ROX-17252: Attempt at temporary fixing data inconsistencies with Image / Image CVE search

### DIFF
--- a/central/image/datastore/fixable_test.go
+++ b/central/image/datastore/fixable_test.go
@@ -54,7 +54,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 		desc     string
 		q        *v1.Query
 		expected []string
-		skip     bool
 	}{
 		{
 			desc: "Search all images with at least some fixable vulnerabilities",
@@ -69,7 +68,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				ProtoQuery(),
 			expected: []string{"image-1", "image-4"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images with at least some non-fixable vulnerabilities",
@@ -83,7 +81,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddBools(search.Fixable, false).
 				AddExactMatches(search.CVE, "cve-2").ProtoQuery(),
 			expected: []string{"image-3", "image-4"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images with at least some fixable vulnerabilities that are deferred",
@@ -107,7 +104,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.Component, "comp-1").
 				AddExactMatches(search.CVE, "cve-1").ProtoQuery(),
 			expected: []string{"image-1", "image-4"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images where 'cve-1' is deferred and fixable in component 'comp-1'",
@@ -125,7 +121,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).ProtoQuery(),
 			expected: []string{"image-1"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images",
@@ -142,9 +137,6 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			if tc.skip {
-				t.SkipNow()
-			}
 			results, err := s.imageDataStore.Search(s.ctx, tc.q)
 			s.NoError(err)
 			actual := search.ResultsToIDs(results)
@@ -158,7 +150,6 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 		desc     string
 		q        *v1.Query
 		expected []string
-		skip     bool
 	}{
 		{
 			desc: "Search all fixable CVEs",
@@ -173,7 +164,6 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 				AddExactMatches(search.ImageSHA, "image-2").
 				ProtoQuery(),
 			expected: []string{"cve-2#"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search CVE 'cve-1' which is not fixable in 'image-2' but fixable elsewhere",
@@ -182,7 +172,6 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				AddExactMatches(search.ImageSHA, "image-2").ProtoQuery(),
 			expected: []string{},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all CVEs in 'image-4' that are fixable",
@@ -253,9 +242,6 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			if tc.skip {
-				t.SkipNow()
-			}
 			results, err := s.cveDataStore.Search(s.ctx, tc.q)
 			s.NoError(err)
 			actual := search.ResultsToIDs(results)
@@ -269,7 +255,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 		desc     string
 		q        *v1.Query
 		expected []string
-		skip     bool
 	}{
 		{
 			desc: "Search all components with at least some fixable vulnerabilities",
@@ -284,7 +269,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				ProtoQuery(),
 			expected: []string{"comp-1#ver-1#"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all components with at least some non-fixable vulnerabilities",
@@ -298,7 +282,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 				AddBools(search.Fixable, false).
 				AddExactMatches(search.CVE, "cve-2").ProtoQuery(),
 			expected: []string{"comp-2#ver-1#"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all components with at least some fixable vulnerabilities that are deferred",
@@ -322,7 +305,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 				AddExactMatches(search.ImageSHA, "image-4").
 				AddExactMatches(search.CVE, "cve-1").ProtoQuery(),
 			expected: []string{"comp-1#ver-1#"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all components where 'cve-1' is deferred and fixable in component 'image-4'",
@@ -340,7 +322,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).ProtoQuery(),
 			expected: []string{"comp-1#ver-1#"},
-			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all components where cve-1 is fixable and deferred OR cve-2 is fixable and observed",
@@ -357,9 +338,6 @@ func (s *FixableSearchTestSuite) TestImageComponentSearch() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			if tc.skip {
-				t.SkipNow()
-			}
 			results, err := s.componentDataStore.Search(s.ctx, tc.q)
 			s.NoError(err)
 			actual := search.ResultsToIDs(results)

--- a/central/image/datastore/fixable_test.go
+++ b/central/image/datastore/fixable_test.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"testing"
 
-	cveDS "github.com/stackrox/rox/central/cve/image/datastore"
 	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
+	imageComponentDS "github.com/stackrox/rox/central/imagecomponent/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -27,17 +27,17 @@ type FixableSearchTestSuite struct {
 	ctx    context.Context
 	testDB *pgtest.TestPostgres
 
-	imageDataStore DataStore
-	cveDataStore   imageCVEDS.DataStore
+	imageDataStore     DataStore
+	cveDataStore       imageCVEDS.DataStore
+	componentDataStore imageComponentDS.DataStore
 }
 
 func (s *FixableSearchTestSuite) SetupSuite() {
 	s.testDB = pgtest.ForT(s.T())
 
-	imageDataStore := GetTestPostgresDataStore(s.T(), s.testDB)
-	s.imageDataStore = imageDataStore
-	cveDataStore := cveDS.GetTestPostgresDataStore(s.T(), s.testDB)
-	s.cveDataStore = cveDataStore
+	s.imageDataStore = GetTestPostgresDataStore(s.T(), s.testDB)
+	s.cveDataStore = imageCVEDS.GetTestPostgresDataStore(s.T(), s.testDB)
+	s.componentDataStore = imageComponentDS.GetTestPostgresDataStore(s.T(), s.testDB)
 
 	s.ctx = sac.WithAllAccess(context.Background())
 	for _, image := range fixableSearchTestImages() {
@@ -69,7 +69,7 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				ProtoQuery(),
 			expected: []string{"image-1", "image-4"},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images with at least some non-fixable vulnerabilities",
@@ -83,7 +83,7 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddBools(search.Fixable, false).
 				AddExactMatches(search.CVE, "cve-2").ProtoQuery(),
 			expected: []string{"image-3", "image-4"},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images with at least some fixable vulnerabilities that are deferred",
@@ -107,7 +107,7 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.Component, "comp-1").
 				AddExactMatches(search.CVE, "cve-1").ProtoQuery(),
 			expected: []string{"image-1", "image-4"},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images where 'cve-1' is deferred and fixable in component 'comp-1'",
@@ -125,7 +125,7 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).ProtoQuery(),
 			expected: []string{"image-1"},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all images",
@@ -173,7 +173,7 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 				AddExactMatches(search.ImageSHA, "image-2").
 				ProtoQuery(),
 			expected: []string{"cve-2#"},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search CVE 'cve-1' which is not fixable in 'image-2' but fixable elsewhere",
@@ -182,7 +182,7 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 				AddExactMatches(search.CVE, "cve-1").
 				AddExactMatches(search.ImageSHA, "image-2").ProtoQuery(),
 			expected: []string{},
-			skip:     true, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
 		},
 		{
 			desc: "Search all CVEs in 'image-4' that are fixable",
@@ -257,6 +257,110 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 				t.SkipNow()
 			}
 			results, err := s.cveDataStore.Search(s.ctx, tc.q)
+			s.NoError(err)
+			actual := search.ResultsToIDs(results)
+			assert.ElementsMatch(t, tc.expected, actual)
+		})
+	}
+}
+
+func (s *FixableSearchTestSuite) TestImageComponentSearch() {
+	for _, tc := range []struct {
+		desc     string
+		q        *v1.Query
+		expected []string
+		skip     bool
+	}{
+		{
+			desc: "Search all components with at least some fixable vulnerabilities",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).ProtoQuery(),
+			expected: []string{"comp-1#ver-1#", "comp-1#ver-3#"},
+		},
+		{
+			desc: "Search all components where 'cve-1' is fixable",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.CVE, "cve-1").
+				ProtoQuery(),
+			expected: []string{"comp-1#ver-1#"},
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+		},
+		{
+			desc: "Search all components with at least some non-fixable vulnerabilities",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, false).ProtoQuery(),
+			expected: []string{"comp-1#ver-3#", "comp-2#ver-1#"},
+		},
+		{
+			desc: "Search all components where 'cve-2' is not fixable",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, false).
+				AddExactMatches(search.CVE, "cve-2").ProtoQuery(),
+			expected: []string{"comp-2#ver-1#"},
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+		},
+		{
+			desc: "Search all components with at least some fixable vulnerabilities that are deferred",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_DEFERRED.String()).ProtoQuery(),
+			expected: []string{"comp-1#ver-1#", "comp-1#ver-3#"},
+		},
+		{
+			desc: "Search all components where 'cve-1' is fixable and deferred",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.CVE, "cve-1").
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_DEFERRED.String()).ProtoQuery(),
+			expected: []string{"comp-1#ver-1#"},
+		},
+		{
+			desc: "Search all components where 'cve-1' is fixable in 'image-4'",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.ImageSHA, "image-4").
+				AddExactMatches(search.CVE, "cve-1").ProtoQuery(),
+			expected: []string{"comp-1#ver-1#"},
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+		},
+		{
+			desc: "Search all components where 'cve-1' is deferred and fixable in component 'image-4'",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.ImageSHA, "image-4").
+				AddExactMatches(search.CVE, "cve-1").
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_DEFERRED.String()).ProtoQuery(),
+			expected: []string{"comp-1#ver-1#"},
+		},
+		{
+			desc: "Search all components where 'cve-1' is fixable and observed",
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.CVE, "cve-1").
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).ProtoQuery(),
+			expected: []string{"comp-1#ver-1#"},
+			skip:     false, // TODO: Enable once https://issues.redhat.com/browse/ROX-17252 is addressed.
+		},
+		{
+			desc: "Search all components where cve-1 is fixable and deferred OR cve-2 is fixable and observed",
+			q: search.DisjunctionQuery(search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				AddExactMatches(search.CVE, "cve-1").
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_DEFERRED.String()).ProtoQuery(),
+				search.NewQueryBuilder().
+					AddBools(search.Fixable, true).
+					AddExactMatches(search.CVE, "cve-2").
+					AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).ProtoQuery(),
+			),
+			expected: []string{"comp-1#ver-1#"},
+		},
+	} {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			if tc.skip {
+				t.SkipNow()
+			}
+			results, err := s.componentDataStore.Search(s.ctx, tc.q)
 			s.NoError(err)
 			actual := search.ResultsToIDs(results)
 			assert.ElementsMatch(t, tc.expected, actual)

--- a/central/image/datastore/fixable_test.go
+++ b/central/image/datastore/fixable_test.go
@@ -34,7 +34,7 @@ type FixableSearchTestSuite struct {
 }
 
 func (s *FixableSearchTestSuite) SetupSuite() {
-	s.T().Setenv(env.ImageCVEEdgeJoinWorkaround.EnvVar(), "true")
+	s.T().Setenv(env.ImageCVEEdgeCustomJoin.EnvVar(), "true")
 	s.testDB = pgtest.ForT(s.T())
 
 	s.imageDataStore = GetTestPostgresDataStore(s.T(), s.testDB)
@@ -145,8 +145,8 @@ func (s *FixableSearchTestSuite) TestImageSearch() {
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
 			if tc.skipWhenWorkaroundDisabled {
-				if !env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
-					t.Skip("Skip test case when ROX_IMAGE_CVE_EDGE_JOIN_WORKAROUND is disabled")
+				if !env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+					t.Skip("Skip test case when ROX_IMAGE_CVE_EDGE_CUSTOM_JOIN is disabled")
 					t.SkipNow()
 				}
 			}
@@ -259,8 +259,8 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
 			if tc.skipWhenWorkaroundDisabled {
-				if !env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
-					t.Skip("Skip test case when ROX_IMAGE_CVE_EDGE_JOIN_WORKAROUND is disabled")
+				if !env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+					t.Skip("Skip test case when ROX_IMAGE_CVE_EDGE_CUSTOM_JOIN is disabled")
 					t.SkipNow()
 				}
 			}
@@ -273,8 +273,8 @@ func (s *FixableSearchTestSuite) TestCVESearch() {
 }
 
 func (s *FixableSearchTestSuite) TestImageComponentSearch() {
-	if !env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
-		s.T().Skip("Skip tests when ROX_IMAGE_CVE_EDGE_JOIN_WORKAROUND is disabled")
+	if !env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+		s.T().Skip("Skip tests when ROX_IMAGE_CVE_EDGE_CUSTOM_JOIN is disabled")
 		s.T().SkipNow()
 	}
 	for _, tc := range []struct {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package imagecve
 
 import (
@@ -961,7 +963,7 @@ func standardizeImages(images ...*storage.Image) {
 	}
 }
 
-func TestImageCVEEdgeSearch(t *testing.T) {
+func TestImageCVEEdgeIsJoinedLast(t *testing.T) {
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)
 
@@ -978,11 +980,11 @@ func TestImageCVEEdgeSearch(t *testing.T) {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.CVE, "cve-2018-1").
 		AddBools(search.Fixable, false).
-		AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+		AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_DEFERRED.String()).
 		ProtoQuery()
 	imageIDs, err := cveView.GetImageIDs(ctx, query)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(imageIDs))
+	assert.ElementsMatch(t, []string{"sha2"}, imageIDs)
 }
 
 func testImages() []*storage.Image {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1,5 +1,3 @@
-//go:build sql_integration
-
 package imagecve
 
 import (
@@ -28,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -959,5 +958,170 @@ func standardizeImages(images ...*storage.Image) {
 			}
 			return components[i].Name < components[j].Name
 		})
+	}
+}
+
+func TestImageCVEEdgeSearch(t *testing.T) {
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(t)
+
+	// Initialize the datastore.
+	imageStore := imageDS.GetTestPostgresDataStore(t, testDB.DB)
+
+	// Upsert test images.
+	images := testImages()
+	for _, image := range images {
+		assert.NoError(t, imageStore.UpsertImage(ctx, image))
+	}
+
+	cveView := NewCVEView(testDB.DB)
+	query := search.NewQueryBuilder().
+		AddExactMatches(search.CVE, "cve-2018-1").
+		AddBools(search.Fixable, false).
+		AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+		ProtoQuery()
+	imageIDs, err := cveView.GetImageIDs(ctx, query)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(imageIDs))
+}
+
+func testImages() []*storage.Image {
+	t1, err := protocompat.ConvertTimeToTimestampOrError(time.Unix(0, 1000))
+	utils.CrashOnError(err)
+	t2, err := protocompat.ConvertTimeToTimestampOrError(time.Unix(0, 2000))
+	utils.CrashOnError(err)
+	return []*storage.Image{
+		{
+			Id: "sha1",
+			Name: &storage.ImageName{
+				Registry: "reg1",
+				Remote:   "img1",
+				Tag:      "tag1",
+				FullName: "reg1/img1:tag1",
+			},
+			SetCves: &storage.Image_Cves{
+				Cves: 3,
+			},
+			Scan: &storage.ImageScan{
+				Components: []*storage.EmbeddedImageScanComponent{
+					{
+						Name:    "comp1",
+						Version: "0.9",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve: "cve-2018-1",
+								SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+									FixedBy: "1.1",
+								},
+								Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+					{
+						Name:    "comp2",
+						Version: "1.1",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve: "cve-2018-1",
+								SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+									FixedBy: "1.5",
+								},
+								Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+					{
+						Name:     "comp3",
+						Version:  "1.0",
+						Source:   storage.SourceType_JAVA,
+						Location: "p/q/r",
+						HasLayerIndex: &storage.EmbeddedImageScanComponent_LayerIndex{
+							LayerIndex: 10,
+						},
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "cve-2019-1",
+								Cvss:     4,
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+							{
+								Cve:      "cve-2019-2",
+								Cvss:     3,
+								Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+				},
+				ScanTime: t1,
+			},
+		},
+		{
+			Id: "sha2",
+			Name: &storage.ImageName{
+				Registry: "reg2",
+				Remote:   "img2",
+				Tag:      "tag2",
+				FullName: "reg2/img2:tag2",
+			},
+			SetCves: &storage.Image_Cves{
+				Cves: 5,
+			},
+			Scan: &storage.ImageScan{
+				Components: []*storage.EmbeddedImageScanComponent{
+					{
+						Name:    "comp5",
+						Version: "0.9",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "cve-2018-1",
+								Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+								State:    storage.VulnerabilityState_DEFERRED,
+							},
+						},
+					},
+					{
+						Name:     "comp3",
+						Version:  "1.0",
+						Source:   storage.SourceType_JAVA,
+						Location: "p/q/r",
+						HasLayerIndex: &storage.EmbeddedImageScanComponent_LayerIndex{
+							LayerIndex: 10,
+						},
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "cve-2019-1",
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+								Cvss:     4,
+							},
+							{
+								Cve:      "cve-2019-2",
+								Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+								Cvss:     3,
+							},
+						},
+					},
+					{
+						Name:     "comp4",
+						Version:  "1.0",
+						Source:   storage.SourceType_PYTHON,
+						Location: "a/b/c",
+						HasLayerIndex: &storage.EmbeddedImageScanComponent_LayerIndex{
+							LayerIndex: 10,
+						},
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "cve-2017-1",
+								Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+							},
+							{
+								Cve:      "cve-2017-2",
+								Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+				},
+				ScanTime: t2,
+			},
+		},
 	}
 }

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	imageSamples "github.com/stackrox/rox/pkg/fixtures/image"
 	"github.com/stackrox/rox/pkg/mathutil"
@@ -964,6 +965,11 @@ func standardizeImages(images ...*storage.Image) {
 }
 
 func TestImageCVEEdgeIsJoinedLast(t *testing.T) {
+	t.Setenv(env.ImageCVEEdgeJoinWorkaround.EnvVar(), "true")
+	if !env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+		t.Skip("Skip tests when ROX_VULN_MGMT_REPORTING_ENHANCEMENTS disabled")
+		t.SkipNow()
+	}
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)
 

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -965,9 +965,9 @@ func standardizeImages(images ...*storage.Image) {
 }
 
 func TestImageCVEEdgeIsJoinedLast(t *testing.T) {
-	t.Setenv(env.ImageCVEEdgeJoinWorkaround.EnvVar(), "true")
-	if !env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
-		t.Skip("Skip tests when ROX_VULN_MGMT_REPORTING_ENHANCEMENTS disabled")
+	t.Setenv(env.ImageCVEEdgeCustomJoin.EnvVar(), "true")
+	if !env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+		t.Skip("Skip tests when ROX_IMAGE_CVE_EDGE_CUSTOM_JOIN disabled")
 		t.SkipNow()
 	}
 	ctx := sac.WithAllAccess(context.Background())

--- a/pkg/env/vulnerability_management.go
+++ b/pkg/env/vulnerability_management.go
@@ -9,4 +9,7 @@ var (
 
 	// ReportCustomEmailBodyMaxLen sets the maximum allowed length for custom email body in vulnerability report emails
 	ReportCustomEmailBodyMaxLen = RegisterIntegerSetting("ROX_REPORT_CUSTOM_EMAIL_BODY_MAX_LEN", 1500)
+
+	// ImageCVEEdgeJoinWorkaround is to enable/disable the temporary workaround to fix image_cve_edge search issue (ROX-17252)
+	ImageCVEEdgeJoinWorkaround = RegisterBooleanSetting("ROX_IMAGE_CVE_EDGE_JOIN_WORKAROUND", false)
 )

--- a/pkg/env/vulnerability_management.go
+++ b/pkg/env/vulnerability_management.go
@@ -10,6 +10,7 @@ var (
 	// ReportCustomEmailBodyMaxLen sets the maximum allowed length for custom email body in vulnerability report emails
 	ReportCustomEmailBodyMaxLen = RegisterIntegerSetting("ROX_REPORT_CUSTOM_EMAIL_BODY_MAX_LEN", 1500)
 
-	// ImageCVEEdgeJoinWorkaround is to enable/disable the temporary workaround to fix image_cve_edge search issue (ROX-17252)
-	ImageCVEEdgeJoinWorkaround = RegisterBooleanSetting("ROX_IMAGE_CVE_EDGE_JOIN_WORKAROUND", false)
+	// ImageCVEEdgeCustomJoin is to enable/disable the adding custom join with image_cve_edges table.
+	// It is a temporary workaround to fix image_cve_edge search issue (ROX-17252)
+	ImageCVEEdgeCustomJoin = RegisterBooleanSetting("ROX_IMAGE_CVE_EDGE_CUSTOM_JOIN", true)
 )

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -278,7 +278,7 @@ func (q *query) AsSQL() string {
 		querySB.WriteString(innerJoin.rightTable)
 		querySB.WriteString(" on")
 
-		if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+		if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 			if (i == len(q.InnerJoins)-1) && (innerJoin.rightTable == pkgSchema.ImageCveEdgesTableName) {
 				// Step 4: Join image_cve_edges table such that both its ImageID and ImageCveId columns are matched with the joins so far
 				imageIDTable := findImageIDTableAndField(q.InnerJoins)
@@ -406,7 +406,7 @@ func standardizeQueryAndPopulatePath(ctx context.Context, q *v1.Query, schema *w
 	innerJoins, dbFields := getJoinsAndFields(schema, q)
 
 	var err error
-	if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 		innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
 		if err != nil {
 			return nil, err

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -278,7 +278,7 @@ func (q *query) AsSQL() string {
 		querySB.WriteString(innerJoin.rightTable)
 		querySB.WriteString(" on")
 		if (i == len(q.InnerJoins)-1) && (innerJoin.rightTable == pkgSchema.ImageCveEdgesTableName) {
-			// Step 3: Join image_cve_edges table such that both its ImageID and ImageCveId columns are matched with the joins so far
+			// Step 4: Join image_cve_edges table such that both its ImageID and ImageCveId columns are matched with the joins so far
 			imageIDTable := findImageIDTableAndField(q.InnerJoins)
 			imageCVEIDTable := findImageCVEIDTableAndField(q.InnerJoins)
 			if imageIDTable != "" && imageCVEIDTable != "" {
@@ -473,7 +473,7 @@ func handleImageCveEdgesTableInJoins(schema *walker.Schema, innerJoins []innerJo
 		}
 	}
 
-	// Step 2: If image_cve_edges table is the right table of any inner join, move that join to the end of the list.
+	// Step 3: If image_cve_edges table is the right table of any inner join, move that join to the end of the list.
 	// When building SQL query, this will ensure that we have already joined tables needed to match both CVEId and
 	// ImageId columns from image_cve_edges table.
 	idx, isRightTable := findTableInJoins(innerJoins, func(join innerJoin) bool {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/random"
@@ -38,6 +39,16 @@ var (
 	emptyQueryErr = errox.InvalidArgs.New("empty query")
 
 	cursorDefaultTimeout = env.PostgresDefaultCursorTimeout.DurationSetting()
+
+	tableWithImageIDToField = map[string]string{
+		pkgSchema.ImagesTableName:              "Id",
+		pkgSchema.ImageComponentEdgesTableName: "ImageId",
+	}
+
+	tableWithImageCVEIDToField = map[string]string{
+		pkgSchema.ImageCvesTableName:              "Id",
+		pkgSchema.ImageComponentCveEdgesTableName: "ImageCveId",
+	}
 )
 
 // QueryType describe what type of query to execute
@@ -261,10 +272,27 @@ func (q *query) AsSQL() string {
 	querySB.WriteString(q.getPortionBeforeFromClause())
 	querySB.WriteString(" from ")
 	querySB.WriteString(q.From)
-	for _, innerJoin := range q.InnerJoins {
+
+	for i, innerJoin := range q.InnerJoins {
 		querySB.WriteString(" inner join ")
 		querySB.WriteString(innerJoin.rightTable)
 		querySB.WriteString(" on")
+		if (i == len(q.InnerJoins)-1) && (innerJoin.rightTable == pkgSchema.ImageCveEdgesTableName) {
+			// Step 3: Join image_cve_edges table such that both its ImageID and ImageCveId columns are matched with the joins so far
+			imageIDTable := findImageIDTableAndField(q.InnerJoins)
+			imageCVEIDTable := findImageCVEIDTableAndField(q.InnerJoins)
+			if imageIDTable != "" && imageCVEIDTable != "" {
+				imageIDField := tableWithImageIDToField[imageIDTable]
+				imageCVEIDField := tableWithImageCVEIDToField[imageCVEIDTable]
+				querySB.WriteString(fmt.Sprintf("(%s.%s = %s.%s and %s.%s = %s.%s)",
+					imageIDTable, imageIDField, pkgSchema.ImageCveEdgesTableName, "ImageId",
+					imageCVEIDTable, imageCVEIDField, pkgSchema.ImageCveEdgesTableName, "ImageCveId"))
+				continue
+			} else {
+				log.Error("Could not find tables to match both ImageId and ImageCveId columns on image_cve_edges table. " +
+					"Continuing with incomplete join")
+			}
+		}
 		for i, columnNamePair := range innerJoin.columnNamePairs {
 			if i > 0 {
 				querySB.WriteString(" and")
@@ -306,6 +334,34 @@ func (q *query) AsSQL() string {
 	return replaceVars(querySB.String())
 }
 
+func findImageIDTableAndField(joins []innerJoin) string {
+	for _, join := range joins {
+		_, found := tableWithImageIDToField[join.leftTable]
+		if found {
+			return join.leftTable
+		}
+		_, found = tableWithImageIDToField[join.rightTable]
+		if found {
+			return join.rightTable
+		}
+	}
+	return ""
+}
+
+func findImageCVEIDTableAndField(joins []innerJoin) string {
+	for _, join := range joins {
+		_, found := tableWithImageCVEIDToField[join.leftTable]
+		if found {
+			return join.leftTable
+		}
+		_, found = tableWithImageCVEIDToField[join.rightTable]
+		if found {
+			return join.rightTable
+		}
+	}
+	return ""
+}
+
 type parsedPaginationQuery struct {
 	OrderBys []orderByEntry
 	Limit    int
@@ -344,6 +400,11 @@ func standardizeQueryAndPopulatePath(ctx context.Context, q *v1.Query, schema *w
 	}
 	standardizeFieldNamesInQuery(q)
 	innerJoins, dbFields := getJoinsAndFields(schema, q)
+
+	innerJoins, err := handleImageCveEdgesTableInJoins(schema, innerJoins)
+	if err != nil {
+		return nil, err
+	}
 
 	queryEntry, err := compileQueryToPostgres(schema, q, dbFields, nowForQuery)
 	if err != nil {
@@ -391,6 +452,48 @@ func standardizeQueryAndPopulatePath(ctx context.Context, q *v1.Query, schema *w
 	}
 
 	return parsedQuery, nil
+}
+
+func handleImageCveEdgesTableInJoins(schema *walker.Schema, innerJoins []innerJoin) ([]innerJoin, error) {
+	// By avoiding ImageCveEdgesSchema as long as possible in getJoinsAndFields, we should have ensured that
+	// unless ImageCveEdgesSchema is the src schema, it is not a leftTable in any of the inner joins. This means that
+	// we have found an alternative route (via image_components) to join image and image_cves tables and if present,
+	// image_cve_edges table is only there because of its required fields. In other words, it is not being used to join
+	// any two distant tables.
+	// But we validate the same just to be safe here
+	if schema != pkgSchema.ImageCveEdgesSchema {
+		idx, isLeftTable := findTableInJoins(innerJoins, func(join innerJoin) bool {
+			return join.leftTable == pkgSchema.ImageCveEdgesTableName
+		})
+
+		if isLeftTable {
+			return nil, errors.Wrapf(errox.InvariantViolation,
+				"Even though '%s' is not the root table in the query, it is the left table in inner join '%v'",
+				pkgSchema.ImageCveEdgesTableName, innerJoins[idx])
+		}
+	}
+
+	// Step 2: If image_cve_edges table is the right table of any inner join, move that join to the end of the list.
+	// When building SQL query, this will ensure that we have already joined tables needed to match both CVEId and
+	// ImageId columns from image_cve_edges table.
+	idx, isRightTable := findTableInJoins(innerJoins, func(join innerJoin) bool {
+		return join.rightTable == pkgSchema.ImageCveEdgesTableName
+	})
+	if isRightTable {
+		elem := innerJoins[idx]
+		innerJoins = append(innerJoins[:idx], innerJoins[idx+1:]...)
+		innerJoins = append(innerJoins, elem)
+	}
+	return innerJoins, nil
+}
+
+func findTableInJoins(innerJoins []innerJoin, matchTables func(join innerJoin) bool) (int, bool) {
+	for i, join := range innerJoins {
+		if matchTables(join) {
+			return i, true
+		}
+	}
+	return -1, false
 }
 
 func combineQueryEntries(entries []*pgsearch.QueryEntry, separator string) *pgsearch.QueryEntry {

--- a/pkg/search/postgres/joins.go
+++ b/pkg/search/postgres/joins.go
@@ -141,7 +141,7 @@ type searchFieldMetadata struct {
 func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]innerJoin, map[string]searchFieldMetadata) {
 	unreachedFields := collectFields(q)
 
-	if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 		// Step 1: If ImageCveEdgesSchema is going to be a part of joins, we want to ensure that we are able to join on both
 		//  ImageId and ImageCveId fields
 		if src != schema.ImageCveEdgesSchema &&
@@ -171,7 +171,7 @@ func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]innerJoin, map[string
 		currElem := queue[0]
 		queue = queue[1:]
 
-		if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+		if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 			// Step 2: Avoid using ImageCveEdgesSchema unless there is no other way to get to the required fields.
 			// If ImageCveEdgesSchema is root schema, then it is unavoidable.
 			if currElem.schema == schema.ImageCveEdgesSchema && currElem.schema != src {
@@ -226,7 +226,7 @@ func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]innerJoin, map[string
 				}
 			}
 
-			if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+			if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 				// We want to make sure ImageCveEdgesSchema gets added only once to queue. If there are multiple copies of
 				// ImageCveEdgesSchema in the queue, then we can enter an infinite loop trying to push one copy after another
 				// to the end of queue.

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -10,6 +10,7 @@ import (
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
@@ -66,9 +67,11 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 		return nil, nil
 	}
 
-	innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
-	if err != nil {
-		return nil, err
+	if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+		innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	parsedQuery := &query{

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -66,6 +66,11 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 		return nil, nil
 	}
 
+	innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
+	if err != nil {
+		return nil, err
+	}
+
 	parsedQuery := &query{
 		Schema:     schema,
 		QueryType:  queryType,

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -67,7 +67,7 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 		return nil, nil
 	}
 
-	if env.ImageCVEEdgeJoinWorkaround.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
 		innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

Not proud of this approach. It is just something to patch the leaks until we have a better solution.

`image_cve_edges` table joins `images` and `image_cves` tables. However, there is another way to join `images` and `image_cves` : `images - image_component_edges - image_components - image_component_cve_edges - image_cves`. Now whenever a search query includes fields from both `image_cve_edges` table and one of the component tables, the BFS based SQL query builder ends up building a query where `image_cve_edges` table is joined only on one of `ImageId` or `ImageCveId` but not the other field. This ends up in a situation where cves get mapped to wrong images.

Example:
Consider following data
```
images
-------
sha-1
sha-2

image_cves
------------
cve-1
cve-2

image_cve_edges
------------------
sha-1  |  cve-1  |  observed
sha-1  |  cve-2  |  deferred
sha-2  |  cve-1  |  observed
sha-2  |  cve-2  |  observed

image_components
--------------------
comp-1
comp-2

image_component_edges
--------------------------
sha-1   |   comp-1
sha-2   |   comp-2

image_component_cve_edges
-------------------------------
comp-1   |   cve-1   |  fixable
comp-1   |   cve-2  |  fixable
comp-2  |   cve-1   |  fixable
comp-2  |   cve-2  |  non-fixable
```

Now if we try to search for image_cves where `image : sha-2 + Fixable : true + State: Observed`, the query should return `cve-1` . The search framework creates the following query

```
select distinct(image_cves.Id) as CVE_ID from 
image_cves 
inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId 
inner join image_cve_edges on image_cves.Id = image_cve_edges.ImageCveId 
inner join images on image_cve_edges.ImageId = images.Id 
where (image_component_cve_edges.IsFixable = 't' and images.Id = 'sha-2' and (image_cve_edges.State = 'observed'))
```

Inner joined data before where clause is applied would look like below

```
------------------------------------------------
image_cves   |  image_component_cve_edges       |  image_cve_edges                     |  images
--------------|-----------------------------------|--------------------------------|------------
cve-1              |     comp-1  |  cve-1  |  fixable            |    sha-1  |  cve-1  |  observed      |   sha-1
cve-1              |     comp-1  |  cve-1  |  fixable            |    sha-2  |  cve-1  |  observed     |   sha-2
cve-1              |     comp-2  |  cve-1  |  fixable            |   sha-1  |  cve-1  |  observed      |   sha-1
cve-1              |     comp-2  |  cve-1  |  fixable            |   sha-2  |  cve-1  |  observed     |   sha-2
cve-2             |    comp-1  |  cve-2  |  fixable             |    sha-1  |  cve-2  |  deferred       |   sha-1
cve-2             |    comp-1  |  cve-2  |  fixable             |    sha-2  |  cve-2  |  observed     |   sha-2
cve-2             |    comp-2  |  cve-2  |  non-fixable     |    sha-1  |  cve-2  |  deferred      |   sha-1
cve-2             |    comp-2  |  cve-2  |  non-fixable     |    sha-2  |  cve-2  |  observed     |   sha-2
``` 

After applying the `distinct(image_cves.Id)`  and where clauses to this, we get both `cve-1` and `cve-2` . This happens because the query joined `comp-1` with images `sha-1` and `sha-2` even though `comp-1` is part of `sha-1` only. Same for `comp-2`.

To avoid this type of issues, this PR changes the query builder to avoid using `image_cve_edges` table as long as possible. If the query must join `image_cve_edges` table, then we ensure that it is joined at last and joined on both `ImageId` and `ImageCveId` from the other joins. This will ensure that we do not have any unintended mapping. After the temporary fix in this PR, the SQL query looks like below

```
select distinct(image_cves.Id) as CVE_ID from 
image_cves 
inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId 
inner join image_component_edges on image_component_cve_edges.ImageComponentId = image_component_edges.ImageComponentId 
inner join images on image_component_edges.ImageId = images.Id 
inner join image_cve_edges on(image_component_edges.ImageId = image_cve_edges.ImageId and image_cves.Id = image_cve_edges.ImageCveId) 
where (image_component_cve_edges.IsFixable = 't' and images.Id = 'sha-2' and (image_cve_edges.State = 'observed'))
```

This query correctly returns `cve-1`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added unit tests

Manually tested to make sure everything looks good in UI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
