### PR TITLE
ROX-23033: +ROX-23035 Add sorting to Node CVE overview tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -7,24 +7,55 @@ import DateDistance from 'Components/DateDistance';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import { getTableUIState } from 'utils/getTableUIState';
 import useURLPagination from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import { ApiSortOption } from 'types/search';
 
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+
+import {
+    CLUSTER_SORT_FIELD,
+    NODE_SCAN_TIME_SORT_FIELD,
+    NODE_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+} from '../../utils/sortFields';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
 import useNodes from './useNodes';
 
+export const sortFields = [
+    NODE_SORT_FIELD,
+    CLUSTER_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+    NODE_SCAN_TIME_SORT_FIELD,
+];
+
+export const defaultSortOption = { field: NODE_SORT_FIELD, direction: 'asc' } as const;
+
 export type NodesTableProps = {
     querySearchFilter: QuerySearchFilter;
     isFiltered: boolean;
     pagination: ReturnType<typeof useURLPagination>;
+    sortOption: ApiSortOption;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTableProps) {
+function NodesTable({
+    querySearchFilter,
+    isFiltered,
+    pagination,
+    sortOption,
+    getSortParams,
+}: NodesTableProps) {
     const { page, perPage } = pagination;
 
-    const { data, previousData, loading, error } = useNodes(querySearchFilter, page, perPage);
+    const { data, previousData, loading, error } = useNodes(
+        querySearchFilter,
+        page,
+        perPage,
+        sortOption
+    );
     const tableData = data ?? previousData;
 
     const tableState = getTableUIState({
@@ -48,14 +79,14 @@ function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTablePro
         >
             <Thead noWrap>
                 <Tr>
-                    <Th>Node</Th>
+                    <Th sort={getSortParams(NODE_SORT_FIELD)}>Node</Th>
                     <Th>
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th>Cluster</Th>
-                    <Th>Operating system</Th>
-                    <Th>Scan time</Th>
+                    <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
+                    <Th sort={getSortParams(OPERATING_SYSTEM_SORT_FIELD)}>Operating system</Th>
+                    <Th sort={getSortParams(NODE_SCAN_TIME_SORT_FIELD)}>Scan time</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,5 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
+import { ApiSortOption } from 'types/search';
+import { Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -57,21 +59,19 @@ export type NodeCVE = {
 export default function useNodeCves(
     querySearchFilter: QuerySearchFilter,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<
         { nodeCVEs: NodeCVE[] },
         {
             query: string;
-            pagination: {
-                offset: number;
-                limit: number;
-            };
+            pagination: Pagination;
         }
     >(cvesListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,5 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
+import { ApiSortOption } from 'types/search';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 
@@ -60,12 +61,13 @@ type Node = {
 export default function useNodes(
     querySearchFilter: QuerySearchFilter,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<{ nodes: Node[] }>(nodeListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -3,9 +3,16 @@ export const CVE_SORT_FIELD = 'CVE';
 export const CVSS_SORT_FIELD = 'CVSS';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
 export const CVE_COUNT_SORT_FIELD = 'CVE Count';
+export const OPERATING_SYSTEM_SORT_FIELD = 'Operating System';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';
 export const CLUSTER_CVE_STATUS_SORT_FIELD = 'Cluster CVE Fixable';
 export const CLUSTER_TYPE_SORT_FIELD = 'Cluster Platform Type';
 export const CLUSTER_KUBERNETES_VERSION_SORT_FIELD = 'Cluster Kubernetes Version';
+
+// Node sort fields
+export const NODE_SORT_FIELD = 'Node';
+export const NODE_TOP_CVSS_SORT_FIELD = 'Node Top CVSS';
+export const NODE_COUNT_SORT_FIELD = 'Node Count';
+export const NODE_SCAN_TIME_SORT_FIELD = 'Node Scan Time';


### PR DESCRIPTION
## Description

Adds sort fields to the Node CVE Overview page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual verification of the correct sorting parameters being sent over the API.

For the sake of sparing this PR many, many screenshots, repeat the testing steps in https://github.com/stackrox/stackrox/pull/11238 on the Node CVE overview page and verify the correct sort parameters are being sent over the API for all sortable fields.