### PR TITLE
ROX-23628: configure extra scopes

### DIFF
--- a/generated/api/v1/auth_service.swagger.json
+++ b/generated/api/v1/auth_service.swagger.json
@@ -361,7 +361,8 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Config holds auth provider specific configuration. Each configuration options\nare different based on the given auth provider type.\nOIDC:\n- \"issuer\": the OIDC issuer according to https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier.\n- \"client_id\": the client ID according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.2.\n- \"client_secret\": the client secret according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1.\n- \"do_not_use_client_secret\": set to \"true\" if you want to create a configuration with only\n  a client ID and no client secret.\n- \"mode\": the OIDC callback mode, choosing from \"fragment\", \"post\", or \"query\".\n- \"disable_offline_access_scope\": set to \"true\" if no offline tokens shall be issued.\n- \"extra_scopes\": a space-delimited string of additional scopes to request in addition to \"openid profile email\"\n  according to https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3.\n\nOpenShift Auth: supports no extra configuration options.\n\nUser PKI:\n- \"keys\": the trusted certificates PEM encoded.\n\nSAML:\n- \"sp_issuer\": the service provider issuer according to https://datatracker.ietf.org/doc/html/rfc7522#section-3.\n- \"idp_metadata_url\": the metadata URL according to https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf.\n- \"idp_issuer\": the IdP issuer.\n- \"idp_cert_pem\": the cert PEM encoded for the IdP endpoint.\n- \"idp_sso_url\": the IdP SSO URL.\n- \"idp_nameid_format\": the IdP name ID format.\n\nIAP:\n- \"audience\": the audience to use."
         },
         "loginUrl": {
           "type": "string",

--- a/generated/api/v1/authprovider_service.swagger.json
+++ b/generated/api/v1/authprovider_service.swagger.json
@@ -442,7 +442,8 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Config holds auth provider specific configuration. Each configuration options\nare different based on the given auth provider type.\nOIDC:\n- \"issuer\": the OIDC issuer according to https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier.\n- \"client_id\": the client ID according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.2.\n- \"client_secret\": the client secret according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1.\n- \"do_not_use_client_secret\": set to \"true\" if you want to create a configuration with only\n  a client ID and no client secret.\n- \"mode\": the OIDC callback mode, choosing from \"fragment\", \"post\", or \"query\".\n- \"disable_offline_access_scope\": set to \"true\" if no offline tokens shall be issued.\n- \"extra_scopes\": a space-delimited string of additional scopes to request in addition to \"openid profile email\"\n  according to https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3.\n\nOpenShift Auth: supports no extra configuration options.\n\nUser PKI:\n- \"keys\": the trusted certificates PEM encoded.\n\nSAML:\n- \"sp_issuer\": the service provider issuer according to https://datatracker.ietf.org/doc/html/rfc7522#section-3.\n- \"idp_metadata_url\": the metadata URL according to https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf.\n- \"idp_issuer\": the IdP issuer.\n- \"idp_cert_pem\": the cert PEM encoded for the IdP endpoint.\n- \"idp_sso_url\": the IdP SSO URL.\n- \"idp_nameid_format\": the IdP name ID format.\n\nIAP:\n- \"audience\": the audience to use."
         },
         "loginUrl": {
           "type": "string",

--- a/generated/storage/auth_provider.pb.go
+++ b/generated/storage/auth_provider.pb.go
@@ -25,12 +25,40 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Next Tag: 15.
 type AuthProvider struct {
-	Id         string            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"`     // @gotags: sql:"pk"
-	Name       string            `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" sql:"unique"` // @gotags: sql:"unique"
-	Type       string            `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
-	UiEndpoint string            `protobuf:"bytes,4,opt,name=ui_endpoint,json=uiEndpoint,proto3" json:"ui_endpoint,omitempty"`
-	Enabled    bool              `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	Config     map[string]string `protobuf:"bytes,6,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" scrub:"map-values"` // @gotags: scrub:"map-values"
+	Id         string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"`     // @gotags: sql:"pk"
+	Name       string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" sql:"unique"` // @gotags: sql:"unique"
+	Type       string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	UiEndpoint string `protobuf:"bytes,4,opt,name=ui_endpoint,json=uiEndpoint,proto3" json:"ui_endpoint,omitempty"`
+	Enabled    bool   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Config holds auth provider specific configuration. Each configuration options
+	// are different based on the given auth provider type.
+	// OIDC:
+	// - "issuer": the OIDC issuer according to https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier.
+	// - "client_id": the client ID according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.2.
+	// - "client_secret": the client secret according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1.
+	// - "do_not_use_client_secret": set to "true" if you want to create a configuration with only
+	//   a client ID and no client secret.
+	// - "mode": the OIDC callback mode, choosing from "fragment", "post", or "query".
+	// - "disable_offline_access_scope": set to "true" if no offline tokens shall be issued.
+	// - "extra_scopes": a space-delimited string of additional scopes to request in addition to "openid profile email"
+	//   according to https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3.
+	//
+	// OpenShift Auth: supports no extra configuration options.
+	//
+	// User PKI:
+	// - "keys": the trusted certificates PEM encoded.
+	//
+	// SAML:
+	// - "sp_issuer": the service provider issuer according to https://datatracker.ietf.org/doc/html/rfc7522#section-3.
+	// - "idp_metadata_url": the metadata URL according to https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf.
+	// - "idp_issuer": the IdP issuer.
+	// - "idp_cert_pem": the cert PEM encoded for the IdP endpoint.
+	// - "idp_sso_url": the IdP SSO URL.
+	// - "idp_nameid_format": the IdP name ID format.
+	//
+	// IAP:
+	// - "audience": the audience to use.
+	Config map[string]string `protobuf:"bytes,6,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" scrub:"map-values"` // @gotags: scrub:"map-values"
 	// The login URL will be provided by the backend, and may not be specified in a request.
 	LoginUrl  string `protobuf:"bytes,7,opt,name=login_url,json=loginUrl,proto3" json:"login_url,omitempty"`
 	Validated bool   `protobuf:"varint,8,opt,name=validated,proto3" json:"validated,omitempty"` // Deprecated: Do not use.

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -35,6 +35,7 @@ const (
 	IssuerConfigKey       = "issuer"
 	ClientIDConfigKey     = "client_id"
 	ClientSecretConfigKey = "client_secret"
+	ExtraScopesConfigKey  = "extra_scopes"
 	//#nosec G101 -- This is a false positive
 	DontUseClientSecretConfigKey       = "do_not_use_client_secret"
 	ModeConfigKey                      = "mode"
@@ -383,6 +384,11 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		return nil, err
 	}
 
+	extraScopes, extraScopesRequested := config[ExtraScopesConfigKey]
+	if extraScopesRequested {
+		b.baseOauthConfig.Scopes = append(b.baseOauthConfig.Scopes, strings.Split(extraScopes, " ")...)
+	}
+
 	b.config = map[string]string{
 		IssuerConfigKey:       issuerHelper.Issuer(),
 		ClientIDConfigKey:     clientID,
@@ -391,6 +397,9 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 	}
 	if disableOfflineAccessScope {
 		b.config[DisableOfflineAccessScopeConfigKey] = "true"
+	}
+	if extraScopesRequested {
+		b.config[ExtraScopesConfigKey] = extraScopes
 	}
 
 	return b, nil

--- a/pkg/auth/authproviders/oidc/backend_impl_test.go
+++ b/pkg/auth/authproviders/oidc/backend_impl_test.go
@@ -569,6 +569,46 @@ func TestBackend(t *testing.T) {
 				"expires_in":   literalValue{"20"},
 			},
 		},
+		"extra scopes requested": {
+			config: map[string]string{
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "post",
+				ExtraScopesConfigKey:  "groups roles",
+			},
+			oidcProvider: &mockOIDCProvider{
+				responseTypesSupported:     allResponseTypes,
+				responseModesSupported:     allResponseModes,
+				userInfoAssertAccessToken:  mockAccessToken,
+				claimsFromUserInfoEndpoint: suppliedClaims,
+			},
+			wantBackend: &wantBackend{
+				responseMode:  "form_post",
+				responseTypes: []string{"code"},
+				config: map[string]string{
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "post",
+					ExtraScopesConfigKey:  "groups roles",
+				},
+				baseOauthConfig: &oauth2.Config{
+					ClientID:     "testclientid",
+					ClientSecret: "testsecret",
+					Endpoint: oauth2.Endpoint{
+						AuthURL:  "fake-auth-url",
+						TokenURL: "fake-token-url",
+					},
+					Scopes: []string{"openid", "profile", "email", "offline_access", "groups", "roles"},
+				},
+			},
+			issueNonce: true,
+			idpResponseTemplate: map[string]responseValueProvider{
+				"code": literalValue{mockAuthorizationCode},
+			},
+			exchangedTokenClaims: &suppliedClaims,
+		},
 		"mode fragment with both token and id_token, and userinfo endpoint failure": {
 			config: map[string]string{
 				ClientIDConfigKey:     "testclientid",

--- a/proto/storage/auth_provider.proto
+++ b/proto/storage/auth_provider.proto
@@ -15,6 +15,34 @@ message AuthProvider {
   string type = 3;
   string ui_endpoint = 4;
   bool enabled = 5;
+  // Config holds auth provider specific configuration. Each configuration options
+  // are different based on the given auth provider type.
+  // OIDC:
+  // - "issuer": the OIDC issuer according to https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier.
+  // - "client_id": the client ID according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.2.
+  // - "client_secret": the client secret according to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1.
+  // - "do_not_use_client_secret": set to "true" if you want to create a configuration with only
+  //   a client ID and no client secret.
+  // - "mode": the OIDC callback mode, choosing from "fragment", "post", or "query".
+  // - "disable_offline_access_scope": set to "true" if no offline tokens shall be issued.
+  // - "extra_scopes": a space-delimited string of additional scopes to request in addition to "openid profile email"
+  //   according to https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3.
+  //
+  // OpenShift Auth: supports no extra configuration options.
+  //
+  // User PKI:
+  // - "keys": the trusted certificates PEM encoded.
+  //
+  // SAML:
+  // - "sp_issuer": the service provider issuer according to https://datatracker.ietf.org/doc/html/rfc7522#section-3.
+  // - "idp_metadata_url": the metadata URL according to https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf.
+  // - "idp_issuer": the IdP issuer.
+  // - "idp_cert_pem": the cert PEM encoded for the IdP endpoint.
+  // - "idp_sso_url": the IdP SSO URL.
+  // - "idp_nameid_format": the IdP name ID format.
+  //
+  // IAP:
+  // - "audience": the audience to use.
   map<string, string> config = 6; // @gotags: scrub:"map-values"
   // The login URL will be provided by the backend, and may not be specified in a request.
   string login_url = 7;


### PR DESCRIPTION
## Description

Allow to configure extra scopes within the OIDC auth provider besides the standard `openid profile email` ones.

This allows for custom scopes to be added to allow things like populating the `groups` claim or other specifics.

In addition, the API documentation has been updated to make the `config` field of auth providers more transparent.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
