### PR TITLE
ROX-24045: Telemetry `WithMessageIDPrefix` option

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -118,7 +118,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 			telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
 			telemeter.WithTraits(props),
 			// Segment drops events with the same properties from the same day.
-			telemeter.WithMessageIDSalt(time.Now().Format(time.DateOnly)),
+			telemeter.WithMessageIDPrefix(time.Now().Format(time.DateOnly)),
 		}
 		cfg.Telemeter().Track("Updated Secured Cluster Identity", nil, opts...)
 	}

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackrox/rox/central/telemetry/centralclient"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -116,6 +117,8 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 			telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
 			telemeter.WithTraits(props),
+			// Segment drops events with the same properties from the same day.
+			telemeter.WithMessageIDSalt(time.Now().Format(time.DateOnly)),
 		}
 		cfg.Telemeter().Track("Updated Secured Cluster Identity", nil, opts...)
 	}

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -119,18 +119,18 @@ func (t *segmentTelemeter) getAnonymousID(o *telemeter.CallOptions) string {
 // makeMessageID generates and ID based on the provided event data.
 // This may allow Segment to deduplicate events.
 func (t *segmentTelemeter) makeMessageID(event string, props map[string]any, o *telemeter.CallOptions) string {
-	if o == nil || len(o.MessageIDSalt) == 0 {
+	if o == nil || len(o.MessageIDPrefix) == 0 {
 		return ""
 	}
 	h, err := hashstructure.Hash([]any{
-		props, o.Traits, event, t.getUserID(o), t.getAnonymousID(o), o.MessageIDSalt},
+		props, o.Traits, event, t.getUserID(o), t.getAnonymousID(o)},
 		hashstructure.FormatV2, nil)
 	if err != nil {
 		log.Error("Failed to generate Segment message ID: ", err)
 		// Let Segment generate the id.
 		return ""
 	}
-	return fmt.Sprintf("%x", h)
+	return fmt.Sprintf("%s-%x", o.MessageIDPrefix, h)
 }
 
 func (t *segmentTelemeter) makeContext(o *telemeter.CallOptions) *segment.Context {

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -196,7 +196,7 @@ func Test_makeMessageID(t *testing.T) {
 	t.Run("Empty ID with no salt added", func(t *testing.T) {
 		id1 := tt.makeMessageID("test event", props, &telemeter.CallOptions{})
 		assert.Empty(t, id1)
-		id1 = tt.makeMessageID("test event", props, nil)
+		id1 = tt.makeMessageID("test event", nil, nil)
 		assert.Empty(t, id1)
 	})
 }

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -149,7 +149,7 @@ func Test_makeMessageID(t *testing.T) {
 		"bool": true,
 	}
 	salty := func(options ...telemeter.Option) *telemeter.CallOptions {
-		opts := &telemeter.CallOptions{MessageIDSalt: "salt"}
+		opts := &telemeter.CallOptions{MessageIDPrefix: "test"}
 		for _, o := range options {
 			o(opts)
 		}
@@ -159,7 +159,7 @@ func Test_makeMessageID(t *testing.T) {
 	t.Run("Same ID with same input", func(t *testing.T) {
 		id1 := tt.makeMessageID("test event", props, salty())
 		id2 := tt.makeMessageID("test event", props, salty())
-		assert.Len(t, id1, 16)
+		assert.Len(t, id1, 21)
 		assert.Equal(t, id1, id2)
 	})
 	t.Run("Different ID with different props", func(t *testing.T) {
@@ -175,7 +175,7 @@ func Test_makeMessageID(t *testing.T) {
 	})
 	t.Run("Different ID with different salt", func(t *testing.T) {
 		id1 := tt.makeMessageID("test event", props, salty())
-		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithMessageIDSalt("different")))
+		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithMessageIDPrefix("different")))
 		assert.NotEqual(t, id1, id2)
 	})
 	t.Run("Different ID with different event", func(t *testing.T) {

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -139,3 +139,64 @@ func Test_GroupWithProps(t *testing.T) {
 	s.Close()
 	assert.Equal(t, int32(4), i, "Group call had to issue 4 messages")
 }
+
+func Test_makeMessageID(t *testing.T) {
+	tt := NewTelemeter("test-key", "url", "client-id", "client-type", 0, 1)
+
+	props := map[string]any{
+		"key":  "value",
+		"int":  42,
+		"bool": true,
+	}
+	salty := func(options ...telemeter.Option) *telemeter.CallOptions {
+		opts := &telemeter.CallOptions{MessageIDSalt: "salt"}
+		for _, o := range options {
+			o(opts)
+		}
+		return opts
+	}
+
+	t.Run("Same ID with same input", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty())
+		id2 := tt.makeMessageID("test event", props, salty())
+		assert.Len(t, id1, 16)
+		assert.Equal(t, id1, id2)
+	})
+	t.Run("Different ID with different props", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty())
+		props["bool"] = false
+		id2 := tt.makeMessageID("test event", props, salty())
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Different ID with different user props", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty(telemeter.WithTraits(map[string]any{"key": "same"})))
+		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithTraits(map[string]any{"key": "different"})))
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Different ID with different salt", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty())
+		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithMessageIDSalt("different")))
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Different ID with different event", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event 1", props, salty())
+		id2 := tt.makeMessageID("test event 2", props, salty())
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Different ID with different user", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty(telemeter.WithUserID("same")))
+		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithUserID("different")))
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Different ID with different client and user", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, salty(telemeter.WithClient("same", "same")))
+		id2 := tt.makeMessageID("test event", props, salty(telemeter.WithUserID("same")))
+		assert.NotEqual(t, id1, id2)
+	})
+	t.Run("Empty ID with no salt added", func(t *testing.T) {
+		id1 := tt.makeMessageID("test event", props, &telemeter.CallOptions{})
+		assert.Empty(t, id1)
+		id1 = tt.makeMessageID("test event", props, nil)
+		assert.Empty(t, id1)
+	})
+}

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -2,11 +2,11 @@ package telemeter
 
 // CallOptions defines optional features for a Telemeter call.
 type CallOptions struct {
-	UserID        string
-	AnonymousID   string
-	ClientID      string
-	ClientType    string
-	MessageIDSalt string
+	UserID          string
+	AnonymousID     string
+	ClientID        string
+	ClientType      string
+	MessageIDPrefix string
 
 	// [group type: [group id]]
 	Groups map[string][]string
@@ -62,11 +62,11 @@ func WithTraits(traits map[string]any) Option {
 	}
 }
 
