### PR TITLE
chore(ui): Refactor compliance service querying

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -15,7 +15,9 @@ import { getTableUIState } from 'utils/getTableUIState';
 import CheckDetailsTable from './CheckDetailsTable';
 import DetailsPageHeader, { PageHeaderLabel } from './components/DetailsPageHeader';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
+import { CLUSTER_QUERY } from './compliance.coverage.constants';
 import { getClusterResultsStatusObject } from './compliance.coverage.utils';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 
 function sortCheckStats(a: ComplianceCheckStatusCount, b: ComplianceCheckStatusCount) {
     const order: ComplianceCheckStatus[] = [
@@ -33,11 +35,11 @@ function sortCheckStats(a: ComplianceCheckStatusCount, b: ComplianceCheckStatusC
 function CheckDetails() {
     const { checkName, profileName } = useParams();
     const [currentDatetime, setCurrentDatetime] = useState(new Date());
-    const pagination = useURLPagination(10);
+    const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: ['Cluster'],
-        defaultSortOption: { field: 'Cluster', direction: 'asc' },
+        sortFields: [CLUSTER_QUERY],
+        defaultSortOption: { field: CLUSTER_QUERY, direction: 'asc' },
         onSort: () => setPage(1),
     });
 
@@ -52,7 +54,8 @@ function CheckDetails() {
     } = useRestQuery(fetchCheckStats);
 
     const fetchCheckResults = useCallback(
-        () => getComplianceProfileCheckResult(profileName, checkName, sortOption, page, perPage),
+        () =>
+            getComplianceProfileCheckResult(profileName, checkName, { page, perPage, sortOption }),
         [page, perPage, checkName, profileName, sortOption]
     );
     const {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -2,28 +2,30 @@ import React, { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { Divider, PageSection, Title } from '@patternfly/react-core';
 
+import PageTitle from 'Components/PageTitle';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 
-import PageTitle from 'Components/PageTitle';
+import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import CoveragesToggleGroup from './CoveragesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
 
 function ProfileChecksPage() {
     const { profileName } = useParams();
-    const pagination = useURLPagination(10);
+    const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: ['Compliance Check Name'],
-        defaultSortOption: { field: 'Compliance Check Name', direction: 'asc' },
+        sortFields: [CHECK_NAME_QUERY],
+        defaultSortOption: { field: CHECK_NAME_QUERY, direction: 'asc' },
         onSort: () => setPage(1),
     });
 
     const fetchProfileChecks = useCallback(
-        () => getComplianceProfileResults(profileName, sortOption, page, perPage),
+        () => getComplianceProfileResults(profileName, { sortOption, page, perPage }),
         [page, perPage, profileName, sortOption]
     );
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -9,6 +9,8 @@ import useURLSort from 'hooks/useURLSort';
 import { getComplianceClusterStats } from 'services/ComplianceResultsStatsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
+import { CLUSTER_QUERY } from './compliance.coverage.constants';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import CoveragesToggleGroup from './CoveragesToggleGroup';
 import ProfileClustersTable from './ProfileClustersTable';
@@ -16,17 +18,17 @@ import ProfileClustersTable from './ProfileClustersTable';
 function ProfileClustersPage() {
     const { profileName } = useParams();
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
-    const pagination = useURLPagination(10);
+    const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
 
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: ['Cluster'],
-        defaultSortOption: { field: 'Cluster', direction: 'asc' },
+        sortFields: [CLUSTER_QUERY],
+        defaultSortOption: { field: CLUSTER_QUERY, direction: 'asc' },
         onSort: () => setPage(1),
     });
 
     const fetchProfileClusters = useCallback(
-        () => getComplianceClusterStats(profileName, sortOption, page, perPage),
+        () => getComplianceClusterStats(profileName, { sortOption, page, perPage }),
         [page, perPage, profileName, sortOption]
     );
     const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
@@ -1,0 +1,3 @@
+// searchable and sortable query parameter fields
+export const CLUSTER_QUERY = 'Cluster';
+export const CHECK_NAME_QUERY = 'Compliance Check Name';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
@@ -41,9 +41,11 @@ import {
     ComplianceScanConfigurationStatus,
 } from 'services/ComplianceScanConfigurationService';
 import { SortOption } from 'types/table';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { displayOnlyItemOrItemCount } from 'utils/textUtils';
 
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../../compliance.constants';
+import { SCAN_CONFIG_NAME_QUERY } from '../compliance.scanConfigs.constants';
 import { scanConfigDetailsPath } from '../compliance.scanConfigs.routes';
 import { formatScanSchedule } from '../compliance.scanConfigs.utils';
 
@@ -59,9 +61,9 @@ const CreateScanConfigButton = () => {
     );
 };
 
-const sortFields = ['Compliance Scan Config Name'];
+const sortFields = [SCAN_CONFIG_NAME_QUERY];
 const defaultSortOption = {
-    field: 'Compliance Scan Config Name',
+    field: SCAN_CONFIG_NAME_QUERY,
     direction: 'asc',
 } as SortOption;
 
@@ -75,7 +77,7 @@ function ScanConfigsTablePage({
     const [isDeletingScanConfigs, setIsDeletingScanConfigs] = useState(false);
     const history = useHistory();
 
-    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.constants.ts
@@ -1,0 +1,2 @@
+// searchable and sortable query parameter fields
+export const SCAN_CONFIG_NAME_QUERY = 'Compliance Scan Config Name';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/compliance.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/compliance.constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_COMPLIANCE_PAGE_SIZE = 10;

--- a/ui/apps/platform/src/services/ComplianceCommon.ts
+++ b/ui/apps/platform/src/services/ComplianceCommon.ts
@@ -1,3 +1,8 @@
+import qs from 'qs';
+
+import { SearchQueryOptions } from 'types/search';
+import { getPaginationParams } from 'utils/searchUtils';
+
 export const complianceV2Url = '/v2/compliance';
 
 export const ComplianceCheckStatusEnum = {
@@ -48,3 +53,22 @@ export type ListComplianceClusterOverallStatsResponse = {
     scanStats: ComplianceClusterOverallStats[];
     totalCount: number;
 };
+
+/*
+ * Builds query parameters for nested RawQuery in compliance API requests
+ *
+ * This is used when the RawQuery is nested within the request parameter,
+ * not when it's the sole parameter.
+ */
+export function buildNestedRawQueryParams({
+    page,
+    perPage,
+    sortOption,
+}: SearchQueryOptions): string {
+    const queryParameters = {
+        query: {
+            pagination: getPaginationParams({ page, perPage, sortOption }),
+        },
+    };
+    return qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
+}

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,10 +1,8 @@
-import qs from 'qs';
-
 import axios from 'services/instance';
-import { ApiSortOption } from 'types/search';
-import { getPaginationParams } from 'utils/searchUtils';
+import { SearchQueryOptions } from 'types/search';
 
 import {
+    buildNestedRawQueryParams,
     ComplianceCheckStatus,
     ComplianceScanCluster,
     complianceV2Url,
@@ -47,16 +45,9 @@ export type ListComplianceCheckClusterResponse = {
 export function getComplianceProfileCheckResult(
     profileName: string,
     checkName: string,
-    sortOption: ApiSortOption,
-    page: number,
-    perPage: number
+    { sortOption, page, perPage }: SearchQueryOptions
 ): Promise<ListComplianceCheckClusterResponse> {
-    const queryParameters = {
-        query: {
-            pagination: getPaginationParams({ page, perPage, sortOption }),
-        },
-    };
-    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
     return axios
         .get<ListComplianceCheckClusterResponse>(
             `${complianceResultsBaseUrl}/results/profiles/${profileName}/checks/${checkName}?${params}`
@@ -69,17 +60,9 @@ export function getComplianceProfileCheckResult(
  */
 export function getComplianceProfileResults(
     profileName: string,
-    sortOption: ApiSortOption,
-    page: number,
-    perPage: number
+    { sortOption, page, perPage }: SearchQueryOptions
 ): Promise<ListComplianceProfileResults> {
-    const queryParameters = {
-        query: {
-            pagination: getPaginationParams({ page, perPage, sortOption }),
-        },
-    };
-    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
-
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
     return axios
         .get<ListComplianceProfileResults>(
             `${complianceResultsBaseUrl}/results/profiles/${profileName}/checks?${params}`

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -1,11 +1,10 @@
-import qs from 'qs';
 import { generatePath } from 'react-router-dom';
 
 import axios from 'services/instance';
-import { ApiSortOption } from 'types/search';
-import { getPaginationParams } from 'utils/searchUtils';
+import { SearchQueryOptions } from 'types/search';
 
 import {
+    buildNestedRawQueryParams,
     ComplianceCheckResultStatusCount,
     ComplianceCheckStatusCount,
     complianceV2Url,
@@ -41,16 +40,9 @@ export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanS
  */
 export function getComplianceClusterStats(
     profileName: string,
-    sortOption: ApiSortOption,
-    page: number,
-    perPage: number
+    { sortOption, page, perPage }: SearchQueryOptions
 ): Promise<ListComplianceClusterOverallStatsResponse> {
-    const queryParameters = {
-        query: {
-            pagination: getPaginationParams({ page, perPage, sortOption }),
-        },
-    };
-    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
     return axios
         .get<ListComplianceClusterOverallStatsResponse>(
             `${complianceResultsStatsBaseUrl}/profiles/${profileName}/clusters?${params}`

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -33,3 +33,10 @@ export type GraphQLSortOption = {
     id: string;
     desc: boolean;
 };
+
+export type SearchQueryOptions = {
+    searchFilter?: SearchFilter;
+    sortOption?: ApiSortOption;
+    page: number;
+    perPage: number;
+};


### PR DESCRIPTION
## Description

Refactoring done mainly surrounding service calls

Includes:

- Added 3 constants files for default page size and searchable/sortable fields
  - `compliance.constants.ts`
  - `compliance.coverage.constants.ts`
  - `compliance.scanConfigs.constants.ts` 🙃 
- `RawQuery` related service parameters converted to a single object argument
  - Safer, harder to mess up order
  - Separates unique parameters (`checkName`, `clusterID`, etc) required in the path from the ubiquitous parameters (`page`, `sortOption`, etc) found in the query
- Created a function used to build query parameters for nested RawQuery in compliance requests (@sachaudh)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Oops.. things still seem to work