### PR TITLE
ci: allow restricted scc for ocp tests

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -64,6 +64,11 @@ else
     die "ERROR: There is no job script for $ci_job"
 fi
 
+if [[ "${JOB_NAME:-}" =~ -ocp- ]]; then
+    info "Allow restricted SCC for all users and namespaces."
+    oc create clusterrolebinding system:openshift:scc:restricted --clusterrole=system:openshift:scc:restricted --group=system:authenticated || true
+fi
+
 "${job_script}" "$@" &
 job_pid="$!"
 


### PR DESCRIPTION
ocp 4.16 blocks deployments needing more privileges than restrictedv2 allows.
https://access.redhat.com/articles/6973044

Possible alternative to setting restrictions on the test workloads? https://github.com/stackrox/stackrox/pull/10599
https://github.com/stackrox/stackrox/pull/11055

Passing on ocp4.16rc.2 on aws (interop test setup in openshift/release): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50553/rehearse-50553-pull-ci-stackrox-stackrox-master-ocp-4-16-lp-interop-acs-tests-aws/1792662102003945472
Testing on gcp (flakes so far) with this change in a stackrox branch: https://github.com/openshift/release/pull/52250