### PR TITLE
ROX-23972: Add enableNetworkPolicies option to Helm charts

### DIFF
--- a/image/templates/CHANGING_CHARTS.md
+++ b/image/templates/CHANGING_CHARTS.md
@@ -29,6 +29,7 @@ Suppose we add a field `clusterDescription` to the `SecuredClusterServices` char
 1. Locate the Helm chart you want to extend under `image/templates/helm/stackrox-secured-cluster`
 1. Add the field `clusterDescription` to the `internal/config-shape.yaml` at the root level
 1. The value is directly translated into the `._rox` variable which happens in the `stackrox-secured-clusters/templates/init.tpl.htpl`
+1. If appropriate, add a default value in `internal/defaults.yaml.htpl`
 1. The `stackrox-secured-clusters/templates` directory contains the later rendered templates
 1. To read the value now add it to the Sensor deployment in `sensor.yaml.htpl`
 

--- a/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
@@ -1,6 +1,7 @@
 {{- include "srox.init" . -}}
 
-{{- if and ._rox.system.enableNetworkPolicies (not ._rox.scanner.disable) -}}
+{{- if ._rox.system.enableNetworkPolicies -}}
+{{- if not ._rox.scanner.disable -}}
 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -86,4 +87,5 @@ spec:
       app: scanner
   policyTypes:
     - Ingress
+{{ end }}
 {{ end }}

--- a/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
@@ -1,6 +1,6 @@
 {{- include "srox.init" . -}}
 
-{{- if not ._rox.scanner.disable -}}
+{{- if and ._rox.system.enableNetworkPolicies (not ._rox.scanner.disable) -}}
 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
@@ -1,5 +1,5 @@
 {{- include "srox.init" . -}}
