### PR TITLE
ROX-24565: Replace local time with UTC in scan schedules

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -78,7 +78,7 @@ describe('Compliance Schedules', () => {
         getInputByLabel('On day(s)').click();
         cy.get('.pf-v5-c-select.pf-m-expanded .pf-v5-c-check__label:contains("Tuesday")').click();
         cy.get('input[aria-label="Time picker"]').click(); // PF Datepicker doesn't follow pattern used by helper function
-        cy.get('.pf-v5-c-menu.pf-m-scrollable button:contains("12:30 AM")').click();
+        cy.get('.pf-v5-c-menu.pf-m-scrollable button:contains("00:30")').click();
 
         cy.get('.pf-v5-c-wizard__footer button:contains("Next")').click();
     });

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -7,7 +7,7 @@ import { complianceEnhancedSchedulesPath } from 'routePaths';
 
 import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
 import { PageActions } from './compliance.scanConfigs.utils';
-import ScanConfigsTablePage from './Table/ScanConfigsTablePage';
+import ScanConfigsTablePage from './ScanConfigsTablePage';
 import CreateScanConfigPage from './CreateScanConfigPage';
 import ScanConfigDetailPage from './ScanConfigDetailPage';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -7,9 +7,9 @@ import { complianceEnhancedSchedulesPath } from 'routePaths';
 
 import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
 import { PageActions } from './compliance.scanConfigs.utils';
-import ScanConfigsTablePage from './ScanConfigsTablePage';
 import CreateScanConfigPage from './CreateScanConfigPage';
 import ScanConfigDetailPage from './ScanConfigDetailPage';
