### PR TITLE
chore(central): simplify v2 and v4 handling

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -151,59 +151,6 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
-	// UUID is only used by Scanner V2, if empty we assume this is from V4.
-	if r.URL.Query().Get(`uuid`) == "" {
-		h.getV4(w, r)
-		return
-	}
-	h.getV2(w, r)
-}
-
-func (h *httpHandler) getV2(w http.ResponseWriter, r *http.Request) {
-	uuid := r.URL.Query().Get(`uuid`)
-	fileName := r.URL.Query().Get(`file`)
-
-	if uuid == "" {
-		writeErrorBadRequest(w)
-		return
-	}
-
-	// Open the most recent definitions file for the provided uuid.
-	f, err := h.openMostRecentDefinitions(r.Context(), uuid)
-	if err != nil {
-		writeErrorForFile(w, err, uuid)
-		return
-	}
-
-	// It is possible no offline Scanner definitions were uploaded, Central cannot
-	// reach the definitions object, or there are no definitions for the given
-	// uuid; in any of those cases, f will be nil.
-	if f == nil {
-		writeErrorNotFound(w)
-		return
-	}
-
-	defer utils.IgnoreError(f.Close)
-
-	// No specific file was requested, so return all definitions.
-	if fileName == "" {
-		serveContent(w, r, f.Name(), f.modTime, f)
-		return
-	}
-
-	// A specific file was requested, so extract from definitions bundle to a
-	// temporary file and serve that instead.
-	namedFile, cleanUp, err := openFromArchive(f.Name(), fileName)
-	if err != nil {
-		writeErrorForFile(w, err, fileName)
-		return
-	}
-	defer cleanUp()
-	defer utils.IgnoreError(namedFile.Close)
-	serveContent(w, r, namedFile.Name(), f.modTime, namedFile)
-}
-
 func writeErrorNotFound(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = w.Write([]byte("No scanner definitions found"))
@@ -403,75 +350,28 @@ func (h *httpHandler) openOfflineBlob(ctx context.Context, blobName string) (*vu
 	return &vulDefFile{snap.File, modTime, snap.Close}, nil
 }
 
-// openMostRecentDefinitions opens the latest Scanner Definitions based on
-// modification time. It's either the one selected by `uuid` if present and
-// online, otherwise fallback to the manually uploaded definitions. The file
-// object can be `nil` if the definitions file does not exist, rather than
-// returning an error.
-func (h *httpHandler) openMostRecentDefinitions(ctx context.Context, uuid string) (file *vulDefFile, err error) {
-	// If in offline mode or uuid is not provided, default to the offline file.
-	if !h.online || uuid == "" {
-		file, err = h.openOfflineBlob(ctx, offlineScannerDefinitionBlobName)
-		if err == nil && file == nil {
-			log.Warnf("Blob %s does not exist", offlineScannerDefinitionBlobName)
-		}
-		return
-	}
-
-	// Start the updater, can be called multiple times for the same uuid, but will
-	// only start the updater once. The Start() call blocks if the definitions were
-	// not downloaded yet.
-	u := h.getUpdater(v2UpdaterType, uuid)
-
-	toClose := func(f *vulDefFile) {
-		if file != f && f != nil {
-			utils.IgnoreError(f.Close)
-		}
-	}
-
-	// Open both the "online" and "offline", and save their modification times.
-	var onlineFile *vulDefFile
-	onlineOSFile, onlineTime, err := h.startUpdaterAndOpenFile(u)
-	if err != nil {
-		return
-	}
-	if onlineOSFile != nil {
-		onlineFile = &vulDefFile{File: onlineOSFile, modTime: onlineTime}
-	}
-
-	defer toClose(onlineFile)
-	offlineFile, err := h.openOfflineBlob(ctx, offlineScannerDefinitionBlobName)
-	if err != nil {
-		return
-	}
-	defer toClose(offlineFile)
-
-	// Return the most recent file, notice that if both don't exist, nil is returned
-	// since modification time will be zero.
-	file = onlineFile
-	if offlineFile != nil && offlineFile.modTime.After(onlineTime) {
-		file = offlineFile
-	}
-	return
-}
-
-// v4OpenOpts are options to open most recent V4 definition files.
-type v4OpenOpts struct {
+// openOpts are options to open most recent V4 definition files.
+type openOpts struct {
+	// name is a generic name to refer to the definition bundle and its content.
+	name string
 	// urlPath specifies the update URL path when setting up online updaters.
 	urlPath string
-	// mappingFile specifies the mapping file to open for mappings updaters.
-	mappingFile string
+	// fileName specifies one file from within the scanner definition archive to
+	// open, instead of returning the archive itself.
+	fileName string
 	// vulnVersion specifies the version of the vulnerability bundle for
 	// vulnerability updaters.
 	vulnVersion string
 	// vulnBundle specifies the vulnerability bundle name for vulnerability updaters.
 	vulnBundle string
+	// offlineBlobName is the name of the offline blob to use.
+	offlineBlobName string
 }
 
-func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+func (h *httpHandler) openDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	log.Debugf("Fetching scanner V4 (online: %t): type %s: options: %#v", h.online, t, opts)
 
-	file, err := h.openMostRecentV4OfflineFile(ctx, t, opts)
+	file, err := h.openOfflineDefinitions(ctx, t, opts)
 	if !h.online {
 		return file, err
 	}
@@ -488,7 +388,7 @@ func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, o
 		}
 	}()
 
