### PR TITLE
ROX-22547: Add stackrox labels to compliance operator use-cases

### DIFF
--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/sensor/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,12 +42,10 @@ func convertCentralRequestToScanSetting(namespace string, request *central.Apply
 			APIVersion: complianceoperator.GetGroupVersion().String(),
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      request.GetScanName(),
-			Namespace: namespace,
-			Labels:    stackroxLabels,
-			Annotations: map[string]string{
-				"owner": "stackrox",
-			},
+			Name:        request.GetScanName(),
+			Namespace:   namespace,
+			Labels:      utils.GetSensorKubernetesLabels(),
+			Annotations: utils.GetSensorKubernetesAnnotations(),
 		},
 		Roles: []string{masterRole, workerRole},
 		ComplianceSuiteSettings: v1alpha1.ComplianceSuiteSettings{
@@ -79,12 +78,10 @@ func convertCentralRequestToScanSettingBinding(namespace string, request *centra
 			APIVersion: complianceoperator.GetGroupVersion().String(),
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      request.GetScanName(),
-			Namespace: namespace,
-			Labels:    stackroxLabels,
-			Annotations: map[string]string{
-				"owner": "stackrox",
-			},
+			Name:        request.GetScanName(),
+			Namespace:   namespace,
+			Labels:      utils.GetSensorKubernetesLabels(),
+			Annotations: utils.GetSensorKubernetesAnnotations(),
 		},
 		Profiles: profileRefs,
 		SettingsRef: &v1alpha1.NamedObjectReference{

--- a/sensor/kubernetes/localscanner/service_certificates_repository.go
+++ b/sensor/kubernetes/localscanner/service_certificates_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/sensor/utils"
 	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -239,6 +240,8 @@ func (r *serviceCertificatesRepoSecretsImpl) createSecret(ctx context.Context, c
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            secretSpec.secretName,
 			Namespace:       r.namespace,
+			Labels:          utils.GetSensorKubernetesLabels(),
+			Annotations:     utils.GetSensorKubernetesLabels(),
 			OwnerReferences: []metav1.OwnerReference{r.ownerReference},
 		},
 		Data: r.secretDataForCertificate(secretSpec, caPem, certificate),

--- a/sensor/utils/utils.go
+++ b/sensor/utils/utils.go
@@ -4,6 +4,29 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	KubernetesLabelManagedBy = "app.kubernetes.io/managed-by"
+	KubernetesLabelPartOf    = "app.kubernetes.io/created-by-deployment-id"
+	KubernetesLabelCreatedBy = "app.kubernetes.io/created-by"
+	KubernetesLabelName      = "app.kubernetes.io/name"
+)
+
+// GetSensorKubernetesLabels returns the default labels for resources created by the sensor.
+func GetSensorKubernetesLabels() map[string]string {
+	return map[string]string{
+		KubernetesLabelManagedBy: "sensor",
+		KubernetesLabelCreatedBy: "sensor",
+		KubernetesLabelName:      "stackrox",
+	}
+}
+
+// GetSensorKubernetesAnnotations returns the default annotations for resources created by the sensor.
+func GetSensorKubernetesAnnotations() map[string]string {
+	return map[string]string{
+		"owner": "stackrox",
+	}
+}
+
 // HasAPI checks whether the kubernetes server supports the groupVersion API for the specified kind
 func HasAPI(client kubernetes.Interface, groupVersion, kind string) (bool, error) {
 	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion)

--- a/sensor/utils/utils.go
+++ b/sensor/utils/utils.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	KubernetesLabelManagedBy = "app.kubernetes.io/managed-by"
-	KubernetesLabelPartOf    = "app.kubernetes.io/created-by-deployment-id"
-	KubernetesLabelCreatedBy = "app.kubernetes.io/created-by"
-	KubernetesLabelName      = "app.kubernetes.io/name"
+	KubernetesLabelManagedBy  = "app.kubernetes.io/managed-by"
+	KubernetesLabelCreatedBy  = "app.kubernetes.io/created-by"
+	KubernetesLabelName       = "app.kubernetes.io/name"
+	KubernetesOwnerAnnotation = "owner"
 )
 
 // GetSensorKubernetesLabels returns the default labels for resources created by the sensor.
@@ -23,7 +23,7 @@ func GetSensorKubernetesLabels() map[string]string {
 // GetSensorKubernetesAnnotations returns the default annotations for resources created by the sensor.
 func GetSensorKubernetesAnnotations() map[string]string {
 	return map[string]string{
-		"owner": "stackrox",
+		KubernetesOwnerAnnotation: "stackrox",
 	}
 }
 


### PR DESCRIPTION
## Description

Added default stackrox labels to all objects created by Sensor.

Owner References are not supported cross namespace: https://github.com/kubernetes/kubernetes/issues/94631#issuecomment-689201744

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI