### PR TITLE
fix: add protoassert to compare protos

### DIFF
--- a/pkg/protoassert/assert.go
+++ b/pkg/protoassert/assert.go
@@ -1,0 +1,65 @@
+package protoassert
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func Equal(t *testing.T, expected, actual proto.Message, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	e, err := toJson(expected)
+	require.NoError(t, err)
+	a, err := toJson(actual)
+	require.NoError(t, err)
+	return assert.JSONEq(t, e, a, msgAndArgs)
+}
+
+func SlicesEqual[T proto.Message](t *testing.T, expected, actual []T, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	areEqual := assert.Len(t, actual, len(expected), msgAndArgs)
+	for i, e := range expected {
+		a := actual[i]
+		areEqual = areEqual && assert.Equal(t, a, e, msgAndArgs)
+	}
+	return areEqual
+}
+
+func MapSliceEqual[K comparable, T proto.Message](t *testing.T, expected, actual map[K][]T, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	ek := maps.Keys(expected)
+	ea := maps.Keys(actual)
+	if !assert.EqualValues(t, ek, ea, msgAndArgs) {
+		return false
+	}
+	for k, v := range expected {
+		a := actual[k]
+		if !SlicesEqual(t, v, a, msgAndArgs) {
+			return false
+		}
+	}
+	return true
+}
+
+func toJson(m proto.Message) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+
+	marshaller := &jsonpb.Marshaler{
+		EnumsAsInts:  false,
+		EmitDefaults: false,
+		Indent:       "  ",
+	}
+
+	s, err := marshaller.MarshalToString(m)
+	if err != nil {
+		return "", err
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
## Description

This PR creates a test helper function to use when comparing proto objects.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
