### PR TITLE
ROX-24281: do not create matcher client if undesired

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -70,7 +70,7 @@ func NewGRPCScanner(ctx context.Context, opts ...Option) (Scanner, error) {
 	}
 	iConn, mConn := conn, conn
 	connList = append(connList, conn)
-	if !o.comboMode {
+	if !o.indexerOnly && !o.comboMode {
 		mConn, err = createGRPCConn(ctx, o.matcherOpts)
 		if err != nil {
 			utils.IgnoreError(conn.Close)

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -70,7 +70,7 @@ func NewGRPCScanner(ctx context.Context, opts ...Option) (Scanner, error) {
 	}
 	iConn, mConn := conn, conn
 	connList = append(connList, conn)
-	if !o.indexerOnly && !o.comboMode {
+	if !o.comboMode {
 		mConn, err = createGRPCConn(ctx, o.matcherOpts)
 		if err != nil {
 			utils.IgnoreError(conn.Close)

--- a/pkg/scannerv4/client/options.go
+++ b/pkg/scannerv4/client/options.go
@@ -70,6 +70,9 @@ func SkipTLSVerification(o *options) {
 }
 
 // WithAddress specifies the gRPC address to connect.
+//
+// The address will be used for both Indexer service and Matcher service calls. To use different
+// addresses for each service, use With{Indexer,Matcher}Address.
 func WithAddress(address string) Option {
 	return func(o *options) {
 		WithIndexerAddress(address)(o)
@@ -98,9 +101,9 @@ func SkipIndexerTLSVerification(o *options) {
 }
 
 // WithIndexerAddress specifies the gRPC address to connect.
-// This should be used when the client wants to reach out to both the Indexer and Matcher,
-// but they live at different addresses. When the client only wants to reach the Indexer or
-// both the Indexer and Matcher are at the same address, then use WithAddress.
+//
+// Use this to direct the client to perform Indexer service calls to a different address from the default.
+// Matcher service calls will be directed to the default address unless WithMatcherAddress is specified.
 func WithIndexerAddress(address string) Option {
 	return func(o *options) {
 		o.indexerOpts.address = address
@@ -128,9 +131,9 @@ func SkipMatcherTLSVerification(o *options) {
 }
 
 // WithMatcherAddress specifies the gRPC address to connect.
-// This should be used when the client wants to reach out to both the Indexer and Matcher,
-// but they live at different addresses. When the client only wants to reach the Matcher or
-// both the Indexer and Matcher are at the same address, then use WithAddress.
+//
+// Use this to direct the client to perform Matcher service calls to a different address from the default.
+// Indexer service calls will be directed to the default address unless WithIndexerAddress is specified.
 func WithMatcherAddress(address string) Option {
 	return func(o *options) {
 		o.matcherOpts.address = address

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -23,7 +23,7 @@ type remoteIndexer struct {
 
 // NewRemoteIndexer connect to the gRPC address and creates a new remote indexer.
 func NewRemoteIndexer(ctx context.Context, address string) (*remoteIndexer, error) {
-	indexer, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(address))
+	indexer, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithIndexerAddress(address))
 	if err != nil {
 		return nil, err
 	}

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -23,7 +23,7 @@ type remoteIndexer struct {
 
 // NewRemoteIndexer connect to the gRPC address and creates a new remote indexer.
 func NewRemoteIndexer(ctx context.Context, address string) (*remoteIndexer, error) {
-	indexer, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithIndexerAddress(address))
+	indexer, err := client.NewGRPCScanner(ctx, client.WithAddress(address))
 	if err != nil {
 		return nil, err
 	}

--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -164,7 +164,7 @@ func dialV2() (ScannerClient, error) {
 // dialV4 connect to scanner V4 gRPC and return a new ScannerClient.
 func dialV4() (ScannerClient, error) {
 	ctx := context.Background()
-	c, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithIndexerAddress(env.ScannerV4IndexerEndpoint.Setting()))
+	c, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithAddress(env.ScannerV4IndexerEndpoint.Setting()))
 	if err != nil {
 		return nil, err
 	}

--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -164,7 +164,7 @@ func dialV2() (ScannerClient, error) {
 // dialV4 connect to scanner V4 gRPC and return a new ScannerClient.
 func dialV4() (ScannerClient, error) {
 	ctx := context.Background()
-	c, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(env.ScannerV4IndexerEndpoint.Setting()))
+	c, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithIndexerAddress(env.ScannerV4IndexerEndpoint.Setting()))
 	if err != nil {
 		return nil, err
 	}

--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -164,7 +164,7 @@ func dialV2() (ScannerClient, error) {
 // dialV4 connect to scanner V4 gRPC and return a new ScannerClient.
 func dialV4() (ScannerClient, error) {
 	ctx := context.Background()
-	c, err := client.NewGRPCScanner(ctx, client.IndexerOnly(), client.WithAddress(env.ScannerV4IndexerEndpoint.Setting()))
+	c, err := client.NewGRPCScanner(ctx, client.WithAddress(env.ScannerV4IndexerEndpoint.Setting()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

The current implementation meant Sensors which used Scanner V4 would continuously print debug logs indicating it is unable to connect to the Scanner V4 Matcher. It also wastes resources attempting to connect to something which we know does not exist. I expect this same thing to happen to Scanner V4 Matcher, as it connects to the Scanner V4 Indexer, which does not implement the Matcher service.

This PR adds an option to the Scanner V4 client to make it clear when only indexing is desired so we do not waste any resources/logging.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

Tried adding unit tests, but it was proving to be a huge pain (unless I was just doing it wrong). The changes are pretty trivial, though I still tested it with a cluster to confirm it works.

## Testing Performed

### Here I tell how I validated my change

* Deployed ACS Central + Secured Cluster 4.4.2 to OCP via Helm
  * Debug logs were enabled
* Scan image:
  * `roxctl -e <central endpoint> [--insecure-skip-tls-verify] scan image -i quay.io/stackrox-io/scanner:4.4.2`
* Inspect Sensor logs to find the debug log exists
  * `grpc_internal: 2024/06/04 18:30:06.913416 logging.go:59: Debug: [core][Channel #26 SubChannel #27] grpc: addrConn.createTransport failed to connect to {Addr: "[::1]:8443", ServerName: "scanner-v4-matcher.stackrox.svc", }. Err: connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for sensor.stackrox, sensor.stackrox.svc, sensor-webhook.stackrox.svc, not scanner-v4-matcher.stackrox.svc"`
* Redeploy Secured Cluster with version 4.4.x-848-g11a6c13d73 to OCP via Helm
  * Debug logs were enabled
* Scan image:
  * `roxctl -e <central endpoint> [--insecure-skip-tls-verify] scan image -i quay.io/stackrox-io/scanner:4.4.2`
* Inspect Sensor logs and find `scanner-v4-matcher` is no longer referenced

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
