### PR TITLE
ROX-24404: Support pause-reconcile for SecuredCluster.

### DIFF
--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -18,10 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const (
-	pauseReconcileAnnotation = "stackrox.io/pause-reconcile"
-)
-
 // RegisterNewReconciler registers a new helm reconciler in the given k8s controller manager
 func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	proxyEnv := proxy.GetProxyEnvVars() // fix at startup time
@@ -43,7 +39,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
 		pkgReconciler.WithReconcilePeriod(extensions.InitBundleReconcilePeriod),
-		pkgReconciler.WithPauseReconcileAnnotation(pauseReconcileAnnotation),
+		pkgReconciler.WithPauseReconcileAnnotation(commonExtensions.PauseReconcileAnnotation),
 	}
 
 	if features.ScannerV4Support.Enabled() {

--- a/operator/pkg/common/extensions/pause_reconcile.go
+++ b/operator/pkg/common/extensions/pause_reconcile.go
@@ -1,0 +1,6 @@
+package extensions
+
+const (
+	// PauseReconcileAnnotation is the name of the annotation to use for WithPauseReconcileAnnotation in this operator.
+	PauseReconcileAnnotation = "stackrox.io/pause-reconcile"
+)

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -34,6 +34,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
 		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
+		pkgReconciler.WithPauseReconcileAnnotation(commonExtensions.PauseReconcileAnnotation),
 	}
 
 	if features.ScannerV4Support.Enabled() {


### PR DESCRIPTION
## Description

This will allow us to quiesce the operator to not interfere with the manipulations we do during testing.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

The annotation seems undocumented for `Central` so I'm not adding docs for this either.

## Testing Performed

### Here I tell how I validated my change

CI should be enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
