### PR TITLE
fix(scanner): Fix download artifact action usage

### DIFF
--- a/.github/workflows/scanner-db-init-dump.yaml
+++ b/.github/workflows/scanner-db-init-dump.yaml
@@ -58,6 +58,13 @@ jobs:
       #      release branches.
       version: dev
     steps:
+      # Checkout to run ./.github/actions/{download,upload}-artifact-with-retry
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: updater
@@ -107,6 +114,13 @@ jobs:
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+
+      # Checkout to run ./.github/actions/download-artifact-with-retry
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/download-artifact-with-retry
 

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -48,6 +48,7 @@ jobs:
       STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       STACKROX_NVD_API_CALL_INTERVAL: 6s
     steps:
+    # Checkout to run ./.github/actions/{download,upload}-artifact-with-retry
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
@@ -84,6 +85,13 @@ jobs:
     needs:
       - run-updater
     steps:
+    # Checkout to run ./.github/actions/download-artifact-with-retry
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: vulns


### PR DESCRIPTION
## Description

Change scanner-related workflows to checkout the source-code to access `./.github/actions/download-artifact-with-retry` introduced by #11019.

## Testing Performed

### Here I tell how I validated my change

Added `pr-scanner-db-init-bundle` and `pr-update-scanner-vulns`, and checked CI results are :heavy_check_mark: 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
