### PR TITLE
fix: policy checks to ignore whitespace difference

### DIFF
--- a/scripts/ci/jobs/policy-checks.sh
+++ b/scripts/ci/jobs/policy-checks.sh
@@ -14,7 +14,7 @@ check_policy_files() {
     make deps
     make policyutil
     policyutil upgrade -d pkg/defaults/policies/files -o /tmp/policies-in-standard-form --ensure-read-only mitre --ensure-read-only criteria
-    diff pkg/defaults/policies/files /tmp/policies-in-standard-form > /tmp/policies-diff || true
+    diff --ignore-space-change pkg/defaults/policies/files /tmp/policies-in-standard-form > /tmp/policies-diff || true
 
     store_test_results /tmp/policies-diff policies-diff
 


### PR DESCRIPTION
## Description

New version of protobuf does not guarantee that json content will be 100% identical. They add a jitter with number of spaces to force not relaying on it but on content.
This PR fixes this behaviour by ignoring white spaces.
- https://github.com/golang/protobuf/commit/492a476312755200fbec6fb289efcfa9918d228b
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
