### PR TITLE
ROX-24364: Add more debug info to the SummaryTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -21,10 +21,12 @@ import io.stackrox.proto.api.v1.PolicyServiceGrpc
 import io.stackrox.proto.api.v1.SearchServiceGrpc
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
+import io.stackrox.proto.api.v1.SecretServiceGrpc
 import io.stackrox.proto.storage.AlertOuterClass
 import io.stackrox.proto.storage.DeploymentOuterClass.ContainerImage
 import io.stackrox.proto.storage.DeploymentOuterClass.Deployment
 import io.stackrox.proto.storage.DeploymentOuterClass.ListDeployment
+import io.stackrox.proto.storage.SecretOuterClass.ListSecret
 import io.stackrox.proto.storage.DeploymentOuterClass.Pod
 import io.stackrox.proto.storage.ImageOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.EnforcementAction
@@ -75,6 +77,10 @@ class Services extends BaseService {
         return DeploymentServiceGrpc.newBlockingStub(getChannel())
     }
 
+    static SecretServiceGrpc.SecretServiceBlockingStub getSecretClient() {
+        return SecretServiceGrpc.newBlockingStub(getChannel())
+    }
+
     static PodServiceGrpc.PodServiceBlockingStub getPodClient() {
         return PodServiceGrpc.newBlockingStub(getChannel())
     }
