### PR TITLE
ROX-24284: Get k8s logs from scanner v4 bats tests

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -108,13 +108,15 @@ class OperatorE2eTest(BaseTest):
             )
             print("Removing unused catalog source(s)")
             self.run_with_graceful_kill(
-                ["kubectl", "delete", "catalogsource.operators.coreos.com", "--namespace=olm", "--all"],
+                ["kubectl", "delete", "catalogsource.operators.coreos.com",
+                    "--namespace=olm", "--all"],
                 OperatorE2eTest.OLM_SETUP_TIMEOUT_SEC,
             )
             olm_ns = "olm"
         print("Bouncing catalog operator pod to clear its cache")
         self.run_with_graceful_kill(
-            ["kubectl", "delete", "pods", f"--namespace={olm_ns}", "--selector", "app=catalog-operator", "--now=true"],
+            ["kubectl", "delete", "pods",
+                f"--namespace={olm_ns}", "--selector", "app=catalog-operator", "--now=true"],
             OperatorE2eTest.OLM_SETUP_TIMEOUT_SEC,
         )
 
@@ -284,7 +286,6 @@ class ScannerV4Test(BaseTest):
         def set_dirs_after_start():
             # let post test know where results are
             self.test_outputs = [ScannerV4Test.TEST_OUTPUT_DIR]
-
 
         self.run_with_graceful_kill(
             ["tests/e2e/run-scanner-v4.sh", ScannerV4Test.TEST_OUTPUT_DIR],

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -276,13 +276,20 @@ class ScaleTest(BaseTest):
 
 class ScannerV4Test(BaseTest):
     TEST_TIMEOUT = 240 * 60
+    TEST_OUTPUT_DIR = "/tmp/scanner-v4-logs"
 
     def run(self):
         print("Executing the ScannerV4 Test")
 
+        def set_dirs_after_start():
+            # let post test know where results are
+            self.test_outputs = [ScannerV4Test.TEST_OUTPUT_DIR]
+
+
         self.run_with_graceful_kill(
-            ["tests/e2e/run-scanner-v4.sh"],
+            ["tests/e2e/run-scanner-v4.sh", ScannerV4Test.TEST_OUTPUT_DIR],
             ScannerV4Test.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
         )
 
 

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -140,6 +140,7 @@ class StoreArtifacts(RunWithBestEffortMixin):
 class PostClusterTest(StoreArtifacts):
     """The standard cluster test suite of debug gathering and analysis"""
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         collect_collector_metrics=True,

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -142,7 +142,9 @@ class PostClusterTest(StoreArtifacts):
 
     def __init__(
         self,
+        collect_collector_metrics=True,
         collect_central_artifacts=True,
+        collect_service_logs=True,
         check_stackrox_logs=False,
         artifact_destination_prefix=None,
     ):
@@ -153,6 +155,8 @@ class PostClusterTest(StoreArtifacts):
                                                          "k8s-logs")
         else:
             self.service_logs_destination = PostTestsConstants.K8S_LOG_DIR
