### PR TITLE
fix(ui): Add missing import from semantic merge conflict

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -6,7 +6,7 @@ import { resourceTypes, standardEntityTypes, rbacConfigTypes } from 'constants/e
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
 import { ResourceName } from 'types/roleResources';
-import { FeatureFlagPredicate, allEnabled } from 'utils/featureFlagUtils';
+import { FeatureFlagPredicate, allDisabled, allEnabled } from 'utils/featureFlagUtils';
 
 export const mainPath = '/main';
 export const loginPath = '/login';


### PR DESCRIPTION
## Description

Fixes missing import due to two PRs being merged to master - one that removed the only call to this function and then a second that added a new call to this function.

Both PRs fully passed CI and were merge-able without conflict, but will result in a failing build.

This should only result in failures on builds of:

- fcdea9f07b8dc9039b1e2ba42c99ec9114bcda34
- 2d8a7ee22a5434502b58581a73bf7bd9d90a9d26
- any commit to `master` before this PR is merged

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI