### PR TITLE
ROX-23043: node CVE page sorting

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -43,7 +43,7 @@ function mockNode(fields) {
 function setup(tableState) {
     cy.mount(
         <ComponentTestProviders>
-            <AffectedNodesTable tableState={tableState} />
+            <AffectedNodesTable tableState={tableState} getSortParams={() => {}} />
         </ComponentTestProviders>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -12,6 +12,16 @@ import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/Vulnera
 
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import {
+    CLUSTER_SORT_FIELD,
+    COMPONENT_COUNT_SORT_FIELD,
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_STATUS_SORT_FIELD,
+    CVSS_SORT_FIELD,
+    NODE_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+} from '../../utils/sortFields';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import {
     getHighestVulnerabilitySeverity,
@@ -23,6 +33,18 @@ import NodeComponentsTable, {
     NodeComponent,
     nodeComponentFragment,
 } from '../components/NodeComponentsTable';
+
+export const sortFields = [
+    NODE_SORT_FIELD,
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_STATUS_SORT_FIELD,
+    CVSS_SORT_FIELD,
+    CLUSTER_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+    COMPONENT_COUNT_SORT_FIELD,
+];
+
+export const defaultSortOption = { field: CVE_SEVERITY_SORT_FIELD, direction: 'desc' } as const;
 
 export const affectedNodeFragment = gql`
     ${nodeComponentFragment}
@@ -68,10 +90,11 @@ export type AffectedNode = {
 
 export type AffectedNodesTableProps = {
     tableState: TableUIState<AffectedNode>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
 // TODO Add filter icon to dynamic table columns
-function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
+function AffectedNodesTable({ tableState, getSortParams }: AffectedNodesTableProps) {
     const colSpan = 8;
     const expandedRowSet = useSet<string>();
 
@@ -86,13 +109,13 @@ function AffectedNodesTable({ tableState }: AffectedNodesTableProps) {
             <Thead noWrap>
                 <Tr>
                     <Th aria-label="Expand row" />
-                    <Th>Node</Th>
-                    <Th>CVE severity</Th>
-                    <Th>CVE status</Th>
-                    <Th>CVSS score</Th>
-                    <Th>Cluster</Th>
-                    <Th>Operating system</Th>
-                    <Th>Affected components</Th>
+                    <Th sort={getSortParams(NODE_SORT_FIELD)}>Node</Th>
+                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>CVE severity</Th>
+                    <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS score</Th>
+                    <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
+                    <Th sort={getSortParams(OPERATING_SYSTEM_SORT_FIELD)}>Operating system</Th>
+                    <Th sort={getSortParams(COMPONENT_COUNT_SORT_FIELD)}>Affected components</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -15,7 +15,6 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import {
     CLUSTER_SORT_FIELD,
-    COMPONENT_COUNT_SORT_FIELD,
     CVE_SEVERITY_SORT_FIELD,
     CVE_STATUS_SORT_FIELD,
     CVSS_SORT_FIELD,
@@ -41,7 +40,6 @@ export const sortFields = [
     CVSS_SORT_FIELD,
     CLUSTER_SORT_FIELD,
     OPERATING_SYSTEM_SORT_FIELD,
-    COMPONENT_COUNT_SORT_FIELD,
 ];
 
 export const defaultSortOption = { field: CVE_SEVERITY_SORT_FIELD, direction: 'desc' } as const;
@@ -55,9 +53,9 @@ export const affectedNodeFragment = gql`
         cluster {
             name
         }
-        nodeComponents {
+        nodeComponents(query: $query) {
             ...NodeComponentFragment
-            nodeVulnerabilities {
+            nodeVulnerabilities(query: $query) {
                 vulnerabilityId: id
                 cve
                 severity
@@ -115,7 +113,7 @@ function AffectedNodesTable({ tableState, getSortParams }: AffectedNodesTablePro
                     <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS score</Th>
                     <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
                     <Th sort={getSortParams(OPERATING_SYSTEM_SORT_FIELD)}>Operating system</Th>
-                    <Th sort={getSortParams(COMPONENT_COUNT_SORT_FIELD)}>Affected components</Th>
+                    <Th>Affected components</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -26,6 +26,7 @@ import {
     SummaryCardLayout,
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
+import useURLSort from 'hooks/useURLSort';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import {
     getHiddenSeverities,
@@ -34,7 +35,7 @@ import {
 } from '../../utils/searchUtils';
 import CvePageHeader from '../../components/CvePageHeader';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
-import AffectedNodesTable from './AffectedNodesTable';
+import AffectedNodesTable, { defaultSortOption, sortFields } from './AffectedNodesTable';
 import AffectedNodesSummaryCard from './AffectedNodesSummaryCard';
 import useAffectedNodes from './useAffectedNodes';
 import useNodeCveMetadata from './useNodeCveMetadata';
@@ -56,12 +57,17 @@ function NodeCvePage() {
     });
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => setPage(1, 'replace'),
+    });
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
 
     const { metadataRequest, nodeCount, cveData } = useNodeCveMetadata(cveId, query);
 
-    const { affectedNodesRequest, nodeData } = useAffectedNodes(query, page, perPage);
+    const { affectedNodesRequest, nodeData } = useAffectedNodes(query, page, perPage, sortOption);
 
     const nodeCveName = cveData?.cve;
 
@@ -136,15 +142,15 @@ function NodeCvePage() {
                                 page={page}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (nodeCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
+                                    if (nodeCount < (page - 1) * newPerPage) {
+                                        setPage(1, 'replace');
+                                    }
                                 }}
                             />
                         </SplitItem>
                     </Split>
-                    <AffectedNodesTable tableState={tableState} />
+                    <AffectedNodesTable tableState={tableState} getSortParams={getSortParams} />
                 </div>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
@@ -1,4 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
+import { ApiSortOption } from 'types/search';
+import { Pagination } from 'services/types';
+import { getPaginationParams } from 'utils/searchUtils';
 import { affectedNodeFragment, AffectedNode } from './AffectedNodesTable';
 
 const affectedNodesQuery = gql`
@@ -10,22 +13,24 @@ const affectedNodesQuery = gql`
     }
 `;
 
-export default function useAffectedNodes(query: string, page: number, perPage: number) {
+export default function useAffectedNodes(
+    query: string,
+    page: number,
+    perPage: number,
+    sortOption: ApiSortOption
+) {
     const affectedNodesRequest = useQuery<
         {
             nodes: AffectedNode[];
         },
         {
             query: string;
-            pagination: { limit: number; offset: number };
+            pagination: Pagination;
         }
     >(affectedNodesQuery, {
         variables: {
             query,
-            pagination: {
-                limit: perPage,
-                offset: (page - 1) * perPage,
-            },
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -7,24 +7,55 @@ import DateDistance from 'Components/DateDistance';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import { getTableUIState } from 'utils/getTableUIState';
 import useURLPagination from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import { ApiSortOption } from 'types/search';
 
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+
+import {
+    CLUSTER_SORT_FIELD,
+    NODE_SCAN_TIME_SORT_FIELD,
+    NODE_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+} from '../../utils/sortFields';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
 import useNodes from './useNodes';
 
+export const sortFields = [
+    NODE_SORT_FIELD,
+    CLUSTER_SORT_FIELD,
+    OPERATING_SYSTEM_SORT_FIELD,
+    NODE_SCAN_TIME_SORT_FIELD,
+];
+
+export const defaultSortOption = { field: NODE_SORT_FIELD, direction: 'asc' } as const;
+
 export type NodesTableProps = {
     querySearchFilter: QuerySearchFilter;
     isFiltered: boolean;
     pagination: ReturnType<typeof useURLPagination>;
+    sortOption: ApiSortOption;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTableProps) {
+function NodesTable({
+    querySearchFilter,
+    isFiltered,
+    pagination,
+    sortOption,
+    getSortParams,
+}: NodesTableProps) {
     const { page, perPage } = pagination;
 
-    const { data, previousData, loading, error } = useNodes(querySearchFilter, page, perPage);
+    const { data, previousData, loading, error } = useNodes(
+        querySearchFilter,
+        page,
+        perPage,
+        sortOption
+    );
     const tableData = data ?? previousData;
 
     const tableState = getTableUIState({
@@ -48,14 +79,14 @@ function NodesTable({ querySearchFilter, isFiltered, pagination }: NodesTablePro
         >
             <Thead noWrap>
                 <Tr>
-                    <Th>Node</Th>
+                    <Th sort={getSortParams(NODE_SORT_FIELD)}>Node</Th>
                     <Th>
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th>Cluster</Th>
-                    <Th>Operating system</Th>
-                    <Th>Scan time</Th>
+                    <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
+                    <Th sort={getSortParams(OPERATING_SYSTEM_SORT_FIELD)}>Operating system</Th>
+                    <Th sort={getSortParams(NODE_SCAN_TIME_SORT_FIELD)}>Scan time</Th>
                 </Tr>
             </Thead>
             <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,5 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
+import { ApiSortOption } from 'types/search';
+import { Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -57,21 +59,19 @@ export type NodeCVE = {
 export default function useNodeCves(
     querySearchFilter: QuerySearchFilter,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<
         { nodeCVEs: NodeCVE[] },
         {
             query: string;
-            pagination: {
-                offset: number;
-                limit: number;
-            };
+            pagination: Pagination;
         }
     >(cvesListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,5 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
+import { ApiSortOption } from 'types/search';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 
@@ -60,12 +61,13 @@ type Node = {
 export default function useNodes(
     querySearchFilter: QuerySearchFilter,
     page: number,
-    perPage: number
+    perPage: number,
+    sortOption: ApiSortOption
 ) {
     return useQuery<{ nodes: Node[] }>(nodeListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: getPaginationParams(page, perPage),
+            pagination: { ...getPaginationParams(page, perPage), sortOption },
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -6,7 +6,6 @@ export const CVE_STATUS_SORT_FIELD = 'Fixable';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
 export const CVE_COUNT_SORT_FIELD = 'CVE Count';
 export const OPERATING_SYSTEM_SORT_FIELD = 'Operating System';
-export const COMPONENT_COUNT_SORT_FIELD = 'Component Count';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -3,9 +3,16 @@ export const CVE_SORT_FIELD = 'CVE';
 export const CVSS_SORT_FIELD = 'CVSS';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
 export const CVE_COUNT_SORT_FIELD = 'CVE Count';
+export const OPERATING_SYSTEM_SORT_FIELD = 'Operating System';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';
 export const CLUSTER_CVE_STATUS_SORT_FIELD = 'Cluster CVE Fixable';
 export const CLUSTER_TYPE_SORT_FIELD = 'Cluster Platform Type';
 export const CLUSTER_KUBERNETES_VERSION_SORT_FIELD = 'Cluster Kubernetes Version';
+
+// Node sort fields
+export const NODE_SORT_FIELD = 'Node';
+export const NODE_TOP_CVSS_SORT_FIELD = 'Node Top CVSS';
+export const NODE_COUNT_SORT_FIELD = 'Node Count';
+export const NODE_SCAN_TIME_SORT_FIELD = 'Node Scan Time';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -1,9 +1,12 @@
 // General CVE sort fields
 export const CVE_SORT_FIELD = 'CVE';
 export const CVSS_SORT_FIELD = 'CVSS';
+export const CVE_SEVERITY_SORT_FIELD = 'Severity';
+export const CVE_STATUS_SORT_FIELD = 'Fixable';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
 export const CVE_COUNT_SORT_FIELD = 'CVE Count';
 export const OPERATING_SYSTEM_SORT_FIELD = 'Operating System';
+export const COMPONENT_COUNT_SORT_FIELD = 'Component Count';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';


### PR DESCRIPTION
## Description

Adds sorting to the Node table on the Node CVE single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual verification that the correct sort parameter is sent over API calls for each field.
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/5311ff05-ad00-4aad-a6ef-2bc6ae75efc9">
