### PR TITLE
ROX-23139: bump CPU requests for builds on Konflux

### DIFF
--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -75,7 +75,7 @@ spec:
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
-      # Defaults: https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
       #
       # Memory is increased for UI builds to succeed. Otherwise, there's an error like this in logs:
       # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -70,6 +70,13 @@ spec:
     secret:
       secretName: subscription-manager-activation-key
 
+  # The pipeline regularly takes >1h to finish.
+  timeouts:
+    pipeline: 1h30m0s
+
+  pipelineRef:
+    name: main-pipeline
+
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:
@@ -97,10 +104,3 @@ spec:
       computeResources:
         requests:
           cpu: 1
-
-  # The pipeline regularly takes >1h to finish.
-  timeouts:
-    pipeline: 1h30m0s
-
-  pipelineRef:
-    name: main-pipeline

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -72,7 +72,6 @@ spec:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
-      #
       computeResources:
         limits:
           cpu: 2

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -65,3 +65,16 @@ spec:
 
   pipelineRef:
     name: basic-component-pipeline
+
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: build
+      # CPU requests are increased to speed up builds compared to the defaults.
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      #
+      computeResources:
+        limits:
+          cpu: 2
+        requests:
+          cpu: 2

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -72,7 +72,6 @@ spec:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
-      #
       computeResources:
         limits:
           cpu: 2

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -65,3 +65,16 @@ spec:
 
   pipelineRef:
     name: basic-component-pipeline
+
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: build
+      # CPU requests are increased to speed up builds compared to the defaults.
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      #
+      computeResources:
+        limits:
+          cpu: 2
+        requests:
+          cpu: 2

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -65,3 +65,16 @@ spec:
 
   pipelineRef:
     name: scanner-v4-pipeline
+
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: build
+      # CPU requests are increased to speed up builds compared to the defaults.
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      #
+      computeResources:
+        limits:
+          cpu: 2
+        requests:
+          cpu: 2

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -72,7 +72,6 @@ spec:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
-      #
       computeResources:
         limits:
           cpu: 2


### PR DESCRIPTION
| | [f62237f](https://github.com/stackrox/stackrox/pull/11473/commits/f62237ff24ca1dd14b20adc00b890e41f7960cad) - default CPU limits | [e21dca1](https://github.com/stackrox/stackrox/pull/11473/commits/e21dca11f3fc73d0fdf18f4432caee5839c9aa29) - increased CPU limits |
|-|-|-|
| scanner v4 | 8 min | 6 min |
| roxctl | 10 min | 6 min |
| operator | 10 min | 5 min |
 
`main` is still the bottleneck with 33 minutes build time though.
  