### PR TITLE
fix(CI): skip v4 check in this workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -667,8 +667,6 @@ jobs:
             "scanner-db",
             "scanner-db-slim",
             "scanner-slim",
-            "scanner-v4",
-            "scanner-v4-db",
             "stackrox-operator",
           ]
     steps:


### PR DESCRIPTION
## Description

These images are built in a separate workflow which can fail so scanning them here is not optimal. ref: https://redhat-internal.slack.com/archives/CLUNQEEMA/p1717611701252899

Note: scanner v2 checks here are OK because the v2 images are copied in this workflow and will exist before the check is tried.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
