### PR TITLE
ROX-24484: Add advanced filters and regex to namespace view

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -454,14 +454,10 @@ export function interactAndWaitForDeploymentList(callback) {
 }
 
 export function waitForTableLoadCompleteIndicator() {
-    cy.get(selectors.loadingSpinner);
-    cy.get(selectors.loadingSpinner).should('not.exist');
+    cy.get(`table ${selectors.loadingSpinner}`);
+    cy.get(`table ${selectors.loadingSpinner}`).should('not.exist');
 }
 
 export function visitNamespaceView() {
-    const namespaceListOpname = 'getNamespaceViewNamespaces';
-    const namespaceListRouteMatcherMap = getRouteMatcherMapForGraphQL([namespaceListOpname]);
-    return interactAndWaitForResponses(() => {
-        cy.get('button:contains("Prioritize by namespace view")').click();
-    }, namespaceListRouteMatcherMap);
+    cy.get('button:contains("Prioritize by namespace view")').click();
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -457,3 +457,11 @@ export function waitForTableLoadCompleteIndicator() {
     cy.get(selectors.loadingSpinner);
     cy.get(selectors.loadingSpinner).should('not.exist');
 }
+
+export function visitNamespaceView() {
+    const namespaceListOpname = 'getNamespaceViewNamespaces';
+    const namespaceListRouteMatcherMap = getRouteMatcherMapForGraphQL([namespaceListOpname]);
+    return interactAndWaitForResponses(() => {
+        cy.get(selectors.namespaceViewButton).click();
+    }, namespaceListRouteMatcherMap);
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -462,6 +462,6 @@ export function visitNamespaceView() {
     const namespaceListOpname = 'getNamespaceViewNamespaces';
     const namespaceListRouteMatcherMap = getRouteMatcherMapForGraphQL([namespaceListOpname]);
     return interactAndWaitForResponses(() => {
-        cy.get(selectors.namespaceViewButton).click();
+        cy.get('button:contains("Prioritize by namespace view")').click();
     }, namespaceListRouteMatcherMap);
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -55,7 +55,6 @@ export const selectors = {
     paginationNext: "button[aria-label='Go to next page']",
     severityIcon: (severity) => `span.pf-v5-c-icon:contains('${severity}')`,
     loadingSpinner: 'svg[role="progressbar"][aria-valuetext="Loading..."]',
-    namespaceViewButton: 'button:contains("Prioritize by namespace view")',
 
     // Image/Deployment tab selectors
     vulnerabilitiesTab: 'button[role="tab"]:contains("Vulnerabilities")',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -55,6 +55,7 @@ export const selectors = {
     paginationNext: "button[aria-label='Go to next page']",
     severityIcon: (severity) => `span.pf-v5-c-icon:contains('${severity}')`,
     loadingSpinner: 'svg[role="progressbar"][aria-valuetext="Loading..."]',
+    namespaceViewButton: 'button:contains("Prioritize by namespace view")',
 
     // Image/Deployment tab selectors
     vulnerabilitiesTab: 'button[role="tab"]:contains("Vulnerabilities")',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -1,0 +1,26 @@
+import withAuth from '../../../helpers/basicAuth';
+
+import { visitWorkloadCveOverview, visitNamespaceView } from './WorkloadCves.helpers';
+import { selectors } from './WorkloadCves.selectors';
+
+describe('Workload CVE Namespace View', () => {
+    withAuth();
+
+    it('should display the correct search filter chips on the main list page when clicking the deployment link in the table', () => {
+        visitWorkloadCveOverview();
+
+        visitNamespaceView();
+
+        cy.get(selectors.firstTableRow).then(($row) => {
+            const namespace = $row.find('td[data-label="Namespace"]').text();
+            const cluster = $row.find('td[data-label="Cluster"]').text();
+
+            cy.wrap($row.find('td[data-label="Deployments"] a')).click();
+
+            cy.get('h1:contains("Workload CVEs")');
+
+            cy.get(selectors.filterChipGroupItem('Namespace', `^${namespace}$`));
+            cy.get(selectors.filterChipGroupItem('Cluster', `^${cluster}$`));
+        });
+    });
+});

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -1,6 +1,10 @@
 import withAuth from '../../../helpers/basicAuth';
 
-import { visitWorkloadCveOverview, visitNamespaceView } from './WorkloadCves.helpers';
+import {
+    visitWorkloadCveOverview,
+    visitNamespaceView,
+    waitForTableLoadCompleteIndicator,
+} from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE Namespace View', () => {
@@ -10,6 +14,8 @@ describe('Workload CVE Namespace View', () => {
         visitWorkloadCveOverview();
 
         visitNamespaceView();
+
+        waitForTableLoadCompleteIndicator();
 
         cy.get(selectors.firstTableRow).then(($row) => {
             const namespace = $row.find('td[data-label="Namespace"]').text();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -16,8 +16,8 @@ function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName }) {
         vulnerabilityState: 'OBSERVED',
         entityTab: 'Deployment',
         s: {
-            NAMESPACE: `^${namespaceName}$`,
-            CLUSTER: `^${clusterName}$`,
+            Namespace: `^${namespaceName}$`,
+            Cluster: `^${clusterName}$`,
         },
     });
     return (


### PR DESCRIPTION
## Description

Updates the namespace view to use advanced filters and regex search by default.

Also adds a Cypress test to verify that filters are correctly passed to the overview page and displayed as chips. The move to advanced filters broke this subtly and was not detected.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![image](https://github.com/stackrox/stackrox/assets/1292638/ceb6a243-727b-44c5-81d8-a2d33e7c9fa5)
![image](https://github.com/stackrox/stackrox/assets/1292638/0b93f17e-477e-40a7-911f-f619c476a479)
![image](https://github.com/stackrox/stackrox/assets/1292638/a3fdd3ca-d120-44a7-8824-91fd26655f6c)
