### PR TITLE
ROX-23994: remove warning if `--format` is not used

### DIFF
--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -183,13 +183,6 @@ func (i *imageScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.
 		return common.ErrInvalidCommandOption.CausedBy(err)
 	}
 
-	// There is a case where cobra is not printing the deprecation warning to stderr, when a deprecated flag is not
-	// specified, but has default values. So, when --format is left with default values and --output is not specified,
-	// we manually print the deprecation note. We do not need to do this when i.e. --format csv is used, because
-	// then a deprecated flag will be explicitly used and cobra will take over the printing of the deprecation note.
-	if !cmd.Flag("format").Changed && !cmd.Flag("output").Changed {
-		i.env.Logger().WarnfLn("Flag --format has been deprecated, %s", deprecationNote)
-	}
 	// Only create the printer when the old, deprecated output format is not used
 	// TODO(ROX-8303): This can be removed once the old output format is fully deprecated
 	if f.OutputFormat != "" {

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -3,7 +3,6 @@ package scan
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path"
@@ -341,19 +340,15 @@ func (s *imageScanTestSuite) TestConstruct() {
 }
 
 func (s *imageScanTestSuite) TestDeprecationNote() {
-	expectedDeprecationNote := fmt.Sprintf("WARN:\tFlag --format has been deprecated, %s\n", deprecationNote)
 	emptyOutputFormatPrinterFactory, err := printer.NewObjectPrinterFactory("json", printer.NewJSONPrinterFactory(false, false))
 	s.Require().NoError(err)
 	emptyOutputFormatPrinterFactory.OutputFormat = ""
 
 	cases := map[string]struct {
-		formatChanged    bool
-		outputChanged    bool
-		printDeprecation bool
+		formatChanged bool
+		outputChanged bool
 	}{
-		"default values are not changed, the deprecation warning should be printed": {
-			printDeprecation: true,
-		},
+		"default values are not changed, the deprecation warning should not be printed": {},
 		"changes in format, deprecation warning should not be printed": {
 			formatChanged: true,
 		},
@@ -378,11 +373,7 @@ func (s *imageScanTestSuite) TestDeprecationNote() {
 			cmd.Flag("output").Changed = c.outputChanged
 
 			_ = imgScanCmd.Construct(nil, cmd, emptyOutputFormatPrinterFactory)
-			if c.printDeprecation {
-				s.Assert().Equal(expectedDeprecationNote, errOut.String())
-			} else {
-				s.Assert().Empty(errOut.String())
-			}
+			s.Assert().Empty(errOut.String())
 		})
 	}
 }


### PR DESCRIPTION
## Description

Remove warning of the deprecated `--format` option when this option is not being used.
Deprecation is there provided by cobra
https://github.com/stackrox/stackrox/blob/7c654a7b12d8adf71187cd33ec138480a0f01d34/roxctl/image/scan/scan.go#L152

See #11421, that removes the `--format` flag.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
