### PR TITLE
tests: Improve query

### DIFF
--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -151,11 +151,16 @@ FROM
     `acs-san-stackroxci.ci_metrics.stackrox_tests__extended_view`
 WHERE
     CONTAINS_SUBSTR(ShortJobName, "'"${job_name_match}"'")
+    -- omit PR check jobs
     AND NOT IsPullRequest
-    AND CONTAINS_SUBSTR(JobName, "master")
     AND NOT STARTS_WITH(JobName, "rehearse-")
-    AND NOT CONTAINS_SUBSTR(JobName, "ibmcloudz")
-    AND NOT CONTAINS_SUBSTR(JobName, "powervs")
+    -- omit jobs on release branches
+    AND NOT CONTAINS_SUBSTR(JobName, "-release-")
+    -- omit jobs not owned by ACS team
+    AND NOT CONTAINS_SUBSTR(JobName, "-ibmcloudz-")
+    AND NOT CONTAINS_SUBSTR(JobName, "-powervs-")
+    AND NOT CONTAINS_SUBSTR(JobName, "-interop-")
+    -- recent
     AND DATE(Timestamp) >= DATE_SUB(DATE_TRUNC(CURRENT_DATE(), WEEK(MONDAY)), INTERVAL 1 WEEK)
 GROUP BY
     Classname,


### PR DESCRIPTION
## Description

Looking at the `JobName` column, we have:

- `branch-ci-stackrox-stackrox-master-...`
- `branch-ci-stackrox-stackrox-nightlies-...`
- `branch-ci-stackrox-stackrox-release-...`
- `periodic-...` (interop, power, ibm)
- `pull-ci-stackrox-stackrox-master-... `
- `pull-ci-stackrox-stackrox-release-...`
- `rehearse-...`
- `go`
- `go-postgres`
- `local-roxctl-tests`
- `scan-go-binaries`
- `shell-unit-tests`
- `ui`

The current filtering effectively leaves just the top category: `branch-ci-stackrox-stackrox-master-...`. This is too strict.

I guess we want to keep omitting any PR-related jobs, and don't want to report on the release-related jobs either for now.

Instead of just selecting the `-master-` jobs I instead excluded the `-release-` jobs, in order to start reporting on the nightlies.
I also tweaked the condition for the jobs not owned by ACS team to be more a bit more robust and also omit the `-interop-` jobs.

The changes in the filtering should only leave the following:

- `branch-ci-stackrox-stackrox-master-...`
- `branch-ci-stackrox-stackrox-nightlies-...`
- `go`
- `go-postgres`
- `local-roxctl-tests`
- `scan-go-binaries`
- `shell-unit-tests`
- `ui`

The current `slack_top_n_failures` calls only every select the `branch-ci...` jobs, but if we decide to expand on this in the future if it should be possible to report on the other jobs if we tweak the `ShortJobName` condition, but this is not in scope of this change.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Run the job manually and see the report makes sense
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

[Ran the report manually and compared](https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1716790488280869) to `master` version. The numbers do differ as more runs are now taken into account but the results seem reasonable:

![Screenshot from 2024-05-27 08-31-06](https://github.com/stackrox/stackrox/assets/489420/e2f8f64e-1484-4602-978c-479cbc8408f1)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
