### PR TITLE
ROX-23940: re-enable roxctl scan

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -663,8 +663,7 @@ jobs:
             "collector",
             "collector-slim",
             "main",
-            # TODO(ROX-23940): re-enable roxctl scanning after #10928 has been released.
-            # "roxctl",
+            "roxctl",
             "scanner",
             "scanner-db",
             "scanner-db-slim",


### PR DESCRIPTION
## Description

We had disabled the `roxctl` scan job because of a bug in roxctl that caused the job to fail in case no vulnerabilities were found. This bug has been fixed in 4.4.2, which is now released.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
