### PR TITLE
ROX-24381: Fix TestOptionsMap

### DIFF
--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -49,7 +49,7 @@ func TestOptionsMap(t *testing.T) {
 		"Cluster", "Component", "Component Version", "Deployment", "Deployment Annotation", "Deployment Label",
 		"Deployment Type", "Dockerfile Instruction Keyword", "Dockerfile Instruction Value", "Drop Capabilities",
 		"Environment Key", "Environment Value", "Environment Variable Source", "Exposed Node Port", "Exposing Service",
-		"Exposing Service Port", "Exposure Level", "External Hostname", "External IP", "Image", "Image Command",
+		"Exposing Service Port", "Exposure Level", "External Hostname", "External IP", "Image", "Image CVE Count", "Image Command",
 		"Image Created Time", "Image Entrypoint", "Image Label", "Image OS", "Image Pull Secret", "Image Registry",
 		"Image Remote", "Image Scan Time", "Image Tag", "Image Top CVSS", "Image User", "Image Volumes",
 		"Max Exposure Level", "Memory Limit (MB)", "Memory Request (MB)", "Namespace", "Namespace ID",


### PR DESCRIPTION
## Description

Added search tag `Image CVE Count` in #11204 but did not update the options map test e2e. This causes CI failure.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Passing CI is enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
