### PR TITLE
chore(ci): separate scanner go and image build

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -107,7 +107,7 @@ jobs:
           make -C scanner CGO_ENABLED=1 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} image/scanner/bin/scanner
         fi
 
-    - name: Archive Go binary
+    - name: Archive Go binary to preserve permissions
       run: tar -cvzf go-binary.tgz scanner/image/scanner/bin/scanner
 
     - uses: ./.github/actions/upload-artifact-with-retry
@@ -159,7 +159,7 @@ jobs:
       with:
         name: go-binary-${{ matrix.name }}-${{ matrix.goos }}-${{ matrix.goarch }}
 
-    - name: Unpack Go binaries build
+    - name: Unpack Go binary
       run: tar xvzf go-binary.tgz
 
     - name: Set build tag for prerelease images

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -52,8 +52,73 @@ jobs:
         condensed="$(jq -c <<< "$matrix")"
         echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
 
-  build-and-push-scanner:
+  pre-build-scanner-go-binary:
     needs: define-scanner-job-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      # Supports three go binary builds:
+      # default              - built with environment defaults (see handle-tagged-build & env.mk)
+      # prerelease           - built with GOTAGS=release
+      # race-condition-debug - built with -race
+      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.69
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Cache Go dependencies
+      uses: ./.github/actions/cache-go-dependencies
+
+    - uses: ./.github/actions/handle-tagged-build
+
+    - name: Setup Go build environment for release
+      if: |
+        contains(github.event.pull_request.labels.*.name, 'ci-release-build')
+          ||
+        matrix.name == 'prerelease'
+      run: echo "GOTAGS=release" >> "$GITHUB_ENV"
+
+    - name: Setup Go build environment for -race
+      if: |
+        matrix.arch == 'amd64'
+          &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'ci-race-tests')
+            ||
+          matrix.name == 'race-condition-debug'
+        )
+      run: echo "RACE=true" >> "$GITHUB_ENV"
+
+    - name: Build Go binary
+      run: |
+        if [[ "${{ matrix.goarch }}" != "amd64" ]]; then
+          echo "Building non-amd binary (CGO_ENABLED=0)"
+          make -C scanner CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} image/scanner/bin/scanner
+        else
+          echo "Building amd binary (CGO_ENABLED=1)"
+          make -C scanner CGO_ENABLED=1 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} image/scanner/bin/scanner
+        fi
+
+    - name: Archive Go binary
+      run: tar -cvzf go-binary.tgz scanner/image/scanner/bin/scanner
+
+    - uses: ./.github/actions/upload-artifact-with-retry
+      with:
+        name: go-binary-${{ matrix.name }}-${{ matrix.goos }}-${{ matrix.goarch }}
+        path: go-binary.tgz
+
+  build-and-push-scanner:
+    needs:
+    - define-scanner-job-matrix
+    - pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -90,27 +155,16 @@ jobs:
 
     - uses: ./.github/actions/handle-tagged-build
 
-    - name: Setup Go build environment for release
-      if: |
-        contains(github.event.pull_request.labels.*.name, 'ci-release-build')
-          ||
-        matrix.name == 'prerelease'
-      run: echo "GOTAGS=release" >> "$GITHUB_ENV"
+    - uses: ./.github/actions/download-artifact-with-retry
+      with:
+        name: go-binary-${{ matrix.name }}-${{ matrix.goos }}-${{ matrix.goarch }}
+
+    - name: Unpack Go binaries build
+      run: tar xvzf go-binary.tgz
 
     - name: Set build tag for prerelease images
       if: matrix.name == 'prerelease'
       run: echo "BUILD_TAG=$(make -C scanner --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"
-
-    - name: Setup Go build environment for -race
-      if: |
-        matrix.goarch == 'amd64'
-          &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'ci-race-tests')
-            ||
-          matrix.name == 'race-condition-debug'
-        )
-      run: echo "RACE=true" >> "$GITHUB_ENV"
 
     - name: Set build tag for race condition images
       if: matrix.name == 'race-condition-debug'

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -186,7 +186,7 @@ copy-scripts: $(image-scripts-t)
 	@echo "+ $@"
 
 .PHONY: image-scanner
