### PR TITLE
ROX-18831: Fix auditlog tests

### DIFF
--- a/sensor/common/compliance/auditlog_manager.go
+++ b/sensor/common/compliance/auditlog_manager.go
@@ -1,6 +1,8 @@
 package compliance
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -50,9 +52,9 @@ func NewAuditLogCollectionManager() AuditLogCollectionManager {
 		fileStates:              make(map[string]*storage.AuditLogFileState),
 		auditEventMsgs:          make(chan *sensor.MsgFromCompliance),
 		fileStateUpdates:        make(chan *message.ExpiringMessage),
-		stopSig:                 concurrency.NewSignal(),
+		stopper:                 concurrency.NewStopper(),
 		forceUpdateSig:          concurrency.NewSignal(),
 		centralReady:            concurrency.NewSignal(),
-		updateInterval:          defaultInterval,
+		updaterTicker:           time.NewTicker(defaultInterval),
 	}
 }


### PR DESCRIPTION
## Description

The test `TestUpdaterSkipsOnOfflineMode` was flaking due to races in the internal ticker. This PR makes the ticker injectable so it can be controlled in the test. It also makes use of the `Stopper` interface instead of the `stopSignals` to manage the stop process.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI
- [x] Manually tested the unit tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