@@ -117,6 +123,10 @@ class Services extends BaseService {
 
     static List<ListDeployment> getDeployments(RawQuery query = RawQuery.newBuilder().build()) {
         return getDeploymentClient().listDeployments(query).deploymentsList
+    }
+
+    static List<ListSecret> getSecrets(RawQuery query = RawQuery.newBuilder().build()) {
+        return getSecretClient().listSecrets(query).secretsList
     }
 
     static DeploymentServiceOuterClass.GetDeploymentWithRiskResponse getDeploymentWithRisk(String id) {

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -37,25 +37,31 @@ class SummaryTest extends BaseSpecification {
             def stackroxSummaryCounts = SummaryService.getCounts()
             List<String> orchestratorResourceNames = orchestrator.getDeploymentCount() +
                     orchestrator.getDaemonSetCount() +
+                    orchestrator.getStaticPodCount()
                     // Static pods get renamed as "static-<name>-pods" in sensor, so match it for easy debugging
                     orchestrator.getStaticPodCount().collect {  "static-" + it + "-pods"  } +
-                    orchestrator.getStatefulSetCount() +
+                    orchestrator.getStatefulSetCount()
                     orchestrator.getJobCount()
 
+            // Discrepancy here:
+            // Stackrox has: 'kube-rbac-proxy-crio'
+            // Openshift has: 'kube-rbac-proxy-crio-piotr-06-11-cigna-gtnb7-master-2.c.acs-team-temp-dev.internal' (for each node)
+
             if (stackroxSummaryCounts.numDeployments != orchestratorResourceNames.size()) {
-                log.info "The summary count for deployments does not equate to the orchestrator count."
+                log.info "The summary count for deployments does not equal the orchestrator count."
                 log.info "Stackrox count: ${stackroxSummaryCounts.numDeployments}, " +
                         "orchestrator count ${orchestratorResourceNames.size()}"
                 log.info "This diff may help with debug, however deployment names may be different between APIs"
+                log.info "In this diff, 'removed' means 'missing in orchestrator but given in ACS', whereas 'added' the other way round"
                 List<String> stackroxDeploymentNames = Services.getDeployments()*.name
                 Javers javers = JaversBuilder.javers()
                         .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                         .build()
-                log.info javers.compare(stackroxDeploymentNames, orchestratorResourceNames).prettyPrint()
+                log.info javers.compare(stackroxDeploymentNames.sort(), orchestratorResourceNames.sort()).prettyPrint()
 
                 log.info "Use the full set of deployments to compare manually if diff isn't helpful"
-                log.info "Stackrox deployments: " + stackroxDeploymentNames.join(",")
-                log.info "Orchestrator deployments: " + orchestratorResourceNames.join(",")
+                log.info "Stackrox deployments: " + stackroxDeploymentNames.sort().join(",")
+                log.info "Orchestrator deployments: " + orchestratorResourceNames.sort().join(",")
             }
 
             assert Math.abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -45,14 +45,16 @@ class SummaryTest extends BaseSpecification {
 
             // Discrepancy here:
             // Stackrox has: 'kube-rbac-proxy-crio'
-            // Openshift has: 'kube-rbac-proxy-crio-piotr-06-11-cigna-gtnb7-master-2.c.acs-team-temp-dev.internal' (for each node)
+            // Openshift has: 'kube-rbac-proxy-crio-piotr-06-11-cigna-gtnb7-master-2.c.acs-team-temp-dev.internal'
+            // (for each node)
 
             if (stackroxSummaryCounts.numDeployments != orchestratorResourceNames.size()) {
                 log.info "The summary count for deployments in ACS does not equal the orchestrator count."
                 log.info "ACS count: ${stackroxSummaryCounts.numDeployments}, " +
                         "orchestrator count ${orchestratorResourceNames.size()}"
                 log.info "This diff may help with debug, however deployment names may be different between APIs"
-                log.info "In this diff, 'removed' means 'missing in orchestrator but given in ACS', whereas 'added' the other way round"
+                log.info "In this diff, 'removed' means 'missing in orchestrator but given in ACS', " +
+                    "whereas 'added' - the other way round"
                 List<String> stackroxDeploymentNames = Services.getDeployments()*.name
                 Javers javers = JaversBuilder.javers()
                         .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -48,8 +48,8 @@ class SummaryTest extends BaseSpecification {
             // Openshift has: 'kube-rbac-proxy-crio-piotr-06-11-cigna-gtnb7-master-2.c.acs-team-temp-dev.internal' (for each node)
 
             if (stackroxSummaryCounts.numDeployments != orchestratorResourceNames.size()) {
-                log.info "The summary count for deployments does not equal the orchestrator count."
-                log.info "Stackrox count: ${stackroxSummaryCounts.numDeployments}, " +
+                log.info "The summary count for deployments in ACS does not equal the orchestrator count."
+                log.info "ACS count: ${stackroxSummaryCounts.numDeployments}, " +
                         "orchestrator count ${orchestratorResourceNames.size()}"
                 log.info "This diff may help with debug, however deployment names may be different between APIs"
                 log.info "In this diff, 'removed' means 'missing in orchestrator but given in ACS', whereas 'added' the other way round"
@@ -60,15 +60,15 @@ class SummaryTest extends BaseSpecification {
                 log.info javers.compare(stackroxDeploymentNames.sort(), orchestratorResourceNames.sort()).prettyPrint()
 
                 log.info "Use the full set of deployments to compare manually if diff isn't helpful"
-                log.info "Stackrox deployments: " + stackroxDeploymentNames.sort().join(",")
+                log.info "ACS deployments: " + stackroxDeploymentNames.sort().join(",")
                 log.info "Orchestrator deployments: " + orchestratorResourceNames.sort().join(",")
             }
 
             assert Math.abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
             List<String> stackroxSecretNames = Services.getSecrets()*.name
-            log.debug "Stackrox secrets: " + stackroxSecretNames.join(",")
-            assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
-            assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
+            log.info "ACS secrets: " + stackroxSecretNames.join(",")
+            assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 0
+            assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 0
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -37,15 +37,14 @@ class SummaryTest extends BaseSpecification {
             def stackroxSummaryCounts = SummaryService.getCounts()
             List<String> orchestratorResourceNames = orchestrator.getDeploymentCount() +
                     orchestrator.getDaemonSetCount() +
-                    orchestrator.getStaticPodCount()
                     // Static pods get renamed as "static-<name>-pods" in sensor, so match it for easy debugging
                     orchestrator.getStaticPodCount().collect {  "static-" + it + "-pods"  } +
-                    orchestrator.getStatefulSetCount()
+                    orchestrator.getStatefulSetCount() +
                     orchestrator.getJobCount()
 
-            // Discrepancy here:
+            // For Openshift, there is the following discrepancy here:
             // Stackrox has: 'kube-rbac-proxy-crio'
-            // Openshift has: 'kube-rbac-proxy-crio-piotr-06-11-cigna-gtnb7-master-2.c.acs-team-temp-dev.internal'
+            // Openshift has: 'kube-rbac-proxy-crio-<clustername>-gtnb7-master-2.c.acs-team-temp-dev.internal'
             // (for each node)
 
             if (stackroxSummaryCounts.numDeployments != orchestratorResourceNames.size()) {
@@ -69,8 +68,8 @@ class SummaryTest extends BaseSpecification {
             assert Math.abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
             List<String> stackroxSecretNames = Services.getSecrets()*.name
             log.info "ACS secrets: " + stackroxSecretNames.join(",")
-            assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 0
-            assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 0
+            assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
+            assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -59,6 +59,8 @@ class SummaryTest extends BaseSpecification {
             }
 
             assert Math.abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
+            List<String> stackroxSecretNames = Services.getSecrets()*.name
+            log.debug "Stackrox secrets: " + stackroxSecretNames.join(",")
             assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
             assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
         }


### PR DESCRIPTION
## Description

This PR does not fix anything (unfortunately). I just outputs more info to analyze the flake when it happens (and it happens rarely). 

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]

## Testing Performed

### Here I tell how I validated my change

- [x] CI
- [x] Running that e2e test against GKE and Openshift cluster 
    - It was not meant to run on Openshift, but I still gathered some info, so that it could be changed to run there in the future. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
