### PR TITLE
fix(be): Fix imagecveView not returning results for offsets > 0

### DIFF
--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -197,7 +197,7 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	cloned := q.Clone()
 	if len(cveIDsToFilter) > 0 {
 		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
-		cloned.Pagination = q.GetPagination()
+		cloned.Pagination = &v1.QueryPagination{SortOptions: q.GetPagination().GetSortOptions()}
 	}
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(search.CVE).Proto(),

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -197,7 +197,9 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	cloned := q.Clone()
 	if len(cveIDsToFilter) > 0 {
 		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
-		cloned.Pagination = &v1.QueryPagination{SortOptions: q.GetPagination().GetSortOptions()}
+		if q.GetPagination() != nil && q.GetPagination().GetSortOptions() != nil {
+			cloned.Pagination = &v1.QueryPagination{SortOptions: q.GetPagination().GetSortOptions()}
+		}
 	}
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(search.CVE).Proto(),


### PR DESCRIPTION
## Description

The query was split into two parts to improve performance in #11008 : First to get the filtered CVE IDs and the second to get the required details for those CVE IDs. Since first query already returns IDs after applying pagination limit and offset, we do not need to apply them again in the second query.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manual test to verify that pages > 1 in Workload CVEs view returns non-empty list of CVEs

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
