### PR TITLE
[Backport release-4.3] fix: do not install snappy #11365

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -66,7 +66,6 @@ COPY --from=stackrox_data /stackrox-data /stackrox/static-data
 COPY ./docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
 COPY ./docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
 
-RUN if [[ "$(uname -m)" == "x86_64" ]]; then rpm -i /tmp/snappy.rpm && rm /tmp/snappy.rpm; fi
 RUN ln -s /assets/downloads/cli/roxctl-linux-${TARGET_ARCH} /stackrox/roxctl && \
     ln -s /assets/downloads/cli/roxctl-linux-amd64 /assets/downloads/cli/roxctl-linux && \
     rpm --import RPM-GPG-KEY-CentOS-Official && \

--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -28,11 +28,6 @@ if [[ "$DEBUG_BUILD" == "yes" ]]; then
 fi
 
 mkdir -p "$output_dir/rpms"
-# Install all the required compression packages for RocksDB to compile for amd64. RocksDB is not required for other architectures.
-if [[ "$goarch" == "amd64" ]]; then
-  rpm_url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
-  curl --retry 3 --silent --show-error -f -o "${output_dir}/rpms/snappy.rpm" "${rpm_url}"
-fi
 
 if [[ "$arch" == "s390x" ]]; then
   yum install -y --downloadonly --downloaddir=/tmp postgresql postgresql-private-libs


### PR DESCRIPTION
(cherry picked from commit 7a95b979f82d2fdcf7e3057824aa19850677d132)
