### PR TITLE
ROX-24176: improve discovery of authn mechanism

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -218,49 +218,50 @@ function AuthProviders(): ReactElement {
                 <Alert
                     isInline
                     variant="info"
-                    title={
-                        <span>
-                            Consider using short-lived tokens for machine-to-machine communications
-                            such as CI/CD pipelines, scripts, and other automation.
-                        </span>
-                    }
+                    title="Consider using short-lived tokens for machine-to-machine communications
+                            such as CI/CD pipelines, scripts, and other automation."
                 >
-                    <Flex direction={{ default: 'row' }}>
-                        <ExternalLink>
-                            <a
-                                href={getVersionedDocs(
-                                    version,
-                                    'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
-                                )}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                How to configure short-lived access
-                            </a>
-                        </ExternalLink>
-                        {hasWriteAccessForPage && (
-                            <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
-                                Create a machine access configuration
-                            </Link>
-                        )}
-                    </Flex>
-                    <ExpandableSection
-                        toggleText="More resources"
-                        onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
-                        isExpanded={isInfoExpanded}
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsMd' }}
                     >
-                        <Flex direction={{ default: 'column' }}>
+                        <Flex direction={{ default: 'row' }}>
                             <ExternalLink>
                                 <a
-                                    href="https://github.com/stackrox/central-login"
+                                    href={getVersionedDocs(
+                                        version,
+                                        'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
+                                    )}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >
-                                    GitHub Action for short-lived access
+                                    How to configure short-lived access
                                 </a>
                             </ExternalLink>
+                            {hasWriteAccessForPage && (
+                                <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
+                                    Create a machine access configuration
+                                </Link>
+                            )}
                         </Flex>
-                    </ExpandableSection>
+                        <ExpandableSection
+                            toggleText="More resources"
+                            onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
+                            isExpanded={isInfoExpanded}
+                        >
+                            <Flex direction={{ default: 'column' }}>
+                                <ExternalLink>
+                                    <a
+                                        href="https://github.com/stackrox/central-login"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        GitHub Action for short-lived access
+                                    </a>
+                                </ExternalLink>
+                            </Flex>
+                        </ExpandableSection>
+                    </Flex>
                 </Alert>
             </PageSection>
             <PageSection variant={isList ? 'default' : 'light'}>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -32,7 +32,10 @@ import { actions as groupActions } from 'reducers/groups';
 import { actions as inviteActions } from 'reducers/invite';
 import { actions as roleActions, types as roleActionTypes } from 'reducers/roles';
 import { AuthProvider } from 'services/AuthService';
-
+import usePermissions from 'hooks/usePermissions';
+import { integrationsPath } from 'routePaths';
+import { getVersionedDocs } from 'utils/versioning';
+import useMetadata from 'hooks/useMetadata';
 import { getEntityPath, getQueryObject } from '../accessControlPaths';
 import { mergeGroupsWithAuthProviders } from './authProviders.utils';
 
@@ -44,10 +47,6 @@ import AuthProvidersList from './AuthProvidersList';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
-import usePermissions from '../../../hooks/usePermissions';
-import { integrationsPath } from '../../../routePaths';
-import { getVersionedDocs } from '../../../utils/versioning';
-import useMetadata from '../../../hooks/useMetadata';
 
 const entityType = 'AUTH_PROVIDER';
 
@@ -221,7 +220,7 @@ function AuthProviders(): ReactElement {
                     variant="info"
                     title={
                         <span>
-                            Consider using short-lived tokens for machine to machine communications
+                            Consider using short-lived tokens for machine-to-machine communications
                             such as CI/CD pipelines, scripts, and other automation.
                         </span>
                     }
@@ -239,9 +238,11 @@ function AuthProviders(): ReactElement {
                                 How to configure short-lived access
                             </a>
                         </ExternalLink>
-                        <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
-                            Create a machine to machine configuration
-                        </Link>
+                        {hasWriteAccessForPage && (
+                            <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
+                                Create a machine access configuration
+                            </Link>
+                        )}
                     </Flex>
                     <ExpandableSection
                         toggleText="More resources"

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -3,8 +3,19 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { selectors } from 'reducers';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { Bullseye, Button, PageSection, pluralize, Spinner, Title } from '@patternfly/react-core';
+import { useHistory, useLocation, useParams, Link } from 'react-router-dom';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import {
+    Alert,
+    Bullseye,
+    Button,
+    ExpandableSection,
+    Flex,
+    PageSection,
+    pluralize,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
 import {
     Dropdown,
     DropdownItem,
@@ -34,6 +45,9 @@ import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import usePermissions from '../../../hooks/usePermissions';
+import { integrationsPath } from '../../../routePaths';
+import { getVersionedDocs } from '../../../utils/versioning';
+import useMetadata from '../../../hooks/useMetadata';
 
 const entityType = 'AUTH_PROVIDER';
 
@@ -69,8 +83,10 @@ function AuthProviders(): ReactElement {
     const { entityId } = useParams();
     const dispatch = useDispatch();
     const { analyticsTrack } = useAnalytics();
+    const { version } = useMetadata();
 
     const [isCreateMenuOpen, setIsCreateMenuOpen] = useState(false);
+    const [isInfoExpanded, setIsInfoExpanded] = useState(false);
     const {
         authProviders,
         groups,
@@ -125,6 +141,10 @@ function AuthProviders(): ReactElement {
         const provider = availableProviderTypes.find(({ value }) => value === type) ?? {};
         return (provider.label as string) ?? 'auth';
     }
+
+    const onToggle = (_isExpanded: boolean) => {
+        setIsInfoExpanded(_isExpanded);
+    };
 
     const selectedAuthProvider = authProviders.find(({ id }) => id === entityId);
     const hasAction = Boolean(action);
@@ -195,6 +215,53 @@ function AuthProviders(): ReactElement {
                     }
                 />
             )}
+            <PageSection>
+                <Alert
+                    isInline
+                    variant="info"
+                    title={
+                        <span>
+                            Consider using short-lived tokens for machine to machine communications
+                            such as CI/CD pipelines, scripts, and other automation.
+                        </span>
+                    }
+                >
+                    <Flex direction={{ default: 'row' }}>
+                        <ExternalLink>
+                            <a
+                                href={getVersionedDocs(
+                                    version,
+                                    'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                How to configure short-lived access
+                            </a>
+                        </ExternalLink>
+                        <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
+                            Create a machine to machine configuration
+                        </Link>
+                    </Flex>
+                    <ExpandableSection
+                        toggleText="More resources"
+                        onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
+                        isExpanded={isInfoExpanded}
+                    >
+                        <Flex direction={{ default: 'column' }}>
+                            <ExternalLink>
+                                <a
+                                    href="https://github.com/stackrox/central-login"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    GitHub Action for short-lived access
+                                </a>
+                            </ExternalLink>
+                        </Flex>
+                    </ExpandableSection>
+                </Alert>
+            </PageSection>
             <PageSection variant={isList ? 'default' : 'light'}>
                 {isFetchingAuthProviders || isFetchingRoles ? (
                     <Bullseye>


### PR DESCRIPTION
## Description

This PR improves the discovery of authn mechanisms within the access control page.

It adds a new info alert which directs users to the documentation of the short-lived token feature as well as the creation of the m2m config.

Additionally, we link our central-login github action for folks to check out.
![Screenshot 2024-06-03 at 16 19 07](https://github.com/stackrox/stackrox/assets/89904305/3177ad94-8d60-48c0-9c69-2b003e71b99c)
![Screenshot 2024-06-03 at 16 19 21](https://github.com/stackrox/stackrox/assets/89904305/4cd8c58a-1064-44e3-93cc-72ae0f0906f6)



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see Screenshots

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
