### PR TITLE
chore: Stop installing `snappy` and `zstd` in Konflux-built main

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -18,8 +18,7 @@ RUN /tmp/.konflux/subscription-manager-bro.sh register "$FINAL_STAGE_PATH"
 RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
     dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:13 && \
     # find is used in /stackrox/import-additional-cas \
-    # snappy provides libsnappy.so.1, which is needed by most stackrox binaries \
-    dnf -y --installroot="$FINAL_STAGE_PATH" install findutils snappy zstd postgresql && \
+    dnf -y --installroot="$FINAL_STAGE_PATH" install findutils zstd postgresql && \
     # We can do usual cleanup while we're here: remove packages that would trigger violations. \
     dnf -y --installroot="$FINAL_STAGE_PATH" clean all && \
     rpm --root="$FINAL_STAGE_PATH" --verbose -e --nodeps $(rpm --root="$FINAL_STAGE_PATH" -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -18,7 +18,7 @@ RUN /tmp/.konflux/subscription-manager-bro.sh register "$FINAL_STAGE_PATH"
 RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
     dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:13 && \
     # find is used in /stackrox/import-additional-cas \
-    dnf -y --installroot="$FINAL_STAGE_PATH" install findutils zstd postgresql && \
+    dnf -y --installroot="$FINAL_STAGE_PATH" install findutils postgresql && \
     # We can do usual cleanup while we're here: remove packages that would trigger violations. \
     dnf -y --installroot="$FINAL_STAGE_PATH" clean all && \
     rpm --root="$FINAL_STAGE_PATH" --verbose -e --nodeps $(rpm --root="$FINAL_STAGE_PATH" -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \


### PR DESCRIPTION
## Description

These were copied from downstream dockerfile where they are remnants from some former rocksdb times, I believe.

See
- https://redhat-internal.slack.com/archives/CELUQKESC/p1717439341338869
- https://redhat-internal.slack.com/archives/CELUQKESC/p1717703961788399

## Checklist
- [x] Investigated and inspected CI test results

These won't be done.
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Actually, won't do any this time. I take responsibility to fix any issues in Konflux-built product arising from this.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
