### PR TITLE
fix(be): Rename 'CVE Count' search tag in image proto

### DIFF
--- a/generated/storage/image.pb.go
+++ b/generated/storage/image.pb.go
@@ -279,7 +279,7 @@ type Image_Components struct {
 	Components int32 `protobuf:"varint,7,opt,name=components,proto3,oneof" json:"components,omitempty" search:"Component Count,store,hidden"` // @gotags: search:"Component Count,store,hidden"
 }
 type Image_Cves struct {
-	Cves int32 `protobuf:"varint,8,opt,name=cves,proto3,oneof" json:"cves,omitempty" search:"CVE Count,store,hidden"` // @gotags: search:"CVE Count,store,hidden"
+	Cves int32 `protobuf:"varint,8,opt,name=cves,proto3,oneof" json:"cves,omitempty" search:"Image CVE Count,store"` // @gotags: search:"Image CVE Count,store"
 }
 type Image_FixableCves struct {
 	FixableCves int32 `protobuf:"varint,9,opt,name=fixable_cves,json=fixableCves,proto3,oneof" json:"fixable_cves,omitempty" search:"Fixable CVE Count,store,hidden"` // @gotags: search:"Fixable CVE Count,store,hidden"

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -86,6 +86,7 @@ var (
 	ImageTag                       = newFieldLabel("Image Tag")
 	ImageUser                      = newFieldLabel("Image User")
 	ImageCommand                   = newFieldLabel("Image Command")
+	ImageCVECount                  = newFieldLabel("Image CVE Count")
 	ImageEntrypoint                = newFieldLabel("Image Entrypoint")
 	ImageLabel                     = newFieldLabel("Image Label")
 	ImageVolumes                   = newFieldLabel("Image Volumes")

--- a/proto/storage/image.proto
+++ b/proto/storage/image.proto
@@ -28,7 +28,7 @@ message Image {
     int32 components = 7; // @gotags: search:"Component Count,store,hidden"
   }
   oneof set_cves {
-    int32 cves = 8; // @gotags: search:"CVE Count,store,hidden"
+    int32 cves = 8; // @gotags: search:"Image CVE Count,store"
   }
   oneof set_fixable {
     int32 fixable_cves = 9; // @gotags: search:"Fixable CVE Count,store,hidden"


### PR DESCRIPTION
## Description

There is already a derived field label "CVE Count" `CVECount = newDerivedFieldLabel("CVE Count", CVEID, CountDerivationType)`. Because of this it is not possible to use the `cves` field in image proto to filter images directly without having to join with image_cves table. Renaming the field label in image proto should allow direct filtering using it.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manual test to verify that images can be filtered using "Image CVE Count" label.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
