### PR TITLE
ROX-23052: Add sorting to Node single page table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -11,6 +11,13 @@ import { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import {
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVE_STATUS_SORT_FIELD,
+    CVSS_SORT_FIELD,
+} from 'Containers/Vulnerabilities/utils/sortFields';
 import {
     getIsSomeVulnerabilityFixable,
     getHighestVulnerabilitySeverity,
@@ -20,6 +27,17 @@ import NodeComponentsTable, {
     NodeComponent,
     nodeComponentFragment,
 } from '../components/NodeComponentsTable';
+
+export const sortFields = [
+    CVE_SORT_FIELD,
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_STATUS_SORT_FIELD,
+    CVSS_SORT_FIELD,
+    // TODO - Needs a BE field implementation
+    //  AFFECTED_COMPONENTS_SORT_FIELD
+];
+
+export const defaultSortOption = { field: CVE_SEVERITY_SORT_FIELD, direction: 'desc' } as const;
 
 export const nodeVulnerabilityFragment = gql`
     ${nodeComponentFragment}
@@ -55,9 +73,10 @@ export type NodeVulnerability = {
 
 export type CVEsTableProps = {
     tableState: TableUIState<NodeVulnerability>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function CVEsTable({ tableState }: CVEsTableProps) {
+function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
     const COL_SPAN = 6;
     const expandedRowSet = useSet<string>();
 
@@ -72,10 +91,10 @@ function CVEsTable({ tableState }: CVEsTableProps) {
             <Thead noWrap>
                 <Tr>
                     <Th aria-label="Expand row" />
-                    <Th>CVE</Th>
-                    <Th>Top severity</Th>
-                    <Th>CVE status</Th>
-                    <Th>CVSS score</Th>
+                    <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
+                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top severity</Th>
+                    <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS score</Th>
                     <Th>Affected components</Th>
                 </Tr>
             </Thead>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
@@ -1,6 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
+import { ClientPagination, Pagination } from 'services/types';
 import { NodeVulnerability, nodeVulnerabilityFragment } from './CVEsTable';
 
 const nodeVulnerabilitiesQuery = gql`
@@ -16,12 +17,13 @@ const nodeVulnerabilitiesQuery = gql`
     }
 `;
 
-export default function useNodeVulnerabilities(
-    id: string,
-    query: string,
-    page: number,
-    perPage: number
-) {
+export default function useNodeVulnerabilities({
+    nodeId,
+    query,
+    page,
+    perPage,
+    sortOption,
+}: { nodeId: string; query: string } & ClientPagination) {
     return useQuery<
         {
             node: {
@@ -32,13 +34,13 @@ export default function useNodeVulnerabilities(
         {
             id: string;
             query: string;
-            pagination: { limit: number; offset: number };
+            pagination: Pagination;
         }
     >(nodeVulnerabilitiesQuery, {
         variables: {
-            id,
+            id: nodeId,
             query,
-            pagination: getPaginationParams({ page, perPage }),
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 }

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -1,5 +1,13 @@
 import { ApiSortOption } from 'types/search';
 
+/* The type for pagination data stored and generated client side */
+export type ClientPagination = {
+    page: number;
+    perPage: number;
+    sortOption?: ApiSortOption;
+};
+
+/* The type for pagination data passed to the server side APIs */
 export type Pagination = {
     offset: number;
     limit: number;


### PR DESCRIPTION
## Description

Adds sorting to the last node/platform cve table - the node single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

As in previous sorting PRs -- manual verification that the correct parameters are sent to the API when sorting via table headers.