### PR TITLE
ROX-20230: bump image expiration on Konflux to 1 year

### DIFF
--- a/.tekton/central-db-pull-request.yaml
+++ b/.tekton/central-db-pull-request.yaml
@@ -25,7 +25,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/central-db
   - name: path-context

--- a/.tekton/central-db-push.yaml
+++ b/.tekton/central-db-push.yaml
@@ -24,7 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/central-db
   - name: path-context

--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -26,7 +26,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/main
   - name: path-context

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -24,7 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/main
   - name: path-context

--- a/.tekton/operator-pull-request.yaml
+++ b/.tekton/operator-pull-request.yaml
@@ -26,7 +26,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/stackrox-operator
   - name: path-context

--- a/.tekton/operator-push.yaml
+++ b/.tekton/operator-push.yaml
@@ -24,7 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/stackrox-operator
   - name: path-context

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -26,7 +26,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/roxctl
   - name: path-context

--- a/.tekton/roxctl-push.yaml
+++ b/.tekton/roxctl-push.yaml
@@ -24,8 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    # TODO(ROX-20230): make release images not expire.
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/roxctl
   - name: path-context

--- a/.tekton/scanner-v4-db-pull-request.yaml
+++ b/.tekton/scanner-v4-db-pull-request.yaml
@@ -26,7 +26,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4-db
   - name: path-context

--- a/.tekton/scanner-v4-db-push.yaml
+++ b/.tekton/scanner-v4-db-push.yaml
@@ -24,7 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4-db
   - name: path-context

--- a/.tekton/scanner-v4-pull-request.yaml
+++ b/.tekton/scanner-v4-pull-request.yaml
@@ -26,7 +26,8 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4
   - name: path-context

--- a/.tekton/scanner-v4-push.yaml
+++ b/.tekton/scanner-v4-push.yaml
@@ -24,7 +24,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4
   - name: path-context


### PR DESCRIPTION
## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x]  Images build
- [x] Images have 1 year expiration on Quay.io 

![Screenshot 2024-06-05 at 13 52 25](https://github.com/stackrox/stackrox/assets/9576848/95c9ba47-2563-4f8d-9a2a-bbeb4df0b76c)