### PR TITLE
ROX-24045: telemetry gatherer to use `WithNoDuplicates`

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -3,6 +3,7 @@ package centralclient
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/installation/store"
@@ -211,7 +212,11 @@ func Enable() *phonehome.Config {
 			cfg.AddInterceptorFunc(event, f)
 		}
 	}
-	cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
+	cfg.Gatherer().Start(
+		telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
+		// Issue a possible duplicate only once a day as a heartbeat:
+		telemeter.WithNoDuplicates(time.Now().Format(time.DateOnly)),
+	)
 	enabled = true
 	log.Info("Telemetry collection has been enabled.")
 	cfg.Telemeter().Track("Telemetry Enabled", nil)

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -214,8 +214,12 @@ func Enable() *phonehome.Config {
 	}
 	cfg.Gatherer().Start(
 		telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
-		// Issue a possible duplicate only once a day as a heartbeat:
-		telemeter.WithNoDuplicates(time.Now().Format(time.DateOnly)),
+		// Don't capture the time, but call WithNoDuplicates on every gathering
+		// iteration, so that the time is updated.
+		func(co *telemeter.CallOptions) {
+			// Issue a possible duplicate only once a day as a heartbeat.
+			telemeter.WithNoDuplicates(time.Now().Format(time.DateOnly))(co)
+		},
 	)
 	enabled = true
 	log.Info("Telemetry collection has been enabled.")

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -61,12 +61,12 @@ func (s *gathererTestSuite) TestGathererTicker() {
 
 	lastTrack := concurrency.NewSignal()
 	defer lastTrack.Wait()
-	withTraits := matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))
-	const event = "Updated Test Identity"
+	expectedTraits := matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))
+	const expectedEvent = "Updated Test Identity"
 	gomock.InOrder(
-		t.EXPECT().Track(event, nil, withTraits).Times(3),
+		t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(3),
 		// Stop gathering after 3rd heartbeat:
-		t.EXPECT().Track(event, nil, withTraits).Times(1).
+		t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(1).
 			Do(func(any, any, ...any) {
 				lastTrack.Signal()
 			}))
@@ -92,6 +92,37 @@ func (s *gathererTestSuite) TestGathererTicker() {
 	tickChan <- time.Now()
 	s.Equal(int64(3), <-n)
 	s.Equal(int64(4), <-n, "there should have been 4 gathering calls")
+}
+
+func (s *gathererTestSuite) TestGathererWithNoDuplicates() {
+	t := mocks.NewMockTelemeter(gomock.NewController(s.T()))
+
+	lastTrack := concurrency.NewSignal()
+	defer lastTrack.Wait()
+	expectedTraits := matchOptions(
+		telemeter.WithNoDuplicates("abc"),
+		telemeter.WithTraits(map[string]any{"key": "value"}),
+	)
+	const expectedEvent = "Updated Test Identity"
+	t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(1).
+		Do(func(any, any, ...any) {
+			lastTrack.Signal()
+		})
+	g := newGatherer("Test", t, 24*time.Hour)
+	defer g.Stop()
+	n := make(chan int64)
+	defer close(n)
+	var i atomic.Int64
+	g.AddGatherer(func(context.Context) (map[string]any, error) {
+		n <- i.Add(1)
+		return map[string]any{"key": "value"}, nil
+	})
+	g.Start(func(co *telemeter.CallOptions) {
+		telemeter.WithNoDuplicates("abc")(co)
+	})
+	s.Equal(int64(1), <-n, "gathering should be called once on start")
+	// The cache is implemented by the telemeter, and is out of scope here, as
+	// the mock is used. So we don't test the actual deduplication here.
 }
 
 func (s *gathererTestSuite) TestAddTotal() {


### PR DESCRIPTION
Refactoring of the phonehome telemetry gatherer framework:
* Remove the gatherer cache in favor of the generic telemeter cache, enabled with the `WithNoDuplicates` option.
* Remove the "Heartbeat" event in favor of the daily, potentially duplicate, "Updated * Identity" event.

Tests:
* Unit tests