### PR TITLE
chore(ui): Remove risk acceptance vm 1.0

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -336,6 +336,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     // Risk Acceptance must precede generic Vulnerability Management in Body and so here for consistency.
     'vulnerability-management/risk-acceptance': {
+        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL']),
         resourceAccessRequirements: everyResource([
             'VulnerabilityManagementApprovals',
             'VulnerabilityManagementRequests',


### PR DESCRIPTION
## Description

_Easier to review with "Hide whitespace" on_

This removes the Risk Acceptance page and list of CVEs under [VM 1.0 -> Image List Page -> Image Sidebar] when `ROX_VULN_MGMT_UNIFIED_CVE_DEFERRALS` is on. With the exception of "Watch Images", this makes VM 1.0 read-only.

## Follow ups

Remove "Watch images" functionality from VM 1.0 when VM 2.0 is GA.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a VM 1.0 image sidebar with the feature flag off. Notice that the list of CVEs is present in the panel, and that "Risk Acceptance" exists in the navigation.
![image](https://github.com/stackrox/stackrox/assets/1292638/3531f107-fab2-410e-9bfc-77376149000f)


Visit the same sidebar with the feature flag on. The list of CVEs is replaced with an alert, and "Risk Acceptance" is removed from the navigation.
![image](https://github.com/stackrox/stackrox/assets/1292638/fda6c7f4-aa7b-444d-aa38-8d8efdcbcf9a)


Clicking the link in the alert correctly takes you to the corresponding image single page in VM 2.0.
![image](https://github.com/stackrox/stackrox/assets/1292638/a3223671-bd18-4ff5-8b77-57803c73cc3d)
