### PR TITLE
ROX-24163: (tmp) Introduce debug server to access Sensors in memory node store

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
     - '*-nightly-*'
     branches:
     - master
+    - 'maple/customer-support'
+    - 'maple/ROX-24163-debug-server'
   pull_request:
     types:
     - opened

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 include $(CURDIR)/make/env.mk
 
+DEBUG_BUILD=yes
 PLATFORM ?= linux/amd64
 ROX_PROJECT=apollo
 TESTFLAGS=-race -p 4

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -146,8 +146,8 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "k8s_event_processing_duration",
-		Help:      "Time taken to fully process an event from Kubernetes",
-		Buckets:   prometheus.ExponentialBuckets(4, 2, 8),
+		Help:      "Time taken in milliseconds to fully process an event from Kubernetes",
+		Buckets:   prometheus.ExponentialBuckets(4, 2, 12),
 	}, []string{"Action", "Resource", "Dispatcher"})
 
 	clusterMetricsNodeCountGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/deploy/common/sensor-toxiproxy-patch.json
+++ b/deploy/common/sensor-toxiproxy-patch.json
@@ -4,7 +4,7 @@
     "path": "/spec/template/spec/containers/-",
     "value": {
       "name": "toxiproxy",
-      "image": "ghcr.io/shopify/toxiproxy:2.5.0",
+      "image": "ghcr.io/shopify/toxiproxy:2.9.0",
       "args": [
         "-config",
         "/etc/toxiproxy/config.json"

--- a/fetch-core-dump.sh
+++ b/fetch-core-dump.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# get sensor pod name
+sensor_pod_name="$(kubectl -n stackrox get pods -l app=sensor -o=jsonpath='{.items[0].metadata.name}')"
+
+# Create core dump
+kubectl exec ${sensor_pod_name} -- /bin/bash -c "cd /var/cache/stackrox && /bin/bash -c 'gcore 1'"
+
+# Copy core-dump
+kubectl cp "${sensor_pod_name}:/var/cache/stackrox/core.1" "core-dump-${sensor_pod_name}"

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -56,13 +56,8 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 util-linux && \
+    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 util-linux gdb tar && \
     microdnf clean all -y && \
-    rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
-    # (Optional) Remove line below to keep package management utilities
-    # TODO(ROX-13934): Potentially add *RPM* to this list again
-    rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -78,4 +78,7 @@ var (
 	// You can choose between "all" for everything, or one of the following:
 	// role, rolebinding, clusterrole, clusterrolebinding, serviceaccount, secret, misc
 	InformerTraceLogs = RegisterSetting("ROX_INFORMER_TRACE_LOGS", WithDefault(""))
+
+	// FakeTLSCheck disables network calls (during sensor sync) to check TLS of registries defined in dockerconfig secrets
+	FakeTLSCheck = RegisterBooleanSetting("ROX_FAKE_TLSCHECK", false)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -73,4 +73,9 @@ var (
 	// DiagnosticDataCollectionTimeout defines the timeout for the diagnostic data collection on Sensor side.
 	DiagnosticDataCollectionTimeout = registerDurationSetting("ROX_DIAGNOSTIC_DATA_COLLECTION_TIMEOUT",
 		2*time.Minute)
+
+	// InformerTraceLogs enable the trace logs for Kubernetes informer SYNC messages.
+	// You can choose between "all" for everything, or one of the following:
+	// role, rolebinding, clusterrole, clusterrolebinding, serviceaccount, secret, misc
+	InformerTraceLogs = RegisterSetting("ROX_INFORMER_TRACE_LOGS", WithDefault(""))
 )

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	proxyReloadInterval = 5 * time.Second
+	tlsHandshakeTimeout = 2 * time.Second
 )
 
 var (
@@ -127,7 +128,9 @@ func AwareDialContextTLS(ctx context.Context, address string, tlsClientConf *tls
 	log.Debugf("ROX-24163 handshaking %s", address)
 	defer log.Debugf("ROX-24163 [END] handshaking %s", address)
 	tlsConn := tls.Client(conn, tlsClientConf)
-	if err := tlsConn.Handshake(); err != nil {
+	ctxHandshake, cancel := context.WithTimeout(ctx, tlsHandshakeTimeout)
+	defer cancel()
+	if err := tlsConn.HandshakeContext(ctxHandshake); err != nil {
 		utils.IgnoreError(tlsConn.Close)
 		return nil, err
 	}

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -110,7 +110,9 @@ func AwareDialContextTLS(ctx context.Context, address string, tlsClientConf *tls
 		return nil, errors.Wrapf(err, "unparseable address %q", address)
 	}
 
+	log.Debugf("ROX-24163 AwareDialContext dialing %s", address)
 	conn, err := AwareDialContext(ctx, address)
+	log.Debugf("ROX-24163 [END] AwareDialContext dialing %s", address)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +124,8 @@ func AwareDialContextTLS(ctx context.Context, address string, tlsClientConf *tls
 		tlsClientConf = tlsClientConf.Clone()
 		tlsClientConf.ServerName = host
 	}
+	log.Debugf("ROX-24163 handshaking %s", address)
+	defer log.Debugf("ROX-24163 [END] handshaking %s", address)
 	tlsConn := tls.Client(conn, tlsClientConf)
 	if err := tlsConn.Handshake(); err != nil {
 		utils.IgnoreError(tlsConn.Close)

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -128,9 +128,7 @@ func AwareDialContextTLS(ctx context.Context, address string, tlsClientConf *tls
 	log.Debugf("ROX-24163 handshaking %s", address)
 	defer log.Debugf("ROX-24163 [END] handshaking %s", address)
 	tlsConn := tls.Client(conn, tlsClientConf)
-	ctxHandshake, cancel := context.WithTimeout(ctx, tlsHandshakeTimeout)
-	defer cancel()
-	if err := tlsConn.HandshakeContext(ctxHandshake); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		utils.IgnoreError(tlsConn.Close)
 		return nil, err
 	}

--- a/pkg/tlscheck/tlscheck.go
+++ b/pkg/tlscheck/tlscheck.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
@@ -17,6 +18,8 @@ import (
 const (
 	timeout = 2 * time.Second
 )
+
+var log = logging.LoggerForModule()
 
 // CheckTLS checks if the address is using TLS
 func CheckTLS(ctx context.Context, origAddr string) (bool, error) {
@@ -40,7 +43,9 @@ func CheckTLS(ctx context.Context, origAddr string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	log.Debugf("ROX-24163 dialing %s:%s", host, port)
 	conn, err := proxy.AwareDialContextTLS(ctx, fmt.Sprintf("%s:%s", host, port), nil)
+	log.Debugf("ROX-24163 [END] dialing %s:%s", host, port)
 	if err != nil {
 		switch err.(type) {
 		case x509.CertificateInvalidError,

--- a/pkg/tlscheck/tlscheck.go
+++ b/pkg/tlscheck/tlscheck.go
@@ -21,6 +21,10 @@ const (
 
 var log = logging.LoggerForModule()
 
+func CheckTLSHardcoded(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
 // CheckTLS checks if the address is using TLS
 func CheckTLS(ctx context.Context, origAddr string) (bool, error) {
 	addr := urlfmt.TrimHTTPPrefixes(origAddr)

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -23,6 +23,9 @@ const (
 
 	// SensorComponentEventSyncFinished denotes that Sensor finished initial sync.
 	SensorComponentEventSyncFinished SensorComponentEvent = "sync-finished"
+
+	// SensorComponentEventResourceSyncFinished denotes that Sensor finished the k8s resource sync
+	SensorComponentEventResourceSyncFinished SensorComponentEvent = "resource-sync-finished"
 )
 
 // LogSensorComponentEvent returns a unified string for logging the transition between component states/
@@ -42,6 +45,8 @@ func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string)
 		mode = "Offline"
 	case SensorComponentEventSyncFinished:
 		return fmt.Sprintf("%s has received the SyncFinished notification", name)
+	case SensorComponentEventResourceSyncFinished:
+		return fmt.Sprintf("%s has received the ResourceSyncFinished notification", name)
 	}
 	return fmt.Sprintf("%s runs now in %s mode", name, mode)
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -627,7 +627,7 @@ type networkEntityDetails struct {
 func (d *detectorImpl) getNetworkFlowEntityDetails(info *storage.NetworkEntityInfo) (networkEntityDetails, error) {
 	switch info.GetType() {
 	case storage.NetworkEntityInfo_DEPLOYMENT:
-		deployment := d.deploymentStore.Get(info.GetId())
+		deployment := d.deploymentStore.GetSnapshot(info.GetId())
 		if deployment == nil {
 			// Maybe the deployment is already removed. Don't run the flow through policy anymore
 			return networkEntityDetails{}, errors.Wrapf(deploymentNotFoundErr, "Deployment with ID: %q not found while trying to run network flow policy", info.GetId())

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -1,0 +1,56 @@
+package internalmessage
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+const (
+	// SensorMessageSoftRestart is a message kind where components require sensor-central connection to restart.
+	SensorMessageSoftRestart = "SensorMessage_SoftRestart"
+)
+
+// SensorInternalMessageCallback is the callback used by subscribers.
+type SensorInternalMessageCallback func(message *SensorInternalMessage)
+
+// NewMessageSubscriber creates a MessageSubscriber.
+func NewMessageSubscriber() *MessageSubscriber {
+	return &MessageSubscriber{
+		subscribers: map[string][]SensorInternalMessageCallback{
+			SensorMessageSoftRestart: {},
+		},
+		lock: &sync.RWMutex{},
+	}
+}
+
+// MessageSubscriber is a lightweight PubSub-like component that can be used to register callbacks and publish
+// messages.
+type MessageSubscriber struct {
+	subscribers map[string][]SensorInternalMessageCallback
+	lock        *sync.RWMutex
+}
+
+// Publish a message to all subscribers.
+func (m *MessageSubscriber) Publish(msg *SensorInternalMessage) error {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if arr, ok := m.subscribers[msg.Kind]; ok {
+		for _, subCallback := range arr {
+			go subCallback(msg)
+		}
+		return nil
+	}
+	return errors.Errorf("message type %s not found: %v", msg.Kind, msg)
+}
+
+// Subscribe registers a callback based on a message kind.
+func (m *MessageSubscriber) Subscribe(kind string, handler SensorInternalMessageCallback) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if arr, ok := m.subscribers[kind]; ok {
+		arr = append(arr, handler)
+		m.subscribers[kind] = arr
+		return nil
+	}
+	return errors.Errorf("message type %s not found", kind)
+}

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -8,6 +8,9 @@ import (
 const (
 	// SensorMessageSoftRestart is a message kind where components require sensor-central connection to restart.
 	SensorMessageSoftRestart = "SensorMessage_SoftRestart"
+
+	// SensorMessageResourceSyncFinished is a message kind where components require the resource sync to be finished.
+	SensorMessageResourceSyncFinished = "SensorMessage_ResourceSyncFinished"
 )
 
 // SensorInternalMessageCallback is the callback used by subscribers.
@@ -17,7 +20,8 @@ type SensorInternalMessageCallback func(message *SensorInternalMessage)
 func NewMessageSubscriber() *MessageSubscriber {
 	return &MessageSubscriber{
 		subscribers: map[string][]SensorInternalMessageCallback{
-			SensorMessageSoftRestart: {},
+			SensorMessageSoftRestart:          {},
+			SensorMessageResourceSyncFinished: {},
 		},
 		lock: &sync.RWMutex{},
 	}

--- a/sensor/common/internalmessage/message.go
+++ b/sensor/common/internalmessage/message.go
@@ -1,0 +1,28 @@
+package internalmessage
+
+import (
+	"github.com/stackrox/rox/pkg/concurrency"
+)
+
+// SensorInternalMessage is the implementation data structure for text based internal messages.
+type SensorInternalMessage struct {
+	Kind     string
+	Validity concurrency.Waitable
+	Text     string
+}
+
+// IsExpired is a helper function that checks if the context already expired without blocking.
+// If the context isn't set this function will always return false.
+func (im *SensorInternalMessage) IsExpired() bool {
+
+	if im.Validity == nil {
+		return false
+	}
+
+	select {
+	case <-im.Validity.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -537,7 +537,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connection",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: expectEntityLookupContainerHelper(mockEntity, 1, clusterentities.ContainerMetadata{
 				DeploymentID: srcID,
 			}, true),
@@ -560,7 +560,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connections",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -607,7 +607,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received endpoints",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -696,7 +696,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(1)
 	mockEntity.EXPECT().RecordTick().AnyTimes()
 	addHostConnection(m, createHostnameConnections(hostname).withConnectionPair(createConnectionPair()))
-	m.Notify(common.SensorComponentEventCentralReachable)
+	m.Notify(common.SensorComponentEventSyncFinished)
 	fakeTicker <- time.Now()
 	select {
 	case <-time.After(10 * time.Second):
@@ -704,7 +704,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	case msg, ok := <-m.sensorUpdates:
 		s.Require().True(ok, "the sensorUpdates channel should not be closed")
 		m.Notify(common.SensorComponentEventOfflineMode)
-		m.Notify(common.SensorComponentEventCentralReachable)
+		m.Notify(common.SensorComponentEventSyncFinished)
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)
@@ -738,7 +738,7 @@ func (b *sendNetflowsSuite) SetupTest() {
 }
 
 func (b *sendNetflowsSuite) TeardownTest() {
-	b.m.done.Signal()
+	b.m.stopper.Client().Stop()
 }
 
 func (b *sendNetflowsSuite) updateConn(pair *connectionPair) {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -537,7 +537,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connection",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: expectEntityLookupContainerHelper(mockEntity, 1, clusterentities.ContainerMetadata{
 				DeploymentID: srcID,
 			}, true),
@@ -560,7 +560,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connections",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -607,7 +607,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received endpoints",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -696,7 +696,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(1)
 	mockEntity.EXPECT().RecordTick().AnyTimes()
 	addHostConnection(m, createHostnameConnections(hostname).withConnectionPair(createConnectionPair()))
-	m.Notify(common.SensorComponentEventSyncFinished)
+	m.Notify(common.SensorComponentEventResourceSyncFinished)
 	fakeTicker <- time.Now()
 	select {
 	case <-time.After(10 * time.Second):
@@ -704,7 +704,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	case msg, ok := <-m.sensorUpdates:
 		s.Require().True(ok, "the sensorUpdates channel should not be closed")
 		m.Notify(common.SensorComponentEventOfflineMode)
-		m.Notify(common.SensorComponentEventSyncFinished)
+		m.Notify(common.SensorComponentEventResourceSyncFinished)
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
-	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -27,15 +26,14 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		clusterEntities:   mockEntityStore,
 		externalSrcs:      mockExternalStore,
 		policyDetector:    mockDetector,
-		done:              concurrency.NewSignal(),
 		connectionsByHost: make(map[string]*hostConnections),
 		sensorUpdates:     make(chan *message.ExpiringMessage, 5),
 		publicIPs:         newPublicIPsManager(),
 		centralReady:      concurrency.NewSignal(),
 		enricherTicker:    ticker,
-		finished:          &sync.WaitGroup{},
 		activeConnections: make(map[connection]*networkConnIndicator),
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicator),
+		stopper:           concurrency.NewStopper(),
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -85,7 +85,7 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 	store := &Store{
 		factory:                     regFactory,
 		store:                       make(map[string]registries.Set),
-		checkTLSFunc:                tlscheck.CheckTLSHardcoded,
+		checkTLSFunc:                tlscheck.CheckTLS,
 		globalRegistries:            registries.NewSet(regFactory, types.WithGCPTokenManager(gcp.Singleton())),
 		centralRegistryIntegrations: registries.NewSet(regFactory, types.WithGCPTokenManager(gcp.Singleton())),
 		clusterLocalRegistryHosts:   set.NewStringSet(),

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -194,6 +194,11 @@ func (rs *Store) RemoveSecretID(id string) bool {
 	return rs.knownSecretIDs.Remove(id)
 }
 
+// GetAllSecretIDs returns array of all secret IDs
+func (rs *Store) GetAllSecretIDs() []string {
+	return rs.knownSecretIDs.AsSlice()
+}
+
 // UpsertRegistry upserts the given registry with the given credentials in the given namespace into the store.
 func (rs *Store) UpsertRegistry(ctx context.Context, namespace, registry string, dce config.DockerConfigEntry) error {
 	secure, skip, err := rs.checkTLS(ctx, registry)
@@ -228,6 +233,16 @@ func (rs *Store) getRegistriesInNamespace(namespace string) registries.Set {
 	defer rs.mutex.RUnlock()
 
 	return rs.store[namespace]
+}
+
+// GetAllImageRegistries returns all image registries
+func (rs *Store) GetAllImageRegistries() []types.ImageRegistry {
+	var reg []types.ImageRegistry
+	for _, ns := range rs.store {
+		reg = append(reg, ns.GetAll()...)
+	}
+	reg = append(reg, rs.globalRegistries.GetAll()...)
+	return reg
 }
 
 // GetRegistryForImageInNamespace returns the stored registry that matches image.Registry

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -211,13 +211,16 @@ func (rs *Store) UpsertRegistry(ctx context.Context, namespace, registry string,
 		return nil
 	}
 
+	log.Debugf("ROX-24163 get registries for namespace %s registry %s", namespace, registry)
 	regs := rs.getRegistries(namespace)
 
 	// remove http/https prefixes from registry, matching may fail otherwise, the created registry.url will have
 	// the appropriate prefix
 	registry = urlfmt.TrimHTTPPrefixes(registry)
 	name := genIntegrationName(pullSecretNamePrefix, namespace, registry)
+	log.Debugf("ROX-24163 UpdateImageIntegration for registry %s", registry)
 	err = regs.UpdateImageIntegration(createImageIntegration(registry, dce, secure, name))
+	log.Debugf("ROX-24163 [END] UpdateImageIntegration for registry %s", registry)
 	if err != nil {
 		return errors.Wrapf(err, "updating registry store with registry %q", registry)
 	}

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -84,7 +84,7 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 	store := &Store{
 		factory:                     regFactory,
 		store:                       make(map[string]registries.Set),
-		checkTLSFunc:                tlscheck.CheckTLS,
+		checkTLSFunc:                tlscheck.CheckTLSHardcoded,
 		globalRegistries:            registries.NewSet(regFactory, types.WithGCPTokenManager(gcp.Singleton())),
 		centralRegistryIntegrations: registries.NewSet(regFactory, types.WithGCPTokenManager(gcp.Singleton())),
 		clusterLocalRegistryHosts:   set.NewStringSet(),

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/docker/config"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries"
@@ -94,6 +95,9 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 
 	if checkTLS != nil {
 		store.checkTLSFunc = checkTLS
+	}
+	if env.FakeTLSCheck.BooleanSetting() {
+		store.checkTLSFunc = tlscheck.CheckTLSHardcoded
 	}
 
 	return store

--- a/sensor/common/registry/tlscheck.go
+++ b/sensor/common/registry/tlscheck.go
@@ -39,7 +39,9 @@ func (rs *Store) checkTLS(ctx context.Context, registry string) (secure bool, sk
 		utils.Should(errors.Errorf("Unsupported TLS check result: %v", result))
 	}
 
+	log.Debugf("ROX-24163 the TLS check result is not cached for the registry %s", registry)
 	secure, err = rs.doAndCacheTLSCheck(ctx, registry)
+	log.Debugf("ROX-24163 [END] the TLS check result is not cached for the registry %s: secured? %t error %v", registry, secure, err)
 	return secure, false, err
 }
 

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -52,6 +52,7 @@ type centralCommunicationImpl struct {
 }
 
 var (
+	errForcedConnectionRestart       = errors.New("forced connection restart")
 	errCantReconcile                 = errors.New("unable to reconcile")
 	errLargePayload                  = errors.Wrap(errCantReconcile, "deduper payload too large")
 	errTimeoutWaitingForDeduperState = errors.Wrap(errCantReconcile, "timeout reached while waiting for the DeduperState")

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/image"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/scannerclient"
 	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
 )
@@ -68,12 +69,15 @@ type Sensor struct {
 	webhookServer   pkgGRPC.API
 	profilingServer *http.Server
 
+	pubSub *internalmessage.MessageSubscriber
+
 	currentState    common.SensorComponentEvent
 	currentStateMtx *sync.Mutex
 
 	centralConnection        *grpcUtil.LazyClientConn
 	centralCommunication     CentralCommunication
 	centralConnectionFactory centralclient.CentralConnectionFactory
+	centralCommunicationLock *sync.Mutex
 
 	stoppedSig concurrency.ErrorSignal
 
@@ -88,12 +92,14 @@ func NewSensor(
 	detector detector.Detector,
 	imageService image.Service,
 	centralConnectionFactory centralclient.CentralConnectionFactory,
+	pubSub *internalmessage.MessageSubscriber,
 	components ...common.SensorComponent,
 ) *Sensor {
 	return &Sensor{
 		centralEndpoint:    env.CentralEndpoint.Setting(),
 		advertisedEndpoint: env.AdvertisedEndpoint.Setting(),
 
+		pubSub:        pubSub,
 		configHandler: configHandler,
 		detector:      detector,
 		imageService:  imageService,
@@ -101,6 +107,7 @@ func NewSensor(
 
 		centralConnectionFactory: centralConnectionFactory,
 		centralConnection:        grpcUtil.NewLazyClientConn(),
+		centralCommunicationLock: &sync.Mutex{},
 
 		currentState:    common.SensorComponentEventOfflineMode,
 		currentStateMtx: &sync.Mutex{},
@@ -265,6 +272,24 @@ func (s *Sensor) Start() {
 	okSig := s.centralConnectionFactory.OkSignal()
 	errSig := s.centralConnectionFactory.StopSignal()
 
+	err = s.pubSub.Subscribe(internalmessage.SensorMessageSoftRestart, func(message *internalmessage.SensorInternalMessage) {
+		if message.IsExpired() {
+			return
+		}
+
+		s.centralCommunicationLock.Lock()
+		defer s.centralCommunicationLock.Unlock()
+		if s.centralCommunication == nil {
+			log.Warnf("Sensor connection was not yet established when internal message for connection restart was received. Skipping soft restart")
+			return
+		}
+		s.centralCommunication.Stop(errors.Wrap(errForcedConnectionRestart, message.Text))
+	})
+
+	if err != nil {
+		log.Warnf("Failed to register subscription to sensor internal message: %q", err)
+	}
+
 	if features.PreventSensorRestartOnDisconnect.Enabled() {
 		log.Info("Running Sensor with connection retry: preventing sensor restart on disconnect")
 		go s.communicationWithCentralWithRetries(&centralReachable)
@@ -416,7 +441,9 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// suddenly broke.
 		centralCommunication := NewCentralCommunication(s.reconnect.Load(), s.reconcile.Load(), s.components...)
 		syncDone := concurrency.NewSignal()
-		s.centralCommunication = centralCommunication
+		concurrency.WithLock(s.centralCommunicationLock, func() {
+			s.centralCommunication = centralCommunication
+		})
 		centralCommunication.Start(central.NewSensorServiceClient(s.centralConnection), centralReachable, &syncDone, s.configHandler, s.detector)
 		go s.notifySyncDone(&syncDone, centralCommunication)
 		// Reset the exponential back-off if the connection succeeds
@@ -432,8 +459,9 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 						log.Warnf("Sensor cannot reconcile due to: %v", err)
 					}
 					s.reconcile.Store(false)
+					log.Infof("Communication with Central stopped with error: %v. Retrying.", err)
 				}
-				log.Infof("Communication with Central stopped with error: %s. Retrying.", err)
+				log.Infof("Communication with Central stopped: %v. Retrying.", err)
 			} else {
 				log.Info("Communication with Central stopped. Retrying.")
 			}

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
@@ -17,8 +18,21 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 )
 
-// New instantiates the eventPipeline component
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int) common.SensorComponent {
+// New instantiates the eventPipeline component. Sensors pipeline is responsible for the entire lifecycle of a Kubernetes
+// event. From receiving it from the listeners, converting it to storage.Deployment, finding related resources to be
+// reprocessed, and sending events directly to Central or to the detector for processing.
+//
+// Components will communicate with each other using component.ResourceEvent data structure. The pipeline is organized as:
+//
+//	Listener -> Resolver -> Output
+//
+// Each component will write and consume different properties from ResourceEvent, and send the event to the next component in the chain.
+// For an explanation what each property means, check the documentation for component.ResourceEvent.
+//
+// This component introduces a new type of component to sensor:
+// - The event pipeline is a sensor component. That means, it can send messages to the gRPC stream via the .ResponseC function.
+// - Pipeline components are sub-components inside the event pipeline that process a kubernetes event from start to finish (listener, resolver and output are all pipeline components)
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int, pubSub *internalmessage.MessageSubscriber) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	depResolver := resolver.New(outputQueue, storeProvider, queueSize)
 	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider)
@@ -36,5 +50,6 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		detector:    detector,
 		reprocessor: reprocessor,
 		offlineMode: offlineMode,
+		pubSub:      pubSub,
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -35,7 +35,7 @@ import (
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int, pubSub *internalmessage.MessageSubscriber) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	depResolver := resolver.New(outputQueue, storeProvider, queueSize)
-	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider)
+	resourceListener := listener.New(client, configHandler, nodeName, traceWriter, depResolver, storeProvider, pubSub)
 
 	offlineMode := &atomic.Bool{}
 	offlineMode.Store(true)

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -30,6 +31,7 @@ type eventPipeline struct {
 	reprocessor reprocessor.Handler
 
 	offlineMode *atomic.Bool
+	pubSub      *internalmessage.MessageSubscriber
 
 	eventsC chan *message.ExpiringMessage
 	stopSig concurrency.Signal

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
@@ -19,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.StoreProvider) component.ContextListener {
+func New(client client.Interface, configHandler config.Handler, nodeName string, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.StoreProvider, pubSub *internalmessage.MessageSubscriber) component.ContextListener {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),
@@ -29,6 +30,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		outputQueue:        queue,
 		storeProvider:      storeProvider,
 		mayCreateHandlers:  concurrency.NewSignal(),
+		pubSub:             pubSub,
 	}
 	k.mayCreateHandlers.Signal()
 	return k

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
@@ -39,6 +40,7 @@ type listenerImpl struct {
 	storeProvider      *resources.StoreProvider
 	mayCreateHandlers  concurrency.Signal
 	context            context.Context
+	pubSub             *internalmessage.MessageSubscriber
 }
 
 func (k *listenerImpl) StartWithContext(ctx context.Context) error {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -300,6 +300,11 @@ func (k *listenerImpl) handleAllEvents() {
 		},
 		Context: k.context,
 	})
+	utils.Should(k.pubSub.Publish(&internalmessage.SensorInternalMessage{
+		Kind:     internalmessage.SensorMessageResourceSyncFinished,
+		Text:     "Finished the k8s resource sync",
+		Validity: k.context,
+	}))
 }
 
 // Helper function that creates and adds a handler to an informer.

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -360,7 +360,7 @@ func handle(
 	wg.Add(1)
 	go func() {
 		defer func() {
-			wg.Done()
+			wg.Add(-1)
 			log.Debugf("ROX-24163 (defer) for %q has synced: hReg=%t informer=%t", name, handlerRegistration.HasSynced(), informer.HasSynced())
 		}()
 		log.Debugf("ROX-24163 (go func) for %q has synced: hReg=%t informer=%t", name, handlerRegistration.HasSynced(), informer.HasSynced())

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/clusterid"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/processfilter"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -354,7 +354,7 @@ func handle(
 			log.Debugf("ROX-24163 handle(%q): WaitForCacheSync failed", name)
 			return
 		}
-		log.Debugf("ROX-24163 handle(%q): calling PopulateInitialObjects for %q", name)
+		log.Debugf("ROX-24163 handle(%q): calling PopulateInitialObjects", name)
 		doneChannel := handlerImpl.PopulateInitialObjects(informer.GetIndexer().List())
 
 		select {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -122,28 +122,23 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Informers that need to be synced initially
 	handle(k.context, namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "namespace")
-	<-noDependencyWaitGroup.Done()
 	cache.WaitForNamedCacheSync("namespaces", stopSignal.Done(), namespaceInformer.HasSynced)
 	log.Info("Successfully synced namespaces")
 
 	handle(k.context, secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "secret")
-	<-noDependencyWaitGroup.Done()
 	cache.WaitForNamedCacheSync("secrets", stopSignal.Done(), secretInformer.HasSynced)
 	log.Info("Successfully synced secrets")
 
 	handle(k.context, saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "sa")
-	<-noDependencyWaitGroup.Done()
 	cache.WaitForNamedCacheSync("sas", stopSignal.Done(), saInformer.HasSynced)
 	log.Info("Successfully synced service accounts")
 
 	// Roles need to be synced before role bindings because role bindings have a reference
 	handle(k.context, roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "role")
-	<-noDependencyWaitGroup.Done()
 	cache.WaitForNamedCacheSync("roles", stopSignal.Done(), roleInformer.HasSynced)
 	log.Info("Successfully synced roles")
 
 	handle(k.context, clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "clusterrole")
-	<-noDependencyWaitGroup.Done()
 	cache.WaitForNamedCacheSync("clusterroles", stopSignal.Done(), clusterRoleInformer.HasSynced)
 	log.Info("Successfully synced clusterroles")
 

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -122,25 +122,27 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Informers that need to be synced initially
 	handle(k.context, namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "namespace")
-	cache.WaitForNamedCacheSync("namespaces", stopSignal.Done(), namespaceInformer.HasSynced)
+	//cache.WaitForNamedCacheSync("namespaces", stopSignal.Done(), namespaceInformer.HasSynced)
 	log.Info("Successfully synced namespaces")
 
 	handle(k.context, secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "secret")
-	cache.WaitForNamedCacheSync("secrets", stopSignal.Done(), secretInformer.HasSynced)
+	//cache.WaitForNamedCacheSync("secrets", stopSignal.Done(), secretInformer.HasSynced)
 	log.Info("Successfully synced secrets")
 
 	handle(k.context, saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "sa")
-	cache.WaitForNamedCacheSync("sas", stopSignal.Done(), saInformer.HasSynced)
+	//cache.WaitForNamedCacheSync("sas", stopSignal.Done(), saInformer.HasSynced)
 	log.Info("Successfully synced service accounts")
 
 	// Roles need to be synced before role bindings because role bindings have a reference
 	handle(k.context, roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "role")
-	cache.WaitForNamedCacheSync("roles", stopSignal.Done(), roleInformer.HasSynced)
+	//cache.WaitForNamedCacheSync("roles", stopSignal.Done(), roleInformer.HasSynced)
 	log.Info("Successfully synced roles")
 
 	handle(k.context, clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, "clusterrole")
-	cache.WaitForNamedCacheSync("clusterroles", stopSignal.Done(), clusterRoleInformer.HasSynced)
+	//cache.WaitForNamedCacheSync("clusterroles", stopSignal.Done(), clusterRoleInformer.HasSynced)
 	log.Info("Successfully synced clusterroles")
+
+	cache.WaitForNamedCacheSync("first group of informers", stopSignal.Done(), namespaceInformer.HasSynced, clusterRoleInformer.HasSynced, roleInformer.HasSynced, saInformer.HasSynced, secretInformer.HasSynced)
 
 	// For openshift clusters only
 	var osConfigFactory osConfigExtVersions.SharedInformerFactory

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -19,6 +19,7 @@ import (
 // resourceEventHandlerImpl processes OnAdd, OnUpdate, and OnDelete events, and joins the results to an output
 // channel
 type resourceEventHandlerImpl struct {
+	name       string
 	context    context.Context
 	eventLock  *sync.Mutex
 	dispatcher resources.Dispatcher

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -110,7 +110,8 @@ func (h *resourceEventHandlerImpl) registerObject(newObj interface{}) {
 
 	secret, isSecret := newObj.(*corev1.Secret)
 	if isSecret {
-		log.Debugf("ROX-24163 registerObject processes secret ID=%q type=%q", secret.GetUID(), secret.Type)
+		log.Debugf("ROX-24163 registerObject processes secret (ns/name=%s/%s ID=%q type=%q)",
+			secret.GetNamespace(), secret.GetName(), secret.GetUID(), secret.Type)
 	}
 
 	newUID := getObjUID(newObj)
@@ -120,20 +121,20 @@ func (h *resourceEventHandlerImpl) registerObject(newObj interface{}) {
 		h.seenIDs[newUID] = struct{}{}
 	} else if h.missingInitialIDs != nil {
 		if isSecret {
-			log.Debugf("ROX-24163 registerObject deleting secret (ID=%q type=%q) form missingInitialIDs",
-				secret.GetUID(), secret.Type)
+			log.Debugf("ROX-24163 registerObject deleting secret (ns/name=%s/%s ID=%q type=%q) form missingInitialIDs",
+				secret.GetNamespace(), secret.GetName(), secret.GetUID(), secret.Type)
 		}
 		delete(h.missingInitialIDs, newUID)
 		h.checkHasSeenAllInitialIDsNoLock()
 	} else {
 		if isSecret {
-			log.Debugf("ROX-24163 registerObject else-case secret (ID=%q type=%q)",
-				secret.GetUID(), secret.Type)
+			log.Debugf("ROX-24163 registerObject else-case secret (ns/name=%s/%s ID=%q type=%q)",
+				secret.GetNamespace(), secret.GetName(), secret.GetUID(), secret.Type)
 		}
 	}
 	if isSecret {
-		log.Debugf("ROX-24163 registerObject done processing secret (ID=%q type=%q). len(h.missingInitialIDs)=%d",
-			secret.GetUID(), secret.Type, len(h.missingInitialIDs))
+		log.Debugf("ROX-24163 registerObject done processing secret (ns/name=%s/%s ID=%q type=%q). len(h.missingInitialIDs)=%d",
+			secret.GetNamespace(), secret.GetName(), secret.GetUID(), secret.Type, len(h.missingInitialIDs))
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -206,7 +206,7 @@ type metricDispatcher struct {
 
 func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *component.ResourceEvent {
 	comp := env.InformerTraceLogs.Setting()
-	if action == central.ResourceAction_SYNC_RESOURCE {
+	if action == central.ResourceAction_SYNC_RESOURCE || action == central.ResourceAction_REMOVE_RESOURCE {
 		switch v := obj.(type) {
 		case *v1rbac.Role:
 			if comp == "all" || comp == "role" {

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -118,3 +118,7 @@ func (s *nodeStoreImpl) getNodes() []*nodeWrap {
 	}
 	return result
 }
+
+func (s *nodeStoreImpl) GetNodes() map[string]*nodeWrap {
+	return s.nodes
+}

--- a/sensor/kubernetes/listener/resources/rbac/namespaced_binding.go
+++ b/sensor/kubernetes/listener/resources/rbac/namespaced_binding.go
@@ -18,6 +18,10 @@ type namespacedBinding struct {
 	subjects  []namespacedSubject // The subjects that are bound to the referenced role.
 }
 
+func (b *namespacedBinding) GetID() string {
+	return b.bindingID
+}
+
 func (b *namespacedBindingID) IsClusterBinding() bool {
 	return len(b.namespace) == 0
 }

--- a/sensor/kubernetes/listener/resources/rbac/namespaced_role.go
+++ b/sensor/kubernetes/listener/resources/rbac/namespaced_role.go
@@ -29,6 +29,10 @@ type namespacedRole struct {
 	permissionLevel rolePermissionLevel
 }
 
+func (n *namespacedRole) UID() string {
+	return n.latestUID
+}
+
 func ruleToRolePermissionLevel(rule *v1.PolicyRule) rolePermissionLevel {
 	// Note that this will have references to the v1.PolicyRule, so we need to not take
 	// ownership or hold onto the reference beyond the end of this method. This avoids

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -9,6 +9,8 @@ import (
 // Store handles correlating updates to K8s rbac types and generates events from them.
 type Store interface {
 	GetNamespacedRoleIDOrEmpty(roleRef namespacedRoleRef) string
+	GetAllBindings() []*namespacedBinding
+	GetAllRoles() []namespacedRole
 
 	UpsertRole(role *v1.Role)
 	RemoveRole(role *v1.Role)

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -22,6 +22,22 @@ type storeImpl struct {
 	dirty           bool
 }
 
+func (rs *storeImpl) GetAllBindings() []*namespacedBinding {
+	var bindings []*namespacedBinding
+	for _, ns := range rs.bindings {
+		bindings = append(bindings, ns)
+	}
+	return bindings
+}
+
+func (rs *storeImpl) GetAllRoles() []namespacedRole {
+	var roles []namespacedRole
+	for _, ns := range rs.roles {
+		roles = append(roles, ns)
+	}
+	return roles
+}
+
 // Cleanup deletes all entries from store
 func (rs *storeImpl) Cleanup() {
 	rs.lock.Lock()

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -263,7 +263,8 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	for registry, dce := range dockerConfig {
 		if fromDefaultSA {
 			// Store the registry credentials so Sensor can reach it.
-			log.Debugf("ROX-24163 calling UpsertRegisty for docker config from secret %q", secret.UID)
+			log.Debugf("ROX-24163 calling UpsertRegisty for docker config from secret %s/%s ID=%s",
+				secret.GetNamespace(), secret.GetName(), secret.GetUID())
 			err := s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
 			if err != nil {
 				log.Errorf("Unable to upsert registry %q into store: %v", registry, err)
@@ -305,12 +306,16 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 				// as namespace + secret name + registry.
 				var err error
 				if isGlobalPullSecret {
-					log.Debugf("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %q", secret.UID)
+					log.Debugf("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %s/%s ID=%s",
+						secret.GetNamespace(), secret.GetName(), secret.GetUID())
 					err = s.regStore.UpsertGlobalRegistry(context.Background(), registry, dce)
 				} else {
-					log.Debugf("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q registry %s", secret.UID, registry)
+
+					log.Debugf("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret (%s/%s ID=%s) registry %s",
+						secret.GetNamespace(), secret.GetName(), secret.GetUID(), registry)
 					err = s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
-					log.Debugf("ROX-24163 [END] calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q %s", secret.UID, registry)
+					log.Debugf("ROX-24163 [END] calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret (%s/%s ID=%s) registry %s",
+						secret.GetNamespace(), secret.GetName(), secret.GetUID(), registry)
 				}
 				if err != nil {
 					log.Errorf("unable to upsert registry %q into store: %v", registry, err)

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -308,8 +308,9 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 					log.Debugf("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %q", secret.UID)
 					err = s.regStore.UpsertGlobalRegistry(context.Background(), registry, dce)
 				} else {
-					log.Debugf("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q", secret.UID)
+					log.Debugf("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q registry %s", secret.UID, registry)
 					err = s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
+					log.Debugf("ROX-24163 [END] calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q %s", secret.UID, registry)
 				}
 				if err != nil {
 					log.Errorf("unable to upsert registry %q into store: %v", registry, err)

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -263,7 +263,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	for registry, dce := range dockerConfig {
 		if fromDefaultSA {
 			// Store the registry credentials so Sensor can reach it.
-			log.Debug("ROX-24163 calling UpsertRegisty for docker config from secret %q", secret.UID)
+			log.Debugf("ROX-24163 calling UpsertRegisty for docker config from secret %q", secret.UID)
 			err := s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
 			if err != nil {
 				log.Errorf("Unable to upsert registry %q into store: %v", registry, err)
@@ -305,10 +305,10 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 				// as namespace + secret name + registry.
 				var err error
 				if isGlobalPullSecret {
-					log.Debug("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %q", secret.UID)
+					log.Debugf("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %q", secret.UID)
 					err = s.regStore.UpsertGlobalRegistry(context.Background(), registry, dce)
 				} else {
-					log.Debug("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q", secret.UID)
+					log.Debugf("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q", secret.UID)
 					err = s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
 				}
 				if err != nil {

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -396,6 +396,8 @@ func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 	}
 
 	parsedID := string(secret.GetUID())
+	log.Debugf("ROX-24163 processing secret event %q for ID %q (parsed from %q) type %q",
+		action.String(), parsedID, secret.GetUID(), string(secret.Type))
 	switch action {
 	case central.ResourceAction_SYNC_RESOURCE, central.ResourceAction_CREATE_RESOURCE:
 		s.regStore.AddSecretID(parsedID)

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -263,6 +263,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	for registry, dce := range dockerConfig {
 		if fromDefaultSA {
 			// Store the registry credentials so Sensor can reach it.
+			log.Debug("ROX-24163 calling UpsertRegisty for docker config from secret %q", secret.UID)
 			err := s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
 			if err != nil {
 				log.Errorf("Unable to upsert registry %q into store: %v", registry, err)
@@ -304,8 +305,10 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 				// as namespace + secret name + registry.
 				var err error
 				if isGlobalPullSecret {
+					log.Debug("ROX-24163 calling UpsertGlobalRegistry for docker config from secret %q", secret.UID)
 					err = s.regStore.UpsertGlobalRegistry(context.Background(), registry, dce)
 				} else {
+					log.Debug("ROX-24163 calling UpsertRegisty (!isGlobalPullSecret) for docker config from secret %q", secret.UID)
 					err = s.regStore.UpsertRegistry(context.Background(), secret.GetNamespace(), registry, dce)
 				}
 				if err != nil {

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -182,3 +182,11 @@ func (ss *serviceStore) getService(namespace string, name string) *serviceWrap {
 
 	return ss.services[namespace][name]
 }
+
+func (ss *serviceStore) getServiceCount() int {
+	count := 0
+	for _, namespace := range ss.services {
+		count = count + len(namespace)
+	}
+	return count
+}

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -65,3 +65,8 @@ func (sas *ServiceAccountStore) Remove(sa *storage.ServiceAccount) {
 	delete(sas.serviceAccountToPullSecrets, key(sa.GetNamespace(), sa.GetName()))
 	sas.serviceAccountIDs.Remove(sa.Id)
 }
+
+// GetAllServiceAccountIDs returns all SA IDs
+func (sas *ServiceAccountStore) GetAllServiceAccountIDs() []string {
+	return sas.serviceAccountIDs.AsSlice()
+}

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -44,3 +44,8 @@ func (n *OrchestratorNamespaces) IsOrchestratorNamespace(ns string) bool {
 	}
 	return kubernetes.IsSystemNamespace(ns)
 }
+
+// All returns all Namespaces
+func (n *OrchestratorNamespaces) All() []string {
+	return n.nsSet.AsSlice()
+}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -139,7 +139,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		processSignals = signalService.New(processPipeline, indicators, signalService.WithTraceWriter(cfg.processIndicatorWriter))
 	}
 	networkFlowManager :=
-		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector)
+		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector, pubSub)
 	enhancer := deploymentenhancer.CreateEnhancer(storeProvider)
 	components := []common.SensorComponent{
 		admCtrlMsgForwarder,


### PR DESCRIPTION
⚠️⚠️⚠️ This PR must not have recent changes from master - thus the base branch `release-4.4`. It will never be merged to that branch - after we investigate the issue with the client, we will close it.

## Description


This PR introduces a temporary debug server to access the in memory store of Sensor.
Additionally, it contains a new env var that toggle trace logs for Sensors' informers.

### Debug Server
The debug server runs on port 6066. Given a port forward, the following endpoints are available:
- /debug/all
- /debug/stats
- /debug/nodes
- /debug/secrets
- /debug/serviceaccounts
- /debug/rbacroles
- /debug/rbacbindings

`/debug` will give a single json containing all data of the sub-locations including a created timestamp.
`/stats` will give a numerical overview of most of the in memory stores, while the remaining endpoints will dump names and/or uids of the resources.
RBAC Roles / Bindings, ServiceAccounts and Secrets are only dumped by IDs/Refs, as they do not contain publicly accessible names.

Example:
```bash
oc -n stackrox port-forward deployment/sensor 6066:6066
curl -s http://localhost:6066/debug/all > /tmp/sensor_stores.json
```

### Env vars
Setting `ROX_INFORMER_TRACE_LOGS=all` will enable trace logs for all SYNC events of informers.
You can further narrow down components by replacing all with either one of the following:

- role
- rolebinding
- clusterrole
- clusterrolebinding
- serviceaccount
- secret
- misc (log any other resource not listed above)

Example: `oc -n stackrox set env deployment/sensor ROX_INFORMER_TRACE_LOGS=all`


### Using on an operator installed cluster

Enabling the overlay with the image and env variable

```
oc -n stackrox patch SecuredCluster/stackrox-secured-cluster-services --type='merge' -p '{"spec":{"overlays": [{"apiVersion":"apps/v1","kind":"Deployment","name":"sensor","patches":[{"path": "spec.template.spec.containers[name:sensor].image", "value":"quay.io/stackrox-io/main:4.4.3-rc.3-13-g7fe4d7bf03"}, {"path":"spec.template.spec.containers[name:sensor].env[-1]", "value": "name: ROX_INFORMER_TRACE_LOGS\nvalue: all"}]}]}}'
```

cleaning up the overlay

```
oc -n stackrox patch SecuredCluster/stackrox-secured-cluster-services --type=json -p="[{'op': 'remove', 'path': '/spec/overlays'}]"
```
