### PR TITLE
ci: remove -4 from worker count/type set

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,8 +20,6 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
-# TODO:: Remove ocp-stable if it's deleted from the OSCI, e.g.,
-# https://github.com/openshift/release/blob/a14f76e0918b047d2406e9eb6baac82b55ced05a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4.yaml
 if [[ "${JOB_NAME:-}" =~ -ocp- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     set_ci_shared_export WORKER_NODE_COUNT 2


### PR DESCRIPTION
We do not need to include the major OCP version in test or job names. 

The only place I have found "ocp-4" needed instead of "ocp-" is these two places setting the worker node type and count for OSCI jobs.

Example JOB_NAME values:
```
JOB_NAME=pull-ci-stackrox-stackrox-release-4.4-ocp-4-11-operator-e2e-tests
JOB_NAME=pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests
JOB_NAME=pull-ci-stackrox-stackrox-master-ocp-4-15-scanner-v4-tests
```
No jobs in the last month unexpectedly will match `ocp-` (I searched with `[^r][^e][^h].*ocp-[^4].*` and only the ocp-stable scanner tests show up, https://lookerstudio.google.com/reporting/8aaf9153-555d-4779-8236-c5131b4eafff).