### PR TITLE
fix(ui): show short-lived access banner only in list

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -203,6 +203,60 @@ function AuthProviders(): ReactElement {
                             )
                         }
                     />
+                    <PageSection variant="light">
+                        <Alert
+                            isInline
+                            variant="info"
+                            title="Consider using short-lived tokens for machine-to-machine communications
+                            such as CI/CD pipelines, scripts, and other automation."
+                        >
+                            <Flex
+                                direction={{ default: 'column' }}
+                                spaceItems={{ default: 'spaceItemsMd' }}
+                            >
+                                <Flex direction={{ default: 'row' }}>
+                                    <ExternalLink>
+                                        <a
+                                            href={getVersionedDocs(
+                                                version,
+                                                'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
+                                            )}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            How to configure short-lived access
+                                        </a>
+                                    </ExternalLink>
+                                    {hasWriteAccessForPage && (
+                                        <Link
+                                            to={`${integrationsPath}/authProviders/machineAccess/create`}
+                                        >
+                                            Create a machine access configuration
+                                        </Link>
+                                    )}
+                                </Flex>
+                                <ExpandableSection
+                                    toggleText="More resources"
+                                    onToggle={(_event, _isExpanded: boolean) =>
+                                        onToggle(_isExpanded)
+                                    }
+                                    isExpanded={isInfoExpanded}
+                                >
+                                    <Flex direction={{ default: 'column' }}>
+                                        <ExternalLink>
+                                            <a
+                                                href="https://github.com/stackrox/central-login"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                GitHub Action for short-lived access
+                                            </a>
+                                        </ExternalLink>
+                                    </Flex>
+                                </ExpandableSection>
+                            </Flex>
+                        </Alert>
+                    </PageSection>
                 </>
             ) : (
                 <AccessControlBreadcrumbs
@@ -213,60 +267,6 @@ function AuthProviders(): ReactElement {
                             : selectedAuthProvider?.name
                     }
                 />
-            )}
-            {isList && (
-                <PageSection>
-                    <Alert
-                        isInline
-                        variant="info"
-                        title="Consider using short-lived tokens for machine-to-machine communications
-                            such as CI/CD pipelines, scripts, and other automation."
-                    >
-                        <Flex
-                            direction={{ default: 'column' }}
-                            spaceItems={{ default: 'spaceItemsMd' }}
-                        >
-                            <Flex direction={{ default: 'row' }}>
-                                <ExternalLink>
-                                    <a
-                                        href={getVersionedDocs(
-                                            version,
-                                            'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
-                                        )}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        How to configure short-lived access
-                                    </a>
-                                </ExternalLink>
-                                {hasWriteAccessForPage && (
-                                    <Link
-                                        to={`${integrationsPath}/authProviders/machineAccess/create`}
-                                    >
-                                        Create a machine access configuration
-                                    </Link>
-                                )}
-                            </Flex>
-                            <ExpandableSection
-                                toggleText="More resources"
-                                onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
-                                isExpanded={isInfoExpanded}
-                            >
-                                <Flex direction={{ default: 'column' }}>
-                                    <ExternalLink>
-                                        <a
-                                            href="https://github.com/stackrox/central-login"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            GitHub Action for short-lived access
-                                        </a>
-                                    </ExternalLink>
-                                </Flex>
-                            </ExpandableSection>
-                        </Flex>
-                    </Alert>
-                </PageSection>
             )}
             <PageSection variant={isList ? 'default' : 'light'}>
                 {isFetchingAuthProviders || isFetchingRoles ? (

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -214,56 +214,60 @@ function AuthProviders(): ReactElement {
                     }
                 />
             )}
-            <PageSection>
-                <Alert
-                    isInline
-                    variant="info"
-                    title="Consider using short-lived tokens for machine-to-machine communications
+            {isList && (
+                <PageSection>
+                    <Alert
+                        isInline
+                        variant="info"
+                        title="Consider using short-lived tokens for machine-to-machine communications
                             such as CI/CD pipelines, scripts, and other automation."
-                >
-                    <Flex
-                        direction={{ default: 'column' }}
-                        spaceItems={{ default: 'spaceItemsMd' }}
                     >
-                        <Flex direction={{ default: 'row' }}>
-                            <ExternalLink>
-                                <a
-                                    href={getVersionedDocs(
-                                        version,
-                                        'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
-                                    )}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    How to configure short-lived access
-                                </a>
-                            </ExternalLink>
-                            {hasWriteAccessForPage && (
-                                <Link to={`${integrationsPath}/authProviders/machineAccess/create`}>
-                                    Create a machine access configuration
-                                </Link>
-                            )}
-                        </Flex>
-                        <ExpandableSection
-                            toggleText="More resources"
-                            onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
-                            isExpanded={isInfoExpanded}
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
                         >
-                            <Flex direction={{ default: 'column' }}>
+                            <Flex direction={{ default: 'row' }}>
                                 <ExternalLink>
                                     <a
-                                        href="https://github.com/stackrox/central-login"
+                                        href={getVersionedDocs(
+                                            version,
+                                            'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
+                                        )}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
-                                        GitHub Action for short-lived access
+                                        How to configure short-lived access
                                     </a>
                                 </ExternalLink>
+                                {hasWriteAccessForPage && (
+                                    <Link
+                                        to={`${integrationsPath}/authProviders/machineAccess/create`}
+                                    >
+                                        Create a machine access configuration
+                                    </Link>
+                                )}
                             </Flex>
-                        </ExpandableSection>
-                    </Flex>
-                </Alert>
-            </PageSection>
+                            <ExpandableSection
+                                toggleText="More resources"
+                                onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
+                                isExpanded={isInfoExpanded}
+                            >
+                                <Flex direction={{ default: 'column' }}>
+                                    <ExternalLink>
+                                        <a
+                                            href="https://github.com/stackrox/central-login"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            GitHub Action for short-lived access
+                                        </a>
+                                    </ExternalLink>
+                                </Flex>
+                            </ExpandableSection>
+                        </Flex>
+                    </Alert>
+                </PageSection>
+            )}
             <PageSection variant={isList ? 'default' : 'light'}>
                 {isFetchingAuthProviders || isFetchingRoles ? (
                     <Bullseye>


### PR DESCRIPTION
## Description

After introducing the banner about additional information of short-lived access in the access control page when auth providers selected, the banner always showed (i.e. when listing providers as well sa creating them).

During creation the banner is more confusing instead of helpful, so changed the logic to only show when we're listing the providers.

![Screenshot 2024-06-07 at 14 22 26](https://github.com/stackrox/stackrox/assets/89904305/4e697da4-73fb-41b5-a579-bd6b410daffc)
![Screenshot 2024-06-07 at 14 22 45](https://github.com/stackrox/stackrox/assets/89904305/eb497d76-60f7-4661-8054-5cf7f0d09bf4)



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
