### PR TITLE
ROX-24374: Get Controls by RuleNames

### DIFF
--- a/central/complianceoperator/v2/rules/datastore/datastore.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore.go
@@ -28,17 +28,21 @@ type DataStore interface {
 
 	// DeleteRulesByCluster removes rule by cluster id
 	DeleteRulesByCluster(ctx context.Context, clusterID string) error
+
+	// GetControlsByRuleNames returns controls by a list of rule names group by control, standard and rule name.
+	GetControlsByRuleNames(ctx context.Context, ruleNames []string) ([]*ControlResult, error)
 }
 
 // New returns an instance of DataStore.
-func New(complianceRuleStorage pgStore.Store) DataStore {
+func New(complianceRuleStorage pgStore.Store, db postgres.DB) DataStore {
 	return &datastoreImpl{
 		store: complianceRuleStorage,
+		db:    db,
 	}
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
-	return New(store)
+	return New(store, pool)
 }

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl.go
@@ -3,14 +3,18 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/complianceoperator/v2/rules/store/postgres"
+	ruleStore "github.com/stackrox/rox/central/complianceoperator/v2/rules/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
+	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 )
 
 type datastoreImpl struct {
-	store postgres.Store
+	store ruleStore.Store
+	db    postgres.DB
 }
 
 // UpsertRule adds the rule to the database
@@ -34,7 +38,7 @@ func (d *datastoreImpl) SearchRules(ctx context.Context, query *v1.Query) ([]*st
 	return d.store.GetByQuery(ctx, query)
 }
 
