### PR TITLE
ROX-24615: Deployment single page advanced filters

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.js
@@ -9,6 +9,7 @@ import {
 import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE Deployment Single page', () => {
+    const isAdvancedFiltersEnabled = hasFeatureFlag('ROX_VULN_MGMT_ADVANCED_FILTERS');
     withAuth();
 
     before(function () {
@@ -28,15 +29,23 @@ describe('Workload CVE Deployment Single page', () => {
         visitFirstDeployment();
 
         // Check that only applicable resource menu items are present in the toolbar
-        cy.get(selectors.searchOptionsDropdown).click();
-        cy.get(selectors.searchOptionsMenuItem('CVE'));
-        cy.get(selectors.searchOptionsMenuItem('Image'));
-        cy.get(selectors.searchOptionsMenuItem('Component'));
-        cy.get(selectors.searchOptionsMenuItem('Component source'));
-        cy.get(selectors.searchOptionsMenuItem('Deployment')).should('not.exist');
-        cy.get(selectors.searchOptionsMenuItem('Cluster')).should('not.exist');
-        cy.get(selectors.searchOptionsMenuItem('Namespace')).should('not.exist');
-        cy.get(selectors.searchOptionsDropdown).click();
+        if (isAdvancedFiltersEnabled) {
+            cy.get(selectors.searchEntityDropdown).click();
+            cy.get(selectors.searchEntityMenuItem).contains('Image');
+            cy.get(selectors.searchEntityMenuItem).contains('Image CVE');
+            cy.get(selectors.searchEntityMenuItem).contains('Image Component');
+            cy.get(selectors.searchEntityDropdown).click();
+        } else {
+            cy.get(selectors.searchOptionsDropdown).click();
+            cy.get(selectors.searchOptionsMenuItem('CVE'));
+            cy.get(selectors.searchOptionsMenuItem('Image'));
+            cy.get(selectors.searchOptionsMenuItem('Component'));
+            cy.get(selectors.searchOptionsMenuItem('Component source'));
+            cy.get(selectors.searchOptionsMenuItem('Deployment')).should('not.exist');
+            cy.get(selectors.searchOptionsMenuItem('Cluster')).should('not.exist');
+            cy.get(selectors.searchOptionsMenuItem('Namespace')).should('not.exist');
+            cy.get(selectors.searchOptionsDropdown).click();
+        }
     });
 
     it('should navigate between vulnerabilities and resources tabs', () => {


### PR DESCRIPTION
## Description

Conditionally uses Advanced Filters on the Workload CVE Deployment single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual verification of the functionality of each filter against the table data.

Existing e2e tests that have been updated for the new components.