### PR TITLE
fix(scanner): remove extra noRejected from NVD 2.0 API query

### DIFF
--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -112,7 +112,6 @@ func (e *Enricher) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c 
 		e.feed, err = defaultFeed.Parse(".")
 		utils.CrashOnError(err)
 	}
-	e.feed.RawQuery = "noRejected"
 	zlog.Info(ctx).
 		Str("feed", e.feed.String()).
 		Bool("has_api_key", e.apiKey != "").
@@ -277,7 +276,6 @@ func (e *Enricher) feedURL(start time.Time, end time.Time, startIdx int) string 
 	v.Set("startIndex", strconv.Itoa(startIdx))
 	v.Set("pubStartDate", start.Format("2006-01-02T15:04:05Z"))
 	v.Set("pubEndDate", end.Format("2006-01-02T15:04:05Z"))
-	// v.Encode() will always assume there is a value fo each key.
 	// noRejected does not have a value, so manually append it here.
 	u.RawQuery = v.Encode() + "&noRejected"
 	return u.String()


### PR DESCRIPTION
## Description

Previously the URL was encoded as follows:

https://services.nvd.nist.gov/rest/json/cves/2.0/?noRejected=&pubEndDate=2020-01-26T23%3A59%3A59Z&pubStartDate=2019-09-29T00%3A00%3A00Z&startIndex=6158&noRejected

Now it's:

https://services.nvd.nist.gov/rest/json/cves/2.0/?pubEndDate=2020-01-26T23%3A59%3A59Z&pubStartDate=2019-09-29T00%3A00%3A00Z&startIndex=6158&noRejected

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI (see label)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
