### PR TITLE
ROX-24078: Update navigation and tech preview status for VM 2.0

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
+import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,6 +17,11 @@ const entitiesKey = 'cluster-cves';
 
 describe('Vulnerability Management Cluster (Platform) CVEs', () => {
     withAuth();
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -16,6 +17,11 @@ const entitiesKey = 'clusters';
 
 describe('Vulnerability Management Clusters', () => {
     withAuth();
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display all the columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import {
     interactAndWaitForVulnerabilityManagementEntities,
@@ -34,6 +35,11 @@ function selectTopRiskyOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should visit using the left nav', () => {
         visitVulnerabilityManagementDashboardFromLeftNav();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     interactAndWaitForVulnerabilityManagementEntity,
     visitVulnerabilityManagementDashboard,
@@ -50,6 +51,11 @@ function selectTopRiskiestOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     // Some tests might fail in local deployment.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -16,6 +17,12 @@ const entitiesKey = 'deployments';
 
 describe('Vulnerability Management Deployments', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -11,6 +11,12 @@ import { selectors } from './VulnerabilityManagement.selectors';
 describe('Entities single views', () => {
     withAuth();
 
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
+
     // Some tests might fail in local deployment.
 
     // TODO skip pending more robust criterion than deployment count

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -16,6 +17,12 @@ const entitiesKey = 'image-components';
 
 describe('Vulnerability Management Image Components', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -1,5 +1,6 @@
 import { selectors } from './VulnerabilityManagement.selectors';
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -18,6 +19,12 @@ const entitiesKey = 'image-cves';
 
 describe('Vulnerability Management Image CVEs', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -19,6 +20,12 @@ const entitiesKey = 'images';
 
 describe('Vulnerability Management Images', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -16,6 +17,12 @@ const entitiesKey = 'namespaces';
 
 describe('Vulnerability Management Namespaces', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
+import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,6 +17,12 @@ const entitiesKey = 'node-components';
 
 describe('Vulnerability Management Node Components', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -1,6 +1,6 @@
 import { selectors } from './VulnerabilityManagement.selectors';
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
+import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -19,6 +19,12 @@ const entitiesKey = 'node-cves';
 
 describe('Vulnerability Management Node CVEs', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodes.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -16,6 +17,12 @@ const entitiesKey = 'nodes';
 
 describe('Vulnerability Management Nodes', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
+            this.skip();
+        }
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -50,7 +50,7 @@ import './NavigationSidebar.css';
 
 // Child example; Compliance (1.0) if Compliance (2.0) is rendered and Compliance otherwise.
 // Parent example: Vulnerability Management (1.0) if Vulnerability Management (2.0) is rendered and so on.
-type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string;
+type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string | ReactElement;
 
 // Child conditional title finds path to decide presence or absence of counterpart child.
 // Parent conditional title finds key to decide presence or absence of counterpart parent.
@@ -72,6 +72,22 @@ type LinkDescription = {
 // Encapsulate whether path match for child is specific or generic.
 function isActiveLink(pathname: string, { isActive, path }: LinkDescription) {
     return typeof isActive === 'function' ? isActive(pathname) : Boolean(matchPath(pathname, path));
+}
+
+// Predicate function that encapsulates the logic for rendering content based on whether or not Vulnerability
+// Management 2.0 is declared as GA.
+function vulnMgmt2GaContentPredicate(
+    techPreviewContent: string | ReactElement,
+    gaContent: string | ReactElement
+) {
+    return (navDescriptionsFiltered: NavDescription[]) =>
+        navDescriptionsFiltered.some(
+            (navDescription) =>
+                navDescription.type === 'parent' &&
+                navDescription.key === keyForVulnerabilityManagement1
+        )
+            ? techPreviewContent
+            : gaContent;
 }
 
 type SeparatorDescription = {
@@ -211,31 +227,36 @@ const navDescriptions: NavDescription[] = [
     */
     {
         type: 'parent',
-        title: (navDescriptionsFiltered) =>
-            navDescriptionsFiltered.some(
-                (navDescription) =>
-                    navDescription.type === 'parent' &&
-                    navDescription.key === keyForVulnerabilityManagement1
-            )
-                ? 'Vulnerability Management (2.0)'
-                : 'Vulnerability Management',
+        title: vulnMgmt2GaContentPredicate(
+            'Vulnerability Management (2.0)',
+            'Vulnerability Management'
+        ),
         key: keyForVulnerabilityManagement2,
         children: [
             {
                 type: 'link',
-                content: <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
+                content: vulnMgmt2GaContentPredicate(
+                    <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
+                    'Workload CVEs'
+                ),
                 path: vulnerabilitiesWorkloadCvesPath,
                 routeKey: 'workload-cves',
             },
             {
                 type: 'link',
-                content: 'Platform CVEs',
+                content: vulnMgmt2GaContentPredicate(
+                    <NavigationContent variant="TechPreview">Platform CVEs</NavigationContent>,
+                    'Platform CVEs'
+                ),
                 path: vulnerabilitiesPlatformCvesPath,
                 routeKey: 'platform-cves',
             },
             {
                 type: 'link',
-                content: 'Node CVEs',
+                content: vulnMgmt2GaContentPredicate(
+                    <NavigationContent variant="TechPreview">Node CVEs</NavigationContent>,
+                    'Node CVEs'
+                ),
                 path: vulnerabilitiesNodeCvesPath,
                 routeKey: 'node-cves',
             },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -13,6 +13,7 @@ import {
 import TechPreviewBanner from 'Components/TechPreviewBanner';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import usePermissions from 'hooks/usePermissions';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
@@ -26,6 +27,7 @@ const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCves
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
 function WorkloadCvesPage() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
     const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
@@ -33,11 +35,13 @@ function WorkloadCvesPage() {
     return (
         <>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
-            <TechPreviewBanner
-                featureURL={vulnManagementPath}
-                featureName="Vulnerability Management (1.0)"
-                routeKey="vulnerability-management"
-            />
+            {!isFeatureFlagEnabled('ROX_VULN_MGMT_2_GA') && (
+                <TechPreviewBanner
+                    featureURL={vulnManagementPath}
+                    featureName="Vulnerability Management (1.0)"
+                    routeKey="vulnerability-management"
+                />
+            )}
             <Switch>
                 {hasReadAccessForNamespaces && (
                     <Route path={vulnerabilityNamespaceViewPath} component={NamespaceViewPage} />

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -336,12 +336,14 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     // Risk Acceptance must precede generic Vulnerability Management in Body and so here for consistency.
     'vulnerability-management/risk-acceptance': {
+        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_2_GA']),
         resourceAccessRequirements: everyResource([
             'VulnerabilityManagementApprovals',
             'VulnerabilityManagementRequests',
         ]),
     },
     'vulnerability-management': {
+        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_2_GA']),
         resourceAccessRequirements: everyResource([
             // 'Alert', // for Cluster and Deployment and Namespace
             // 'Cluster', // on Dashboard for with most widget


### PR DESCRIPTION
## Description

Updates the Navigation Sidebar and Workload CVE page to conditionally display whether or not VM 2.0 is GA, or tech preview.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With the `ROX_VULN_MGMT_2_GA` flag disabled. Notice the VM 2.0 navigation items, tech preview badges, tech preview banner, and intact VM 1.0 navigation.
![image](https://github.com/stackrox/stackrox/assets/1292638/0192d450-0cfc-42bb-9c8d-d7d7ab037f20)

With the `ROX_VULN_MGMT_2_GA` flag enabled. The VM 1.0 navigation is removed, VM 2.0 is replaced with just `Vulnerability Management`, and all tech preview designations are gone.
![image](https://github.com/stackrox/stackrox/assets/1292638/779993a6-d104-4057-b25d-9f7f89633714)

