### PR TITLE
ROX-24331: Fix problem with comma in report form mailing lists

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
@@ -24,7 +24,7 @@ type NotifierMailingListsProps = {
     fieldIdPrefixForFormikAndPatternFly: string;
     hasWriteAccessForIntegration: boolean;
     isLoadingNotifiers: boolean;
-    mailingLists: string[];
+    mailingListsString: string;
     notifierId: string;
     notifierName: string;
     notifiers: NotifierIntegrationBase[];
@@ -38,7 +38,7 @@ function NotifierMailingLists({
     fieldIdPrefixForFormikAndPatternFly,
     hasWriteAccessForIntegration,
     isLoadingNotifiers,
-    mailingLists,
+    mailingListsString,
     notifierId,
     notifierName,
     notifiers,
@@ -101,7 +101,6 @@ function NotifierMailingLists({
                       {name}
                   </SelectOption>
               ));
-    const mailingListsString = mailingLists.join(', ');
 
     return (
         <>


### PR DESCRIPTION
## Description

### Problem

Thanks to Brad for careful testing to notice that you cannot delete trailing comma in **Distribution list** text input box.

### Analysis

Because `mailingLists` property has `string[]` type in payload and response, the usual single-source-of-truth principle of React implies on change:
* Call `splitAndTrimMailingListsString` to convert to split and trim string value from `TextInput` element.
* Call `mailingLists.join(', ')` to convert back to string.

Here is the unintended result:
1. As soon as someone types a trailing comma, `splitAndTrimMailingListsString` appends an empty string to the array, and join with `', '` appends a space to the string.
2. A backspace deletes the space, but leaves the comma.
3. The split-join round trip replaces the space.

### Solution

A hypothetical solution would replace `TextInput` element with array of `TextInput` elements plus explicit interactions to add or delete items from `mailingLists` array.

Because a redesign is out of scope, **second source of truth** is an alternative solution.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Prerequisite for `yarn start` in ui folder:

```sh
export ROX_COMPLIANCE_REPORTING=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4635821 - 4635821
        total 220 = 11712125 - 11711905
    * `ls -al build/static/js/*.js | wc`
        files 0 = 172 - 172
3. `yarn start` in ui

Add temporary `console.log` statements:
* in `splitAndTrimMailingListsString` function of `NotifierConfigurationForm` component.
* in `updateMailingListsString` function of `NotifierConfigurationForm` component.
* in `NotifierMailingLists` component.

### Manual testing of Vulnerability Reporting

Prerequisite: create at least one collection for vulnerability reports.

Make sure that both sources of truth are consistent and correct for one delivery destination.

1. Visit /main/vulnerabilities/reports and click **Create report**.

2. Click **Add delivery destination** and then select a notifier.
    * See `notifier.labelDefault` in `TextInput` element value.

3. Type comma.
    * See comma instead of comma-space in `TextInput` element value.
    * See absence of empty string item in `mailingLists` formik value.

4. Press delete key.
    * See absence of comma in `TextInput` element value.

5. Type comma, double space, another email address, and then double space.
    * See string exactly as typed in `TextInput` element value.
    * See 2 correctly trimmed items in `mailingLists` formik value.

6. Click **Next**.
    * See 2 correctly trimmed and joined items in **Distribution lists** column of table.
        ![Vulnerability_Reporting_Review](https://github.com/stackrox/stackrox/assets/11862657/f4dcdbfd-ca4b-4ef0-96b2-d1b8213ef4e3)

7. Click **Create**.
    * See expected `mailingLists` property value in payload and response of POST /v2/reports/configurations request.
        ![Vulnerability_Reporting_Create](https://github.com/stackrox/stackrox/assets/11862657/dfd5ce29-da65-49c6-9b6b-746498358c50)

8. Click link in reports table to open report details page.
    * See expected `mailingLists` property value in response of GET /v2/reports/configurations/id request.
    * See 2 correctly trimmed and joined items in **Distribution lists** column of table.
        ![Vulnerability_Reporting_details](https://github.com/stackrox/stackrox/assets/11862657/4b61c0e0-d02c-48d1-a61a-8466b053f60b)

### Manual testing of Compliance Reporting

Make sure that both sources of truth are consistent and correct for multiple delivery destinations.

1. Visit /main/compliance/schedules and click **Create scan schedule**.

2. Click **Add delivery destination** and then select a notifier.
    * See `notifier.labelDefault` in `TextInput` element value.

3. Edit **Email template** to add custom subject.

4. Click **Add delivery destination** and then create a notifier.
    * See `notifier.labelDefault` in `TextInput` element value.

5. Edit the original string, and then add a second string.
    * See 2 correctly trimmed and joined items in `mailingLists` formik value.

6. Type multiple consecutive commas.
    * See only 2 correctly trimmed and joined items in `mailingLists` formik value.

7. Edit **Email template** to add custom body.

8. Click **Add delivery destination** and then create a notifier.
    * See `notifier.labelDefault` in `TextInput` element value.

9. Edit the original string.
    * See expected item in `mailingLists` formik value.

10. Click **Next**.
    * See correctly trimmed and joined items in **Distribution lists** column of table.
        ![Compliance_Schedules_Review_3](https://github.com/stackrox/stackrox/assets/11862657/32b38b6d-cb4c-4348-9de1-ef1c266dee99)

11. Click **Back** and then delete the first delivery destination.
    * See correct values of **Distribution list** and **Email template** for the original second and third delivery destinations.
        ![Compliance_Schedules_Configure_report_2](https://github.com/stackrox/stackrox/assets/11862657/bbc79d90-4861-4cd7-89de-36641b726b7f)

12. Click **Next** and then click **Create**.
    * See expected `mailingLists` property value in payload but unexpected `notifiers: []` in response of POST /v2/compliance/scan/configurations request.
        ![Compliance_Schedules_Create_2 pnt](https://github.com/stackrox/stackrox/assets/11862657/dc992716-463b-4559-b316-59bfc1935884)

13. Click link in reports table to open report details page.
    * See unexpected `notifiers: []` property value in response of GET /v2/compliance/scan/configurations request/id request.
