### PR TITLE
ROX-22051: retry tls dial in test

### DIFF
--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -30,7 +30,7 @@ import (
 type authMode int
 
 const (
-	dialRetires = 3
+	dialRetries = 3
 	timeout     = 30 * time.Second
 
 	userPKIProviderName = "test-userpki"
@@ -195,7 +195,7 @@ func (c *endpointsTestCase) runConnectionTest(t *testing.T, testCtx *endpointsTe
 }
 
 func (c *endpointsTestCase) tlsDialWithRetry(tlsConf *tls.Config) (conn *tls.Conn, err error) {
-	for i := 0; i < dialRetires; i++ {
+	for i := 0; i < dialRetries; i++ {
 		conn, err = tls.DialWithDialer(&dialer, "tcp", c.endpoint(), tlsConf)
 		if err == nil {
 			return


### PR DESCRIPTION
## Description

From time to time we have an error on connecting to central in our non groovy e2e tls test. This PR adds retry mechanism to those calls (only if error is not expected).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
