### PR TITLE
ROX-24404: pause-reconcile for qa e2e tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -408,12 +408,12 @@ pause_stackrox_operator_reconcile() {
     local central_namespace=${1:-stackrox}
     local sensor_namespace=${2:-stackrox}
 
-    kubectl -n "${central_namespace}" \
+    kubectl annotate -n "${central_namespace}" \
         centrals.platform.stackrox.io \
         stackrox-central-services \
         stackrox.io/pause-reconcile=true
 
-    kubectl -n "${sensor_namespace}" \
+    kubectl annotate -n "${sensor_namespace}" \
         securedclusters.platform.stackrox.io \
         stackrox-secured-cluster-services \
         stackrox.io/pause-reconcile=true


### PR DESCRIPTION
## Description

Per ROX-24404, this is required to stop the operator undoing changes made by tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI - ocp-* is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