-	file, err = h.openMostRecentV4OnlineFile(ctx, t, opts)
+	file, err = h.openOnlineDefinitions(ctx, t, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -503,8 +403,9 @@ func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, o
 	return file, err
 }
 
-// openMostRecentV4OnlineFile gets desired "online" file, which is pulled and managed by the updater.
-func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+// openOnlineDefinitions gets desired "online" file, which is pulled and managed
+// by the updater.
+func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	u := h.getUpdater(t, opts.urlPath)
 	// Ensure the updater is running.
 	u.Start()
@@ -517,8 +418,8 @@ func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterTyp
 	}
 	log.Debugf("Compressed data file is available: %s", openedFile.Name())
 	switch t {
-	case mappingUpdaterType:
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.mappingFile)
+	case mappingUpdaterType, v2UpdaterType:
+		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -530,21 +431,24 @@ func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterTyp
 	return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
 }
 
-// openMostRecentV4OfflineFile gets desired offline file from compressed bundle: offlineScannerV4DefinitionBlobName
-func (h *httpHandler) openMostRecentV4OfflineFile(ctx context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+// openOfflineDefinitions gets desired offline file from compressed bundle.
+func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	log.Debugf("Getting v4 offline data for updater: type %s: options: %#v", t, opts)
-	openedFile, err := h.openOfflineBlob(ctx, offlineScannerV4DefinitionBlobName)
-	if err == nil && openedFile == nil {
-		log.Warnf("Blob %s does not exist", offlineScannerV4DefinitionBlobName)
-		return nil, errors.New("No valid scanner V4 file in offline mode")
+	openedFile, err := h.openOfflineBlob(ctx, opts.offlineBlobName)
+	if err != nil {
+		return nil, fmt.Errorf("opening offline definitions: %s: %w",
+			opts.offlineBlobName, err)
 	}
-
+	if openedFile == nil {
+		log.Warnf("Blob %s does not exist", opts.offlineBlobName)
+		return nil, nil
+	}
 	var offlineFile *vulDefFile
 	defer utils.IgnoreError(openedFile.Close)
 	switch t {
-	case mappingUpdaterType:
+	case mappingUpdaterType, v2UpdaterType:
 		// search mapping file
-		fileName := filepath.Base(opts.mappingFile)
+		fileName := filepath.Base(opts.fileName)
 		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), fileName)
 		if err != nil {
 			return nil, err
@@ -577,7 +481,7 @@ func (h *httpHandler) openMostRecentV4OfflineFile(ctx context.Context, t updater
 		defer cleanUp()
 		offlineFile = &vulDefFile{File: vulns, modTime: openedFile.modTime}
 	default:
-		return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
+		return nil, fmt.Errorf("unknown updater type: %s", t)
 	}
 
 	return offlineFile, nil
@@ -637,13 +541,16 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	return tmpFile, cleanup, nil
 }
 
-func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
+func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
+	// URL parameters.
+	uuid := r.URL.Query().Get(`uuid`)
 	fileName := r.URL.Query().Get(`file`)
 	v := r.URL.Query().Get(`version`)
+
 	ctx := r.Context()
 
 	var uType updaterType
-	var opts v4OpenOpts
+	var opts openOpts
 	var contentType string
 
 	switch {
@@ -655,7 +562,9 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		uType = mappingUpdaterType
-		opts.mappingFile = v4FileName
+		opts.name = fileName
+		opts.fileName = v4FileName
+		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
 	case fileName == "" && v != "":
 		// If only version is provided, this is for Scanner V4 vuln file
 		if version.GetVersionKind(v) == version.NightlyKind {
@@ -669,19 +578,31 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 			bundle = "vulnerabilities.zip"
 			contentType = "application/zip"
 		}
+		opts.name = v
 		opts.urlPath = path.Join(v, bundle)
 		opts.vulnVersion = v
 		opts.vulnBundle = bundle
+		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
+	case uuid != "":
+		// Scanner V2 definitions.
+		uType = v2UpdaterType
+		opts.name = uuid
+		opts.urlPath = uuid
+		opts.fileName = fileName
+		opts.offlineBlobName = offlineScannerDefinitionBlobName
 	default:
 		writeErrorBadRequest(w)
 		return
 	}
 
-	f, err := h.openMostRecentV4File(ctx, uType, opts)
+	f, err := h.openDefinitions(ctx, uType, opts)
 	if err != nil {
-		errMsg := fmt.Sprintf("could not read: %s", err)
-		log.Error(errMsg)
-		httputil.WriteGRPCStyleErrorf(w, codes.Internal, errMsg)
+		writeErrorForFile(w, err, opts.name)
+		return
+	}
+
+	if f == nil {
+		writeErrorNotFound(w)
 		return
 	}
 
@@ -691,18 +612,6 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 
 	defer utils.IgnoreError(f.Close)
 	serveContent(w, r, f.Name(), f.modTime, f)
-}
-
-func (h *httpHandler) startUpdaterAndOpenFile(u *requestedUpdater) (*os.File, time.Time, error) {
-	u.Start()
-	osFile, modTime, err := u.file.Open()
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	if osFile == nil {
-		return nil, time.Time{}, nil
-	}
-	return osFile, modTime, nil
 }
 
 func getOfflineFileVersion(mf *os.File) (string, error) {

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -418,7 +418,13 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 	}
 	log.Debugf("Compressed data file is available: %s", openedFile.Name())
 	switch t {
-	case mappingUpdaterType, v2UpdaterType:
+	case v2UpdaterType:
+		if opts.fileName == "" {
+			return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
+		}
+		fallthrough
+	case mappingUpdaterType:
+		defer utils.IgnoreError(openedFile.Close)
 		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
@@ -446,7 +452,11 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 	var offlineFile *vulDefFile
 	switch t {
 	case v2UpdaterType:
-		offlineFile = openedFile
+		if opts.fileName == "" {
+			offlineFile = openedFile
+			break
+		}
+		fallthrough
 	case mappingUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
 		// search mapping file

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -424,6 +424,9 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 		}
 		fallthrough
 	case mappingUpdaterType:
+		// openFromArchive will copy the contents of opts.fileName from openedFile to
+		// targetFile. Because of this, openedFile is not needed outside this function,
+		// so close it here.
 		defer utils.IgnoreError(openedFile.Close)
 		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
@@ -458,6 +461,9 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		}
 		fallthrough
 	case mappingUpdaterType:
