### PR TITLE
ROX-24099: Add profile clusters sorting

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -5,6 +5,7 @@ import { Divider, PageSection, Title } from '@patternfly/react-core';
 import PageTitle from 'Components/PageTitle';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
 import { getComplianceClusterStats } from 'services/ComplianceResultsStatsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
@@ -17,11 +18,16 @@ function ProfileClustersPage() {
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
     const pagination = useURLPagination(10);
 
-    const { page, perPage } = pagination;
+    const { page, perPage, setPage } = pagination;
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: ['Cluster ID'],
+        defaultSortOption: { field: 'Cluster ID', direction: 'asc' },
+        onSort: () => setPage(1),
+    });
 
     const fetchProfileClusters = useCallback(
-        () => getComplianceClusterStats(profileName, page, perPage),
-        [page, perPage, profileName]
+        () => getComplianceClusterStats(profileName, sortOption, page, perPage),
+        [page, perPage, profileName, sortOption]
     );
     const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);
 
@@ -55,6 +61,7 @@ function ProfileClustersPage() {
                         profileClustersResultsCount={profileClusters?.totalCount ?? 0}
                         profileName={profileName}
                         tableState={tableState}
+                        getSortParams={getSortParams}
                     />
                 </PageSection>
             </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -14,6 +14,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { ComplianceClusterOverallStats } from 'services/ComplianceCommon';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
@@ -33,6 +34,7 @@ export type ProfileClustersTableProps = {
     profileClustersResultsCount: number;
     profileName: string;
     tableState: TableUIState<ComplianceClusterOverallStats>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
 function ProfileClustersTable({
@@ -41,6 +43,7 @@ function ProfileClustersTable({
     profileClustersResultsCount,
     profileName,
     tableState,
+    getSortParams,
 }: ProfileClustersTableProps) {
     const { page, perPage, setPage, setPerPage } = pagination;
 
@@ -66,7 +69,7 @@ function ProfileClustersTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th>Cluster</Th>
+                        <Th sort={getSortParams('Cluster ID')}>Cluster</Th>
                         <Th>Last scanned</Th>
                         <Th>Fail status</Th>
                         <Th>Pass status</Th>

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -2,6 +2,7 @@ import qs from 'qs';
 import { generatePath } from 'react-router-dom';
 
 import axios from 'services/instance';
+import { ApiSortOption } from 'types/search';
 import { getPaginationParams } from 'utils/searchUtils';
 
 import {
@@ -40,12 +41,13 @@ export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanS
  */
 export function getComplianceClusterStats(
     profileName: string,
+    sortOption: ApiSortOption,
     page: number,
     perPage: number
 ): Promise<ListComplianceClusterOverallStatsResponse> {
     const queryParameters = {
         query: {
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });


### PR DESCRIPTION
## Description

Adds sorting to the Compliance V2 Profile Clusters table

Note: UX shows ability to sort by compliance statuses and last scanned time, however these columns are unsortable now due to our backend search framework. Will revisit these in a later release.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing, multiple cluster testing will be done at a later time. Tested by clicking on column header and checking the api call.

before:
![Screenshot 2024-05-21 at 11 45 29 AM](https://github.com/stackrox/stackrox/assets/61400697/903c92ee-f13b-47dd-a09d-8e8bd57131e0)

after:
![Screenshot 2024-05-21 at 11 45 45 AM](https://github.com/stackrox/stackrox/assets/61400697/6f7cbd1b-63c6-4e31-a94e-76545e01580f)
