### PR TITLE
ROX-23059: +ROX-23061 platform CVE sorting

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -28,7 +28,7 @@ import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
-import { EntityTab, platformEntityTabValues } from '../../types';
+import { platformEntityTabValues } from '../../types';
 import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 
 import ClustersTable, {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -20,6 +20,7 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
 import useMap from 'hooks/useMap';
+import useURLSort from 'hooks/useURLSort';
 import useSnoozeCveModal from 'Containers/Vulnerabilities/components/SnoozeCvesModal/useSnoozeCveModal';
 import SnoozeCvesModal from 'Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
@@ -30,8 +31,14 @@ import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { platformEntityTabValues } from '../../types';
 import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 
-import ClustersTable from './ClustersTable';
-import CVEsTable from './CVEsTable';
+import ClustersTable, {
+    defaultSortOption as clusterDefaultSortOption,
+    sortFields as clusterSortFields,
+} from './ClustersTable';
+import CVEsTable, {
+    defaultSortOption as cveDefaultSortOption,
+    sortFields as cveSortFields,
+} from './CVEsTable';
 import { usePlatformCveEntityCounts } from './usePlatformCveEntityCounts';
 
 function PlatformCvesOverviewPage() {
@@ -40,6 +47,12 @@ function PlatformCvesOverviewPage() {
     const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
     const { searchFilter, setSearchFilter } = useURLSearch();
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { sortOption, getSortParams, setSortOption } = useURLSort({
+        sortFields: activeEntityTabKey === 'CVE' ? cveSortFields : clusterSortFields,
+        defaultSortOption:
+            activeEntityTabKey === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
+        onSort: () => pagination.setPage(1, 'replace'),
+    });
 
     // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
     const querySearchFilter = searchFilter;
@@ -52,7 +65,10 @@ function PlatformCvesOverviewPage() {
 
     function onEntityTabChange() {
         pagination.setPage(1);
-        // TODO - set default sort here
+        setSortOption(
+            activeEntityTabKey === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
+            'replace'
+        );
     }
 
     const { data } = usePlatformCveEntityCounts(querySearchFilter);
@@ -154,6 +170,8 @@ function PlatformCvesOverviewPage() {
                                     'CLUSTER_CVE',
                                     isViewingSnoozedCves ? 'UNSNOOZE' : 'SNOOZE'
                                 )}
+                                sortOption={sortOption}
+                                getSortParams={getSortParams}
                             />
                         )}
                         {activeEntityTabKey === 'Cluster' && (
@@ -161,6 +179,8 @@ function PlatformCvesOverviewPage() {
                                 querySearchFilter={querySearchFilter}
                                 isFiltered={isFiltered}
                                 pagination={pagination}
+                                sortOption={sortOption}
+                                getSortParams={getSortParams}
                             />
                         )}
                     </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -28,7 +28,7 @@ import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
-import { platformEntityTabValues } from '../../types';
+import { EntityTab, platformEntityTabValues } from '../../types';
 import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 
 import ClustersTable, {
@@ -63,10 +63,10 @@ function PlatformCvesOverviewPage() {
     const selectedCves = useMap<string, { cve: string }>();
     const { snoozeModalOptions, setSnoozeModalOptions, snoozeActionCreator } = useSnoozeCveModal();
 
-    function onEntityTabChange() {
+    function onEntityTabChange(entityTab: 'CVE' | 'Cluster') {
         pagination.setPage(1);
         setSortOption(
-            activeEntityTabKey === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
+            entityTab === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
             'replace'
         );
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -1,5 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
+import { ApiSortOption } from 'types/search';
+import { Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -49,7 +51,8 @@ const cveListQuery = gql`
 export default function usePlatformCves(
     querySearchFilter: QuerySearchFilter,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<
         {
@@ -57,15 +60,12 @@ export default function usePlatformCves(
         },
         {
             query: string;
-            pagination: {
-                offset: number;
-                limit: number;
-            };
+            pagination: Pagination;
         }
     >(cveListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -2,6 +2,7 @@
 export const CVE_SORT_FIELD = 'CVE';
 export const CVSS_SORT_FIELD = 'CVSS';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
+export const CVE_COUNT_SORT_FIELD = 'CVE Count';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';


### PR DESCRIPTION
## Description

Adds sort fields to the Platform CVE Overview page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual verification of the correct sorting parameters being sent over the API:

Default sort of CVE table CVSS descending (data and response are mocked):
![image](https://github.com/stackrox/stackrox/assets/1292638/c14b832f-ccb6-4aab-a1be-38645165dce3)
CVSS acs:
![image](https://github.com/stackrox/stackrox/assets/1292638/d3fb3ac6-7703-4424-afe2-41de962c0566)

CVE desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/c43b1550-37bd-4d06-8a3b-0bd3a5d49ca8)
CVE asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/5766d6c5-9874-49ec-bc85-08c05f5963b1)

CVE status desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/7a33ee34-c5b8-4c75-9ed8-7b62acaf6210)

CVE status asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/729218c1-a62a-43b4-b82a-5ba8b74883bd)

CVE type desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/48f51c00-4a2b-490b-997a-754642c00436)

CVE type asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/e89fed2c-fbd5-4b87-99f1-3eaed9272314)

Default sort of the Cluster table is be CVE count desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/0b442bc8-6ecf-4721-b632-94aa2652996a)

CVE count asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/3312d7f0-7172-4eef-9e95-ac04eafce2b5)

Cluster desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/5124dea0-94ab-4373-a1b6-94f13413844f)

Cluster asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/2349ba49-3de0-4d13-8690-c8c07720b22f)

Cluster type desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/08c9c50b-8fdd-4af9-867b-dfb871a73c92)

Cluster type asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/0f705a3b-0171-480f-84b9-ab7424f023b6)

k8s version desc:
![image](https://github.com/stackrox/stackrox/assets/1292638/f3c51a2b-5404-448a-afae-b3e200c65c17)

k8s version asc:
![image](https://github.com/stackrox/stackrox/assets/1292638/dd8cc95e-7e3f-4b06-b72d-52f511fdae9f)


