### PR TITLE
ROX-24513: Update Image single page to use TbodyUnified

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -235,6 +235,8 @@ export function visitAnyImageSinglePage() {
     selectEntityTab('Image');
     cy.get('tbody tr td[data-label="Image"] a').first().click();
 
+    waitForTableLoadCompleteIndicator();
+
     return cy.get('h1').then(($h1) => {
         return $h1.text().split(':');
     });
@@ -414,4 +416,9 @@ export function interactAndWaitForDeploymentList(callback) {
     const deploymentListRouteMatcherMap = getRouteMatcherMapForGraphQL([deploymentListOpname]);
     deploymentListRouteMatcherMap[deploymentListOpname].times = 1;
     return interactAndWaitForResponses(callback, deploymentListRouteMatcherMap);
+}
+
+export function waitForTableLoadCompleteIndicator() {
+    cy.get(selectors.loadingSpinner);
+    cy.get(selectors.loadingSpinner).should('not.exist');
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -49,6 +49,7 @@ export const selectors = {
 
     // Data table selectors
     isUpdatingTable: '*[aria-busy="true"] table',
+    tableWithLoadingSpinner: 'table tbody svg[aria-label="Loading table data"]',
     nthTableRow: (n) =>
         `.workload-cves-table-container > table > tbody:nth-of-type(${n}) > tr:nth-of-type(1)`,
     firstTableRow: 'table tbody:nth-of-type(1) tr:nth-of-type(1)',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -1,28 +1,24 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import {
-    Bullseye,
     Divider,
     Flex,
     PageSection,
     Pagination,
     pluralize,
-    Spinner,
     Split,
     SplitItem,
     Text,
     Title,
 } from '@patternfly/react-core';
 import { DropdownItem } from '@patternfly/react-core/deprecated';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { gql, useQuery } from '@apollo/client';
+import sum from 'lodash/sum';
 
 import useURLSearch from 'hooks/useURLSearch';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied } from 'utils/searchUtils';
-import EmptyStateTemplate from 'Components/EmptyStateTemplate';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
@@ -32,6 +28,7 @@ import {
     SummaryCardLayout,
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
+import { getTableUIState } from 'utils/getTableUIState';
 import {
     SearchOption,
     IMAGE_CVE_SEARCH_OPTION,
@@ -116,7 +113,7 @@ function ImagePageVulnerabilities({
 
     const currentVulnerabilityState = useVulnerabilityState();
 
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -125,10 +122,11 @@ function ImagePageVulnerabilities({
             field: 'Severity',
             direction: 'desc',
         },
-        onSort: () => setPage(1),
+        onSort: () => setPage(1, 'replace'),
     });
 
-    const { data, previousData, loading, error } = useQuery<
+    // TODO Split metadata, counts, and vulnerabilities into separate queries
+    const { data, loading, error } = useQuery<
         {
             image: ImageMetadataContext & {
                 imageCVECountBySeverity: ResourceCountByCveSeverityAndStatus;
@@ -165,147 +163,138 @@ function ImagePageVulnerabilities({
         createExceptionModalActions,
     } = useExceptionRequestModal();
 
-    let mainContent: ReactNode | null = null;
-
-    const vulnerabilityData = data ?? previousData;
-
     const showDeferralUI = isUnifiedDeferralsEnabled && currentVulnerabilityState === 'OBSERVED';
     const canSelectRows = showDeferralUI;
 
     const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;
 
-    if (error) {
-        mainContent = (
-            <Bullseye>
-                <EmptyStateTemplate
-                    headingLevel="h2"
-                    title={getAxiosErrorMessage(error)}
-                    icon={ExclamationCircleIcon}
-                    iconClassName="pf-v5-u-danger-color-100"
-                >
-                    Adjust your filters and try again
-                </EmptyStateTemplate>
-            </Bullseye>
-        );
-    } else if (loading && !vulnerabilityData) {
-        mainContent = (
-            <Bullseye>
-                <Spinner />
-            </Bullseye>
-        );
-    } else if (vulnerabilityData) {
-        const hiddenSeverities = getHiddenSeverities(querySearchFilter);
-        const hiddenStatuses = getHiddenStatuses(querySearchFilter);
-        const vulnCounter = vulnerabilityData.image.imageCVECountBySeverity;
-        const { critical, important, moderate, low } = vulnCounter;
-        const totalVulnerabilityCount =
-            critical.total + important.total + moderate.total + low.total;
+    const tableState = getTableUIState({
+        isLoading: loading,
+        data: data?.image.imageVulnerabilities,
+        error,
+        searchFilter,
+    });
 
-        mainContent = (
-            <>
-                <SummaryCardLayout error={error} isLoading={loading}>
-                    <SummaryCard
-                        data={vulnerabilityData.image}
-                        loadingText="Loading image vulnerability summary"
-                        renderer={({ data }) => (
-                            <BySeveritySummaryCard
-                                title="CVEs by severity"
-                                severityCounts={data.imageCVECountBySeverity}
-                                hiddenSeverities={hiddenSeverities}
-                            />
-                        )}
-                    />
-                    <SummaryCard
-                        data={vulnerabilityData.image}
-                        loadingText="Loading image vulnerability summary"
-                        renderer={({ data }) => (
-                            <CvesByStatusSummaryCard
-                                cveStatusCounts={data.imageCVECountBySeverity}
-                                hiddenStatuses={hiddenStatuses}
-                                isBusy={loading}
-                            />
-                        )}
-                    />
-                </SummaryCardLayout>
-                <Divider />
-                <div className="pf-v5-u-p-lg">
-                    <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
-                        <SplitItem isFilled>
-                            <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                                <Title headingLevel="h2">
-                                    {pluralize(totalVulnerabilityCount, 'result', 'results')} found
-                                </Title>
-                                {isFiltered && <DynamicTableLabel />}
-                            </Flex>
-                        </SplitItem>
-                        {canSelectRows && (
-                            <>
-                                <SplitItem>
-                                    <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
-                                        <DropdownItem
-                                            key="bulk-defer-cve"
-                                            component="button"
-                                            onClick={() =>
-                                                showModal({
-                                                    type: 'DEFERRAL',
-                                                    cves: Array.from(selectedCves.values()),
-                                                })
-                                            }
-                                        >
-                                            Defer CVEs
-                                        </DropdownItem>
-                                        <DropdownItem
-                                            key="bulk-mark-false-positive"
-                                            component="button"
-                                            onClick={() =>
-                                                showModal({
-                                                    type: 'FALSE_POSITIVE',
-                                                    cves: Array.from(selectedCves.values()),
-                                                })
-                                            }
-                                        >
-                                            Mark as false positives
-                                        </DropdownItem>
-                                    </BulkActionsDropdown>
-                                </SplitItem>
-                                <Divider
-                                    className="pf-v5-u-px-lg"
-                                    orientation={{ default: 'vertical' }}
-                                />
-                            </>
-                        )}
-                        <SplitItem>
-                            <Pagination
-                                itemCount={totalVulnerabilityCount}
-                                page={page}
-                                perPage={perPage}
-                                onSetPage={(_, newPage) => setPage(newPage)}
-                                onPerPageSelect={(_, newPerPage) => {
-                                    setPerPage(newPerPage);
-                                }}
-                            />
-                        </SplitItem>
-                    </Split>
-                    <div
-                        className="workload-cves-table-container"
-                        role="region"
-                        aria-live="polite"
-                        aria-busy={loading ? 'true' : 'false'}
-                    >
-                        <ImageVulnerabilitiesTable
-                            image={vulnerabilityData.image}
-                            getSortParams={getSortParams}
-                            isFiltered={isFiltered}
-                            selectedCves={selectedCves}
-                            canSelectRows={canSelectRows}
-                            vulnerabilityState={currentVulnerabilityState}
-                            createTableActions={createTableActions}
+    const hiddenSeverities = getHiddenSeverities(querySearchFilter);
+    const hiddenStatuses = getHiddenStatuses(querySearchFilter);
+    const severityCounts = data?.image.imageCVECountBySeverity;
+    const totalVulnerabilityCount = sum([
+        severityCounts?.critical.total ?? 0,
+        severityCounts?.important.total ?? 0,
+        severityCounts?.moderate.total ?? 0,
+        severityCounts?.low.total ?? 0,
+    ]);
+
+    // TODO - Inline `mainContent` into the return statement
+    const mainContent = (
+        <>
+            <SummaryCardLayout error={error} isLoading={loading}>
+                <SummaryCard
+                    data={data?.image}
+                    loadingText="Loading image vulnerability summary"
+                    renderer={({ data }) => (
+                        <BySeveritySummaryCard
+                            title="CVEs by severity"
+                            severityCounts={data.imageCVECountBySeverity}
+                            hiddenSeverities={hiddenSeverities}
                         />
-                    </div>
+                    )}
+                />
+                <SummaryCard
+                    data={data?.image}
+                    loadingText="Loading image vulnerability summary"
+                    renderer={({ data }) => (
+                        <CvesByStatusSummaryCard
+                            cveStatusCounts={data.imageCVECountBySeverity}
+                            hiddenStatuses={hiddenStatuses}
+                            isBusy={loading}
+                        />
+                    )}
+                />
+            </SummaryCardLayout>
+            <Divider />
+            <div className="pf-v5-u-p-lg">
+                <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
+                    <SplitItem isFilled>
+                        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                            <Title headingLevel="h2">
+                                {pluralize(totalVulnerabilityCount, 'result', 'results')} found
+                            </Title>
+                            {isFiltered && <DynamicTableLabel />}
+                        </Flex>
+                    </SplitItem>
+                    {canSelectRows && (
+                        <>
+                            <SplitItem>
+                                <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                                    <DropdownItem
+                                        key="bulk-defer-cve"
+                                        component="button"
+                                        onClick={() =>
+                                            showModal({
+                                                type: 'DEFERRAL',
+                                                cves: Array.from(selectedCves.values()),
+                                            })
+                                        }
+                                    >
+                                        Defer CVEs
+                                    </DropdownItem>
+                                    <DropdownItem
+                                        key="bulk-mark-false-positive"
+                                        component="button"
+                                        onClick={() =>
+                                            showModal({
+                                                type: 'FALSE_POSITIVE',
+                                                cves: Array.from(selectedCves.values()),
+                                            })
+                                        }
+                                    >
+                                        Mark as false positives
+                                    </DropdownItem>
+                                </BulkActionsDropdown>
+                            </SplitItem>
+                            <Divider
+                                className="pf-v5-u-px-lg"
+                                orientation={{ default: 'vertical' }}
+                            />
+                        </>
+                    )}
+                    <SplitItem>
+                        <Pagination
+                            itemCount={totalVulnerabilityCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => {
+                                setPerPage(newPerPage);
+                            }}
+                        />
+                    </SplitItem>
+                </Split>
+                <div
+                    className="workload-cves-table-container"
+                    role="region"
+                    aria-live="polite"
+                    aria-busy={loading ? 'true' : 'false'}
+                >
+                    <ImageVulnerabilitiesTable
+                        imageMetadata={data?.image}
+                        tableState={tableState}
+                        getSortParams={getSortParams}
+                        isFiltered={isFiltered}
+                        selectedCves={selectedCves}
+                        canSelectRows={canSelectRows}
+                        vulnerabilityState={currentVulnerabilityState}
+                        createTableActions={createTableActions}
+                        onClearFilters={() => {
+                            setSearchFilter({});
+                            setPage(1, 'replace');
+                        }}
+                    />
                 </div>
-            </>
-        );
-    }
+            </div>
+        </>
+    );
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -23,6 +23,8 @@ import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { TableUIState } from 'utils/getTableUIState';
 import { getIsSomeVulnerabilityFixable } from '../../utils/vulnerabilityUtils';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import ImageComponentVulnerabilitiesTable, {
@@ -31,7 +33,6 @@ import ImageComponentVulnerabilitiesTable, {
     imageComponentVulnerabilitiesFragment,
 } from './ImageComponentVulnerabilitiesTable';
 
-import EmptyTableResults from '../components/EmptyTableResults';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
@@ -68,9 +69,8 @@ export type ImageVulnerability = {
 };
 
 export type ImageVulnerabilitiesTableProps = {
-    image: ImageMetadataContext & {
-        imageVulnerabilities: ImageVulnerability[];
-    };
+    imageMetadata: ImageMetadataContext | undefined;
+    tableState: TableUIState<ImageVulnerability>;
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     canSelectRows: boolean;
@@ -81,16 +81,19 @@ export type ImageVulnerabilitiesTableProps = {
         summary: string;
         numAffectedImages: number;
     }) => IAction[];
+    onClearFilters: () => void;
 };
 
 function ImageVulnerabilitiesTable({
-    image,
+    imageMetadata,
+    tableState,
     getSortParams,
     isFiltered,
     canSelectRows,
     selectedCves,
     vulnerabilityState,
     createTableActions,
+    onClearFilters,
 }: ImageVulnerabilitiesTableProps) {
     const expandedRowSet = useSet<string>();
     const showExceptionDetailsLink = vulnerabilityState && vulnerabilityState !== 'OBSERVED';
@@ -127,121 +130,126 @@ function ImageVulnerabilitiesTable({
                     {createTableActions && <Th aria-label="CVE actions" />}
                 </Tr>
             </Thead>
-            {image.imageVulnerabilities.length === 0 && <EmptyTableResults colSpan={7} />}
-            {image.imageVulnerabilities.map(
-                (
-                    {
-                        cve,
-                        severity,
-                        summary,
-                        cvss,
-                        scoreVersion,
-                        imageComponents,
-                        discoveredAtImage,
-                        pendingExceptionCount,
-                    },
-                    rowIndex
-                ) => {
-                    const vulnerabilities = imageComponents.flatMap(
-                        (imageComponent) => imageComponent.imageVulnerabilities
-                    );
-                    const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
-                    const isExpanded = expandedRowSet.has(cve);
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={colSpan}
+                emptyProps={{ message: 'There were no CVEs detected for this image' }}
+                filteredEmptyProps={{ onClearFilters }}
+                renderer={({ data }) =>
+                    data.map((vulnerability, rowIndex) => {
+                        const {
+                            cve,
+                            severity,
+                            summary,
+                            cvss,
+                            scoreVersion,
+                            imageComponents,
+                            discoveredAtImage,
+                            pendingExceptionCount,
+                        } = vulnerability;
+                        const vulnerabilities = imageComponents.flatMap(
+                            (imageComponent) => imageComponent.imageVulnerabilities
+                        );
+                        const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
+                        const isExpanded = expandedRowSet.has(cve);
 
-                    return (
-                        <Tbody key={cve} isExpanded={isExpanded}>
-                            <Tr>
-                                <Td
-                                    expand={{
-                                        rowIndex,
-                                        isExpanded,
-                                        onToggle: () => expandedRowSet.toggle(cve),
-                                    }}
-                                />
-                                {canSelectRows && (
-                                    <CVESelectionTd
-                                        selectedCves={selectedCves}
-                                        rowIndex={rowIndex}
-                                        item={{ cve, summary, numAffectedImages: 1 }}
+                        return (
+                            <Tbody key={cve} isExpanded={isExpanded}>
+                                <Tr>
+                                    <Td
+                                        expand={{
+                                            rowIndex,
+                                            isExpanded,
+                                            onToggle: () => expandedRowSet.toggle(cve),
+                                        }}
                                     />
-                                )}
-                                <Td dataLabel="CVE" modifier="nowrap">
-                                    <PendingExceptionLabelLayout
-                                        hasPendingException={pendingExceptionCount > 0}
-                                        cve={cve}
-                                        vulnerabilityState={vulnerabilityState}
-                                    >
-                                        <Link
-                                            to={getWorkloadEntityPagePath(
-                                                'CVE',
-                                                cve,
-                                                vulnerabilityState
-                                            )}
-                                        >
-                                            {cve}
-                                        </Link>
-                                    </PendingExceptionLabelLayout>
-                                </Td>
-                                <Td modifier="nowrap" dataLabel="CVE severity">
-                                    {isVulnerabilitySeverity(severity) && (
-                                        <VulnerabilitySeverityIconText severity={severity} />
+                                    {canSelectRows && (
+                                        <CVESelectionTd
+                                            selectedCves={selectedCves}
+                                            rowIndex={rowIndex}
+                                            item={{ cve, summary, numAffectedImages: 1 }}
+                                        />
                                     )}
-                                </Td>
-                                <Td modifier="nowrap" dataLabel="CVE status">
-                                    <VulnerabilityFixableIconText isFixable={isFixableInImage} />
-                                </Td>
-                                <Td modifier="nowrap" dataLabel="CVSS">
-                                    <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
-                                </Td>
-                                <Td dataLabel="Affected components">
-                                    {imageComponents.length === 1
-                                        ? imageComponents[0].name
-                                        : `${imageComponents.length} components`}
-                                </Td>
-                                <Td dataLabel="First discovered">
-                                    <DateDistance date={discoveredAtImage} />
-                                </Td>
-                                {showExceptionDetailsLink && (
-                                    <ExceptionDetailsCell
-                                        cve={cve}
-                                        vulnerabilityState={vulnerabilityState}
-                                    />
-                                )}
-                                {createTableActions && (
-                                    <Td className="pf-v5-u-px-0">
-                                        <ActionsColumn
-                                            // menuAppendTo={() => document.body}
-                                            items={createTableActions({
-                                                cve,
-                                                summary,
-                                                numAffectedImages: 1,
-                                            })}
+                                    <Td dataLabel="CVE" modifier="nowrap">
+                                        <PendingExceptionLabelLayout
+                                            hasPendingException={pendingExceptionCount > 0}
+                                            cve={cve}
+                                            vulnerabilityState={vulnerabilityState}
+                                        >
+                                            <Link
+                                                to={getWorkloadEntityPagePath(
+                                                    'CVE',
+                                                    cve,
+                                                    vulnerabilityState
+                                                )}
+                                            >
+                                                {cve}
+                                            </Link>
+                                        </PendingExceptionLabelLayout>
+                                    </Td>
+                                    <Td modifier="nowrap" dataLabel="CVE severity">
+                                        {isVulnerabilitySeverity(severity) && (
+                                            <VulnerabilitySeverityIconText severity={severity} />
+                                        )}
+                                    </Td>
+                                    <Td modifier="nowrap" dataLabel="CVE status">
+                                        <VulnerabilityFixableIconText
+                                            isFixable={isFixableInImage}
                                         />
                                     </Td>
-                                )}
-                            </Tr>
-                            <Tr isExpanded={isExpanded}>
-                                <Td />
-                                <Td colSpan={colSpan}>
-                                    <ExpandableRowContent>
-                                        {summary && image ? (
-                                            <>
-                                                <p className="pf-v5-u-mb-md">{summary}</p>
-                                                <ImageComponentVulnerabilitiesTable
-                                                    imageMetadataContext={image}
-                                                    componentVulnerabilities={imageComponents}
-                                                />
-                                            </>
-                                        ) : (
-                                            <PartialCVEDataAlert />
-                                        )}
-                                    </ExpandableRowContent>
-                                </Td>
-                            </Tr>
-                        </Tbody>
-                    );
+                                    <Td modifier="nowrap" dataLabel="CVSS">
+                                        <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
+                                    </Td>
+                                    <Td dataLabel="Affected components">
+                                        {imageComponents.length === 1
+                                            ? imageComponents[0].name
+                                            : `${imageComponents.length} components`}
+                                    </Td>
+                                    <Td dataLabel="First discovered">
+                                        <DateDistance date={discoveredAtImage} />
+                                    </Td>
+                                    {showExceptionDetailsLink && (
+                                        <ExceptionDetailsCell
+                                            cve={cve}
+                                            vulnerabilityState={vulnerabilityState}
+                                        />
+                                    )}
+                                    {createTableActions && (
+                                        <Td className="pf-v5-u-px-0">
+                                            <ActionsColumn
+                                                // menuAppendTo={() => document.body}
+                                                items={createTableActions({
+                                                    cve,
+                                                    summary,
+                                                    numAffectedImages: 1,
+                                                })}
+                                            />
+                                        </Td>
+                                    )}
+                                </Tr>
+                                <Tr isExpanded={isExpanded}>
+                                    <Td />
+                                    <Td colSpan={colSpan}>
+                                        <ExpandableRowContent>
+                                            {summary && imageMetadata ? (
+                                                <>
+                                                    <p className="pf-v5-u-mb-md">{summary}</p>
+                                                    <ImageComponentVulnerabilitiesTable
+                                                        imageMetadataContext={imageMetadata}
+                                                        componentVulnerabilities={imageComponents}
+                                                    />
+                                                </>
+                                            ) : (
+                                                <PartialCVEDataAlert />
+                                            )}
+                                        </ExpandableRowContent>
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
                 }
-            )}
+            />
         </Table>
     );
 }


### PR DESCRIPTION
## Description

As titled, updates the Workload CVE Image single page table for consistency.

_Easier to review with "Hide whitespace" enabled_

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Existing Cypress tests.

Manual testing of table functionality:
https://github.com/stackrox/stackrox/assets/1292638/9d0c5f21-3f29-4c6b-8ce1-a26a8a422a8f

Test the filtered-empty state and table "Clear filters" action:
![image](https://github.com/stackrox/stackrox/assets/1292638/bb651525-9b33-45bf-9533-e0a047fbc6fa)
![image](https://github.com/stackrox/stackrox/assets/1292638/4b80a210-bc6c-4d6d-948f-800df694595f)

Test the empty state by visiting an image with no CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/82c4a8ea-a447-4d1b-84c0-ec3b0cb06d0f)


