### PR TITLE
ROX-19958: Adjust Fast Stream builds to be manifest-deployable

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -54,7 +54,7 @@ spec:
     type: string
   - default: "-fast"
     description: Suffix that will be appended to the output image tag.
-    name: output-image-tag-suffix
+    name: output-tag-suffix
     type: string
   - default: .
     description: Path to the source code of an application's component from where
@@ -183,7 +183,7 @@ spec:
   - name: determine-image-tag
     params:
     - name: tag-suffix
-      value: $(params.output-image-tag-suffix)
+      value: $(params.output-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository
@@ -230,7 +230,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -228,6 +228,9 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -52,6 +52,10 @@ spec:
   - description: Output Image Repository
     name: output-image-repo
     type: string
+  - default: "-fast"
+    description: Suffix that will be appended to the output image tag.
+    name: output-image-tag-suffix
+    type: string
   - default: .
     description: Path to the source code of an application's component from where
       to build image.
@@ -177,6 +181,9 @@ spec:
       workspace: git-auth
 
   - name: determine-image-tag
+    params:
+    - name: tag-suffix
+      value: $(params.output-image-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository

--- a/.tekton/determine-image-tag-task.yaml
+++ b/.tekton/determine-image-tag-task.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   description: Determines the tag for the output image using the StackRox convention from 'make tag' output.
   params:
+  - name: tag-suffix
+    description: Suffix to append to generated image tag.
+    type: string
   results:
   - name: image-tag
     description: Image Tag determined by custom logic.
@@ -20,7 +23,7 @@ spec:
       dnf -y install git make
       cd "$(workspaces.source.path)/source"
       scripts/konflux/fail-build-if-git-is-dirty.sh
-      echo -n "$(make --quiet --no-print-directory tag)-fast" | tee "$(results.image-tag.path)"
+      echo -n "$(make --quiet --no-print-directory tag)$(params.tag-suffix)" | tee "$(results.image-tag.path)"
   workspaces:
   - name: source
     description: The workspace where source code is included.

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -261,6 +261,9 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
     runAfter:
     - copy-subscription-manager-activation-key
     - prefetch-dependencies

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -52,6 +52,10 @@ spec:
   - description: Output Image Repository
     name: output-image-repo
     type: string
+  - default: "-fast"
+    description: Suffix that will be appended to the output image tag.
+    name: output-image-tag-suffix
+    type: string
   - default: .
     description: Path to the source code of an application's component from where
       to build image.
@@ -178,6 +182,9 @@ spec:
       workspace: git-auth
 
   - name: determine-image-tag
+    params:
+    - name: tag-suffix
+      value: $(params.output-image-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -54,7 +54,7 @@ spec:
     type: string
   - default: "-fast"
     description: Suffix that will be appended to the output image tag.
-    name: output-image-tag-suffix
+    name: output-tag-suffix
     type: string
   - default: .
     description: Path to the source code of an application's component from where
@@ -184,7 +184,7 @@ spec:
   - name: determine-image-tag
     params:
     - name: tag-suffix
-      value: $(params.output-image-tag-suffix)
+      value: $(params.output-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository
@@ -263,7 +263,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
     runAfter:
     - copy-subscription-manager-activation-key
     - prefetch-dependencies

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -53,8 +53,8 @@ spec:
     name: output-image-repo
     type: string
   - default: "-fast"
-    description: Suffix that will be appended to the output image tag.
-    name: output-image-tag-suffix
+    description: Suffix that will be appended to the output image tag and embedded version strings.
+    name: output-tag-suffix
     type: string
   - default: .
     description: Path to the source code of an application's component from where
@@ -183,7 +183,7 @@ spec:
   - name: determine-image-tag
     params:
     - name: tag-suffix
-      value: $(params.output-image-tag-suffix)
+      value: $(params.output-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository
@@ -242,7 +242,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
     runAfter:
     - prefetch-dependencies
     - fetch-vuln-mappings

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -240,6 +240,9 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - VERSIONS_SUFFIX=$(params.output-image-tag-suffix)
     runAfter:
     - prefetch-dependencies
     - fetch-vuln-mappings

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -52,6 +52,10 @@ spec:
   - description: Output Image Repository
     name: output-image-repo
     type: string
+  - default: "-fast"
+    description: Suffix that will be appended to the output image tag.
+    name: output-image-tag-suffix
+    type: string
   - default: .
     description: Path to the source code of an application's component from where
       to build image.
@@ -177,6 +181,9 @@ spec:
       workspace: git-auth
 
   - name: determine-image-tag
+    params:
+    - name: tag-suffix
+      value: $(params.output-image-tag-suffix)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SILENT ?= @
 UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests|stackrox/rox/operator/tests|stackrox/rox/central/reports/config/store/postgres|stackrox/rox/central/complianceoperator/v2/scanconfigurations/store/postgres|stackrox/rox/central/auth/store/postgres|stackrox/rox/scanner/e2etests"
 
 ifeq ($(TAG),)
-TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')
+TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')$(MAIN_TAG_SUFFIX)
 endif
 
 # Set expiration on Quay.io for non-release tags.
@@ -750,11 +750,11 @@ ossls-notice: deps
 
 .PHONY: collector-tag
 collector-tag:
-	@cat COLLECTOR_VERSION
+	@echo "$$(cat COLLECTOR_VERSION)$(COLLECTOR_TAG_SUFFIX)"
 
 .PHONY: scanner-tag
 scanner-tag:
-	@cat SCANNER_VERSION
+	@echo "$$(cat SCANNER_VERSION)$(SCANNER_TAG_SUFFIX)"
 
 .PHONY: clean-dev-tools
 clean-dev-tools: gotools-clean

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -124,11 +124,11 @@ LABEL \
 
 EXPOSE 8443
 
-# TODO(ROX-22245): set proper image flavor for Fast Stream images.
+# TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
 # TODO(ROX-22338): switch branding to RHACS_BRANDING when intermediate Konflux repos aren't public.
 ENV PATH="/stackrox:$PATH" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
-    ROX_IMAGE_FLAVOR="rhacs" \
+    ROX_IMAGE_FLAVOR="development_build" \
     ROX_PRODUCT_BRANDING="STACKROX_BRANDING"
 
 COPY .konflux/stackrox-data/external-networks/external-networks.zip /stackrox/static-data/external-networks/external-networks.zip

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -74,8 +74,7 @@ ENV PATH="$PATH:/go/src/github.com/stackrox/rox/app/scripts/konflux/bootstrap-ya
 
 # This sets branding during UI build time. This is to make sure UI is branded as commercial RHACS (not StackRox).
 # ROX_PRODUCT_BRANDING is also set in the resulting image so that Central Go code knows its RHACS.
-# TODO(ROX-22338): switch branding to RHACS_BRANDING when intermediate Konflux repos aren't public.
-ENV ROX_PRODUCT_BRANDING="STACKROX_BRANDING"
+ENV ROX_PRODUCT_BRANDING="RHACS_BRANDING"
 
 # UI build is not hermetic because Cachi2 does not support pulling packages according to V1 of yarn.lock.
 # TODO(ROX-20723): enable yarn package prefetch and make UI builds hermetic.
@@ -125,11 +124,10 @@ LABEL \
 EXPOSE 8443
 
 # TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
-# TODO(ROX-22338): switch branding to RHACS_BRANDING when intermediate Konflux repos aren't public.
 ENV PATH="/stackrox:$PATH" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
     ROX_IMAGE_FLAVOR="development_build" \
-    ROX_PRODUCT_BRANDING="STACKROX_BRANDING"
+    ROX_PRODUCT_BRANDING="RHACS_BRANDING"
 
 COPY .konflux/stackrox-data/external-networks/external-networks.zip /stackrox/static-data/external-networks/external-networks.zip
 

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -45,8 +45,6 @@ ENV MAIN_TAG_SUFFIX="$VERSIONS_SUFFIX" COLLECTOR_TAG_SUFFIX="$VERSIONS_SUFFIX" S
 
 ENV GOFLAGS=""
 ENV CGO_ENABLED=1
-# TODO(ROX-19958): figure out if we need BUILD_TAG
-# ENV BUILD_TAG="${CI_VERSION}"
 # TODO(ROX-24276): re-enable release builds for fast stream.
 # TODO(ROX-20240): enable non-release development builds.
 # ENV GOTAGS="release"

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -40,6 +40,9 @@ COPY . .
 RUN git restore scripts/konflux/bootstrap-yarn/package-lock.json && \
     scripts/konflux/fail-build-if-git-is-dirty.sh
 
+ARG VERSIONS_SUFFIX
+ENV MAIN_TAG_SUFFIX="$VERSIONS_SUFFIX" COLLECTOR_TAG_SUFFIX="$VERSIONS_SUFFIX" SCANNER_TAG_SUFFIX="$VERSIONS_SUFFIX"
+
 ENV GOFLAGS=""
 ENV CGO_ENABLED=1
 # TODO(ROX-19958): figure out if we need BUILD_TAG

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -16,6 +16,9 @@ RUN scripts/konflux/fail-build-if-git-is-dirty.sh
 
 RUN mkdir -p image/bin
 
+ARG VERSIONS_SUFFIX
+ENV MAIN_TAG_SUFFIX="$VERSIONS_SUFFIX" COLLECTOR_TAG_SUFFIX="$VERSIONS_SUFFIX" SCANNER_TAG_SUFFIX="$VERSIONS_SUFFIX"
+
 ENV CI=1 GOFLAGS=""
 # TODO(ROX-24276): re-enable release builds for fast stream.
 # TODO(ROX-20240): enable non-release development builds.

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -24,8 +24,7 @@ ENV CI=1 GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
 # ENV GOTAGS="release"
 
-# TODO(ROX-19958): figure out if setting BUILD_TAG is actually needed.
-RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) BUILD_TAG=$(make tag) scripts/go-build.sh ./roxctl && \
+RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build.sh ./roxctl && \
     cp bin/linux_$(go env GOARCH)/roxctl image/bin/roxctl
 
 # TODO(ROX-20312): pin image tags when there's a process that updates them automatically.

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -17,8 +17,7 @@ ENV MAIN_TAG_SUFFIX="$VERSIONS_SUFFIX" COLLECTOR_TAG_SUFFIX="$VERSIONS_SUFFIX" S
 # GOTAGS="release"
 ENV CI=1 GOFLAGS="" CGO_ENABLED=1
 
-# TODO(ROX-19958): figure out if setting BUILD_TAG is actually needed.
-RUN GOOS=linux GOARCH=$(go env GOARCH) BUILD_TAG=$(make tag) scripts/go-build.sh operator && \
+RUN GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build.sh operator && \
     cp bin/linux_$(go env GOARCH)/operator image/bin/operator
 
 # TODO(ROX-20312): pin image tags when there's a process that updates them automatically.

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -47,8 +47,8 @@ RUN microdnf upgrade -y --nobest && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-# TODO(ROX-22245): set proper image flavor for Fast Stream images.
-ENV ROX_IMAGE_FLAVOR="rhacs"
+# TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
+ENV ROX_IMAGE_FLAVOR="development_build"
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -8,6 +8,9 @@ COPY . .
 
 RUN scripts/konflux/fail-build-if-git-is-dirty.sh
 
+ARG VERSIONS_SUFFIX
+ENV MAIN_TAG_SUFFIX="$VERSIONS_SUFFIX" COLLECTOR_TAG_SUFFIX="$VERSIONS_SUFFIX" SCANNER_TAG_SUFFIX="$VERSIONS_SUFFIX"
+
 # Build the operator binary.
 # TODO(ROX-24276): re-enable release builds for fast stream.
 # TODO(ROX-20240): enable non-release development builds.

--- a/status.sh
+++ b/status.sh
@@ -2,6 +2,6 @@
 
 # Note: This requires .git directory in the build context (e.g. builder container)
 echo "STABLE_MAIN_VERSION $(make --quiet --no-print-directory tag)"
-echo "STABLE_COLLECTOR_VERSION $(cat COLLECTOR_VERSION)"
-echo "STABLE_SCANNER_VERSION $(cat SCANNER_VERSION)"
+echo "STABLE_COLLECTOR_VERSION $(make --quiet --no-print-directory collector-tag)"
+echo "STABLE_SCANNER_VERSION $(make --quiet --no-print-directory scanner-tag)"
 echo "STABLE_GIT_SHORT_SHA $(make --quiet --no-print-directory shortcommit)"


### PR DESCRIPTION
## Description

This also addresses ROX-22338.

## Checklist
- [x] Investigated and inspected CI test results

These aren't relevant and won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] I verified that E2E tests have no regressions caused by this.
- [x] Deployed the product with manifests without image repo/tag overrides and got a functioning product (no smoke test, just cluster and system status).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
