### PR TITLE
refactor(ui): Update Image CVE page to use TbodyUnified/TableUIState

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -9,8 +9,9 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { VulnerabilityState } from 'types/cve.proto';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import DateDistance from 'Components/DateDistance';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { TableUIState } from 'utils/getTableUIState';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
-import EmptyTableResults from '../components/EmptyTableResults';
 import DeploymentComponentVulnerabilitiesTable, {
     DeploymentComponentVulnerability,
     ImageMetadataContext,
@@ -56,21 +57,23 @@ export const deploymentsForCveFragment = gql`
 `;
 
 export type AffectedDeploymentsTableProps = {
-    deployments: DeploymentForCve[];
+    tableState: TableUIState<DeploymentForCve>;
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     cve: string;
     vulnerabilityState: VulnerabilityState | undefined; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     filteredSeverities?: VulnerabilitySeverityLabel[];
+    onClearFilters: () => void;
 };
 
 function AffectedDeploymentsTable({
-    deployments,
+    tableState,
     getSortParams,
     isFiltered,
     cve,
     vulnerabilityState,
     filteredSeverities,
+    onClearFilters,
 }: AffectedDeploymentsTableProps) {
     const expandedRowSet = useSet<string>();
     return (
@@ -94,87 +97,94 @@ function AffectedDeploymentsTable({
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
-            {deployments.length === 0 && <EmptyTableResults colSpan={7} />}
-            {deployments.map((deployment, rowIndex) => {
-                const {
-                    id,
-                    name,
-                    namespace,
-                    clusterName,
-                    lowImageCount,
-                    moderateImageCount,
-                    importantImageCount,
-                    criticalImageCount,
-                    created,
-                    images,
-                } = deployment;
-                const isExpanded = expandedRowSet.has(id);
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={8}
+                emptyProps={{ message: 'No deployments were found that are affected by this CVE' }}
+                filteredEmptyProps={{ onClearFilters }}
+                renderer={({ data }) =>
+                    data.map((deployment, rowIndex) => {
+                        const {
+                            id,
+                            name,
+                            namespace,
+                            clusterName,
+                            lowImageCount,
+                            moderateImageCount,
+                            importantImageCount,
+                            criticalImageCount,
+                            created,
+                            images,
+                        } = deployment;
+                        const isExpanded = expandedRowSet.has(id);
 
-                const imageComponentVulns = images.map((image) => ({
-                    imageMetadataContext: image,
-                    componentVulnerabilities: image.imageComponents,
-                }));
+                        const imageComponentVulns = images.map((image) => ({
+                            imageMetadataContext: image,
+                            componentVulnerabilities: image.imageComponents,
+                        }));
 
-                return (
-                    <Tbody key={id} isExpanded={isExpanded}>
-                        <Tr>
-                            <Td
-                                expand={{
-                                    rowIndex,
-                                    isExpanded,
-                                    onToggle: () => expandedRowSet.toggle(id),
-                                }}
-                            />
-                            <Td dataLabel="Deployment">
-                                <Flex
-                                    direction={{ default: 'column' }}
-                                    spaceItems={{ default: 'spaceItemsNone' }}
-                                >
-                                    <Link
-                                        to={getWorkloadEntityPagePath(
-                                            'Deployment',
-                                            id,
-                                            vulnerabilityState
-                                        )}
-                                    >
-                                        <Truncate position="middle" content={name} />
-                                    </Link>
-                                </Flex>
-                            </Td>
-                            <Td modifier="nowrap" dataLabel="Images by severity">
-                                <SeverityCountLabels
-                                    criticalCount={criticalImageCount}
-                                    importantCount={importantImageCount}
-                                    moderateCount={moderateImageCount}
-                                    lowCount={lowImageCount}
-                                    filteredSeverities={filteredSeverities}
-                                />
-                            </Td>
-                            <Td dataLabel="Cluster">{clusterName}</Td>
-                            <Td dataLabel="Namespace">{namespace}</Td>
-                            <Td modifier="nowrap" dataLabel="Images">
-                                {pluralize(images.length, 'image')}
-                            </Td>
-
-                            <Td modifier="nowrap" dataLabel="First discovered">
-                                <DateDistance date={created} />
-                            </Td>
-                        </Tr>
-                        <Tr isExpanded={isExpanded}>
-                            <Td />
-                            <Td colSpan={6}>
-                                <ExpandableRowContent>
-                                    <DeploymentComponentVulnerabilitiesTable
-                                        images={imageComponentVulns}
-                                        cve={cve}
-                                        vulnerabilityState={vulnerabilityState}
+                        return (
+                            <Tbody key={id} isExpanded={isExpanded}>
+                                <Tr>
+                                    <Td
+                                        expand={{
+                                            rowIndex,
+                                            isExpanded,
+                                            onToggle: () => expandedRowSet.toggle(id),
+                                        }}
                                     />
-                                </ExpandableRowContent>
-                            </Td>
-                        </Tr>
-                    </Tbody>
-                );
-            })}
+                                    <Td dataLabel="Deployment">
+                                        <Flex
+                                            direction={{ default: 'column' }}
+                                            spaceItems={{ default: 'spaceItemsNone' }}
+                                        >
+                                            <Link
+                                                to={getWorkloadEntityPagePath(
+                                                    'Deployment',
+                                                    id,
+                                                    vulnerabilityState
+                                                )}
+                                            >
+                                                <Truncate position="middle" content={name} />
+                                            </Link>
+                                        </Flex>
+                                    </Td>
+                                    <Td modifier="nowrap" dataLabel="Images by severity">
+                                        <SeverityCountLabels
+                                            criticalCount={criticalImageCount}
+                                            importantCount={importantImageCount}
+                                            moderateCount={moderateImageCount}
+                                            lowCount={lowImageCount}
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Cluster">{clusterName}</Td>
+                                    <Td dataLabel="Namespace">{namespace}</Td>
+                                    <Td modifier="nowrap" dataLabel="Images">
+                                        {pluralize(images.length, 'image')}
+                                    </Td>
+
+                                    <Td modifier="nowrap" dataLabel="First discovered">
+                                        <DateDistance date={created} />
+                                    </Td>
+                                </Tr>
+                                <Tr isExpanded={isExpanded}>
+                                    <Td />
+                                    <Td colSpan={6}>
+                                        <ExpandableRowContent>
+                                            <DeploymentComponentVulnerabilitiesTable
+                                                images={imageComponentVulns}
+                                                cve={cve}
+                                                vulnerabilityState={vulnerabilityState}
+                                            />
+                                        </ExpandableRowContent>
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
+                }
+            />
         </Table>
     );
 }


### PR DESCRIPTION
## Description

As titled, first of four pages in Workload CVEs that needed to be updated for consistency.

_Better reviewed with "Hide whitespace" on_

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Existing e2e tests.

Manual testing of both image and deployment tables to validate the following states:

- Loading
- Error
- Empty
- FilteredEmpty
- Complete