### PR TITLE
ROX-24463: Improve clarity in compliance schedules

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -20,19 +20,19 @@ const routeMatcherMapForComplianceScanConfigs = {
 export function visitComplianceEnhancedCoverageFromLeftNav(staticResponseMap) {
     visitFromLeftNavExpandable('Compliance (2.0)', 'Coverage', null, staticResponseMap);
 
-    cy.get(`h1:contains("Cluster compliance")`);
+    cy.get(`h1:contains("Cluster compliance")`); // TODO obsolete but function is not called
 }
 
 export function visitComplianceEnhancedSchedulesFromLeftNav(staticResponseMap) {
     visitFromLeftNavExpandable('Compliance (2.0)', 'Schedules', null, staticResponseMap);
 
-    cy.get(`h1:contains("Cluster compliance")`);
+    cy.get(`h1:contains("Schedules")`);
 }
 
 export function visitComplianceEnhancedCoverage(staticResponseMap) {
     visit(complianceEnhancedCoveragePath, null, staticResponseMap);
 
-    cy.get(`h1:contains("Cluster compliance")`);
+    cy.get(`h1:contains("Cluster compliance")`); // TODO obsolete but function is not called
 }
 
 export function visitComplianceEnhancedScanConfigs(staticResponseMap) {

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -47,7 +47,7 @@ describe('Compliance Schedules', () => {
     it('should have have a form to add a new scan config', () => {
         visitComplianceEnhancedScanConfigs();
 
-        cy.get('.pf-v5-c-toolbar__content a:contains("Create scan schedule")').click();
+        cy.get('.pf-v5-l-flex.pf-m-row a:contains("Create scan schedule")').click();
 
         cy.get(`h1:contains("Create scan schedule")`);
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -5,7 +5,7 @@ function CoveragesPageHeader() {
     return (
         <>
             <PageSection component="div" variant="light">
-                <Title headingLevel="h1">Compliance coverage</Title>
+                <Title headingLevel="h1">Coverage</Title>
                 <Text>
                     Assess profile compliance for nodes and platform resources across clusters
                 </Text>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/EditScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/EditScanConfigDetail.tsx
@@ -57,7 +57,7 @@ function EditScanConfigDetail({
                         className="pf-v5-u-py-lg pf-v5-u-px-lg"
                     >
                         <FlexItem flex={{ default: 'flex_1' }}>
-                            <Title headingLevel="h1">{scanConfig.scanName}</Title>
+                            <Title headingLevel="h1">Edit {scanConfig.scanName}</Title>
                         </FlexItem>
                     </Flex>
                 )}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
@@ -283,17 +283,6 @@ function ScanConfigsTablePage({
                         </FlexItem>
                     )}
                 </Flex>
-                {alertObj !== null && (
-                    <Alert
-                        title={alertObj.title}
-                        variant={alertObj.type}
-                        className="pf-v5-u-mb-lg pf-v5-u-mx-lg"
-                        component="h2"
-                        actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
-                    >
-                        {alertObj.children}
-                    </Alert>
-                )}
             </PageSection>
             <Divider component="div" />
             {error ? (
@@ -304,6 +293,19 @@ function ScanConfigsTablePage({
                 </PageSection>
             ) : (
                 <PageSection>
+                    {alertObj !== null && (
+                        <Alert
+                            title={alertObj.title}
+                            variant={alertObj.type}
+                            isInline
+                            className="pf-v5-u-mb-lg"
+                            component="h2"
+                            actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
+                        >
+                            {alertObj.children}
+                        </Alert>
+                    )}
+
                     <Toolbar>
                         <ToolbarContent>
                             <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Table/ScanConfigsTablePage.tsx
@@ -20,6 +20,7 @@ import {
     Spinner,
     Text,
     TextContent,
+    Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
@@ -30,7 +31,7 @@ import { OutlinedClockIcon } from '@patternfly/react-icons';
 import { complianceEnhancedCoveragePath, complianceEnhancedSchedulesPath } from 'routePaths';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
-import TabNavHeader from 'Components/TabNav/TabNavHeader';
+import PageTitle from 'Components/PageTitle';
 import TabNavSubHeader from 'Components/TabNav/TabNavSubHeader';
 import useAlert from 'hooks/useAlert';
 import useRestQuery from 'hooks/useRestQuery';
@@ -266,31 +267,34 @@ function ScanConfigsTablePage({
 
     return (
         <>
-            <TabNavHeader
-                currentTabTitle="Schedules"
-                tabLinks={[
-                    { title: 'Coverage', href: complianceEnhancedCoveragePath },
-                    { title: 'Schedules', href: complianceEnhancedSchedulesPath },
-                ]}
-                pageTitle="Compliance - Cluster compliance"
-                mainTitle="Cluster compliance"
-            />
-            <Divider component="div" />
-            <TabNavSubHeader
-                actions={hasWriteAccessForCompliance ? <CreateScanConfigButton /> : <></>}
-                description="Configure a scan schedule to run profile compliance checks on selected clusters"
-            />
-            {alertObj !== null && (
-                <Alert
-                    title={alertObj.title}
-                    variant={alertObj.type}
-                    className="pf-v5-u-mb-lg pf-v5-u-mx-lg"
-                    component="h2"
-                    actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
-                >
-                    {alertObj.children}
-                </Alert>
-            )}
+            <PageTitle title="Compliance - Schedules" />
+            <PageSection component="div" variant="light">
+                <Flex direction={{ default: 'row' }}>
+                    <FlexItem>
+                        <Title headingLevel="h1">Schedules</Title>
+                        <Text>
+                            Configure scan schedules to run profile compliance checks on selected
+                            clusters
+                        </Text>
+                    </FlexItem>
+                    {hasWriteAccessForCompliance && (
+                        <FlexItem align={{ default: 'alignRight' }}>
+                            <CreateScanConfigButton />
+                        </FlexItem>
+                    )}
+                </Flex>
+                {alertObj !== null && (
+                    <Alert
+                        title={alertObj.title}
+                        variant={alertObj.type}
+                        className="pf-v5-u-mb-lg pf-v5-u-mx-lg"
+                        component="h2"
+                        actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
+                    >
+                        {alertObj.children}
+                    </Alert>
+                )}
+            </PageSection>
             <Divider component="div" />
             {error ? (
                 <PageSection variant="light" isFilled id="policies-table-error">

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
@@ -21,11 +21,11 @@ function ReportConfiguration(): ReactElement {
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex direction={{ default: 'column' }} className="pf-v5-u-py-lg pf-v5-u-px-lg">
                     <FlexItem>
-                        <Title headingLevel="h2">Report configuration</Title>
+                        <Title headingLevel="h2">Report</Title>
                     </FlexItem>
                     <FlexItem>
                         Optionally configure e-mail delivery destinations for manually triggered
-                        reports.
+                        reports
                     </FlexItem>
                 </Flex>
             </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -54,7 +54,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                     <FlexItem>
                         <Title headingLevel="h2">Review</Title>
                     </FlexItem>
-                    <FlexItem>Review and create your scan configuration</FlexItem>
+                    <FlexItem>Review the scan schedule before you save changes</FlexItem>
                     {errorMessage && (
                         <Alert
                             title={'Scan configuration request failure'}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -56,9 +56,9 @@ function ScanConfigOptions(): ReactElement {
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex direction={{ default: 'column' }} className="pf-v5-u-py-lg pf-v5-u-px-lg">
                     <FlexItem>
-                        <Title headingLevel="h2">Configuration options</Title>
+                        <Title headingLevel="h2">Parameters</Title>
                     </FlexItem>
-                    <FlexItem>Set up name, schedule, and options</FlexItem>
+                    <FlexItem>Set name and schedule to scan on a recurring basis</FlexItem>
                 </Flex>
             </PageSection>
             <Divider component="div" />
@@ -111,10 +111,7 @@ function ScanConfigOptions(): ReactElement {
                     <StackItem>
                         <Flex direction={{ default: 'column' }}>
                             <FlexItem>
-                                <Title headingLevel="h3">Configure schedule</Title>
-                            </FlexItem>
-                            <FlexItem>
-                                Configure or setup a schedule to scan on a recurring basis.
+                                <Title headingLevel="h3">Schedule</Title>
                             </FlexItem>
                             <FlexItem flex={{ default: 'flexNone' }}>
                                 <Flex direction={{ default: 'column' }}>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardFooter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardFooter.tsx
@@ -6,7 +6,6 @@ import useModal from 'hooks/useModal';
 export type ScanConfigWizardFooterProps = {
     wizardSteps: WizardStep[];
     onSave: () => void;
-    isEditing: boolean;
     isSaving: boolean;
     proceedToNextStepIfValid: (nextFunction: () => void, stepId: string) => void;
 };
@@ -14,7 +13,6 @@ export type ScanConfigWizardFooterProps = {
 function ScanConfigWizardFooter({
     wizardSteps,
     onSave,
-    isEditing,
     isSaving,
     proceedToNextStepIfValid,
 }: ScanConfigWizardFooterProps) {
@@ -41,7 +39,7 @@ function ScanConfigWizardFooter({
                         onClick={onSave}
                         isLoading={isSaving}
                     >
-                        {isEditing ? 'Save' : 'Create'}
+                        Save
                     </Button>
                 )}
                 <Button

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -29,7 +29,7 @@ const SELECT_PROFILES = 'Select profiles';
 const SELECT_PROFILES_ID = 'profiles';
 const CONFIGURE_REPORT = 'Configure report';
 const CONFIGURE_REPORT_ID = 'report';
-const REVIEW_CONFIG = 'Review and create';
+const REVIEW_CONFIG = 'Review';
 const REVIEW_CONFIG_ID = 'review';
 
 type ScanConfigWizardFormProps = {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -21,7 +21,7 @@ import ScanConfigWizardFooter from './ScanConfigWizardFooter';
 import useFormikScanConfig from './useFormikScanConfig';
 import { convertFormikToScanConfig, ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
-const PARAMETERS = 'Set Parameters';
+const PARAMETERS = 'Set parameters';
 const PARAMETERS_ID = 'parameters';
 const SELECT_CLUSTERS = 'Select clusters';
 const SELECT_CLUSTERS_ID = 'clusters';
@@ -188,8 +188,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
         },
     ].filter(({ id }) => id !== CONFIGURE_REPORT_ID || isComplianceReportingEnabled);
 
-    const isEditing = initialFormValues?.id !== undefined;
-
     return (
         <>
             <FormikProvider value={formik}>
@@ -206,7 +204,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                             onSave={onSave}
                             isSaving={isCreating}
                             proceedToNextStepIfValid={proceedToNextStepIfValid}
-                            isEditing={isEditing}
                         />
                     }
                 />


### PR DESCRIPTION
## Description

Remove rough edges in user experience before cross-functional acceptance testing.

### Changes

1. Edit ComplianceEnhanced.helpers.js file.
    * Add TODO comments for unused functions that has obsolete assertions.
    * Update assertion for **Schedules** heading.
2. Edit CoveragesPageHeader.tsx file.
    * Replace **Compliance coverage** with **Coverage** so `h1` element is consistent with link title in left navigation, following the recent pattern in **Vulnerabilities**.
3. Edit EditScanConfigDetail.tsx file.
    * Add **Edit** to `h1` element parallel with breadcrumb item to be consistent with **Create** in both.
4. Edit ScanConfigsTablePage.tsx file.
    * Replace `TabNavHeader` and `TabNavSubHeader` elements with heading page section for **Schedules** that is parallel with **Coverage**.
5. Edit ReportConfiguration.tsx file.
    * Replace **Report configuration** with **Report** that is parallel with **Clusters** and **Profiles**.
6. Edit ReviewConfig.tsx file.
    * Replace **Review and create your scan configuration** with **Review the scan schedule before you save changes** which is neutral for create or update.
7. Edit ScanConfigOptions.tsx file.
    * Replace **Configuration options** with **Parameters** that is parallel with **Clusters** and **Profiles**.
    * Replace vague **and options** with **to scan on a recurring basis**.
    * Replace **Configure schedule** with schedule.
    * Delete redundant blurb sentence.
8. Edit ScanConfigWizardFooter.tsx file.
    * Replace `{isEditing ? 'Save' : 'Create'}` with `Save` for simplicity and consistency with policies wizard.
9. Edit ScanConfigWizardForm.tsx file.
    * Replace title case **Set Parameters** with sentence case **Set parameters** in wizard steps.
    * Replace **Review and create** with **Review** which is neutral for create or update (and consistent with PatternFly examples).
    * Delete `isEditing` prop for simplicity and consistency with policies wizard.

### Residue

1. Replace local time with universal time in `TimePicker` element.
2. Search for **Compliance coverage** in page titles that I did not change to precent merge conflicts with work-in-progress.
3. Move ScanConfigsTablePage.tsx file from Table subfolder to Schedules folder.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Prerequisite for `yarn start` in ui folder:

```sh
export ROX_COMPLIANCE_REPORTING=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4635856 - 4635856
        total -1947 = 11697116 - 11699063
    * `ls -al build/static/js/*.js | wc`
        files 0 = 171 - 171
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/coverage

    * Before changes, see **Compliance coverage** that is inconsistent with left navigation.
        ![CoveragesPageHeader_Compliance_coverage](https://github.com/stackrox/stackrox/assets/11862657/33619228-8386-46ab-926a-aa1d113a4151)

    * After changes, see consistent **Coverage** that is consistent with left navigation.
        ![CoveragesPageHeader_Coverage](https://github.com/stackrox/stackrox/assets/11862657/9ed6d7f4-e4e7-44c5-a23d-fe3094fb6963)

2. Visit /main/compliance/schedules

    * Before changes, see **Cluster compliance** that is inconsistent with left navigation.
        ![ScanConfigsTablePage_Cluster_compliance](https://github.com/stackrox/stackrox/assets/11862657/65b60499-d515-4a09-a92f-696878703c8e)

    * After changes, see consistent **Schedules** that is consistent with left navigation.
        ![ScanConfigsTablePage_Schedules](https://github.com/stackrox/stackrox/assets/11862657/5335d7b6-07df-4a62-9236-f5b3e9e43ad3)

    * After rebase, render `Alert` element in same `PageSection` as `Table` element.
        ![Alert](https://github.com/stackrox/stackrox/assets/11862657/3bb4c9fd-bfb2-4bc5-a1c1-dcdca9545ad6)

3. Click a link, and then click **Edit scan schedule** (an independent change replaces 2 buttons with **Actions** dropdown).

    * See **Edit whatever** in breadcrumb item and page heading.
        ![EditScanConfigDetail](https://github.com/stackrox/stackrox/assets/11862657/861e41e6-741d-4936-9a67-1f36cbc88313)

4. Go back to /main/compliance/schedules and click **Create compliance scan**

    * See sentence case in left navigation plus simplified headings and blurb sentences.
        ![ScanConfigOptions](https://github.com/stackrox/stackrox/assets/11862657/4d833d37-0791-43db-bfaf-e7b94998b786)

5. Progress to **Configure report** step.

    * See simplified heading and consistent punctuation in blurb sentence.
        ![ReportConfiguration](https://github.com/stackrox/stackrox/assets/11862657/ef2979ce-07c8-446d-9703-36ede0536ec7)

6. Click **Next**.

    * See **Review** in wizard steps, improved blurb sentence, and **Save** button.
        ![ReviewConfig](https://github.com/stackrox/stackrox/assets/11862657/1ad314de-f8b8-4071-972d-f3a1a3957f18)
