### PR TITLE
ROX-24002: Check details sorting

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -6,6 +6,7 @@ import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
 import { getComplianceProfileCheckStats } from 'services/ComplianceResultsStatsService';
 import { getComplianceProfileCheckResult } from 'services/ComplianceResultsService';
@@ -33,8 +34,12 @@ function CheckDetails() {
     const { checkName, profileName } = useParams();
     const [currentDatetime, setCurrentDatetime] = useState(new Date());
     const pagination = useURLPagination(10);
-
-    const { page, perPage } = pagination;
+    const { page, perPage, setPage } = pagination;
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: ['Cluster'],
+        defaultSortOption: { field: 'Cluster', direction: 'asc' },
+        onSort: () => setPage(1),
+    });
 
     const fetchCheckStats = useCallback(
         () => getComplianceProfileCheckStats(profileName, checkName),
@@ -47,8 +52,8 @@ function CheckDetails() {
     } = useRestQuery(fetchCheckStats);
 
     const fetchCheckResults = useCallback(
-        () => getComplianceProfileCheckResult(profileName, checkName, page, perPage),
-        [page, perPage, checkName, profileName]
+        () => getComplianceProfileCheckResult(profileName, checkName, sortOption, page, perPage),
+        [page, perPage, checkName, profileName, sortOption]
     );
     const {
         data: checkResultsResponse,
@@ -123,6 +128,7 @@ function CheckDetails() {
                     pagination={pagination}
                     profileName={profileName}
                     tableState={tableState}
+                    getSortParams={getSortParams}
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -14,6 +14,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import IconText from 'Components/PatternFly/IconText/IconText';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { ClusterCheckStatus } from 'services/ComplianceResultsService';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
@@ -27,6 +28,7 @@ export type CheckDetailsTableProps = {
     pagination: UseURLPaginationResult;
     profileName: string;
     tableState: TableUIState<ClusterCheckStatus>;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
 function CheckDetailsTable({
@@ -35,6 +37,7 @@ function CheckDetailsTable({
     pagination,
     profileName,
     tableState,
+    getSortParams,
 }: CheckDetailsTableProps) {
     const { page, perPage, setPage, setPerPage } = pagination;
 
@@ -56,7 +59,7 @@ function CheckDetailsTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th>Cluster</Th>
+                        <Th sort={getSortParams('Cluster')}>Cluster</Th>
                         <Th>Last scanned</Th>
                         <Th>Compliance status</Th>
                     </Tr>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -20,8 +20,8 @@ function ProfileClustersPage() {
 
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: ['Cluster ID'],
-        defaultSortOption: { field: 'Cluster ID', direction: 'asc' },
+        sortFields: ['Cluster'],
+        defaultSortOption: { field: 'Cluster', direction: 'asc' },
         onSort: () => setPage(1),
     });
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -69,7 +69,7 @@ function ProfileClustersTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th sort={getSortParams('Cluster ID')}>Cluster</Th>
+                        <Th sort={getSortParams('Cluster')}>Cluster</Th>
                         <Th>Last scanned</Th>
                         <Th>Fail status</Th>
                         <Th>Pass status</Th>

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -47,12 +47,13 @@ export type ListComplianceCheckClusterResponse = {
 export function getComplianceProfileCheckResult(
     profileName: string,
     checkName: string,
+    sortOption: ApiSortOption,
     page: number,
     perPage: number
 ): Promise<ListComplianceCheckClusterResponse> {
     const queryParameters = {
         query: {
-            pagination: getPaginationParams({ page, perPage }),
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     };
     const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });


### PR DESCRIPTION
## Description

Adds sorting to the Compliance V2 Check Details table

Note: UX shows ability to sort by last scanned time, however this columns is currently unsortable due to our backend search framework. Will revisit this in a later release.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Default (Cluster name, asc):
![Screenshot 2024-05-29 at 1 18 27 PM](https://github.com/stackrox/stackrox/assets/61400697/8f86fe34-f5ad-43a5-be25-122f8360706f)



Reverse (Cluster name, desc):
![Screenshot 2024-05-29 at 1 18 35 PM](https://github.com/stackrox/stackrox/assets/61400697/375f68b5-f605-4293-a942-0e63a2427d58)
