### PR TITLE
ROX-24570: Adding table filters to Profile Clusters

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -24,18 +24,13 @@ import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/Com
 import { getFilteredConfig } from 'Components/CompoundSearchFilter/utils/searchFilterConfig';
 import useURLSearch from 'hooks/useURLSearch';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import {
-    CHECK_NAME_QUERY,
-    CHECK_STATUS_QUERY,
-    CLUSTER_QUERY,
-} from './compliance.coverage.constants';
+import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
-import CheckStatusDropdown from './components/CheckStatusDropdown';
 
 function ProfileChecksPage() {
     const { profileName } = useParams();
@@ -46,13 +41,13 @@ function ProfileChecksPage() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields: [CHECK_NAME_QUERY],
         defaultSortOption: { field: CHECK_NAME_QUERY, direction: 'asc' },
-        onSort: () => setPage(1),
+        onSort: () => setPage(1, 'replace'),
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfileChecks = useCallback(
-        () => getComplianceProfileResults(profileName, { sortOption, page, perPage }),
-        [page, perPage, profileName, sortOption]
+        () => getComplianceProfileResults(profileName, { sortOption, page, perPage, searchFilter }),
+        [page, perPage, profileName, sortOption, searchFilter]
     );
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
@@ -76,24 +71,6 @@ function ProfileChecksPage() {
         setSearchFilter({
             ...searchFilter,
             [category]: newSelection,
-        });
-    };
-
-    const onSelectCheckStatus = (
-        filterType: 'Compliance Check Status',
-        checked: boolean,
-        selection: string
-    ) => {
-        const currentSelection = searchFilter[filterType] || [];
-        let newSelection = !Array.isArray(currentSelection) ? [currentSelection] : currentSelection;
-        if (checked) {
-            newSelection.push(selection);
-        } else {
-            newSelection = newSelection.filter((value) => value !== selection);
-        }
-        setSearchFilter({
-            ...searchFilter,
-            [filterType]: newSelection,
         });
     };
 
@@ -131,12 +108,6 @@ function ProfileChecksPage() {
                                         onSearch={onSearch}
                                     />
                                 </ToolbarItem>
-                                <ToolbarItem align={{ default: 'alignRight' }}>
-                                    <CheckStatusDropdown
-                                        searchFilter={searchFilter}
-                                        onSelect={onSelectCheckStatus}
-                                    />
-                                </ToolbarItem>
                             </ToolbarGroup>
                             <ToolbarGroup className="pf-v5-u-w-100">
                                 <SearchFilterChips
@@ -148,10 +119,6 @@ function ProfileChecksPage() {
                                         {
                                             displayName: 'Cluster',
                                             searchFilterName: CLUSTER_QUERY,
-                                        },
-                                        {
-                                            displayName: 'Compliance Status',
-                                            searchFilterName: CHECK_STATUS_QUERY,
                                         },
                                     ]}
                                 />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
@@ -1,4 +1,3 @@
 // searchable and sortable query parameter fields
 export const CLUSTER_QUERY = 'Cluster';
 export const CHECK_NAME_QUERY = 'Compliance Check Name';
-export const CHECK_STATUS_QUERY = 'Compliance Check Status';

--- a/ui/apps/platform/src/services/ComplianceCommon.ts
+++ b/ui/apps/platform/src/services/ComplianceCommon.ts
@@ -1,7 +1,7 @@
 import qs from 'qs';
 
 import { SearchQueryOptions } from 'types/search';
-import { getPaginationParams } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 export const complianceV2Url = '/v2/compliance';
 
@@ -64,10 +64,14 @@ export function buildNestedRawQueryParams({
     page,
     perPage,
     sortOption,
+    searchFilter = {},
 }: SearchQueryOptions): string {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const pagination = getPaginationParams({ page, perPage, sortOption });
     const queryParameters = {
         query: {
-            pagination: getPaginationParams({ page, perPage, sortOption }),
+            query,
+            pagination,
         },
     };
     return qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -70,9 +70,9 @@ export function getComplianceProfileCheckResult(
  */
 export function getComplianceProfileResults(
     profileName: string,
-    { sortOption, page, perPage }: SearchQueryOptions
+    { sortOption, page, perPage, searchFilter }: SearchQueryOptions
 ): Promise<ListComplianceProfileResults> {
-    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption, searchFilter });
     return axios
         .get<ListComplianceProfileResults>(
             `${complianceResultsBaseUrl}/results/profiles/${profileName}/checks?${params}`

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -55,9 +55,9 @@ export function getComplianceProfilesStats(
  */
 export function getComplianceClusterStats(
     profileName: string,
-    { sortOption, page, perPage }: SearchQueryOptions
+    { sortOption, page, perPage, searchFilter }: SearchQueryOptions
 ): Promise<ListComplianceClusterOverallStatsResponse> {
-    const params = buildNestedRawQueryParams({ page, perPage, sortOption });
+    const params = buildNestedRawQueryParams({ page, perPage, sortOption, searchFilter });
     return axios
         .get<ListComplianceClusterOverallStatsResponse>(
             `${complianceResultsStatsBaseUrl}/profiles/${profileName}/clusters?${params}`


### PR DESCRIPTION
## Description

This PR integrates Advanced Filters into the Compliance Profile Clusters page. After discussions with David Shrewsberry and Brad, I'm also adjusting a few things on the Compliance Profile Checks page.

1. The compliance status dropdown was removed on both pages because it didn't make sense in this context
2. Hooking up URL search to filter API results
3. Adding search filter chips

## Profile Clusters
<img width="1552" alt="Screenshot 2024-06-06 at 1 11 27 PM" src="https://github.com/stackrox/stackrox/assets/4805485/a7b803a5-deb0-4a8d-ada4-29c11e43ede3">
<img width="1552" alt="Screenshot 2024-06-06 at 1 11 33 PM" src="https://github.com/stackrox/stackrox/assets/4805485/ac8e7af1-e6ca-4847-9253-27f755a3f41e">

## Profile Checks

<img width="1552" alt="Screenshot 2024-06-06 at 1 11 42 PM" src="https://github.com/stackrox/stackrox/assets/4805485/903e5059-9453-48d6-bb26-e8ee2d22806b">
<img width="1552" alt="Screenshot 2024-06-06 at 1 11 46 PM" src="https://github.com/stackrox/stackrox/assets/4805485/adc4b0ed-ec13-4e9c-ae5e-c1c587da59fd">


