### PR TITLE
fix(ci): fix Scanner dev vuln updates

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -48,6 +48,12 @@ jobs:
       STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       STACKROX_NVD_API_CALL_INTERVAL: 6s
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: updater


### PR DESCRIPTION
## Description

This fixes the following error:

```
[run-updater](https://github.com/stackrox/stackrox/actions/runs/9195096942/job/25290347930#step:2:1)
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/stackrox/stackrox/.github/actions/download-artifact-with-retry'. Did you forget to run actions/checkout before running your local action?
```

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

See the CI run for this PR

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