-// delete rule by cluster id
+// DeleteRulesByCluster delete rule by cluster id
 func (d *datastoreImpl) DeleteRulesByCluster(ctx context.Context, clusterID string) error {
 	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
 	_, err := d.store.DeleteByQuery(ctx, query)
@@ -42,4 +46,34 @@ func (d *datastoreImpl) DeleteRulesByCluster(ctx context.Context, clusterID stri
 		return err
 	}
 	return nil
+}
+
+// ControlResult represents a result of a control.
+type ControlResult struct {
+	Control  string `db:"compliance_control"`
+	Standard string `db:"compliance_standard"`
+	RuleName string `db:"compliance_rule_name"`
+}
+
+// GetControlsByRuleNames returns controls by a list of rule names group by control, standard and rule name.
+func (d *datastoreImpl) GetControlsByRuleNames(ctx context.Context, ruleNames []string) ([]*ControlResult, error) {
+	builder := search.NewQueryBuilder()
+	builder.AddSelectFields(
+		search.NewQuerySelect(search.ComplianceOperatorControl),
+		search.NewQuerySelect(search.ComplianceOperatorStandard),
+		search.NewQuerySelect(search.ComplianceOperatorRuleName),
+	)
+
+	builder.AddExactMatches(search.ComplianceOperatorRuleName, ruleNames...)
+
+	// Add a group by clause to group the rule names by name, control and standard to reduce the result set.
+	builder.AddGroupBy(search.ComplianceOperatorRuleName, search.ComplianceOperatorControl, search.ComplianceOperatorStandard)
+
+	query := builder.ProtoQuery()
+	results, err := pgSearch.RunSelectRequestForSchema[ControlResult](ctx, d.db, postgresSchema.ComplianceOperatorRuleV2Schema, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl.go
@@ -67,7 +67,11 @@ func (d *datastoreImpl) GetControlsByRuleNames(ctx context.Context, ruleNames []
 	builder.AddExactMatches(search.ComplianceOperatorRuleName, ruleNames...)
 
 	// Add a group by clause to group the rule names by name, control and standard to reduce the result set.
-	builder.AddGroupBy(search.ComplianceOperatorRuleName, search.ComplianceOperatorControl, search.ComplianceOperatorStandard)
+	builder.AddGroupBy(
+		search.ComplianceOperatorRuleName,
+		search.ComplianceOperatorControl,
+		search.ComplianceOperatorStandard,
+	)
 
 	query := builder.ProtoQuery()
 	results, err := pgSearch.RunSelectRequestForSchema[ControlResult](ctx, d.db, postgresSchema.ComplianceOperatorRuleV2Schema, query)

--- a/central/complianceoperator/v2/rules/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/rules/datastore/mocks/datastore.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	datastore "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
@@ -67,6 +68,21 @@ func (m *MockDataStore) DeleteRulesByCluster(ctx context.Context, clusterID stri
 func (mr *MockDataStoreMockRecorder) DeleteRulesByCluster(ctx, clusterID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRulesByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteRulesByCluster), ctx, clusterID)
+}
+
+// GetControlsByRuleNames mocks base method.
+func (m *MockDataStore) GetControlsByRuleNames(ctx context.Context, ruleNames []string) ([]*datastore.ControlResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControlsByRuleNames", ctx, ruleNames)
+	ret0, _ := ret[0].([]*datastore.ControlResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControlsByRuleNames indicates an expected call of GetControlsByRuleNames.
+func (mr *MockDataStoreMockRecorder) GetControlsByRuleNames(ctx, ruleNames any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlsByRuleNames", reflect.TypeOf((*MockDataStore)(nil).GetControlsByRuleNames), ctx, ruleNames)
 }
 
 // GetRulesByCluster mocks base method.

--- a/central/complianceoperator/v2/rules/datastore/singleton.go
+++ b/central/complianceoperator/v2/rules/datastore/singleton.go
@@ -14,7 +14,7 @@ var (
 )
 
 func initialize() {
-	dataStore = New(pgStore.New(globaldb.GetPostgres()))
+	dataStore = New(pgStore.New(globaldb.GetPostgres()), globaldb.GetPostgres())
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -240,7 +240,6 @@ var (
 	ComplianceOperatorProfileRef             = newFieldLabel("Profile Ref ID")
 	ComplianceOperatorScanRef                = newFieldLabel("Scan Ref ID")
 	ComplianceOperatorRuleRef                = newFieldLabel("Rule Ref ID")
-	ComplianceOperatorRuleId                 = newFieldLabel("Compliance Rule ID")
 	ComplianceOperatorRemediationName        = newFieldLabel("Compliance Remediation Name")
 	ComplianceOperatorBenchmarkName          = newFieldLabel("Compliance Benchmark Name")
 	ComplianceOperatorProfileAnnotation      = newFieldLabel("Compliance Profile Annotation")

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -240,7 +240,10 @@ var (
 	ComplianceOperatorProfileRef             = newFieldLabel("Profile Ref ID")
 	ComplianceOperatorScanRef                = newFieldLabel("Scan Ref ID")
 	ComplianceOperatorRuleRef                = newFieldLabel("Rule Ref ID")
+	ComplianceOperatorRuleId                 = newFieldLabel("Compliance Rule ID")
 	ComplianceOperatorRemediationName        = newFieldLabel("Compliance Remediation Name")
+	ComplianceOperatorBenchmarkName          = newFieldLabel("Compliance Benchmark Name")
+	ComplianceOperatorProfileAnnotation      = newFieldLabel("Compliance Profile Annotation")
 
 	// Node search fields
 	Node             = newFieldLabel("Node")

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -9,7 +9,7 @@ import (
 // Set is a generic set type.
 type Set[KeyType comparable] map[KeyType]struct{}
 
-// Add adds an element of type KeyType.
+// Add adds an element of type KeyType, returns true if type was added, false if it already existed.
 func (k *Set[KeyType]) Add(i KeyType) bool {
 	if *k == nil {
 		*k = make(map[KeyType]struct{})
@@ -52,7 +52,7 @@ func (k *Set[KeyType]) AddAll(is ...KeyType) bool {
 	return len(*k) > oldLen
 }
 
-// Remove removes an element of type KeyType.
+// Remove removes an element of type KeyType. Returns true if the element was removed, false if it was not present.
 func (k *Set[KeyType]) Remove(i KeyType) bool {
 	if len(*k) == 0 {
 		return false


### PR DESCRIPTION
## Description

Get Controls by RuleNames.
RuleNames are group by Name, Control and Standard to reduce the number of results. This improves performance later on to enrich API responses, otherwise the results would have been (Standard * Control * Rule Name * Cluster).

Specification:

1. Return all controls, standards and rule names for a list of rule names.
2. Only return distinct results, do not return results per cluster.

Follow-up PR: https://github.com/stackrox/stackrox/pull/11266/files

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

 - Unit tests
 - More testing follows with the API implementations