### PR TITLE
chore(ui): Lift up construction of workload cves query

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -9,17 +9,12 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useMap from 'hooks/useMap';
-import { getHasSearchApplied } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
 
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
-import {
-    getStatusesForExceptionCount,
-    getVulnStateScopedQueryString,
-    parseWorkloadQuerySearchFilter,
-} from '../../utils/searchUtils';
+import { getStatusesForExceptionCount } from '../../utils/searchUtils';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import ExceptionRequestModal, {
     ExceptionRequestModalProps,
@@ -34,6 +29,8 @@ export type CVEsTableContainerProps = {
     vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     sort: ReturnType<typeof useURLSort>;
+    workloadCvesScopedQueryString: string;
+    isFiltered: boolean;
     isUnifiedDeferralsEnabled: boolean; // TODO Remove this when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
 };
 
@@ -44,17 +41,17 @@ function CVEsTableContainer({
     vulnerabilityState,
     pagination,
     sort,
+    workloadCvesScopedQueryString,
+    isFiltered,
     isUnifiedDeferralsEnabled,
 }: CVEsTableContainerProps) {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
-    const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
     const { error, loading, data, previousData } = useQuery(cveListQuery, {
         variables: {
-            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
+            query: workloadCvesScopedQueryString,
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -5,38 +5,32 @@ import { Bullseye, Spinner, Divider } from '@patternfly/react-core';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import { getHasSearchApplied } from 'utils/searchUtils';
-import { VulnerabilityState } from 'types/cve.proto';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
-import {
-    getVulnStateScopedQueryString,
-    parseWorkloadQuerySearchFilter,
-} from '../../utils/searchUtils';
 import { VulnerabilitySeverityLabel } from '../../types';
 
 type DeploymentsTableContainerProps = {
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
-    vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     sort: ReturnType<typeof useURLSort>;
+    workloadCvesScopedQueryString: string;
+    isFiltered: boolean;
 };
 
 function DeploymentsTableContainer({
     filterToolbar,
     entityToggleGroup,
     rowCount,
-    vulnerabilityState,
     pagination,
     sort,
+    workloadCvesScopedQueryString,
+    isFiltered,
 }: DeploymentsTableContainerProps) {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
-    const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -44,7 +38,7 @@ function DeploymentsTableContainer({
         deployments: Deployment[];
     }>(deploymentListQuery, {
         variables: {
-            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
+            query: workloadCvesScopedQueryString,
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -5,15 +5,9 @@ import { Bullseye, Spinner, Divider } from '@patternfly/react-core';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import { getHasSearchApplied } from 'utils/searchUtils';
-import { VulnerabilityState } from 'types/cve.proto';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 import ImagesTable, { ImagesTableProps, imageListQuery } from '../Tables/ImagesTable';
-import {
-    getVulnStateScopedQueryString,
-    parseWorkloadQuerySearchFilter,
-} from '../../utils/searchUtils';
 import { VulnerabilitySeverityLabel } from '../../types';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 
@@ -23,9 +17,10 @@ type ImagesTableContainerProps = {
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
-    vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     sort: ReturnType<typeof useURLSort>;
+    workloadCvesScopedQueryString: string;
+    isFiltered: boolean;
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
     onUnwatchImage: ImagesTableProps['onUnwatchImage'];
@@ -35,22 +30,21 @@ function ImagesTableContainer({
     filterToolbar,
     entityToggleGroup,
     rowCount,
-    vulnerabilityState,
     pagination,
     sort,
+    workloadCvesScopedQueryString,
+    isFiltered,
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableContainerProps) {
     const { searchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
-    const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
     const { error, loading, data, previousData } = useQuery(imageListQuery, {
         variables: {
-            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
+            query: workloadCvesScopedQueryString,
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -35,6 +35,7 @@ import {
     COMPONENT_SEARCH_OPTION,
     COMPONENT_SOURCE_SEARCH_OPTION,
 } from 'Containers/Vulnerabilities/searchOptions';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import {
     DefaultFilters,
     WorkloadEntityTab,
@@ -121,13 +122,19 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
     const [activeEntityTabKey] = useURLStringUnion('entityTab', workloadEntityTabValues);
 
+    const workloadCvesScopedQueryString = getVulnStateScopedQueryString(
+        querySearchFilter,
+        currentVulnerabilityState
+    );
+    const isFiltered = getHasSearchApplied(querySearchFilter);
+
     const { data } = useQuery<{
         imageCount: number;
         imageCVECount: number;
         deploymentCount: number;
     }>(entityTypeCountsQuery, {
         variables: {
-            query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
+            query: workloadCvesScopedQueryString,
         },
     });
     const entityCounts = {
@@ -288,6 +295,8 @@ function WorkloadCvesOverviewPage() {
                                     rowCount={entityCounts.CVE}
                                     pagination={pagination}
                                     sort={sort}
+                                    workloadCvesScopedQueryString={workloadCvesScopedQueryString}
+                                    isFiltered={isFiltered}
                                     vulnerabilityState={currentVulnerabilityState}
                                     isUnifiedDeferralsEnabled={isUnifiedDeferralsEnabled}
                                 />
@@ -298,9 +307,10 @@ function WorkloadCvesOverviewPage() {
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.Image}
                                     sort={sort}
+                                    workloadCvesScopedQueryString={workloadCvesScopedQueryString}
+                                    isFiltered={isFiltered}
                                     pagination={pagination}
                                     hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
-                                    vulnerabilityState={currentVulnerabilityState}
                                     onWatchImage={(imageName) => {
                                         setDefaultWatchedImageName(imageName);
                                         watchedImagesModalToggle.openSelect();
@@ -319,7 +329,8 @@ function WorkloadCvesOverviewPage() {
                                     rowCount={entityCounts.Deployment}
                                     pagination={pagination}
                                     sort={sort}
-                                    vulnerabilityState={currentVulnerabilityState}
+                                    workloadCvesScopedQueryString={workloadCvesScopedQueryString}
+                                    isFiltered={isFiltered}
                                 />
                             )}
                         </CardBody>


### PR DESCRIPTION
## Description

Small refactor in preparation for adding a "no CVEs" view to Workload CVEs.

This moves the construction of the search filter sent to CVE, Image, and Deployment queries to the top level where it is already being create elsewhere, in order to avoid duplication and out-of-sync issues.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI

Manual testing of the Workload CVE tables.