### PR TITLE
fix(ci): reorder gke tags and labels variable expansions

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -103,20 +103,25 @@ create_cluster() {
         die "Support is missing for this CI environment"
     fi
 
+    # Refresher on bash shell parameter expansion:
+    # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+    # ${VAR//./-} : Replaces all "." with a "-"
+    # ${VAR/%-/}  : Deletes the last "-"
+    # ${VAR,,}    : Converts all alphabetic to their lowercase form
     tags="${tags},stackrox-ci-${job_name:0:50}"
-    tags="${tags/%-/x}"
+    tags="${tags//./-}"
+    tags="${tags/%-/}"
     labels="${labels},stackrox-ci-job=${job_name:0:63}"
-    labels="${labels/%-/x}"
+    labels="${labels//./-}"
+    labels="${labels/%-/}"
     labels="${labels},stackrox-ci-build-id=${build_num:0:63}"
-    labels="${labels/%-/x}"
+    labels="${labels//./-}"
+    labels="${labels/%-/}"
 
     if is_in_PR_context; then
         labels="${labels},pr=$(get_PR_number)"
     fi
 
-    # remove . from branch names
-    tags="${tags//./-}"
-    labels="${labels//./-}"
     # lowercase
     tags="${tags,,}"
     labels="${labels,,}"


### PR DESCRIPTION
## Description

If you're really unlucky, you can get a `.` at the end of the `tags` variable, which will be substituted for `-` _after_ we replace the last `-` with `x`.  GKE doesn't allow for `-` at the end of the string, which is why we change the last `-`.

See https://github.com/openshift/release/pull/47789 for a real-world example of this problem.

These changes reorders the shell expansion so we first replace all `.` with `-`, _then_ delete the last `-`.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

Only relevant to CI.

## Testing Performed

### Here I tell how I validated my change

Testing the variable expansions:
```sh
# Before
❯ JOB_NAME=rehearse-47789-pull-ci-stackrox-scanner-release-2.32-e2e-tests
❯ tags="stackrox-ci"
❯ tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2.
❯ tags="${tags/%-/x}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2.
❯ tags="${tags//./-}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2-

# After
❯ JOB_NAME=rehearse-47789-pull-ci-stackrox-scanner-release-2.32-e2e-tests
❯ tags="stackrox-ci"
❯ tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
❯ tags="${tags//./-}"
❯ tags="${tags/%-/}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2
```

Otherwise, CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
