### PR TITLE
fix(ui): Fix compliance status dropdown search

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
@@ -1,6 +1,9 @@
 import { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
 
+import { SearchFilter } from 'types/search';
+import { SetSearchFilter } from 'hooks/useURLSearch';
 import {
+    OnSearchPayload,
     PartialCompoundSearchFilterConfig,
     SearchFilterAttribute,
     SearchFilterAttributeName,
@@ -102,3 +105,25 @@ export function makeFilterChipDescriptors(
         }))
     );
 }
+
+// Function to take a compound search "onSearch" payload and update the URL
+export const onURLSearch = (
+    searchFilter: SearchFilter,
+    setSearchFilter: SetSearchFilter,
+    payload: OnSearchPayload
+) => {
+    const { action, category, value } = payload;
+    const currentSelection = searchFilter[category] || [];
+    let newSelection = !Array.isArray(currentSelection) ? [currentSelection] : currentSelection;
+    if (action === 'ADD') {
+        newSelection = [...newSelection, value];
+    } else if (action === 'REMOVE') {
+        newSelection = newSelection.filter((datum) => datum !== value);
+    } else {
+        // Do nothing
+    }
+    setSearchFilter({
+        ...searchFilter,
+        [category]: newSelection,
+    });
+};

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -15,6 +15,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 import useURLSearch from 'hooks/useURLSearch';
 import { getFilteredConfig } from 'Components/CompoundSearchFilter/utils/searchFilterConfig';
 import { OnSearchPayload, clusterSearchFilterConfig } from 'Components/CompoundSearchFilter/types';
+import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import CheckDetailsTable from './CheckDetailsTable';
 import DetailsPageHeader, { PageHeaderLabel } from './components/DetailsPageHeader';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
@@ -107,22 +108,8 @@ function CheckDetails() {
         }
     }, [checkResultsResponse]);
 
-    // @TODO: Consider making a function to make this more reusable
     const onSearch = (payload: OnSearchPayload) => {
-        const { action, category, value } = payload;
-        const currentSelection = searchFilter[category] || [];
-        let newSelection = !Array.isArray(currentSelection) ? [currentSelection] : currentSelection;
-        if (action === 'ADD') {
-            newSelection.push(value);
-        } else if (action === 'REMOVE') {
-            newSelection = newSelection.filter((datum) => datum !== value);
-        } else {
-            // Do nothing
-        }
-        setSearchFilter({
-            ...searchFilter,
-            [category]: newSelection,
-        });
+        onURLSearch(searchFilter, setSearchFilter, payload);
     };
 
     const onCheckStatusSelect = (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -29,6 +29,7 @@ import {
     profileCheckSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
 
+import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import ClusterDetailsTable from './ClusterDetailsTable';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
@@ -95,22 +96,8 @@ function ClusterDetailsPage() {
         history.push(path);
     }
 
-    // @TODO: Consider making a function to make this more reusable
     const onSearch = (payload: OnSearchPayload) => {
-        const { action, category, value } = payload;
-        const currentSelection = searchFilter[category] || [];
-        let newSelection = !Array.isArray(currentSelection) ? [currentSelection] : currentSelection;
-        if (action === 'ADD') {
-            newSelection.push(value);
-        } else if (action === 'REMOVE') {
-            newSelection = newSelection.filter((datum) => datum !== value);
-        } else {
-            // Do nothing
-        }
-        setSearchFilter({
-            ...searchFilter,
-            [category]: newSelection,
-        });
+        onURLSearch(searchFilter, setSearchFilter, payload);
     };
 
     const onCheckStatusSelect = (

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -5,9 +5,11 @@ import { SearchFilter } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
 import useURLParameter, { HistoryAction, QueryValue } from './useURLParameter';
 
+export type SetSearchFilter = (newFilter: SearchFilter, historyAction?: HistoryAction) => void;
+
 type UseUrlSearchReturn = {
     searchFilter: SearchFilter;
-    setSearchFilter: (newFilter: SearchFilter, historyAction?: HistoryAction) => void;
+    setSearchFilter: SetSearchFilter;
 };
 
 function parseFilter(rawFilter: QueryValue): SearchFilter {


### PR DESCRIPTION
## Description

When filtering by `Compliance status`, the `ADD` for the select dropdown would not trigger an API call. This PR fixes that issue

## Before the fix

https://github.com/stackrox/stackrox/assets/4805485/2fccbb6c-8f79-45b6-9de6-9324df26f944

## After the fix

https://github.com/stackrox/stackrox/assets/4805485/f845f9bd-4b14-43f8-817e-468d527bacc9


