### PR TITLE
chore(ci): add Scanner V4 DB integration tests

### DIFF
--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -1,0 +1,43 @@
+name: Scanner DB integration tests
+
+on:
+  push:
+    tags:
+    - '*'
+    branches:
+    - master
+    - release-*
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+jobs:
+  db-integration-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.69
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Run Postgres
+      run: |
+        su postgres -c 'initdb -D /tmp/data'
+        su postgres -c 'pg_ctl -D /tmp/data start'
+
+    - name: Cache Go dependencies
+      uses: ./.github/actions/cache-go-dependencies
+
+    - name: Is Postgres ready
+      run: pg_isready -h 127.0.0.1
+
+    - name: DB Integration tests
+      run: make -C scanner db-integration-test

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.69
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.69-15-gbb3c0fc973
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.69-15-gbb3c0fc973
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.1
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description

This adds (optional) Scanner V4 DB integration tests to CI. This relies on https://github.com/stackrox/rox-ci-image/pull/212

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