-// WithMessageIDSalt enables generation of custom message ID, which is a hash
-// of the event data and provided salt.
-func WithMessageIDSalt(salt string) Option {
+// WithMessageIDPrefix enables generation of custom message ID, which is
+// computed as the <provided prefix>-<message data hash>.
+func WithMessageIDPrefix(prefix string) Option {
 	return func(o *CallOptions) {
-		o.MessageIDSalt = salt
+		o.MessageIDPrefix = prefix
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -62,6 +62,8 @@ func WithTraits(traits map[string]any) Option {
 	}
 }
 
+// WithMessageIDSalt enables generation of custom message ID, which is a hash
+// of the event data and provided salt.
 func WithMessageIDSalt(salt string) Option {
 	return func(o *CallOptions) {
 		o.MessageIDSalt = salt

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -2,10 +2,11 @@ package telemeter
 
 // CallOptions defines optional features for a Telemeter call.
 type CallOptions struct {
-	UserID      string
-	AnonymousID string
-	ClientID    string
-	ClientType  string
+	UserID        string
+	AnonymousID   string
+	ClientID      string
+	ClientType    string
+	MessageIDSalt string
 
 	// [group type: [group id]]
 	Groups map[string][]string
@@ -58,6 +59,12 @@ func WithGroups(groupType string, groupID string) Option {
 func WithTraits(traits map[string]any) Option {
 	return func(o *CallOptions) {
 		o.Traits = traits
+	}
+}
+
+func WithMessageIDSalt(salt string) Option {
+	return func(o *CallOptions) {
+		o.MessageIDSalt = salt
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -13,13 +13,13 @@ func Test_With(t *testing.T) {
 		WithGroups("groupA", "groupA_id1"),
 		WithGroups("groupA", "groupA_id2"),
 		WithGroups("groupB", "groupB_id"),
-		WithMessageIDSalt("salt"),
+		WithMessageIDPrefix("test"),
 	},
 	)
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
-	assert.Equal(t, "salt", opts.MessageIDSalt)
+	assert.Equal(t, "test", opts.MessageIDPrefix)
 
 	props := map[string][]string{
 		"groupA": {"groupA_id1", "groupA_id2"},

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -13,11 +13,13 @@ func Test_With(t *testing.T) {
 		WithGroups("groupA", "groupA_id1"),
 		WithGroups("groupA", "groupA_id2"),
 		WithGroups("groupB", "groupB_id"),
+		WithMessageIDSalt("salt"),
 	},
 	)
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
+	assert.Equal(t, "salt", opts.MessageIDSalt)
 
 	props := map[string][]string{
 		"groupA": {"groupA_id1", "groupA_id2"},


### PR DESCRIPTION
## Description

`WithMessageIDPrefix` option makes Segment client generate the message ID based on the prefixed message content hash. Provided with the current date, it will generate same ID for equal messages during a day. This in turn will allow Segment to drop duplicates occurring in a 1 day range.

This is to complement, or prepare for #11011, where a cache is implemented to block duplicate events on the client side.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit tests.

#### Segment

See the custom `messageId`:

```json
{
  "anonymousId": "70232094-8d6e-4292-a71a-dc6f5df57a29",
  "context": {
    "device": {
      "id": "70232094-8d6e-4292-a71a-dc6f5df57a29",
      "type": "Secured Cluster Server"
    },
    "groups": {
      "Tenant": [
        "7de3653e-5d0a-47f2-b231-e9a2438be867"
      ]
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Admission Controller": true,
      "CPU Capacity": 8,
      "Cluster Type": "KUBERNETES_CLUSTER",
      "Collection Method": "CORE_BPF",
      "Collector Image": "",
      "Main Image": "quay.io/rhacs-eng/main:4.4.1",
      "Managed By": "MANAGER_TYPE_UNKNOWN",
      "Orchestrator Version": "v1.28.7-gke.1026000",
      "Priority": 1,
      "Provider": "Google",
      "Provider Region": "us-central1",
      "Provider Verified": true,
      "Provider Zone": "us-central1-b",
      "Slim Collector": false,
      "Total Nodes": 2
    }
  },
  "event": "Updated Secured Cluster Identity",
  "integrations": {},
  "messageId": "11ab57d491010982",
  "originalTimestamp": "2024-05-15T16:55:46.440632828Z",
  "receivedAt": "2024-05-15T16:55:46.780Z",
  "sentAt": "2024-05-15T16:55:46.440Z",
  "timestamp": "2024-05-15T16:55:46.779Z",
  "type": "track",
  "writeKey": "REDACTED"
}
```

There were no further events from the secured clusters.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
