### PR TITLE
ROX-23582: Platform CVEs graphQL resolvers

### DIFF
--- a/central/graphql/resolvers/cluster_count_by_platform_type.go
+++ b/central/graphql/resolvers/cluster_count_by_platform_type.go
@@ -1,0 +1,56 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/views/platformcve"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("ClusterCountByPlatformType", []string{
+			"generic: Int!",
+			"kubernetes: Int!",
+			"openshift: Int!",
+			"openshift4: Int!",
+		}),
+	)
+}
+
+type clusterCountByPlatformTypeResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data platformcve.ClusterCountByPlatformType
+}
+
+func (resolver *Resolver) wrapClusterCountByPlatformTypeWithContext(ctx context.Context, value platformcve.ClusterCountByPlatformType, err error) (*clusterCountByPlatformTypeResolver, error) {
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return &clusterCountByPlatformTypeResolver{ctx: ctx, root: resolver, data: platformcve.NewEmptyClusterCountByPlatformType()}, nil
+	}
+	return &clusterCountByPlatformTypeResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+// Generic returns number of clusters of type GENERIC
+func (resolver *clusterCountByPlatformTypeResolver) Generic(_ context.Context) int32 {
+	return int32(resolver.data.GetGenericClusterCount())
+}
+
+// Kubernetes returns the number of clusters of type KUBERNETES
+func (resolver *clusterCountByPlatformTypeResolver) Kubernetes(_ context.Context) int32 {
+	return int32(resolver.data.GetKubernetesClusterCount())
+}
+
+// Openshift returns the number of clusters of type OPENSHIFT
+func (resolver *clusterCountByPlatformTypeResolver) Openshift(_ context.Context) int32 {
+	return int32(resolver.data.GetOpenshiftClusterCount())
+}
+
+// Openshift4 retruns the number of clusters of type OPENSHIFT4
+func (resolver *clusterCountByPlatformTypeResolver) Openshift4(_ context.Context) int32 {
+	return int32(resolver.data.GetOpenshift4ClusterCount())
+}

--- a/central/graphql/resolvers/platform_cve_core.go
+++ b/central/graphql/resolvers/platform_cve_core.go
@@ -203,7 +203,7 @@ func (resolver *platformCVECoreResolver) Clusters(ctx context.Context, args stru
 		return nil, err
 	}
 
-	query := search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetCVEID()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.CVEID, resolver.data.GetCVEID()).ProtoQuery()
 	if resolver.subFieldQuery != nil {
 		query = search.ConjunctionQuery(query, resolver.subFieldQuery)
 	}

