### PR TITLE
feat(ui): Unify compliance routes for flexible left navigation

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -3,8 +3,7 @@ import { visit } from '../../helpers/visit';
 
 // path
 
-export const basePath = '/main/compliance-enhanced';
-export const statusDashboardPath = `${basePath}/status`;
+export const basePath = '/main/compliance';
 export const complianceEnhancedCoveragePath = `${basePath}/coverage`;
 export const complianceEnhancedScanConfigsPath = `${basePath}/schedules`;
 

--- a/ui/apps/platform/src/Containers/Compliance/Page.js
+++ b/ui/apps/platform/src/Containers/Compliance/Page.js
@@ -1,23 +1,31 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { workflowPaths } from 'routePaths';
-import PageNotFound from 'Components/PageNotFound';
 import isEqual from 'lodash/isEqual';
+
+import PageNotFound from 'Components/PageNotFound';
 import searchContext from 'Containers/searchContext';
-import { searchParams } from 'constants/searchParams';
-import useCases from 'constants/useCaseTypes';
+import { mainPath } from 'routePaths';
+
 import Dashboard from './Dashboard/ComplianceDashboardPage';
 import Entity from './Entity/Page';
 import List from './List/Page';
 
+const pageEntityListType = 'clusters|controls|deployments|namespaces|nodes';
+const pageEntityType = 'cluster|control|deployment|namespace|node|standard';
+
+// mainPath instead of complianceBasePath because URLService requires param context = 'compliance'
+const complianceDashboardPath = `${mainPath}/:context`;
+const complianceListPath = `${mainPath}/:context/:pageEntityListType(${pageEntityListType})/:entityId1?/:entityType2?/:entityId2?`;
+const complianceEntityPath = `${mainPath}/:context/:pageEntityType(${pageEntityType})/:pageEntityId?/:entityType1?/:entityId1?/:entityType2?/:entityId2?`;
+
 const Page = () => (
-    <searchContext.Provider value={searchParams.page}>
+    <searchContext.Provider value="s">
         <Switch>
-            <Route exact path={workflowPaths.DASHBOARD} component={Dashboard} />
-            <Route path={workflowPaths.LIST} component={List} />
-            <Route path={workflowPaths.ENTITY} component={Entity} />
+            <Route exact path={complianceDashboardPath} component={Dashboard} />
+            <Route path={complianceListPath} component={List} />
+            <Route path={complianceEntityPath} component={Entity} />
             <Route>
-                <PageNotFound useCase={useCases.COMPLIANCE} />
+                <PageNotFound useCase="compliance" />
             </Route>
         </Switch>
     </searchContext.Provider>

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -15,7 +15,8 @@ import {
     clustersPathWithParam,
     clustersSecureClusterPath,
     collectionsPath,
-    complianceEnhancedBasePath,
+    complianceEnhancedCoveragePath,
+    complianceEnhancedSchedulesPath,
     compliancePath,
     configManagementPath,
     dashboardPath,
@@ -65,7 +66,7 @@ function NotFoundPage(): ReactElement {
 
 type RouteComponent = {
     component: ElementType;
-    path: string;
+    path: string | string[];
 };
 
 // routeComponentMap corresponds to routeRequirementsMap in src/routePaths.ts file.
@@ -123,15 +124,16 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         component: asyncComponent(() => import('Containers/Collections/CollectionsPage')),
         path: collectionsPath,
     },
-    compliance: {
-        component: asyncComponent(() => import('Containers/Compliance/Page')),
-        path: compliancePath,
-    },
+    // Compliance enhanced must precede compliance classic.
     'compliance-enhanced': {
         component: asyncComponent(
             () => import('Containers/ComplianceEnhanced/ComplianceEnhancedPage')
         ),
-        path: complianceEnhancedBasePath,
+        path: [complianceEnhancedCoveragePath, complianceEnhancedSchedulesPath],
+    },
+    compliance: {
+        component: asyncComponent(() => import('Containers/Compliance/Page')),
+        path: compliancePath,
     },
     configmanagement: {
         component: asyncComponent(() => import('Containers/ConfigManagement/Page')),

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -122,6 +122,8 @@ const navDescriptions: NavDescription[] = [
         path: violationsBasePath,
         routeKey: 'violations',
     },
+    // Compliance with divided navigation.
+    // /*
     {
         type: 'parent',
         title: (navDescriptionsFiltered) =>
@@ -158,7 +160,51 @@ const navDescriptions: NavDescription[] = [
                 : 'Compliance',
         path: complianceBasePath,
         routeKey: 'compliance',
+        isActive: (pathname) =>
+            Boolean(matchPath(pathname, complianceBasePath)) &&
+            !matchPath(pathname, [complianceEnhancedCoveragePath, complianceEnhancedSchedulesPath]),
     },
+    // */
+    // Compliance with unified navigation.
+    /*
+    {
+        type: 'parent',
+        title: (navDescriptionsFiltered) =>
+            navDescriptionsFiltered.some(
+                (navDescription) =>
+                    navDescription.type === 'link' && navDescription.routeKey === 'compliance'
+            )
+                ? 'Compliance (2.0)'
+                : 'Compliance',
+        key: keyForCompliance2,
+        children: [
+            {
+                type: 'link',
+                content: 'Coverage',
+                path: complianceEnhancedCoveragePath,
+                routeKey: 'compliance-enhanced',
+            },
+            {
+                type: 'link',
+                content: 'Schedules',
+                path: complianceEnhancedSchedulesPath,
+                routeKey: 'compliance-enhanced',
+            },
+            {
+                type: 'link',
+                content: 'PLACEHOLDER',
+                path: complianceBasePath,
+                routeKey: 'compliance',
+                isActive: (pathname) =>
+                    Boolean(matchPath(pathname, complianceBasePath)) &&
+                    !matchPath(pathname, [
+                        complianceEnhancedCoveragePath,
+                        complianceEnhancedSchedulesPath,
+                    ]),
+            },
+        ],
+    },
+    */
     {
         type: 'parent',
         title: (navDescriptionsFiltered) =>

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -34,7 +34,7 @@ export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
 export const complianceBasePath = `${mainPath}/compliance`;
 export const compliancePath = `${mainPath}/:context(compliance)`;
-export const complianceEnhancedBasePath = `${mainPath}/compliance-enhanced`;
+export const complianceEnhancedBasePath = `${mainPath}/compliance`;
 export const complianceEnhancedCoveragePath = `${complianceEnhancedBasePath}/coverage`;
 export const complianceEnhancedSchedulesPath = `${complianceEnhancedBasePath}/schedules`;
 export const configManagementPath = `${mainPath}/configmanagement`;
@@ -449,7 +449,7 @@ export const basePathToLabelMap: Record<string, string> = {
     [listeningEndpointsBasePath]: 'Listening Endpoints',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
-    [complianceEnhancedBasePath]: 'Compliance (2.0)',
+    // [complianceEnhancedBasePath]: 'Compliance (2.0)',
     ...vulnerabilitiesPathToLabelMap,
     ...vulnManagementPathToLabelMap,
     [configManagementPath]: 'Configuration Management',


### PR DESCRIPTION
## Description

### Problem

Some customers misunderstand relationship between Compliance 1.0 and 2.0 as analogous to Vulnerability Management 1.0 and 2.0 (in which 2.0 supersedes and replaces 1.0).

### Analysis

Initial routes followed previous pattern of disjoint routes:
* Network Graph: /main/network versus /main/network-graph
* Policies: /main/policies versus /main/policy-management/policies
* Vulnerability Management: /main/vulnerability-management versus /main/vulnerabilities

However, path segments are disjoint:
* Compliance 1.0: clusters, controls, deployments, and so on
* Compliance 2.0: coverage, schedule

There is more flexibility that we supposed for divided or unified left navigation.

### Solution

To allow either divided or unified left navigation, unify compliance routes.

1. Edit Containers/Compliance/Page.js file.
    * Replace generic workflow with specific compliance entity types and paths.
2. Edit Containers/MainPage/Body.tsx file.
    * Allow path array. Thanks to Brad for bringing this to my attention.
    * Move `'compliance-enhanced'` which has more specific paths to precede `'compliance'` which has more generic path.
3. Edit Containers/MainPage/Sidebar/NavigationSidebar.tsx file.
    * Add `isActive` property for disjoint **Compliance 1.0** link to exclude more specific paths.
    * Add alternative unified links.
4. Edit routePaths.ts file.
    * Make `complianceEnhancedBasePath` same as `complianceBasePath`
    * Comment out redundant `basePathToLabelMap`

### Residue

1. Decide whether redirects are needed from initial /main/compliance-enhanced routes.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing divided

1. Visit /main/dashboard: see **Dashboard** is active.
    ![divided_main_Dashboard](https://github.com/stackrox/stackrox/assets/11862657/7630d89b-9920-442e-87f3-b25c72fad2fe)

2. Visit /main/compliance/coverage: see **Compliance (2.0)** is expanded and **Coverage** is active.
    Visit various pages within **Coverage** route.
    ![divided_Coverage](https://github.com/stackrox/stackrox/assets/11862657/d386e150-15ae-4851-b488-5f6d234f8357)

3. Click **Schedules** in left navigation: see /main/compliance/schedules page.
    Visit various pages within **Schedules** route.
    ![divided_Schedules](https://github.com/stackrox/stackrox/assets/11862657/1b14b597-2151-43c5-b7e6-c4b35aaa7a5c)

4. Click **Compliance 1.0** in left navigation: see /main/compliance page.
    Visit various pages within classic compliance.
    ![divided_Compliance_Dashboard](https://github.com/stackrox/stackrox/assets/11862657/a9315b51-6555-4bd8-bfec-38b1688708be)

### Manual testing unified

1. Visit /main/dashboard: see **Dashboard** is active.
    ![unified_main_Dashboard](https://github.com/stackrox/stackrox/assets/11862657/dd80e29a-b005-49db-892f-eb29c4d6e0a2)

2. Visit /main/compliance/coverage: see **Compliance** is expanded and **Coverage** is active.
    Visit various pages within **Coverage** route.
    ![unified_Coverage](https://github.com/stackrox/stackrox/assets/11862657/5344424c-8736-49dd-b415-8b9cec0e8642)

3. Click **Schedules** in left navigation: see /main/compliance/schedules page.
    Visit various pages within **Schedules** route.
    ![unified_Schedules](https://github.com/stackrox/stackrox/assets/11862657/c471a64f-09a2-4598-a2c6-47ea9a6922d5)

4. Click **PLACEHOLDER** in left navigation: see /main/compliance page.
    Visit various pages within classic compliance.
    ![unified_Compliance_Dashboard](https://github.com/stackrox/stackrox/assets/11862657/92798e94-a2d3-442b-8d49-c33dd018ef8c)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_COMPLIANCE_ENHANCEMENTS=true
```

* compliance-enhanved/complianceEnhancedScanConfigs.test.js
* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js