### PR TITLE
ROX-24698: Use totalCount from listComplianceScanConfigurations

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -39,7 +39,6 @@ import useURLSort from 'hooks/useURLSort';
 import {
     ComplianceScanConfigurationStatus,
     deleteComplianceScanConfiguration,
-    getComplianceScanConfigurationsCount,
     listComplianceScanConfigurations,
     runComplianceReport,
     runComplianceScanConfiguration,
@@ -95,10 +94,7 @@ function ScanConfigsTablePage({
         () => listComplianceScanConfigurations(sortOption, page - 1, perPage),
         [sortOption, page, perPage]
     );
-    const { data: scanSchedules, loading: isLoading, error, refetch } = useRestQuery(listQuery);
-
-    const countQuery = useCallback(() => getComplianceScanConfigurationsCount(), []);
-    const { data: scanSchedulesCount } = useRestQuery(countQuery);
+    const { data: listData, loading: isLoading, error, refetch } = useRestQuery(listQuery);
 
     const { alertObj, setAlertObj, clearAlertObj } = useAlert();
 
@@ -181,7 +177,7 @@ function ScanConfigsTablePage({
     }
 
     const renderTableContent = () => {
-        return scanSchedules?.map((scanSchedule) => {
+        return listData?.configurations?.map((scanSchedule) => {
             const { id, scanName, scanConfig, lastExecutedTime, clusterStatus } = scanSchedule;
             const scanConfigUrl = generatePath(scanConfigDetailsPath, {
                 scanConfigId: id,
@@ -261,7 +257,7 @@ function ScanConfigsTablePage({
         if (isLoading) {
             return renderLoadingContent();
         }
-        if (scanSchedules && scanSchedules.length > 0) {
+        if (Array.isArray(listData?.configurations) && listData.configurations.length > 0) {
             return renderTableContent();
         }
         return renderEmptyContent();
@@ -312,7 +308,7 @@ function ScanConfigsTablePage({
                         <ToolbarContent>
                             <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
                                 <Pagination
-                                    itemCount={scanSchedulesCount ?? 0}
+                                    itemCount={listData?.totalCount ?? 0}
                                     page={page}
                                     perPage={perPage}
                                     onSetPage={(_, newPage) => setPage(newPage)}

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -78,6 +78,11 @@ export type ComplianceScanConfigurationStatus = {
     lastExecutedTime: string | null; // either ISO 8601 date string or null when scan is in progress
 };
 
+export type ListComplianceScanConfigurationsResponse = {
+    configurations: ComplianceScanConfigurationStatus[];
+    totalCount: number; // int32
+};
+
 /*
  * Fetches a list of scan configurations.
  */
@@ -85,7 +90,7 @@ export function listComplianceScanConfigurations(
     sortOption: ApiSortOption,
     page?: number,
     pageSize?: number
-): Promise<ComplianceScanConfigurationStatus[]> {
+): Promise<ListComplianceScanConfigurationsResponse> {
     let offset: number | undefined;
     if (typeof page === 'number' && typeof pageSize === 'number') {
         offset = page > 0 ? page * pageSize : 0;
@@ -95,11 +100,9 @@ export function listComplianceScanConfigurations(
     };
     const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<{
-            configurations: ComplianceScanConfigurationStatus[];
-        }>(`${complianceScanConfigBaseUrl}?${params}`)
+        .get<ListComplianceScanConfigurationsResponse>(`${complianceScanConfigBaseUrl}?${params}`)
         .then((response) => {
-            return response?.data?.configurations ?? [];
+            return response?.data ?? { configurations: [], totalCount: 0 };
         });
 }
 
@@ -148,19 +151,6 @@ export function deleteComplianceScanConfiguration(scanConfigId: string) {
         .delete<Empty>(`${complianceScanConfigBaseUrl}/${scanConfigId}`)
         .then((response) => {
             return response.data;
-        });
-}
-
-/*
- * Returns the count of scan configurations.
- */
-export function getComplianceScanConfigurationsCount(): Promise<number> {
-    return axios
-        .get<{
-            count: number;
-        }>(`${complianceV2Url}/scan/count/configurations`)
-        .then((response) => {
-            return response?.data?.count ?? 0;
         });
 }
 


### PR DESCRIPTION
## Description

Replace count from `getComplianceScanConfigurationsCount` call with `totalCount` property in response of `listComplianceScanConfigurations` service function.

Prerequisite for backend team to delete the obsolete endpoint.

### Changes

1. Edit ScanConfigsTablePage.tsx file.
    * Delete `getComplianceScanConfigurationsCount` function call.
    * Replace `scanSchedules` with `listData?.configurations` from `listComplianceScanConfigurations` function call.
    * Replace `scanSchedulesCount` with `listData?.totalCount` from `listComplianceScanConfigurations` function call.

2. Edit ComplianceScanConfigurationService.ts file.
    * Add `ListComplianceScanConfigurationsResponse` type.
        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/compliance_scan_configuration_service.proto#L68-L71
    * Return both `configurations` and `totalCount` in data object for `listComplianceScanConfigurations` function.
    * Delete `getComplianceScanConfigurationsCount` function.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636804 - 4636804
        total -51 = 11722186 - 11722237
    * `ls -al build/static/js/*.js | wc`
        files 0 = 174 - 174
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/schedules

    * Before change with `getComplianceScanConfigurationsCount` function call.
        See two requests:
        GET /v2/compliance/scan/configurations?… has `totalCount: 1` in response.
        GET /v2/compliance/scan/count/configurations has `count: 1` in response.
        ![with_getComplianceScanConfigurationsCount](https://github.com/stackrox/stackrox/assets/11862657/9f2adcf0-69f4-45f4-b81f-523b61a95487)

    * After change without `getComplianceScanConfigurationsCount` function call.
        See one request:
        GET /v2/compliance/scan/configurations?… has `totalCount: 1` in response.
        ![without_getComplianceScanConfigurationsCount](https://github.com/stackrox/stackrox/assets/11862657/eea6c8d6-5f97-4750-b3e3-9d16020e317c)
