### PR TITLE
ROX-23789: Central sends scan configd on sensor connection

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -55,7 +55,7 @@ var (
 		},
 	})
 
-	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
+	configNameRegexp = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`)
 
 	reservedConfigNames = []string{"default", "default-auto-apply"}
 )

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -343,7 +343,11 @@ func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 		return errors.Wrap(errox.InvalidArgs, "At least one cluster is required for a scan configuration")
 	}
 
-	if req.GetScanConfig() == nil || len(req.GetScanConfig().GetProfiles()) == 0 {
+	if req.GetScanConfig() == nil {
+		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil.")
+	}
+
+	if len(req.GetScanConfig().GetProfiles()) == 0 {
 		return errors.Wrap(errox.InvalidArgs, "At least one profile is required for a scan configuration")
 	}
 

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -55,7 +55,7 @@ var (
 		},
 	})
 
-	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*[a-z0-9]?$`)
+	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
 
 	reservedConfigNames = []string{"default", "default-auto-apply"}
 )

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -177,7 +177,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	request.ScanConfig = nil
 	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 	s.Require().Nil(config)
 
 	request = getTestAPIRec()
@@ -220,7 +220,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	request.ScanConfig = nil
 	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 
 	// Test Case 4: No clusters
 	request = getTestAPIRec()

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -520,7 +520,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 		return nil, err
 	}
 
-	var reformatedConfigs []*central.ApplyComplianceScanConfigRequest
+	var reformattedConfigs []*central.ApplyComplianceScanConfigRequest
 	for _, scanConfig := range scanConfigs {
 		var profiles []string
 		for _, profile := range scanConfig.GetProfiles() {
@@ -542,7 +542,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 				},
 			},
 		}
-		reformatedConfigs = append(reformatedConfigs, &scanConfigRequest)
+		reformattedConfigs = append(reformattedConfigs, &scanConfigRequest)
 	}
 
 	return &central.MsgToSensor{
@@ -550,7 +550,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 			ComplianceRequest: &central.ComplianceRequest{
 				Request: &central.ComplianceRequest_SyncScanConfigs{
 					SyncScanConfigs: &central.SyncComplianceScanConfigRequest{
-						ScanConfigs: reformatedConfigs,
+						ScanConfigs: reformattedConfigs,
 					},
 				},
 			},
@@ -753,8 +753,6 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		}
 	}
 
-	metrics.IncrementSensorConnect(c.clusterID, c.sensorHello.GetSensorState().String())
-
 	scanMsg, err := c.getScanConfigurationMsg(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get scan config for %q", c.clusterID)
@@ -762,6 +760,8 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 	if err := server.Send(scanMsg); err != nil {
 		return errors.Wrapf(err, "unable to sync config to cluster %q", c.clusterID)
 	}
+
+	metrics.IncrementSensorConnect(c.clusterID, c.sensorHello.GetSensorState().String())
 
 	c.runRecv(ctx, server)
 	return c.stopSig.Err()

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -532,6 +532,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 						StrictNodeScan: true,
 						Profiles:       profiles,
 					},
+					Cron: scanConfig.Schedule.String(),
 				},
 			},
 		}

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -112,7 +112,7 @@ func (s *testSuite) TestSendsScanConfigurationMsgOnRun() {
 		sendC:              make(chan *central.MsgToSensor),
 	}
 
