### PR TITLE
ROX-20304: cache init bundles

### DIFF
--- a/central/clusterinit/store/postgres/gen.go
+++ b/central/clusterinit/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.InitBundleMeta --table=cluster_init_bundles --permission-checker sac.NewAllGlobalResourceAllowedPermissionChecker(resources.Administration,resources.Integration)
+//go:generate pg-table-bindings-wrapper --type=storage.InitBundleMeta --cached-store --table=cluster_init_bundles --permission-checker sac.NewAllGlobalResourceAllowedPermissionChecker(resources.Administration,resources.Integration)


### PR DESCRIPTION
## Description

Use the cached store for init bundles. Init bundles isn't a high cardinality store and less frequently written to, however quite often read from during the mTLS gRPC interceptor.
It's best to use the cached store for this purpose to lower the potential for latency in requests as well as avoid availablity issues.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
