### PR TITLE
fix: Block "no cves view" tests when unified deferrals flag is off

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -84,7 +84,10 @@ describe('Workload CVE overview page tests', () => {
 
     describe('Images without CVEs view tests', () => {
         beforeEach(function () {
-            if (!hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')) {
+            if (
+                !hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS') ||
+                !hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+            ) {
                 this.skip();
             }
         });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -22,12 +22,6 @@ import TooltipTh from 'Components/TooltipTh';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
-<<<<<<< Updated upstream
-=======
-import { TableUIState } from 'utils/getTableUIState';
-import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import ExpandRowTd from 'Components/ExpandRowTableHeader';
->>>>>>> Stashed changes
 import { VulnerabilitySeverityLabel } from '../../types';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
@@ -153,7 +147,7 @@ function CVEsTable({
         <Table borders={false} variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <ExpandRowTd />
+                    <Th>{/* Header for expanded column */}</Th>
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <TooltipTh tooltip="Severity of this CVE across images">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -22,6 +22,12 @@ import TooltipTh from 'Components/TooltipTh';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
+<<<<<<< Updated upstream
+=======
+import { TableUIState } from 'utils/getTableUIState';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import ExpandRowTd from 'Components/ExpandRowTableHeader';
+>>>>>>> Stashed changes
 import { VulnerabilitySeverityLabel } from '../../types';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
@@ -147,7 +153,7 @@ function CVEsTable({
         <Table borders={false} variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTd />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <TooltipTh tooltip="Severity of this CVE across images">


### PR DESCRIPTION
## Description

The "fixability filters" flag was recently enabled, which caused these tests to run in CI. It was then discovered that the tests require "unified deferrals" to be enabled as well.

This slipped through CI since UI e2e tests do not run against PRs when a feature flag is changed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI