### PR TITLE
feat(central): defs: Switch to multi bundle definitions

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -644,6 +644,7 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 
 	var uType updaterType
 	var opts v4OpenOpts
+	var contentType string
 
 	switch {
 	case fileName != "" && v == "":
@@ -663,6 +664,11 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 		}
 		uType = vulnerabilityUpdaterType
 		bundle := "vulns.json.zst"
+		contentType = "application/zstd"
+		if r.Header.Get("X-Scanner-V4-Accept") == "application/vnd.stackrox.scanner-v4.multi-bundle+zip" {
+			bundle = "vulnerabilities.zip"
+			contentType = "application/zip"
+		}
 		opts.urlPath = path.Join(v, bundle)
 		opts.vulnVersion = v
 		opts.vulnBundle = bundle
@@ -679,8 +685,8 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if uType == vulnerabilityUpdaterType {
-		w.Header().Set("Content-Type", "application/zstd")
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
 	}
 
 	defer utils.IgnoreError(f.Close)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -74,7 +74,7 @@ var (
 	ScannerV4 = registerFeature("Enables Scanner V4 runtime functionality", "ROX_SCANNER_V4", false)
 
 	// ScannerV4MultiBundle enables Scanner V4 to consume vulnerabilities using multi-bundle archives.
-	ScannerV4MultiBundle = registerFeature("Enables Scanner V4 to consume vulnerabilities using multi-bundle archives", "ROX_SCANNER_V4_MULTI_BUNDLE", false)
+	ScannerV4MultiBundle = registerFeature("Enables Scanner V4 to consume vulnerabilities using multi-bundle archives", "ROX_SCANNER_V4_MULTI_BUNDLE", true)
 
 	// CloudCredentials enables support for short-lived cloud credentials.
 	CloudCredentials = registerFeature("Enable support for short-lived cloud credentials", "ROX_CLOUD_CREDENTIALS", true)

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -479,7 +479,10 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 			return nil, time.Time{}, err
 		}
 		req.Header.Set(ifModifiedSince, prevTimestamp.Format(http.TimeFormat))
-
+		// Request multi-bundle if multi-bundle is enabled.
+		if features.ScannerV4MultiBundle.Enabled() {
+			req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
+		}
 		resp, err = u.client.Do(req)
 		if err != nil {
 			var opErr *net.OpError


### PR DESCRIPTION
## Description

This will modify Central to serve multi-bundle vulnerabilities upon the client passing `X-Scanner-V4-Accept` headers with a specific application-specific content type. It will modify Scanner V4 to pass such header if the multi-bundle feature is set to "true", which is now the default. A test was added for the multi-bundle updater.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Deploy the image and observe Scanner V4 requesting multi-bundle vulnerabilities, and Central granting them.

This can be confirmed by observing the two Matchers running updates concurrently.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
