### PR TITLE
tests: retry kubectl on i/o timeouts

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -90,12 +90,14 @@ SCORECARD_WAIT_TIME_DURATION ?= 5m
 # TODO(ROX-12349): Figure out where scorecard gets the namespace name from, elliminate this source, and remove the flag here.
 SCORECARD_ARGS ?= --storage-image="$(SCORECARD_STORAGE_IMAGE)" --wait-time="$(SCORECARD_WAIT_TIME_DURATION)" --verbose --namespace default
 
+PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # TEST_NAMESPACE is where the operator is installed for e2e tests by CI.
 TEST_NAMESPACE ?= stackrox-operator
 
 # TEST_E2E_ENV_IS_OPENSHIFT is "true" when the cluster to run e2e tests on is an
 # OpenShift one, and "false" otherwise.
-TEST_E2E_ENV_IS_OPENSHIFT ?= $(shell kubectl get scc > /dev/null 2>&1 && echo true || echo false)
+TEST_E2E_ENV_IS_OPENSHIFT ?= $(shell $(PROJECT_DIR)/hack/retry-kubectl.sh < /dev/null get scc > /dev/null 2>&1 && echo true || echo false)
 
 # KUTTL_TEST_RUN_LABELS_ARGS specifies what label set to use for kuttl tests.
 KUTTL_TEST_RUN_LABELS_ARGS ?= --test-run-labels openshift=$(TEST_E2E_ENV_IS_OPENSHIFT)
@@ -112,8 +114,6 @@ ROX_IMAGE_FLAVOR ?= $(shell $(MAKE) --quiet --no-print-directory -C .. image-fla
 
 # Lowercase Operating System name, needed for downloading GitHub releases.
 OS=$(shell uname | tr A-Z a-z)
-
-PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
@@ -248,19 +248,19 @@ validate-crs: yq
 .PHONY: test-e2e
 test-e2e: build install validate-crs kuttl ensure-rox-main-image-exists ## Run e2e tests with local manager.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
 
 .PHONY: test-e2e-deployed
 test-e2e-deployed: validate-crs kuttl ## Run e2e tests with manager deployed on cluster.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) SKIP_MANAGER_START=1 $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" SKIP_MANAGER_START=1 $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
 
 .PHONY: test-upgrade
 test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts-upgrade
 	SKIP_MANAGER_START=1 \
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
-	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade $(KUTTL_TEST_RUN_LABELS_ARGS) tests/upgrade
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade $(KUTTL_TEST_RUN_LABELS_ARGS) tests/upgrade
 
 .PHONY: test-bundle-helpers
 test-bundle-helpers: ## Run Python unit tests against helper scripts.
@@ -271,9 +271,9 @@ test-bundle-helpers: ## Run Python unit tests against helper scripts.
 .PHONY: stackrox-image-pull-secret
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.
 # Create stackrox namespace if not exists.
-	echo '{ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "$(NAMESPACE)" } }' | kubectl apply -f -
+	echo '{ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "$(NAMESPACE)" } }' | $(PROJECT_DIR)/hack/retry-kubectl.sh apply -f -
 # Create stackrox image pull secret in stackrox namespace.
-	$(PROJECT_DIR)/../deploy/common/pull-secret.sh stackrox quay.io | kubectl -n "$(NAMESPACE)" apply -f -
+	$(PROJECT_DIR)/../deploy/common/pull-secret.sh stackrox quay.io | $(PROJECT_DIR)/hack/retry-kubectl.sh -n "$(NAMESPACE)" apply -f -
 
 .PHONY: check-ci-setup
 check-ci-setup: ## Make sure this target is not started in CI environment.
@@ -340,11 +340,11 @@ olm-uninstall: operator-sdk ## Uninstall OLM previously installed on Kubernetes 
 
 .PHONY: install
 install: check-ci-setup manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | $(PROJECT_DIR)/hack/retry-kubectl.sh apply -f -
 
 .PHONY: uninstall
 uninstall: check-ci-setup manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | $(PROJECT_DIR)/hack/retry-kubectl.sh delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: check-ci-setup manifests kustomize ## Deploy operator image to the K8s cluster specified in ~/.kube/config.
@@ -353,26 +353,26 @@ deploy: check-ci-setup manifests kustomize ## Deploy operator image to the K8s c
 		cd config/local-deploy-versioned && \
 		$(KUSTOMIZE) create --resources ../default && \
 		$(KUSTOMIZE) edit set image quay.io/stackrox-io/stackrox-operator=$(IMG)
-	$(KUSTOMIZE) build config/local-deploy-versioned | kubectl create -f -
+	$(KUSTOMIZE) build config/local-deploy-versioned | $(PROJECT_DIR)/hack/retry-kubectl.sh apply -f -
 
 .PHONY: undeploy
 undeploy: check-ci-setup kustomize ## Undeploy operator image from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | $(PROJECT_DIR)/hack/retry-kubectl.sh delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy-via-olm
 deploy-via-olm: ## Deploy operator image to the cluster using OLM.
 # This requires operator, bundle and index images to already be pushed, but we do not depend on the
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION)
 
 .PHONY: deploy-via-olm-midstream
 deploy-via-olm-midstream: ## Deploy operator image to the cluster using OLM and midstream index images.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION) $(OPERATOR_VERSION)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION) $(OPERATOR_VERSION)
 
 .PHONY: deploy-dirty-tag-via-olm
 deploy-dirty-tag-via-olm: ## Deploy operator dirty tagged image to the cluster using OLM.
 # This target ignores filter for dirty tagged images.
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh --allow-dirty-tag $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-install.sh --allow-dirty-tag $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION)
 
 .PHONY: deploy-previous-via-olm
 deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of operator image to the cluster using OLM.
