### PR TITLE
fix: do not install snappy

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -51,7 +51,6 @@ COPY static-bin /stackrox/
 COPY --from=downloads /output/rpms/ /tmp/
 COPY --from=downloads /output/go/ /go/
 
-RUN if [[ "$(uname -m)" == "x86_64" ]]; then rpm -i /tmp/snappy.rpm && rm /tmp/snappy.rpm; fi
 RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \

--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -33,11 +33,6 @@ if [[ "$DEBUG_BUILD" == "yes" ]]; then
 fi
 
 mkdir -p "$output_dir/rpms"
-# Install all the required compression packages for RocksDB to compile for amd64. RocksDB is not required for other architectures.
-if [[ "$goarch" == "amd64" ]]; then
-  rpm_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
-  curl --retry 3 --silent --show-error -f -o "${output_dir}/rpms/snappy.rpm" "${rpm_url}"
-fi
 
 if [[ "$arch" == "s390x" ]]; then
   dnf install -y --downloadonly --downloaddir=/tmp postgresql postgresql-private-libs


### PR DESCRIPTION
## Description

snappy is no longer available. This PR removes it as it may not be required due to removal of rocksdb

- https://github.com/stackrox/stackrox/pull/10875/files

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