--- a/central/graphql/resolvers/platform_cve_core.go
+++ b/central/graphql/resolvers/platform_cve_core.go
@@ -1,0 +1,249 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/views/platformcve"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+const (
+	maxClusters = 1000
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		// NOTE: This list is and should remain alphabetically ordered
+		schema.AddType("PlatformCVECore",
+			[]string{
+				"clusterCountByPlatformType: ClusterCountByPlatformType!",
+				"clusterCount: Int!",
+				"clusters: [Cluster!]!",
+				"clusterVulnerability: ClusterVulnerability!",
+				"cve: String!",
+				"cveType: String!",
+				"cvss: Float!",
+				"firstDiscoveredTime: Time",
+				"id: ID!",
+				"isFixable(query: String): Boolean!",
+			}),
+		schema.AddQuery("platformCVECount(query: String): Int!"),
+		schema.AddQuery("platformCVEs(query: String, pagination: Pagination): [PlatformCVECore!]!"),
+		// `subfieldScopeQuery` applies the scope query to all the subfields of the PlatformCVE resolver.
+		// This eliminates the need to pass queries to individual resolvers.
+		schema.AddQuery("platformCVE(cve: String, subfieldScopeQuery: String): PlatformCVECore"),
+	)
+}
+
+type platformCVECoreResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data platformcve.CveCore
+
+	subFieldQuery *v1.Query
+}
+
+func (resolver *Resolver) wrapPlatformCVECoreWithContext(ctx context.Context, value platformcve.CveCore, err error) (*platformCVECoreResolver, error) {
+	if err != nil || value == nil {
+		return nil, err
+	}
+	return &platformCVECoreResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapPlatformCVECoresWithContext(ctx context.Context, values []platformcve.CveCore, err error) ([]*platformCVECoreResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	ret := make([]*platformCVECoreResolver, len(values))
+	for i, v := range values {
+		ret[i] = &platformCVECoreResolver{ctx: ctx, root: resolver, data: v}
+	}
+	return ret, nil
+}
+
+// PlatformCVECount returns the count of platform cves satisfying the specified query.
+// Note: By default, snoozed CVEs will be excluded. To get the count of snoozed CVEs, client should explicitly pass
+// the filter "CVE Snoozed: true"
+func (resolver *Resolver) PlatformCVECount(ctx context.Context, q RawQuery) (int32, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PlatformCVECount")
+
+	if !features.VulnMgmtNodePlatformCVEs.Enabled() {
+		return 0, errors.Errorf("Feature %s is disabled", features.VulnMgmtWorkloadCVEs.Name())
+	}
+	if err := readClusters(ctx); err != nil {
+		return 0, err
+	}
+	query, err := q.AsV1QueryOrEmpty()
+	if err != nil {
+		return 0, err
+	}
+
+	count, err := resolver.PlatformCVEView.Count(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	return int32(count), nil
+}
+
+// PlatformCVEs returns graphQL resolver for platform cves satisfying the specified query.
+// Note: By default, snoozed CVEs will be excluded. To get snoozed CVEs, client should explicitly pass
+// the filter "CVE Snoozed: true"
+func (resolver *Resolver) PlatformCVEs(ctx context.Context, q PaginatedQuery) ([]*platformCVECoreResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PlatformCVEs")
+
+	if !features.VulnMgmtNodePlatformCVEs.Enabled() {
+		return nil, errors.Errorf("Feature %s is disabled", features.VulnMgmtWorkloadCVEs.Name())
+	}
+	if err := readClusters(ctx); err != nil {
+		return nil, err
+	}
+	query, err := q.AsV1QueryOrEmpty()
+	if err != nil {
+		return 0, err
+	}
+
+	cves, err := resolver.PlatformCVEView.Get(ctx, query)
+	ret, err := resolver.wrapPlatformCVECoresWithContext(ctx, cves, err)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range ret {
+		r.subFieldQuery = query
+	}
+
+	return ret, nil
+}
+
+// PlatformCVE returns graphQL resolver for specified platform cve id.
+func (resolver *Resolver) PlatformCVE(ctx context.Context, args struct {
+	CveID              *string
+	SubfieldScopeQuery *string
+}) (*platformCVECoreResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PlatformCVE")
+
+	if !features.VulnMgmtNodePlatformCVEs.Enabled() {
+		return nil, errors.Errorf("Feature %s is disabled", features.VulnMgmtWorkloadCVEs.Name())
+	}
+	if err := readClusters(ctx); err != nil {
+		return nil, err
+	}
+	if args.CveID == nil {
+		return nil, errors.New("cveID variable must be set")
+	}
+
+	query := search.NewQueryBuilder().AddExactMatches(search.CVEID, *args.CveID).ProtoQuery()
+	if args.SubfieldScopeQuery != nil {
+		rQuery := RawQuery{
+			Query: args.SubfieldScopeQuery,
+		}
+		filterQuery, err := rQuery.AsV1QueryOrEmpty()
+		if err != nil {
+			return nil, err
+		}
+		query = search.ConjunctionQuery(query, filterQuery)
+	}
+
+	cves, err := resolver.PlatformCVEView.Get(ctx, query)
+	if len(cves) == 0 {
+		return nil, nil
+	}
+	if len(cves) > 1 {
+		utils.Should(errors.Errorf("Retrieved multiple rows when only one row is expected for CVEID=%s query", *args.Cve))
+		return nil, err
+	}
+	ret, err := resolver.wrapPlatformCVECoreWithContext(ctx, cves[0], err)
+	if err != nil {
+		return nil, err
+	}
+	ret.subFieldQuery = query
+
+	return ret, nil
+}
+
+// CVE returns the platform cve name
+func (resolver *platformCVECoreResolver) CVE(_ context.Context) string {
+	return resolver.data.GetCVE()
+}
+
+// CVEType returns the type of the given platform cve
+func (resolver *platformCVECoreResolver) CVEType(_ context.Context) string {
+	return resolver.data.GetCVEType().String()
+}
+
+func (resolver *platformCVECoreResolver) CVSS(_ context.Context) float64 {
+	return float64(resolver.data.GetCVSS())
+}
+
+// ClusterCountByPlatformType returns the number of clusters of each type affected by the given platform cve
+func (resolver *platformCVECoreResolver) ClusterCountByPlatformType(ctx context.Context) (*clusterCountByPlatformTypeResolver, error) {
+	return resolver.root.wrapClusterCountByPlatformTypeWithContext(ctx, resolver.data.GetClusterCountByPlatformType(), nil)
+}
+
+// ClusterCount returns the number of clusters affected by the given platform cve
+func (resolver *platformCVECoreResolver) ClusterCount(_ context.Context) int32 {
+	return int32(resolver.data.GetClusterCount())
+}
+
+// Clusters returns a paginated list of clusters containing given platform cve
+func (resolver *platformCVECoreResolver) Clusters(ctx context.Context, args struct{ Pagination *inputtypes.Pagination }) ([]*clusterResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.PlatformCVECore, "Clusters")
+
+	if err := readClusters(ctx); err != nil {
+		return nil, err
+	}
+
+	query := search.NewQueryBuilder().AddExactMatches(search.CVE, resolver.data.GetCVEID()).ProtoQuery()
+	if resolver.subFieldQuery != nil {
+		query = search.ConjunctionQuery(query, resolver.subFieldQuery)
+	}
+	if args.Pagination != nil {
+		paginated.FillPagination(query, args.Pagination.AsV1Pagination(), maxClusters)
+	}
+
+	clusters, err := resolver.root.ClusterDataStore.SearchRawClusters(ctx, query)
+	return resolver.root.wrapClustersWithContext(ctx, clusters, err)
+}
+
+// ClusterVulnerability returns the associated cluster vulnerability with the given platform cve.
+// The cluster vulnerability contains metadata for cve like link, summary, etc
+func (resolver *platformCVECoreResolver) ClusterVulnerability(ctx context.Context) (ClusterVulnerabilityResolver, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.PlatformCVECore, "ClusterVulnerability")
+
+	cveID := graphql.ID(resolver.data.GetCVEID())
+
+	return resolver.root.ClusterVulnerability(ctx, IDQuery{
+		ID: &cveID,
+	})
+}
+
+// FirstDiscoveredTime returns the first time the given platform cve was discovered across all clusters
+func (resolver *platformCVECoreResolver) FirstDiscoveredTime(_ context.Context) *graphql.Time {
+	ts := resolver.data.GetFirstDiscoveredTime()
+	if ts == nil {
+		return nil
+	}
+	return &graphql.Time{
+		Time: *ts,
+	}
+}
+
+// ID of the given platform CVE
+func (resolver *platformCVECoreResolver) ID(_ context.Context) graphql.ID {
+	return graphql.ID(resolver.data.GetCVEID())
+}
+
+// IsFixable returns true if the given platform cve is fixable in any of the clusters matched by the given query
+func (resolver *platformCVECoreResolver) IsFixable(ctx context.Context, args RawQuery) bool {
+	return resolver.data.GetFixability()
+}