-	mgrMock.EXPECT().GetCluster(ctx, gomock.Any()).Return(&storage.Cluster{}, true, nil).AnyTimes()
+	mgrMock.EXPECT().GetCluster(ctx, gomock.Any()).Return(&storage.Cluster{}, true, nil).Times(2)
 	s.scanConfigDS.EXPECT().GetScanConfigurations(ctx, gomock.Any()).Return(scanConfigs, nil).Times(1)
 
 	server := &mockServer{

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -154,12 +154,6 @@ func TestCentralSendsScanConfiguration(t *testing.T) {
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v2.NewComplianceScanConfigurationServiceClient(conn)
-	/*
-		serviceCluster := v1.NewClustersServiceClient(conn)
-		clusters, err := serviceCluster.GetClusters(ctx, &v1.GetClustersRequest{})
-		assert.NoError(t, err)
-		clusterID := clusters.GetClusters()[0].GetId()
-	*/
 
 	resp, err := service.CreateComplianceScanConfiguration(ctx, &scanConfig1)
 	assert.NoError(t, err)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -177,7 +177,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
-	_, err = service.CreateComplianceScanConfiguration(ctx, &modifiedScanConfig)
+	resp, err := service.CreateComplianceScanConfiguration(ctx, &modifiedScanConfig)
 	assert.NoError(t, err)
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 1)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	scanConfig1 = v2.ComplianceScanConfiguration{
-		ScanName: "testConfig1",
+		ScanName: "test-scan",
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test123",
 			OneTimeScan: false,
@@ -50,7 +50,7 @@ var (
 		},
 	}
 	modifiedScanConfig1 = v2.ComplianceScanConfiguration{
-		ScanName: "testConfig1",
+		ScanName: "test-scan",
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test456",
 			OneTimeScan: false,
@@ -161,7 +161,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	query := &v2.RawQuery{Query: ""}
 	scanConfigs, err := service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
-	assert.Equal(t, len(scanConfigs.GetConfigurations()), 1)
+	require.Equal(t, len(scanConfigs.GetConfigurations()), 1)
 
 	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
 
@@ -177,7 +177,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	query = &v2.RawQuery{Query: ""}
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
-	assert.Equal(t, len(scanConfigs.GetConfigurations()), 1)
+	require.Equal(t, len(scanConfigs.GetConfigurations()), 1)
 	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -187,7 +187,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
 	reqDelete := &v2.ResourceByID{
-		Id: "testConfig1",
+		Id: "test-scan",
 	}
 	_, err = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
 	assert.NoError(t, err)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -127,7 +127,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test123",
 			OneTimeScan: false,
-			Profiles:    []string{"ocp4-e8"},
+			Profiles:    []string{"ocp4-cis-1-4"},
 			ScanSchedule: &v2.Schedule{
 				Hour:         2,
 				Minute:       0,
@@ -147,7 +147,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test456",
 			OneTimeScan: false,
-			Profiles:    []string{"rhcos4-e8"},
+			Profiles:    []string{"ocp4-cis-1-4-5"},
 			ScanSchedule: &v2.Schedule{
 				Hour:         2,
 				Minute:       0,

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -109,13 +109,6 @@ func waitForComplianceSuiteToComplete(t *testing.T, suiteName string, interval, 
 	}
 }
 
-func assertNameIDDescriptionAndProfilesMatch(t *testing.T, expected *v2.ComplianceScanConfigurationStatus, actual *v2.ComplianceScanConfiguration) {
-	assert.Equal(t, expected.GetScanName(), actual.GetScanName())
-	assert.Equal(t, expected.GetId(), actual.GetId())
-	assert.Equal(t, expected.GetScanConfig().GetDescription(), actual.GetScanConfig().GetDescription())
-	assert.Equal(t, expected.GetScanConfig().GetProfiles(), actual.GetScanConfig().GetProfiles())
-}
-
 func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := createK8sClient(t)
@@ -180,7 +173,6 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	assert.NotNil(t, matchingConfig)
 	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
 
-	//assertNameIDDescriptionAndProfilesMatch(t, matchingConfig, resp)
 	assert.Equal(t, scanConfig, matchingConfig)
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
@@ -197,7 +189,6 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	assert.NotNil(t, matchingConfig)
 	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
 
-	//assertNameIDDescriptionAndProfilesMatch(t, matchingConfig, resp)
 	assert.Equal(t, modifiedScanConfig, matchingConfig)
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -120,9 +120,12 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 	clusterID := clusters.GetClusters()[0].GetId()
 
+	scanName := fmt.Sprintf("test-%s", uuid.NewV4().String())
+	scanID := uuid.NewDummy().String()
+
 	scanConfig := v2.ComplianceScanConfiguration{
-		ScanName: "test-scan",
-		Id:       "test-scan-ID",
+		ScanName: scanName,
+		Id:       scanID,
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test123",
@@ -141,8 +144,8 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 		},
 	}
 	modifiedScanConfig := v2.ComplianceScanConfiguration{
-		ScanName: "test-scan",
-		Id:       "test-scan-ID",
+		ScanName: scanName,
+		Id:       scanID,
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test456",
@@ -187,7 +190,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
 	reqDelete := &v2.ResourceByID{
-		Id: "test-scan-ID",
+		Id: scanID,
 	}
 	_, err = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
 	assert.NoError(t, err)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -109,6 +109,13 @@ func waitForComplianceSuiteToComplete(t *testing.T, suiteName string, interval, 
 	}
 }
 
+func assertNameIDDescriptionAndProfilesMatch(t *testing.T, expected *v2.ComplianceScanConfigurationStatus, actual *v2.ComplianceScanConfiguration) {
+	assert.Equal(t, expected.GetScanName(), actual.GetScanName())
+	assert.Equal(t, expected.GetId(), actual.GetId())
+	assert.Equal(t, expected.GetScanConfig().GetDescription(), actual.GetScanConfig().GetDescription())
+	assert.Equal(t, expected.GetScanConfig().GetProfiles(), actual.GetScanConfig().GetProfiles())
+}
+
 func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := createK8sClient(t)
@@ -171,7 +178,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
 
-	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
+	assertNameIDDescriptionAndProfilesMatch(t, scanConfigs.GetConfigurations()[0], resp)
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
@@ -184,7 +191,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
 	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
-	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
+	assertNameIDDescriptionAndProfilesMatch(t, scanConfigs.GetConfigurations()[0], resp)
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
@@ -199,7 +206,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	query = &v2.RawQuery{Query: ""}
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
-	assert.Equal(t, len(scanConfigs.GetConfigurations()), 0)
+	assert.Equal(t, 0, len(scanConfigs.GetConfigurations()))
 }
 
 // ACS API test suite for integration testing for the Compliance Operator.

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -122,7 +122,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 
 	scanConfig := v2.ComplianceScanConfiguration{
 		ScanName: "test-scan",
-		Id:       "",
+		Id:       "test-scan-ID",
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test123",
@@ -142,7 +142,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	}
 	modifiedScanConfig := v2.ComplianceScanConfiguration{
 		ScanName: "test-scan",
-		Id:       "",
+		Id:       "test-scan-ID",
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test456",
@@ -187,7 +187,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
 	reqDelete := &v2.ResourceByID{
-		Id: "test-scan",
+		Id: "test-scan-ID",
 	}
 	_, err = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
 	assert.NoError(t, err)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -121,11 +121,10 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	clusterID := clusters.GetClusters()[0].GetId()
 
 	scanName := fmt.Sprintf("test-%s", uuid.NewV4().String())
-	scanID := uuid.NewDummy().String()
 
 	scanConfig := v2.ComplianceScanConfiguration{
 		ScanName: scanName,
-		Id:       scanID,
+		Id:       "",
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test123",
@@ -145,7 +144,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	}
 	modifiedScanConfig := v2.ComplianceScanConfiguration{
 		ScanName: scanName,
-		Id:       scanID,
+		Id:       "",
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			Description: "test456",
@@ -190,7 +189,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
 	reqDelete := &v2.ResourceByID{
-		Id: scanID,
+		Id: resp.GetId(),
 	}
 	_, err = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
 	assert.NoError(t, err)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -148,7 +148,7 @@ func waitForComplianceSuiteToComplete(t *testing.T, suiteName string, interval, 
 	}
 }
 
-func TestCentralSendsScanConfiguration(t *testing.T) {
+func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := createK8sClient(t)
 

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -167,11 +167,9 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	query := &v2.RawQuery{Query: ""}
 	scanConfigs, err := service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
-	require.Equal(t, len(scanConfigs.GetConfigurations()), 1)
+	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
 
 	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
-
-	k8sClient.AutoscalingV1()
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)
 
@@ -183,7 +181,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	query = &v2.RawQuery{Query: ""}
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
 	assert.NoError(t, err)
-	require.Equal(t, len(scanConfigs.GetConfigurations()), 1)
+	require.GreaterOrEqual(t, len(scanConfigs.GetConfigurations()), 1)
 	assert.Equal(t, resp, scanConfigs.GetConfigurations()[0])
 
 	scaleToN(ctx, k8sClient, "deploy/sensor", "stackrox", 0)


### PR DESCRIPTION
## Description

Central side counterpart to https://github.com/stackrox/stackrox/pull/11051

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

~~No testing beyond~~ confirming that the messages sent are of the type expected in Sensor as seen in https://github.com/stackrox/stackrox/pull/11051.

Added unit tests
E2e tests work in progress