### PR TITLE
fix(ui): Don't disable the entity/attribute selector

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
@@ -29,7 +29,7 @@ function AttributeSelector({
 
     const entityAttributes = getEntityAttributes(selectedEntity, config);
 
-    if (entityAttributes.length === 0) {
+    if (entityAttributes.length <= 1) {
         return null;
     }
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
@@ -39,7 +39,6 @@ function AttributeSelector({
             onChange={onChange}
             ariaLabelMenu="compound search filter attribute selector menu"
             ariaLabelToggle="compound search filter attribute selector toggle"
-            isDisabled={entityAttributes.length === 1}
         >
             {entityAttributes.map((attribute) => {
                 return (

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -11,7 +11,6 @@ import {
     imageSearchFilterConfig,
     nodeComponentSearchFilterConfig,
 } from '../types';
-import { getFilteredConfig } from '../utils/searchFilterConfig';
 
 const selectors = {
     entitySelectToggle: 'button[aria-label="compound search filter entity selector toggle"]',
@@ -78,20 +77,6 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.entitySelectToggle).should('not.exist');
     });
 
-    it('should disable the entity selector when only one entity is present', () => {
-        const config = {
-            Image: imageSearchFilterConfig,
-        };
-        const onSearch = cy.stub().as('onSearch');
-        const searchFilter = {};
-
-        setup(config, searchFilter, onSearch);
-
-        cy.get(selectors.entitySelectToggle).should('contain.text', 'Image');
-
-        cy.get(selectors.entitySelectToggle).should('be.disabled');
-    });
-
     it('should display Image and Deployment entities in the entity selector', () => {
         const config = {
             Image: imageSearchFilterConfig,
@@ -130,21 +115,6 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.entitySelectItems).eq(0).should('have.text', 'Image');
         cy.get(selectors.entitySelectItems).eq(1).should('have.text', 'Deployment');
         cy.get(selectors.entitySelectItems).eq(2).should('have.text', 'Cluster');
-    });
-
-    it('should disable the attribute selector when only one attribute is present', () => {
-        const config = {
-            Image: getFilteredConfig(imageSearchFilterConfig, ['Name']),
-        };
-        const onSearch = cy.stub().as('onSearch');
-        const searchFilter = {};
-
-        setup(config, searchFilter, onSearch);
-
-        cy.get(selectors.entitySelectToggle).should('contain.text', 'Image');
-        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
-
-        cy.get(selectors.attributeSelectToggle).should('be.disabled');
     });
 
     it('should display Image attributes in the attribute selector', () => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
@@ -33,7 +33,6 @@ function EntitySelector({ selectedEntity, onChange, config }: EntitySelectorProp
             onChange={onChange}
             ariaLabelMenu="compound search filter entity selector menu"
             ariaLabelToggle="compound search filter entity selector toggle"
-            isDisabled={entities.length === 1}
         >
             {entities.map((entity) => {
                 const displayName = config[entity]?.displayName;


### PR DESCRIPTION
## Description

This PR will undo the change that allowed us to disable the entity/attribute selectors when there was only one option. There were some concerns about possibly confusing the user with the disabled inputs. They might wonder why they can't open it. 

## Screenshots

<img width="1438" alt="Screenshot 2024-06-11 at 12 16 30 PM" src="https://github.com/stackrox/stackrox/assets/4805485/473a5164-1985-410d-9762-aa55f5ec6f27">
