### PR TITLE
chore(ui): Update prettier 3.3.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -160,7 +160,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.38",
         "postcss-cli": "^8.3.1",
-        "prettier": "^3.2.2",
+        "prettier": "^3.3.0",
         "react-app-rewired": "^2.2.1",
         "react-scripts": "^5.0.1",
         "react-test-renderer": "^17.0.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14041,10 +14041,10 @@ prettier@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
-prettier@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.2.tgz#96e580f7ca9c96090ad054616c0c4597e2844b65"
-  integrity sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==
+prettier@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.0.tgz#d173ea0524a691d4c0b1181752f2b46724328cdf"
+  integrity sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://prettier.io/blog/2024/06/01/3.3.0

Update sooner than later to reduce complexity of supporting releases for longer time period.

Here are bug fixes that do not affect current code, but could affect lint for future code.

https://prettier.io/blog/2024/06/01/3.3.0#format-embedded-gql-in-template-literal-statements-16064httpsgithubcomprettierprettierpull16064-by-keithlaynehttpsgithubcomkeithlayne

https://prettier.io/blog/2024/06/01/3.3.0#allow-linebreaks-in-member-expressions-in-template-interpolations-16116httpsgithubcomprettierprettierpull16116-by-bakkothttpsgithubcombakkot

https://prettier.io/blog/2024/06/01/3.3.0#add-missing-parentheses-to-tsinfertype-16031httpsgithubcomprettierprettierpull16031-by-fiskerhttpsgithubcomfisker

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui