### PR TITLE
ROX-21171: Use qa namespace instead of default

### DIFF
--- a/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
@@ -6,6 +6,7 @@ import io.stackrox.proto.api.v1.AuthproviderService
 import io.stackrox.proto.storage.NetworkPolicyOuterClass
 import io.stackrox.proto.storage.RoleOuterClass
 
+import common.Constants
 import services.ApiTokenService
 import services.AuthProviderService
 import services.BaseService
@@ -28,7 +29,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: qa-rbac-test-apply
-  namespace: default
+  namespace: ${Constants.ORCHESTRATOR_NAMESPACE}
 spec:
   podSelector:
     matchLabels:
@@ -102,7 +103,6 @@ spec:
 
     @Unroll
     @Tag("BAT")
-    @IgnoreIf({ Env.CI_JOB_NAME.contains("rosa") || Env.CI_JOB_NAME.contains("osd") }) // ROX-21171
     def "Verify RBAC with Role/Token combinations: #resourceAccess"() {
         when:
         "Create a test role"


### PR DESCRIPTION
## Description

The issue is in the test attempts to create a NetworkPolicy in the default namespace, which is a protected namespace on OSD/ROSA clusters. 
See https://github.com/openshift/managed-cluster-validating-webhooks/blob/b2a3251625399523c0333cf6caa490b8c7aac532/pkg/config/namespaces.go#L12 and https://github.com/openshift/managed-cluster-validating-webhooks/blob/b2a3251625399523c0333cf6caa490b8c7aac532/pkg/webhooks/networkpolicies/networkpolicies.go#L114-L116.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
