### PR TITLE
ROX-23038: search filters node CVE single page

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -4,7 +4,13 @@ import {
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
 } from '../types';
-import { getEntities, getEntityAttributes, getDefaultEntity, getDefaultAttribute } from './utils';
+import {
+    getEntities,
+    getEntityAttributes,
+    getDefaultEntity,
+    getDefaultAttribute,
+    makeFilterChipDescriptors,
+} from './utils';
 
 describe('utils', () => {
     describe('getEntities', () => {
@@ -102,6 +108,35 @@ describe('utils', () => {
             const result = getDefaultAttribute('Image CVE', config);
 
             expect(result).toStrictEqual('ID');
+        });
+    });
+
+    describe('makeFilterChipDescriptors', () => {
+        it('should create an array of FilterChipGroupDescriptor objects from a config object', () => {
+            const config: Partial<CompoundSearchFilterConfig> = {
+                'Image CVE': imageCVESearchFilterConfig,
+            };
+
+            const result = makeFilterChipDescriptors(config);
+
+            expect(result).toStrictEqual([
+                {
+                    displayName: 'Image CVE ID',
+                    searchFilterName: 'CVE ID',
+                },
+                {
+                    displayName: 'Image CVE Discovered Time',
+                    searchFilterName: 'CVE Created Time',
+                },
+                {
+                    displayName: 'Image CVE CVSS',
+                    searchFilterName: 'CVSS',
+                },
+                {
+                    displayName: 'Image CVE Type',
+                    searchFilterName: 'CVE Type',
+                },
+            ]);
         });
     });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
@@ -1,3 +1,5 @@
+import { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
+
 import {
     PartialCompoundSearchFilterConfig,
     SearchFilterAttribute,
@@ -81,4 +83,22 @@ export function ensureConditionNumber(value: unknown): { condition: string; numb
         condition: '',
         number: 0,
     };
+}
+
+/**
+ * Helper function to convert a search filter config object into an
+ * array of FilterChipGroupDescriptor objects for use in the SearchFilterChips component
+ *
+ * @param searchFilterConfig Config object for the search filter
+ * @returns An array of FilterChipGroupDescriptor objects
+ */
+export function makeFilterChipDescriptors(
+    searchFilterConfig: PartialCompoundSearchFilterConfig
+): FilterChipGroupDescriptor[] {
+    return Object.values(searchFilterConfig).flatMap(({ attributes = {} }) =>
+        Object.values(attributes).map((attributeConfig) => ({
+            displayName: attributeConfig.filterChipLabel,
+            searchFilterName: attributeConfig.searchTerm,
+        }))
+    );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -27,6 +27,7 @@ import {
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import useURLSort from 'hooks/useURLSort';
+import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import {
     getHiddenSeverities,
@@ -34,6 +35,7 @@ import {
     getRegexScopedQueryString,
 } from '../../utils/searchUtils';
 import CvePageHeader from '../../components/CvePageHeader';
+import { nodeSearchFilterConfig, nodeComponentSearchFilterConfig } from '../../searchFilterConfig';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import AffectedNodesTable, { defaultSortOption, sortFields } from './AffectedNodesTable';
 import AffectedNodesSummaryCard from './AffectedNodesSummaryCard';
@@ -42,8 +44,13 @@ import useNodeCveMetadata from './useNodeCveMetadata';
 
 const nodeCveOverviewCvePath = getOverviewPagePath('Node', { entityTab: 'CVE' });
 
+const searchFilterConfig = {
+    Node: nodeSearchFilterConfig,
+    'Node Component': nodeComponentSearchFilterConfig,
+} as const;
+
 function NodeCvePage() {
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
     const querySearchFilter = searchFilter;
 
@@ -102,6 +109,17 @@ function NodeCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-v5-u-flex-grow-1">
+                <AdvancedFiltersToolbar
+                    searchFilter={searchFilter}
+                    searchFilterConfig={searchFilterConfig}
+                    onFilterChange={(newFilter, { action }) => {
+                        setSearchFilter(newFilter);
+
+                        if (action === 'ADD') {
+                            // TODO - Add analytics tracking
+                        }
+                    }}
+                />
                 <SummaryCardLayout
                     error={metadataRequest.error}
                     isLoading={metadataRequest.loading}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.css
@@ -1,0 +1,13 @@
+.advanced-filters-toolbar .pf-m-typeahead .pf-v5-c-chip-group,
+.advanced-filters-toolbar .pf-m-typeahead button.pf-v5-c-select__toggle-clear {
+    display: none;
+}
+
+.advanced-filters-toolbar .pf-v5-c-select__toggle-wrapper {
+    flex-wrap: nowrap
+}
+
+/* Fixes the issue where badge counts in select components wrap to a new line */
+.advanced-filters-toolbar .vm-filter-toolbar-dropdown .pf-v5-c-select__toggle-wrapper {
+  flex-wrap: nowrap;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { Toolbar, ToolbarGroup, ToolbarContent, Flex } from '@patternfly/react-core';
+import { uniq } from 'lodash';
+import { Globe } from 'react-feather';
+
+import CompoundSearchFilter, {
+    CompoundSearchFilterProps,
+} from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { SearchFilter } from 'types/search';
+import { searchValueAsArray } from 'utils/searchUtils';
+
+import { DefaultFilters } from '../types';
+import CVESeverityDropdown from './CVESeverityDropdown';
+import CVEStatusDropdown from './CVEStatusDropdown';
+
+import './AdvancedFiltersToolbar.css';
+
+type FilterChipProps = {
+    isGlobal?: boolean;
+    name: string;
+};
+
+function FilterChip({ isGlobal, name }: FilterChipProps) {
+    if (isGlobal) {
+        return (
+            <Flex alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
+                <Globe height="15px" />
+                {name}
+            </Flex>
+        );
+    }
+    return <Flex>{name}</Flex>;
+}
+
+function makeDefaultFilterDescriptor(
+    defaultFilters: DefaultFilters,
+    { displayName, searchFilterName }: { displayName: string; searchFilterName: string }
+) {
+    return {
+        displayName,
+        searchFilterName,
+        render: (filter: string) => (
+            <FilterChip
+                isGlobal={defaultFilters[searchFilterName]?.some((value) => value === filter)}
+                name={filter}
+            />
+        ),
+    };
+}
+
+export type FilterChangeDiff = {
+    action: 'add' | 'remove';
+    category: string;
+    value: string;
+};
+
+const emptyDefaultFilters = {
+    SEVERITY: [],
+    FIXABLE: [],
+};
+
+type AdvancedFiltersToolbarProps = {
+    searchFilterConfig: CompoundSearchFilterProps['config'];
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
+    defaultFilters?: DefaultFilters;
+    includeCveFilters?: boolean;
+    // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
+    // autocompleteSearchContext?: unknown;
+};
+
+function AdvancedFiltersToolbar({
+    searchFilterConfig,
+    searchFilter,
+    onFilterChange,
+    defaultFilters = emptyDefaultFilters,
+    includeCveFilters = true,
+    // TODO We need to be able to apply the autocomplete search context to the advanced filters component
+    // autocompleteSearchContext,
+}: AdvancedFiltersToolbarProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');
+
+    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
+        .concat(
+            includeCveFilters
+                ? makeDefaultFilterDescriptor(defaultFilters, {
+                      displayName: 'CVE severity',
+                      searchFilterName: 'SEVERITY',
+                  })
+                : []
+        )
+        .concat(
+            includeCveFilters && isFixabilityFiltersEnabled
+                ? makeDefaultFilterDescriptor(defaultFilters, {
+                      displayName: 'CVE status',
+                      searchFilterName: 'FIXABLE',
+                  })
+                : []
+        );
+
+    function onFilterApplied({ category, value, action }: OnSearchPayload) {
+        const selectedSearchFilter = searchValueAsArray(searchFilter[category]);
+
+        const newFilter = {
+            ...searchFilter,
+            [category]:
+                action === 'ADD'
+                    ? uniq([...selectedSearchFilter, value])
+                    : selectedSearchFilter.filter((oldValue) => value !== oldValue),
+        };
+        onFilterChange(newFilter, { category, value, action });
+    }
+
+    return (
+        <Toolbar className="advanced-filters-toolbar pf-v5-u-pb-0 pf-v5-u-px-sm">
+            <ToolbarContent>
+                <ToolbarGroup
+                    variant="filter-group"
+                    className="pf-v5-u-display-flex pf-v5-u-flex-grow-1"
+                >
+                    <CompoundSearchFilter
+                        config={searchFilterConfig}
+                        searchFilter={searchFilter}
+                        onSearch={onFilterApplied}
+                    />
+                </ToolbarGroup>
+                {includeCveFilters && (
+                    <ToolbarGroup>
+                        <CVESeverityDropdown
+                            searchFilter={searchFilter}
+                            onSelect={(category, checked, value) =>
+                                onFilterApplied({
+                                    category,
+                                    value,
+                                    action: checked ? 'ADD' : 'REMOVE',
+                                })
+                            }
+                        />
+                        {isFixabilityFiltersEnabled && (
+                            <CVEStatusDropdown
+                                searchFilter={searchFilter}
+                                onSelect={(category, checked, value) =>
+                                    onFilterApplied({
+                                        category,
+                                        value,
+                                        action: checked ? 'ADD' : 'REMOVE',
+                                    })
+                                }
+                            />
+                        )}
+                    </ToolbarGroup>
+                )}
+                <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
+                    <SearchFilterChips filterChipGroupDescriptors={filterChipGroupDescriptors} />
+                </ToolbarGroup>
+            </ToolbarContent>
+        </Toolbar>
+    );
+}
+
+export default AdvancedFiltersToolbar;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.css
@@ -1,3 +1,4 @@
+/* TODO - This file should be deleted once ROX_VULN_MGMT_ADVANCED_FILTERS is deleted */
 #filter-autocomplete-toolbar-group .pf-m-typeahead .pf-v5-c-chip-group,
 #filter-autocomplete-toolbar-group .pf-m-typeahead button.pf-v5-c-select__toggle-clear {
     display: none;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.cy.jsx
@@ -1,3 +1,4 @@
+/* TODO - This file should be deleted once ROX_VULN_MGMT_ADVANCED_FILTERS is deleted */
 import React from 'react';
 
 import ComponentTestProviders from 'test-utils/ComponentProviders';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
@@ -1,3 +1,4 @@
+/* TODO - This file should be deleted once ROX_VULN_MGMT_ADVANCED_FILTERS is deleted */
 import React, { useState, useMemo } from 'react';
 import { debounce, Skeleton, ToolbarGroup } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterDropdowns.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterDropdowns.css
@@ -1,3 +1,4 @@
+/* TODO - This file should be deleted once ROX_VULN_MGMT_ADVANCED_FILTERS is deleted */
 /* Fixes the issue where badge counts in select components wrap to a new line */
 .vm-filter-toolbar-dropdown .pf-v5-c-select__toggle-wrapper {
   flex-wrap: nowrap;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,0 +1,4 @@
+export {
+    nodeSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';


### PR DESCRIPTION
## Description

Implements advanced filters for the Node CVE single page, as well as the core components to be used throughout VM 2.0

For the `AdvancedFilterToolbar`, I opted to create an entirely new component instead of modify the existing component from Workload CVEs. This will make it easier to swap between the two with a feature flag until the functionality is stable, at which point we can just delete the old components.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Queries are currently mocked for this page, so manually verify the correct values are being sent in the request.
![image](https://github.com/stackrox/stackrox/assets/1292638/68c94db6-652f-4023-bf62-0615607ef75d)
![image](https://github.com/stackrox/stackrox/assets/1292638/89767a5d-ad91-4c49-8355-794acb3be977)
![image](https://github.com/stackrox/stackrox/assets/1292638/1bf3cd8c-15bb-4801-a05f-fee38688cfd5)
![image](https://github.com/stackrox/stackrox/assets/1292638/bb9af6b5-c34e-463c-9f0d-ecafba2c074f)
![image](https://github.com/stackrox/stackrox/assets/1292638/31d23b91-ea2c-45d6-adb9-0b32ea9e4b75)

Test clearing query filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/4df7be61-e90c-45fc-91eb-4e5a9e867d56)



