### PR TITLE
ROX-21570: retry curls in validation.sh

### DIFF
--- a/tests/upgrade/validation.sh
+++ b/tests/upgrade/validation.sh
@@ -15,7 +15,7 @@ createRocksDBScopes() {
     for scopeJSON in "${scopes[@]}"
     do
       tmpOutput=$(mktemp)
-      status=$(curl -k -u "admin:${ROX_PASSWORD}" -X POST \
+      status=$(curl --retry 3 -k -u "admin:${ROX_PASSWORD}" -X POST \
         -d "${scopeJSON}" \
         -o "${tmpOutput}" \
         -w "%{http_code}\n" \
@@ -31,7 +31,7 @@ createRocksDBScopes() {
 checkForRocksAccessScopes() {
     info "checkForRocksAccessScopes"
     local accessScopes
-    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    accessScopes=$(curl --retry 3 -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
     echo "access scopes: ${accessScopes}"
     test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "RocksScope1") | .name' -r)" "RocksScope1"
     test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "RocksScope2") | .name' -r)" "RocksScope2"
@@ -47,7 +47,7 @@ createPostgresScopes() {
         for scopeJSON in "${scopes[@]}"
         do
           tmpOutput=$(mktemp)
-          status=$(curl -k -u "admin:${ROX_PASSWORD}" -X POST \
+          status=$(curl --retry 3 -k -u "admin:${ROX_PASSWORD}" -X POST \
             -d "${scopeJSON}" \
             -o "$tmpOutput" \
             -w "%{http_code}\n" \
@@ -63,7 +63,7 @@ createPostgresScopes() {
 checkForPostgresAccessScopes() {
     info "checkForPostgresAccessScopes"
     local accessScopes
-    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    accessScopes=$(curl --retry 3 -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
     echo "access scopes: ${accessScopes}"
     test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope1") | .name' -r)" "PostgresScope1"
     test_equals_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope2") | .name' -r)" "PostgresScope2"
@@ -72,7 +72,7 @@ checkForPostgresAccessScopes() {
 verifyNoPostgresAccessScopes() {
     info "verifyNoPostgresAccessScopes"
     local accessScopes
-    accessScopes=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
+    accessScopes=$(curl --retry 3 -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/simpleaccessscopes)
     echo "access scopes: ${accessScopes}"
     test_empty_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope1") | .name' -r)"
     test_empty_non_silent "$(echo "$accessScopes" | jq '.accessScopes[] | select(.name == "PostgresScope2") | .name' -r)"


### PR DESCRIPTION
## Description

Similar to:
- https://github.com/stackrox/stackrox/pull/9990


https://curl.haxx.se/docs/manpage.html

> `--retry`
> 
> If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 5xx response code.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