+        self._collect_collector_metrics = collect_collector_metrics
+        self._collect_service_logs = collect_service_logs
         self._check_stackrox_logs = check_stackrox_logs
         self.k8s_namespaces = [
             "stackrox",
@@ -174,12 +178,14 @@ class PostClusterTest(StoreArtifacts):
         self.collect_central_artifacts = collect_central_artifacts
 
     def run(self, test_outputs=None):
-        self.collect_collector_metrics()
+        if self._collect_collector_metrics:
+            self.collect_collector_metrics()
         if self.collect_central_artifacts and self.wait_for_central_api():
             self.get_central_debug_dump()
             self.get_central_diagnostics()
             self.grab_central_data()
-        self.collect_service_logs()
+        if self._collect_service_logs:
+            self.collect_service_logs()
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
         self.store_artifacts(test_outputs)

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -265,7 +265,8 @@ class TestClusterTestSetsRunner(unittest.TestCase):
             ClusterTestSetsRunner(
                 sets=[
                     {"test": test1},
-                    {"test": skipped_test, "post_test": post_skipped_test, "always_run": False},
+                    {"test": skipped_test, "post_test": post_skipped_test,
+                        "always_run": False},
                     {"test": test3, "post_test": post_test3},
                 ]
             ).run()

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -16,13 +16,6 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"
 
-# The current Scanner v4 tests only test Scanner v4 installation in different scenarios.
-# Due to the way the tests are structured the different test cases include a teardown at the end.
-# This would cause the standard PostClusterTest would to fail, therefore we use the
-# NullPostTest() here.
-#
-# A seperate test focusing on Scanner v4 functionality (as opposed to just installation)
-# should use the standard PostClusterTest() machinery.
 ClusterTestRunner(
     cluster=GKECluster("scanner-v4-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -8,7 +8,7 @@ from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests
 from ci_tests import ScannerV4Test
-from post_tests import NullPostTest, FinalPost
+from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["STORE_METRICS"] = "true"
@@ -27,6 +27,10 @@ ClusterTestRunner(
     cluster=GKECluster("scanner-v4-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),
     test=ScannerV4Test(),
-    post_test=NullPostTest(),
+    post_test=PostClusterTest(
+        collect_collector_metrics=False,
+        collect_central_artifacts=False,
+        check_stackrox_logs=False,
+    ),
     final_post=FinalPost(),
 ).run()

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -21,6 +21,9 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=ScannerV4Test(),
     post_test=PostClusterTest(
+        # Stackrox is torn down as part of each test execution so data
+        # collection and standard log checks are skipped in this post suite
+        # step. The scanner-v4 test teardown() handles debug collection.
         collect_collector_metrics=False,
         collect_central_artifacts=False,
         check_stackrox_logs=False,

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -8,7 +8,7 @@ from runners import ClusterTestRunner
 from clusters import AutomationFlavorsCluster
 from ci_tests import ScannerV4Test
 from pre_tests import PreSystemTests
-from post_tests import NullPostTest, FinalPost
+from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["STORE_METRICS"] = "true"
@@ -21,6 +21,10 @@ ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),
     pre_test=PreSystemTests(),
     test=ScannerV4Test(),
-    post_test=NullPostTest(),
+    post_test=PostClusterTest(
+        collect_collector_metrics=False,
+        collect_central_artifacts=False,
+        check_stackrox_logs=False,
+    ),
     final_post=FinalPost(),
 ).run()

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -22,6 +22,9 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=ScannerV4Test(),
     post_test=PostClusterTest(
+        # Stackrox is torn down as part of each test execution so data
+        # collection and standard log checks are skipped in this post suite
+        # step. The scanner-v4 test teardown() handles debug collection.
         collect_collector_metrics=False,
         collect_central_artifacts=False,
         check_stackrox_logs=False,

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -187,11 +187,11 @@ teardown() {
     fi
 
     "$ROOT/scripts/ci/collect-service-logs.sh" "${central_namespace}" \
-      "${K8S_LOGS_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
+      "${SCANNER_V4_LOG_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
 
     if [[ "${central_namespace}" != "${sensor_namespace}" && -n "${sensor_namespace}" ]]; then
       "$ROOT/scripts/ci/collect-service-logs.sh" "${sensor_namespace}" \
-        "${K8S_LOGS_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
+        "${SCANNER_V4_LOG_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
     fi
 
     if [[ -z "${BATS_TEST_COMPLETED:-}" && -z "${BATS_TEST_SKIPPED}" && -n "${central_namespace}" ]]; then

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -283,7 +283,7 @@ teardown_file() {
 
     _deploy_stackrox
 
-    verify_scannerV2_deployed "stackroxer"
+    verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
     verify_deployment_scannerV4_env_var_set "stackrox" "sensor"

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -283,7 +283,7 @@ teardown_file() {
 
     _deploy_stackrox
 
-    verify_scannerV2_deployed "stackrox"
+    verify_scannerV2_deployed "stackroxer"
     verify_scannerV4_deployed "stackrox"
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
     verify_deployment_scannerV4_env_var_set "stackrox" "sensor"

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -186,6 +186,14 @@ teardown() {
         sensor_namespace="${CUSTOM_SENSOR_NAMESPACE}"
     fi
 
+    "$ROOT/scripts/ci/collect-service-logs.sh" "${central_namespace}" \
+      "${K8S_LOGS_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
+
+    if [[ "${central_namespace}" != "${sensor_namespace}" && -n "${sensor_namespace}" ]]; then
+      "$ROOT/scripts/ci/collect-service-logs.sh" "${sensor_namespace}" \
+        "${K8S_LOGS_DIR}/${BATS_TEST_NUMBER}-${BATS_TEST_NAME}"
+    fi
+
     if [[ -z "${BATS_TEST_COMPLETED:-}" && -z "${BATS_TEST_SKIPPED}" && -n "${central_namespace}" ]]; then
         # Test did not "complete" and was not skipped. Collect some analysis data.
         describe_pods_in_namespace "${central_namespace}"

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -6,6 +6,7 @@ source "${ROOT}/scripts/ci/lib.sh"
 
 set -euo pipefail
 
+export K8S_LOGS_DIR="$1"
 REPORTS_DIR=$(mktemp -d)
 FAILED=0
 

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -6,7 +6,7 @@ source "${ROOT}/scripts/ci/lib.sh"
 
 set -euo pipefail
 
-export K8S_LOGS_DIR="$1"
+export SCANNER_V4_LOG_DIR="$1"
 REPORTS_DIR=$(mktemp -d)
 FAILED=0
 


### PR DESCRIPTION
## Description

K8s objects and pod logs can be useful for failure debug, This PR gets them for the scanner-v4 bats e2e test suite.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- Data gathered for each bats test under "Additional Stackrox Artifacts"
  - [x] GKE
  - [x] OCP
- Data gathered for failing bats test
  - [x] [forced failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11490/pull-ci-stackrox-stackrox-master-ocp-4-12-scanner-v4-tests/1801026196994002944)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
