### PR TITLE
ROX-24318: workload CVE ux polish

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
@@ -12,12 +12,7 @@ import { SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 
 import { CRITICAL_SEVERITY_COLOR } from 'constants/severityColors';
 import { ObservedCveMode, isObservedCveMode, observedCveModeValues } from '../../types';
-
-export const WITH_CVE_OPTION_TITLE = 'Image vulnerabilities';
-export const WITHOUT_CVE_OPTION_TITLE = 'Images without vulnerabilities';
-export const WITH_CVE_OPTION_DESCRIPTION = 'Images and deployments observed with CVEs';
-export const WITHOUT_CVE_OPTION_DESCRIPTION =
-    'Images and deployments observed without CVEs (results may be inaccurate due to scanner errors)';
+import { getViewStateDescription, getViewStateTitle } from './string.utils';
 
 export type ObservedCveModeSelectProps = {
     observedCveMode: ObservedCveMode;
@@ -73,15 +68,15 @@ function ObservedCveModeSelect({
             <SelectList style={{ maxWidth: '300px' }}>
                 <SelectOption
                     value={observedCveModeValues[0]}
-                    description={WITH_CVE_OPTION_DESCRIPTION}
+                    description={getViewStateDescription('OBSERVED', 'WITH_CVES')}
                 >
-                    {WITH_CVE_OPTION_TITLE}
+                    {getViewStateTitle('OBSERVED', 'WITH_CVES')}
                 </SelectOption>
                 <SelectOption
                     value={observedCveModeValues[1]}
-                    description={WITHOUT_CVE_OPTION_DESCRIPTION}
+                    description={getViewStateDescription('OBSERVED', 'WITHOUT_CVES')}
                 >
-                    {WITHOUT_CVE_OPTION_TITLE}
+                    {getViewStateTitle('OBSERVED', 'WITHOUT_CVES')}
                 </SelectOption>
             </SelectList>
         </Select>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
@@ -10,9 +10,10 @@ import {
 } from '@patternfly/react-core';
 import { SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 
-import { CRITICAL_SEVERITY_COLOR } from 'constants/severityColors';
 import { ObservedCveMode, isObservedCveMode, observedCveModeValues } from '../../types';
 import { getViewStateDescription, getViewStateTitle } from './string.utils';
+
+const width = '330px';
 
 export type ObservedCveModeSelectProps = {
     observedCveMode: ObservedCveMode;
@@ -26,11 +27,7 @@ function ObservedCveModeSelect({
     const [isCveModeSelectOpen, setIsCveModeSelectOpen] = useState(false);
     const isViewingWithCves = observedCveMode === 'WITH_CVES';
 
-    const menuToggleIcon = isViewingWithCves ? (
-        <SecurityIcon color={CRITICAL_SEVERITY_COLOR} />
-    ) : (
-        <UnknownIcon />
-    );
+    const menuToggleIcon = isViewingWithCves ? <SecurityIcon /> : <UnknownIcon />;
 
     const menuToggleText = isViewingWithCves
         ? 'View image vulnerabilities'
@@ -49,6 +46,7 @@ function ObservedCveModeSelect({
             onOpenChange={(isOpen) => setIsCveModeSelectOpen(isOpen)}
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                 <MenuToggle
+                    style={{ width }}
                     aria-label="Observed CVE mode select"
                     ref={toggleRef}
                     onClick={() => setIsCveModeSelectOpen(!isCveModeSelectOpen)}
@@ -65,7 +63,7 @@ function ObservedCveModeSelect({
             )}
             shouldFocusToggleOnSelect
         >
-            <SelectList style={{ maxWidth: '300px' }}>
+            <SelectList style={{ width }}>
                 <SelectOption
                     value={observedCveModeValues[0]}
                     description={getViewStateDescription('OBSERVED', 'WITH_CVES')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -72,12 +72,8 @@ import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import DefaultFilterModal from '../components/DefaultFilterModal';
 import WorkloadCveFilterToolbar from '../components/WorkloadCveFilterToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
-import ObservedCveModeSelect, {
-    WITHOUT_CVE_OPTION_DESCRIPTION,
-    WITHOUT_CVE_OPTION_TITLE,
-    WITH_CVE_OPTION_DESCRIPTION,
-    WITH_CVE_OPTION_TITLE,
-} from './ObservedCveModeSelect';
+import ObservedCveModeSelect from './ObservedCveModeSelect';
+import { getViewStateDescription, getViewStateTitle } from './string.utils';
 
 const searchOptions: SearchOption[] = [
     IMAGE_SEARCH_OPTION,
@@ -362,41 +358,46 @@ function WorkloadCvesOverviewPage() {
                             >
                                 <FlexItem>
                                     <Title headingLevel="h2">
-                                        {isViewingWithCves
-                                            ? WITH_CVE_OPTION_TITLE
-                                            : WITHOUT_CVE_OPTION_TITLE}
+                                        {getViewStateTitle(
+                                            currentVulnerabilityState ?? 'OBSERVED',
+                                            observedCveMode
+                                        )}
                                     </Title>
                                     <Text className="pf-v5-u-font-size-sm">
-                                        {isViewingWithCves
-                                            ? WITH_CVE_OPTION_DESCRIPTION
-                                            : WITHOUT_CVE_OPTION_DESCRIPTION}
+                                        {getViewStateDescription(
+                                            currentVulnerabilityState ?? 'OBSERVED',
+                                            observedCveMode
+                                        )}
                                     </Text>
                                 </FlexItem>
-                                {isViewingWithCves && (
-                                    <FlexItem>
-                                        <Flex
-                                            direction={{ default: 'row' }}
-                                            alignItems={{ default: 'alignItemsCenter' }}
-                                            spaceItems={{ default: 'spaceItemsSm' }}
-                                        >
-                                            {hasReadAccessForNamespaces && (
-                                                <Link to={vulnerabilityNamespaceViewPath}>
-                                                    <Button variant="secondary">
-                                                        Prioritize by namespace view
-                                                    </Button>
-                                                </Link>
-                                            )}
-                                            {isFixabilityFiltersEnabled && (
-                                                <DefaultFilterModal
-                                                    defaultFilters={
-                                                        localStorageValue.preferences.defaultFilters
-                                                    }
-                                                    setLocalStorage={updateDefaultFilters}
-                                                />
-                                            )}
-                                        </Flex>
-                                    </FlexItem>
-                                )}
+                                {isViewingWithCves &&
+                                    (currentVulnerabilityState === 'OBSERVED' ||
+                                        currentVulnerabilityState === undefined) && (
+                                        <FlexItem>
+                                            <Flex
+                                                direction={{ default: 'row' }}
+                                                alignItems={{ default: 'alignItemsCenter' }}
+                                                spaceItems={{ default: 'spaceItemsSm' }}
+                                            >
+                                                {hasReadAccessForNamespaces && (
+                                                    <Link to={vulnerabilityNamespaceViewPath}>
+                                                        <Button variant="secondary">
+                                                            Prioritize by namespace view
+                                                        </Button>
+                                                    </Link>
+                                                )}
+                                                {isFixabilityFiltersEnabled && (
+                                                    <DefaultFilterModal
+                                                        defaultFilters={
+                                                            localStorageValue.preferences
+                                                                .defaultFilters
+                                                        }
+                                                        setLocalStorage={updateDefaultFilters}
+                                                    />
+                                                )}
+                                            </Flex>
+                                        </FlexItem>
+                                    )}
                             </Flex>
                             {activeEntityTabKey === 'CVE' && (
                                 <CVEsTableContainer

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -46,6 +46,7 @@ import {
     COMPONENT_SOURCE_SEARCH_OPTION,
 } from 'Containers/Vulnerabilities/searchOptions';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import { VulnerabilityState } from 'types/cve.proto';
 import {
     DefaultFilters,
     WorkloadEntityTab,
@@ -243,6 +244,20 @@ function WorkloadCvesOverviewPage() {
         }
     }
 
+    function onVulnerabilityStateChange(vulnerabilityState: VulnerabilityState) {
+        // Reset all filters, sorting, and pagination and apply to the current history entry
+        setActiveEntityTabKey('CVE');
+        setSearchFilter({}, 'replace');
+        sort.setSortOption(getDefaultWorkloadSortOption('CVE'), 'replace');
+        pagination.setPage(1, 'replace');
+        setObservedCveMode('WITH_CVES', 'replace');
+
+        // Re-apply the default filters when changing to the "OBSERVED" state
+        if (vulnerabilityState === 'OBSERVED') {
+            applyDefaultFilters();
+        }
+    }
+
     function applyDefaultFilters() {
         if (isFixabilityFiltersEnabled) {
             setSearchFilter(localStorageValue.preferences.defaultFilters, 'replace');
@@ -332,12 +347,7 @@ function WorkloadCvesOverviewPage() {
                     component="div"
                     className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
                 >
-                    <VulnerabilityStateTabs
-                        onChange={() => {
-                            setObservedCveMode('WITH_CVES');
-                            pagination.setPage(1, 'replace');
-                        }}
-                    />
+                    <VulnerabilityStateTabs onChange={onVulnerabilityStateChange} />
                 </PageSection>
                 {isNoCvesViewEnabled && currentVulnerabilityState === 'OBSERVED' && (
                     <PageSection className="pf-v5-u-py-md" component="div" variant="light">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
@@ -1,0 +1,40 @@
+import { ObservedCveMode } from 'Containers/Vulnerabilities/types';
+import _ from 'lodash';
+import { VulnerabilityState } from 'types/cve.proto';
+import { ensureExhaustive } from 'utils/type.utils';
+
+export function getViewStateTitle(
+    vulnerabilityState: VulnerabilityState,
+    cveViewingMode: ObservedCveMode
+): string {
+    switch (vulnerabilityState) {
+        case 'OBSERVED':
+            return cveViewingMode === 'WITH_CVES'
+                ? 'Image vulnerabilities'
+                : 'Images without vulnerabilities';
+        case 'DEFERRED':
+            return 'Deferred vulnerabilities';
+        case 'FALSE_POSITIVE':
+            return 'False-positive vulnerabilities';
+        default:
+            return ensureExhaustive(vulnerabilityState);
+    }
+}
+
+export function getViewStateDescription(
+    vulnerabilityState: VulnerabilityState,
+    cveViewingMode: ObservedCveMode
+): string {
+    switch (vulnerabilityState) {
+        case 'OBSERVED':
+            return cveViewingMode === 'WITH_CVES'
+                ? 'Images and deployments observed with CVEs'
+                : 'Images and deployments observed without CVEs (results may be inaccurate due to scanner errors)';
+        case 'DEFERRED':
+            return 'Observed vulnerabilities that are approved by administrators to be deferred for a period of time or until fixable';
+        case 'FALSE_POSITIVE':
+            return 'Observed vulnerabilities that are approved by administrators to be marked as false-positives indefinitely';
+        default:
+            return ensureExhaustive(vulnerabilityState);
+    }
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
@@ -1,5 +1,4 @@
 import { ObservedCveMode } from 'Containers/Vulnerabilities/types';
-import _ from 'lodash';
 import { VulnerabilityState } from 'types/cve.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 


### PR DESCRIPTION
## Description

A handful of UX fixes, mostly related to the new "With CVEs"/"Without CVEs" views, that help streamline the difference between the three Vulnerability State tabs and the ability to filter by "with cves"/"without cves".

1. Removes the red "critical" color from the icon in the dropdown, opting for plain black
2. Adjusts the header title and description above the table for all of the three vulnerability state tabs, including removing the default filters and namespace buttons from the Deferred/FP tables.
3. Resets the filters, page, sorting, and current entity tab when switching between the three vulnerability states. With this change and the previous change, this makes the tabs feel more like independent sets of data. Prior to these changes, switching tabs looked like a minor state update, now the separation between the interactions is more clear. Fixes https://issues.redhat.com/browse/ROX-24318 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Verify that the color of the icon in the dropdown is no longer red:
![image](https://github.com/stackrox/stackrox/assets/1292638/9b229bd6-41a8-4cd8-a54e-531200db85c9)

2.,3. Verify the behavior of the table title/description, and resetting of page state when navigating across vulnerability state tabs: (note that the zero results when filtering by `Deployment:wordpress` is due to not having the correct parameters sent to the autocomplete component. This needs to be fixed in a follow up.)

https://github.com/stackrox/stackrox/assets/1292638/0ddfac04-fb21-4c4b-9399-e1925ca18927


