### PR TITLE
ROX-24096: Add profile checks sorting

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -4,6 +4,7 @@ import { Divider, PageSection, Title } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
 import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 
 import PageTitle from 'Components/PageTitle';
@@ -14,12 +15,16 @@ import ProfileChecksTable from './ProfileChecksTable';
 function ProfileChecksPage() {
     const { profileName } = useParams();
     const pagination = useURLPagination(10);
-
-    const { page, perPage } = pagination;
+    const { page, perPage, setPage } = pagination;
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: ['Compliance Check Name'],
+        defaultSortOption: { field: 'Compliance Check Name', direction: 'asc' },
+        onSort: () => setPage(1),
+    });
 
     const fetchProfileChecks = useCallback(
-        () => getComplianceProfileResults(profileName, page, perPage),
-        [page, perPage, profileName]
+        () => getComplianceProfileResults(profileName, sortOption, page, perPage),
+        [page, perPage, profileName, sortOption]
     );
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
@@ -41,6 +46,7 @@ function ProfileChecksPage() {
                         profileChecksResultsCount={profileChecks?.totalCount ?? 0}
                         profileName={profileName}
                         pagination={pagination}
+                        getSortParams={getSortParams}
                     />
                 </PageSection>
             </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -16,6 +16,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { ComplianceCheckResultStatusCount } from 'services/ComplianceCommon';
 import { getTableUIState } from 'utils/getTableUIState';
 
@@ -37,6 +38,7 @@ export type ProfileChecksTableProps = {
     profileChecksResultsCount: number;
     profileName: string;
     pagination: UseURLPaginationResult;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
 function ProfileChecksTable({
@@ -46,6 +48,7 @@ function ProfileChecksTable({
     profileChecksResultsCount,
     profileName,
     pagination,
+    getSortParams,
 }: ProfileChecksTableProps) {
     const tableState = getTableUIState({
         isLoading,
@@ -78,7 +81,9 @@ function ProfileChecksTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th width={60}>Check</Th>
+                        <Th sort={getSortParams('Compliance Check Name')} width={60}>
+                            Check
+                        </Th>
                         <Th modifier="fitContent">Controls</Th>
                         <Th modifier="fitContent">Fail status</Th>
                         <Th modifier="fitContent">Pass status</Th>

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,6 +1,7 @@
 import qs from 'qs';
 
 import axios from 'services/instance';
+import { ApiSortOption } from 'types/search';
 import { getPaginationParams } from 'utils/searchUtils';
 
 import {
@@ -37,12 +38,13 @@ export type ComplianceCheckResult = {
  */
 export function getComplianceProfileResults(
     profileName: string,
+    sortOption: ApiSortOption,
     page: number,
     perPage: number
 ): Promise<ListComplianceProfileResults> {
     const queryParameters = {
         query: {
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });


### PR DESCRIPTION
## Description

Adds sorting to the Compliance V2 Profile Checks table

Note: UX shows ability to sort by compliance statuses, however these columns are unsortable now due to our backend search framework. Will revisit these in a later release.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing, backend implementation not available. Tested by clicking on column header and checking the api call.

before:
![Screenshot 2024-05-20 at 2 53 03 PM](https://github.com/stackrox/stackrox/assets/61400697/f46c968b-cb59-417f-bcb5-552de467f35a)

after:
![Screenshot 2024-05-20 at 2 53 12 PM](https://github.com/stackrox/stackrox/assets/61400697/cb0400a8-565c-49e8-a59e-c21d6c5f611a)


