### PR TITLE
ROX-24612: workload CVE list advanced filters

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -82,6 +82,23 @@ export function selectSearchOption(searchOption) {
     cy.get(selectors.searchOptionsDropdown).click();
 }
 
+export function selectEntitySearchOption(entity) {
+    cy.get(selectors.searchEntityDropdown).click();
+    cy.get(selectors.searchEntityMenuItem)
+        .contains(new RegExp(`^${entity}$`))
+        .click();
+
+    cy.get(selectors.searchEntityDropdown).click();
+}
+
+export function selectAttributeSearchOption(searchAttribute) {
+    cy.get(selectors.searchAttributeDropdown).click();
+    cy.get(selectors.searchAttributeMenuItem)
+        .contains(new RegExp(`^${searchAttribute}$`))
+        .click();
+    cy.get(selectors.searchAttributeDropdown).click();
+}
+
 /**
  * Type a value into the filter autocomplete typeahead and select the first matching value.
  * @param {('CVE' | 'Image' | 'Deployment' | 'Cluster' | 'Namespace' | 'Requester' | 'Request name')} searchOption
@@ -108,6 +125,23 @@ export function typeAndSelectCustomSearchFilterValue(searchOption, value) {
     cy.get(selectors.searchOptionsValueTypeahead(searchOption)).type(value);
     cy.get(selectors.searchOptionsValueMenuItem(searchOption)).contains(`Add "${value}"`).click();
     cy.get(selectors.searchOptionsValueTypeahead(searchOption)).click();
+}
+
+/**
+ * Type and enter custom text into the search filter typeahead
+ * @param {string} entity
+ * @param {string} searchTerm
+ * @param {string} value
+ */
+export function typeAndEnterCustomSearchFilterValue(entity, searchTerm, value) {
+    selectEntitySearchOption(entity);
+    selectAttributeSearchOption(searchTerm);
+    cy.get(selectors.searchValueTypeahead).click();
+    cy.get(selectors.searchValueTypeahead).type(value);
+    cy.get(selectors.searchValueApplyButton).click();
+    // TODO Needs implementation
+    // cy.get(selectors.searchValueMenuItem).contains(`Add "${value}"`).click();
+    cy.get(selectors.searchValueTypeahead).click();
 }
 
 /**

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -30,6 +30,19 @@ export const selectors = {
     filterChipGroupItemRemove: (category, item) =>
         `${selectors.filterChipGroupItem(category, item)} button[aria-label="close"]`,
 
+    searchEntityDropdown:
+        '.pf-v5-c-toolbar button[aria-label="compound search filter entity selector toggle"]',
+    searchEntityMenuItem:
+        '.pf-v5-c-toolbar div[aria-label="compound search filter entity selector menu"] button',
+    searchAttributeDropdown:
+        '.pf-v5-c-toolbar button[aria-label="compound search filter attribute selector toggle"]',
+    searchAttributeMenuItem:
+        '.pf-v5-c-toolbar div[aria-label="compound search filter attribute selector menu"] button',
+    searchValueTypeahead: '.pf-v5-c-toolbar input[aria-label^="Filter results by"]',
+    searchValueMenuItem: '.pf-v5-c-toolbar div[aria-label="Filter results select menu"] button',
+    searchValueApplyButton:
+        '.pf-v5-c-toolbar button[aria-label="Apply autocomplete input to search"]',
+
     // General selectors
     filteredViewLabel: '.pf-v5-c-label:contains("Filtered view")',
     entityTypeToggleItem: (entityType) =>

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -7,6 +7,7 @@ import {
     selectEntityTab,
     visitWorkloadCveOverview,
     typeAndSelectCustomSearchFilterValue,
+    typeAndEnterCustomSearchFilterValue,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
@@ -27,7 +28,11 @@ describe('Workload CVE Image Single page', () => {
         // If unified deferrals are not enabled, there is a good chance none of the visible images will
         // have CVEs, so we apply a wildcard filter to ensure only images with CVEs are visible
         if (!hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')) {
-            typeAndSelectCustomSearchFilterValue('CVE', '.*');
+            if (hasFeatureFlag('ROX_VULN_MGMT_ADVANCED_FILTERS')) {
+                typeAndEnterCustomSearchFilterValue('Image CVE', 'Name', '.*');
+            } else {
+                typeAndSelectCustomSearchFilterValue('CVE', '.*');
+            }
         }
 
         // Ensure the data in the table has settled

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -10,10 +10,13 @@ import {
     interactAndWaitForCveList,
     interactAndWaitForImageList,
     interactAndWaitForDeploymentList,
+    typeAndEnterCustomSearchFilterValue,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE overview page tests', () => {
+    const isAdvancedFiltersEnabled = hasFeatureFlag('ROX_VULN_MGMT_ADVANCED_FILTERS');
+
     withAuth();
 
     before(function () {
@@ -66,7 +69,8 @@ describe('Workload CVE overview page tests', () => {
             selectEntityTab(entity);
 
             // Ensure that only the correct filter chip is present
-            cy.get(selectors.filterChipGroupItem('Severity', 'Critical'));
+            const filterChipGroupName = isAdvancedFiltersEnabled ? 'CVE severity' : 'Severity';
+            cy.get(selectors.filterChipGroupItem(filterChipGroupName, 'Critical'));
             cy.get(selectors.filterChipGroupItems).should('have.lengthOf', 1);
 
             // TODO - See if there is a clean way to re-enable this to handle both cases where the
@@ -157,19 +161,27 @@ describe('Workload CVE overview page tests', () => {
         });
 
         it('should apply the correct filters when switching between "with cves" and "without cves" views', () => {
+            const severityChip = isAdvancedFiltersEnabled ? 'CVE severity' : 'Severity';
+            const cveStatusChip = 'CVE status';
+            const imageNameChip = isAdvancedFiltersEnabled ? 'Image Name' : 'Image';
+
             // Since we want to test the behavior of the default filters with the two cve views, we
             // do not clear them by default in this case
             visitWorkloadCveOverview({ clearFiltersOnVisit: false });
 
             interactAndWaitForCveList(() => {
                 // Add a local filter
-                typeAndSelectCustomSearchFilterValue('Image', 'quay.io/bogus');
+                if (isAdvancedFiltersEnabled) {
+                    typeAndEnterCustomSearchFilterValue('Image', 'Name', 'quay.io/bogus');
+                } else {
+                    typeAndSelectCustomSearchFilterValue('Image', 'quay.io/bogus');
+                }
 
                 // Check that default filters and the local filter are present
-                cy.get(selectors.filterChipGroupItem('Severity', 'Critical'));
-                cy.get(selectors.filterChipGroupItem('Severity', 'Important'));
-                cy.get(selectors.filterChipGroupItem('CVE status', 'Fixable'));
-                cy.get(selectors.filterChipGroupItem('Image', 'quay.io/bogus'));
+                cy.get(selectors.filterChipGroupItem(severityChip, 'Critical'));
+                cy.get(selectors.filterChipGroupItem(severityChip, 'Important'));
+                cy.get(selectors.filterChipGroupItem(cveStatusChip, 'Fixable'));
+                cy.get(selectors.filterChipGroupItem(imageNameChip, 'quay.io/bogus'));
             }).should((xhr) => {
                 // Ensure the default "with cves" view passes a "Vulnerability State" filter automatically
                 // Ensure default and local filters are passed as well
@@ -200,7 +212,11 @@ describe('Workload CVE overview page tests', () => {
 
             interactAndWaitForImageList(() => {
                 // Apply a filter in the "without cves" view
-                typeAndSelectCustomSearchFilterValue('Image', 'quay.io/bogus');
+                if (isAdvancedFiltersEnabled) {
+                    typeAndEnterCustomSearchFilterValue('Image', 'Name', 'quay.io/bogus');
+                } else {
+                    typeAndSelectCustomSearchFilterValue('Image', 'quay.io/bogus');
+                }
             }).should((xhr) => {
                 // On switching views, all filters, including the defaults should be cleared
                 const requestQuery = xhr.request.body.variables.query.toLowerCase();
@@ -214,11 +230,13 @@ describe('Workload CVE overview page tests', () => {
                 // and reapply the default filters
                 changeObservedCveViewingMode('Image vulnerabilities');
                 // Check that default filters are present
-                cy.get(selectors.filterChipGroupItem('Severity', 'Critical'));
-                cy.get(selectors.filterChipGroupItem('Severity', 'Important'));
-                cy.get(selectors.filterChipGroupItem('CVE status', 'Fixable'));
+                cy.get(selectors.filterChipGroupItem(severityChip, 'Critical'));
+                cy.get(selectors.filterChipGroupItem(severityChip, 'Important'));
+                cy.get(selectors.filterChipGroupItem(cveStatusChip, 'Fixable'));
                 // check that the local applied filter is not present
-                cy.get(selectors.filterChipGroupItem('Image', 'quay.io/bogus')).should('not.exist');
+                cy.get(selectors.filterChipGroupItem(imageNameChip, 'quay.io/bogus')).should(
+                    'not.exist'
+                );
             }).should((xhr) => {
                 const requestQuery = xhr.request.body.variables.query.toLowerCase();
                 expect(requestQuery).to.contain('vulnerability state');

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -275,10 +275,10 @@ export const imageCVESearchFilterConfig = {
     displayName: 'Image CVE',
     searchCategory: 'IMAGE_VULNERABILITIES',
     attributes: {
-        ID: {
-            displayName: 'ID',
-            filterChipLabel: 'Image CVE ID',
-            searchTerm: 'CVE ID',
+        Name: {
+            displayName: 'Name',
+            filterChipLabel: 'Image CVE',
+            searchTerm: 'CVE',
             inputType: 'autocomplete',
         },
         'Discovered Time': {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -39,9 +39,9 @@ describe('utils', () => {
 
             expect(result).toStrictEqual([
                 {
-                    displayName: 'ID',
-                    filterChipLabel: 'Image CVE ID',
-                    searchTerm: 'CVE ID',
+                    displayName: 'Name',
+                    filterChipLabel: 'Image CVE',
+                    searchTerm: 'CVE',
                     inputType: 'autocomplete',
                 },
                 {
@@ -107,7 +107,7 @@ describe('utils', () => {
 
             const result = getDefaultAttribute('Image CVE', config);
 
-            expect(result).toStrictEqual('ID');
+            expect(result).toStrictEqual('Name');
         });
     });
 
@@ -121,8 +121,8 @@ describe('utils', () => {
 
             expect(result).toStrictEqual([
                 {
-                    displayName: 'Image CVE ID',
-                    searchFilterName: 'CVE ID',
+                    displayName: 'Image CVE',
+                    searchFilterName: 'CVE',
                 },
                 {
                     displayName: 'Image CVE Discovered Time',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -20,7 +20,11 @@ import { getUrlQueryStringForSearchFilter, getHasSearchApplied } from 'utils/sea
 
 import BySeveritySummaryCard from 'Containers/Vulnerabilities/components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from 'Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard';
-import { getHiddenSeverities, getHiddenStatuses } from '../../utils/searchUtils';
+import {
+    getHiddenSeverities,
+    getHiddenStatuses,
+    parseQuerySearchFilter,
+} from '../../utils/searchUtils';
 
 import CVEsTable, { sortFields, defaultSortOption } from './CVEsTable';
 import useNodeVulnerabilities from './useNodeVulnerabilities';
@@ -35,8 +39,7 @@ export type NodePageVulnerabilitiesProps = {
 function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
 
-    // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
-    const querySearchFilter = searchFilter;
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -27,12 +27,13 @@ import {
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import useURLSort from 'hooks/useURLSort';
-import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import {
     getHiddenSeverities,
     getOverviewPagePath,
     getRegexScopedQueryString,
+    parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import CvePageHeader from '../../components/CvePageHeader';
 import { nodeSearchFilterConfig, nodeComponentSearchFilterConfig } from '../../searchFilterConfig';
@@ -51,8 +52,7 @@ const searchFilterConfig = {
 
 function NodeCvePage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
-    const querySearchFilter = searchFilter;
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     // We need to scope all queries to the *exact* CVE name so that we don't accidentally get
     // data that matches a prefix of the CVE name in the nested fields
@@ -110,6 +110,7 @@ function NodeCvePage() {
             <Divider component="div" />
             <PageSection className="pf-v5-u-flex-grow-1">
                 <AdvancedFiltersToolbar
+                    className="pf-v5-u-pt-lg pf-v5-u-pb-0 pf-v5-u-px-sm"
                     searchFilter={searchFilter}
                     searchFilterConfig={searchFilterConfig}
                     onFilterChange={(newFilter, { action }) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -21,6 +21,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
+import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
 import useSnoozeCveModal from '../../components/SnoozeCvesModal/useSnoozeCveModal';
@@ -57,8 +58,7 @@ function NodeCvesOverviewPage() {
         onSort: () => pagination.setPage(1, 'replace'),
     });
 
-    // TODO - Need an equivalent function implementation for filter sanitization for Node CVEs
-    const querySearchFilter = searchFilter;
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const isViewingSnoozedCves = querySearchFilter['CVE Snoozed']?.[0] === 'true';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -19,7 +19,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import useURLSort from 'hooks/useURLSort';
 import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
-import { getHiddenStatuses } from '../../utils/searchUtils';
+import { getHiddenStatuses, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import useClusterVulnerabilities from './useClusterVulnerabilities';
@@ -34,8 +34,7 @@ export type ClusterPageVulnerabilitiesProps = {
 
 function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
-    // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
-    const querySearchFilter = searchFilter;
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -25,6 +25,7 @@ import useSnoozeCveModal from 'Containers/Vulnerabilities/components/SnoozeCvesM
 import SnoozeCvesModal from 'Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 
+import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
@@ -54,8 +55,7 @@ function PlatformCvesOverviewPage() {
         onSort: () => pagination.setPage(1, 'replace'),
     });
 
-    // TODO - Need an equivalent function implementation for filter sanitization for Platform CVEs
-    const querySearchFilter = searchFilter;
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const isViewingSnoozedCves = querySearchFilter['CVE Snoozed']?.[0] === 'true';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -39,7 +39,7 @@ import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,
 } from '../SummaryCards/CvesByStatusSummaryCard';
 import {
-    parseWorkloadQuerySearchFilter,
+    parseQuerySearchFilter,
     getHiddenSeverities,
     getHiddenStatuses,
     getVulnStateScopedQueryString,
@@ -105,7 +105,7 @@ function DeploymentPageVulnerabilities({
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     const { page, setPage, perPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -49,7 +49,7 @@ import {
     getHiddenStatuses,
     getStatusesForExceptionCount,
     getVulnStateScopedQueryString,
-    parseWorkloadQuerySearchFilter,
+    parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
@@ -114,7 +114,7 @@ function ImagePageVulnerabilities({
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultSortFields,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -48,7 +48,7 @@ import {
     getOverviewPagePath,
     getStatusesForExceptionCount,
     getVulnStateScopedQueryString,
-    parseWorkloadQuerySearchFilter,
+    parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import { getDefaultWorkloadSortOption } from '../../utils/sortUtils';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
@@ -183,7 +183,7 @@ function ImageCvePage() {
     const cveId = urlParams.cveId ?? '';
     const exactCveIdSearchRegex = `^${cveId}$`;
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const querySearchFilter = parseWorkloadQuerySearchFilter(searchFilter);
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getVulnStateScopedQueryString(
         {
             ...querySearchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -52,12 +52,6 @@ function makeDefaultFilterDescriptor(
     };
 }
 
-export type FilterChangeDiff = {
-    action: 'add' | 'remove';
-    category: string;
-    value: string;
-};
-
 const emptyDefaultFilters = {
     SEVERITY: [],
     FIXABLE: [],
@@ -67,6 +61,7 @@ type AdvancedFiltersToolbarProps = {
     searchFilterConfig: CompoundSearchFilterProps['config'];
     searchFilter: SearchFilter;
     onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
+    className?: string;
     defaultFilters?: DefaultFilters;
     includeCveFilters?: boolean;
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
@@ -77,6 +72,7 @@ function AdvancedFiltersToolbar({
     searchFilterConfig,
     searchFilter,
     onFilterChange,
+    className = '',
     defaultFilters = emptyDefaultFilters,
     includeCveFilters = true,
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component
@@ -117,7 +113,7 @@ function AdvancedFiltersToolbar({
     }
 
     return (
-        <Toolbar className="advanced-filters-toolbar pf-v5-u-pb-0 pf-v5-u-px-sm">
+        <Toolbar className={`advanced-filters-toolbar ${className}`}>
             <ToolbarContent>
                 <ToolbarGroup
                     variant="filter-group"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
@@ -78,7 +78,10 @@ function FilterAutocompleteSelect({
     // 1. The typeahead is not empty
     // 2. The search option supports regex matching
     autocompleteSearchFilter[searchOption.value] =
-        typeahead !== '' && regexSearchOptions.some((option) => option === searchOption.value)
+        typeahead !== '' &&
+        regexSearchOptions.some(
+            (option) => option.toLowerCase() === searchOption.value.toLowerCase()
+        )
             ? [`r/${typeahead}`]
             : [typeahead];
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,4 +1,10 @@
 export {
     nodeSearchFilterConfig,
     nodeComponentSearchFilterConfig,
+    imageSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
@@ -1,4 +1,15 @@
 import { SearchCategory } from 'services/SearchService';
+import { SearchFilterAttribute } from 'Components/CompoundSearchFilter/types';
+import {
+    nodeSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+    imageSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
+} from './searchFilterConfig';
 
 export type SearchOptionValue =
     | 'CLUSTER'
@@ -15,18 +26,24 @@ export type SearchOptionValue =
     | 'Requester User Name'
     | 'SEVERITY';
 
-// Search fields that will default to regex search
-export const regexSearchOptions: SearchOptionValue[] = [
-    'CLUSTER',
-    'COMPONENT',
-    'CVE',
-    'DEPLOYMENT',
-    'IMAGE',
-    'NAMESPACE',
-    'Namespace Label',
-    'Request Name',
-    'Requester User Name',
-] as const;
+/*
+ Search terms that will default to regex search.
+
+ We only convert to regex search if the search field is of type 'text' or 'autocomplete'
+*/
+export const regexSearchOptions = [
+    nodeSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+    imageSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
+]
+    .flatMap((config) => Object.values<SearchFilterAttribute>(config.attributes))
+    .filter(({ inputType }) => inputType === 'text' || inputType === 'autocomplete')
+    .map(({ searchTerm }) => searchTerm);
 
 export type SearchOption = { label: string; value: SearchOptionValue; category: SearchCategory };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -14,17 +14,15 @@ export function isFixableStatus(value: unknown): value is FixableStatus {
     return fixableStatuses.some((status) => status === value);
 }
 
