### PR TITLE
ROX-24003: Check details table results

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -7,7 +7,7 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useRestQuery from 'hooks/useRestQuery';
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
 import { getComplianceProfileCheckStats } from 'services/ComplianceResultsStatsService';
-import { GetComplianceProfileCheckResult } from 'services/ComplianceResultsService';
+import { getComplianceProfileCheckResult } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import CheckDetailsTable from './CheckDetailsTable';
@@ -43,7 +43,7 @@ function CheckDetails() {
     } = useRestQuery(fetchCheckStats);
 
     const fetchCheckResults = useCallback(
-        () => GetComplianceProfileCheckResult(profileName, checkName),
+        () => getComplianceProfileCheckResult(profileName, checkName),
         [checkName, profileName]
     );
     const {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -1,17 +1,18 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
-
-import { complianceEnhancedCoveragePath } from 'routePaths';
-import useRestQuery from 'hooks/useRestQuery';
-import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
-import { getComplianceProfileCheckStats } from 'services/ComplianceResultsStatsService';
+import { generatePath, useParams } from 'react-router-dom';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
-import NotFoundMessage from 'Components/NotFoundMessage';
+import useRestQuery from 'hooks/useRestQuery';
+import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
+import { getComplianceProfileCheckStats } from 'services/ComplianceResultsStatsService';
+import { GetComplianceProfileCheckResult } from 'services/ComplianceResultsService';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import CheckDetailsTable from './CheckDetailsTable';
 import DetailsPageHeader, { PageHeaderLabel } from './components/DetailsPageHeader';
+import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 
 function sortCheckStats(a: ComplianceCheckStatusCount, b: ComplianceCheckStatusCount) {
@@ -29,37 +30,43 @@ function sortCheckStats(a: ComplianceCheckStatusCount, b: ComplianceCheckStatusC
 
 function CheckDetails() {
     const { checkName, profileName } = useParams();
+    const [currentDatetime, setCurrentDatetime] = useState(new Date());
 
-    const complianceCoverageChecksURL = `${complianceEnhancedCoveragePath}/profiles/${profileName}/checks`;
-
-    const profileCheckByIdFn = useCallback(
+    const fetchCheckStats = useCallback(
         () => getComplianceProfileCheckStats(profileName, checkName),
         [profileName, checkName]
     );
-    const { data, loading: isLoading, error } = useRestQuery(profileCheckByIdFn);
+    const {
+        data: checkStats,
+        loading: isLoadingCheckStats,
+        error: checkStatsError,
+    } = useRestQuery(fetchCheckStats);
 
-    if (error) {
-        return (
-            <PageSection variant="light">
-                <TableErrorComponent
-                    error={error}
-                    message="An error occurred. Try refreshing again"
-                />
-            </PageSection>
-        );
-    }
+    const fetchCheckResults = useCallback(
+        () => GetComplianceProfileCheckResult(profileName, checkName),
+        [checkName, profileName]
+    );
+    const {
+        data: checkResults,
+        loading: isLoadingCheckResults,
+        error: checkResultsError,
+    } = useRestQuery(fetchCheckResults);
 
-    if (!isLoading && !data) {
-        return (
-            <NotFoundMessage
-                title="404: Profile check does not exist."
-                message={`A profile check called "${checkName}" could not be found.`}
-            />
-        );
-    }
+    const tableState = getTableUIState({
+        isLoading: isLoadingCheckResults,
+        data: checkResults?.checkResults,
+        error: checkResultsError,
+        searchFilter: {},
+    });
+
+    useEffect(() => {
+        if (checkResults) {
+            setCurrentDatetime(new Date());
+        }
+    }, [checkResults]);
 
     const checkStatsLabels =
-        data?.checkStats
+        checkStats?.checkStats
             .sort(sortCheckStats)
             .reduce((acc, checkStat) => {
                 const statusObject = getClusterResultsStatusObject(checkStat.status);
@@ -81,7 +88,11 @@ function CheckDetails() {
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItem>Compliance coverage</BreadcrumbItem>
-                    <BreadcrumbItemLink to={complianceCoverageChecksURL}>
+                    <BreadcrumbItemLink
+                        to={generatePath(coverageProfileChecksPath, {
+                            profileName,
+                        })}
+                    >
                         {profileName}
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>{checkName}</BreadcrumbItem>
@@ -90,15 +101,24 @@ function CheckDetails() {
             <Divider component="div" />
             <PageSection variant="light">
                 <DetailsPageHeader
-                    isLoading={isLoading}
+                    isLoading={isLoadingCheckStats}
                     name={checkName}
                     labels={checkStatsLabels}
-                    summary={data?.rationale}
+                    summary={checkStats?.rationale}
                     nameScreenReaderText="Loading profile check details"
                     metadataScreenReaderText="Loading profile check details"
+                    error={checkStatsError}
+                    errorAlertTitle="Unable to fetch profile check stats"
                 />
             </PageSection>
             <Divider component="div" />
+            <PageSection>
+                <CheckDetailsTable
+                    currentDatetime={currentDatetime}
+                    tableState={tableState}
+                    profileName={profileName}
+                />
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -70,7 +70,7 @@ function CheckDetails() {
             .sort(sortCheckStats)
             .reduce((acc, checkStat) => {
                 const statusObject = getClusterResultsStatusObject(checkStat.status);
-                if (statusObject) {
+                if (statusObject && checkStat.count > 0) {
                     const label: PageHeaderLabel = {
                         text: `${statusObject.statusText}: ${checkStat.count}`,
                         icon: statusObject.icon,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { generatePath, Link } from 'react-router-dom';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import IconText from 'Components/PatternFly/IconText/IconText';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { ClusterCheckStatus } from 'services/ComplianceResultsService';
+import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { TableUIState } from 'utils/getTableUIState';
+
+import { coverageClusterDetailsPath } from './compliance.coverage.routes';
+import { getClusterResultsStatusObject } from './compliance.coverage.utils';
+
+export type CheckDetailsTableProps = {
+    currentDatetime: Date;
+    profileName: string;
+    tableState: TableUIState<ClusterCheckStatus>;
+};
+
+function CheckDetailsTable({ currentDatetime, profileName, tableState }: CheckDetailsTableProps) {
+    return (
+        <>
+            <Table>
+                <Thead>
+                    <Tr>
+                        <Th>Cluster</Th>
+                        <Th>Last scanned</Th>
+                        <Th>Compliance status</Th>
+                    </Tr>
+                </Thead>
+                <TbodyUnified
+                    tableState={tableState}
+                    colSpan={3}
+                    errorProps={{
+                        title: 'There was an error loading results for this check',
+                    }}
+                    emptyProps={{
+                        message: 'No results found for this check',
+                    }}
+                    filteredEmptyProps={{
+                        title: 'No results found',
+                        message: 'Clear all filters and try again',
+                    }}
+                    renderer={({ data }) => (
+                        <Tbody>
+                            {data.map((clusterInfo) => {
+                                const {
+                                    cluster: { clusterId, clusterName },
+                                    lastScanTime,
+                                    status,
+                                } = clusterInfo;
+                                const clusterStatusObject = getClusterResultsStatusObject(status);
+                                const firstDiscoveredAsPhrase = getDistanceStrictAsPhrase(
+                                    lastScanTime,
+                                    currentDatetime
+                                );
+
+                                return (
+                                    <Tr key={clusterId}>
+                                        <Td dataLabel="Cluster">
+                                            <Link
+                                                to={generatePath(coverageClusterDetailsPath, {
+                                                    clusterId,
+                                                    profileName,
+                                                })}
+                                            >
+                                                {clusterName}
+                                            </Link>
+                                        </Td>
+                                        <Td dataLabel="Last scanned">{firstDiscoveredAsPhrase}</Td>
+                                        <Td dataLabel="Compliance status">
+                                            <Tooltip content={clusterStatusObject.tooltipText}>
+                                                <Button isInline variant={ButtonVariant.link}>
+                                                    <IconText
+                                                        icon={clusterStatusObject.icon}
+                                                        text={clusterStatusObject.statusText}
+                                                    />
+                                                </Button>
+                                            </Tooltip>
+                                        </Td>
+                                    </Tr>
+                                );
+                            })}
+                        </Tbody>
+                    )}
+                />
+            </Table>
+        </>
+    );
+}
+
+export default CheckDetailsTable;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/DetailsPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/DetailsPageHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Alert,
     Flex,
     FlexItem,
     Label,
@@ -9,6 +10,8 @@ import {
     Text,
     Title,
 } from '@patternfly/react-core';
+
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type PageHeaderLabel = {
     text: string;
@@ -23,6 +26,8 @@ export type DetailsPageHeaderProps = {
     summary?: string;
     nameScreenReaderText: string;
     metadataScreenReaderText: string;
+    error: Error | undefined;
+    errorAlertTitle: string;
 };
 
 const MAX_NUM_LABELS = 7;
@@ -34,6 +39,8 @@ function DetailsPageHeader({
     summary,
     nameScreenReaderText,
     metadataScreenReaderText,
+    error,
+    errorAlertTitle,
 }: DetailsPageHeaderProps) {
     if (isLoading) {
         return (
@@ -54,11 +61,21 @@ function DetailsPageHeader({
                 <Title headingLevel="h1" className="pf-v5-u-mb-sm">
                     {name}
                 </Title>
+                {error && (
+                    <Alert variant="danger" title={errorAlertTitle} component="div" isInline>
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
                 {labels && labels.length !== 0 && (
                     <LabelGroup numLabels={MAX_NUM_LABELS}>
                         {labels.map((label) => {
                             return (
-                                <Label variant="filled" icon={label.icon} color={label.color}>
+                                <Label
+                                    variant="filled"
+                                    icon={label.icon}
+                                    color={label.color}
+                                    key={label.text}
+                                >
                                     {label.text}
                                 </Label>
                             );

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -44,7 +44,7 @@ export type ListComplianceCheckClusterResponse = {
 /**
  * Fetches statuses per cluster based off a single check.
  */
-export function GetComplianceProfileCheckResult(
+export function getComplianceProfileCheckResult(
     profileName: string,
     checkName: string
 ): Promise<ListComplianceCheckClusterResponse> {

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -18,6 +18,7 @@ export type ClusterCheckStatus = {
     status: ComplianceCheckStatus;
     createdTime: string; // ISO 8601 date string
     checkUid: string;
+    lastScanTime: string; // ISO 8601 date string
 };
 
 export type ComplianceCheckResult = {
@@ -32,6 +33,27 @@ export type ComplianceCheckResult = {
     valuesUsed: string[];
     warnings: string[];
 };
+
+export type ListComplianceCheckClusterResponse = {
+    checkResults: ClusterCheckStatus[];
+    profileName: string;
+    checkName: string;
+    totalCount: number;
+};
+
+/**
+ * Fetches statuses per cluster based off a single check.
+ */
+export function GetComplianceProfileCheckResult(
+    profileName: string,
+    checkName: string
+): Promise<ListComplianceCheckClusterResponse> {
+    return axios
+        .get<ListComplianceCheckClusterResponse>(
+            `${complianceResultsBaseUrl}/results/profiles/${profileName}/checks/${checkName}`
+        )
+        .then((response) => response.data);
+}
 
 /**
  * Fetches the profile check results.


### PR DESCRIPTION
## Description

Create a table to display check details results by cluster

Notes:

- That check details modal when clicking on the status will come at a later date. We need to figure out how we are going to pull that info into the `CheckDetailsPage` component. However, we should be able to use the `CheckStatusModal` once we pull that data in.
- Changed error handling so that the table can still be displayed in the off chance that fetching check stats results in an error
- Now we only show the label group for non-zero counts

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![Screenshot 2024-05-23 at 10 09 59 AM](https://github.com/stackrox/stackrox/assets/61400697/7d0e2c10-8c66-4b05-a47c-127569654395)
