### PR TITLE
fix: equal calls on proto objects

### DIFF
--- a/central/graphql/resolvers/inputtypes/vuln_req_test.go
+++ b/central/graphql/resolvers/inputtypes/vuln_req_test.go
@@ -1,12 +1,12 @@
 package inputtypes
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stretchr/testify/suite"
 )
@@ -102,7 +102,7 @@ func (s *VulnReqInputResolversTestSuite) TestAsRequestExpiry() {
 
 	for _, c := range cases {
 		s.T().Run(c.name, func(t *testing.T) {
-			s.True(reflect.DeepEqual(c.expectedExpiry, c.input.AsRequestExpiry()))
+			s.True(protocompat.Equal(c.expectedExpiry, c.input.AsRequestExpiry()))
 		})
 	}
 }

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"reflect"
 	"slices"
 	"sort"
 
@@ -267,7 +266,7 @@ func IsUpdateNoOp(req *storage.VulnerabilityRequest, update *common.UpdateReques
 	if deferralUpdate := update.DeferralUpdate; deferralUpdate != nil {
 		newCVEs := deferralUpdate.GetCVEs()
 		return equal(existingCVEs, newCVEs) &&
-			reflect.DeepEqual(req.GetDeferralReq().GetExpiry(), deferralUpdate.GetExpiry())
+			protocompat.Equal(req.GetDeferralReq().GetExpiry(), deferralUpdate.GetExpiry())
 	}
 
 	if falsePositiveUpdate := update.FalsePositiveUpdate; falsePositiveUpdate != nil {

--- a/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/policy_migrator.go
+++ b/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/policy_migrator.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"embed"
 	"path/filepath"
-	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	pglog "github.com/stackrox/rox/migrator/log"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
 )
@@ -70,7 +70,7 @@ func diffPolicies(beforePolicy, afterPolicy *storage.Policy) (PolicyUpdates, err
 	beforePolicy.Exclusions = nil
 	afterPolicy.Exclusions = nil
 
-	if !reflect.DeepEqual(beforePolicy, afterPolicy) {
+	if !protocompat.Equal(beforePolicy, afterPolicy) {
 		return PolicyUpdates{}, errors.New("policies have diff after nil-ing out fields we checked, please update this function " +
 			"to be able to diff more fields")
 	}
@@ -81,7 +81,7 @@ func getExclusionsUpdates(beforePolicy *storage.Policy, afterPolicy *storage.Pol
 	matchedAfterExclusionsIdxs := set.NewSet[int]()
 	for _, beforeExclusion := range beforePolicy.GetExclusions() {
 		for afterExclusionIdx, afterExclusion := range afterPolicy.GetExclusions() {
-			if reflect.DeepEqual(beforeExclusion, afterExclusion) {
+			if protocompat.Equal(beforeExclusion, afterExclusion) {
 				matchedAfterExclusionsIdxs.Add(afterExclusionIdx)
 				break
 			}

--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_impl.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_impl.go
@@ -2,7 +2,6 @@ package m192tom193
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -10,6 +9,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -194,7 +194,7 @@ func migrate(database *types.Databases) error {
 				return errors.Wrapf(err, "failed to query v2 report config with id %s", newConfig.GetId())
 			}
 			if migrated {
-				if !reflect.DeepEqual(newConfig, data) {
+				if !protocompat.Equal(newConfig, data) {
 					log.Errorf("v1 report config %+v was migrated to create v2 report config.The v1 config has changed since last migration. Skipping re-migration...", reportConfigProto)
 				}
 				continue

--- a/migrator/migrations/policymigrationhelper/policy_migrator.go
+++ b/migrator/migrations/policymigrationhelper/policy_migrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/log"
 	"github.com/stackrox/rox/pkg/jsonutil"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 )
@@ -118,7 +119,7 @@ func (u *PolicyUpdates) applyToPolicy(policy *storage.Policy) {
 func removeExclusion(policy *storage.Policy, exclusionToRemove *storage.Exclusion) bool {
 	exclusions := policy.GetExclusions()
 	for i, exclusion := range exclusions {
-		if reflect.DeepEqual(exclusion, exclusionToRemove) {
+		if protocompat.Equal(exclusion, exclusionToRemove) {
 			policy.Exclusions = append(exclusions[:i], exclusions[i+1:]...)
 			return true
 		}
@@ -259,7 +260,7 @@ func diffPolicies(beforePolicy, afterPolicy *storage.Policy) (PolicyUpdates, err
 
 	// TODO: Add others as needed
 
-	if !reflect.DeepEqual(beforePolicy, afterPolicy) {
+	if !protocompat.Equal(beforePolicy, afterPolicy) {
 		return PolicyUpdates{}, errors.New("policies have diff after nil-ing out fields we checked, please update this function " +
 			"to be able to diff more fields")
 	}
@@ -271,7 +272,7 @@ func getExclusionsUpdates(beforePolicy *storage.Policy, afterPolicy *storage.Pol
 	for _, beforeExclusion := range beforePolicy.GetExclusions() {
 		var found bool
 		for afterExclusionIdx, afterExclusion := range afterPolicy.GetExclusions() {
-			if reflect.DeepEqual(beforeExclusion, afterExclusion) {
+			if protocompat.Equal(beforeExclusion, afterExclusion) {
 				if !matchedAfterExclusionsIdxs.Contains(afterExclusionIdx) { // to account for duplicates
 					found = true
 					matchedAfterExclusionsIdxs.Add(afterExclusionIdx)

--- a/migrator/migrations/policymigrationhelper/policy_migrator.go
+++ b/migrator/migrations/policymigrationhelper/policy_migrator.go
@@ -2,7 +2,6 @@ package policymigrationhelper
 
 import (
 	"embed"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,6 +9,7 @@ import (
 	"github.com/stackrox/rox/migrator/log"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 )
@@ -143,12 +143,12 @@ type FieldComparator func(first, second *storage.Policy) bool
 
 // PolicySectionComparator compares the policySections of both policies and returns true if they are equal
 func PolicySectionComparator(first, second *storage.Policy) bool {
-	return reflect.DeepEqual(first.GetPolicySections(), second.GetPolicySections())
+	return protoutils.SlicesEqual(first.GetPolicySections(), second.GetPolicySections())
 }
 
 // ExclusionComparator compares the Exclusions of both policies and returns true if they are equal
 func ExclusionComparator(first, second *storage.Policy) bool {
-	return reflect.DeepEqual(first.GetExclusions(), second.GetExclusions())
+	return protoutils.SlicesEqual(first.GetExclusions(), second.GetExclusions())
 }
 
 // NameComparator compares both policies' names and returns true if they are equal
@@ -205,14 +205,14 @@ func diffPolicies(beforePolicy, afterPolicy *storage.Policy) (PolicyUpdates, err
 	afterPolicy.Exclusions = nil
 
 	// Policy section
-	if !reflect.DeepEqual(beforePolicy.GetPolicySections(), afterPolicy.GetPolicySections()) {
+	if !protoutils.SlicesEqual(beforePolicy.GetPolicySections(), afterPolicy.GetPolicySections()) {
 		updates.PolicySections = afterPolicy.PolicySections
 	}
 	beforePolicy.PolicySections = nil
 	afterPolicy.PolicySections = nil
 
 	// MITRE section
-	if !reflect.DeepEqual(beforePolicy.GetMitreAttackVectors(), afterPolicy.GetMitreAttackVectors()) {
+	if !protoutils.SlicesEqual(beforePolicy.GetMitreAttackVectors(), afterPolicy.GetMitreAttackVectors()) {
 		updates.MitreVectors = afterPolicy.MitreAttackVectors
 	}
 	beforePolicy.MitreAttackVectors = nil

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sensor/hash"
 	"github.com/stackrox/rox/sensor/common"
 	configMocks "github.com/stackrox/rox/sensor/common/config/mocks"
@@ -374,7 +374,7 @@ func newMessagesMatcher(errorMsg string, msgs ...*central.MsgFromSensor) *messag
 			if x.GetEvent() == nil || y.GetEvent() == nil {
 				return false
 			}
-			return x.GetEvent().GetId() == y.GetEvent().GetId() && cmp.Equal(x.GetEvent().GetDeployment(), y.GetEvent().GetDeployment())
+			return x.GetEvent().GetId() == y.GetEvent().GetId() && protocompat.Equal(x.GetEvent().GetDeployment(), y.GetEvent().GetDeployment())
 		},
 	}
 	for _, m := range msgs {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
@@ -593,7 +594,7 @@ func (m *deploymentMatcher) Matches(target interface{}) bool {
 			return m.acceptableNumberOfMismatches >= 0
 		}
 
-		if !cmp.Equal(m.expectedExposureInfos, deployment.GetPorts()[0].GetExposureInfos()) {
+		if !protoutils.SlicesEqual(m.expectedExposureInfos, deployment.GetPorts()[0].GetExposureInfos()) {
 			diff := cmp.Diff(m.expectedExposureInfos, deployment.GetPorts()[0].GetExposureInfos())
 			m.error = fmt.Sprintf("Exposure info differs: %s", diff)
 			m.acceptableNumberOfMismatches--

--- a/tools/roxvet/analyzers/donotcompareproto/analyzer.go
+++ b/tools/roxvet/analyzers/donotcompareproto/analyzer.go
@@ -36,9 +36,7 @@ var (
 		"map[string]":   "MapEqual",
 	}
 
-	allowedCallerPackages = []string{
-		"github.com/stackrox/rox",
-	}
+	allowedCallerPackages []string
 
 	bannedEqualFunctions = set.NewFrozenStringSet(
 		"github.com/google/go-cmp/cmp.Equal",


### PR DESCRIPTION
## Description

This PR fixes calls to `DeepEqual` and `cmp.Equal` on proto objects.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
