### PR TITLE
ROX-20855: Unmark central-db docker-entrypoint.sh as owned by postgres

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -45,8 +45,6 @@ RUN microdnf upgrade -y --nobest && \
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
 # Use SIGINT to bring down with Fast Shutdown mode


### PR DESCRIPTION
## Description

There's no need to own executable by `postgres` user, hence removed `chown`.
There's no need to add executable flag because `COPY` statement preserves it and the original file has it, hence removed `chmod`.

## Checklist
- [ ] Investigated and inspected CI test results

I don't think changelog is needed, rest too.
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Only CI but it should show if central-db malfunctions.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
