### PR TITLE
ROX-22376: config changes for acscsemail integration

### DIFF
--- a/central/notifiers/acscsemail/client_impl.go
+++ b/central/notifiers/acscsemail/client_impl.go
@@ -59,10 +59,10 @@ func ClientSingleton() Client {
 }
 
 func transportWithServiceCA() http.RoundTripper {
-	return transportWithAdditonalCA(serviceOperatorCAPath)
+	return transportWithAdditionalCA(serviceOperatorCAPath)
 }
 
-func transportWithAdditonalCA(caFile string) *http.Transport {
+func transportWithAdditionalCA(caFile string) *http.Transport {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		rootCAs = x509.NewCertPool()

--- a/central/notifiers/acscsemail/client_impl_test.go
+++ b/central/notifiers/acscsemail/client_impl_test.go
@@ -159,7 +159,7 @@ func TestTransportWithAdditonalCA(t *testing.T) {
 	tlsServ.StartTLS()
 	defer tlsServ.Close()
 
-	transport := transportWithAdditonalCA(filePath)
+	transport := transportWithAdditionalCA(filePath)
 	httpClient := http.Client{Transport: transport}
 	err = retry.WithRetry(
 		// there's a chance the first call fails on tests depending on

--- a/pkg/env/managed.go
+++ b/pkg/env/managed.go
@@ -4,7 +4,7 @@ var (
 	// ManagedCentral is set to true to signal that the central is running as a managed instance.
 	ManagedCentral = RegisterBooleanSetting("ROX_MANAGED_CENTRAL", false)
 
-	ACSCSEmailURL = RegisterSetting("ROX_ACSCS_EMAIL_URL", WithDefault("https://emailsender.rhacs.svc.cluster.local"))
+	ACSCSEmailURL = RegisterSetting("ROX_ACSCS_EMAIL_URL", WithDefault("https://emailsender.rhacs.svc"))
 
 	// TenantID is set from the according central pod label with the Downward API.
 	TenantID = RegisterSetting("ROX_TENANT_ID", AllowEmpty())

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -104,7 +104,7 @@ var (
 	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", false)
 
 	// ACSCSEmailNotifier enables support for the ACSCS email notifier integratioon
-	ACSCSEmailNotifier = registerFeature("Enable support for ACSCS Email notifier type", "ROX_ACSCS_EMAIL_NOTIFIER", false)
+	ACSCSEmailNotifier = registerFeature("Enable support for ACSCS Email notifier type", "ROX_ACSCS_EMAIL_NOTIFIER", true)
 
 	// AttemptManifestDigest enables attempting to pull manifest digests from registres that historically did not
 	// support it but now appear to (ie: Nexus and RHEL).


### PR DESCRIPTION
## Description

This PR adds two minor changes to the acscsemail integration.

- The feature flag ROX_ACSCS_EMAIL_NOTIFIER is now `true` by default since development of that feature is done, thus going forward only `ROX_MANAGED_CENTRAL` needs to be explicitly set to use the integration
- Remove `.cluster.local` suffix for default emailsender URL because cert generated by service-ca operator does only allow `emailsender.rhacs.svc`. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- CI is sufficent

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
