### PR TITLE
ROX-23253: trust service-ca operator CA in acscsEmail integration

### DIFF
--- a/central/notifiers/acscsemail/client_impl.go
+++ b/central/notifiers/acscsemail/client_impl.go
@@ -59,13 +59,17 @@ func ClientSingleton() Client {
 }
 
 func transportWithServiceCA() http.RoundTripper {
+	return transportWithAdditonalCA(serviceOperatorCAPath)
+}
+
+func transportWithAdditonalCA(caFile string) *http.Transport {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		rootCAs = x509.NewCertPool()
 	}
 
 	// Trust local cluster services.
-	if serviceCA, err := os.ReadFile(serviceOperatorCAPath); err == nil {
+	if serviceCA, err := os.ReadFile(caFile); err == nil {
 		rootCAs.AppendCertsFromPEM(serviceCA)
 	}
 

--- a/central/notifiers/acscsemail/client_impl.go
+++ b/central/notifiers/acscsemail/client_impl.go
@@ -3,9 +3,12 @@ package acscsemail
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/notifiers/acscsemail/message"
@@ -14,6 +17,11 @@ import (
 	"github.com/stackrox/rox/pkg/satoken"
 	"github.com/stackrox/rox/pkg/utils"
 )
+
+// serviceOperatorCAPath points to the secret of the service account, which within an OpenShift environment
+// also has the service-ca.crt, which includes the CA to verify certificates issued by the service-ca operator.
+// The service-ca operator is used to issue the certificate used by the emailsender service in ACSCS
+const serviceOperatorCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 
 const sendMsgPath = "/api/v1/acscsemail"
 
@@ -44,10 +52,29 @@ func ClientSingleton() Client {
 	client = &clientImpl{
 		loadToken:  satoken.LoadTokenFromFile,
 		url:        url,
-		httpClient: &http.Client{Transport: proxy.RoundTripper()},
+		httpClient: &http.Client{Transport: transportWithServiceCA()},
 	}
 
 	return client
+}
+
+func transportWithServiceCA() http.RoundTripper {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Trust local cluster services.
+	if serviceCA, err := os.ReadFile(serviceOperatorCAPath); err == nil {
+		rootCAs.AppendCertsFromPEM(serviceCA)
+	}
+
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs,
+		},
+		Proxy: proxy.FromConfig(),
+	}
 }
 
 func (c *clientImpl) SendMessage(ctx context.Context, msg message.AcscsEmail) error {

--- a/central/notifiers/acscsemail/client_impl_test.go
+++ b/central/notifiers/acscsemail/client_impl_test.go
@@ -1,13 +1,28 @@
 package acscsemail
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/central/notifiers/acscsemail/message"
+	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,4 +135,79 @@ type testRoundTripper func(req *http.Request) (*http.Response, error)
 
 func (t testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t(req)
+}
+
+func TestTransportWithAdditonalCA(t *testing.T) {
+	ca, err := certgen.GenerateCA()
+	require.NoError(t, err, "failed to generate test CA")
+
+	caDir := t.TempDir()
+	filePath := path.Join(caDir, "cert.pem")
+	err = os.WriteFile(filePath, ca.CertPEM(), 0644)
+	require.NoError(t, err, "failed to write test CA to file")
+
+	testServerCalled := false
+	tlsServ := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testServerCalled = true
+		w.WriteHeader(200)
+	}))
+
+	tlsServ.TLS = &tls.Config{
+		Certificates: []tls.Certificate{generateTestServerCert(t, ca)},
+	}
+
+	tlsServ.StartTLS()
+	defer tlsServ.Close()
+
+	transport := transportWithAdditonalCA(filePath)
+	httpClient := http.Client{Transport: transport}
+	err = retry.WithRetry(
+		// there's a chance the first call fails on tests depending on
+		// server startup timing
+		func() error {
+			_, err := httpClient.Get(tlsServ.URL)
+			return err
+		},
+		retry.Tries(3),
+		retry.BetweenAttempts(func(_ int) {
+			time.Sleep(1 * time.Second)
+		}),
+	)
+
+	require.NoError(t, err, "expected HTTP call to test server to succeed")
+	require.True(t, testServerCalled, "expected test server to be called succesfully")
+}
+
+func generateTestServerCert(t *testing.T, ca mtls.CA) tls.Certificate {
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "failed to generate test server TLS key")
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.Certificate(), certKey.Public(), ca.PrivateKey())
+	require.NoError(t, err, "failed to generate test server TLS cert")
+
+	certPem := &bytes.Buffer{}
+	err = pem.Encode(certPem, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	require.NoError(t, err, "failed to encode test server TLS cert to pem")
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(certKey)
+	require.NoError(t, err, "failed to marshal test server TLS key")
+	keyPem := &bytes.Buffer{}
+	err = pem.Encode(keyPem, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, err, "failed to encode test server TLS key to pem")
+
+	cert, err := tls.X509KeyPair(certPem.Bytes(), keyPem.Bytes())
+	require.NoError(t, err, "failed to create test server TLS key pair")
+	return cert
 }


### PR DESCRIPTION
## Description

We're going to use the service CA operator to generate a CA for the internal emailsender service used by the acscsEmail integration.

I added a configuration to the transport for the acscsEmail http.Client so that we trust those certificates.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added a unit test that generates a new CA and server certificate and makes sure the function to extend the rootCAs is working properly.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