-// `QuerySearchFilter` is a restricted subset of the `SearchFilter` obtained from the URL that only
-// supports search keys that are valid in the Workload CVE section of the app
-export type QuerySearchFilter = Partial<{
-    SEVERITY: VulnerabilitySeverity[];
-    FIXABLE: ('true' | 'false')[];
-    CVE: string[];
-    IMAGE: string[];
-    DEPLOYMENT: string[];
-    NAMESPACE: string[];
-    CLUSTER: string[];
-}>;
+// `QuerySearchFilter` is a restricted subset of the `SearchFilter` obtained from the URL that
+// has been parsed to convert values to the format expected by the backend. It also restricts
+// the filter values to a `string[]` for consistency.
+export type QuerySearchFilter = Partial<
+    {
+        SEVERITY: VulnerabilitySeverity[];
+        FIXABLE: ('true' | 'false')[];
+    } & Record<string, string[]>
+>;
 
 const vulnMgmtLocalStorageSchema = yup.object({
     preferences: yup.object({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -26,16 +26,7 @@ import {
     isFixableStatus,
     isVulnerabilitySeverityLabel,
 } from '../types';
-import {
-    IMAGE_CVE_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    DEPLOYMENT_SEARCH_OPTION,
-    NAMESPACE_SEARCH_OPTION,
-    CLUSTER_SEARCH_OPTION,
-    COMPONENT_SOURCE_SEARCH_OPTION,
-    COMPONENT_SEARCH_OPTION,
-    regexSearchOptions,
-} from '../searchOptions';
+import { regexSearchOptions } from '../searchOptions';
 
 export type OverviewPageSearch = {
     s?: SearchFilter;
@@ -129,24 +120,14 @@ export function severityLabelToSeverity(label: VulnerabilitySeverityLabel): Vuln
 }
 
 /**
- * Parses an open `SearchFilter` obtained from the URL into a restricted `SearchFilter` that
+ * Parses an open `SearchFilter` obtained from the URL into a `SearchFilter` that
  * matches the fields and values expected by the backend.
  */
-export function parseWorkloadQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySearchFilter {
+export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySearchFilter {
     const cleanSearchFilter: QuerySearchFilter = {};
 
-    // SearchFilter values that can be directly translated over to the backend equivalent
-    const unprocessedSearchKeys = [
-        IMAGE_CVE_SEARCH_OPTION.value,
-        IMAGE_SEARCH_OPTION.value,
-        DEPLOYMENT_SEARCH_OPTION.value,
-        NAMESPACE_SEARCH_OPTION.value,
-        CLUSTER_SEARCH_OPTION.value,
-        COMPONENT_SEARCH_OPTION.value,
-        COMPONENT_SOURCE_SEARCH_OPTION.value,
-    ] as const;
-    unprocessedSearchKeys.forEach((key) => {
-        const values = searchValueAsArray(rawSearchFilter[key]);
+    Object.entries(rawSearchFilter).forEach(([key, value]) => {
+        const values = searchValueAsArray(value);
         if (values.length > 0) {
             cleanSearchFilter[key] = values;
         }
@@ -243,7 +224,7 @@ export function applyRegexSearchModifiers(searchFilter: SearchFilter): SearchFil
     const regexSearchFilter = cloneDeep(searchFilter);
 
     Object.entries(regexSearchFilter).forEach(([key, value]) => {
-        if (regexSearchOptions.some((option) => option === key)) {
+        if (regexSearchOptions.some((option) => option.toLowerCase() === key.toLowerCase())) {
             regexSearchFilter[key] = searchValueAsArray(value).map((val) => `r/${val}`);
         }
     });


### PR DESCRIPTION
## Description

Updates the Workload CVE list page to conditionally use advanced filters.

As part of this work the following was needed:
- Slightly relaxed the parsing of search filters to not require strict search term names
- Use this relaxed parsing function throughout Node and Platform CVEs, instead of creating specifics for each of those subsections
- Remove the "Image CVE ID" filter and replace it with "Image CVE Name"

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing.

Updated Cypress tests to account for new filter component. (CI will tests against the old component until the feature flag is enabled. Local run with the new component below).

![image](https://github.com/stackrox/stackrox/assets/1292638/4a7fcdba-e0d5-4eaf-ad8d-29d6e876b96b)
