### PR TITLE
chore(scanner): misc minor cleanup

### DIFF
--- a/scanner/datastore/postgres/vuln_update.go
+++ b/scanner/datastore/postgres/vuln_update.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4"
+	"github.com/quay/zlog"
 )
 
 const SingleBundleUpdateKey = `last-vuln-update`
@@ -86,12 +87,31 @@ func (m *matcherMetadataStore) GetOrSetLastVulnerabilityUpdate(ctx context.Conte
 // Removes all entries for inactive vulnerability bundles that are older than the
 // last know update.
 func (m *matcherMetadataStore) GCVulnerabilityUpdates(ctx context.Context, activeUpdaters []string, lastUpdate time.Time) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/matcherMetadataStore.GCVulnerabilityUpdates")
 	const deleteUnknownAndInactive = `
 		DELETE FROM last_vuln_update
-		WHERE NOT key = ANY($1) AND update_timestamp < $2`
-	_, err := m.pool.Exec(ctx, deleteUnknownAndInactive, activeUpdaters, sanitizeTimestamp(lastUpdate))
+		WHERE NOT key = ANY($1) AND update_timestamp < $2
+		RETURNING key`
+	rows, err := m.pool.Query(ctx, deleteUnknownAndInactive, activeUpdaters, sanitizeTimestamp(lastUpdate))
 	if err != nil {
 		return err
+	}
+	defer rows.Close()
+	var deletedRows []string
+	for rows.Next() {
+		var deletedRow string
+		err := rows.Scan(&deletedRow)
+		if err != nil {
+			zlog.Warn(ctx).Err(err).Msg("scanning deleted row")
+			continue
+		}
+		deletedRows = append(deletedRows, deletedRow)
+	}
+	if rows.Err() != nil {
+		zlog.Warn(ctx).Err(err).Msg("reading deleted rows")
+	}
+	if len(deletedRows) > 0 {
+		zlog.Info(ctx).Strs("deleted_bundles", deletedRows).Msg("deleted inactive vulnerability bundle(s)")
 	}
 	return nil
 }

--- a/scanner/datastore/postgres/vuln_update.go
+++ b/scanner/datastore/postgres/vuln_update.go
@@ -107,7 +107,7 @@ func (m *matcherMetadataStore) GCVulnerabilityUpdates(ctx context.Context, activ
 		}
 		deletedRows = append(deletedRows, deletedRow)
 	}
-	if rows.Err() != nil {
+	if err := rows.Err(); err != nil {
 		zlog.Warn(ctx).Err(err).Msg("reading deleted rows")
 	}
 	if len(deletedRows) > 0 {

--- a/scanner/enricher/fixedby/fixedby.go
+++ b/scanner/enricher/fixedby/fixedby.go
@@ -90,15 +90,13 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 		fixedBy.Package = &p
 
 		// Set the Distribution.
-		// Just use the first one, as we only support single-distribution images.
+		// If we cannot not identify the distribution, then just use a dummy one,
+		// as we still want to support language-level packages.
+		fixedBy.Distribution = &claircore.Distribution{}
 		for _, d := range vr.Distributions {
+			// Just use the first one, as we only support single-distribution images.
 			fixedBy.Distribution = d
 			break
-		}
-		// If we could not identify the distribution, then just use a dummy one.
-		// Do not fail here, as we still want to support language-level packages.
-		if fixedBy.Distribution == nil {
-			fixedBy.Distribution = &claircore.Distribution{}
 		}
 
 		// Set the Repository.

--- a/scanner/enricher/fixedby/fixedby.go
+++ b/scanner/enricher/fixedby/fixedby.go
@@ -90,7 +90,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 		fixedBy.Package = &p
 
 		// Set the Distribution.
-		// If we cannot not identify the distribution, then just use a dummy one,
+		// If we cannot identify the distribution, then use a dummy one,
 		// as we still want to support language-level packages.
 		fixedBy.Distribution = &claircore.Distribution{}
 		for _, d := range vr.Distributions {

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -167,9 +167,6 @@ func toProtoV4Contents(
 		}
 	}
 	var packages []*v4.Package
-	if pkgFixedBy == nil {
-		pkgFixedBy = map[string]string{}
-	}
 	for _, ccP := range pkgs {
 		pkg, err := toProtoV4Package(ccP)
 		if err != nil {
@@ -612,6 +609,7 @@ func filterPackages(packages map[string]*claircore.Package, environments map[str
 	}
 }
 
+// pkgFixedBy unmarshals and returns the package-fixed-by enrichment, if it exists.
 func pkgFixedBy(enrichments map[string][]json.RawMessage) (map[string]string, error) {
 	enrichmentsList := enrichments[fixedby.Type]
 	if len(enrichmentsList) == 0 {

--- a/scanner/matcher/updater/distribution/updater.go
+++ b/scanner/matcher/updater/distribution/updater.go
@@ -86,7 +86,7 @@ func (u *Updater) Start() error {
 			if isInitial {
 				if u.vulnInitializedFunc != nil && !u.vulnInitializedFunc(u.ctx) {
 					d := 15 * time.Minute
-					zlog.Info(ctx).Msgf("vulnerability updater is running, wait %s and try again...", d)
+					zlog.Info(ctx).Msgf("vulnerabilities uninitialized: retrying in %s...", d)
 					t.Reset(d)
 					continue
 				}

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	ifModifiedSince = `If-Modified-Since`
-	lastModified    = `Last-Modified`
+	ifModifiedSinceHeader = `If-Modified-Since`
+	lastModifiedHeader    = `Last-Modified`
 
 	updateName = `scanner-v4-updater`
 
@@ -281,6 +281,7 @@ func (u *Updater) tryRemoveExiting() {
 	files, err := fs.Glob(os.DirFS(u.root), updateFilePattern)
 	if err != nil {
 		zlog.Warn(ctx).Err(err).Msg("searching for previous update files to remove")
+		return
 	}
 	for _, file := range files {
 		if err := os.Remove(filepath.Join(u.root, file)); err != nil {
@@ -331,7 +332,7 @@ func (u *Updater) Initialized(ctx context.Context) bool {
 	if u.initialized.Load() {
 		return true
 	}
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/Updater.Initialized")
+	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.Initialized")
 	ts, err := u.metadataStore.GetLastVulnerabilityUpdate(ctx)
 	if err != nil {
 		zlog.
@@ -500,6 +501,8 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 }
 
 func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time.Time, prevTime time.Time) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.updateBundle")
+
 	// Use TryLock to prevent simultaneous updates for the same bundle.
 	lCtx, lDone := u.locker.TryLock(ctx, zipF.Name)
 	defer lDone()
@@ -556,36 +559,44 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.fetch")
 
 	var resp *http.Response
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			utils.IgnoreError(resp.Body.Close)
+		}
+	}()
 	var err error
-	for attempt := 0; attempt < u.retryMax; attempt++ {
-		zlog.Info(ctx).Str("url", u.url).Msg("fetching vuln update")
+	// After this loop, either resp != nil or we will have returned an error.
+	for attempt := 1; attempt <= u.retryMax; attempt++ {
+		zlog.Info(ctx).
+			Str("url", u.url).
+			Int("attempt", attempt).
+			Msg("fetching vuln update")
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.url, nil)
 		if err != nil {
 			return nil, time.Time{}, err
 		}
-		req.Header.Set(ifModifiedSince, prevTimestamp.Format(http.TimeFormat))
+		req.Header.Set(ifModifiedSinceHeader, prevTimestamp.Format(http.TimeFormat))
 		// Request multi-bundle if multi-bundle is enabled.
 		if features.ScannerV4MultiBundle.Enabled() {
 			req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
 		}
 		resp, err = u.client.Do(req)
+		// If the vuln URL is unavailable and when we haven't exhausted our connection refused attempts, retry.
+		if isConnectionRefused(err) && attempt < u.retryMax {
+			zlog.Error(ctx).
+				Err(err).
+				Str("delay", u.retryDelay.String()).
+				Msg("retrying...")
+			time.Sleep(u.retryDelay) // Wait for retryDelay before retrying
+			continue
+		}
+		// If there is some other kind of error or when we have exhausted our retry attempts, do not retry.
 		if err != nil {
-			var opErr *net.OpError
-			if errors.As(err, &opErr) && opErr.Op == "dial" && strings.Contains(opErr.Err.Error(), "connection refused") {
-				// Retry when vuln URL is unavailable
-				zlog.Error(ctx).Err(err).Msg("connection refused, retrying...")
-				if attempt < u.retryMax-1 {
-					time.Sleep(u.retryDelay) // Wait for retryDelay before retrying
-					continue
-				}
-			}
-			// For other errors, do not retry
-			closeResponse(resp)
 			return nil, time.Time{}, err
 		}
-		break // no error, no retry
+
+		break // No errors, so don't retry.
 	}
-	defer closeResponse(resp)
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -622,10 +633,10 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 		return nil, time.Time{}, fmt.Errorf("seeking temp update file to start: %w", err)
 	}
 
-	modTime := resp.Header.Get(lastModified)
+	modTime := resp.Header.Get(lastModifiedHeader)
 	timestamp, err := http.ParseTime(modTime)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("parsing Last-Modified header: %w", err)
+		return nil, time.Time{}, fmt.Errorf("parsing %s header: %w", lastModifiedHeader, err)
 	}
 	succeeded = true
 	return f, timestamp, nil
@@ -635,8 +646,7 @@ func jitter() time.Duration {
 	return jitterMinutes[random.Intn(len(jitterMinutes))]
 }
 
-func closeResponse(resp *http.Response) {
-	if resp != nil && resp.Body != nil {
-		utils.IgnoreError(resp.Body.Close)
-	}
+func isConnectionRefused(err error) bool {
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "dial" && strings.Contains(opErr.Err.Error(), "connection refused")
 }


### PR DESCRIPTION
## Description

Was combing through the Scanner V4 code and found a few places I wanted to update:

* Datastore - Figured it'd be nice to log which update operations we no longer track
* Mapper/updater - some code cleanup

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

1. Deployed the Central cluster with Scanner V4 enabled
2. Found the following logs:

```
{"level":"info","host":"scanner-v4-matcher-7dd46887cb-55rhb","component":"matcher/updater/vuln/Updater.runMultiBundleUpdate","timestamp":"0001-01-01T00:00:00Z","time":"2024-06-04T21:02:37Z","message":"previous vuln update"}
{"level":"info","host":"scanner-v4-matcher-7dd46887cb-55rhb","component":"matcher/updater/vuln/Updater.fetch","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev","attempt":1,"time":"2024-06-04T21:02:37Z","message":"fetching vuln update"}
{"level":"error","host":"scanner-v4-matcher-7dd46887cb-55rhb","component":"matcher/updater/vuln/Updater.fetch","error":"Get \"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev\": dial tcp 172.30.181.29:443: connect: connection refused","delay":"10s","time":"2024-06-04T21:02:37Z","message":"retrying..."}
{"level":"info","host":"scanner-v4-matcher-7dd46887cb-55rhb","component":"matcher/updater/vuln/Updater.fetch","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev","attempt":2,"time":"2024-06-04T21:02:47Z","message":"fetching vuln update"}
{"level":"info","host":"scanner-v4-matcher-7dd46887cb-55rhb","component":"matcher/updater/vuln/Updater.runMultiBundleUpdate","bundle":"bundles/alpine.json.zst","time":"2024-06-04T21:02:48Z","message":"starting bundle update"}
```

(can see similar for the other matcher)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