-{{- if ._rox.scannerV4._dbEnabled }}
+{{- if and ._rox.scannerV4._dbEnabled ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
-{{- if and ._rox.scannerV4._dbEnabled ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.scannerV4._dbEnabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -33,5 +34,6 @@ spec:
       protocol: TCP
   policyTypes:
   - Ingress
+{{- end }}
 {{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
-{{- if and ._rox.scannerV4._indexerEnabled ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.scannerV4._indexerEnabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -84,5 +85,6 @@ spec:
       app: scanner-v4-indexer
   policyTypes:
     - Ingress
+{{- end }}
 {{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
@@ -1,5 +1,5 @@
 {{- include "srox.init" . -}}
-{{- if ._rox.scannerV4._indexerEnabled }}
+{{- if and ._rox.scannerV4._indexerEnabled ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
@@ -1,5 +1,5 @@
 {{- include "srox.init" . -}}
-{{- if ._rox.scannerV4._matcherEnabled }}
+{{- if and ._rox.scannerV4._matcherEnabled ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
-{{- if and ._rox.scannerV4._matcherEnabled ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.system.enableNetworkPolicies }}
+{{- if ._rox.scannerV4._matcherEnabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -68,5 +69,6 @@ spec:
       app: scanner-v4-matcher
   policyTypes:
     - Ingress
+{{- end }}
 {{- end }}
 {{- end }}

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -188,3 +188,4 @@ meta:
 globalPrefix: null # string
 system:
   enablePodSecurityPolicies: null # bool
+  enableNetworkPolicies: null # bool

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -320,6 +320,7 @@ defaults:
     [<- if not .AutoSensePodSecurityPolicies >]
     enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]
     [<- end >]
+    enableNetworkPolicies: true
 
 pvcDefaults:
   claimName: "stackrox-db"

--- a/image/templates/helm/stackrox-central/templates/00-stackrox-application.yaml
+++ b/image/templates/helm/stackrox-central/templates/00-stackrox-application.yaml
@@ -97,7 +97,7 @@ spec:
       kind: ClusterRoleBinding
     - group: apps
       kind: Deployment
-{{- if ._rox.system.enablePodSecurityPolicies }}
+{{- if ._rox.system.enableNetworkPolicies }}
     - group: networking.k8s.io
       kind: NetworkPolicy
 {{- end }}

--- a/image/templates/helm/stackrox-central/templates/00-stackrox-application.yaml
+++ b/image/templates/helm/stackrox-central/templates/00-stackrox-application.yaml
@@ -97,8 +97,10 @@ spec:
       kind: ClusterRoleBinding
     - group: apps
       kind: Deployment
+{{- if ._rox.system.enablePodSecurityPolicies }}
     - group: networking.k8s.io
       kind: NetworkPolicy
+{{- end }}
     - group: rbac.authorization.k8s.io
       kind: Role
     - group: rbac.authorization.k8s.io

--- a/image/templates/helm/stackrox-central/templates/01-central-10-db-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-10-db-networkpolicy.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
-{{ if not ._rox.central.db.external -}}
+
+{{ if and ._rox.system.enableNetworkPolicies (not ._rox.central.db.external) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/image/templates/helm/stackrox-central/templates/01-central-10-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-10-networkpolicy.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
 
+{{ if ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -62,4 +63,5 @@ spec:
       app: central
   policyTypes:
     - Ingress
+{{- end }}
 {{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -194,3 +194,4 @@ meta:
     extraAPIResources: null # [string]
 system:
   enablePodSecurityPolicies: null # bool
+  enableNetworkPolicies: null # bool

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -119,6 +119,9 @@ collector:
 auditLogs:
   disableCollection: {{ ne ._rox.env.openshift 4 }}
 
+system:
+  enableNetworkPolicies: true
+
 enableOpenShiftMonitoring: false
 ---
 sensor:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-netpol.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
 
+{{- if ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -43,4 +44,5 @@ spec:
       app: admission-control
   policyTypes:
     - Ingress
+{{- end }}
 {{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-netpol.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
 
+{{- if ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -41,4 +42,5 @@ spec:
       app: collector
   policyTypes:
     - Ingress
-{{ end }}
+{{- end }}
+{{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
 
+{{- if ._rox.system.enableNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -90,4 +91,5 @@ spec:
       app: sensor
   policyTypes:
     - Ingress
+{{- end }}
 {{- end }}

--- a/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
@@ -68,3 +68,4 @@ monitoring:
     enabled: true
 system:
   enablePodSecurityPolicies: true
+  enableNetworkPolicies: true

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -63,6 +63,21 @@ tests:
     .rolebindings["stackrox-central-psp"] | assertThat(. == null)
     .clusterroles["stackrox-central-psp"] | assertThat(. == null)
 
+- name: "central with network policies enabled"
+  values:
+    system:
+      enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["allow-ext-to-central"] | assertThat(. != null)
+    .networkpolicys["central-db"] | assertThat(. != null)
+
+- name: "central with network policies disabled"
+  values:
+    system:
+      enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["allow-ext-to-central"] | assertThat(. == null)
+    .networkpolicys["central-db"] | assertThat(. == null)
 
 # TODO(ROX-21206): Add test case for OS4 with stock SCCs and set hostPath, to check for hostmount-anyuid
 - name: "central with OpenShift 4 and stock SCCs"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -38,6 +38,13 @@ tests:
           ]
         .networkpolicys["central-monitoring-tls"] | assertThat(. != null)
 
+    - name: "network policies are disabled"
+      values:
+        system:
+          enableNetworkPolicies: false
+      expect: |
+        .networkpolicys["central-monitoring-tls"] | assertThat(. == null)
+
 - name: "When enabled"
   set:
     monitoring.openshift.enabled: true
@@ -105,7 +112,14 @@ tests:
             assertThat(.targetPort == "monitoring-tls"),
             assertThat(.port == 9091)
           ]
-        .networkpolicys["scanner-v4-matcher-monitoring-tls"] | assertThat(. != null)
+
+    - name: "network policies are disabled"
+      values:
+        system:
+          enableNetworkPolicies: false
+      expect: |
+        .networkpolicys["central-monitoring-tls"] | assertThat(. == null)
+        .networkpolicys["scanner-v4-matcher-monitoring-tls"] | assertThat(. == null)
 
 - name: "When enabled via default value"
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -154,6 +154,26 @@ tests:
     .rolebindings["stackrox-scanner-v4-psp"] | assertThat(. != null)
     .clusterroles["stackrox-scanner-v4-psp"] | assertThat(. != null)
 
+- name: "scanner with network policies enabled"
+  values:
+    scannerV4:
+      disable: false
+    system:
+      enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["scanner-v4-indexer"] | assertThat(. != null)
+    .networkpolicys["scanner-v4-matcher"] | assertThat(. != null)
+    .networkpolicys["scanner-v4-db"] | assertThat(. != null)
+
+- name: "scanner with network policies disabled"
+  values:
+    system:
+      enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["scanner-v4-indexer"] | assertThat(. == null)
+    .networkpolicys["scanner-v4-matcher"] | assertThat(. == null)
+    .networkpolicys["scanner-v4-db"] | assertThat(. == null)
+
 - name: "scanner v4 DB uses expected default configuration"
   values:
     scannerV4:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -167,6 +167,8 @@ tests:
 
 - name: "scanner with network policies disabled"
   values:
+    scannerV4:
+      disable: false
     system:
       enableNetworkPolicies: false
   expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -68,6 +68,22 @@ tests:
     .rolebindings["stackrox-scanner-psp"] | assertThat(. != null)
     .clusterroles["stackrox-scanner-psp"] | assertThat(. != null)
 
+- name: "scanner with network policies enabled"
+  values:
+    system:
+      enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["scanner"] | assertThat(. != null)
+    .networkpolicys["scanner-db"] | assertThat(. != null)
+
+- name: "scanner with network policies disabled"
+  values:
+    system:
+      enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["scanner"] | assertThat(. == null)
+    .networkpolicys["scanner-db"] | assertThat(. == null)
+
 #TODO: Add istio tests
 - name: "configured scanner"
   values:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
@@ -3,6 +3,8 @@ values:
     allowNone: true
   scannerV4:
     disable: false
+  system:
+    enableNetworkPolicies: true
 tests:
 - name: monitoring should not be exposed by default
   expect: |
@@ -19,6 +21,7 @@ tests:
 - name: monitoring should be exposed when enabled
   set:
     exposeMonitoring: true
+    system.enableNetworkPolicies: true
   expect: |
     verifyMonitoringExposed(.services.sensor)
     verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))
@@ -29,6 +32,16 @@ tests:
     verifyMonitoringExposed(.services["scanner-v4-indexer"])
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+
+- name: network policies should not be created when disabled
+  set:
+    exposeMonitoring: true
+    system.enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["sensor-monitoring"] | assertThat(. == null)
+    .networkpolicys["collector-monitoring"] | assertThat(. == null)
+    .networkpolicys["admission-control-monitoring"] | assertThat(. == null)
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)
 
 - name: monitoring should be overridable on a per-component basis (sensor)
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -161,3 +161,23 @@ tests:
     kubeVersion:
       version: "v1.11.0"
   tests: *disabled-test
+
+- name: "Network policy is enabled"
+  set:
+    env.openshift: 4
+    scannerV4.disable: false
+    monitoring.openshift.enabled: true
+    system.enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["sensor-monitoring-tls"] | assertThat(. != null)
+    .networkpolicys["scanner-v4-indexer-monitoring-tls"] | assertThat(. != null)
+
+- name: "Network policy is disabled"
+  set:
+    env.openshift: 4
+    scannerV4.disable: false
+    monitoring.openshift.enabled: true
+    system.enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["sensor-monitoring-tls"] | assertThat(. == null)
+    .networkpolicys["scanner-v4-indexer-monitoring-tls"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -65,9 +65,19 @@ tests:
     imagePullSecrets.allowNone: true
     scanner.disable: false
     scanner.mode: "slim"
+    system.enableNetworkPolicies: true
   expect: |
     .networkpolicys["scanner"].spec.ingress | assertThat(length == 2)
     .networkpolicys["scanner"].spec.ingress[1] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
+
+- name: "Network policies are disabled"
+  set:
+    imagePullSecrets.allowNone: true
+    scanner.disable: false
+    scanner.mode: "slim"
+    system.enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["scanner"] | assertThat(. == null)
 
 - name: "scanner slim service account can access image pull secrets"
   server:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -246,6 +246,24 @@ tests:
     .networkpolicys["scanner-v4-indexer"].spec.ingress[0] | .ports | assertThat(length == 1)
     .networkpolicys["scanner-v4-indexer"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
 
+- name: "scanner with network policies enabled"
+  set:
+    scannerV4.disable: false
+    imagePullSecrets.allowNone: true
+    system.enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["scanner-v4-indexer"] | assertThat(. != null)
+    .networkpolicys["scanner-v4-matcher"] | assertThat(. == null)  # No matcher in secured cluster
+
+- name: "scanner with network policies disabled"
+  set:
+    scannerV4.disable: false
+    imagePullSecrets.allowNone: true
+    system.enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["scanner-v4-indexer"] | assertThat(. == null)
+    .networkpolicys["scanner-v4-matcher"] | assertThat(. == null)
+
 - name: "Scanner V4 DB is backed by an emptyDir"
   set:
     scannerV4.disable: false

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
@@ -38,3 +38,15 @@ tests:
     .networkpolicys["sensor"].spec.ingress[0] | .from[2].podSelector.matchLabels.app | assertThat(. == "admission-control")
     .networkpolicys["sensor"].spec.ingress[0] | .from[3].podSelector.matchLabels.app | assertThat(. == "scanner")
     .networkpolicys["sensor"].spec.ingress[0] | .from[4].podSelector.matchLabels.app | assertThat(. == "scanner-v4-indexer")
+
+- name: "network policies enabled"
+  set:
+    system.enableNetworkPolicies: true
+  expect: |
+    .networkpolicys["sensor"] | assertThat(. != null)
+
+- name: "network policies disabled"
+  set:
+    system.enableNetworkPolicies: false
+  expect: |
+    .networkpolicys["sensor"] | assertThat(. == null)


### PR DESCRIPTION
## Description

Add the enableNetworkPolicies flag (default true) to the ACS Operator's CentralServices and SecuredClusterServices charts. Disabling it will prevent NetworkPolicy objects from being created.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

### Here I tell how I validated my change

- `go test -v github.com/stackrox/rox/pkg/helm/charts/tests/centralservices`
- `go test -v github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices`
- CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
