### PR TITLE
test: Do not run on every push govulncheck.sh

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -587,7 +587,6 @@ jobs:
 
   scan-go-binaries:
     if: |
-      github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/


### PR DESCRIPTION
## Description

This change helps avoid red "x" appearing on PRs for reasons unrelated to the PR (such as a new vulnerability appearing in the DB).

We already have a process to address vulnerabilities from downstream builds, so we're not losing much by disabling this. Of course it would be nice to "shift left" as much as possible, but without a process set up to address failures in a timely manner this is mostly teaching folks to ignore the check.

The job will still run when a label is set on a PR.

cc @janisz 

Perhaps we can still run it on pushes to `master` but that requires crafting a more elaborate logic which I don't have the bandwitdh to create right now.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] make sure it does not run
- [ ] make sure it runs when I re-run the workflow after applying the label

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