+		// openFromArchive will copy the contents of opts.fileName from openedFile to
+		// targetFile. Because of this, openedFile is not needed outside this function,
+		// so close it here.
 		defer utils.IgnoreError(openedFile.Close)
 		// search mapping file
 		fileName := filepath.Base(opts.fileName)
@@ -468,6 +474,9 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		defer cleanUp()
 		offlineFile = &vulDefFile{File: targetFile, modTime: openedFile.modTime}
 	case vulnerabilityUpdaterType:
+		// openFromArchive will copy the contents of opts.fileName from openedFile to
+		// mf. Because of this, openedFile is not needed outside this function,
+		// so close it here.
 		defer utils.IgnoreError(openedFile.Close)
 		// check version information in manifest
 		mf, cleanUp, err := openFromArchive(openedFile.Name(), "manifest.json")

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -20,18 +21,25 @@ import (
 	"github.com/stackrox/rox/central/blob/datastore/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 const (
 	content1 = "Hello, world!"
 	content2 = "Papaya"
+
+	v2ManifestContent = `{
+  "since": "yesterday",
+  "until": "today"
+}`
+	v4ManifestContent = `{
+  "version": "dev"
+}`
 )
 
 type handlerTestSuite struct {
@@ -64,192 +72,85 @@ func (s *handlerTestSuite) SetupTest() {
 }
 
 func (s *handlerTestSuite) TearDownSuite() {
-	entries, err := os.ReadDir(s.tmpDir)
-	s.NoError(err)
-	s.LessOrEqual(len(entries), 3)
-	if len(entries) == 3 {
-		s.True(strings.HasPrefix(entries[0].Name(), definitionsBaseDir))
-		s.True(strings.HasPrefix(entries[1].Name(), definitionsBaseDir))
-		s.True(strings.HasPrefix(entries[2].Name(), definitionsBaseDir))
-	}
-
 	s.testDB.Teardown(s.T())
-	utils.IgnoreError(func() error { return os.RemoveAll(s.tmpDir) })
 }
 
-func (s *handlerTestSuite) mustGetRequest(t *testing.T) *http.Request {
-	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe"
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+func (s *handlerTestSuite) postRequestV2() *http.Request {
+	var manifestBuf bytes.Buffer
+	zw := zip.NewWriter(&manifestBuf)
+	file, err := zw.CreateHeader(&zip.FileHeader{
+		Name:               "manifest.json",
+		Comment:            "Scanner V2 manifest",
+		UncompressedSize64: uint64(len(v2ManifestContent)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(v2ManifestContent))
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
 
-	require.NoError(t, err)
+	var buf bytes.Buffer
+	zw = zip.NewWriter(&buf)
+	file, err = zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-defs.zip",
+		Comment:            "Scanner V2 content",
+		UncompressedSize64: uint64(manifestBuf.Len()),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write(manifestBuf.Bytes())
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, "https://central.stackrox.svc/scannerdefinitions", &buf)
+	s.Require().NoError(err)
 
 	return req
 }
 
-func (s *handlerTestSuite) getRequestWithJSONFile(t *testing.T, file string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?file=%s", file)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
+func (s *handlerTestSuite) postRequestV4() *http.Request {
+	// V4 ZIP file contents.
+	var v4Buf bytes.Buffer
+	zw := zip.NewWriter(&v4Buf)
+	file, err := zw.CreateHeader(&zip.FileHeader{
+		Name:               "manifest.json",
+		Comment:            "Scanner V4 manifest",
+		UncompressedSize64: uint64(len(v4ManifestContent)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(v4ManifestContent))
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
+
+	var buf bytes.Buffer
+	zw = zip.NewWriter(&buf)
+
+	// Currently, we need both V2 and V4 files when Scanner V4 is enabled.
+	file, err = zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-defs.zip",
+		Comment:            "Scanner V2 content",
+		UncompressedSize64: uint64(len(content1)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(content1))
+	s.Require().NoError(err)
+
+	file, err = zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-v4-defs.zip",
+		Comment:            "Scanner V4 content",
+		UncompressedSize64: uint64(v4Buf.Len()),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write(v4Buf.Bytes())
+	s.Require().NoError(err)
+
+	s.Require().NoError(zw.Close())
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, "https://central.stackrox.svc/scannerdefinitions", &buf)
+	s.Require().NoError(err)
 
 	return req
 }
 
-func (s *handlerTestSuite) getRequestWithVersionedFile(t *testing.T, v string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?version=%s", v)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) mustGetRequestWithFile(t *testing.T, file string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe&file=%s", file)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) mustGetBadRequest(t *testing.T) *http.Request {
-	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=fail"
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Offline_Get() {
-	t := s.T()
-	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
-
-	h := New(s.datastore, handlerOpts{})
-
-	// No scanner defs found.
-	req := s.mustGetRequest(t)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Add scanner defs.
-	s.mustWriteOffline(content1, time.Now())
-
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, content1, w.Body.String())
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	// Should not get anything.
-	req := s.mustGetBadRequest(t)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Should get file from online update.
-	req = s.mustGetRequestWithFile(t, "manifest.json")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	assert.Regexpf(t, `{"since":".*","until":".*"}`, w.Body.String(), "content1 did not match")
-
-	// Should get online update.
-	req = s.mustGetRequest(t)
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	// Write offline definitions.
-	s.mustWriteOffline(content1, time.Now())
-
-	// Set the offline dump's modified time to later than the online update's.
-	s.mustWriteOffline(content1, time.Now().Add(time.Hour))
-
-	// Served the offline dump, as it is more recent.
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, content1, w.Body.String())
-
-	// Set the offline dump's modified time to earlier than the online update's.
-	s.mustWriteOffline(content2, nov23)
-
-	// Serve the online dump, as it is now more recent.
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.NotEqual(t, content2, w.Body.String())
-
-	// File is unmodified.
-	req.Header.Set(ifModifiedSinceHeader, time.Now().UTC().Format(http.TimeFormat))
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotModified, w.Code)
-	assert.Empty(t, w.Body.String())
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_ZSTD_Bundle_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	w := httptest.NewRecorder()
-	req := s.getRequestWithVersionedFile(t, "randomName")
-	h.ServeHTTP(w, req)
-	// If the version is invalid or versioned bundle cannot be found, it's a 500
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-
-	// Should get dev zstd file from online update.
-	req = s.getRequestWithVersionedFile(t, "dev")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-
-	req = s.getRequestWithVersionedFile(t, "4.3.x-173-g6bbb2e07dc")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-
-	// Should get dev zstd file from online update.
-	req = s.getRequestWithVersionedFile(t, "4.3.x-nightly-20240106")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_Mappings_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	w := httptest.NewRecorder()
-
-	// Nothing should be found
-	req := s.getRequestWithJSONFile(t, "randomName")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Should get mapping json file from online update.
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-
-	// Should get mapping json file from online update.
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-}
-
-func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
+func (s *handlerTestSuite) mustWriteBlob(content string, modTime time.Time) {
 	modifiedTime, err := protocompat.ConvertTimeToTimestampOrError(modTime)
 	s.Require().NoError(err)
 	blob := &storage.Blob{
@@ -261,68 +162,44 @@ func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
 	s.Require().NoError(s.datastore.Upsert(s.ctx, blob, bytes.NewBuffer([]byte(content))))
 }
 
-func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
-	t := s.T()
-	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
-	h := New(s.datastore, handlerOpts{})
-	w := httptest.NewRecorder()
-
-	// No scanner defs found.
-	req := s.getRequestWithVersionedFile(t, "4.3.0")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// No mapping json file
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// No mapping json file
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	tempDir := t.TempDir()
-	filePath := tempDir + "/test.zip"
-
-	url := "https://storage.googleapis.com/scanner-support-public/offline/v1/4.3/scanner-vulns-4.3.zip"
-	resp, err := http.Get(url)
-	// Skip the test if file cannot be downloaded or status code is not OK.
-	if err != nil {
-		return
-	}
-	defer utils.IgnoreError(resp.Body.Close)
-	if resp.StatusCode != http.StatusOK {
-		return
-	}
-
-	outFile, err := os.Create(filePath)
+func (s *handlerTestSuite) getRequestUUID() *http.Request {
+	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
 
-	_, err = io.Copy(outFile, resp.Body)
+	return req
+}
+
+func (s *handlerTestSuite) getRequestFile(file string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?file=%s", file)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
-	utils.IgnoreError(outFile.Close)
 
-	err = s.mockHandleZipContents(filePath)
+	return req
+}
+
+func (s *handlerTestSuite) getRequestVersion(v string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?version=%s", v)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
 
-	req = s.getRequestWithVersionedFile(t, "4.3.0")
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
+	return req
+}
 
-	w = httptest.NewRecorder()
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+func (s *handlerTestSuite) getRequestUUIDAndFile(file string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe&file=%s", file)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+	s.Require().NoError(err)
 
-	w = httptest.NewRecorder()
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	return req
+}
+
+func (s *handlerTestSuite) getRequestBadUUID() *http.Request {
+	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=fail"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+	s.Require().NoError(err)
+
+	return req
 }
 
 func (s *handlerTestSuite) mockHandleDefsFile(zipF *zip.File, blobName string) error {
@@ -352,4 +229,254 @@ func (s *handlerTestSuite) mockHandleZipContents(zipPath string) error {
 		}
 	}
 	return errors.New("test failed")
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Post_V2() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "false")
+
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	req := s.postRequestV2()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Get_V2() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "false")
+
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	// No scanner-defs found.
+	getReq := s.getRequestUUID()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Post scanner-defs.
+	postReq := s.postRequestV2()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, postReq)
+	s.Require().Equal(http.StatusOK, w.Code)
+
+	// Bad request after data is uploaded should give offline data.
+	getReq = s.getRequestBadUUID()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+
+	// Get offline data again with good UUID.
+	getReq = s.getRequestUUID()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+	s.Greater(w.Body.Len(), 0)
+
+	// Should get file from offline data.
+	getReq = s.getRequestUUIDAndFile("manifest.json")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+	s.Equal(v2ManifestContent, w.Body.String())
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V2() {
+	s.T().Setenv(features.ScannerV4.EnvVar(), "false")
+
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	// Should not get anything with bad UUID.
+	req := s.getRequestBadUUID()
+	h.ServeHTTP(w, req)
+	// TODO: This should be a 404. Update in a followup.
+	s.Equal(http.StatusInternalServerError, w.Code)
+
+	// Should get online vulns.
+	req = s.getRequestUUID()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+	s.Greater(w.Body.Len(), 0)
+
+	// Should get file from online update.
+	req = s.getRequestUUIDAndFile("manifest.json")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+	s.Regexpf(`{"since":".*","until":".*"}`, w.Body.String(), "content1 did not match")
+
+	// Write offline definitions, directly.
+	// Set the offline dump's modified time to later than the online update's.
+	s.mustWriteBlob(content1, time.Now().Add(time.Hour))
+
+	// Serve the offline dump, as it is more recent.
+	req = s.getRequestUUID()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal(content1, w.Body.String())
+
+	// Set the offline dump's modified time to earlier than the online update's.
+	s.mustWriteBlob(content2, nov23)
+
+	// Serve the online dump, as it is now more recent.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.NotEqual(content2, w.Body.String())
+
+	// File is unmodified.
+	req.Header.Set(ifModifiedSinceHeader, time.Now().UTC().Format(http.TimeFormat))
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotModified, w.Code)
+	s.Empty(w.Body.String())
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Post_V4() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "true")
+
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	req := s.postRequestV4()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Get_V4() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "true")
+
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	// No scanner defs found.
+	req := s.getRequestVersion("4.5.0")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// No mapping json file
+	req = s.getRequestFile("name2repos")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// No mapping json file
+	req = s.getRequestFile("repo2cpe")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	url := "https://storage.googleapis.com/scanner-support-public/offline/v1/4.5/scanner-vulns-4.5.zip"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, url, nil)
+	s.Require().NoError(err)
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer utils.IgnoreError(resp.Body.Close)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	filePath := filepath.Join(s.T().TempDir(), "test.zip")
+	outFile, err := os.Create(filePath)
+	s.Require().NoError(err)
+
+	_, err = io.Copy(outFile, resp.Body)
+	s.Require().NoError(err)
+	utils.IgnoreError(outFile.Close)
+
+	err = s.mockHandleZipContents(filePath)
+	s.Require().NoError(err)
+
+	// This will fail because 4.5.0 uses the multi-bundle ZIP format.
+	req = s.getRequestVersion("4.5.0")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Set the header properly.
+	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+
+	w = httptest.NewRecorder()
+	req = s.getRequestFile("repo2cpe")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+
+	w = httptest.NewRecorder()
+	req = s.getRequestFile("name2repos")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	req := s.getRequestVersion("randomName")
+	h.ServeHTTP(w, req)
+	// If the version is invalid or versioned bundle cannot be found, it's a 500
+	s.Equal(http.StatusInternalServerError, w.Code)
+
+	// Should get dev zstd file from online update.
+	req = s.getRequestVersion("dev")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Release version.
+	req = s.getRequestVersion("4.4.0")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Should get dev zstd file from online update.
+	req = s.getRequestVersion("4.3.x-nightly-20240106")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Multi-bundle ZIP.
+	req = s.getRequestVersion("dev")
+	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4_Mappings() {
+	h := New(s.datastore, handlerOpts{})
+	w := httptest.NewRecorder()
+
+	// Nothing should be found
+	req := s.getRequestFile("randomName")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Should get mapping json file from online update.
+	req = s.getRequestFile("name2repos")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+
+	// Should get mapping json file from online update.
+	req = s.getRequestFile("repo2cpe")
+	w.Body.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
 }

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -1,4 +1,4 @@
-//go:build sql_integration
+////go:build sql_integration
 
 package handler
 

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -270,17 +270,17 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	// No scanner defs found.
 	req := s.getRequestWithVersionedFile(t, "4.3.0")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// No mapping json file
 	req = s.getRequestWithJSONFile(t, "name2repos")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// No mapping json file
 	req = s.getRequestWithJSONFile(t, "repo2cpe")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	tempDir := t.TempDir()
 	filePath := tempDir + "/test.zip"

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -1,4 +1,4 @@
-////go:build sql_integration
+//go:build sql_integration
 
 package handler
 

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -399,6 +399,7 @@ func (s *handlerTestSuite) TestServeHTTP_Offline_Get_V4() {
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusNotFound, w.Code)
 
