### PR TITLE
ROX-23284: fix suspicious logs

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -197,7 +197,8 @@ class DeploymentCheck extends BaseSpecification {
         assert !res.getRemarksList().findAll { it.getName() == secondDeployment }.isEmpty()
     }
 
-    static String createDeploymentYaml(String deploymentName, String namespace, String image = "nginx:latest") {
+    static String createDeploymentYaml(String deploymentName, String namespace,
+        String image = "quay.io/rhacs-eng/qa-multi-arch-nginx:latest") {
         """
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -26,9 +26,12 @@ policy/v1beta1 PodSecurityPolicy is deprecated in v1.21., unavailable in v1.25.
 apps\.openshift\.io\/v1 DeploymentConfig is deprecated in v4\.14\+, unavailable in v4\.10000\+
 # Image enrichment errors are expected in some test (i.e. testing for non-existing images).
 # Skip those specifically.
-Error: error enriching image
+Error: Error enriching image
 # Network flakiness can lead to this error occurring in Sensor k8s libraries. All tests pass and it is not
 # an indication of a Sensor issue
 request.go:1116] Unexpected error when reading response body: context deadline exceeded
 # Collector downloading a probe while Sensor is Offline (http.StatusServiceUnavailable -- ROX-19018)
 Unexpected HTTP request failure (HTTP 503)
+# 502 errors should be ignored (this is especially happening in image enrichment
+http: non-successful response (status=502
+unexpected status code 502 Bad Gateway


### PR DESCRIPTION
## Description

This PR fixes two things: ensure we use quay.io images instead of docker.io images since they are suspectible to rate limiting, extend the allow list pattern for suspicious logs to also cover more errors related to image enrichment.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI pass.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
