### PR TITLE
fix: scan latest with roxctl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -700,18 +700,17 @@ jobs:
       - name: Scan images for vulnerabilities
         run: |
           release_tag=$(make tag)
-          if [[ ${{ matrix.image }} =~ "operator" ]]; then
-            release_tag=$(make -C operator --silent tag)
-          fi
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
               release_tag="latest"
+          fi
+          if [[ ${{ matrix.image }} =~ "operator" ]]; then
+            release_tag=$(make -C operator --silent tag)
           fi
           roxctl image scan --retries=10 --retry-delay=15 --force --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif
 
       - name: Upload roxctl scan results to GitHub Security tab
-        if: "!contains(github.ref, '-nightly-')"
         uses: github/codeql-action/upload-sarif@v3
         with:
           category: ${{ matrix.image }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -703,11 +703,15 @@ jobs:
           if [[ ${{ matrix.image }} =~ "operator" ]]; then
             release_tag=$(make -C operator --silent tag)
           fi
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
+              release_tag="latest"
+          fi
           roxctl image scan --retries=10 --retry-delay=15 --force --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif
 
       - name: Upload roxctl scan results to GitHub Security tab
+        if: "!contains(github.ref, '-nightly-')"
         uses: github/codeql-action/upload-sarif@v3
         with:
           category: ${{ matrix.image }}


### PR DESCRIPTION
## Description

Currently we scan images based on their just builded tag. This results in many security issues as every issues if reported for every commit (and nightly tag). This PR changes scanning logic to scan the latest tag if we are on master (as it should be just pushed) and keep tags if not on master.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Hard to test as we need to be on master to scan.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