+import ScanConfigsTablePage from './ScanConfigsTablePage';
 
 function ScanConfigsPage() {
     /*

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState, useCallback } from 'react';
 import { generatePath, Link, useHistory } from 'react-router-dom';
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
 import {
@@ -49,11 +48,14 @@ import { SortOption } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { displayOnlyItemOrItemCount } from 'utils/textUtils';
 
-import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../../compliance.constants';
-import { SCAN_CONFIG_NAME_QUERY } from '../compliance.scanConfigs.constants';
-import { scanConfigDetailsPath } from '../compliance.scanConfigs.routes';
-import { formatScanSchedule } from '../compliance.scanConfigs.utils';
-import ScanConfigActionsColumn from '../ScanConfigActionsColumn';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
+import { SCAN_CONFIG_NAME_QUERY } from './compliance.scanConfigs.constants';
+import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
+import {
+    formatScanSchedule,
+    getTimeWithHourMinuteFromISO8601,
+} from './compliance.scanConfigs.utils';
+import ScanConfigActionsColumn from './ScanConfigActionsColumn';
 
 type ScanConfigsTablePageProps = {
     hasWriteAccessForCompliance: boolean;
@@ -193,7 +195,7 @@ function ScanConfigsTablePage({
                     <Td dataLabel="Schedule">{formatScanSchedule(scanConfig.scanSchedule)}</Td>
                     <Td dataLabel="Last run">
                         {lastExecutedTime
-                            ? format(lastExecutedTime, 'DD MMM YYYY, h:mm:ss A')
+                            ? getTimeWithHourMinuteFromISO8601(lastExecutedTime)
                             : 'Scanning now'}
                     </Td>
                     <Td dataLabel="Clusters">

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -16,7 +16,6 @@ import {
     FlexItem,
     PageSection,
     Spinner,
-    Timestamp,
     Title,
 } from '@patternfly/react-core';
 
@@ -33,7 +32,11 @@ import {
 } from 'services/ComplianceScanConfigurationService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import { customBodyDefault, getSubjectDefault } from './compliance.scanConfigs.utils';
+import {
+    customBodyDefault,
+    getSubjectDefault,
+    getTimeWithHourMinuteFromISO8601,
+} from './compliance.scanConfigs.utils';
 import ScanConfigParametersView from './components/ScanConfigParametersView';
 import ScanConfigProfilesView from './components/ScanConfigProfilesView';
 import ScanConfigClustersTable from './components/ScanConfigClustersTable';
@@ -189,27 +192,19 @@ function ViewScanConfigDetail({
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Last run</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            {scanConfig.lastExecutedTime ? (
-                                                <Timestamp
-                                                    date={new Date(scanConfig.lastExecutedTime)}
-                                                    dateFormat="short"
-                                                    timeFormat="long"
-                                                    className="pf-v5-u-color-100 pf-v5-u-font-size-md"
-                                                />
-                                            ) : (
-                                                'Scan is in progress'
-                                            )}
+                                            {scanConfig.lastExecutedTime
+                                                ? getTimeWithHourMinuteFromISO8601(
+                                                      scanConfig.lastExecutedTime
+                                                  )
+                                                : 'Scan is in progress'}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Last updated</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Timestamp
-                                                date={new Date(scanConfig.lastUpdatedTime)}
-                                                dateFormat="short"
-                                                timeFormat="long"
-                                                className="pf-v5-u-color-100 pf-v5-u-font-size-md"
-                                            />
+                                            {getTimeWithHourMinuteFromISO8601(
+                                                scanConfig.lastUpdatedTime
+                                            )}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 </ScanConfigParametersView>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -17,9 +17,11 @@ import {
 import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
-import { getTimeHoursMinutes } from 'utils/dateUtils';
 
-import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
+import {
+    ScanConfigFormValues,
+    getHourMinuteStringFromScheduleBase,
+} from '../compliance.scanConfigs.utils';
 
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
@@ -38,9 +40,7 @@ function ScanConfigOptions(): ReactElement {
         isValid?: boolean
     ): void {
         if (isValid && hour !== undefined) {
-            const date = new Date();
-            date.setHours(hour, minute, 0, 0);
-            const timeString = getTimeHoursMinutes(date);
+            const timeString = getHourMinuteStringFromScheduleBase({ hour, minute: minute ?? 0 });
             formik.setFieldValue('parameters.time', timeString);
         } else {
             formik.setFieldValue('parameters.time', time);
@@ -196,9 +196,11 @@ function ScanConfigOptions(): ReactElement {
                                             errors={formik.errors}
                                             isRequired
                                             touched={formik.touched}
+                                            helperText="Select scan time in UTC"
                                         >
                                             <TimePicker
                                                 time={formik.values.parameters.time}
+                                                is24Hour
                                                 onChange={handleTimeChange}
                                                 inputProps={{
                                                     onBlur: formik.handleBlur,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.test.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.test.ts
@@ -13,7 +13,7 @@ describe('compliance.scanConfigs.utils', () => {
                 name: 'ok-ok.ok',
                 description: 'Needles and Pins',
                 intervalType: 'DAILY',
-                time: '3:00 AM',
+                time: '03:00',
                 daysOfWeek: [],
                 daysOfMonth: [],
             };
@@ -33,7 +33,7 @@ describe('compliance.scanConfigs.utils', () => {
                 description:
                     'Several Species of Small Furry Animals Gathered Together in a Cave and Grooving with a Pict',
                 intervalType: 'WEEKLY',
-                time: '13:00 PM',
+                time: '13:00',
                 daysOfWeek: ['1'],
                 daysOfMonth: [],
             };
@@ -56,7 +56,7 @@ describe('compliance.scanConfigs.utils', () => {
                 description:
                     'Several Species of Small Furry Animals Gathered Together in a Cave and Grooving with a Pict',
                 intervalType: 'MONTHLY',
-                time: '11:00 PM',
+                time: '23:00',
                 daysOfWeek: [],
                 daysOfMonth: ['1', '15'],
             };
@@ -86,7 +86,7 @@ describe('compliance.scanConfigs.utils', () => {
 
             expect(formValues).toEqual({
                 intervalType: 'DAILY',
-                time: '10:00 PM',
+                time: '22:00',
                 daysOfWeek: [],
                 daysOfMonth: [],
             });
@@ -106,7 +106,7 @@ describe('compliance.scanConfigs.utils', () => {
 
             expect(formValues).toEqual({
                 intervalType: 'WEEKLY',
-                time: '3:00 PM',
+                time: '15:00',
                 daysOfWeek: ['1'],
                 daysOfMonth: [],
             });
@@ -126,7 +126,7 @@ describe('compliance.scanConfigs.utils', () => {
 
             expect(formValues).toEqual({
                 intervalType: 'MONTHLY',
-                time: '5:00 AM',
+                time: '05:00',
                 daysOfWeek: [],
                 daysOfMonth: ['15'],
             });

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
@@ -39,7 +39,7 @@ export type PageActions = 'create' | 'edit' | 'clone';
 export function getTimeWithHourMinuteFromISO8601(timeISO8601: string) {
     // Given an ISO 8601 date time string from response, for example, 2024-02-29T17:13:28.710959319Z
     // Return yy-mm-dd hh:mm UTC
-    return `${timeISO8601.slice(0, 10)} ${timeISO8601.slice(11, 16)} UTC`;
+    return `${timeISO8601.slice(0, 8)} ${timeISO8601.slice(9, 14)} UTC`;
 }
 
 function pad2(timeElement: number) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
@@ -43,13 +43,13 @@ export function getTimeWithHourMinuteFromISO8601(timeISO8601: string) {
     return `${timeISO8601.slice(0, 10)} ${timeISO8601.slice(11, 16)} UTC`;
 }
 
-function pad2(timeElement: number) {
+function padStart2(timeElement: number) {
     return timeElement.toString().padStart(2, '0');
 }
 
 export function getHourMinuteStringFromScheduleBase({ hour, minute }: ScheduleBase) {
     // Return 24-hour hh:mm string for hour and minute.
-    return [pad2(hour), pad2(minute)].join(':');
+    return [padStart2(hour), padStart2(minute)].join(':');
 }
 
 function getScheduleBaseFromHourMinuteString(time: string): ScheduleBase {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
@@ -37,9 +37,10 @@ export type ScanConfigFormValues = {
 export type PageActions = 'create' | 'edit' | 'clone';
 
 export function getTimeWithHourMinuteFromISO8601(timeISO8601: string) {
-    // Given an ISO 8601 date time string from response, for example, 2024-02-29T17:13:28.710959319Z
-    // Return yy-mm-dd hh:mm UTC
-    return `${timeISO8601.slice(0, 8)} ${timeISO8601.slice(9, 14)} UTC`;
+    // Given an ISO 8601 date time string from response,
+    // for example, 2024-02-29T17:13:28.710959319Z
+    // Return yyyy-mm-dd hh:mm UTC
+    return `${timeISO8601.slice(0, 10)} ${timeISO8601.slice(11, 16)} UTC`;
 }
 
 function pad2(timeElement: number) {


### PR DESCRIPTION
## Description

### Problems

* Not clear on form that **Time** of scan schedule is UTC.
* To make even less clear, scan schedule details present local times.
* Scan schedule time and **Last run** time need consistent time zone.

### Analysis

* David Shrewsberry confirmed that Central and Compliance Operator interpret `{ hour, minute }` in `scanSchedule` as UTC.

### Solution

* Replace 12-hour AM/PM which implies local time with 24-hour with UTC.

### Changes

1. Edit compliance.scanConfigs.utils.tsx file.
    * Add `getTimeWithHourMinuteFromISO8601` function for `lastExecutedTime` and `listUpdatedTime` from responses.
    * Factor out `getHourMinuteStringForScheduleBase` and `getScheduleBaseForHourMinuteString` functions to convert between `{ hour, minute }` in payload/response and HH:MM string for `TimePicker` element.
    * Include **UTC** suffix in `formatScanSchedule` function called by `ScanConfigsParametersView` and `ScanConfigsTablePage` elements.
2. Edit ScanConfigOptions.tsx file.
    * Replace indirect date conversion via `getTimeHoursMinutes` with `getHourMinuteStringForScheduleBase` function.
3. Edit ScanConfigsPage.tsx file.
    * Adjust path to ScanConfigsTablePage.tsx file.
4. Move and edit ScanConfigsTablePage.tsx file.
    * Replace `format` from date-fns package with `getTimeWithHourMinuteFromISO8601` function.
5. Edit ViewScanConfigDetail.tsx file.
    * Replace `TimeStamp` element with `getTimeWithHourMinuteFromISO8601` function.
### Residue

1. Investigate whether `if` statement is needed, or just `formik.setFieldValue('parameters.time', time);` from `else` block for 24-hour time:

    ```ts
    if (isValid && hour !== undefined) {
        const timeString = getHourMinuteStringFromScheduleBase({ hour, minute: minute ?? 0 });
        formik.setFieldValue('parameters.time', timeString);
    } else {
        formik.setFieldValue('parameters.time', time);
    }
    ```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Prerequisite for `yarn start` in ui folder:

```sh
export ROX_COMPLIANCE_REPORTING=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636748 - 4636748
        total -2065 = 11711269 - 11713334
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/schedules

    * Before changes, see 12-hour **AM** or **PM** in **Last run** column.
        ![ScanConfigsTablePage_12](https://github.com/stackrox/stackrox/assets/11862657/7804a0c3-d499-49a6-a572-915c04cc04f0)

    * After changes, see 24-hour **UTC** in **Last run** column.
        ![ScanConfigsTablePage_24](https://github.com/stackrox/stackrox/assets/11862657/3878d895-76f4-45ac-91a9-5525b911b2d0)

2. Click the link to scan config detail page.

    * Before changes, see 12-hour **AM** or **PM** in **Schedule** value plus local time zone in **Last run** and **Last updated** values.
        ![ViewScanConfigDetail_12](https://github.com/stackrox/stackrox/assets/11862657/3ca016e2-a32c-4208-9e85-3a9c41da97e0)

    * After changes, see 24-hour **UTC** in the 3 date values.
        ![ViewScanConfigDetail_24](https://github.com/stackrox/stackrox/assets/11862657/06e3f1e4-82dc-441f-9729-67c02a355a2c)

3. Click **Actions** and then click **Edit scan schedule**.

    * Before changes, see 12-hour **AM** or **PM** in **Time** value.
        ![ScanConfigOptions_12](https://github.com/stackrox/stackrox/assets/11862657/13188807-b801-4573-a739-de8aed539e67)

    * After changes, se 24-hour **UTC** in **Time** value plus helper text.
        ![ScanConfigOptions_24](https://github.com/stackrox/stackrox/assets/11862657/4bc35f15-8ee6-40f7-9fc4-6428048cf30d)

4. Click **Review**.

    * Before changes, see 12-hour **AM** or **PM** in **Schedule** value.
        ![ReviewConfig_12](https://github.com/stackrox/stackrox/assets/11862657/c35c106e-f2a2-41fa-a71c-3a55cf9e5168)

    * After changes, se 24-hour **UTC** in **Schedule** value.
        ![ReviewConfig_24](https://github.com/stackrox/stackrox/assets/11862657/172c5769-1eec-4fb9-b5f6-d430c8926731)
