### PR TITLE
ROX-24679: Unify VM 1.0 and VM 2.0 navigation under "Vulnerabilities"

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -1,4 +1,3 @@
-import { hasFeatureFlag } from '../../helpers/features';
 import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
@@ -127,11 +126,8 @@ function getEntityPath(entitiesKey, entityId) {
 }
 
 export function visitVulnerabilityManagementDashboardFromLeftNav() {
-    const oldVulnMgmtNavText = hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')
-        ? 'Vulnerability Management (1.0)'
-        : 'Vulnerability Management';
     visitFromLeftNavExpandable(
-        oldVulnMgmtNavText,
+        'Vulnerabilities',
         'Dashboard',
         routeMatcherMapForVulnerabilityManagementDashboard
     );

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -56,8 +56,7 @@ type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string | Reac
 // Parent conditional title finds key to decide presence or absence of counterpart parent.
 const keyForNetwork = 'Network';
 const keyForPlatformConfiguration = 'Platform Configuration';
-const keyForVulnerabilityManagement1 = 'Vulnerability Management (1.0)';
-const keyForVulnerabilityManagement2 = 'Vulnerability Management (2.0)';
+const keyForVulnerabilities = 'Vulnerabilities';
 const keyForCompliance2 = 'Compliance (2.0)';
 type IsActiveCallback = (pathname: string) => boolean;
 
@@ -217,8 +216,8 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
     */
         {
             type: 'parent',
-            title: 'Vulnerability Management (2.0)',
-            key: keyForVulnerabilityManagement2,
+            title: 'Vulnerabilities',
+            key: keyForVulnerabilities,
             children: [
                 {
                     type: 'link',
@@ -229,6 +228,22 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                     ),
                     path: vulnerabilitiesWorkloadCvesPath,
                     routeKey: 'workload-cves',
+                },
+                {
+                    type: 'link',
+                    content: 'Exception Management',
+                    path: exceptionManagementPath,
+                    routeKey: 'exception-management',
+                },
+                {
+                    type: 'link',
+                    content: 'Vulnerability Reporting',
+                    path: vulnerabilityReportsPath,
+                    routeKey: 'vulnerabilities/reports',
+                },
+                {
+                    type: 'separator',
+                    key: 'following-workload-cves',
                 },
                 {
                     type: 'link',
@@ -252,36 +267,15 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                 },
                 {
                     type: 'separator',
-                    key: 'following-cves',
+                    key: 'following-node-cves',
                 },
                 {
                     type: 'link',
-                    content: 'Exception Management',
-                    path: exceptionManagementPath,
-                    routeKey: 'exception-management',
-                },
-                {
-                    type: 'link',
-                    content: 'Vulnerability Reporting',
-                    path: vulnerabilityReportsPath,
-                    routeKey: 'vulnerabilities/reports',
-                },
-            ],
-        },
-        {
-            type: 'parent',
-            key: keyForVulnerabilityManagement1,
-            title: isVulnMgmt2GAEnabled ? (
-                <NavigationContent variant="Deprecated">
-                    Vulnerability Management (1.0)
-                </NavigationContent>
-            ) : (
-                'Vulnerability Management (1.0)'
-            ),
-            children: [
-                {
-                    type: 'link',
-                    content: 'Dashboard',
+                    content: isVulnMgmt2GAEnabled ? (
+                        <NavigationContent variant="Deprecated">Dashboard</NavigationContent>
+                    ) : (
+                        'Dashboard'
+                    ),
                     path: vulnManagementPath,
                     routeKey: 'vulnerability-management',
                     isActive: (pathname) =>


### PR DESCRIPTION
## Description

As titled. Removes the old "VM 1.0"/"VM 2.0" naming in the navigation sidebar and replaces both with a single "Vulnerabilities" top level item.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


With VM 2 GA, NODE/PLATFORM and UNIFIED_DEFERRALS disabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/6c9e6d3f-fb97-4ad9-adfb-cb0e90f20949)

With VM 2 GA, NODE/PLATFORM disabled, and UNIFIED_DEFERRALS enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/947d35c9-2d7d-4546-8cd0-03c3dc89f0db)

With VM 2 GA, UNIFIED_DEFERRALS disabled, and  NODE/PLATFORM enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/20c31abc-f3df-4b6e-aeb0-efec40ab61ae)

With VM 2 GA disabled, UNIFIED_DEFERRALS and NODE/PLATFORM enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/996b4fd1-813c-470b-8a32-a2be3a869a2a)

With all feature flags enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/070c5bbc-8d27-42c2-8ee1-d66ded38a858)