+	w = httptest.NewRecorder()
 	// Set the header properly.
 	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
 	h.ServeHTTP(w, req)
@@ -429,21 +430,21 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
 
 	// Should get dev zstd file from online update.
 	req = s.getRequestVersion("dev")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
 
 	// Release version.
 	req = s.getRequestVersion("4.4.0")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
 
 	// Should get dev zstd file from online update.
 	req = s.getRequestVersion("4.3.x-nightly-20240106")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
@@ -451,7 +452,7 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
 	// Multi-bundle ZIP.
 	req = s.getRequestVersion("dev")
 	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zip", w.Header().Get("Content-Type"))
@@ -468,14 +469,14 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4_Mappings() {
 
 	// Should get mapping json file from online update.
 	req = s.getRequestFile("name2repos")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/json", w.Header().Get("Content-Type"))
 
 	// Should get mapping json file from online update.
 	req = s.getRequestFile("repo2cpe")
-	w.Body.Reset()
+	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/json", w.Header().Get("Content-Type"))


### PR DESCRIPTION
## Description

Simplifies the scanner definitions handler by combining related functions for Scanner v2 and V4. This also removes an annoying misleading log about missing offline files, when they're not needed.

I also removed `startUpdaterAndOpenFile` because it's no longer used.

This is the first PR in a series of PRs to fix this file for bugs and readability purposes:

* https://github.com/stackrox/stackrox/pull/11212 <-- This
* https://github.com/stackrox/stackrox/pull/11825 (replaces https://github.com/stackrox/stackrox/pull/11282 which was originally merged into here but was somehow lost...)
* https://github.com/stackrox/stackrox/pull/11836
* https://github.com/stackrox/stackrox/pull/11837
* https://github.com/stackrox/stackrox/pull/11841
* https://github.com/stackrox/stackrox/pull/11842
* https://github.com/stackrox/stackrox/pull/11843

Once the followups are merged into this branch, then this branch will be merged.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

This was tested in https://github.com/stackrox/stackrox/pull/11283.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
