### PR TITLE
ci(ocp-4): set max_wait for ocp to 10min

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -948,7 +948,7 @@ wait_for_api() {
 
     start_time="$(date '+%s')"
     max_seconds=${MAX_WAIT_SECONDS:-300}
-    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
+    if [[ "${ORCHESTRATOR_FLAVOR:-}" == "openshift" ]]; then
         # OCP Interop tests are run on minimal instances and will take longer
         # Allow override with MAX_WAIT_SECONDS
         max_seconds=${MAX_WAIT_SECONDS:-600}


### PR DESCRIPTION
OCP, especially preview and candidate builds and when running on QE Interop's minimized instances, can be slow and the Central api often takes roughly the default timeout of 5 minutes. Increasing the timeout to 10 minutes allows the tests to still run and not show as test failures despite being caused by a slow environment.