### PR TITLE
chore(scanner): log update import prior to attempt

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -215,6 +215,10 @@ func (u *Updater) Import(ctx context.Context, in io.Reader) (err error) {
 				return true
 			}
 		}
+		zlog.Info(ctx).
+			Str("updater", op.Updater).
+			Str("kind", string(op.Kind)).
+			Msg("importing update")
 		var ref uuid.UUID
 		count := 0
 		switch op.Kind {


### PR DESCRIPTION
## Description

We currently only log after the update is imported successfully. This makes it hard to tell which update is currently happening/failed. Adding this log prior to running the update process makes this easier to debug

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

I didn't

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
