### PR TITLE
fix: drop execution environment header with no value

### DIFF
--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -126,7 +126,9 @@ func sanitizeHeaderValue(value string) string {
 func setCustomHeaders(headers func(string, ...string)) {
 	headers(clientconn.RoxctlCommandHeader, RoxctlCommand)
 	headers(clientconn.RoxctlCommandIndexHeader, fmt.Sprint(RoxctlCommandIndex.Add(1)))
-	headers(clientconn.ExecutionEnvironment, sanitizeHeaderValue(env.ExecutionEnvironment.Setting()))
+	if e := env.ExecutionEnvironment.Setting(); e != "" {
+		headers(clientconn.ExecutionEnvironment, sanitizeHeaderValue(e))
+	}
 }
 
 // Do executes a http.Request

--- a/roxctl/common/client_test.go
+++ b/roxctl/common/client_test.go
@@ -1,8 +1,12 @@
 package common
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,4 +20,20 @@ func TestSanitizeHeaderValue(t *testing.T) {
 	} {
 		assert.Equal(t, expected, sanitizeHeaderValue(value), value)
 	}
+}
+
+func Test_setCustomHeaders(t *testing.T) {
+	headers := http.Header{}
+	setCustomHeaders(phonehome.Headers(headers).Set)
+	assert.Len(t, headers, 2)
+	assert.Equal(t, "", headers.Get(clientconn.RoxctlCommandHeader))
+	assert.Equal(t, "1", headers.Get(clientconn.RoxctlCommandIndexHeader))
+
+	t.Setenv(env.ExecutionEnvironment.EnvVar(), "test")
+	RoxctlCommand = "custom command"
+	setCustomHeaders(phonehome.Headers(headers).Set)
+	assert.Len(t, headers, 3)
+	assert.Equal(t, RoxctlCommand, headers.Get(clientconn.RoxctlCommandHeader))
+	assert.Equal(t, "2", headers.Get(clientconn.RoxctlCommandIndexHeader))
+	assert.Equal(t, "test", headers.Get(clientconn.ExecutionEnvironment))
 }


### PR DESCRIPTION
## Description

HTTP headers with no values are discouraged:

* RFC 2616 (HTTP/1.1 Specification):
  According to RFC 2616, each header field consists of a name followed by a colon (":") and the field value. Empty field values can lead to undefined or non-standard behaviors.

* Mozilla Developer Network (MDN):
  The MDN documentation specifies that headers should have valid values. An empty value may lead to incorrect handling or rejection of the request by the server.

* OWASP (Open Web Application Security Project):
  OWASP guidelines emphasize the importance of proper HTTP header values to ensure secure communication and avoid potential security risks.

Let's not add `Rh-Execution-Environment` header if no value is provided.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

### Here I tell how I validated my change

#### No value

```console
me@work$ bin/linux_amd64/roxctl central whoami --plaintext --insecure -e localhost:8000 -p abc
---
me@work$ nc -l localhost 8000
POST /v1.AuthService/GetAuthStatus HTTP/1.1
Host: localhost
User-Agent: roxctl/4.4.x-699-gc6cddd0f4f (linux; amd64) grpc-go/1.61.1
Transfer-Encoding: chunked
Accept: application/grpc
Accept: application/grpc-web
Authorization: Basic YWRtaW46YWJj
Content-Type: application/grpc
Grpc-Timeout: 19999792u
Rh-Roxctl-Command: central whoami
Rh-Roxctl-Command-Index: 1
Te: trailers
Accept-Encoding: gzip
```

#### With value

```console
me@work$ ROX_EXECUTION_ENV=abc bin/linux_amd64/roxctl central whoami --plaintext --insecure -e localhost:8000 -p abc
---
me@work$ nc -l localhost 8000
POST /v1.AuthService/GetAuthStatus HTTP/1.1
Host: localhost
User-Agent: roxctl/4.4.x-699-gc6cddd0f4f (linux; amd64) grpc-go/1.61.1
Transfer-Encoding: chunked
Accept: application/grpc
Accept: application/grpc-web
Authorization: Basic YWRtaW46YWJj
Content-Type: application/grpc
Grpc-Timeout: 19999785u
Rh-Execution-Environment: abc
Rh-Roxctl-Command: central whoami
Rh-Roxctl-Command-Index: 1
Te: trailers
Accept-Encoding: gzip
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
