### PR TITLE
chore(ui): Refactor pagination util function

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
@@ -38,7 +38,7 @@ export default function useNodeVulnerabilities(
         variables: {
             id,
             query,
-            pagination: getPaginationParams(page, perPage),
+            pagination: getPaginationParams({ page, perPage }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
@@ -30,7 +30,7 @@ export default function useAffectedNodes(
     >(affectedNodesQuery, {
         variables: {
             query,
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -71,7 +71,7 @@ export default function useNodeCves(
     >(cvesListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -67,7 +67,7 @@ export default function useNodes(
     return useQuery<{ nodes: Node[] }>(nodeListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
@@ -42,7 +42,7 @@ export default function useClusterVulnerabilities(
         variables: {
             id,
             query,
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -65,7 +65,7 @@ export default function usePlatformCves(
     >(cveListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
@@ -46,7 +46,7 @@ export default function usePlatformCveMetadata(
         variables: {
             cve,
             query,
-            pagination: getPaginationParams(page, perPage),
+            pagination: getPaginationParams({ page, perPage }),
         },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -124,10 +124,7 @@ function NamespaceViewPage() {
                 ...searchFilter,
                 ...defaultSearchFilters,
             }),
-            pagination: {
-                ...getPaginationParams(page, perPage),
-                sortOption,
-            },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
         pollInterval,
     });

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -52,7 +52,7 @@ export function getComplianceProfileCheckResult(
 ): Promise<ListComplianceCheckClusterResponse> {
     const queryParameters = {
         query: {
-            pagination: { ...getPaginationParams(page, perPage) },
+            pagination: getPaginationParams({ page, perPage }),
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -74,7 +74,7 @@ export function getComplianceProfileResults(
 ): Promise<ListComplianceProfileResults> {
     const queryParameters = {
         query: {
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -47,7 +47,7 @@ export function getComplianceClusterStats(
 ): Promise<ListComplianceClusterOverallStatsResponse> {
     const queryParameters = {
         query: {
-            pagination: { ...getPaginationParams(page, perPage), sortOption },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
+import { Pagination } from 'services/types';
 import { ValueOf } from './type.utils';
 
 /**
@@ -222,13 +223,21 @@ export function getListQueryParams(
  * Calculates the API pagination limit and offset parameters given the
  * current page and number of items per page
  */
-export function getPaginationParams(
-    page: number,
-    perPage: number
-): { offset: number; limit: number } {
+export function getPaginationParams({
+    page,
+    perPage,
+    sortOption,
+}: {
+    page: number;
+    perPage: number;
+    sortOption?: ApiSortOption;
+}): Pagination {
+    const sortObject = sortOption ? { sortOption } : {};
+
     return {
         offset: (page - 1) * perPage,
         limit: perPage,
+        ...sortObject,
     };
 }
 


### PR DESCRIPTION
## Description

As discussed yesterday, refactors the `getPaginationParams` function to accept a single object argument of the shape `{ page: number; perPage: number; sortOption?: ApiSortOption }` instead of two positional `number` arguments in order to prevent the possibility of passing arguments in the incorrect order.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Existing unit tests, added unit tests, verification that the build type checks.
