### PR TITLE
fix(release): vulncheck exception

### DIFF
--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -6,6 +6,9 @@
     "GO-2023-2186": {
       "reason": "False positive as this path is not exercised in the codebase"
     },
+    "GO-2024-2842": {
+      "reason": "Requires version bump"
+    },
     "GO-2023-2382": {
       "reason": "Requires version bump"
     },


### PR DESCRIPTION
## Description

Add `GO-2024-2842` in the exception list

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

None, but given warning in https://github.com/stackrox/stackrox/actions/runs/9172134384/job/25218755631 it should be fixed:
```
GO-2024-2842 Unexpected authenticated registry accesses in github.com/containers/image/v5
Found vulnerabilities. If they are false positives, add them to govulncheck-allowlist.json
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
