### PR TITLE
fix(proxy): add openshift svc to default excludes

### DIFF
--- a/pkg/httputil/proxy/config.go
+++ b/pkg/httputil/proxy/config.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	defaultExcludes = []string{
+		"openshift.default.svc",
 		"*.stackrox",
 		"*.stackrox.svc",
 		"localhost",


### PR DESCRIPTION
## Description

Add the default openshift service we use in OpenShift Auth to the list of default no_proxy targets we have.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
