### PR TITLE
ROX-23766: add roxctl scan to tekton pipeline

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -356,6 +356,28 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: roxctl-image-scan
+    params:
+    - name: image
+      value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: output_format
+      value: table
+    runAfter:
+    - build-container
+    taskRef:
+      params:
+      - name: name
+        value: rhacs-image-scan
+      - name: bundle
+        value: gcr.io/tekton-releases/catalog/upstream/rhacs-image-scan@sha256:6be52f9e623e3fecbf2d2b542ac59cc9c6993311306e78651aba98f4e520aa6c
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+
   - name: sbom-json-check
     params:
     - name: IMAGE_URL

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -391,6 +391,28 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: roxctl-image-scan
+    params:
+    - name: image
+      value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: output_format
+      value: table
+    runAfter:
+    - build-container
+    taskRef:
+      params:
+      - name: name
+        value: rhacs-image-scan
+      - name: bundle
+        value: gcr.io/tekton-releases/catalog/upstream/rhacs-image-scan@sha256:6be52f9e623e3fecbf2d2b542ac59cc9c6993311306e78651aba98f4e520aa6c
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+
   - name: sbom-json-check
     params:
     - name: IMAGE_URL


### PR DESCRIPTION
## Description

Add a `roxctl image scan` task to the tekton basic and main pipelines.

**Note: This uses the old 3.71 task version for now.**

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
