### PR TITLE
ROX-24285:  compliance fix overwritten sort

### DIFF
--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -91,7 +91,7 @@ func (d *datastoreImpl) ComplianceCheckResultStats(ctx context.Context, query *v
 		},
 	}
 
-	if cloned.Pagination == nil {
+	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
@@ -135,7 +135,7 @@ func (d *datastoreImpl) ComplianceProfileResultStats(ctx context.Context, query 
 		},
 	}
 
-	if cloned.Pagination == nil {
+	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
@@ -179,7 +179,7 @@ func (d *datastoreImpl) ComplianceProfileResults(ctx context.Context, query *v1.
 		},
 	}
 
-	if cloned.Pagination == nil {
+	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
@@ -228,7 +228,7 @@ func (d *datastoreImpl) ComplianceClusterStats(ctx context.Context, query *v1.Qu
 		},
 	}
 
-	if cloned.Pagination == nil {
+	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -93,17 +93,17 @@ func (d *datastoreImpl) ComplianceCheckResultStats(ctx context.Context, query *v
 
 	if cloned.Pagination == nil {
 		cloned.Pagination = &v1.QueryPagination{}
-	}
-	cloned.Pagination.SortOptions = []*v1.QuerySortOption{
-		{
-			Field: search.ComplianceOperatorScanConfigName.String(),
-		},
-		{
-			Field: search.ClusterID.String(),
-		},
-		{
-			Field: search.Cluster.String(),
-		},
+		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
+			{
+				Field: search.ComplianceOperatorScanConfigName.String(),
+			},
+			{
+				Field: search.ClusterID.String(),
+			},
+			{
+				Field: search.Cluster.String(),
+			},
+		}
 	}
 
 	countQuery := d.withCountByResultSelectQuery(cloned, search.ClusterID)
@@ -137,11 +137,11 @@ func (d *datastoreImpl) ComplianceProfileResultStats(ctx context.Context, query 
 
 	if cloned.Pagination == nil {
 		cloned.Pagination = &v1.QueryPagination{}
-	}
-	cloned.Pagination.SortOptions = []*v1.QuerySortOption{
-		{
-			Field: search.ComplianceOperatorProfileName.String(),
-		},
+		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
+			{
+				Field: search.ComplianceOperatorProfileName.String(),
+			},
+		}
 	}
 
 	countQuery := d.withCountByResultSelectQuery(cloned, search.ComplianceOperatorProfileName)
@@ -181,20 +181,20 @@ func (d *datastoreImpl) ComplianceProfileResults(ctx context.Context, query *v1.
 
 	if cloned.Pagination == nil {
 		cloned.Pagination = &v1.QueryPagination{}
-	}
-	cloned.Pagination.SortOptions = []*v1.QuerySortOption{
-		{
-			Field: search.ComplianceOperatorProfileName.String(),
-		},
-		{
-			Field: search.ComplianceOperatorCheckName.String(),
-		},
-		{
-			Field: search.ComplianceOperatorCheckRationale.String(),
-		},
-		{
-			Field: search.ComplianceOperatorRuleName.String(),
-		},
+		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
+			{
+				Field: search.ComplianceOperatorProfileName.String(),
+			},
+			{
+				Field: search.ComplianceOperatorCheckName.String(),
+			},
+			{
+				Field: search.ComplianceOperatorCheckRationale.String(),
+			},
+			{
+				Field: search.ComplianceOperatorRuleName.String(),
+			},
+		}
 	}
 
 	countQuery := d.withCountByResultSelectQuery(cloned, search.ComplianceOperatorProfileName)

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -91,8 +91,10 @@ func (d *datastoreImpl) ComplianceCheckResultStats(ctx context.Context, query *v
 		},
 	}
 
-	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
+	if cloned.GetPagination() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
+	}
+	if cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
 				Field: search.ComplianceOperatorScanConfigName.String(),
@@ -135,8 +137,10 @@ func (d *datastoreImpl) ComplianceProfileResultStats(ctx context.Context, query 
 		},
 	}
 
-	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
+	if cloned.GetPagination() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
+	}
+	if cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
 				Field: search.ComplianceOperatorProfileName.String(),
@@ -179,8 +183,10 @@ func (d *datastoreImpl) ComplianceProfileResults(ctx context.Context, query *v1.
 		},
 	}
 
-	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
+	if cloned.GetPagination() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
+	}
+	if cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
 				Field: search.ComplianceOperatorProfileName.String(),
@@ -228,8 +234,10 @@ func (d *datastoreImpl) ComplianceClusterStats(ctx context.Context, query *v1.Qu
 		},
 	}
 
-	if cloned.GetPagination() == nil && cloned.GetPagination().GetSortOptions() == nil {
+	if cloned.GetPagination() == nil {
 		cloned.Pagination = &v1.QueryPagination{}
+	}
+	if cloned.GetPagination().GetSortOptions() == nil {
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
 				Field: search.ClusterID.String(),


### PR DESCRIPTION
## Description

Sort order was overwritten when the default sorts should have only been applied if there was no sort options present.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
```
curl --insecure "https://central-stackrox.apps.ds-05-17-cooing-color-intere.ocp.infra.rox.systems:443/v2/compliance/scan/results/profiles/rhcos4-e8/checks?query.pagination.sortOption.field=Compliance%20Check%20Name&query.pagination.sortOption.reversed=true" -u admin:XXX | json_pp > ~/Downloads/profile_checks_reverse.json
```
[profile_checks_reverse.json](https://github.com/stackrox/stackrox/files/15354382/profile_checks_reverse.json)


```
curl --insecure "https://central-stackrox.apps.ds-05-17-cooing-color-intere.ocp.infra.rox.systems:443/v2/compliance/scan/stats/profiles?pagination.sortOption.field=Compliance%20Profile%20Name&pagination.sortOption.reversed=true" -u admin:XXX | json_pp > ~/Downloads/profile_stats_reverse.json
```
[profile_stats_reverse.json](https://github.com/stackrox/stackrox/files/15354377/profile_stats_reverse.json)


```
curl --insecure "https://central-stackrox.apps.ds-05-17-cooing-color-intere.ocp.infra.rox.systems:443/v2/compliance/stats/configurations/clusters/c3fa495a-be64-4aaf-bfee-171935ebbc05?query.pagination.sortOption.field=Compliance%20Scan%20Config%20Name&query.pagination.sortOption.reversed=true" -u admin:XXX | json_pp > ~/Downloads/cluster_stats_reverse_by_config_name.json
```
[cluster_stats_reverse_by_config_name.json](https://github.com/stackrox/stackrox/files/15354373/cluster_stats_reverse_by_config_name.json)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
