### PR TITLE
chore(ui): Pin graphql to 16.8.1 instead of 16.0.0

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -36,7 +36,7 @@
         "file-saver": "^2.0.5",
         "formik": "^2.2.9",
         "framer-motion": "^10.0.0",
-        "graphql": "^16.0.0",
+        "graphql": "^16.8.1",
         "history": "^4.9.0",
         "html2canvas": "1.0.0-rc.7",
         "initials": "^3.1.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9345,7 +9345,7 @@ graphql-tag@^2.12.6:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^16.0.0:
+graphql@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
   integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==


### PR DESCRIPTION
## Description

As suggested in https://issues.redhat.com/browse/ROX-19807 -- an easy change with little (zero?) downside.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Non-functional change
