### PR TITLE
ROX-23515: Adding condition-number input to compound search filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -217,4 +217,54 @@ describe(Cypress.spec.relative, () => {
         // Check updated date value
         cy.get('input[aria-label="Filter by date"]').should('have.value', '2034-01-15');
     });
+
+    it('should display the condition-number input for the image cvss filter', () => {
+        const config = {
+            Image: imageSearchFilterConfig,
+        };
+
+        setup(config);
+
+        cy.get(selectors.attributeSelectToggle).click();
+        cy.get(selectors.attributeSelectItem('CVSS')).click();
+
+        // should have default values
+        cy.get('button[aria-label="Condition selector toggle"]').should(
+            'have.text',
+            'Is greater than'
+        );
+        cy.get('input[aria-label="Condition value input"]').should('have.value', '0');
+
+        // change condition and number value
+        cy.get('button[aria-label="Condition selector toggle"]').click();
+        cy.get('div[aria-label="Condition selector menu"] li button:contains("Is less than")')
+            .filter((_, element) => {
+                // Get exact value
+                // @TODO: Could be a custom command
+                return Cypress.$(element).text().trim() === 'Is less than';
+            })
+            .click();
+        cy.get('input[aria-label="Condition value input"]').clear();
+        cy.get('input[aria-label="Condition value input"]').type(9.9);
+        cy.get('input[aria-label="Condition value input"]').blur();
+
+        // should have new values
+        cy.get('button[aria-label="Condition selector toggle"]').should(
+            'have.text',
+            'Is less than'
+        );
+        cy.get('input[aria-label="Condition value input"]').should('have.value', '9.9');
+
+        // should increment
+        cy.get('button[aria-label="Condition value plus button"]').click();
+        cy.get('button[aria-label="Condition value plus button"]').should('be.disabled');
+        cy.get('input[aria-label="Condition value input"]').should('have.value', '10');
+
+        // should decrement
+        cy.get('input[aria-label="Condition value input"]').clear();
+        cy.get('input[aria-label="Condition value input"]').type(0.1);
+        cy.get('button[aria-label="Condition value minus button"]').click();
+        cy.get('button[aria-label="Condition value minus button"]').should('be.disabled');
+        cy.get('input[aria-label="Condition value input"]').should('have.value', '0');
+    });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -8,12 +8,17 @@ import {
     SearchFilterAttribute,
     SelectSearchFilterAttribute,
 } from '../types';
-import { ensureString, ensureStringArray } from '../utils/utils';
+import { ensureConditionNumber, ensureString, ensureStringArray } from '../utils/utils';
 
 import CheckboxSelect from './CheckboxSelect';
 import ConditionNumber from './ConditionNumber';
 
