### PR TITLE
ROX-22019: Skip internal fields used by protobuf framework in walkers

### DIFF
--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoreflect"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
@@ -179,6 +180,12 @@ func (o *AugmentedObjMeta) addPathsForSearchTagsFromStruct(currentType reflect.T
 		field := currentType.Field(i)
 		if _, inAugmented := augmentedFields[field.Name]; inAugmented {
 			// Skip this field -- it has been clobbered by an augment.
+			continue
+		}
+
+		// We need to skip internal fields for proto generated structs,
+		// because they contain recursive references.
+		if protoreflect.IsProtoMessage(currentType) && protoreflect.IsInternalGeneratorField(field) {
 			continue
 		}
 

--- a/pkg/protoreflect/field.go
+++ b/pkg/protoreflect/field.go
@@ -1,6 +1,16 @@
 package protoreflect
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/stackrox/rox/pkg/protocompat"
+)
+
+func IsProtoMessage(msgType reflect.Type) bool {
+	_, ok := reflect.New(msgType).Interface().(protocompat.Message)
+
+	return ok
+}
 
 func IsInternalGeneratorField(structField reflect.StructField) bool {
 	return structField.Tag.Get("protobuf") == "" && structField.Tag.Get("protobuf_oneof") == ""


### PR DESCRIPTION
## Description

**This is protobuf V2 pre-migration modification!** We have identified a few problems during work on #10951 PR. And we want to move changes that can be done before switching to protobuf V2.

This PR is added logic to ignore (or skip) internal fields generated by proto-generation tools.

In some cases, we are checking if the struct is `proto.Message` to support non-proto structs in walkers.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Only CI pipeline because nothing should change in tests or generated codes.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
