### PR TITLE
ROX-24183: images without vulns queries

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -19,6 +19,7 @@ type DeploymentsTableContainerProps = {
     sort: ReturnType<typeof useURLSort>;
     workloadCvesScopedQueryString: string;
     isFiltered: boolean;
+    showCveDetailFields: boolean;
 };
 
 function DeploymentsTableContainer({
@@ -29,6 +30,7 @@ function DeploymentsTableContainer({
     sort,
     workloadCvesScopedQueryString,
     isFiltered,
+    showCveDetailFields,
 }: DeploymentsTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const { page, perPage } = pagination;
@@ -78,6 +80,7 @@ function DeploymentsTableContainer({
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
                         filteredSeverities={searchFilter.SEVERITY as VulnerabilitySeverityLabel[]}
+                        showCveDetailFields={showCveDetailFields}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -24,6 +24,7 @@ type ImagesTableContainerProps = {
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
     onUnwatchImage: ImagesTableProps['onUnwatchImage'];
+    showCveDetailFields: boolean;
 };
 
 function ImagesTableContainer({
@@ -37,6 +38,7 @@ function ImagesTableContainer({
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
+    showCveDetailFields,
 }: ImagesTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const { page, perPage } = pagination;
@@ -87,6 +89,7 @@ function ImagesTableContainer({
                         hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
                         onWatchImage={onWatchImage}
                         onUnwatchImage={onUnwatchImage}
+                        showCveDetailFields={showCveDetailFields}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
@@ -23,18 +23,17 @@ function ObservedCveModeSelect({
     setObservedCveMode,
 }: ObservedCveModeSelectProps) {
     const [isCveModeSelectOpen, setIsCveModeSelectOpen] = useState(false);
+    const isViewingWithCves = observedCveMode === 'WITH_CVES';
 
-    const menuToggleIcon =
-        observedCveMode === 'WITH_CVES' ? (
-            <SecurityIcon color={CRITICAL_SEVERITY_COLOR} />
-        ) : (
-            <UnknownIcon />
-        );
+    const menuToggleIcon = isViewingWithCves ? (
+        <SecurityIcon color={CRITICAL_SEVERITY_COLOR} />
+    ) : (
+        <UnknownIcon />
+    );
 
-    const menuToggleText =
-        observedCveMode === 'WITH_CVES'
-            ? 'View image vulnerabilities'
-            : 'View images without vulnerabilities';
+    const menuToggleText = isViewingWithCves
+        ? 'View image vulnerabilities'
+        : 'View images without vulnerabilities';
 
     return (
         <Select

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -64,6 +64,7 @@ type DeploymentsTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     filteredSeverities?: VulnerabilitySeverityLabel[];
+    showCveDetailFields: boolean;
 };
 
 function DeploymentsTable({
@@ -71,6 +72,7 @@ function DeploymentsTable({
     getSortParams,
     isFiltered,
     filteredSeverities,
+    showCveDetailFields,
 }: DeploymentsTableProps) {
     const vulnerabilityState = useVulnerabilityState();
     return (
@@ -79,11 +81,15 @@ function DeploymentsTable({
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>
-                    <Th sort={getSortParams('Deployment Risk Priority')}>Risk priority</Th>
-                    <TooltipTh tooltip="CVEs by severity across this deployment">
-                        CVEs by severity
-                        {isFiltered && <DynamicColumnIcon />}
-                    </TooltipTh>
+                    {showCveDetailFields && (
+                        <Th sort={getSortParams('Deployment Risk Priority')}>Risk priority</Th>
+                    )}
+                    {showCveDetailFields && (
+                        <TooltipTh tooltip="CVEs by severity across this deployment">
+                            CVEs by severity
+                            {isFiltered && <DynamicColumnIcon />}
+                        </TooltipTh>
+                    )}
                     <Th sort={getSortParams('Cluster')}>Cluster</Th>
                     <Th sort={getSortParams('Namespace')}>Namespace</Th>
                     <Th>
@@ -128,22 +134,26 @@ function DeploymentsTable({
                                         <Truncate position="middle" content={name} />
                                     </Link>
                                 </Td>
-                                <Td
-                                    dataLabel="Risk priority"
-                                    className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
-                                >
-                                    {priority}
-                                </Td>
-                                <Td>
-                                    <SeverityCountLabels
-                                        criticalCount={criticalCount}
-                                        importantCount={importantCount}
-                                        moderateCount={moderateCount}
-                                        lowCount={lowCount}
-                                        entity="deployment"
-                                        filteredSeverities={filteredSeverities}
-                                    />
-                                </Td>
+                                {showCveDetailFields && (
+                                    <Td
+                                        dataLabel="Risk priority"
+                                        className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
+                                    >
+                                        {priority}
+                                    </Td>
+                                )}
+                                {showCveDetailFields && (
+                                    <Td>
+                                        <SeverityCountLabels
+                                            criticalCount={criticalCount}
+                                            importantCount={importantCount}
+                                            moderateCount={moderateCount}
+                                            lowCount={lowCount}
+                                            entity="deployment"
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
+                                )}
                                 <Td>{clusterName}</Td>
                                 <Td>{namespace}</Td>
                                 <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -89,6 +89,7 @@ export type ImagesTableProps = {
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: (imageName: string) => void;
     onUnwatchImage: (imageName: string) => void;
+    showCveDetailFields: boolean;
 };
 
 function ImagesTable({
@@ -99,8 +100,9 @@ function ImagesTable({
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
+    showCveDetailFields,
 }: ImagesTableProps) {
-    const colSpan = hasWriteAccessForWatchedImage ? 8 : 7;
+    const colSpan = 5 + (hasWriteAccessForWatchedImage ? 1 : 0) + (showCveDetailFields ? 2 : 0);
 
     return (
         <Table borders={false} variant="compact">
@@ -108,11 +110,15 @@ function ImagesTable({
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Image')}>Image</Th>
-                    <Th sort={getSortParams('Image Risk Priority')}>Risk priority</Th>
-                    <TooltipTh tooltip="CVEs by severity across this image">
-                        CVEs by severity
-                        {isFiltered && <DynamicColumnIcon />}
-                    </TooltipTh>
+                    {showCveDetailFields && (
+                        <Th sort={getSortParams('Image Risk Priority')}>Risk priority</Th>
+                    )}
+                    {showCveDetailFields && (
+                        <TooltipTh tooltip="CVEs by severity across this image">
+                            CVEs by severity
+                            {isFiltered && <DynamicColumnIcon />}
+                        </TooltipTh>
+                    )}
                     <Th sort={getSortParams('Image OS')}>Operating system</Th>
                     <Th>
                         Deployments
@@ -180,22 +186,26 @@ function ImagesTable({
                                         'Image name not available'
                                     )}
                                 </Td>
-                                <Td
-                                    dataLabel="Risk priority"
-                                    className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
-                                >
-                                    {priority}
-                                </Td>
-                                <Td dataLabel="CVEs by severity">
-                                    <SeverityCountLabels
-                                        criticalCount={criticalCount}
-                                        importantCount={importantCount}
-                                        moderateCount={moderateCount}
-                                        lowCount={lowCount}
-                                        entity="image"
-                                        filteredSeverities={filteredSeverities}
-                                    />
-                                </Td>
+                                {showCveDetailFields && (
+                                    <Td
+                                        dataLabel="Risk priority"
+                                        className="pf-v5-u-pr-2xl pf-v5-u-text-align-center-on-md"
+                                    >
+                                        {priority}
+                                    </Td>
+                                )}
+                                {showCveDetailFields && (
+                                    <Td dataLabel="CVEs by severity">
+                                        <SeverityCountLabels
+                                            criticalCount={criticalCount}
+                                            importantCount={importantCount}
+                                            moderateCount={moderateCount}
+                                            lowCount={lowCount}
+                                            entity="image"
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
+                                )}
                                 <Td>{operatingSystem}</Td>
                                 <Td modifier="nowrap">
                                     {deploymentCount > 0 ? (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -32,7 +32,7 @@ function VulnerabilityStateTabs({
             activeKey={vulnerabilityStateKey}
             onSelect={(_e, tab) => {
                 setVulnerabilityStateKey(tab);
-                if (onChange && isVulnerabilityState(tab)) {
+                if (onChange && isVulnerabilityState(tab) && tab !== vulnerabilityStateKey) {
                     onChange(tab);
                 }
             }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -49,6 +49,7 @@ type WorkloadCveFilterToolbarProps = {
     searchOptions: SearchOption[];
     autocompleteSearchContext?: FilterAutocompleteSelectProps['autocompleteSearchContext'];
     onFilterChange?: (searchFilter: SearchFilter) => void;
+    showCveFilterDropdowns?: boolean;
 };
 
 function WorkloadCveFilterToolbar({
@@ -56,6 +57,7 @@ function WorkloadCveFilterToolbar({
     searchOptions,
     autocompleteSearchContext,
     onFilterChange = noop,
+    showCveFilterDropdowns = true,
 }: WorkloadCveFilterToolbarProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');
@@ -170,12 +172,14 @@ function WorkloadCveFilterToolbar({
                     searchOptions={searchOptions}
                     autocompleteSearchContext={autocompleteSearchContext}
                 />
-                <ToolbarGroup>
-                    <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />
-                    {isFixabilityFiltersEnabled && (
-                        <CVEStatusDropdown searchFilter={searchFilter} onSelect={onSelect} />
-                    )}
-                </ToolbarGroup>
+                {showCveFilterDropdowns && (
+                    <ToolbarGroup>
+                        <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />
+                        {isFixabilityFiltersEnabled && (
+                            <CVEStatusDropdown searchFilter={searchFilter} onSelect={onSelect} />
+                        )}
+                    </ToolbarGroup>
+                )}
                 <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                     <SearchFilterChips
                         onFilterChange={onFilterChange}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -217,6 +217,13 @@ export function getVulnStateScopedQueryString(
     });
 }
 
+export function getZeroCveScopedQueryString(searchFilter: QuerySearchFilter): string {
+    return getRequestQueryStringForSearchFilter({
+        'Image CVE Count': '0',
+        ...applyRegexSearchModifiers(searchFilter),
+    });
+}
+
 /**
  * Returns the statuses that should be used to query for exception counts given
  * the current vulnerability state.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -42,6 +42,7 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): string[] {
 
 /**
  *  Get the default table sort option for a given Workload CVE entity
+ *
  * @param entityTab The chosen entity
  * @returns The default sort option
  */
@@ -53,6 +54,26 @@ export function getDefaultWorkloadSortOption(entityTab: WorkloadEntityTab): Sort
             return { field: 'Deployment Risk Priority', direction: 'asc' };
         case 'Image':
             return { field: 'Image Risk Priority', direction: 'asc' };
+        default:
+            return ensureExhaustive(entityTab);
+    }
+}
+
+/**
+ * Gets the default sort option for a given Workload CVE entity when the user is viewing
+ * the images and deployments that are observed to have zero CVEs.
+ *
+ * @param entityTab The chosen entity
+ * @returns The default sort option
+ */
+export function getDefaultZeroCveSortOption(entityTab: WorkloadEntityTab): SortOption {
+    switch (entityTab) {
+        case 'CVE':
+            return { field: 'CVE', direction: 'asc' };
+        case 'Deployment':
+            return { field: 'Deployment', direction: 'asc' };
+        case 'Image':
+            return { field: 'Image', direction: 'asc' };
         default:
             return ensureExhaustive(entityTab);
     }


### PR DESCRIPTION
## Description

Adds the implementation for the core "Images without vulnerabilities" functionality. When this option is selected:
- The "CVEs" table will disappear ("Images" will be selected if the user was previously viewing CVEs)
- All filters, pagination, and sorting will be reset
- Entity counts and table GraphQL queries will no longer use a "Vulnerability State" filter, and instead will always contain a filter of `"Image CVE Count:0"`. (This is currently being implemented by the BE.)
- CVE related fields will be hidden from the tables
- The "CVE", "CVE Severity", and "CVE Status" options will be removed from the toolbar

An additional change, since it was discovered during this PR, is that all URL parameter changes on the Workload CVE Overview page are now batched with `"replace"` in places where multiple changes occur at once. This should resolve both https://issues.redhat.com/browse/ROX-23376 and https://issues.redhat.com/browse/ROX-23567

## Follow ups

- Implementation of the table header
- Adjustment of how Default filters are applied
- e2e tests

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Workload CVEs and select the "without CVEs" option from the dropdown.
![image](https://github.com/stackrox/stackrox/assets/1292638/430a791a-f19d-47ff-a8c5-a05c85108d9b)
![image](https://github.com/stackrox/stackrox/assets/1292638/fe2d50f1-e3a0-42da-83ff-bd576b65f724)

Filters are cleared, the CVE filter option is removed, severity and fixability filters are removed:
![image](https://github.com/stackrox/stackrox/assets/1292638/4c376d6e-4cce-49cd-80b0-8aef5c9b3686)

Entity counts are updated, the table data reflects images without CVEs, and CVE based columns in the table are removed:
![image](https://github.com/stackrox/stackrox/assets/1292638/0797f5e9-c9d8-4d03-a928-784157468ab2)

Clicking the deployment tab shows deployments that contain an image with no CVEs and the CVE based columns in that table are removed:
![image](https://github.com/stackrox/stackrox/assets/1292638/f26c3b4c-6e2e-4294-a84f-945992bacfaf)

Re-selecting the "With CVEs" option correctly reloads the data to items that contain CVEs and restores the table columns and filter options.
![image](https://github.com/stackrox/stackrox/assets/1292638/b100a86f-8b6c-4d70-aa9a-ebe217b6336c)


