### PR TITLE
test(scannerv4): Use e2-standard-16 machines on OCP

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -50,3 +50,8 @@ if [[ "${JOB_NAME:-}" =~ -eks- ]]; then
     aws sts get-caller-identity | jq -r '.Arn'
     set_ci_shared_export USER_ARNS "$(aws sts get-caller-identity | jq -r '.Arn')"
 fi
+
+if [[ "${JOB_NAME:-}" =~ ocp-.*-scanner-v4-tests.* ]]; then
+    info "Setting worker node type for OCP Scanner V4 tests to e2-standard-16"
+    set_ci_shared_export WORKER_NODE_TYPE e2-standard-16
+fi

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 REPORTS_DIR=$(mktemp -d)
 FAILED=0
 
+echo "Worker node types for Scanner V4 tests:"
+kubectl get nodes -o json | \
+    jq -jr '.items[] | .metadata.name, ": ", .metadata.labels."beta.kubernetes.io/instance-type", "\n"'
+echo
+
 bats \
     --print-output-on-failure \
     --verbose-run \


### PR DESCRIPTION
## Description

Use bigger machine types for worker nodes for the Scanner V4 tests when running on OCP because of the huge resource requirements. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Just CI.

Verified that the expected machine types are printed to the CI logs.
