### PR TITLE
ROX-24105: Add interaction for on-demand compliance report

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -1,0 +1,122 @@
+import React, { ReactElement, useState } from 'react';
+import { generatePath, useHistory } from 'react-router-dom';
+import {
+    Dropdown,
+    DropdownItem,
+    DropdownSeparator,
+    DropdownToggle,
+} from '@patternfly/react-core/deprecated';
+import { CaretDownIcon } from '@patternfly/react-icons';
+
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
+
+import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
+
+// Component for scan config details page corresponds to ScanConfigActionsColumn for scan configs table table page.
+// One difference: omit delete on details page.
+
+// Caller is responsible for conditional rendering only if READ_WRITE_ACCESS level for Compliance resource.
+
+export type ScanConfigActionDropdownProps = {
+    handleRunScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    handleSendReport: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    isScanning: boolean;
+    scanConfigResponse: ComplianceScanConfigurationStatus;
+};
+
+function ScanConfigActionDropdown({
+    handleRunScanConfig,
+    handleSendReport,
+    isScanning,
+    scanConfigResponse,
+}: ScanConfigActionDropdownProps): ReactElement {
+    const history = useHistory();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
+
+    const [isOpen, setIsOpen] = useState(false);
+
+    const { id, scanConfig } = scanConfigResponse;
+    const { notifiers } = scanConfig;
+    const scanConfigUrl = generatePath(scanConfigDetailsPath, {
+        scanConfigId: id,
+    });
+
+    function onToggle() {
+        setIsOpen((prevValue) => !prevValue);
+    }
+
+    function onSelect() {
+        setIsOpen(false);
+    }
+
+    const dropdownItems = [
+        <DropdownItem
+            key="Edit scan schedule"
+            component="button"
+            description={isScanning ? 'Edit is disabled while scan is running' : ''}
+            isDisabled={isScanning}
+            onClick={() => {
+                history.push({
+                    pathname: scanConfigUrl,
+                    search: 'action=edit',
+                });
+            }}
+        >
+            Edit scan schedule
+        </DropdownItem>,
+        <DropdownSeparator key="Separator" />,
+        <DropdownItem
+            key="Run scan now"
+            component="button"
+            description={isScanning ? 'Run is disabled while scan is already running' : ''}
+            isDisabled={isScanning}
+            onClick={() => {
+                handleRunScanConfig(scanConfigResponse);
+            }}
+        >
+            Run scan now
+        </DropdownItem>,
+    ];
+
+    if (isComplianceReportingEnabled) {
+        /* eslint-disable no-nested-ternary */
+        dropdownItems.push(
+            <DropdownItem
+                key="Send report now"
+                component="button"
+                description={
+                    notifiers.length === 0
+                        ? 'Send is disabled if no delivery destinations'
+                        : isScanning
+                          ? 'Send is disabled while scan is running'
+                          : ''
+                }
+                isDisabled={notifiers.length === 0 || isScanning}
+                onClick={() => {
+                    handleSendReport(scanConfigResponse);
+                }}
+            >
+                Send report now
+            </DropdownItem>
+        );
+        /* eslint-enable no-nested-ternary */
+    }
+
+    return (
+        <Dropdown
+            onSelect={onSelect}
+            position="right"
+            toggle={
+                <DropdownToggle onToggle={onToggle} toggleIndicator={CaretDownIcon}>
+                    Actions
+                </DropdownToggle>
+            }
+            isOpen={isOpen}
+            dropdownItems={dropdownItems}
+        />
+    );
+}
+
+export default ScanConfigActionDropdown;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -55,8 +55,8 @@ function ScanConfigActionDropdown({
         <DropdownItem
             key="Edit scan schedule"
             component="button"
-            description={isScanning ? 'Edit is disabled while scan is running' : ''}
-            isDisabled={isScanning}
+            // description={isScanning ? 'Edit is disabled while scan is running' : ''}
+            // isDisabled={isScanning}
             onClick={() => {
                 history.push({
                     pathname: scanConfigUrl,
@@ -89,11 +89,11 @@ function ScanConfigActionDropdown({
                 description={
                     notifiers.length === 0
                         ? 'Send is disabled if no delivery destinations'
-                        : isScanning
-                          ? 'Send is disabled while scan is running'
-                          : ''
+                        : /* : isScanning
+                          ? 'Send is disabled while scan is running' */
+                          ''
                 }
-                isDisabled={notifiers.length === 0 || isScanning}
+                isDisabled={notifiers.length === 0 /* || isScanning */}
                 onClick={() => {
                     handleSendReport(scanConfigResponse);
                 }}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -28,18 +28,18 @@ function ScanConfigActionsColumn({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
 
-    const { id, lastExecutedTime, scanConfig } = scanConfigResponse;
+    const { id, /* lastExecutedTime, */ scanConfig } = scanConfigResponse;
     const { notifiers } = scanConfig;
     const scanConfigUrl = generatePath(scanConfigDetailsPath, {
         scanConfigId: id,
     });
-    const isScanning = lastExecutedTime === null;
+    // const isScanning = lastExecutedTime === null;
 
     const items = [
         {
             title: 'Edit scan schedule',
-            description: isScanning ? 'Edit is disabled while scan is running' : '',
-            isDisabled: isScanning,
+            // description: isScanning ? 'Edit is disabled while scan is running' : '',
+            // isDisabled: isScanning,
             onClick: (event) => {
                 event.preventDefault();
                 history.push({
@@ -53,8 +53,8 @@ function ScanConfigActionsColumn({
         },
         {
             title: 'Run scan now',
-            description: isScanning ? 'Run is disabled while scan is already running' : '',
-            isDisabled: isScanning,
+            // description: isScanning ? 'Run is disabled while scan is already running' : '',
+            // isDisabled: isScanning,
             onClick: (event) => {
                 event.preventDefault();
                 handleRunScanConfig(scanConfigResponse);
@@ -66,10 +66,10 @@ function ScanConfigActionsColumn({
             description:
                 notifiers.length === 0
                     ? 'Send is disabled if no delivery destinations'
-                    : isScanning
+                    : /* isScanning
                       ? 'Send is disabled while scan is running'
-                      : '',
-            isDisabled: notifiers.length === 0 || isScanning,
+                      : */ '',
+            isDisabled: notifiers.length === 0 /* || isScanning */,
             onClick: (event) => {
                 event.preventDefault();
                 handleSendReport(scanConfigResponse);
@@ -81,12 +81,12 @@ function ScanConfigActionsColumn({
         },
         {
             title: (
-                <span className={isScanning ? '' : 'pf-v5-u-danger-color-100'}>
+                <span className={/* isScanning ? '' : */ 'pf-v5-u-danger-color-100'}>
                     Delete scan schedule
                 </span>
             ),
-            description: isScanning ? 'Delete is disabled while scan is running' : '',
-            isDisabled: isScanning,
+            // description: isScanning ? 'Delete is disabled while scan is running' : '',
+            // isDisabled: isScanning,
             onClick: (event) => {
                 event.preventDefault();
                 handleDeleteScanConfig(scanConfigResponse);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -1,0 +1,105 @@
+import React, { ReactElement } from 'react';
+import { generatePath, useHistory } from 'react-router-dom';
+import { ActionsColumn } from '@patternfly/react-table';
+
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
+
+import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
+
+// Component for scan configs table table page corresponds to ScanConfigActionDropdown for scan config details page.
+
+// Caller is responsible for conditional rendering only if READ_WRITE_ACCESS level for Compliance resource.
+
+export type ScanConfigActionsColumnProps = {
+    handleDeleteScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    handleRunScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    handleSendReport: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    scanConfigResponse: ComplianceScanConfigurationStatus;
+};
+
+function ScanConfigActionsColumn({
+    handleDeleteScanConfig,
+    handleRunScanConfig,
+    handleSendReport,
+    scanConfigResponse,
+}: ScanConfigActionsColumnProps): ReactElement {
+    const history = useHistory();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
+
+    const { id, lastExecutedTime, scanConfig } = scanConfigResponse;
+    const { notifiers } = scanConfig;
+    const scanConfigUrl = generatePath(scanConfigDetailsPath, {
+        scanConfigId: id,
+    });
+    const isScanning = lastExecutedTime === null;
+
+    const items = [
+        {
+            title: 'Edit scan schedule',
+            description: isScanning ? 'Edit is disabled while scan is running' : '',
+            isDisabled: isScanning,
+            onClick: (event) => {
+                event.preventDefault();
+                history.push({
+                    pathname: scanConfigUrl,
+                    search: 'action=edit',
+                });
+            },
+        },
+        {
+            isSeparator: true,
+        },
+        {
+            title: 'Run scan now',
+            description: isScanning ? 'Run is disabled while scan is already running' : '',
+            isDisabled: isScanning,
+            onClick: (event) => {
+                event.preventDefault();
+                handleRunScanConfig(scanConfigResponse);
+            },
+        },
+        /* eslint-disable no-nested-ternary */
+        {
+            title: 'Send report now',
+            description:
+                notifiers.length === 0
+                    ? 'Send is disabled if no delivery destinations'
+                    : isScanning
+                      ? 'Send is disabled while scan is running'
+                      : '',
+            isDisabled: notifiers.length === 0 || isScanning,
+            onClick: (event) => {
+                event.preventDefault();
+                handleSendReport(scanConfigResponse);
+            },
+        },
+        /* eslint-enable no-nested-ternary */
+        {
+            isSeparator: true,
+        },
+        {
+            title: (
+                <span className={isScanning ? '' : 'pf-v5-u-danger-color-100'}>
+                    Delete scan schedule
+                </span>
+            ),
+            description: isScanning ? 'Delete is disabled while scan is running' : '',
+            isDisabled: isScanning,
+            onClick: (event) => {
+                event.preventDefault();
+                handleDeleteScanConfig(scanConfigResponse);
+            },
+        },
+    ].filter(({ title }) => title !== 'Send report now' || isComplianceReportingEnabled);
+
+    return (
+        <ActionsColumn
+            // menuAppendTo={() => document.body}
+            items={items}
+        />
+    );
+}
+
+export default ScanConfigActionsColumn;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -133,8 +133,8 @@ function ViewScanConfigDetail({
                                         handleRunScanConfig={handleRunScanConfig}
                                         handleSendReport={handleSendReport}
                                         isScanning={
-                                            isTriggeringRescan ||
-                                            scanConfig.lastExecutedTime === null
+                                            isTriggeringRescan /* ||
+                                            scanConfig.lastExecutedTime === null */
                                         }
                                         scanConfigResponse={scanConfig}
                                     />

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -174,3 +174,24 @@ export function runComplianceScanConfiguration(scanConfigId: string) {
             return response.data;
         });
 }
+
+export type ComplianceReportRunState = 'SUBMITTED' | 'ERROR';
+
+export type ComplianceRunReportResponse = {
+    runState: ComplianceReportRunState;
+    submittedAt: string; // ISO 8601 date string
+    errorMsg: string;
+};
+
+/*
+ * Run an on demand compliance report for the scan configuration ID.
+ */
+export function runComplianceReport(scanConfigId: string): Promise<ComplianceRunReportResponse> {
+    return axios
+        .put<ComplianceRunReportResponse>(`${complianceScanConfigBaseUrl}/reports/run`, {
+            scanConfigId,
+        })
+        .then((response) => {
+            return response.data;
+        });
+}


### PR DESCRIPTION
## Description

Frontend counterpart to #11117

### Precedents in Vulnerability Reporting

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx#L450-L512

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx#L195-L270

### Changes in Compliance Schedules

Factor out row actions and **Action** dropdown as sibling files:
* Consistency becomes easier to maintain.
* Data dependencies that were implicit from closure become explicit as props.

Although I considered components subfolder, I decided on same folder as rendering components for visibility.

1. Add ScanConfigActionDropdown.tsx file.
    * Adapt from table actions but omit delete action.
        ViewVulnReportPage.tsx file was my example.
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx#L195-L270
2. Add ScanConfigActionsColumn.tsx file.
    * Add `description` props with conditional content.
    * Replace `isDisabled: !hasWriteAccessForCompliance` with `isDisabled: isScanning` because caller is responsible for conditional rendering.
    * Add separators.
    * Add `span` with `className` prop for **Delete scan schedule** action.
3. Edit ScanConfigsTablePage.tsx file.
    * To prevent merge conflict, wait until later to move out of Tables subfolder.
    * Add `handleWhatever` callback functions.
    * Add conditional rendering and replace `rowActions` with `ScanConfigActionsColumn` element.
    * Add `alertObj` rendering pattern.
4. Edit ViewScanConfigDetail.tsx file.
    * Rename `onTriggerRescan` as `handleRunScanConfig` function.
    * Add `handleSendReport` function.
    * Add conditional rendering and replace separate **Re-scan** and **Edit scan schedule** buttons with `ScanConfigActionDropdown` element.
5. Edit ComplianceScanConfigurationService.ts file.
    * Add `ComplianceRunReportResponse` type and `runComplianceReport` function.

### Residue

1. Investigate inability to create and update report delivery destinations:
    * Double check correspondence between backend and frontend types:
        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/compliance_scan_configuration_service.proto#L40
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts#L60
    * Ask backend coworkers whether the implementation is incomplete.
2. ScanConfigActionsColumn.tsx file:
    * Investigate why `event.preventDefault()` in table row actions but not in `DropdownItem` elements.
    * Investigate `// menuAppendTo={() => document.body}` in `ActionsColumn` element left over from PatternFly 5 upgrade.
3. ScanConfigsTablePage.tsx file:
    * Think more carefully about (not yet rendered) `errorResult` for delete action, `error` for main request, and `alertObj` for row actions.
4. ComplianceScanConfigurationService.ts file:
    * Investigate why 404 Unknown status for 

### Learning

It had been long enough that I forgot, and searched for a precedent for the request property.

https://github.com/stackrox/stackrox/blob/master/proto/api/v2/compliance_scan_configuration_service.proto

```proto
message ComplianceRunReportRequest {
  string scan_config_id = 1;
}
```

```proto
  rpc RunReport(ComplianceRunReportRequest) returns (ComplianceRunReportResponse) {
    option (google.api.http) = {
      put: "/v2/compliance/scan/configurations/reports/run"
      body: "*"
    };
  }
```

Corresponds **not** to `scanConfigId` in template literal, but instead to the `{ scanConfigId }` property in payload object:

```ts
        put<ComplianceRunReportResponse>(`${complianceScanConfigBaseUrl}/reports/run`, {
            scanConfigId,
        })
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Prerequisite for `yarn start` in ui folder:

```sh
export ROX_COMPLIANCE_REPORTING=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4635860 - 4635860
        total 2926 = 11693535 - 11690609
    * `ls -al build/static/js/*.js | wc`
        files 0 = 171 - 171
3. `yarn start` in ui

### Manual testing in Vulnerability Reporting

1. Visit /main/vulnerabilities/reports and click kabob to open row actions.
    ![VulnReportsPage](https://github.com/stackrox/stackrox/assets/11862657/285a6ef7-9a0c-4491-a40a-2c331f7c346a)

2. Click report link, and then click **Actions** dropdown.
    ![ViewVulnReportPage](https://github.com/stackrox/stackrox/assets/11862657/d9ad8b3d-031e-4b84-9647-3e43b690f5de)

### Manual testing in Compliance Schedules

Temporarily edit code to ignore `notifiers.length === 0` condition which disables **Send** action.

1. Visit /main/compliance/schedules and click kabob to open row actions.

    * Before changes, with fewer actions.
        ![ScanConfigsTablePage_without](https://github.com/stackrox/stackrox/assets/11862657/7b17e68f-5ce9-4a0a-bfca-924b33edd9a6)

    * After changes, with more actions.
        ![ScanConfigsTablePage_with](https://github.com/stackrox/stackrox/assets/11862657/f63e04a9-cd50-4db9-8a67-0c6a3580d9a4)

        * Click **Edit scan schedule** to visit wizard /main/compliance/schedules/id?action=edit

        * Click **Run scan now** and see alert element and expected requests:
            POST /v2/compliance/scan/configurations/id/run
            GET /v2/compliance/scan/configurations?…
            ![ScanConfigsTablePage_with_Run_scan_now](https://github.com/stackrox/stackrox/assets/11862657/ba77f9f2-2445-447e-962e-1600a9d59ee8)

        * Click **Send report now** and see alert element and expected request:
            PUT /v2/compliance/scan/configurations/reports/run
            ![ScanConfigsTablePage_with_Send_report_now](https://github.com/stackrox/stackrox/assets/11862657/ec1530d8-3d2f-433e-9402-0861d3302f71)

        * Click **Delete scan schedule** and see modal.
            ![ScanConfigsTablePage_with_Delete_scan_schedule](https://github.com/stackrox/stackrox/assets/11862657/884979ec-7749-473c-8cbc-4f8a1a3b8133)

2. Click report link:

    * Before changes, with **Edit scan schedule** button only.
        ![ViewScanConfigDetail_without](https://github.com/stackrox/stackrox/assets/11862657/0fd07108-1305-495c-aed9-dc9d036588b4)

    * After changes, with **Actions** dropdown.
        ![ViewScanConfigDetail_with](https://github.com/stackrox/stackrox/assets/11862657/f830c7b7-1b19-4da6-b123-7e8482e313ac)