-export type InputFieldValue = string | number | undefined | string[];
+export type InputFieldValue =
+    | string
+    | number
+    | undefined
+    | string[]
+    | { condition: string; number: number };
 export type InputFieldOnChange = (value: InputFieldValue) => void;
 
 export type CompoundSearchFilterInputFieldProps = {
@@ -79,10 +84,13 @@ function CompoundSearchFilterInputField({
     if (attributeObject.inputType === 'condition-number') {
         return (
             <ConditionNumber
-                value={ensureString(value)}
-                onSearch={(value) => {
-                    onChange(value);
-                    onSearch(value);
+                value={ensureConditionNumber(value)}
+                onChange={(newValue) => {
+                    onChange(newValue);
+                }}
+                onSearch={(newValue) => {
+                    onChange(newValue);
+                    onSearch(newValue);
                 }}
             />
         );

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -8,8 +8,10 @@ import {
     SearchFilterAttribute,
     SelectSearchFilterAttribute,
 } from '../types';
+import { ensureString, ensureStringArray } from '../utils/utils';
 
 import CheckboxSelect from './CheckboxSelect';
+import ConditionNumber from './ConditionNumber';
 
 export type InputFieldValue = string | number | undefined | string[];
 export type InputFieldOnChange = (value: InputFieldValue) => void;
@@ -27,20 +29,6 @@ function isSelectType(
     attributeObject: SearchFilterAttribute
 ): attributeObject is SelectSearchFilterAttribute {
     return attributeObject.inputType === 'select';
-}
-
-function ensureStringArray(value: InputFieldValue): string[] {
-    if (Array.isArray(value) && value.every((element) => typeof element === 'string')) {
-        return value;
-    }
-    return [];
-}
-
-function ensureString(value: InputFieldValue): string {
-    if (typeof value === 'string') {
-        return value;
-    }
-    return '';
 }
 
 function CompoundSearchFilterInputField({
@@ -82,6 +70,17 @@ function CompoundSearchFilterInputField({
                 buttonAriaLabel="Filter by date toggle"
                 value={ensureString(value)}
                 onChange={(_event, value) => {
+                    onChange(value);
+                    onSearch(value);
+                }}
+            />
+        );
+    }
+    if (attributeObject.inputType === 'condition-number') {
+        return (
+            <ConditionNumber
+                value={ensureString(value)}
+                onSearch={(value) => {
                     onChange(value);
                     onSearch(value);
                 }}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import { Button, NumberInput, SelectOption } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+
+import { ensureString } from '../utils/utils';
+
+import SimpleSelect from './SimpleSelect';
+
+export type ConditionNumberProps = {
+    value: string;
+    onSearch: (value: string) => void;
+};
+
+const conditionMap = {
+    'Is greater than': '>',
+    'Is greater than or equal to': '>=',
+    'Is equal to': '=',
+    'Is less than or equal to': '<=',
+    'Is less than': '<',
+};
+
+const conditions = Object.keys(conditionMap);
+
+const minValue = 0;
+const maxValue = 10;
+const incrementValue = 0.1;
+
+function roundToOneDecimalPlace(value: number) {
+    return parseFloat(value.toFixed(1));
+}
+
+const normalizeBetween = (value: number, min: number, max: number) => {
+    if (min !== undefined && max !== undefined) {
+        return Math.max(Math.min(value, max), min);
+    }
+    if (value <= min) {
+        return min;
+    }
+    if (value >= max) {
+        return max;
+    }
+    return value;
+};
+
+function getDefaultCondition() {
+    return conditions[0];
+}
+
+function getDefaultNumber() {
+    return minValue;
+}
+
+function valueToConditionNumber(value: string) {
+    const [newConditionValue, newNumber] = value.split(' ');
+    const newCondition =
+        conditions.find((condition) => {
+            return conditionMap[condition] === newConditionValue;
+        }) || conditions[0];
+    return {
+        newCondition,
+        newNumber: Number(newNumber) || minValue,
+    };
+}
+
+function conditionNumberToValue(conditionLabel: string, number: number): string {
+    const conditionValue = conditionMap[conditionLabel];
+    const newValue = `${conditionValue} ${number}`;
+    return newValue;
+}
+
+function ConditionNumber({ value, onSearch }: ConditionNumberProps) {
+    const [selectedCondition, setSelectedCondition] = useState(() => getDefaultCondition());
+    const [number, setNumber] = useState(() => getDefaultNumber());
+
+    useEffect(() => {
+        const { newCondition, newNumber } = valueToConditionNumber(value);
+        setSelectedCondition(newCondition);
+        setNumber(newNumber);
+    }, [value]);
+
+    const onMinus = () => {
+        const incrementedNumber = (number || 0) - incrementValue;
+        const roundedNumber = roundToOneDecimalPlace(incrementedNumber);
+        const normalizedNumber = normalizeBetween(roundedNumber, minValue, maxValue);
+        setNumber(normalizedNumber);
+    };
+
+    const onPlus = () => {
+        const incrementedNumber = (number || 0) + incrementValue;
+        const roundedNumber = roundToOneDecimalPlace(incrementedNumber);
+        const normalizedNumber = normalizeBetween(roundedNumber, minValue, maxValue);
+        setNumber(normalizedNumber);
+    };
+
+    return (
+        <>
+            <SimpleSelect
+                value={selectedCondition}
+                onChange={(val) => setSelectedCondition(ensureString(val))}
+                ariaLabelMenu="Condition selector menu"
+                ariaLabelToggle="Condition selector toggle"
+            >
+                {conditions.map((condition) => {
+                    return (
+                        <SelectOption key={condition} value={condition}>
+                            {condition}
+                        </SelectOption>
+                    );
+                })}
+            </SimpleSelect>
+            <NumberInput
+                inputAriaLabel="Condition value input"
+                value={number}
+                min={0}
+                max={10}
+                onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                    const { value: newNumber } = event.target as HTMLInputElement;
+                    setNumber(Number(newNumber));
+                }}
+                onBlur={(event: React.FormEvent<HTMLInputElement>) => {
+                    const target = event.target as HTMLInputElement;
+                    const normalizedNumber = normalizeBetween(
+                        Number.isNaN(+target.value)
+                            ? 0
+                            : roundToOneDecimalPlace(Number(target.value)),
+                        minValue,
+                        maxValue
+                    );
+                    setNumber(normalizedNumber);
+                }}
+                onMinus={onMinus}
+                onPlus={onPlus}
+                minusBtnAriaLabel="Condition value minus button"
+                plusBtnAriaLabel="Condition value plus button"
+            />
+            <Button
+                variant="control"
+                aria-label="Apply condition and number input to search"
+                onClick={() => {
+                    const newValue = conditionNumberToValue(selectedCondition, number);
+                    onSearch(newValue);
+                }}
+            >
+                <ArrowRightIcon />
+            </Button>
+        </>
+    );
+}
+
+export default ConditionNumber;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -52,7 +52,7 @@ export const imageSearchFilterConfig = {
             displayName: 'CVSS',
             filterChipLabel: 'Image CVSS',
             searchTerm: 'Image Top CVSS',
-            inputType: 'dropdown-slider',
+            inputType: 'condition-number',
         },
         Label: {
             displayName: 'Label',
@@ -230,7 +230,7 @@ export const nodeSearchFilterConfig = {
             displayName: 'Top CVSS',
             filterChipLabel: 'Node Top CVSS',
             searchTerm: 'Node Top CVSS',
-            inputType: 'dropdown-slider',
+            inputType: 'condition-number',
         },
         Label: {
             displayName: 'Label',
@@ -291,7 +291,7 @@ export const imageCVESearchFilterConfig = {
             displayName: 'CVSS',
             filterChipLabel: 'Image CVE CVSS',
             searchTerm: 'CVSS',
-            inputType: 'dropdown-slider',
+            inputType: 'condition-number',
         },
         Type: {
             displayName: 'Type',
@@ -339,7 +339,7 @@ export const nodeCVESearchFilterConfig = {
             displayName: 'CVSS',
             filterChipLabel: 'Node CVE CVSS',
             searchTerm: 'CVSS',
-            inputType: 'dropdown-slider',
+            inputType: 'condition-number',
         },
         // TODO: Add Top CVSS
         Snoozed: {
@@ -391,7 +391,7 @@ export const platformCVESearchFilterConfig = {
             displayName: 'CVSS',
             filterChipLabel: 'Platform CVE CVSS',
             searchTerm: 'CVSS',
-            inputType: 'dropdown-slider',
+            inputType: 'condition-number',
         },
         Snoozed: {
             displayName: 'Snoozed',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -48,7 +48,7 @@ describe('utils', () => {
                     displayName: 'CVSS',
                     filterChipLabel: 'Image CVE CVSS',
                     searchTerm: 'CVSS',
-                    inputType: 'dropdown-slider',
+                    inputType: 'condition-number',
                 },
                 {
                     displayName: 'Type',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
@@ -59,3 +59,23 @@ export function ensureString(value: unknown): string {
     }
     return '';
 }
+
+export function ensureConditionNumber(value: unknown): { condition: string; number: number } {
+    if (
+        typeof value === 'object' &&
+        value !== null &&
+        'condition' in value &&
+        'number' in value &&
+        typeof value.condition === 'string' &&
+        typeof value.number === 'number'
+    ) {
+        return {
+            condition: value.condition,
+            number: value.number,
+        };
+    }
+    return {
+        condition: '',
+        number: 0,
+    };
+}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
@@ -45,3 +45,17 @@ export function getDefaultAttribute(
     }
     return undefined;
 }
+
+export function ensureStringArray(value: unknown): string[] {
+    if (Array.isArray(value) && value.every((element) => typeof element === 'string')) {
+        return value as string[];
+    }
+    return [];
+}
+
+export function ensureString(value: unknown): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    return '';
+}


### PR DESCRIPTION
## Description

This PR adds the `condition-number` option  to the compound search filter 🔍 . The `ConditionNumber` component will do the following:

1. Show a dropdown to choose a condition (ie. `Is less than`, etc.)
2. Allow inputting a number
3. Restrict the number to a range (between a `min` and `max` value) on blur
4. Disables the `plus` and `minus` buttons when it reaches the `min` or `max` value
5. Has a search button that will trigger the search once it's clicked. We don't want to modify the search on every interaction

Note: This new option will replace the `dropdown-slider` option after discussions with UX

## Screenshots

<img width="518" alt="Screenshot 2024-05-20 at 9 17 04 AM" src="https://github.com/stackrox/stackrox/assets/4805485/2c35aa06-362a-47ab-b5cc-f34d4537007c">
<img width="1552" alt="Screenshot 2024-05-20 at 8 52 17 AM" src="https://github.com/stackrox/stackrox/assets/4805485/a2c24846-2578-4580-8d89-77bbd17af74d">

