### PR TITLE
ROX-23672: Filter compliance standards on main dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -12,21 +12,23 @@ import {
     patternflySeverityTheme,
 } from 'utils/chartUtils';
 
-const labelLinkCallback = ({ datum }: ChartLabelProps, data: ComplianceData) => {
+const labelLinkCallback = ({ datum }: ChartLabelProps, data: ComplianceLevelByStandard[]) => {
     return typeof datum === 'number' ? data[datum - 1]?.link ?? '' : '';
 };
 
-export type ComplianceData = {
+export type ComplianceLevelByStandard = {
     name: string;
     passing: number;
     link: string;
-}[];
-
-type ComplianceLevelsByStandardChartProps = {
-    complianceData: ComplianceData;
 };
 
-function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByStandardChartProps) {
+type ComplianceLevelsByStandardChartProps = {
+    complianceLevelsByStandard: ComplianceLevelByStandard[];
+};
+
+function ComplianceLevelsByStandardChart({
+    complianceLevelsByStandard,
+}: ComplianceLevelsByStandardChartProps) {
     const history = useHistory();
     const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
     const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
@@ -50,7 +52,9 @@ function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByS
                 <ChartAxis
                     tickLabelComponent={
                         <LinkableChartLabel
-                            linkWith={(props) => labelLinkCallback(props, complianceData)}
+                            linkWith={(props) =>
+                                labelLinkCallback(props, complianceLevelsByStandard)
+                            }
                         />
                     }
                 />
@@ -61,7 +65,7 @@ function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByS
                     dependentAxis
                 />
                 <ChartGroup horizontal>
-                    {complianceData.map(({ name, passing, link }) => (
+                    {complianceLevelsByStandard.map(({ name, passing, link }) => (
                         <ChartBar
                             key={name}
                             style={{ data: { fill: solidBlueChartColor } }}


### PR DESCRIPTION
## Description

### Problem

**Manage standards** affects compliance dashboard but not **Compliance by standard** on main dashboard.

### Analysis

Response to `getAggregatedResults` query by `ComplianceLevelsByStandard` component includes `complianceStandards` property:

```json
{
    "data": {
        "complianceStandards": [
            {"id": "PCI_DSS_3_2", "PCI DSS 3.2.1"}
        ],
        "controls": {
            "results": [
                {
                    "aggregationKeys": {"id": "PCI_DSS_3_2", "scope": "STANDARD"},
                    "numFailing": 15,
                    "numPassing": 27,
                    "numSkipped": 80,
                    "unit": "CONTROL"
                }
            ]
        }
    }
}
```

### Solution

1. Edit ComplianceLevelsByStandard.tsx file.
    * Include `complianceStandards` in `ComplianceData` type.
    * Add condition to `processData` function.
    * Move `slice` and `reverse` into `processData` function because of difficulty to keep them in `useMemo` hook.
        Ironically, I had recommended not including them during original review.
    * Render empty state inline with conditional rendering to distinguish:
        * No standards selected
        * No results available
2. Edit ComplianceLevelsByStandardChart.tsx file.
    * Rename `ComplianceData` as `ComplianceLevelByStandard` type.
    * Rename `complianceData` as `complianceLevelsByStandard` prop.

### Residue

Existing problems that might become more obvious:
* Victory charts spreads few bars in a way that might distract.
* Compliance dashboard widgets do not distinguish **No standards selected** from **No data available**

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4635426 - 4635426
        total 299 = 11689769 - 11689470
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard

    * with no standards selected
        ![No_standards_selected](https://github.com/stackrox/stackrox/assets/11862657/bf8ee8f1-bbe9-4440-bac5-ab3f6a4cae90)

    * with one standard selected
        ![PCI](https://github.com/stackrox/stackrox/assets/11862657/1ad80325-ec0f-443b-8019-ef360d89dd95)

    * with two standards selected
        ![NIST](https://github.com/stackrox/stackrox/assets/11862657/229c5223-c9d9-47dd-872e-4af1704ba399)

2. Visit /main/compliance

    * with no standards selected
        ![No_data_available](https://github.com/stackrox/stackrox/assets/11862657/1b0ab0c6-0898-4b78-84c9-5352a272d85f)

### Integration testing

First 2 tests passed even with only 2 NIST standards selected, but not hideScanResults.

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js

### Component testing

* src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.cy.jsx