### PR TITLE
ROX-24439: Add key prop for None option in RepeatScheduleDropdown

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
@@ -38,7 +38,12 @@ function RepeatScheduleDropdown({
         </SelectOption>,
     ];
     if (showNoResultsOption) {
-        options = [<SelectOption isNoResultsOption>None</SelectOption>, ...options];
+        options = [
+            <SelectOption key="none" isNoResultsOption>
+                None
+            </SelectOption>,
+            ...options,
+        ];
     }
     return (
         <SelectSingle


### PR DESCRIPTION
## Description

Recently, I saw error in browser console while testing improvments to vulnerability reporting.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/vulnerabilities/reports and then click **Create report**.

2. Fill required fields in step 1 and then click **Next**.

    * Before change: see error without `key` prop.
        ![showNoResultsOption](https://github.com/stackrox/stackrox/assets/11862657/513fc4aa-8067-4c4a-b19d-10683615ed9c)

    * After change: see absence of error with `key` prop.