### PR TITLE
ROX-24182: update workload CVE overview header

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
@@ -13,6 +13,12 @@ import { SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 import { CRITICAL_SEVERITY_COLOR } from 'constants/severityColors';
 import { ObservedCveMode, isObservedCveMode, observedCveModeValues } from '../../types';
 
+export const WITH_CVE_OPTION_TITLE = 'Image vulnerabilities';
+export const WITHOUT_CVE_OPTION_TITLE = 'Images without vulnerabilities';
+export const WITH_CVE_OPTION_DESCRIPTION = 'Images and deployments observed with CVEs';
+export const WITHOUT_CVE_OPTION_DESCRIPTION =
+    'Images and deployments observed without CVEs (results may be inaccurate due to scanner errors)';
+
 export type ObservedCveModeSelectProps = {
     observedCveMode: ObservedCveMode;
     setObservedCveMode: (value: ObservedCveMode) => void;
@@ -66,15 +72,15 @@ function ObservedCveModeSelect({
             <SelectList style={{ maxWidth: '300px' }}>
                 <SelectOption
                     value={observedCveModeValues[0]}
-                    description="Images and deployments observed with CVEs"
+                    description={WITH_CVE_OPTION_DESCRIPTION}
                 >
-                    Image vulnerabilities
+                    {WITH_CVE_OPTION_TITLE}
                 </SelectOption>
                 <SelectOption
                     value={observedCveModeValues[1]}
-                    description="Images observed without CVEs (results may be inaccurate due to scanner errors)"
+                    description={WITHOUT_CVE_OPTION_DESCRIPTION}
                 >
-                    Images without vulnerabilities
+                    {WITHOUT_CVE_OPTION_TITLE}
                 </SelectOption>
             </SelectList>
         </Select>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -77,16 +77,17 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
     return (
         <>
             <Button
-                variant="tertiary"
+                variant="secondary"
+                className="pf-v5-u-display-inline-flex pf-v5-u-align-items-center"
                 onClick={handleModalToggle}
-                icon={<Globe className="pf-v5-u-mr-sm" />}
                 countOptions={{
                     isRead: true,
                     count: totalFilters,
                     className: 'custom-badge-unread',
                 }}
             >
-                Default filters
+                <Globe height="20px" width="20px" className="pf-v5-u-mr-sm" />
+                <span>Default filters</span>
             </Button>
             <Modal
                 title="Default filters"


### PR DESCRIPTION
## Description

Updates the Workload CVE page to have a more descriptive header above the table, and moves the Namespace View and Default filter buttons into this header.

## Follow up

The NS view and Default Filter buttons should only be displayed for "Observed" - we need to remove them for Deferred and FP tabs. https://issues.redhat.com/browse/ROX-24318

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/0751ffcb-d613-430e-812f-5eb946807cde)

Without CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/95126888-b891-4093-8860-6bf97fad3af7)

Feature flag off:
![image](https://github.com/stackrox/stackrox/assets/1292638/c6d74ae3-ca8d-475c-8b7b-f716a5c1743b)
