### PR TITLE
ROX-24255: improve custom rule keys UX

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -108,7 +108,7 @@ function RuleGroups({
                                             direction="up"
                                             isCreatable
                                             variant="typeahead"
-                                            placeholderText="Select or enter a key"
+                                            placeholderText="Create or select a key"
                                         >
                                             {augmentedRuleKeys.map((ruleKey) => (
                                                 <SelectOption key={ruleKey} value={ruleKey} />
@@ -123,7 +123,8 @@ function RuleGroups({
                                                             : 'default'
                                                     }
                                                 >
-                                                    {errors[index]?.props?.key ?? ''}
+                                                    {errors[index]?.props?.key ??
+                                                        'Create or select a key'}
                                                 </HelperTextItem>
                                             </HelperText>
                                         </FormHelperText>


### PR DESCRIPTION
## Description

We've received feedback in the past that the custom rule keys select box, which also supports adding custom options, isn't as obvious that it does support this.

The PR improves the helper texts and placeholders around that, and we'll see whether that will improve the solution. We decided against doing a
custom component for this one as depicted in the mocks regarding the complexities it will increase within the formik for the rules.

Empty fields:
![Screenshot 2024-06-06 at 04 46 11](https://github.com/stackrox/stackrox/assets/89904305/552951b4-3963-4003-a1ed-290eebd33909)

Choosing existing key:
![Screenshot 2024-06-06 at 04 46 27](https://github.com/stackrox/stackrox/assets/89904305/7632512b-d1e4-485a-bff8-af890d6ffbb4)

Creating a custom key:
![Screenshot 2024-06-06 at 04 46 39](https://github.com/stackrox/stackrox/assets/89904305/1c6932c8-fded-4293-bc7c-be74e2d781cd)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
