### PR TITLE
fix(leak): Fix leak in compliance service

### DIFF
--- a/sensor/common/compliance/service.go
+++ b/sensor/common/compliance/service.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/compliance"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/orchestrator"
 )
@@ -44,5 +46,6 @@ func NewService(orchestrator orchestrator.Orchestrator, auditEventsInput chan *s
 		auditLogCollectionManager: auditLogCollectionManager,
 		connectionManager:         newConnectionManager(),
 		offlineMode:               offlineMode,
+		stopper:                   set.NewSet[concurrency.Stopper](),
 	}
 }


### PR DESCRIPTION
## Description

Some of the goroutines were not being closed properly in the tests.

Before these changes, if the tests were executed with a high `count`, the tests would fail due to leaked goroutines.

- Note: this is a follow-up of #11457 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Running the tests like `go test -race -count=10 github.com/stackrox/rox/sensor/common/compliance` should pass

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
