### PR TITLE
feat(cm): Add option in the ChannelMultiplexer to configure a context

### DIFF
--- a/pkg/channelmultiplexer/channelmultiplexer.go
+++ b/pkg/channelmultiplexer/channelmultiplexer.go
@@ -10,9 +10,9 @@ import (
 // OptionFunc provides options for the ChannelMultiplexer.
 type OptionFunc[K any] func(*ChannelMultiplexer[K])
 
-// WithChannel provides a context to the ChannelMultiplexer,
+// WithContext provides a context to the ChannelMultiplexer,
 // If it's not provided context.Background will be used.
-func WithChannel[K any](ctx context.Context) OptionFunc[K] {
+func WithContext[K any](ctx context.Context) OptionFunc[K] {
 	return func(cm *ChannelMultiplexer[K]) {
 		cm.ctx = ctx
 	}

--- a/pkg/channelmultiplexer/channelmultiplexer.go
+++ b/pkg/channelmultiplexer/channelmultiplexer.go
@@ -7,22 +7,37 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
+// OptionFunc provides options for the ChannelMultiplexer.
+type OptionFunc[K any] func(*ChannelMultiplexer[K])
+
+// WithChannel provides a context to the ChannelMultiplexer,
+// If it's not provided context.Background will be used.
+func WithChannel[K any](ctx context.Context) OptionFunc[K] {
+	return func(cm *ChannelMultiplexer[K]) {
+		cm.ctx = ctx
+	}
+}
+
 // ChannelMultiplexer combines n input channels of type T into one output channel of type T
 type ChannelMultiplexer[T any] struct {
 	inputChannels  []<-chan T
 	outputCommands chan T
+	ctx            context.Context
 
 	started concurrency.Signal
 }
 
 // NewMultiplexer creates a ChannelMultiplexer of type T
-func NewMultiplexer[T any]() *ChannelMultiplexer[T] {
-	multiplexer := ChannelMultiplexer[T]{
+func NewMultiplexer[T any](opts ...OptionFunc[T]) *ChannelMultiplexer[T] {
+	multiplexer := &ChannelMultiplexer[T]{
 		inputChannels:  make([]<-chan T, 0),
 		outputCommands: make(chan T),
-		started:        concurrency.NewSignal()}
-
-	return &multiplexer
+		started:        concurrency.NewSignal(),
+	}
+	for _, opt := range opts {
+		opt(multiplexer)
+	}
+	return multiplexer
 }
 
 // AddChannel Adds a channel to ComplianceCommunicator, AddChannel must be called
@@ -37,9 +52,11 @@ func (c *ChannelMultiplexer[T]) AddChannel(channel <-chan T) {
 // Run starts the ChannelMultiplexer. Make sure to only call Run after all AddChannel calls
 func (c *ChannelMultiplexer[T]) Run() {
 	c.started.Signal()
-	ctx := context.Background()
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
 
-	output := FanIn[T](ctx, c.inputChannels...)
+	output := FanIn[T](c.ctx, c.inputChannels...)
 	go func() {
 		defer close(c.outputCommands)
 		for o := range output {
@@ -61,11 +78,19 @@ func FanIn[T any](ctx context.Context, channels ...<-chan T) <-chan T {
 
 	multiplex := func(ch <-chan T) {
 		defer wg.Done()
-		for i := range ch {
+		for {
 			select {
 			case <-ctx.Done():
 				return
-			case multiplexedStream <- i:
+			case i, ok := <-ch:
+				if !ok {
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case multiplexedStream <- i:
+				}
 			}
 		}
 	}

--- a/pkg/channelmultiplexer/channelmultiplexer_test.go
+++ b/pkg/channelmultiplexer/channelmultiplexer_test.go
@@ -1,7 +1,9 @@
 package channelmultiplexer
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -55,5 +57,31 @@ func TestMultiplexingChannels(t *testing.T) {
 				assert.Equal(t, m.str, received)
 			}
 		})
+	}
+}
+
+func TestCancelContext(t *testing.T) {
+	numChannels := 2
+	ctx, cancelFn := context.WithCancel(context.Background())
+	cm := NewMultiplexer[int](WithChannel[int](ctx))
+	channels := make([]chan int, numChannels)
+	for i := range channels {
+		channels[i] = make(chan int)
+		cm.AddChannel(channels[i])
+	}
+	t.Cleanup(func() {
+		for _, c := range channels {
+			close(c)
+		}
+	})
+
+	cm.Run()
+	cancelFn()
+
+	select {
+	case <-time.NewTimer(5 * time.Second).C:
+		t.Error("timeout reached waiting for the channel multiplexer to stop")
+	case _, ok := <-cm.GetOutput():
+		assert.False(t, ok, "the output channel should be closed")
 	}
 }

--- a/pkg/channelmultiplexer/channelmultiplexer_test.go
+++ b/pkg/channelmultiplexer/channelmultiplexer_test.go
@@ -63,7 +63,7 @@ func TestMultiplexingChannels(t *testing.T) {
 func TestCancelContext(t *testing.T) {
 	numChannels := 2
 	ctx, cancelFn := context.WithCancel(context.Background())
-	cm := NewMultiplexer[int](WithChannel[int](ctx))
+	cm := NewMultiplexer[int](WithContext[int](ctx))
 	channels := make([]chan int, numChannels)
 	for i := range channels {
 		channels[i] = make(chan int)


### PR DESCRIPTION
## Description

The `ChannelMultiplexer` has a context to stop the goroutines that it spawns. Previously the context was hardcoded as `context.Background` making impossible for the consumers of the multiplexer to cancel the goroutines unless all added channels are closed. 

This PR adds an option to the `ChannelMultiplexer` to configure a context so it can be cancelled from the consumer side.

This PR also fixes a leak that could happen if the multiplexer is started but no input is added to the multiplexed channels:

```golang
// This will block indefinitely until something is pushed to the channel `ch` or the channel is closed
for i := range ch {
	select {
	case <-ctx.Done():
		return
	case multiplexedStream <- i:
}
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI should be happy
- [x] New unit tests passes

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
