### PR TITLE
fix: use generated Un/Marshal in protocompat

### DIFF
--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -112,8 +112,10 @@ func (s *fullStoreImpl) readRows(
 		}
 
 		var procMsg storage.ProcessIndicator
-		if err := protocompat.Unmarshal(procSerialized, &procMsg); err != nil {
-			return nil, err
+		if procSerialized != nil {
+			if err := protocompat.Unmarshal(procSerialized, &procMsg); err != nil {
+				return nil, err
+			}
 		}
 
 		podUID = msg.GetPodUid()

--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -37,16 +37,16 @@ var ErrNil = errors.New("proto: Marshal called with nil")
 
 // Marshal takes a protocol buffer message and encodes it into
 // the wire format, returning the data. This is the main entry point.
-func Marshal(msg marshalable) ([]byte, error) {
-	res, err := msg.Marshal()
-	if res == nil && err == nil {
+func Marshal[T any, PT marshalable[T]](msg PT) ([]byte, error) {
+	var null PT
+	if msg == null {
 		return nil, ErrNil
 	}
-
-	return res, err
+	return msg.Marshal()
 }
 
-type marshalable interface {
+type marshalable[T any] interface {
+	*T
 	Marshal() ([]byte, error)
 }
 

--- a/pkg/protocompat/nil_test.go
+++ b/pkg/protocompat/nil_test.go
@@ -1,39 +1,38 @@
-package protoutils
+package protocompat
 
 import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stretchr/testify/assert"
 )
 
 var null = (*storage.Image)(nil)
 
 func TestErrorOnNilMarshal(t *testing.T) {
-	_, err := protocompat.Marshal(null)
+	_, err := Marshal(null)
 	assert.Equal(t, proto.ErrNil, err)
 
 	var msg *storage.Image
-	_, err = protocompat.Marshal(msg)
+	_, err = Marshal(msg)
 	assert.Equal(t, proto.ErrNil, err)
 
-	_, err = protocompat.Marshal(&storage.Image{})
+	_, err = Marshal(&storage.Image{})
 	assert.NoError(t, err)
 }
 
 func TestErrorOnNilUnmarshal(t *testing.T) {
-	err := protocompat.Unmarshal([]byte{}, null)
+	err := Unmarshal([]byte{}, null)
 	assert.NoError(t, err)
 
-	err = protocompat.Unmarshal(nil, null)
+	err = Unmarshal(nil, null)
 	assert.Equal(t, proto.ErrNil, err)
 
-	err = protocompat.Unmarshal(nil, null)
+	err = Unmarshal(nil, null)
 	assert.Equal(t, proto.ErrNil, err)
 
 	img := &storage.Image{}
-	err = protocompat.Unmarshal([]byte{}, img)
+	err = Unmarshal([]byte{}, img)
 	assert.NoError(t, err)
 }

--- a/pkg/protoutils/nil_test.go
+++ b/pkg/protoutils/nil_test.go
@@ -17,8 +17,7 @@ func TestErrorOnNilMarshal(t *testing.T) {
 	assert.Equal(t, proto.ErrNil, err)
 
 	var img *storage.Image
-	var msg protocompat.Message = img
-	_, err = protocompat.Marshal(msg)
+	_, err = protocompat.Marshal(img)
 	assert.Equal(t, proto.ErrNil, err)
 
 	_, err = protocompat.Marshal(&storage.Image{})
@@ -26,10 +25,7 @@ func TestErrorOnNilMarshal(t *testing.T) {
 }
 
 func TestErrorOnNilUnmarshal(t *testing.T) {
-	err := protocompat.Unmarshal(nil, nil)
-	assert.Equal(t, proto.ErrNil, err)
-
-	err = protocompat.Unmarshal(nil, (*storage.Image)(nil))
+	err := protocompat.Unmarshal(nil, (*storage.Image)(nil))
 	assert.Equal(t, proto.ErrNil, err)
 
 	var img *storage.Image

--- a/pkg/protoutils/nil_test.go
+++ b/pkg/protoutils/nil_test.go
@@ -9,15 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var null = (*storage.Image)(nil)
+
 func TestErrorOnNilMarshal(t *testing.T) {
-	_, err := protocompat.Marshal(nil)
+	_, err := protocompat.Marshal(null)
 	assert.Equal(t, proto.ErrNil, err)
 
-	_, err = protocompat.Marshal((*storage.Image)(nil))
-	assert.Equal(t, proto.ErrNil, err)
-
-	var img *storage.Image
-	_, err = protocompat.Marshal(img)
+	var msg *storage.Image
+	_, err = protocompat.Marshal(msg)
 	assert.Equal(t, proto.ErrNil, err)
 
 	_, err = protocompat.Marshal(&storage.Image{})
@@ -25,14 +24,16 @@ func TestErrorOnNilMarshal(t *testing.T) {
 }
 
 func TestErrorOnNilUnmarshal(t *testing.T) {
-	err := protocompat.Unmarshal(nil, (*storage.Image)(nil))
+	err := protocompat.Unmarshal([]byte{}, null)
+	assert.NoError(t, err)
+
+	err = protocompat.Unmarshal(nil, null)
 	assert.Equal(t, proto.ErrNil, err)
 
-	var img *storage.Image
-	err = protocompat.Unmarshal(nil, img)
+	err = protocompat.Unmarshal(nil, null)
 	assert.Equal(t, proto.ErrNil, err)
 
-	img = &storage.Image{}
+	img := &storage.Image{}
 	err = protocompat.Unmarshal([]byte{}, img)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

We have generated methods for marshaling that have better performance thane `proto` version that is based on reflection. Let's use them.

Moved nil tests to a package that is actually tested.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
