### PR TITLE
ROX-17542: Updating image summary count link on dashboard to VM 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCount.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCount.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Button, Stack } from '@patternfly/react-core';
+import { Button, Stack, Tooltip } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 
@@ -8,10 +8,11 @@ export type SummaryCountProps = {
     count: number;
     href: string;
     noun: string;
+    tooltip?: string;
 };
 
-function SummaryCount({ count, href, noun }: SummaryCountProps): ReactElement {
-    return (
+function SummaryCount({ count, href, noun, tooltip }: SummaryCountProps): ReactElement {
+    const content = (
         <Button variant="link" component={LinkShim} href={href}>
             <Stack className="pf-v5-u-px-xs pf-v5-u-px-sm-on-xl pf-v5-u-align-items-center">
                 <span className="pf-v5-u-font-size-lg-on-md pf-v5-u-font-size-sm pf-v5-u-font-weight-bold">
@@ -23,6 +24,14 @@ function SummaryCount({ count, href, noun }: SummaryCountProps): ReactElement {
             </Stack>
         </Button>
     );
+    if (tooltip) {
+        return (
+            <Tooltip content={<div>{tooltip}</div>} position="bottom">
+                {content}
+            </Tooltip>
+        );
+    }
+    return content;
 }
 
 export default SummaryCount;

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,8 +1,9 @@
 import qs from 'qs';
-import { generatePath } from 'react-router-dom';
+
 import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
 import { Pagination } from 'services/types';
 import { ValueOf } from './type.utils';
+import { safeGeneratePath } from './urlUtils';
 
 /**
  *  Checks if the modifier exists in the searchOptions
@@ -314,7 +315,7 @@ export function addRegexPrefixToFilters(
 
 // Uses the generatePath function from react-router in addition to adding the query params
 export const generatePathWithQuery = (pathTemplate, params, queryParams) => {
-    const path = generatePath(pathTemplate, params);
+    const path = safeGeneratePath(pathTemplate, params, pathTemplate);
     const searchParams = new URLSearchParams(queryParams).toString();
     return `${path}?${searchParams}`;
 };

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,4 +1,5 @@
 import qs from 'qs';
+import { generatePath } from 'react-router-dom';
 import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
 import { Pagination } from 'services/types';
 import { ValueOf } from './type.utils';
@@ -310,3 +311,10 @@ export function addRegexPrefixToFilters(
 
     return modifiedFilter;
 }
+
+// Uses the generatePath function from react-router in addition to adding the query params
+export const generatePathWithQuery = (pathTemplate, params, queryParams) => {
+    const path = generatePath(pathTemplate, params);
+    const searchParams = new URLSearchParams(queryParams).toString();
+    return `${path}?${searchParams}`;
+};


### PR DESCRIPTION
## Description

When the `ROX_VULN_MGMT_2_GA` feature flag is enabled, we will navigate to the Images tab in Workload CVEs when the dashboard image summary count is clicked. When the `ROX_VULN_MGMT_2_GA` feature is disabled, we will navigate to the VM 1.0 Image List page when the dashboard image summary count is clicked.

## Feature Flag Enabled

https://github.com/stackrox/stackrox/assets/4805485/e44ec92f-dc1d-414a-a6c2-72ac960a6f6e

<img width="721" alt="Screenshot 2024-06-10 at 6 12 43 PM" src="https://github.com/stackrox/stackrox/assets/4805485/afa51138-33d5-4269-afda-1021c7088242">


## Feature Flag Disabled

https://github.com/stackrox/stackrox/assets/4805485/10cb9246-aa5f-4f8e-9da4-c6091ecbebec


