### PR TITLE
ROX-23155: Add slim/full collector image deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Deprecated Features
 
+- Slim/Full Collector images have been deprecated and will be removed in a
+  future release. The two image flavors are now functionally identical (neither contain any kernel drivers.)
+
 ### Technical Changes
 
 - ROX-18969: Added a label selector for the caching configuration of secrets and configmaps to the operator.


### PR DESCRIPTION
## Description

Simply the addition of a changelog entry for slim Collector image deprecation.

## Checklist
- [x] Evaluated and added CHANGELOG entry if required

## Testing Performed

None - purely documentation change.
