### PR TITLE
chore(runtime-improvements): NetworkFlow processing improvements

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -629,7 +629,7 @@ type networkEntityDetails struct {
 func (d *detectorImpl) getNetworkFlowEntityDetails(info *storage.NetworkEntityInfo) (networkEntityDetails, error) {
 	switch info.GetType() {
 	case storage.NetworkEntityInfo_DEPLOYMENT:
-		deployment := d.deploymentStore.Get(info.GetId())
+		deployment := d.deploymentStore.GetSnapshot(info.GetId())
 		if deployment == nil {
 			// Maybe the deployment is already removed. Don't run the flow through policy anymore
 			return networkEntityDetails{}, errors.Wrapf(deploymentNotFoundErr, "Deployment with ID: %q not found while trying to run network flow policy", info.GetId())

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -317,7 +317,7 @@ func (m *networkFlowManager) Notify(e common.SensorComponentEvent) {
 	if !features.SensorCapturesIntermediateEvents.Enabled() {
 		log.Info(common.LogSensorComponentEvent(e))
 		switch e {
-		case common.SensorComponentEventCentralReachable:
+		case common.SensorComponentEventSyncFinished:
 			m.resetContext()
 			m.resetLastSentState()
 			m.centralReady.Signal()

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -247,15 +248,16 @@ func NewManager(
 		externalSrcs:      externalSrcs,
 		policyDetector:    policyDetector,
 		enricherTicker:    enricherTicker,
+		initialSync:       &atomic.Bool{},
 		finished:          &sync.WaitGroup{},
 		activeConnections: make(map[connection]*networkConnIndicator),
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicator),
 	}
 
+	enricherTicker.Stop()
 	if features.SensorCapturesIntermediateEvents.Enabled() {
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.NetworkFlowBufferSize))
 	} else {
-		enricherTicker.Stop()
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage)
 	}
 
@@ -284,6 +286,7 @@ type networkFlowManager struct {
 	ctxMutex    sync.Mutex
 	cancelCtx   context.CancelFunc
 	pipelineCtx context.Context
+	initialSync *atomic.Bool
 
 	enricherTicker *time.Ticker
 
@@ -314,18 +317,25 @@ func (m *networkFlowManager) Capabilities() []centralsensor.SensorCapability {
 }
 
 func (m *networkFlowManager) Notify(e common.SensorComponentEvent) {
-	if !features.SensorCapturesIntermediateEvents.Enabled() {
-		log.Info(common.LogSensorComponentEvent(e))
-		switch e {
-		case common.SensorComponentEventSyncFinished:
-			m.resetContext()
-			m.resetLastSentState()
-			m.centralReady.Signal()
-			m.enricherTicker.Reset(tickerTime)
-		case common.SensorComponentEventOfflineMode:
-			m.centralReady.Reset()
-			m.enricherTicker.Stop()
+	log.Info(common.LogSensorComponentEvent(e))
+	switch e {
+	case common.SensorComponentEventSyncFinished:
+		if features.SensorCapturesIntermediateEvents.Enabled() {
+			if m.initialSync.CompareAndSwap(false, true) {
+				m.enricherTicker.Reset(tickerTime)
+			}
+			return
 		}
+		m.resetContext()
+		m.resetLastSentState()
+		m.centralReady.Signal()
+		m.enricherTicker.Reset(tickerTime)
+	case common.SensorComponentEventOfflineMode:
+		if features.SensorCapturesIntermediateEvents.Enabled() {
+			return
+		}
+		m.centralReady.Reset()
+		m.enricherTicker.Stop()
 	}
 }
 

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -537,7 +537,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connection",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: expectEntityLookupContainerHelper(mockEntity, 1, clusterentities.ContainerMetadata{
 				DeploymentID: srcID,
 			}, true),
@@ -560,7 +560,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connections",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -607,7 +607,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received endpoints",
-			notify:   common.SensorComponentEventCentralReachable,
+			notify:   common.SensorComponentEventSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -696,7 +696,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(1)
 	mockEntity.EXPECT().RecordTick().AnyTimes()
 	addHostConnection(m, createHostnameConnections(hostname).withConnectionPair(createConnectionPair()))
-	m.Notify(common.SensorComponentEventCentralReachable)
+	m.Notify(common.SensorComponentEventSyncFinished)
 	fakeTicker <- time.Now()
 	select {
 	case <-time.After(10 * time.Second):
@@ -704,7 +704,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	case msg, ok := <-m.sensorUpdates:
 		s.Require().True(ok, "the sensorUpdates channel should not be closed")
 		m.Notify(common.SensorComponentEventOfflineMode)
-		m.Notify(common.SensorComponentEventCentralReachable)
+		m.Notify(common.SensorComponentEventSyncFinished)
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)


### PR DESCRIPTION
## Description

This PR adds a few improvements in how the NetworkFlows are processed:
- The NetworkFlows do not start getting processed after the initial sync is done with k8s.
- The NetworkFlows use the `GetSnapshot` function instead of the `Get` function.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
