### PR TITLE
ROX-24009: Cluster details sorting and pagination

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -1,33 +1,70 @@
 import React, { useState } from 'react';
 import { generatePath, Link } from 'react-router-dom';
-import { Button, ButtonVariant, Text, TextVariants, Tooltip } from '@patternfly/react-core';
+import {
+    Button,
+    ButtonVariant,
+    Pagination,
+    Text,
+    TextVariants,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    Tooltip,
+} from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { ComplianceCheckResult } from 'services/ComplianceResultsService';
 import { TableUIState } from 'utils/getTableUIState';
 
+import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
 import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import CheckStatusModal from './components/CheckStatusModal';
 
 export type ClusterDetailsTableProps = {
+    checkResultsCount: number;
     clusterId: string;
     profileName: string;
     tableState: TableUIState<ComplianceCheckResult>;
+    pagination: UseURLPaginationResult;
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function ClusterDetailsTable({ clusterId, profileName, tableState }: ClusterDetailsTableProps) {
+function ClusterDetailsTable({
+    checkResultsCount,
+    clusterId,
+    profileName,
+    tableState,
+    pagination,
+    getSortParams,
+}: ClusterDetailsTableProps) {
     const [selectedCheckResult, setSelectedCheckResult] = useState<ComplianceCheckResult | null>(
         null
     );
+    const { page, perPage, setPage, setPerPage } = pagination;
     return (
         <>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                        <Pagination
+                            itemCount={checkResultsCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
             <Table>
                 <Thead>
                     <Tr>
-                        <Th>Check</Th>
+                        <Th sort={getSortParams(CHECK_NAME_QUERY)}>Check</Th>
                         <Td modifier="fitContent" width={10}>
                             Controls
                         </Td>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -20,6 +20,7 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { ComplianceCheckResultStatusCount } from 'services/ComplianceCommon';
 import { getTableUIState } from 'utils/getTableUIState';
 
+import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
@@ -81,7 +82,7 @@ function ProfileChecksTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th sort={getSortParams('Compliance Check Name')} width={60}>
+                        <Th sort={getSortParams(CHECK_NAME_QUERY)} width={60}>
                             Check
                         </Th>
                         <Th modifier="fitContent">Controls</Th>

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -85,11 +85,13 @@ export function getComplianceProfileResults(
  */
 export function getComplianceProfileClusterResults(
     profileName: string,
-    clusterId: string
+    clusterId: string,
+    { sortOption, page, perPage }: SearchQueryOptions
 ): Promise<ListComplianceCheckResultResponse> {
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
     return axios
         .get<ListComplianceCheckResultResponse>(
-            `${complianceResultsBaseUrl}/results/profiles/${profileName}/clusters/${clusterId}`
+            `${complianceResultsBaseUrl}/results/profiles/${profileName}/clusters/${clusterId}?${params}`
         )
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

Adds sorting and pagination to the Compliance V2 Cluster Details table

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2024-06-05 at 11 48 43 AM](https://github.com/stackrox/stackrox/assets/61400697/71c37d52-635e-4494-b5a1-08f77c76978b)


