### PR TITLE
fix: update snappy url

### DIFF
--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -35,7 +35,7 @@ fi
 mkdir -p "$output_dir/rpms"
 # Install all the required compression packages for RocksDB to compile for amd64. RocksDB is not required for other architectures.
 if [[ "$goarch" == "amd64" ]]; then
-  rpm_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
+  rpm_url="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
   curl --retry 3 --silent --show-error -f -o "${output_dir}/rpms/snappy.rpm" "${rpm_url}"
 fi
 


### PR DESCRIPTION
## Description

Previous URL does not longer work and returns 404 causing build failures. This PR upgrades URL to centos 9. This should be fine and easy to backport.

In long term we should remove this dependency.
- https://github.com/stackrox/stackrox/pull/11346

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