@@ -380,15 +380,15 @@ deploy-previous-via-olm: kuttl bundle-post-process ## Deploy replaced version of
 # target(s) that do it here, because CI does it in a separate job, in parallel with cluster deployment.
 	$(SILENT)replaced_version_no_v=$$(sed -E -n 's/^[[:space:]]*replaces:[[:space:]]*[^.]+\.v(.*)$$/\1/p' build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml) ;\
 	set -x ;\
-	KUTTL=$(KUTTL) ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION) $${replaced_version_no_v}
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-install.sh $(TEST_NAMESPACE) $(IMAGE_TAG_BASE) $(VERSION) $${replaced_version_no_v}
 
 .PHONY: upgrade-via-olm
 upgrade-via-olm: kuttl
-	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-upgrade.sh $(TEST_NAMESPACE) $(VERSION)
 
 .PHONY: upgrade-dirty-tag-via-olm
 upgrade-dirty-tag-via-olm: kuttl
-	KUTTL=$(KUTTL) ./hack/olm-operator-upgrade.sh --allow-dirty-tag $(TEST_NAMESPACE) $(VERSION)
+	KUTTL=$(KUTTL) PATH="$(PROJECT_DIR)/hack:$${PATH}" ./hack/olm-operator-upgrade.sh --allow-dirty-tag $(TEST_NAMESPACE) $(VERSION)
 
 ##@ Bundle and Index build
 

--- a/operator/hack/retry-kubectl.sh
+++ b/operator/hack/retry-kubectl.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Runs kubectl with supplied arguments, and retries on failures indicating network errors.
+#
+# NOTE: Reads all of stdin. If no input should be passed to kubectl, caller should redirect stdin from /dev/null!
+#
+# To detect such transient timeout errors, stderr from kubectl is redirected to a file and grepped for certain patterns
+# in case kubectl exits with an error code.
+
+set -euo pipefail
+
+error_regex=': i/o timeout$|net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)$'
+
+tmp_in="$(mktemp)"
+tmp_out="$(mktemp --suffix=-stdout.txt)"
+tmp_err="$(mktemp --suffix=-stderr.txt)"
+grep_out="$(mktemp)"
+trap 'cat ${tmp_out}; cat ${tmp_err} >&2; rm -f ${tmp_in} ${tmp_out} ${tmp_err} ${grep_out}' EXIT
+
+cat > "${tmp_in}"
+
+# We do not set -e on purpose, to be able to capture the exit code.
+set +e
+set +o pipefail
+
+attempts=5
+for attempt in $(seq 0 ${attempts})
+do
+    delay=$((attempt*attempt)) # Crude exponential backoff.
+    sleep "${delay}"
+    "${KUBECTL:-kubectl}" "$@" < "${tmp_in}" > "${tmp_out}" 2>"${tmp_err}"
+    ret="$?"
+    [[ $ret -eq 0 ]] && exit 0
+    if [[ ${attempt} -eq ${attempts} ]] || ! grep --extended-regexp "${error_regex}" "${tmp_err}" > "${grep_out}"
+    then
+        break
+    fi
+    echo "$(date -Ins) Found the following message(s) in kubectl stderr, retrying..." >&2
+    cat "${grep_out}" >&2
+done
+exit "${ret}"

--- a/operator/tests/central/central-basic/020-verify-password.yaml
+++ b/operator/tests/central/central-basic/020-verify-password.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein
+- script: retry-kubectl.sh exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein

--- a/operator/tests/central/central-basic/060-use-new-password.yaml
+++ b/operator/tests/central/central-basic/060-use-new-password.yaml
@@ -5,7 +5,7 @@ commands:
     # Updating the password may take some time, so retry until it works.
     set +e
     for i in `seq 60`; do
