### PR TITLE
ROX-22885: K8sRbacTest better output

### DIFF
--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -3,6 +3,10 @@ import static util.Helpers.withRetry
 import com.google.common.base.CaseFormat
 import io.fabric8.openshift.api.model.PolicyRule
 import orchestratormanager.OrchestratorTypes
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.Diff
+import org.javers.core.diff.ListCompareAlgorithm
 
 import io.stackrox.proto.api.v1.RbacServiceOuterClass
 import io.stackrox.proto.api.v1.ServiceAccountServiceOuterClass
@@ -245,6 +249,10 @@ class K8sRbacTest extends BaseSpecification {
 
     @Tag("BAT")
     def "Verify scraped bindings"() {
+        given:
+        Javers javers = JaversBuilder.javers()
+                .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
+                .build()
         expect:
         "SR should have the same bindings"
         withRetry(5, 30) {
@@ -253,7 +261,10 @@ class K8sRbacTest extends BaseSpecification {
 
             def stackroxBindingsSet = stackroxBindings.collect { "${it.namespace}/${it.name}" }
             def orchestratorBindingsSet = orchestratorBindings.collect { "${it.namespace}/${it.name}" }
-            assert stackroxBindingsSet.toSet() == orchestratorBindingsSet.toSet()
+
+            Diff diff = javers.compareCollections(stackroxBindingsSet, orchestratorBindingsSet, String)
+            log.info(diff.prettyPrint())
+            assert diff.changes.empty
 
             stackroxBindings.each { Rbac.K8sRoleBinding b ->
                 K8sRoleBinding binding = orchestratorBindings.find {

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -263,8 +263,7 @@ class K8sRbacTest extends BaseSpecification {
             def orchestratorBindingsSet = orchestratorBindings.collect { "${it.namespace}/${it.name}" }
 
             Diff diff = javers.compareCollections(stackroxBindingsSet, orchestratorBindingsSet, String)
-            log.info(diff.prettyPrint())
-            assert diff.changes.empty
+            assert diff.changes.empty, diff.prettyPrint()
 
             stackroxBindings.each { Rbac.K8sRoleBinding b ->
                 K8sRoleBinding binding = orchestratorBindings.find {


### PR DESCRIPTION
## Description

This PR changes the set comparison output as in failures is too big and is not rendered by spock. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

```groovy
import org.javers.core.Javers
import org.javers.core.JaversBuilder
import org.javers.core.diff.ListCompareAlgorithm

import spock.lang.Specification
import spock.lang.Tag

@Tag("BAT")
class Test extends Specification{
    def "test"() {
        Javers javers = JaversBuilder.javers()
                .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                .build()
        when:
        def a = ['a','p','p', 'l', 'e']
        def b = ['r','e','d','h','a','t']
        def diff = javers.compareCollections(a, b, String)
        then:
        assert diff.changes.empty, diff.prettyPrint()
    }
}
```
```
Condition not satisfied:

diff.changes.empty
|    |       |
|    |       false
|    [ListChange{ property: 'list', elementChanges:6, left.size: 5, right.size: 6}]
Diff:
* changes on org.javers.core.graph.LiveGraphFactory$ListWrapper/ :
  - 'list' collection changes :
     . 'p' removed
     . 'l' removed
     · 'r' added
     · 'd' added
     · 't' added
     · 'h' added

Diff:
* changes on org.javers.core.graph.LiveGraphFactory$ListWrapper/ :
  - 'list' collection changes :
     . 'p' removed
     . 'l' removed
     · 'r' added
     · 'd' added
     · 't' added
     · 'h' added


	at Test.test(Test.groovy:19)
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
