### PR TITLE
tests: Improve messages related to ROX-22594.

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -156,7 +156,7 @@ class TLSChallengeTest extends BaseSpecification {
         while (t.IsValid()) {
             List<ClusterOuterClass.Cluster> list = Services.getClusterClient().getClusters().getClustersList()
             if (list.empty) {
-                throw new OrchestratorManagerException("Central dos not know about any secured clusters.")
+                throw new OrchestratorManagerException("Central does not know about any secured clusters.")
             }
             if (list.size() > 1) {
                 throw new OrchestratorManagerException("Central knows about more than one secured cluster.")

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -202,7 +202,7 @@ func (s *centralCommunicationImpl) sendEvents(client central.SensorServiceClient
 	s.allFinished.Add(2)
 	s.receiver.Start(stream, s.Stop, s.sender.Stop)
 	s.sender.Start(stream, s.clientReconcile, s.initialDeduperState, s.Stop, s.receiver.Stop)
-	log.Info("Communication with central started.")
+	log.Info("Communication with central started.") // Do not change this line, it is checked by TLSChallengeTest.
 
 	// Wait for stop.
 	/////////////////

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -164,7 +164,7 @@ func createKOCacheSource(centralEndpoint string, centralCerts []*x509.Certificat
 // It returns once tasks have successfully started.
 func (s *Sensor) Start() {
 	// Start up connections.
-	log.Infof("Connecting to Central server %s", s.centralEndpoint)
+	log.Infof("Connecting to Central server %s", s.centralEndpoint) // Do not change this line, it is checked by TLSChallengeTest.
 	if chaos.HasChaosProxy() {
 		chaos.InitializeChaosConfiguration(context.Background())
 	}


### PR DESCRIPTION
## Description

These are changes I was making when getting familiar with the test while investigating the flakes in ROX-22594. The flakes turned out to have an unrelated cause, but I think these improvements are worth merging anyway.

- improve messages and comments
- use consistent gerund form
- add a couple of log messages
- add a check for multiple clusters
- add comments to messages which are checked by tests

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
