### PR TITLE
chore(ui): Re-enable VM 1.0 in navigation, mark deprecated

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
+import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,11 +17,6 @@ const entitiesKey = 'cluster-cves';
 
 describe('Vulnerability Management Cluster (Platform) CVEs', () => {
     withAuth();
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,11 +16,6 @@ const entitiesKey = 'clusters';
 
 describe('Vulnerability Management Clusters', () => {
     withAuth();
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display all the columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import {
     interactAndWaitForVulnerabilityManagementEntities,
@@ -35,11 +34,6 @@ function selectTopRiskyOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should visit using the left nav', () => {
         visitVulnerabilityManagementDashboardFromLeftNav();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     interactAndWaitForVulnerabilityManagementEntity,
     visitVulnerabilityManagementDashboard,
@@ -51,11 +50,6 @@ function selectTopRiskiestOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     // Some tests might fail in local deployment.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,12 +16,6 @@ const entitiesKey = 'deployments';
 
 describe('Vulnerability Management Deployments', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -11,12 +11,6 @@ import { selectors } from './VulnerabilityManagement.selectors';
 describe('Entities single views', () => {
     withAuth();
 
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
-
     // Some tests might fail in local deployment.
 
     // TODO skip pending more robust criterion than deployment count

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,12 +16,6 @@ const entitiesKey = 'image-components';
 
 describe('Vulnerability Management Image Components', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -1,6 +1,5 @@
 import { selectors } from './VulnerabilityManagement.selectors';
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -19,12 +18,6 @@ const entitiesKey = 'image-cves';
 
 describe('Vulnerability Management Image CVEs', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -20,12 +19,6 @@ const entitiesKey = 'images';
 
 describe('Vulnerability Management Images', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,12 +16,6 @@ const entitiesKey = 'namespaces';
 
 describe('Vulnerability Management Namespaces', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
+import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,12 +17,6 @@ const entitiesKey = 'node-components';
 
 describe('Vulnerability Management Node Components', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -1,6 +1,6 @@
 import { selectors } from './VulnerabilityManagement.selectors';
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor, hasFeatureFlag } from '../../helpers/features';
+import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -19,12 +19,6 @@ const entitiesKey = 'node-cves';
 
 describe('Vulnerability Management Node CVEs', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodes.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -17,12 +16,6 @@ const entitiesKey = 'nodes';
 
 describe('Vulnerability Management Nodes', () => {
     withAuth();
-
-    before(function () {
-        if (hasFeatureFlag('ROX_VULN_MGMT_2_GA')) {
-            this.skip();
-        }
-    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationContent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationContent.tsx
@@ -1,25 +1,23 @@
-import React, { CSSProperties, ReactElement, ReactNode } from 'react';
-import { Flex, Label } from '@patternfly/react-core';
+import React, { ReactElement, ReactNode } from 'react';
+import { Label } from '@patternfly/react-core';
 
 import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
 
 type NavigationContentVariant = 'Deprecated' | 'TechPreview';
 
-const badgeMap: Record<string, ReactElement> = {
+const badgeMap = {
     Deprecated: (
         <Label
             isCompact
-            style={
-                {
-                    '--pf-v5-c-label--BackgroundColor': 'var(--pf-v5-global--disabled-color--200)',
-                } as CSSProperties
-            }
+            style={{
+                '--pf-v5-c-label__content--Color': 'var(--pf-v5-global--Color--dark-100)',
+            }}
         >
             Deprecated
         </Label>
     ),
     TechPreview: <TechPreviewLabel />,
-}; // TODO why does tsc build fail with missing semicolon with satisfies Record<string, ReactElement>
+} satisfies Record<string, ReactElement>;
 
 export type NavigationContentProps = {
     children: ReactNode;
@@ -28,10 +26,10 @@ export type NavigationContentProps = {
 
 function NavigationContent({ children, variant }: NavigationContentProps): ReactElement {
     return (
-        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+        <>
             <span>{children}</span>
-            <span>{badgeMap[variant]}</span>
-        </Flex>
+            <span className="pf-v5-u-ml-sm">{badgeMap[variant]}</span>
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -83,7 +83,7 @@ type ChildDescription = LinkDescription | SeparatorDescription;
 
 type ParentDescription = {
     type: 'parent';
-    title: string | TitleCallback;
+    title: string | ReactElement | TitleCallback;
     key: string; // for key prop and especially for title callback
     children: ChildDescription[];
 };
@@ -91,9 +91,7 @@ type ParentDescription = {
 type NavDescription = LinkDescription | ParentDescription;
 
 function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDescription[] {
-    const vulnMgmt2GaContentPredicate =
-        (techPreviewContent: string | ReactElement, gaContent: string | ReactElement) => () =>
-            isFeatureFlagEnabled('ROX_VULN_MGMT_2_GA') ? gaContent : techPreviewContent;
+    const isVulnMgmt2GAEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_2_GA');
 
     return [
         {
@@ -224,27 +222,30 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
             children: [
                 {
                     type: 'link',
-                    content: vulnMgmt2GaContentPredicate(
-                        <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
+                    content: isVulnMgmt2GAEnabled ? (
                         'Workload CVEs'
+                    ) : (
+                        <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>
                     ),
                     path: vulnerabilitiesWorkloadCvesPath,
                     routeKey: 'workload-cves',
                 },
                 {
                     type: 'link',
-                    content: vulnMgmt2GaContentPredicate(
-                        <NavigationContent variant="TechPreview">Platform CVEs</NavigationContent>,
+                    content: isVulnMgmt2GAEnabled ? (
                         'Platform CVEs'
+                    ) : (
+                        <NavigationContent variant="TechPreview">Platform CVEs</NavigationContent>
                     ),
                     path: vulnerabilitiesPlatformCvesPath,
                     routeKey: 'platform-cves',
                 },
                 {
                     type: 'link',
-                    content: vulnMgmt2GaContentPredicate(
-                        <NavigationContent variant="TechPreview">Node CVEs</NavigationContent>,
+                    content: isVulnMgmt2GAEnabled ? (
                         'Node CVEs'
+                    ) : (
+                        <NavigationContent variant="TechPreview">Node CVEs</NavigationContent>
                     ),
                     path: vulnerabilitiesNodeCvesPath,
                     routeKey: 'node-cves',
@@ -270,11 +271,12 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         {
             type: 'parent',
             key: keyForVulnerabilityManagement1,
-            title: vulnMgmt2GaContentPredicate(
-                'Vulnerability Management (1.0)',
+            title: isVulnMgmt2GAEnabled ? (
                 <NavigationContent variant="Deprecated">
                     Vulnerability Management (1.0)
                 </NavigationContent>
+            ) : (
+                'Vulnerability Management (1.0)'
             ),
             children: [
                 {

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -74,22 +74,6 @@ function isActiveLink(pathname: string, { isActive, path }: LinkDescription) {
     return typeof isActive === 'function' ? isActive(pathname) : Boolean(matchPath(pathname, path));
 }
 
-// Predicate function that encapsulates the logic for rendering content based on whether or not Vulnerability
-// Management 2.0 is declared as GA.
-function vulnMgmt2GaContentPredicate(
-    techPreviewContent: string | ReactElement,
-    gaContent: string | ReactElement
-) {
-    return (navDescriptionsFiltered: NavDescription[]) =>
-        navDescriptionsFiltered.some(
-            (navDescription) =>
-                navDescription.type === 'parent' &&
-                navDescription.key === keyForVulnerabilityManagement1
-        )
-            ? techPreviewContent
-            : gaContent;
-}
-
 type SeparatorDescription = {
     type: 'separator';
     key: string; // corresponds to React key prop
@@ -106,83 +90,91 @@ type ParentDescription = {
 
 type NavDescription = LinkDescription | ParentDescription;
 
-const navDescriptions: NavDescription[] = [
-    {
-        type: 'link',
-        content: 'Dashboard',
-        path: dashboardPath,
-        routeKey: 'dashboard',
-    },
-    {
-        type: 'parent',
-        title: 'Network',
-        key: keyForNetwork,
-        children: [
-            {
-                type: 'link',
-                content: 'Network Graph',
-                path: networkBasePath,
-                routeKey: 'network-graph',
-            },
-            {
-                type: 'link',
-                content: 'Listening Endpoints',
-                path: listeningEndpointsBasePath,
-                routeKey: 'listening-endpoints',
-            },
-        ],
-    },
-    {
-        type: 'link',
-        content: 'Violations',
-        path: violationsBasePath,
-        routeKey: 'violations',
-    },
-    // Compliance with divided navigation.
-    // /*
-    {
-        type: 'parent',
-        title: (navDescriptionsFiltered) =>
-            navDescriptionsFiltered.some(
-                (navDescription) =>
-                    navDescription.type === 'link' && navDescription.routeKey === 'compliance'
-            )
-                ? 'Compliance (2.0)'
-                : 'Compliance',
-        key: keyForCompliance2,
-        children: [
-            {
-                type: 'link',
-                content: 'Coverage',
-                path: complianceEnhancedCoveragePath,
-                routeKey: 'compliance-enhanced',
-            },
-            {
-                type: 'link',
-                content: 'Schedules',
-                path: complianceEnhancedSchedulesPath,
-                routeKey: 'compliance-enhanced',
-            },
-        ],
-    },
-    {
-        type: 'link',
-        content: (navDescriptionsFiltered) =>
-            navDescriptionsFiltered.some(
-                (navDescription) =>
-                    navDescription.type === 'parent' && navDescription.key === keyForCompliance2
-            )
-                ? 'Compliance (1.0)'
-                : 'Compliance',
-        path: complianceBasePath,
-        routeKey: 'compliance',
-        isActive: (pathname) =>
-            Boolean(matchPath(pathname, complianceBasePath)) &&
-            !matchPath(pathname, [complianceEnhancedCoveragePath, complianceEnhancedSchedulesPath]),
-    },
-    // */
-    // Compliance with unified navigation.
-    /*
+function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDescription[] {
+    const vulnMgmt2GaContentPredicate =
+        (techPreviewContent: string | ReactElement, gaContent: string | ReactElement) => () =>
+            isFeatureFlagEnabled('ROX_VULN_MGMT_2_GA') ? gaContent : techPreviewContent;
+
+    return [
+        {
+            type: 'link',
+            content: 'Dashboard',
+            path: dashboardPath,
+            routeKey: 'dashboard',
+        },
+        {
+            type: 'parent',
+            title: 'Network',
+            key: keyForNetwork,
+            children: [
+                {
+                    type: 'link',
+                    content: 'Network Graph',
+                    path: networkBasePath,
+                    routeKey: 'network-graph',
+                },
+                {
+                    type: 'link',
+                    content: 'Listening Endpoints',
+                    path: listeningEndpointsBasePath,
+                    routeKey: 'listening-endpoints',
+                },
+            ],
+        },
+        {
+            type: 'link',
+            content: 'Violations',
+            path: violationsBasePath,
+            routeKey: 'violations',
+        },
+        // Compliance with divided navigation.
+        // /*
+        {
+            type: 'parent',
+            title: (navDescriptionsFiltered) =>
+                navDescriptionsFiltered.some(
+                    (navDescription) =>
+                        navDescription.type === 'link' && navDescription.routeKey === 'compliance'
+                )
+                    ? 'Compliance (2.0)'
+                    : 'Compliance',
+            key: keyForCompliance2,
+            children: [
+                {
+                    type: 'link',
+                    content: 'Coverage',
+                    path: complianceEnhancedCoveragePath,
+                    routeKey: 'compliance-enhanced',
+                },
+                {
+                    type: 'link',
+                    content: 'Schedules',
+                    path: complianceEnhancedSchedulesPath,
+                    routeKey: 'compliance-enhanced',
+                },
+            ],
+        },
+        {
+            type: 'link',
+            content: (navDescriptionsFiltered) =>
+                navDescriptionsFiltered.some(
+                    (navDescription) =>
+                        navDescription.type === 'parent' && navDescription.key === keyForCompliance2
+                )
+                    ? 'Compliance (1.0)'
+                    : 'Compliance',
+            path: complianceBasePath,
+            routeKey: 'compliance',
+            isActive: (pathname) =>
+                Boolean(matchPath(pathname, complianceBasePath)) &&
+                !matchPath(pathname, [
+                    complianceEnhancedCoveragePath,
+                    complianceEnhancedSchedulesPath,
+                ]),
+        },
+        // */
+        // Compliance with unified navigation.
+        /*
     {
         type: 'parent',
         title: (navDescriptionsFiltered) =>
@@ -225,161 +217,157 @@ const navDescriptions: NavDescription[] = [
         ],
     },
     */
-    {
-        type: 'parent',
-        title: vulnMgmt2GaContentPredicate(
-            'Vulnerability Management (2.0)',
-            'Vulnerability Management'
-        ),
-        key: keyForVulnerabilityManagement2,
-        children: [
-            {
-                type: 'link',
-                content: vulnMgmt2GaContentPredicate(
-                    <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
-                    'Workload CVEs'
-                ),
-                path: vulnerabilitiesWorkloadCvesPath,
-                routeKey: 'workload-cves',
-            },
-            {
-                type: 'link',
-                content: vulnMgmt2GaContentPredicate(
-                    <NavigationContent variant="TechPreview">Platform CVEs</NavigationContent>,
-                    'Platform CVEs'
-                ),
-                path: vulnerabilitiesPlatformCvesPath,
-                routeKey: 'platform-cves',
-            },
-            {
-                type: 'link',
-                content: vulnMgmt2GaContentPredicate(
-                    <NavigationContent variant="TechPreview">Node CVEs</NavigationContent>,
-                    'Node CVEs'
-                ),
-                path: vulnerabilitiesNodeCvesPath,
-                routeKey: 'node-cves',
-            },
-            {
-                type: 'separator',
-                key: 'following-cves',
-            },
-            {
-                type: 'link',
-                content: 'Exception Management',
-                path: exceptionManagementPath,
-                routeKey: 'exception-management',
-            },
-            {
-                type: 'link',
-                content: 'Vulnerability Reporting',
-                path: vulnerabilityReportsPath,
-                routeKey: 'vulnerabilities/reports',
-            },
-        ],
-    },
-    {
-        type: 'parent',
-        key: keyForVulnerabilityManagement1,
-        title: (navDescriptionsFiltered) =>
-            navDescriptionsFiltered.some(
-                (navDescription) =>
-                    navDescription.type === 'parent' &&
-                    navDescription.key === keyForVulnerabilityManagement2
-            )
-                ? 'Vulnerability Management (1.0)'
-                : 'Vulnerability Management',
-        children: [
-            {
-                type: 'link',
-                content: 'Dashboard',
-                path: vulnManagementPath,
-                routeKey: 'vulnerability-management',
-                isActive: (pathname) =>
-                    Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
-            },
-            {
-                type: 'link',
-                content: 'Risk Acceptance',
-                path: vulnManagementRiskAcceptancePath,
-                routeKey: 'vulnerability-management/risk-acceptance',
-            },
-        ],
-    },
-    {
-        type: 'link',
-        content: 'Configuration Management',
-        path: configManagementPath,
-        routeKey: 'configmanagement',
-    },
-    {
-        type: 'link',
-        content: 'Risk',
-        path: riskBasePath,
-        routeKey: 'risk',
-    },
-    {
-        type: 'parent',
-        key: 'Platform Configuration',
-        title: keyForPlatformConfiguration,
-        children: [
-            {
-                type: 'link',
-                content: 'Clusters',
-                path: clustersBasePath,
-                routeKey: 'clusters',
-            },
-            {
-                type: 'link',
-                content: 'Policy Management',
-                path: policyManagementBasePath,
-                routeKey: 'policy-management',
-            },
-            {
-                type: 'link',
-                content: 'Collections',
-                path: collectionsBasePath,
-                routeKey: 'collections',
-            },
-            {
-                type: 'link',
-                content: 'Integrations',
-                path: integrationsPath,
-                routeKey: 'integrations',
-            },
-            {
-                type: 'link',
-                content: 'Exception Configuration',
-                path: exceptionConfigurationPath,
-                routeKey: 'exception-configuration',
-            },
-            {
-                type: 'link',
-                content: 'Access Control',
-                path: accessControlBasePath,
-                routeKey: 'access-control',
-            },
-            {
-                type: 'link',
-                content: 'System Configuration',
-                path: systemConfigPath,
-                routeKey: 'systemconfig',
-            },
-            {
-                type: 'link',
-                content: 'Administration Events',
-                path: administrationEventsBasePath,
-                routeKey: 'administration-events',
-            },
-            {
-                type: 'link',
-                content: 'System Health',
-                path: systemHealthPath,
-                routeKey: 'system-health',
-            },
-        ],
-    },
-];
+        {
+            type: 'parent',
+            title: 'Vulnerability Management (2.0)',
+            key: keyForVulnerabilityManagement2,
+            children: [
+                {
+                    type: 'link',
+                    content: vulnMgmt2GaContentPredicate(
+                        <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
+                        'Workload CVEs'
+                    ),
+                    path: vulnerabilitiesWorkloadCvesPath,
+                    routeKey: 'workload-cves',
+                },
+                {
+                    type: 'link',
+                    content: vulnMgmt2GaContentPredicate(
+                        <NavigationContent variant="TechPreview">Platform CVEs</NavigationContent>,
+                        'Platform CVEs'
+                    ),
+                    path: vulnerabilitiesPlatformCvesPath,
+                    routeKey: 'platform-cves',
+                },
+                {
+                    type: 'link',
+                    content: vulnMgmt2GaContentPredicate(
+                        <NavigationContent variant="TechPreview">Node CVEs</NavigationContent>,
+                        'Node CVEs'
+                    ),
+                    path: vulnerabilitiesNodeCvesPath,
+                    routeKey: 'node-cves',
+                },
+                {
+                    type: 'separator',
+                    key: 'following-cves',
+                },
+                {
+                    type: 'link',
+                    content: 'Exception Management',
+                    path: exceptionManagementPath,
+                    routeKey: 'exception-management',
+                },
+                {
+                    type: 'link',
+                    content: 'Vulnerability Reporting',
+                    path: vulnerabilityReportsPath,
+                    routeKey: 'vulnerabilities/reports',
+                },
+            ],
+        },
+        {
+            type: 'parent',
+            key: keyForVulnerabilityManagement1,
+            title: vulnMgmt2GaContentPredicate(
+                'Vulnerability Management (1.0)',
+                <NavigationContent variant="Deprecated">
+                    Vulnerability Management (1.0)
+                </NavigationContent>
+            ),
+            children: [
+                {
+                    type: 'link',
+                    content: 'Dashboard',
+                    path: vulnManagementPath,
+                    routeKey: 'vulnerability-management',
+                    isActive: (pathname) =>
+                        Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
+                },
+                {
+                    type: 'link',
+                    content: 'Risk Acceptance',
+                    path: vulnManagementRiskAcceptancePath,
+                    routeKey: 'vulnerability-management/risk-acceptance',
+                },
+            ],
+        },
+        {
+            type: 'link',
+            content: 'Configuration Management',
+            path: configManagementPath,
+            routeKey: 'configmanagement',
+        },
+        {
+            type: 'link',
+            content: 'Risk',
+            path: riskBasePath,
+            routeKey: 'risk',
+        },
+        {
+            type: 'parent',
+            key: 'Platform Configuration',
+            title: keyForPlatformConfiguration,
+            children: [
+                {
+                    type: 'link',
+                    content: 'Clusters',
+                    path: clustersBasePath,
+                    routeKey: 'clusters',
+                },
+                {
+                    type: 'link',
+                    content: 'Policy Management',
+                    path: policyManagementBasePath,
+                    routeKey: 'policy-management',
+                },
+                {
+                    type: 'link',
+                    content: 'Collections',
+                    path: collectionsBasePath,
+                    routeKey: 'collections',
+                },
+                {
+                    type: 'link',
+                    content: 'Integrations',
+                    path: integrationsPath,
+                    routeKey: 'integrations',
+                },
+                {
+                    type: 'link',
+                    content: 'Exception Configuration',
+                    path: exceptionConfigurationPath,
+                    routeKey: 'exception-configuration',
+                },
+                {
+                    type: 'link',
+                    content: 'Access Control',
+                    path: accessControlBasePath,
+                    routeKey: 'access-control',
+                },
+                {
+                    type: 'link',
+                    content: 'System Configuration',
+                    path: systemConfigPath,
+                    routeKey: 'systemconfig',
+                },
+                {
+                    type: 'link',
+                    content: 'Administration Events',
+                    path: administrationEventsBasePath,
+                    routeKey: 'administration-events',
+                },
+                {
+                    type: 'link',
+                    content: 'System Health',
+                    path: systemHealthPath,
+                    routeKey: 'system-health',
+                },
+            ],
+        },
+    ];
+}
 
 type NavigationSidebarProps = {
     hasReadAccess: HasReadAccess;
@@ -410,7 +398,7 @@ function NavigationSidebar({
             : true;
     }
 
-    const navDescriptionsFiltered = navDescriptions
+    const navDescriptionsFiltered = getNavDescriptions(isFeatureFlagEnabled)
         .map((navDescription) => {
             switch (navDescription.type) {
                 case 'parent': {

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -336,14 +336,12 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     // Risk Acceptance must precede generic Vulnerability Management in Body and so here for consistency.
     'vulnerability-management/risk-acceptance': {
-        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_2_GA']),
         resourceAccessRequirements: everyResource([
             'VulnerabilityManagementApprovals',
             'VulnerabilityManagementRequests',
         ]),
     },
     'vulnerability-management': {
-        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_2_GA']),
         resourceAccessRequirements: everyResource([
             // 'Alert', // for Cluster and Deployment and Namespace
             // 'Cluster', // on Dashboard for with most widget


### PR DESCRIPTION
## Description

An almost total revert of https://github.com/stackrox/stackrox/pull/11220

__Much easier to review with "Hide whitespace" enabled.__

### Rationale

We would like to keep VM 1.0 available in read-only mode during the initial VM 2.0 GA release. This retains the old VM 1.0 dashboard, clearly marked as "Deprecated", so that users can more gradually migrate workflows to VM 2.0.

### Follow ups

- Remove the "Risk Acceptance" page and the Observed/Deferred/False Positive CVE lists from VM 1.0 when "ROX_VULN_MGMT_UNIFIED_DEFERRALS" is enabled.
- Remove the "Watch image" functionality from VM 1.0

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the sidebar navigation with `ROX_VULN_MGMT_2_GA` enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/f88fb7a0-eb11-4f3f-a847-1b9a8fa2031a)

View the sidebar navigation with `ROX_VULN_MGMT_2_GA` disabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/65858773-e5e6-43ec-a16c-72c68660b6e2)


