### PR TITLE
fix(ui): Allow passing of "action" to sort and pagination hooks

### DIFF
--- a/ui/apps/platform/src/hooks/useURLPagination.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLPagination.test.tsx
@@ -1,0 +1,169 @@
+import React, { ReactNode } from 'react';
+import { MemoryRouter, Route, RouteComponentProps } from 'react-router-dom';
+import { renderHook, act } from '@testing-library/react';
+
+import { URLSearchParams } from 'url';
+import useURLPagination from './useURLPagination';
+
+type WrapperProps = {
+    children: ReactNode;
+    onRouteRender: (renderResult: RouteComponentProps) => void;
+    initialEntries: string[];
+};
+
+function Wrapper({ children, onRouteRender, initialEntries = [] }: WrapperProps) {
+    return (
+        <MemoryRouter
+            initialEntries={initialEntries}
+            initialIndex={Math.max(0, initialEntries.length - 1)}
+        >
+            <Route path="*" render={onRouteRender} />
+            {children}
+        </MemoryRouter>
+    );
+}
+
+const createWrapper = (props) => {
+    return function CreatedWrapper({ children }) {
+        return <Wrapper {...props}>{children}</Wrapper>;
+    };
+};
+
+test('should update pagination parameters in the URL', async () => {
+    let params;
+    let testLocation;
+
+    const { result } = renderHook(() => useURLPagination(10), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location }) => {
+                testLocation = location;
+            },
+            initialEntries: [''],
+        }),
+    });
+
+    // Check new and existing values before setter function is called
+    params = new URLSearchParams(testLocation.search);
+    expect(result.current.page).toBe(1);
+    expect(result.current.perPage).toBe(10);
+    // When default values equal the current values, the URL parameters are not set
+    expect(params.get('page')).toBe(null);
+    expect(params.get('perPage')).toBe(null);
+
+    // Check new and existing values when URL parameter is set
+    act(() => {
+        const { setPage } = result.current;
+        setPage(2);
+    });
+    params = new URLSearchParams(testLocation.search);
+    expect(result.current.page).toBe(2);
+    expect(result.current.perPage).toBe(10);
+    expect(params.get('page')).toBe('2');
+    expect(params.get('perPage')).toBe(null);
+
+    // Check that updating the perPage parameter also resets the page parameter to 1
+    act(() => {
+        const { setPerPage } = result.current;
+        setPerPage(20);
+    });
+    params = new URLSearchParams(testLocation.search);
+    expect(result.current.page).toBe(1);
+    expect(result.current.perPage).toBe(20);
+    expect(params.get('page')).toBe('1');
+    expect(params.get('perPage')).toBe('20');
+});
+
+test('should not add history states when setting values with a "replace" action', async () => {
+    let params;
+    let historyLength;
+    let testLocation;
+
+    const { result } = renderHook(() => useURLPagination(10), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location, history }) => {
+                testLocation = location;
+                historyLength = history.length;
+            },
+            initialEntries: [''],
+        }),
+    });
+
+    // Check the length of the initial history stack
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
+    expect(params.get('page')).toBe(null);
+    expect(params.get('perPage')).toBe(null);
+
+    // Update the page parameter with a 'replace' action
+    act(() => {
+        const { setPage } = result.current;
+        setPage(2, 'replace');
+    });
+
+    // Check the length of the history stack after updating the page parameter
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
+    expect(params.get('page')).toBe('2');
+    expect(params.get('perPage')).toBe(null);
+
+    // Update the perPage parameter with a 'replace' action
+    act(() => {
+        const { setPerPage } = result.current;
+        setPerPage(20, 'replace');
+    });
+
+    // Check the length of the history stack after updating the perPage parameter
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
+    expect(params.get('page')).toBe('1');
+    expect(params.get('perPage')).toBe('20');
+});
+
+test('should only add a single history state when setting perPage without an action parameter', async () => {
+    let params;
+    let historyLength;
+    let testLocation;
+
+    const { result } = renderHook(() => useURLPagination(10), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location, history }) => {
+                testLocation = location;
+                historyLength = history.length;
+            },
+            initialEntries: [''],
+        }),
+    });
+
+    // Check the length of the initial history stack
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
+    expect(params.get('page')).toBe(null);
+    expect(params.get('perPage')).toBe(null);
+
+    // Update the page parameter
+    act(() => {
+        const { setPage } = result.current;
+        setPage(2);
+    });
+
+    // Check the length of the history stack after updating the page parameter
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(2);
+    expect(params.get('page')).toBe('2');
+    expect(params.get('perPage')).toBe(null);
+
+    // Update the perPage parameter and check the length of the history stack
+    act(() => {
+        const { setPerPage } = result.current;
+        setPerPage(20);
+    });
+
+    // Check the length of the history stack after updating the perPage parameter
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(3);
+    expect(params.get('page')).toBe('1');
+    expect(params.get('perPage')).toBe('20');
+});

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
-import useURLParameter from './useURLParameter';
+import useURLParameter, { Action } from './useURLParameter';
 
 export type UseURLPaginationResult = {
     page: number;
     perPage: number;
-    setPage: (page: number) => void;
-    setPerPage: (perPage: number) => void;
+    setPage: (page: number, historyAction?: Action | undefined) => void;
+    setPerPage: (perPage: number, historyAction?: Action | undefined) => void;
 };
 
 function safeNumber(val: unknown, defaultVal: number) {
@@ -18,13 +18,17 @@ function useURLPagination(defaultPerPage: number): UseURLPaginationResult {
     const [page, setPageString] = useURLParameter('page', '1');
     const [perPage, setPerPageString] = useURLParameter('perPage', `${defaultPerPage}`);
     const setPage = useCallback(
-        (num: number) => setPageString(num > 1 ? String(num) : undefined),
+        (num: number, historyAction?: Action | undefined) =>
+            setPageString(num > 1 ? String(num) : undefined, historyAction),
         [setPageString]
     );
     const setPerPage = useCallback(
-        (num: number) => {
-            setPageString('1');
-            setPerPageString(num !== defaultPerPage ? String(num) : undefined);
+        (num: number, historyAction?: Action | undefined) => {
+            // If the history action is 'replace', we replace both the perPage and page in-place.
+            // If the history action is 'push', we push a new perPage and replace the page in
+            // order to keep a single record on the history stack.
+            setPerPageString(num !== defaultPerPage ? String(num) : undefined, historyAction);
+            setPageString('1', 'replace');
         },
         [setPageString, setPerPageString, defaultPerPage]
     );

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
-import useURLParameter, { Action } from './useURLParameter';
+import useURLParameter, { HistoryAction } from './useURLParameter';
 
 export type UseURLPaginationResult = {
     page: number;
     perPage: number;
-    setPage: (page: number, historyAction?: Action | undefined) => void;
-    setPerPage: (perPage: number, historyAction?: Action | undefined) => void;
+    setPage: (page: number, historyAction?: HistoryAction | undefined) => void;
+    setPerPage: (perPage: number, historyAction?: HistoryAction | undefined) => void;
 };
 
 function safeNumber(val: unknown, defaultVal: number) {
@@ -18,12 +18,12 @@ function useURLPagination(defaultPerPage: number): UseURLPaginationResult {
     const [page, setPageString] = useURLParameter('page', '1');
     const [perPage, setPerPageString] = useURLParameter('perPage', `${defaultPerPage}`);
     const setPage = useCallback(
-        (num: number, historyAction?: Action | undefined) =>
+        (num: number, historyAction?: HistoryAction | undefined) =>
             setPageString(num > 1 ? String(num) : undefined, historyAction),
         [setPageString]
     );
     const setPerPage = useCallback(
-        (num: number, historyAction?: Action | undefined) => {
+        (num: number, historyAction?: HistoryAction | undefined) => {
             // If the history action is 'replace', we replace both the perPage and page in-place.
             // If the history action is 'push', we push a new perPage and replace the page in
             // order to keep a single record on the history stack.

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -6,11 +6,11 @@ import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 export type QueryValue = undefined | string | string[] | qs.ParsedQs | qs.ParsedQs[];
 
 // Note that when we upgrade React Router and 'history' we can probably import a more accurate version of this type
-export type Action = 'push' | 'replace';
+export type HistoryAction = 'push' | 'replace';
 
 export type UseURLParameterResult = [
     QueryValue,
-    (newValue: QueryValue, historyAction?: Action) => void,
+    (newValue: QueryValue, historyAction?: HistoryAction) => void,
 ];
 
 /**
@@ -38,7 +38,7 @@ function useURLParameter(keyPrefix: string, defaultValue: QueryValue): UseURLPar
     // memoize the setter function to retain referential equality as long
     // as the URL parameters do not change
     const setValue = useCallback(
-        (newValue: QueryValue, historyAction: Action = 'push') => {
+        (newValue: QueryValue, historyAction: HistoryAction = 'push') => {
             // Note that we use the version of `location` on `history` here, since it is mutable (compared
             // to the immutable `location` when used directly.) In this case, we aren't looking
             // for a reference change to trigger a rerender, we are looking for the current up-to-date

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -3,11 +3,11 @@ import isEqual from 'lodash/isEqual';
 
 import { SearchFilter } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
-import useURLParameter, { Action, QueryValue } from './useURLParameter';
+import useURLParameter, { HistoryAction, QueryValue } from './useURLParameter';
 
 type UseUrlSearchReturn = {
     searchFilter: SearchFilter;
-    setSearchFilter: (newFilter: SearchFilter, historyAction?: Action) => void;
+    setSearchFilter: (newFilter: SearchFilter, historyAction?: HistoryAction) => void;
 };
 
 function parseFilter(rawFilter: QueryValue): SearchFilter {

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
-import useURLParameter from 'hooks/useURLParameter';
+import useURLParameter, { Action } from 'hooks/useURLParameter';
 import { SortAggregate, SortDirection, SortOption, ThProps } from 'types/table';
 import { ApiSortOption } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
@@ -19,7 +19,7 @@ export type UseURLSortProps = {
 
 export type UseURLSortResult = {
     sortOption: ApiSortOption;
-    setSortOption: (newSortOption: SortOption) => void;
+    setSortOption: (newSortOption: SortOption, historyAction?: Action | undefined) => void;
     getSortParams: GetSortParams;
 };
 
@@ -126,9 +126,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
 
     return {
         sortOption: internalSortResultOption.current,
-        setSortOption: (newSortOption: SortOption) => {
-            setSortOption(newSortOption);
-        },
+        setSortOption,
         getSortParams,
     };
 }

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
-import useURLParameter, { Action } from 'hooks/useURLParameter';
+import useURLParameter, { HistoryAction } from 'hooks/useURLParameter';
 import { SortAggregate, SortDirection, SortOption, ThProps } from 'types/table';
 import { ApiSortOption } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
@@ -19,7 +19,7 @@ export type UseURLSortProps = {
 
 export type UseURLSortResult = {
     sortOption: ApiSortOption;
-    setSortOption: (newSortOption: SortOption, historyAction?: Action | undefined) => void;
+    setSortOption: (newSortOption: SortOption, historyAction?: HistoryAction | undefined) => void;
     getSortParams: GetSortParams;
 };
 

--- a/ui/apps/platform/src/hooks/useURLStringUnion.ts
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 
-import useURLParameter, { Action } from 'hooks/useURLParameter';
+import useURLParameter, { HistoryAction } from 'hooks/useURLParameter';
 import { NonEmptyArray } from 'utils/type.utils';
 
 export type UseURLStringUnionReturn<Value> = [
     Value,
-    (nextValue: unknown, historyAction?: Action) => void,
+    (nextValue: unknown, historyAction?: HistoryAction) => void,
 ];
 
 function isValidValue<Values extends Readonly<NonEmptyArray<unknown>>>(
@@ -41,7 +41,7 @@ export default function useURLStringUnion<Values extends Readonly<NonEmptyArray<
         setParamValue(currentValue, 'replace');
     }, [currentValue, setParamValue]);
 
-    function safeSetValue(nextValue: unknown, historyAction?: Action) {
+    function safeSetValue(nextValue: unknown, historyAction?: HistoryAction) {
         // Ensures the value cannot be set incorrectly by calling code
         if (isValidValue(values, nextValue)) {
             setParamValue(nextValue, historyAction);


### PR DESCRIPTION
## Description

We have a general purpose `useURLParameter()` hook that allows setting arbitrary values in the URL state and allows the caller to choose whether to `"push"` the history state, or `"replace"` it in place. Dependent on this hook are a handful of purpose built URL state hooks that we use throughout the application:
- `useURLSearch()`
- `useURLStringUnion()`
- `useURLPagination()`
- `useURLSort()`

The first two allow the caller to pass the history action when setting the state, which defaults to `"push"` and is rarely, if ever, called with `"replace"`. The latter two hooks omit this ability even though support for it can be easily added without needing to change any call sites.

The lack of this parameter becomes a problem when we want to change multiple URL parameter states at once and use the default history action of "push". In these cases a single user action that should push a single new URL may push _multiple_ URL history states, leading to buggy looking behavior when using the back button.

One instance of this is inherent in the `useURLPagination()` hook, which resets the `page` to `1` when the `perPage` value is changed, leading to an extra invalid history state.

This PR exposes the history action in the remaining hooks, and fixes the history state in the `useURLPagination()` hook to only add a single entry when `setPerPage()` is called with the default `"push"` action.

## Note on future recommendation

When updating multiple URL parameters from the above hooks at once based on a single user action, if the "push" history state is desired we should follow the pattern shown here in the `useURLPagination()` hook change:
1. "push" the first state change
2. "replace" all following changes
This will result in a single atomic URL update that reflects all state changes as a single entry in the history stack.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added unit tests to validate the new `useURLPagination()` behavior.

🤞 that we don't have any e2e tests that depend on this buggy behavior, but will verify when CI runs.

Manual check of a page using this hook to ensure the history state is added correctly:

Visit Violations:
![image](https://github.com/stackrox/stackrox/assets/1292638/13e6630d-8029-4a72-8874-befffff6c0f3)
Go to page 2:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad0edeae-3333-459a-945a-10a0cf8a3f35)
Set perPage to 10:
![image](https://github.com/stackrox/stackrox/assets/1292638/a328f80b-e81a-4363-af82-2a0d1e797e09)
Go back and verify that "page == 2" and "perPage" is unset in the URL.
![image](https://github.com/stackrox/stackrox/assets/1292638/d03d16e6-f4ce-4c55-8810-0ed632494110)

Prior to this change, in the final step "page" would be equal to "1" since there was an additional history state added to the stack, and the user would need to go back again to get to "page == 2".

