### PR TITLE
ROX-24559: pruning alert improvements

### DIFF
--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -885,7 +885,7 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 			return nil
 		})
 		if err != nil {
-			log.Error("Unable to prune alerts for query %v", query)
+			log.Errorf("Unable to prune alerts for query %v", query)
 			continue
 		}
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -791,6 +791,7 @@ func getConfigValues(config *storage.PrivateConfig) (pruneResolvedDeployAfter, p
 }
 
 func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
+	log.Infof("SHREWS -- collectAlerts")
 	alertRetention := config.GetAlertRetention()
 	if alertRetention == nil {
 		log.Info("[Alert pruning] Alert pruning has been disabled.")
@@ -871,6 +872,7 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 			log.Error(err)
 		}
 	}
+	log.Infof("SHREWS -- end collectAlerts")
 }
 
 func (g *garbageCollectorImpl) removeOrphanedRisks() {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -870,18 +870,13 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 	prunedAlertCount := 0
 	// Go through the various queries and remove those batches.
 	for key, query := range queryMap {
-		log.Infof("Pruning for key %q", key)
-		alertResults, err := g.alerts.Search(ctx, query)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		alertsToPrune := make([]string, 0, len(alertResults))
+		log.Debugf("Pruning for key %q", key)
+		var alertsToPrune []string
 		// The alert searcher is opinionated and adds some default query parameters.
 		// Those should not be included for pruning.  Simpler to just use `WalkByQuery`
-		err = g.alerts.WalkByQuery(ctx, query, func(alert *storage.Alert) error {
+		err := g.alerts.WalkByQuery(ctx, query, func(alert *storage.Alert) error {
 			alertsToPrune = append(alertsToPrune, alert.GetId())
+
 			return nil
 		})
 		if err != nil {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -833,12 +833,12 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 	}
 
 	if pruneDeletedRuntimeAfter > 0 && pruneAllRuntimeAfter != pruneDeletedRuntimeAfter {
-		qTest := search.NewQueryBuilder().
+		q := search.NewQueryBuilder().
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
 			AddDays(search.ViolationTime, int64(pruneDeletedRuntimeAfter)).
 			AddBools(search.Inactive, true).
 			ProtoQuery()
-		queryMap[pruneDeletedRuntimeAfterKey] = qTest
+		queryMap[pruneDeletedRuntimeAfterKey] = q
 	}
 
 	if pruneAttemptedDeployAfter > 0 {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -54,9 +54,16 @@ const (
 	logImbueGCFreq     = 24 * time.Hour
 	logImbueWindow     = 24 * 7 * time.Hour
 
-	alertQueryTimeout = 10 * time.Minute
+	alertQueryTimeout    = 10 * time.Minute
+	alertDeleteBatchSize = 5000
 
 	flowsSemaphoreWeight = 5
+
+	pruneResolvedDeployAfterKey   = "pruneResolvedDeployAfter"
+	pruneAllRuntimeAfterKey       = "pruneAllRuntimeAfter"
+	pruneDeletedRuntimeAfterKey   = "pruneDeletedRuntimeAfter"
+	pruneAttemptedDeployAfterKey  = "pruneAttemptedDeployAfter"
+	pruneAttemptedRuntimeAfterKey = "pruneAttemptedRuntimeAfter"
 )
 
 var (
@@ -791,7 +798,6 @@ func getConfigValues(config *storage.PrivateConfig) (pruneResolvedDeployAfter, p
 }
 
 func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
-	log.Infof("SHREWS -- collectAlerts")
 	alertRetention := config.GetAlertRetention()
 	if alertRetention == nil {
 		log.Info("[Alert pruning] Alert pruning has been disabled.")
@@ -804,15 +810,18 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 		pruneAttemptedDeployAfter,
 		pruneAttemptedRuntimeAfter := getConfigValues(config)
 
-	var queries []*v1.Query
+	queryMap := make(map[string]*v1.Query)
 
+	// Originally we collected all alerts in one query.  This resulted in a query with 4 large or clauses.
+	// That will always result in a full table scan.  ROX-24559 will break these up into smaller queries to
+	// increase the likelihood that indexes are used to acquire the data.
 	if pruneResolvedDeployAfter > 0 {
 		q := search.NewQueryBuilder().
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).
 			AddExactMatches(search.ViolationState, storage.ViolationState_RESOLVED.String()).
 			AddDays(search.ViolationTime, int64(pruneResolvedDeployAfter)).
 			ProtoQuery()
-		queries = append(queries, q)
+		queryMap[pruneResolvedDeployAfterKey] = q
 	}
 
 	if pruneAllRuntimeAfter > 0 {
@@ -820,16 +829,16 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
 			AddDays(search.ViolationTime, int64(pruneAllRuntimeAfter)).
 			ProtoQuery()
-		queries = append(queries, q)
+		queryMap[pruneAllRuntimeAfterKey] = q
 	}
 
 	if pruneDeletedRuntimeAfter > 0 && pruneAllRuntimeAfter != pruneDeletedRuntimeAfter {
-		q := search.NewQueryBuilder().
+		qTest := search.NewQueryBuilder().
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).
 			AddDays(search.ViolationTime, int64(pruneDeletedRuntimeAfter)).
 			AddBools(search.Inactive, true).
 			ProtoQuery()
-		queries = append(queries, q)
+		queryMap[pruneDeletedRuntimeAfterKey] = qTest
 	}
 
 	if pruneAttemptedDeployAfter > 0 {
@@ -838,7 +847,7 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 			AddExactMatches(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
 			AddDays(search.ViolationTime, int64(pruneAttemptedDeployAfter)).
 			ProtoQuery()
-		queries = append(queries, q)
+		queryMap[pruneAttemptedDeployAfterKey] = q
 	}
 
 	if pruneAttemptedRuntimeAfter > 0 {
@@ -847,10 +856,10 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 			AddExactMatches(search.ViolationState, storage.ViolationState_ATTEMPTED.String()).
 			AddDays(search.ViolationTime, int64(pruneAttemptedRuntimeAfter)).
 			ProtoQuery()
-		queries = append(queries, q)
+		queryMap[pruneAttemptedRuntimeAfterKey] = q
 	}
 
-	if len(queries) == 0 {
+	if len(queryMap) == 0 {
 		log.Info("No alert retention configuration, skipping")
 		return
 	}
@@ -858,21 +867,53 @@ func (g *garbageCollectorImpl) collectAlerts(config *storage.PrivateConfig) {
 	ctx, cancel := context.WithTimeout(pruningCtx, alertQueryTimeout)
 	defer cancel()
 
-	alertResults, err := g.alerts.Search(ctx, search.DisjunctionQuery(queries...))
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	alertsToPrune := search.ResultsToIDs(alertResults)
-
-	if len(alertsToPrune) > 0 {
-		log.Infof("[Alert pruning] Removing %d alerts", len(alertsToPrune))
-		if err := g.alerts.DeleteAlerts(pruningCtx, alertsToPrune...); err != nil {
+	prunedAlertCount := 0
+	// Go through the various queries and remove those batches.
+	for key, query := range queryMap {
+		log.Infof("Pruning for key %q", key)
+		alertResults, err := g.alerts.Search(ctx, query)
+		if err != nil {
 			log.Error(err)
+			return
+		}
+
+		alertsToPrune := make([]string, 0, len(alertResults))
+		// The alert searcher is opinionated and adds some default query parameters.
+		// Those should not be included for pruning.  Simpler to just use `WalkByQuery`
+		err = g.alerts.WalkByQuery(ctx, query, func(alert *storage.Alert) error {
+			alertsToPrune = append(alertsToPrune, alert.GetId())
+			return nil
+		})
+		if err != nil {
+			log.Error("Unable to prune alerts for query %v", query)
+			continue
+		}
+
+		localBatchSize := alertDeleteBatchSize
+
+		for {
+			if len(alertsToPrune) == 0 {
+				break
+			}
+
+			if len(alertsToPrune) < localBatchSize {
+				localBatchSize = len(alertsToPrune)
+			}
+
+			alertBatch := alertsToPrune[:localBatchSize]
+			log.Infof("[Alert pruning] Removing %d alerts for %q", len(alertBatch), key)
+			if err := g.alerts.DeleteAlerts(pruningCtx, alertBatch...); err != nil {
+				log.Error(err)
+			} else {
+				prunedAlertCount = prunedAlertCount + len(alertBatch)
+			}
+
+			// Move the slice forward to start the next batch
+			alertsToPrune = alertsToPrune[localBatchSize:]
 		}
 	}
-	log.Infof("SHREWS -- end collectAlerts")
+
+	log.Infof("Pruned %d alerts based on retention configuration", prunedAlertCount)
 }
 
 func (g *garbageCollectorImpl) removeOrphanedRisks() {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -335,6 +335,7 @@ func (q *query) AsSQL() string {
 	}
 	// Performing this operation on full query is safe since table names and column names
 	// can only contain alphanumeric and underscore character.
+	log.Info(replaceVars(querySB.String()))
 	return replaceVars(querySB.String())
 }
 

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -335,7 +335,6 @@ func (q *query) AsSQL() string {
 	}
 	// Performing this operation on full query is safe since table names and column names
 	// can only contain alphanumeric and underscore character.
-	log.Info(replaceVars(querySB.String()))
 	return replaceVars(querySB.String())
 }
 


### PR DESCRIPTION
## Description

Alert pruning combined all the retention configs into one massive query with 4 separate or clauses.  
```
select alerts.Id::text as Alert_ID 
	from alerts 
	where (((alerts.LifecycleStage = 0) and (alerts.State = 2) and alerts.Time <= now() at time zone 'utc' - INTERVAL '5 MINUTES')
	or ((alerts.LifecycleStage = 2) and alerts.Time <= now() at time zone 'utc' - INTERVAL '5 MINUTES') 
	or (alerts.Deployment_Inactive = true and (alerts.LifecycleStage = 2) and alerts.Time <= now() at time zone 'utc' - INTERVAL '5 MINUTES') 
	or ((alerts.LifecycleStage = 0) and (alerts.State = 3) and alerts.Time <= now() at time zone 'utc' - INTERVAL '5 MINUTES') 
	or ((alerts.LifecycleStage = 2) and (alerts.State = 3) and alerts.Time <= now() at time zone 'utc' - INTERVAL '5 MINUTES'));
```

At scale this resulted in a query that would always result in a full table scan.  In environments with a database at or near capacity the pruning query would often not return and thus prevent any pruning.  Additionally, we've seen in the field that there are times the call to `DeleteMany` will also timeout and thus not prune any objects.

This change does 2 things.
1. Splits the query into the 5 separate pieces to greatly increase the likelihood that the indexes are used.
2. batches the deletes into smaller chunks to increase the probability that some of the alerts are pruned and as such reduce the load on the database.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

unit test and scale test.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