--- a/central/graphql/resolvers/platform_cve_core.go
+++ b/central/graphql/resolvers/platform_cve_core.go
@@ -29,7 +29,7 @@ func init() {
 			[]string{
 				"clusterCountByPlatformType: ClusterCountByPlatformType!",
 				"clusterCount: Int!",
-				"clusters: [Cluster!]!",
+				"clusters(pagination: Pagination): [Cluster!]!",
 				"clusterVulnerability: ClusterVulnerability!",
 				"cve: String!",
 				"cveType: String!",
@@ -42,7 +42,7 @@ func init() {
 		schema.AddQuery("platformCVEs(query: String, pagination: Pagination): [PlatformCVECore!]!"),
 		// `subfieldScopeQuery` applies the scope query to all the subfields of the PlatformCVE resolver.
 		// This eliminates the need to pass queries to individual resolvers.
-		schema.AddQuery("platformCVE(cve: String, subfieldScopeQuery: String): PlatformCVECore"),
+		schema.AddQuery("platformCVE(cveID: String, subfieldScopeQuery: String): PlatformCVECore"),
 	)
 }
 
@@ -110,7 +110,7 @@ func (resolver *Resolver) PlatformCVEs(ctx context.Context, q PaginatedQuery) ([
 	}
 	query, err := q.AsV1QueryOrEmpty()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	cves, err := resolver.PlatformCVEView.Get(ctx, query)
@@ -159,7 +159,7 @@ func (resolver *Resolver) PlatformCVE(ctx context.Context, args struct {
 		return nil, nil
 	}
 	if len(cves) > 1 {
-		utils.Should(errors.Errorf("Retrieved multiple rows when only one row is expected for CVEID=%s query", *args.Cve))
+		utils.Should(errors.Errorf("Retrieved multiple rows when only one row is expected for CVEID=%s query", *args.CveID))
 		return nil, err
 	}
 	ret, err := resolver.wrapPlatformCVECoreWithContext(ctx, cves[0], err)

--- a/central/graphql/resolvers/platform_cve_core_test.go
+++ b/central/graphql/resolvers/platform_cve_core_test.go
@@ -1,0 +1,224 @@
+package resolvers
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
+	"github.com/stackrox/rox/central/views/platformcve"
+	platformCVEViewMock "github.com/stackrox/rox/central/views/platformcve/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPlatformCVECoreResolver(t *testing.T) {
+	suite.Run(t, new(PlatformCVEResolverTestSuite))
+}
+
+type PlatformCVEResolverTestSuite struct {
+	suite.Suite
+
+	mockCtrl *gomock.Controller
+	ctx      context.Context
+
+	platformCVEView *platformCVEViewMock.MockCveView
+
+	resolver *Resolver
+}
+
+func (s *PlatformCVEResolverTestSuite) SetupSuite() {
+	s.T().Setenv(features.VulnMgmtNodePlatformCVEs.EnvVar(), "true")
+
+	if !features.VulnMgmtNodePlatformCVEs.Enabled() {
+		s.T().Skipf("Skiping test. %s=false", features.VulnMgmtNodePlatformCVEs.EnvVar())
+		s.T().SkipNow()
+	}
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.ctx = contextWithClusterPerm(s.T(), s.mockCtrl)
+	s.platformCVEView = platformCVEViewMock.NewMockCveView(s.mockCtrl)
+	s.resolver, _ = SetupTestResolver(s.T(), s.platformCVEView)
+}
+
+func (s *PlatformCVEResolverTestSuite) TearDownSuite() {}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEsNoClusterPerm() {
+	q := &PaginatedQuery{}
+	response, err := s.resolver.PlatformCVEs(context.Background(), *q)
+	s.Error(err)
+	s.Nil(response)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEsEmpty() {
+	q := &PaginatedQuery{}
+	expectedQ, err := q.AsV1QueryOrEmpty()
+	s.Require().NoError(err)
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(nil, nil)
+	response, err := s.resolver.PlatformCVEs(s.ctx, *q)
+	s.NoError(err)
+	s.Len(response, 0)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEsNonEmpty() {
+	q := &PaginatedQuery{}
+	expectedQ, err := q.AsV1QueryOrEmpty()
+	s.Require().NoError(err)
+
+	expected := []platformcve.CveCore{
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+	}
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(expected, nil)
+	response, err := s.resolver.PlatformCVEs(s.ctx, *q)
+	s.NoError(err)
+	s.Len(response, 3)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEsWithQuery() {
+	q := &PaginatedQuery{
+		Query: pointers.String("CVE:cve-2022-xyz"),
+	}
+	expectedQ := search.NewQueryBuilder().AddStrings(search.CVE, "cve-2022-xyz").
+		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+
+	expected := []platformcve.CveCore{
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+	}
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(expected, nil)
+	response, err := s.resolver.PlatformCVEs(s.ctx, *q)
+	s.NoError(err)
+	s.Len(response, 3)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestPlatformCVEsCVEsWithPaginatedQuery() {
+	q := &PaginatedQuery{
+		Pagination: &inputtypes.Pagination{
+			SortOption: &inputtypes.SortOption{
+				Field: pointers.String(search.CVSS.String()),
+				AggregateBy: &inputtypes.AggregateBy{
+					AggregateFunc: pointers.String(aggregatefunc.Max.Name()),
+				},
+			},
+		},
+	}
+	expectedQ := search.NewQueryBuilder().WithPagination(
+		search.NewPagination().AddSortOption(
+			search.NewSortOption(search.CVSS).AggregateBy(aggregatefunc.Max, false),
+		).Limit(math.MaxInt32),
+	).ProtoQuery()
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(nil, nil)
+	_, err := s.resolver.PlatformCVEs(s.ctx, *q)
+	s.NoError(err)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestPlatformCVECountNoClusterPerm() {
+	response, err := s.resolver.PlatformCVECount(context.Background(), RawQuery{})
+	s.Error(err)
+	s.Zero(response)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestPlatformCVECount() {
+	q := &RawQuery{}
+	expectedQ, err := q.AsV1QueryOrEmpty()
+	s.Require().NoError(err)
+
+	s.platformCVEView.EXPECT().Count(s.ctx, expectedQ).Return(0, nil)
+	response, err := s.resolver.PlatformCVECount(s.ctx, *q)
+	s.NoError(err)
+	s.Equal(response, int32(0))
+}
+
+func (s *PlatformCVEResolverTestSuite) TestPlatformCVECountWithQuery() {
+	q := &RawQuery{
+		Query: pointers.String("Cluster:c1"),
+	}
+	expectedQ := search.NewQueryBuilder().AddStrings(search.Cluster, "c1").ProtoQuery()
+
+	s.platformCVEView.EXPECT().Count(s.ctx, expectedQ).Return(3, nil)
+	response, err := s.resolver.PlatformCVECount(s.ctx, *q)
+	s.NoError(err)
+	s.Equal(response, int32(3))
+}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEMalformed() {
+	_, err := s.resolver.PlatformCVE(s.ctx, struct {
+		CveID              *string
+		SubfieldScopeQuery *string
+	}{})
+	s.Error(err)
+}
+
+func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVENonEmpty() {
+	// without filter
+	expectedQ := search.NewQueryBuilder().AddExactMatches(search.CVEID, "cve-xyz#K8S_CVE").ProtoQuery()
+	expected := []platformcve.CveCore{
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+	}
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(expected, nil)
+	response, err := s.resolver.PlatformCVE(
+		s.ctx, struct {
+			CveID              *string
+			SubfieldScopeQuery *string
+		}{
+			CveID: pointers.String("cve-xyz#K8S_CVE"),
+		},
+	)
+	s.NoError(err)
+	s.NotNil(response.data)
+
+	// with filter
+	expectedQ = search.NewQueryBuilder().
+		AddExactMatches(search.CVEID, "cve-xyz#K8S_CVE").
+		AddStrings(search.Cluster, "c1").
+		ProtoQuery()
+	expected = []platformcve.CveCore{
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+	}
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(expected, nil)
+	response, err = s.resolver.PlatformCVE(s.ctx, struct {
+		CveID              *string
+		SubfieldScopeQuery *string
+	}{
+		CveID:              pointers.String("cve-xyz#K8S_CVE"),
+		SubfieldScopeQuery: pointers.String("Cluster:c1"),
+	},
+	)
+	s.NoError(err)
+	s.NotNil(response.data)
+
+	// with filter
+	expectedQ = search.NewQueryBuilder().
+		AddExactMatches(search.CVEID, "cve-xyz#K8S_CVE").
+		AddStrings(search.ClusterPlatformType, storage.ClusterType_KUBERNETES_CLUSTER.String()).
+		ProtoQuery()
+	expected = []platformcve.CveCore{
+		platformCVEViewMock.NewMockCveCore(s.mockCtrl),
+	}
+
+	s.platformCVEView.EXPECT().Get(s.ctx, expectedQ).Return(expected, nil)
+	response, err = s.resolver.PlatformCVE(s.ctx, struct {
+		CveID              *string
+		SubfieldScopeQuery *string
+	}{
+		CveID:              pointers.String("cve-xyz#K8S_CVE"),
+		SubfieldScopeQuery: pointers.String("Cluster Platform Type:KUBERNETES_CLUSTER"),
+	},
+	)
+	s.NoError(err)
+	s.NotNil(response.data)
+}

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -52,6 +52,7 @@ import (
 	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
 	"github.com/stackrox/rox/central/views/imagecve"
+	"github.com/stackrox/rox/central/views/platformcve"
 	vulnReqDataStore "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/manager/querymgr"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/manager/requestmgr"
@@ -119,7 +120,8 @@ type Resolver struct {
 	AuditLogger                   auditPkg.Auditor
 
 	// Views
-	ImageCVEView imagecve.CveView
+	ImageCVEView    imagecve.CveView
+	PlatformCVEView platformcve.CveView
 }
 
 // New returns a Resolver wired into the relevant data stores
@@ -181,6 +183,12 @@ func New() *Resolver {
 			}
 			return nil
 		}(),
+		PlatformCVEView: func() platformcve.CveView {
+			if features.VulnMgmtNodePlatformCVEs.Enabled() {
+				return platformcve.Singleton()
+			}
+			return nil
+		},
 	}
 
 	return resolver

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -188,7 +188,7 @@ func New() *Resolver {
 				return platformcve.Singleton()
 			}
 			return nil
-		},
+		}(),
 	}
 
 	return resolver

--- a/central/graphql/resolvers/test_setup_utils.go
+++ b/central/graphql/resolvers/test_setup_utils.go
@@ -52,6 +52,7 @@ import (
 	mockRisks "github.com/stackrox/rox/central/risk/datastore/mocks"
 	connMgrMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	"github.com/stackrox/rox/central/views/imagecve"
+	"github.com/stackrox/rox/central/views/platformcve"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/cache"
 	vulnReqDatastore "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
 	"github.com/stackrox/rox/generated/storage"
@@ -115,6 +116,8 @@ func SetupTestResolver(t testing.TB, datastores ...interface{}) (*Resolver, *gra
 
 		case imagecve.CveView:
 			resolver.ImageCVEView = ds
+		case platformcve.CveView:
+			resolver.PlatformCVEView = ds
 		}
 	}
 

--- a/central/graphql/resolvers/test_utils.go
+++ b/central/graphql/resolvers/test_utils.go
@@ -712,3 +712,9 @@ func contextWithNodePerm(t testing.TB, ctrl *gomock.Controller) context.Context 
 	id.EXPECT().Permissions().Return(map[string]storage.Access{"Node": storage.Access_READ_ACCESS}).AnyTimes()
 	return authn.ContextWithIdentity(sac.WithAllAccess(loaders.WithLoaderContext(context.Background())), id, t)
 }
+
+func contextWithClusterPerm(t testing.TB, ctrl *gomock.Controller) context.Context {
+	id := mockIdentity.NewMockIdentity(ctrl)
+	id.EXPECT().Permissions().Return(map[string]storage.Access{"Cluster": storage.Access_READ_ACCESS}).AnyTimes()
+	return authn.ContextWithIdentity(sac.WithAllAccess(loaders.WithLoaderContext(context.Background())), id, t)
+}

--- a/pkg/metrics/resolver_string.go
+++ b/pkg/metrics/resolver_string.go
@@ -36,11 +36,12 @@ func _() {
 	_ = x[ClusterCVEs-25]
 	_ = x[NodeComponents-26]
 	_ = x[ImageCVECore-27]
+	_ = x[PlatformCVECore-28]
 }
 
-const _Resolver_name = "ClusterComplianceComlianceControlCVEsDeploymentsGroupsImagesImageComponentsK8sRolesNamespacesNodesNotifiersPermissionSetsPoliciesRolesRootSecretsServiceAccountsSubjectsTokensViolationsPodsContainerInstancesImageCVEsNodeCVEsClusterCVEsNodeComponentsImageCVECore"
+const _Resolver_name = "ClusterComplianceComlianceControlCVEsDeploymentsGroupsImagesImageComponentsK8sRolesNamespacesNodesNotifiersPermissionSetsPoliciesRolesRootSecretsServiceAccountsSubjectsTokensViolationsPodsContainerInstancesImageCVEsNodeCVEsClusterCVEsNodeComponentsImageCVECorePlatformCVECore"
 
-var _Resolver_index = [...]uint16{0, 7, 17, 33, 37, 48, 54, 60, 75, 83, 93, 98, 107, 121, 129, 134, 138, 145, 160, 168, 174, 184, 188, 206, 215, 223, 234, 248, 260}
+var _Resolver_index = [...]uint16{0, 7, 17, 33, 37, 48, 54, 60, 75, 83, 93, 98, 107, 121, 129, 134, 138, 145, 160, 168, 174, 184, 188, 206, 215, 223, 234, 248, 260, 275}
 
 func (i Resolver) String() string {
 	if i < 0 || i >= Resolver(len(_Resolver_index)-1) {

--- a/pkg/metrics/resolvers.go
+++ b/pkg/metrics/resolvers.go
@@ -35,4 +35,5 @@ const (
 	ClusterCVEs
 	NodeComponents
 	ImageCVECore
+	PlatformCVECore
 )


### PR DESCRIPTION
## Description

Added graphQL resolvers for PlatformCVEs. These resolvers get the data from PlatformCVEView added in PR #10588 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added unit tests

Manual testing by running graphQL queries

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
