### PR TITLE
chore(ui): Node & Platform CVE refactor + cleanup

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -120,9 +120,6 @@ function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
                                     setPerPage(newPerPage);
-                                    if (nodeCount < (page - 1) * newPerPage) {
-                                        setPage(1, 'replace');
-                                    }
                                 }}
                             />
                         </SplitItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -143,9 +143,6 @@ function NodeCvePage() {
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
                                     setPerPage(newPerPage);
-                                    if (nodeCount < (page - 1) * newPerPage) {
-                                        setPage(1, 'replace');
-                                    }
                                 }}
                             />
                         </SplitItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -67,7 +67,12 @@ function NodeCvePage() {
 
     const { metadataRequest, nodeCount, cveData } = useNodeCveMetadata(cveId, query);
 
-    const { affectedNodesRequest, nodeData } = useAffectedNodes(query, page, perPage, sortOption);
+    const { affectedNodesRequest, nodeData } = useAffectedNodes({
+        query,
+        page,
+        perPage,
+        sortOption,
+    });
 
     const nodeCveName = cveData?.cve;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
@@ -1,6 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
-import { ApiSortOption } from 'types/search';
-import { Pagination } from 'services/types';
+import { ClientPagination, Pagination } from 'services/types';
 import { getPaginationParams } from 'utils/searchUtils';
 import { affectedNodeFragment, AffectedNode } from './AffectedNodesTable';
 
@@ -13,12 +12,12 @@ const affectedNodesQuery = gql`
     }
 `;
 
-export default function useAffectedNodes(
-    query: string,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function useAffectedNodes({
+    query,
+    page,
+    perPage,
+    sortOption,
+}: { query: string } & ClientPagination) {
     const affectedNodesRequest = useQuery<
         {
             nodes: AffectedNode[];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -74,12 +74,12 @@ function CVEsTable({
 }: CVEsTableProps) {
     const { page, perPage } = pagination;
 
-    const { data, previousData, loading, error } = useNodeCves(
+    const { data, previousData, loading, error } = useNodeCves({
         querySearchFilter,
         page,
         perPage,
-        sortOption
-    );
+        sortOption,
+    });
     const totalNodeCount = useTotalNodeCount();
 
     const tableData = data ?? previousData;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -50,12 +50,12 @@ function NodesTable({
 }: NodesTableProps) {
     const { page, perPage } = pagination;
 
-    const { data, previousData, loading, error } = useNodes(
+    const { data, previousData, loading, error } = useNodes({
         querySearchFilter,
         page,
         perPage,
-        sortOption
-    );
+        sortOption,
+    });
     const tableData = data ?? previousData;
 
     const tableState = getTableUIState({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,7 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ApiSortOption } from 'types/search';
-import { Pagination } from 'services/types';
+import { ClientPagination, Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -56,12 +55,12 @@ export type NodeCVE = {
     }[];
 };
 
-export default function useNodeCves(
-    querySearchFilter: QuerySearchFilter,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function useNodeCves({
+    querySearchFilter,
+    page,
+    perPage,
+    sortOption,
+}: { querySearchFilter: QuerySearchFilter } & ClientPagination) {
     return useQuery<
         { nodeCVEs: NodeCVE[] },
         {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ApiSortOption } from 'types/search';
+import { ClientPagination } from 'services/types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 
@@ -58,12 +58,12 @@ type Node = {
     scanTime: string;
 };
 
-export default function useNodes(
-    querySearchFilter: QuerySearchFilter,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function useNodes({
+    querySearchFilter,
+    page,
+    perPage,
+    sortOption,
+}: { querySearchFilter: QuerySearchFilter } & ClientPagination) {
     return useQuery<{ nodes: Node[] }>(nodeListQuery, {
         variables: {
             query: getRegexScopedQueryString(querySearchFilter),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -45,13 +45,13 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
         onSort: () => setPage(1, 'replace'),
     });
 
-    const { data, loading, error } = useClusterVulnerabilities(
+    const { data, loading, error } = useClusterVulnerabilities({
         clusterId,
         query,
         page,
         perPage,
-        sortOption
-    );
+        sortOption,
+    });
     const summaryRequest = useClusterSummaryData(clusterId, query);
 
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -112,9 +112,6 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                                 page={page}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (clusterVulnerabilityCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
@@ -2,8 +2,7 @@ import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
 
-import { Pagination } from 'services/types';
-import { ApiSortOption } from 'types/search';
+import { ClientPagination, Pagination } from 'services/types';
 import { ClusterVulnerability, clusterVulnerabilityFragment } from './CVEsTable';
 
 const clusterVulnerabilitiesQuery = gql`
@@ -19,13 +18,13 @@ const clusterVulnerabilitiesQuery = gql`
     }
 `;
 
-export default function useClusterVulnerabilities(
-    id: string,
-    query: string,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function useClusterVulnerabilities({
+    clusterId,
+    query,
+    page,
+    perPage,
+    sortOption,
+}: { clusterId: string; query: string } & ClientPagination) {
     return useQuery<
         {
             cluster: {
@@ -40,7 +39,7 @@ export default function useClusterVulnerabilities(
         }
     >(clusterVulnerabilitiesQuery, {
         variables: {
-            id,
+            id: clusterId,
             query,
             pagination: getPaginationParams({ page, perPage, sortOption }),
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -82,12 +82,12 @@ function CVEsTable({
 }: CVEsTableProps) {
     const { page, perPage } = pagination;
 
-    const { data, previousData, error, loading } = usePlatformCves(
+    const { data, previousData, error, loading } = usePlatformCves({
         querySearchFilter,
         page,
         perPage,
-        sortOption
-    );
+        sortOption,
+    });
     const totalClusterCountRequest = useQuery(totalClusterCountQuery);
     const totalClusterCount = totalClusterCountRequest.data?.clusterCount ?? 0;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -1,7 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ApiSortOption } from 'types/search';
-import { Pagination } from 'services/types';
+import { ClientPagination, Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
@@ -48,12 +47,12 @@ const cveListQuery = gql`
     }
 `;
 
-export default function usePlatformCves(
-    querySearchFilter: QuerySearchFilter,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function usePlatformCves({
+    querySearchFilter,
+    page,
+    perPage,
+    sortOption,
+}: { querySearchFilter: QuerySearchFilter } & ClientPagination) {
     return useQuery<
         {
             platformCVEs: PlatformCVE[];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -61,13 +61,13 @@ function PlatformCvePage() {
         onSort: () => setPage(1),
     });
 
-    const { affectedClustersRequest, clusterData, clusterCount } = useAffectedClusters(
+    const { affectedClustersRequest, clusterData, clusterCount } = useAffectedClusters({
         query,
         page,
         perPage,
-        sortOption
-    );
-    const metadataRequest = usePlatformCveMetadata(cveId, query, page, perPage);
+        sortOption,
+    });
+    const metadataRequest = usePlatformCveMetadata({ cve: cveId, query, page, perPage });
     const cveName = metadataRequest.data?.platformCVE?.cve;
     const isFiltered = getHasSearchApplied(querySearchFilter);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -139,9 +139,6 @@ function PlatformCvePage() {
                                 page={page}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (clusterCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
-import { ApiSortOption } from 'types/search';
-import { Pagination } from 'services/types';
+import { ClientPagination, Pagination } from 'services/types';
+import { getPaginationParams } from 'utils/searchUtils';
 import { AffectedCluster, affectedClusterFragment } from './AffectedClustersTable';
 
 const affectedClustersQuery = gql`
@@ -13,12 +13,12 @@ const affectedClustersQuery = gql`
     }
 `;
 
-export default function useAffectedClusters(
-    query: string,
-    page: number,
-    perPage: number,
-    sortOption: ApiSortOption
-) {
+export default function useAffectedClusters({
+    query,
+    page,
+    perPage,
+    sortOption,
+}: { query: string } & ClientPagination) {
     const affectedClustersRequest = useQuery<
         {
             clusterCount: number;
@@ -31,11 +31,7 @@ export default function useAffectedClusters(
     >(affectedClustersQuery, {
         variables: {
             query,
-            pagination: {
-                limit: perPage,
-                offset: (page - 1) * perPage,
-                sortOption,
-            },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
@@ -2,6 +2,7 @@ import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
 
+import { ClientPagination } from 'services/types';
 import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
 
 const platformCveMetadataQuery = gql`
@@ -32,12 +33,12 @@ export type PlatformCveMetadata = {
     firstDiscoveredInSystem: string;
 };
 
-export default function usePlatformCveMetadata(
-    cve: string,
-    query: string,
-    page: number,
-    perPage: number
-) {
+export default function usePlatformCveMetadata({
+    cve,
+    query,
+    page,
+    perPage,
+}: { cve: string; query: string } & ClientPagination) {
     return useQuery<{
         totalClusterCount: number;
         clusterCount: number;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -102,9 +102,6 @@ function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageRes
                                 perPage={perPage}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (imageCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -254,9 +254,6 @@ function DeploymentPageVulnerabilities({
                                     perPage={perPage}
                                     onSetPage={(_, newPage) => setPage(newPage)}
                                     onPerPageSelect={(_, newPerPage) => {
-                                        if (totalVulnerabilityCount < (page - 1) * newPerPage) {
-                                            setPage(1);
-                                        }
                                         setPerPage(newPerPage);
                                     }}
                                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -105,9 +105,6 @@ function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
                                 perPage={perPage}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (deploymentCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -281,9 +281,6 @@ function ImagePageVulnerabilities({
                                 perPage={perPage}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (totalVulnerabilityCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -438,9 +438,6 @@ function ImageCvePage() {
                                 perPage={perPage}
                                 onSetPage={(_, newPage) => setPage(newPage)}
                                 onPerPageSelect={(_, newPerPage) => {
-                                    if (tableRowCount < (page - 1) * newPerPage) {
-                                        setPage(1);
-                                    }
                                     setPerPage(newPerPage);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
@@ -55,9 +55,6 @@ function TableEntityToolbar({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                if (tableRowCount < (page - 1) * newPerPage) {
-                                    setPage(1);
-                                }
                                 setPerPage(newPerPage);
                             }}
                         />


### PR DESCRIPTION
## Description

Two commits, two cleanups:

1. Remove all cases under **VM 2.0** where we manually reset the `page` when the `perPage` value changes. This happens automatically in the hook call as of 9 months ago.
2. Update signatures of **Node/Platform CVE** custom hooks to prefer a single object instead of positional parameters when the hook expects many parameters with overlapping types

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual smoke tests of Node and Platform CVE pages.

CI e2e tests.