### PR TITLE
ROX-21732: Standardize on collection label for VM report in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -146,7 +146,7 @@ function CloneVulnReportPage() {
                         <Title headingLevel="h1">Clone report</Title>
                     </FlexItem>
                     <FlexItem>
-                        Configure reports, define report scopes, and assign delivery destinations to
+                        Configure reports, define collections, and assign delivery destinations to
                         report on vulnerabilities across the organization.
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -104,7 +104,7 @@ function CreateVulnReportPage() {
                         <Title headingLevel="h1">Create report</Title>
                     </FlexItem>
                     <FlexItem>
-                        Configure reports, define report scopes, and assign delivery destinations to
+                        Configure reports, define collections, and assign delivery destinations to
                         report on vulnerabilities across the organization.
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -139,7 +139,7 @@ function EditVulnReportPage() {
                         <Title headingLevel="h1">Edit report</Title>
                     </FlexItem>
                     <FlexItem>
-                        Configure reports, define report scopes, and assign delivery destinations to
+                        Configure reports, define collections, and assign delivery destinations to
                         report on vulnerabilities across the organization.
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -194,7 +194,7 @@ function VulnReportsPage() {
                                 </Flex>
                             </FlexItem>
                             <FlexItem>
-                                Configure reports, define report scopes, and assign delivery
+                                Configure reports, define collections, and assign delivery
                                 destinations to report on vulnerabilities across the organization.
                             </FlexItem>
                         </Flex>
@@ -301,7 +301,7 @@ function VulnReportsPage() {
                                                 popoverContent={
                                                     <div>
                                                         A set of user-configured rules for selecting
-                                                        deployments as part of the report scope
+                                                        deployments as part of the collection
                                                     </div>
                                                 }
                                             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/EmailTemplatePreview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/EmailTemplatePreview.tsx
@@ -119,7 +119,7 @@ function EmailTemplatePreview({
                             </div>
                             <div style={{ padding: '0 0 10px 0' }}>
                                 <span style={{ fontWeight: 'bold', marginRight: '10px' }}>
-                                    Report scope:
+                                    Collection included:
                                 </span>
                                 <span>{reportParameters.reportScope?.name || '-'}</span>
                             </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
@@ -89,7 +89,7 @@ function ReportParametersDetails({ formValues }: ReportParametersDetailsProps): 
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
-                        <DescriptionListTerm>Report scope</DescriptionListTerm>
+                        <DescriptionListTerm>Collection included</DescriptionListTerm>
                         <DescriptionListDescription>
                             {formValues.reportParameters.reportScope?.name || 'None'}
                         </DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -274,7 +274,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                     </FormLabelGroup>
                 )}
                 <FormLabelGroup
-                    label="Configure report scope"
+                    label="Configure collection included"
                     isRequired
                     fieldId="reportParameters.reportScope"
                     errors={formik.errors}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -113,7 +113,7 @@ const validationSchema = yup.object().shape({
             then: (schema) => schema.required('A custom start date is required'),
             otherwise: (schema) => schema,
         }),
-        reportScope: yup.object().required('A report scope is required'),
+        reportScope: yup.object().required('A collection is required'),
     }),
     deliveryDestinations: yup
         .array()


### PR DESCRIPTION
## Description

This change to some of the labels in Reporting in VM 2.0 addresses the last request, a bug, for the Epic "Collections In-use".

> The vulnerability reporting menus are referencing collections as "report scopes". While I think this is the intention of the collections it was confusing because I looked for "collections" and searched via ctrl + F and couldn't find it.

I asked the ACS docs teams to decide, and this is what @kcarmichael08 suggested in a comment on the Jira ticket:

> Maybe it's called "scope" because collections replaced "access scopes" in reporting? The page where you're setting up the report parameters isn't too confusing because the guidance says "Select a collection" in the drop-down list, but if you wanted to be more clear, an alternative would be "Collection included" in both places instead of "Report scope".

Two important points:

1. The column heading on the VM Reporting table page already used the term "Collection" instead of "Report scope", so you can think of this change as bringing all the other places where this concept is mentioned into alignment with the table page.
2. A search of the code base revealed a few more places on those pages where we used the wording "report scope" (like the form error message; so, I changes those places, too.


## Checklist
- [x] Investigated and inspected CI test results (single failure in one ui-e2e-tests run is a known flake)


## Testing Performed

### Here I tell how I validated my change

I did not find where we checked for the wording "report scope" in automated tests.

Where we already use the word "Collections" in the table column heading, I brought the page description into alignment.
![Screenshot 2024-05-16 at 11 59 03 AM](https://github.com/stackrox/stackrox/assets/715729/7b48f0ac-c795-4510-985d-541038111438)

Read-only detail view label
![Screenshot 2024-05-16 at 11 59 10 AM](https://github.com/stackrox/stackrox/assets/715729/c25f0d48-c19c-41bc-9345-36b598c31237)

Edit view form label
![Screenshot 2024-05-16 at 11 59 21 AM](https://github.com/stackrox/stackrox/assets/715729/c6fe766c-7ade-473a-a1d2-ba0bdacb6a87)

Edit view form error message
![Screenshot 2024-05-16 at 11 59 46 AM](https://github.com/stackrox/stackrox/assets/715729/61206e93-fe37-4a82-b56e-0e06f6497bb0)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
