### PR TITLE
ROX-24613: image CVE single advanced filters

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -127,6 +127,16 @@ export function typeAndSelectCustomSearchFilterValue(searchOption, value) {
     cy.get(selectors.searchOptionsValueTypeahead(searchOption)).click();
 }
 
+export function typeAndEnterSearchFilterValue(entity, searchTerm, value) {
+    selectEntitySearchOption(entity);
+    selectAttributeSearchOption(searchTerm);
+    cy.get(selectors.searchValueTypeahead).click();
+    cy.get(selectors.searchValueTypeahead).type(value);
+    cy.get(selectors.searchValueMenuItem)
+        .contains(new RegExp(`^${value}$`))
+        .click();
+}
+
 /**
  * Type and enter custom text into the search filter typeahead
  * @param {string} entity
@@ -141,7 +151,6 @@ export function typeAndEnterCustomSearchFilterValue(entity, searchTerm, value) {
     cy.get(selectors.searchValueApplyButton).click();
     // TODO Needs implementation
     // cy.get(selectors.searchValueMenuItem).contains(`Add "${value}"`).click();
-    cy.get(selectors.searchValueTypeahead).click();
 }
 
 /**

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -17,6 +17,7 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
@@ -33,6 +34,13 @@ import {
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { getTableUIState } from 'utils/getTableUIState';
+import {
+    imageSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
 import {
     SearchOption,
     IMAGE_SEARCH_OPTION,
@@ -59,6 +67,7 @@ import AffectedImagesTable, {
     ImageForCve,
     imagesForCveFragment,
 } from '../Tables/AffectedImagesTable';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import AffectedDeploymentsTable, {
     DeploymentForCve,
@@ -175,7 +184,18 @@ const searchOptions: SearchOption[] = [
     COMPONENT_SOURCE_SEARCH_OPTION,
 ];
 
+const searchFilterConfig = {
+    Image: imageSearchFilterConfig,
+    ImageComponent: imageComponentSearchFilterConfig,
+    Deployment: deploymentSearchFilterConfig,
+    Namespace: namespaceSearchFilterConfig,
+    Cluster: clusterSearchFilterConfig,
+};
+
 function ImageCvePage() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
+
     const { analyticsTrack } = useAnalytics();
     const currentVulnerabilityState = useVulnerabilityState();
 
@@ -383,13 +403,29 @@ function ImageCvePage() {
                 />
                 <div className="pf-v5-u-background-color-100">
                     <div className="pf-v5-u-px-sm">
-                        <WorkloadCveFilterToolbar
-                            searchOptions={searchOptions}
-                            autocompleteSearchContext={{
-                                CVE: exactCveIdSearchRegex,
-                            }}
-                            onFilterChange={() => setPage(1)}
-                        />
+                        {isAdvancedFiltersEnabled ? (
+                            <AdvancedFiltersToolbar
+                                className="pf-v5-u-py-md"
+                                searchFilterConfig={searchFilterConfig}
+                                searchFilter={searchFilter}
+                                onFilterChange={(newFilter, { action }) => {
+                                    setSearchFilter(newFilter);
+                                    setPage(1, 'replace');
+
+                                    if (action === 'ADD') {
+                                        // TODO - Add analytics tracking ROX-24532
+                                    }
+                                }}
+                            />
+                        ) : (
+                            <WorkloadCveFilterToolbar
+                                searchOptions={searchOptions}
+                                autocompleteSearchContext={{
+                                    CVE: exactCveIdSearchRegex,
+                                }}
+                                onFilterChange={() => setPage(1)}
+                            />
+                        )}
                     </div>
                     <SummaryCardLayout
                         error={summaryRequest.error}


### PR DESCRIPTION
## Description

Updates the Image CVE single page to use advanced filters when the feature flag is enabled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of filtered results.

Updating of existing e2e tests:
![image](https://github.com/stackrox/stackrox/assets/1292638/8ab088dd-ba37-4866-83ff-4305ed3f8b7b)
