### PR TITLE
ci: wait for not provisioning before gke destroy

### DIFF
--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -29,8 +29,8 @@ class NullCluster:
 class GKECluster:
     # Provisioning timeout is tightly coupled to the time it may take gke.sh to
     # create a cluster.
-    PROVISION_TIMEOUT = 5 * 60  # do not wait - 140 * 60
-    WAIT_TIMEOUT = 5 * 60  # do not wait - 20 * 60
+    PROVISION_TIMEOUT = 140 * 60
+    WAIT_TIMEOUT = 20 * 60
     TEARDOWN_TIMEOUT = 5 * 60
     # separate script names used for testability - test_clusters.py
     PROVISION_PATH = "scripts/ci/gke.sh"


### PR DESCRIPTION
`gcloud cluster delete [clustername] --async` fails before becoming async if a cluster is still being created.

Example forced timeout of create, wait for not `PROVISIONING` then delete: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11275/pull-ci-stackrox-stackrox-master-gke-operator-e2e-tests/1797850733219942400#1:build-log.txt%3A75