### PR TITLE
Add serviceaccount exception to default access_kubeadmin policy

### DIFF
--- a/pkg/defaults/policies/files/access_kubeadmin_secret.json
+++ b/pkg/defaults/policies/files/access_kubeadmin_secret.json
@@ -59,6 +59,9 @@
             },
             {
               "value": "system:serviceaccount:openshift-oauth-apiserver:oauth-apiserver-sa"
+            },
+            {
+              "value": "system:serviceaccount:open-cluster-management-agent-addon:config-policy-controller-sa"
             }
           ]
         }


### PR DESCRIPTION
## Description

This adds an exception for the default policy access_kubeadmin_secret.json to accommodate users of RHACM/oCm who may have implemented an RHACM/OCM Policy to check for (and possibly remove) the kubeadmin.  White noise.

https://github.com/open-cluster-management-io/policy-collection/blob/main/community/SC-System-and-Communications-Protection/policy-remove-kubeadmin.yaml

I found no specific tests around this; however, `central/splunk/violations_test.go` has some copied code that looks like it has only 3 of 5 exceptions currently in place.  Maybe that needs updating?

Similar in process to https://issues.redhat.com/browse/ROX-8288

Let me know if you would like a JIRA filed too.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested as a custom policy edited from original default. 

### Here I tell how I validated my change

I don't think existing CI testing covers this or the existing SA exceptions. It would require a mock of the SA making the GET request that was caught by the default policy:
Access to secret "kubeadmin" in namespace "kube-system"

~~~
Time
    05/21/2024 | 3:51:23PM
Verb
    GET
Username
    system:serviceaccount:open-cluster-management-agent-addon:config-policy-controller-sa
Groups
    system:serviceaccounts, system:serviceaccounts:open-cluster-management-agent-addon, system:authenticated
User agent
    config-policy-controller/v0.0.0 (linux/amd64) kubernetes/$Format
Ip address
    X.X.X.X
Resource
    /api/v1/namespaces/kube-system/secrets/kubeadmin
~~~

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
