### PR TITLE
tests: add a script to run nongroovy tests on ocp

### DIFF
--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run tests/e2e in an OCP cluster
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import AutomationFlavorsCluster
+from pre_tests import PreSystemTests
+from ci_tests import NonGroovyE2e
+from post_tests import PostClusterTest, FinalPost
+
+# set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
+
+ClusterTestRunner(
+    cluster=AutomationFlavorsCluster(),
+    pre_test=PreSystemTests(),
+    test=NonGroovyE2e(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=False,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -12,7 +12,7 @@ from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
-os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"


### PR DESCRIPTION
## Description

This is in the context of ROX-22594 - [I don't really trust](https://issues.redhat.com/browse/ROX-22594?focusedId=24632449&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24632449) the whole k8s interaction layer underlying qa test suite. Rather than invest time into debugging and fixing groovy code, I'd like to take a step back and use this opportunity to try and port `TLSChallengeTest` to Go (possibly as a baby step towards ROX-9116).

However in order not to lose coverage, we'd have to start running the nongroovy-e2e job against OCP.
I certainly don't expect this job to succeed on the first run, but adding this script is the first prerequisite step towards making this a reality.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Will be tested once [the ci-config is updated](https://github.com/openshift/release/pull/52868).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
