### PR TITLE
ROX-24100: Profile clusters table pagination

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -4,6 +4,7 @@ import { Divider, PageSection, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
 import { getComplianceClusterStats } from 'services/ComplianceResultsStatsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
@@ -14,10 +15,13 @@ import ProfileClustersTable from './ProfileClustersTable';
 function ProfileClustersPage() {
     const { profileName } = useParams();
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
+    const pagination = useURLPagination(10);
+
+    const { page, perPage } = pagination;
 
     const fetchProfileClusters = useCallback(
-        () => getComplianceClusterStats(profileName),
-        [profileName]
+        () => getComplianceClusterStats(profileName, page, perPage),
+        [page, perPage, profileName]
     );
     const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);
 
@@ -47,6 +51,8 @@ function ProfileClustersPage() {
                     <Divider />
                     <ProfileClustersTable
                         currentDatetime={currentDatetime}
+                        pagination={pagination}
+                        profileClustersResultsCount={profileClusters?.totalCount ?? 0}
                         profileName={profileName}
                         tableState={tableState}
                     />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { generatePath, Link } from 'react-router-dom';
 import {
     Divider,
+    Pagination,
     Progress,
     ProgressMeasureLocation,
     Toolbar,
@@ -12,6 +13,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { ComplianceClusterOverallStats } from 'services/ComplianceCommon';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
@@ -27,21 +29,36 @@ import StatusCountIcon from './components/StatusCountIcon';
 
 export type ProfileClustersTableProps = {
     currentDatetime: Date;
+    pagination: UseURLPaginationResult;
+    profileClustersResultsCount: number;
     profileName: string;
     tableState: TableUIState<ComplianceClusterOverallStats>;
 };
 
 function ProfileClustersTable({
     currentDatetime,
+    pagination,
+    profileClustersResultsCount,
     profileName,
     tableState,
 }: ProfileClustersTableProps) {
+    const { page, perPage, setPage, setPerPage } = pagination;
+
     return (
         <>
             <Toolbar>
                 <ToolbarContent>
                     <ToolbarItem>
                         <ProfilesTableToggleGroup activeToggle="clusters" />
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                        <Pagination
+                            itemCount={profileClustersResultsCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        />
                     </ToolbarItem>
                 </ToolbarContent>
             </Toolbar>

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -1,13 +1,15 @@
+import qs from 'qs';
 import { generatePath } from 'react-router-dom';
 
 import axios from 'services/instance';
+import { getPaginationParams } from 'utils/searchUtils';
 
 import {
     ComplianceCheckResultStatusCount,
     ComplianceCheckStatusCount,
+    complianceV2Url,
     ListComplianceClusterOverallStatsResponse,
     ListComplianceProfileResults,
-    complianceV2Url,
 } from './ComplianceCommon';
 
 const complianceResultsStatsBaseUrl = `${complianceV2Url}/scan/stats`;
@@ -37,11 +39,19 @@ export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanS
  * Fetches the profile cluster results.
  */
 export function getComplianceClusterStats(
-    profileName: string
+    profileName: string,
+    page: number,
+    perPage: number
 ): Promise<ListComplianceClusterOverallStatsResponse> {
+    const queryParameters = {
+        query: {
+            pagination: getPaginationParams(page, perPage),
+        },
+    };
+    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<ListComplianceClusterOverallStatsResponse>(
-            `${complianceResultsStatsBaseUrl}/profiles/${profileName}/clusters`
+            `${complianceResultsStatsBaseUrl}/profiles/${profileName}/clusters?${params}`
         )
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

Adds pagination to the Compliance V2 Profile Clusters table

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![Screenshot 2024-05-16 at 12 17 09 PM](https://github.com/stackrox/stackrox/assets/61400697/25d631dc-3978-4bbb-b22d-16ca8c1591d8)
