### PR TITLE
ROX-23679: Add delivery destination to scan config in Compliance 2.0

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
@@ -245,7 +245,7 @@ function NotifierConfigurationForm({
                         const index = notifierConfigurations.indexOf(notifierConfigurationSelected);
                         if (index >= 0) {
                             const { emailConfig } = notifierConfigurationSelected;
-                            setFieldValue(`deliveryDestinations[${index}]`, {
+                            setFieldValue(`${fieldIdPrefixForFormikAndPatternFly}[${index}]`, {
                                 ...notifierConfigurationSelected,
                                 emailConfig: {
                                     ...emailConfig,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
@@ -1,0 +1,48 @@
+import React, { ReactElement } from 'react';
+import { FormikContextType, useFormikContext } from 'formik';
+import { Divider, Flex, FlexItem, Form, PageSection, Title } from '@patternfly/react-core';
+
+import NotifierConfigurationForm from 'Components/NotifierConfiguration/NotifierConfigurationForm';
+import usePermissions from 'hooks/usePermissions';
+
+import {
+    ScanConfigFormValues,
+    customBodyDefault,
+    getSubjectDefault,
+} from '../compliance.scanConfigs.utils';
+
+function ReportConfiguration(): ReactElement {
+    const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
+
+    return (
+        <>
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'column' }} className="pf-v5-u-py-lg pf-v5-u-px-lg">
+                    <FlexItem>
+                        <Title headingLevel="h2">Report configuration</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        Optionally configure e-mail delivery destinations for manually triggered
+                        reports.
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <Divider component="div" />
+            <Form className="pf-v5-u-py-lg pf-v5-u-px-lg">
+                <NotifierConfigurationForm
+                    customBodyDefault={customBodyDefault}
+                    customSubjectDefault={getSubjectDefault(formik.values.parameters.name)}
+                    errors={formik.errors}
+                    fieldIdPrefixForFormikAndPatternFly="report.notifierConfigurations"
+                    hasWriteAccessForIntegration={hasWriteAccessForIntegration}
+                    notifierConfigurations={formik.values.report.notifierConfigurations}
+                    setFieldValue={formik.setFieldValue}
+                />
+            </Form>
+        </>
+    );
+}
+
+export default ReportConfiguration;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -106,7 +106,6 @@ function ReviewConfig({ clusters, profiles, errorMessage }: ProfileSelectionProp
                 </StackItem>
                 {isComplianceReportingEnabled && (
                     <StackItem>
-                        <Title headingLevel="h3">Report configuration</Title>
                         <NotifierConfigurationView
                             customBodyDefault={customBodyDefault}
                             customSubjectDefault={getSubjectDefault(formikValues.parameters.name)}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -15,12 +15,16 @@ import {
     Title,
 } from '@patternfly/react-core';
 
+import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { ComplianceIntegration } from 'services/ComplianceIntegrationService';
 import { ComplianceProfileSummary } from 'services/ComplianceProfileService';
 
 import {
     convertFormikParametersToSchedule,
+    customBodyDefault,
     formatScanSchedule,
+    getSubjectDefault,
     ScanConfigFormValues,
 } from '../compliance.scanConfigs.utils';
 
@@ -32,6 +36,8 @@ export type ProfileSelectionProps = {
 
 function ReviewConfig({ clusters, profiles, errorMessage }: ProfileSelectionProps) {
     const { values: formikValues }: FormikContextType<ScanConfigFormValues> = useFormikContext();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
 
     const scanSchedule = convertFormikParametersToSchedule(formikValues.parameters);
     const formattedScanSchedule = formatScanSchedule(scanSchedule);
@@ -98,6 +104,16 @@ function ReviewConfig({ clusters, profiles, errorMessage }: ProfileSelectionProp
                         ))}
                     </TextList>
                 </StackItem>
+                {isComplianceReportingEnabled && (
+                    <StackItem>
+                        <Title headingLevel="h3">Report configuration</Title>
+                        <NotifierConfigurationView
+                            customBodyDefault={customBodyDefault}
+                            customSubjectDefault={getSubjectDefault(formikValues.parameters.name)}
+                            notifierConfigurations={formikValues.report.notifierConfigurations}
+                        />
+                    </StackItem>
+                )}
             </Stack>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
@@ -1,6 +1,11 @@
 import { FormikProps, useFormik } from 'formik';
 import * as yup from 'yup';
 
+import {
+    customBodyValidation,
+    customSubjectValidation,
+} from 'Components/EmailTemplate/EmailTemplate.utils';
+
 import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 export const defaultScanConfigFormValues: ScanConfigFormValues = {
@@ -14,6 +19,9 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
     },
     clusters: [],
     profiles: [],
+    report: {
+        notifierConfigurations: [],
+    },
 };
 
 const validationSchema = yup.object().shape({
@@ -46,6 +54,25 @@ const validationSchema = yup.object().shape({
     }),
     clusters: yup.array().min(1),
     profiles: yup.array().min(1),
+    report: yup.object().shape({
+        notifierConfigurations: yup
+            .array()
+            .of(
+                yup.object().shape({
+                    emailConfig: yup.object().shape({
+                        notifierId: yup.string().required('A notifier is required'),
+                        mailingLists: yup
+                            .array()
+                            .of(yup.string())
+                            .min(1, 'At least 1 delivery destination is required'),
+                        customSubject: customSubjectValidation,
+                        customBody: customBodyValidation,
+                    }),
+                    notifierName: yup.string(),
+                })
+            )
+            .strict(),
+    }),
 });
 
 function useFormikScanConfig(initialFormValues): FormikProps<ScanConfigFormValues> {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/emailTemplateFormUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/emailTemplateFormUtils.ts
@@ -2,12 +2,11 @@ import { getProductBranding } from 'constants/productBranding';
 
 // Helper functions
 
-const { type: productBrand } = getProductBranding();
+const { shortName, type: productBrand } = getProductBranding();
 const productBrandText =
     productBrand === 'RHACS_BRANDING' ? 'Red Hat Advanced Cluster Security (RHACS)' : 'StackRox';
-const shortenedProductBrandText = productBrand === 'RHACS_BRANDING' ? 'RHACS' : 'StackRox';
 
-export const defaultEmailSubjectTemplate = `${shortenedProductBrandText} Workload CVE Report for <Config name>; Scope: <Collection name>`;
+export const defaultEmailSubjectTemplate = `${shortName} Workload CVE Report for <Config name>; Scope: <Collection name>`;
 
 export const defaultEmailBody = `${productBrandText} for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. The attached Vulnerability report lists those workload CVEs and associated details to help with remediation. Please review the vulnerable software packages/components from the impacted images and update them to a version containing the fix, if one is available.\n\nPlease note that an attachment of the report data will not be provided if no CVEs are found.`;
 

--- a/ui/apps/platform/src/constants/productBranding.ts
+++ b/ui/apps/platform/src/constants/productBranding.ts
@@ -14,6 +14,8 @@ export interface BrandingAssets {
     logoAltText: string;
     /** Value to use as the base in the <title> element */
     basePageTitle: string;
+    /** Value for default subject of report e-mail */
+    shortName: string;
     /** Absolute path to the page favicon */
     favicon: string;
 }
@@ -23,6 +25,7 @@ const rhacsBranding: BrandingAssets = {
     logoSvg: rhacsLogoSvg,
     logoAltText: 'Red Hat Advanced Cluster Security Logo',
     basePageTitle: 'Red Hat Advanced Cluster Security',
+    shortName: 'RHACS',
     favicon: rhacsFavicon,
 };
 
@@ -31,6 +34,7 @@ const stackroxBranding: BrandingAssets = {
     logoSvg: stackroxLogoSvg,
     logoAltText: 'StackRox Logo',
     basePageTitle: 'StackRox',
+    shortName: 'StackRox',
     favicon: stackroxFavicon,
 };
 

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -6,6 +6,7 @@ import { SlimUser } from 'types/user.proto';
 
 import { complianceV2Url } from './ComplianceCommon';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { NotifierConfiguration } from './ReportsService.types';
 import { Empty } from './types';
 
 const complianceScanConfigBaseUrl = `${complianceV2Url}/scan/configurations`;
@@ -56,6 +57,7 @@ type BaseComplianceScanConfigurationSettings = {
     profiles: string[];
     scanSchedule: Schedule;
     description?: string;
+    notifiers: NotifierConfiguration[];
 };
 
 export type ComplianceScanConfiguration = {


### PR DESCRIPTION
## Description

Frontend counterpart to backend #10954

1. Conditionally render reusable elements with `ROX_COMPLIANCE_REPORTING` feature flag.
2. Add compliance email template to utils file.
3. Judgment call to use `notifierConfigurations` instead of `notifiers` in form state to avoid ambiguity with notifiers themselves, especially since there are convert functions.

### Changed files

1. Edit NotifierConfigurationForm.tsx file.
    * Replace incorrect specific `deliveryDestinations` with correct generic `fieldIdPrefixForFormikAndPatternFly` prop.
2. Add ReportConfiguration.tsx file.
    * Render reusable `NotifierConfigurationForm` element.
3. Edit ReviewConfig.tsx file.
   * Conditionally render reusable `NotifierConfigurationView` element.
4. Edit ScanConfigWizardForm.tsx file.
    * Conditionally render `ReportConfiguration` element as step 4.
5. Edit useFormikScanConfig.tsx file.
    * Add property to `defaultScanConfigFormValues` variable.
    * Add property to `validationSchema` variable.
6. Edit compliance.scanConfigs.utils.tsx file.
    * Add property to `ScanConfigFormValues` type.
    * Add property in `convertFormikToScanConfig` function.
    * Add property in `convertScanConfigToFormik` function.
    * Add `customBodyDefault` and `getSubjectDefault` for compliance email template.
7. Edit emailTemplateFormUtils.ts file.
    * Reuse `shortName` property.
8. Edit productBranding.ts file
    * Factor out `shortName` property for reuse.
9. Edit ComplianceScanConfigurationService.ts file.
    * Add property to `BaseComplianceScanConfigurationSettings` type.

### Residue

1. Remove redundancy in `ReviewConfig` and `ViewScanConfigDetail` elements.
2. Improve heading levels: both **Report configuration** and **Delivery destinations** have `h3` element.
3. Investigate difference between height of step 4 for create versus edit action.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Prerequisite in ui folder:

```sh
export ROX_COMPLIANCE_REPORTING=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 94 = 4635516 - 4635422
        total 4413 = 11691440 - 11687027
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance-enhanced/schedules
    * See GET /v2/compliance/scan/configurations?pagination.offset=0&pagination.limit=10&pagination.sortOption.field=Compliance%20Scan%20Config%20Name&pagination.sortOption.reversed=false request which has `notifiers: []` in response

2. Click **Create scan schedule**
    * See `?action=create` query string in page address.
    * See step 4 **Configure report** at left of wizard.
    ![1_Set_Parameters](https://github.com/stackrox/stackrox/assets/11862657/ef094e34-427a-4470-9548-38deaf6e496a)

3. Continue to step 4
    * See GET /v1/notifiers request
    ![4_Configure_report_create](https://github.com/stackrox/stackrox/assets/11862657/7b49749f-14e1-4671-b26b-6f98f6d9baec)

4. Continue to step 5 with no delivery destinations
    * See both **Report configuration** and **Delivery destinations** have `h3` element.
    ![5_Review_and_create_with_no_delivery_destinations](https://github.com/stackrox/stackrox/assets/11862657/432b07a6-7351-431e-b766-f189f3e995f6).

5. Click **Create**
    * See POST /v2/compliance/scan/configurations request which has `notifiers: []` in payload and response.

6. Click link to view the scan schedule.
    * See GET /v2/compliance/scan/configurations/id request.
    * See absence of report configuration until we remove redundancy (see Residue item 1).

7. Click **Edit scan schedule**
    * See `?action=edit` query string in page address.

8. Click step 4 **Configure report** at left of wizard
    * See GET /v1/notifiers request.
    * See content area does not have full height (see Residue item 3).
    ![4_Configure_report_edit](https://github.com/stackrox/stackrox/assets/11862657/58a320f9-7c6a-47b2-9cfa-7218df8c3386)

9. Click **Add delivery destination**
    * See that the action has no reaction when `fieldIdPrefixForFormikAndPatternFly` prop had incorrect value!
    ![Add_delivery_destination](https://github.com/stackrox/stackrox/assets/11862657/4d0fcc8b-adfc-47f3-86b1-a0b016535c25)

10. Select a notifier, and then verify on **Review** step.

11. Edit **Distribution list**, and then verify on **Review** step.

12. Edit email template, and then verify on **Review** step.
    * See no change until I replace incorrect specific `deliveryDestinations` with correct generic `fieldIdPrefixForFormikAndPatternFly` prop in `NotifierConfigurationForm` component.
    ![Email_template_modal_default](https://github.com/stackrox/stackrox/assets/11862657/bd9585cf-3ee3-435b-ba70-5159caa0bae4)
    ![5_Review_and_create_with_delivery_destinations](https://github.com/stackrox/stackrox/assets/11862657/9856f167-4e80-497e-8cb5-cb1af11d3aa9)

13. Click **Save**
    * See PUT /v2/compliance/scan/configurations/id request with expected `notifiers: [{ … }]` in payload.