### PR TITLE
ROX-24561: Added notifier in scanstatus

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/convert.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/convert.go
@@ -103,7 +103,7 @@ func convertProtoNotifierConfigToV2(notifierConfig *storage.NotifierConfiguratio
 	}
 
 	if notifierConfig.GetEmailConfig() == nil {
-		return nil, errors.New("Email config read from database is nil")
+		return nil, errors.New("Email notifier is not configured")
 	}
 
 	return &v2.NotifierConfiguration{

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -11,6 +11,7 @@ import (
 	scanConfigMocks "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore/mocks"
 	scanSettingBindingMocks "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore/mocks"
 	suiteMocks "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore/mocks"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	v2 "github.com/stackrox/rox/generated/api/v2"
@@ -85,6 +86,7 @@ type ComplianceScanConfigServiceTestSuite struct {
 	scanConfigDatastore         *scanConfigMocks.MockDataStore
 	scanSettingBindingDatastore *scanSettingBindingMocks.MockDataStore
 	suiteDataStore              *suiteMocks.MockDataStore
+	notifierDS                  *notifierDS.MockDataStore
 	service                     Service
 }
 
@@ -105,7 +107,7 @@ func (s *ComplianceScanConfigServiceTestSuite) SetupTest() {
 	s.scanConfigDatastore = scanConfigMocks.NewMockDataStore(s.mockCtrl)
 	s.scanSettingBindingDatastore = scanSettingBindingMocks.NewMockDataStore(s.mockCtrl)
 	s.suiteDataStore = suiteMocks.NewMockDataStore(s.mockCtrl)
-	s.service = New(s.scanConfigDatastore, s.scanSettingBindingDatastore, s.suiteDataStore, s.manager, s.reportManager)
+	s.service = New(s.scanConfigDatastore, s.scanSettingBindingDatastore, s.suiteDataStore, s.manager, s.reportManager, s.notifierDS)
 }
 
 func (s *ComplianceScanConfigServiceTestSuite) TearDownTest() {
@@ -597,6 +599,7 @@ func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *apiV2.Complian
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,
 			Description:  "test-description",
+			Notifiers:    []*v2.NotifierConfiguration{},
 		},
 		ClusterStatus: []*apiV2.ClusterScanStatus{
 			{

--- a/central/complianceoperator/v2/scanconfigurations/service/singleton.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/singleton.go
@@ -6,6 +6,7 @@ import (
 	scanSettingsDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
 	scanSettingBindingsDS "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
 	suiteDS "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -27,7 +28,7 @@ func Singleton() Service {
 
 	serviceInstanceInit.Do(func() {
 		serviceInstance = New(scanSettingsDS.Singleton(), scanSettingBindingsDS.Singleton(), suiteDS.Singleton(),
-			compliancemanager.Singleton(), reportManager.Singleton())
+			compliancemanager.Singleton(), reportManager.Singleton(), notifierDS.Singleton())
 	})
 	return serviceInstance
 }


### PR DESCRIPTION
List/Get scan config does not return notifiers attached to the scan config. This PR fixes the bug

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
