### PR TITLE
fix(ui): Add ExpandRowTh component for table headers

### DIFF
--- a/ui/apps/platform/src/Components/ExpandRowTh.tsx
+++ b/ui/apps/platform/src/Components/ExpandRowTh.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Th, ThProps } from '@patternfly/react-table';
+
+const expandButtonWidth = '1em';
+const expandButtonPaddingX = '(var(--pf-v5-global--spacer--md) * 2)';
+const firstTableCellPadding = 'var(--pf-v5-c-table--cell--PaddingLeft)';
+
+export default function ExpandRowTh(props: ThProps) {
+    return (
+        <Th
+            {...props}
+            aria-label={props['aria-label'] || 'Expand row'}
+            style={{
+                // Setting a defined width here prevents column shift when the table is in a loading state
+                width: `calc(${expandButtonWidth} + ${expandButtonPaddingX} + ${firstTableCellPadding})`,
+                ...props.style,
+            }}
+        />
+    );
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -18,6 +18,7 @@ import {
     CVE_STATUS_SORT_FIELD,
     CVSS_SORT_FIELD,
 } from 'Containers/Vulnerabilities/utils/sortFields';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     getIsSomeVulnerabilityFixable,
     getHighestVulnerabilitySeverity,
@@ -90,7 +91,7 @@ function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
         >
             <Thead noWrap>
                 <Tr>
-                    <Th aria-label="Expand row" />
+                    <ExpandRowTh />
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                     <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top severity</Th>
                     <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -26,6 +26,7 @@ import useMap from 'hooks/useMap';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { ApiSortOption } from 'types/search';
 
+import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     CVE_SORT_FIELD,
     NODE_COUNT_SORT_FIELD,
@@ -103,7 +104,7 @@ function CVEsTable({
         >
             <Thead noWrap>
                 <Tr>
-                    <Th aria-label="Expand row" />
+                    <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                     <TooltipTh tooltip="The number of nodes affected by this CVE, grouped by the severity of the CVE on each node">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -11,6 +11,7 @@ import { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
 import { UseURLSortResult } from 'hooks/useURLSort';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     CLUSTER_CVE_STATUS_SORT_FIELD,
     CVE_SORT_FIELD,
@@ -81,7 +82,7 @@ function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
         >
             <Thead noWrap>
                 <Tr>
-                    <Th aria-label="Expand row" />
+                    <ExpandRowTh />
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                     <Th sort={getSortParams(CLUSTER_CVE_STATUS_SORT_FIELD)}>CVE status</Th>
                     <Th sort={getSortParams(CVE_TYPE_SORT_FIELD)}>CVE type</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -28,6 +28,7 @@ import CvssFormatted from 'Components/CvssFormatted';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 
+import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     CLUSTER_CVE_STATUS_SORT_FIELD,
     CVE_SORT_FIELD,
@@ -113,7 +114,7 @@ function CVEsTable({
         >
             <Thead noWrap>
                 <Tr>
-                    <Th aria-label="Expand row" />
+                    <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                     <Th sort={getSortParams(CLUSTER_CVE_STATUS_SORT_FIELD)}>CVE status</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -11,6 +11,7 @@ import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { TableUIState } from 'utils/getTableUIState';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import DeploymentComponentVulnerabilitiesTable, {
     DeploymentComponentVulnerability,
@@ -77,12 +78,10 @@ function AffectedDeploymentsTable({
 }: AffectedDeploymentsTableProps) {
     const expandedRowSet = useSet<string>();
     return (
-        // TODO UX question - Collapse to cards, or allow headers to overflow?
-        // <TableComposable gridBreakPoint="grid-xl">
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTh />
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>
                     <Th>
                         Images by severity

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -12,6 +12,7 @@ import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { TableUIState } from 'utils/getTableUIState';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     getIsSomeVulnerabilityFixable,
     getHighestCvssScore,
@@ -96,7 +97,7 @@ function AffectedImagesTable({
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTh />
                     <Th sort={getSortParams('Image')}>Image</Th>
                     <Th>CVE severity</Th>
                     <Th>CVSS</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -24,6 +24,7 @@ import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import { TableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import { VulnerabilitySeverityLabel } from '../../types';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
@@ -150,7 +151,7 @@ function CVEsTable({
         <Table borders={false} variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <TooltipTh tooltip="Severity of this CVE across images">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -11,6 +11,7 @@ import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/Vulnera
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import { TableUIState } from 'utils/getTableUIState';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 
@@ -65,7 +66,7 @@ function DeploymentVulnerabilitiesTable({
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTh />
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <Th>OS</Th>
                     <Th>CVE severity</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -23,6 +23,7 @@ import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
+import ExpandRowTh from 'Components/ExpandRowTh';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { TableUIState } from 'utils/getTableUIState';
 import { getIsSomeVulnerabilityFixable } from '../../utils/vulnerabilityUtils';
@@ -108,7 +109,7 @@ function ImageVulnerabilitiesTable({
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <Th sort={getSortParams('Severity')}>CVE severity</Th>


### PR DESCRIPTION
## Description

Adds and implements in VM 2.0 a new component that auto-sets the width on the table header for the column that holds the button to expand a table row. Additionally ensures the `aria-label` prop is set for this otherwise empty header cell.

The width is calculated based on the contents of a `Td` component with the `expand` prop set.

Note that manual widths for other table columns need to be applied to remove this problem completely, but applying this to the first column (that collapses to a width of zero) greatly reduces the impact.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before:

https://github.com/stackrox/stackrox/assets/1292638/c7bb0cbc-61a1-4d82-88de-b3f4c198a2b9


After:

https://github.com/stackrox/stackrox/assets/1292638/8910c0a0-ccae-41e6-8f08-036775b0432d