-      kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
+      retry-kubectl.sh exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
       sleep 1
     done
     exit 1

--- a/operator/tests/central/central-misc/064-assert-after-unset-expose-monitoring.yaml
+++ b/operator/tests/central/central-misc/064-assert-after-unset-expose-monitoring.yaml
@@ -13,7 +13,7 @@ commands:
 - script: |
     set -eu # shell in CI does not grok -o pipefail
     # Test that Central auth reader rolebinding DOES NOT exist in kube-system any more.
-    ! kubectl get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
+    ! retry-kubectl.sh get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -13,10 +13,10 @@ collectors:
 - type: pod
   selector: app=scanner-db
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l app=central
-- command: kubectl describe pod -n $NAMESPACE -l app=central-db
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-db
 timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1

--- a/operator/tests/common/central-cr-with-scanner-v4-assert.yaml
+++ b/operator/tests/common/central-cr-with-scanner-v4-assert.yaml
@@ -22,13 +22,13 @@ collectors:
 - type: pod
   selector: app=scanner-v4-db
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l app=central
-- command: kubectl describe pod -n $NAMESPACE -l app=central-db
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-indexer
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-matcher
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-indexer
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-matcher
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-db
 # Please keep the above lists in sync with pods-debug.yaml
 timeout: 1500
 ---

--- a/operator/tests/common/delete-central-assert.yaml
+++ b/operator/tests/common/delete-central-assert.yaml
@@ -12,4 +12,4 @@ commands:
     # With 3 objects we specify a timeout value of 25, aiming for ~5 minutes.
     ./hack/envsubst-kuttl.sh tests/common/delete-central-errors-cluster.envsubst.yaml errors --timeout 25
     # With 2 objects we specify a timeout value of 32, aiming for ~5 minutes.
-    if kubectl get scc > /dev/null 2>&1; then ./hack/envsubst-kuttl.sh tests/common/delete-central-errors-cluster-openshift.envsubst.yaml errors --timeout 32; fi
+    if retry-kubectl.sh get scc > /dev/null 2>&1; then ./hack/envsubst-kuttl.sh tests/common/delete-central-errors-cluster-openshift.envsubst.yaml errors --timeout 32; fi

--- a/operator/tests/common/image-pull-secrets.yaml
+++ b/operator/tests/common/image-pull-secrets.yaml
@@ -7,6 +7,6 @@ commands:
     secret=$(mktemp)
     registry_hostname=quay.io
     ../../../../deploy/common/pull-secret.sh e2e-test-pull-secret ${registry_hostname} > $secret
-    kubectl -n $NAMESPACE create -f $secret
+    retry-kubectl.sh -n $NAMESPACE apply -f $secret
     echo "Created pull secret for ${registry_hostname} in $NAMESPACE"
     rm $secret

--- a/operator/tests/common/init-bundle-fetch.yaml
+++ b/operator/tests/common/init-bundle-fetch.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: kubectl exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
-- script: kubectl apply -n $NAMESPACE -f init-bundle.yaml
+- script: retry-kubectl.sh exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
+- script: retry-kubectl.sh apply -n $NAMESPACE -f init-bundle.yaml

--- a/operator/tests/common/monitoring-auth-reader-assert.yaml
+++ b/operator/tests/common/monitoring-auth-reader-assert.yaml
@@ -11,7 +11,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
 # Test that Central auth reader rolebinding exists in kube-system.
-- command: kubectl get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
+- command: retry-kubectl.sh get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/common/pods-debug.yaml
+++ b/operator/tests/common/pods-debug.yaml
@@ -22,13 +22,13 @@ collectors:
 - type: pod
   selector: app=scanner-v4-db
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l app=central
-- command: kubectl describe pod -n $NAMESPACE -l app=central-db
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-indexer
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-matcher
-- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=central-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-db
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-indexer
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-matcher
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=scanner-v4-db
 # Please keep the above lists in sync with central-cr-assert.yaml
 - type: pod
   selector: app=sensor
@@ -39,7 +39,7 @@ collectors:
 - type: pod
   selector: app=collector
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l app=sensor
-- command: kubectl describe pod -n $NAMESPACE -l app=admission-control
-- command: kubectl describe pod -n $NAMESPACE -l app=collector
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=sensor
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=admission-control
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=collector
 # Please keep the above lists in sync with secured-cluster-cr-assert.yaml

--- a/operator/tests/common/secured-cluster-cr-assert.yaml
+++ b/operator/tests/common/secured-cluster-cr-assert.yaml
@@ -10,9 +10,9 @@ collectors:
 - type: pod
   selector: app=collector
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l app=sensor
-- command: kubectl describe pod -n $NAMESPACE -l app=admission-control
-- command: kubectl describe pod -n $NAMESPACE -l app=collector
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=sensor
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=admission-control
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l app=collector
 # Please keep the above lists in sync with pods-debug.yaml
 timeout: 1500
 ---

--- a/operator/tests/controller/metrics/100-assert-rbac-works.yaml
+++ b/operator/tests/controller/metrics/100-assert-rbac-works.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
-- command: kubectl auth can-i get /metrics --as=system:serviceaccount:$NAMESPACE:operator-metrics-privileged --quiet
+- command: retry-kubectl.sh auth can-i get /metrics --as=system:serviceaccount:$NAMESPACE:operator-metrics-privileged --quiet

--- a/operator/tests/controller/metrics/100-rbac.yaml
+++ b/operator/tests/controller/metrics/100-rbac.yaml
@@ -12,4 +12,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 # We cannot simply apply a ClusterRoleBinding resource, because of the variable $NAMESPACE
-- command: kubectl create clusterrolebinding rhacs-metrics-$NAMESPACE --clusterrole=rhacs-operator-metrics-reader --serviceaccount=$NAMESPACE:operator-metrics-privileged
+- script: |
+    kubectl create --dry-run=client -o yaml clusterrolebinding rhacs-metrics-$NAMESPACE \
+      --clusterrole=rhacs-operator-metrics-reader --serviceaccount=$NAMESPACE:operator-metrics-privileged | \
+      retry-kubectl.sh apply -f -

--- a/operator/tests/controller/metrics/200-assert.yaml
+++ b/operator/tests/controller/metrics/200-assert.yaml
@@ -32,4 +32,4 @@ collectors:
 - type: pod
   selector: test=metrics-access
   tail: -1
-- command: kubectl describe pod -n $NAMESPACE -l test=metrics-access
+- command: retry-kubectl.sh describe pod -n $NAMESPACE -l test=metrics-access

--- a/operator/tests/scripts/validate-crs.sh
+++ b/operator/tests/scripts/validate-crs.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+
+OPERATOR_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/../.."
+readonly OPERATOR_ROOT_DIR
+
 FAILED=0
 CRS_VALIDATED=0
 YQ="${YQ:-yq}"
@@ -24,7 +28,7 @@ echo
 # Extract kind names for the CRDs.
 CRD_KINDS=$(
     for crd in "${CRDS[@]}"; do
-        if kubectl get crd "$crd" -o jsonpath='{.spec.names.kind}'; then
+        if "${OPERATOR_ROOT_DIR}/hack/retry-kubectl.sh" < /dev/null get crd "$crd" -o jsonpath='{.spec.names.kind}'; then
             echo
         else
             die "Failed to lookup kind name for CRD $crd. Make sure CRDs are applied (make install) before validation is attempted."
@@ -42,7 +46,8 @@ CRS=$(
 # Validate CRs.
 for cr in $CRS; do
     echo -n "Validating stackrox custom resources in $cr with kubectl... "
-    if output=$("${YQ}" eval '. | select(.apiVersion | test("^platform.stackrox.io/"))' "$cr" | kubectl apply --dry-run=client --validate=true -f - 2>&1); then
+    if output=$("${YQ}" eval '. | select(.apiVersion | test("^platform.stackrox.io/"))' "$cr" | \
+      "${OPERATOR_ROOT_DIR}/hack/retry-kubectl.sh" apply --dry-run=client --validate=true -f - 2>&1); then
         echo PASSED
     else
         FAILED=1

--- a/operator/tests/securedcluster/sc-basic/040-assert.yaml
+++ b/operator/tests/securedcluster/sc-basic/040-assert.yaml
@@ -16,4 +16,4 @@ commands:
 - script: |
     set -eu # shell in CI does not grok -o pipefail
     # On OpenShift, test that Sensor auth reader rolebinding exists in kube-system.
-    if kubectl get scc > /dev/null 2>&1; then kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system; fi
+    if retry-kubectl.sh get scc > /dev/null 2>&1; then kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system; fi


### PR DESCRIPTION
## Description

This change:
* introduces a wrapper script for kubectl which on failures retries if it finds signs of i/o timeouts in stderr
* uses this script for operator tests

With some luck this will fix flakes such as:
- https://issues.redhat.com/browse/ROX-21559
- https://issues.redhat.com/browse/ROX-22097
- https://issues.redhat.com/browse/ROX-22929

In case it does not solve them, we'll at least get detailed timestamps that will allow us to investigate these timeouts deeper.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be enough.
- `ci/prow/ocp-4-preview-operator-e2e-tests` failed to create its cluster

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