-image-scanner:  $(if $(CI),,image/scanner/bin/scanner) \
+image-scanner: $(if $(CI),,image/scanner/bin/scanner) \
                $(image-scripts-t) \
                ossls-notice
 	@echo "+ $@"

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -42,9 +42,6 @@ endif
 # If you need to separate the declaration and the usage in Dockerfile, do this instead
 #    ARG CGO_ENABLED=1
 #    RUN make CGO_ENABLED=$CGO_ENABLED blah
-#
-# TODO(ROX-23969): remove this assignment so that CGO_ENABLED is set to 1 (see env.mk) in order to minimize testing
-# difference with FIPS builds.
 CGO_ENABLED = 0
 RACE_FLAG =
 ifeq ($(RACE),true)
@@ -139,18 +136,20 @@ $(build-t): $(build-deps-t)
 ifdef NODEPS
 .PHONY: $(build-deps-t)
 else
-$(build-deps-t): ../go.mod
+$(build-deps-t): $(shell find $(CURDIR)/.. -name "go.sum")
+	@echo "+ $@"
+	$(SILENT)touch $@
+endif
+
+%/go.sum: %/go.mod
 	@echo "+ $@"
 	$(SILENT)go mod tidy
 ifdef CI
-	$(SILENT)git diff --exit-code -- ../go.mod ../go.sum || { \
-		echo "go.mod/go.sum files were updated after running 'go mod tidy': run this command on your local machine and commit the results." ; \
-		exit 1 ; \
-	}
+	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "Go toolchain does not match with installed Go version. This is a compatibility check that prevents breaking downstream builds. If you really need to update the toolchain version, ask in #forum-acs-golang" ; exit 1 ; }
+	$(SILENT)git diff --exit-code -- ../go.mod ../go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 endif
 	$(SILENT)go mod verify
 	$(SILENT)touch $@
-endif
 
 ############
 ## Images ##
@@ -187,9 +186,9 @@ copy-scripts: $(image-scripts-t)
 	@echo "+ $@"
 
 .PHONY: image-scanner
-image-scanner: image/scanner/bin/scanner \
+image-scanner:  $(if $(CI),,image/scanner/bin/scanner) \
                $(image-scripts-t) \
-               $(if $(CI),ossls-notice-no-download,ossls-notice)
+               ossls-notice
 	@echo "+ $@"
 	$(DOCKERBUILD) \
         -t stackrox/$(image-prefix):$(TAG) \
@@ -230,17 +229,15 @@ image-db: $(image-db-init-t)
 ## Tools ##
 ###########
 
-.PHONY: ossls-notice-no-download
-ossls-notice-no-download: $(build-deps-t)
+.PHONY: ossls-notice
+ossls-notice: $(build-deps-t)
 	@echo "+ $@"
+ifdef CI
 	$(SILENT)ossls version
 	$(SILENT)ossls audit --export image/scanner/THIRD_PARTY_NOTICES
-
-.PHONY: ossls-notice
-ossls-notice: $(build-deps-t) $(OSSLS_BIN)
-	@echo "+ $@"
-	$(SILENT)$(OSSLS_BIN) version
-	$(SILENT)$(OSSLS_BIN) audit --export image/scanner/THIRD_PARTY_NOTICES
+else
+	$(SILENT)mkdir -p image/scanner/THIRD_PARTY_NOTICES
+endif
 
 #################
 ## Integration ##


### PR DESCRIPTION
## Description

Separate the Go and image build steps in CI in hopes of speeding things up. This also aligns closer to the main image build step.

This builds the Go binary with `CGO_ENABLED=1` for `amd64`.

This also updates a few make targets:

* `image-scanner` target now only runs the `image/scanner/bin` target outside of CI
* `ossls-notices-no-download` is deleted
* `ossls-notices` now just creates an empty `THIRD_PARTY_NOTICES` directory outside of CI

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
