### PR TITLE
ROX-24699: Fix accessibility problems in compliance pages

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -28,7 +28,7 @@ import {
 } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
-import CheckDetailsTable from './CheckDetailsTable';
+import CheckDetailsTable, { tabContentIdForResults } from './CheckDetailsTable';
 import CheckDetailsInfo from './components/CheckDetailsInfo';
 import DetailsPageHeader, { PageHeaderLabel } from './components/DetailsPageHeader';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
@@ -38,6 +38,8 @@ import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 
 export const DETAILS_TAB = 'Details';
 const RESULTS_TAB = 'Results';
+
+const tabContentIdForDetails = 'check-details-Details-tab-section';
 
 export const TAB_NAV_QUERY = 'detailsTab';
 const TAB_NAV_VALUES = [RESULTS_TAB, DETAILS_TAB] as const;
@@ -190,10 +192,17 @@ function CheckDetails() {
                 }}
                 component={TabsComponent.nav}
                 className="pf-v5-u-pl-md pf-v5-u-background-color-100 pf-v5-u-flex-shrink-0"
-                role="region"
             >
-                <Tab eventKey={RESULTS_TAB} title={RESULTS_TAB} />
-                <Tab eventKey={DETAILS_TAB} title={DETAILS_TAB} />
+                <Tab
+                    eventKey={RESULTS_TAB}
+                    title={RESULTS_TAB}
+                    tabContentId={tabContentIdForResults}
+                />
+                <Tab
+                    eventKey={DETAILS_TAB}
+                    title={DETAILS_TAB}
+                    tabContentId={tabContentIdForDetails}
+                />
             </Tabs>
             <PageSection>
                 {activeTabKey === RESULTS_TAB && (
@@ -211,7 +220,7 @@ function CheckDetails() {
                     />
                 )}
                 {activeTabKey === DETAILS_TAB && (
-                    <PageSection variant="light" component="div">
+                    <PageSection variant="light" component="div" id={tabContentIdForDetails}>
                         <CheckDetailsInfo
                             checkDetails={checkDetailsResponse}
                             isLoading={isLoadingCheckDetails}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -30,6 +30,8 @@ import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import { CHECK_STATUS_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
 
+export const tabContentIdForResults = 'check-details-Results-tab-section';
+
 export type CheckDetailsTableProps = {
     checkResultsCount: number;
     currentDatetime: Date;
@@ -62,7 +64,7 @@ function CheckDetailsTable({
     const { page, perPage, setPage, setPerPage } = pagination;
 
     return (
-        <>
+        <div id={tabContentIdForResults}>
             <Toolbar>
                 <ToolbarContent>
                     <ToolbarGroup className="pf-v5-u-w-100">
@@ -168,7 +170,7 @@ function CheckDetailsTable({
                     )}
                 />
             </Table>
-        </>
+        </div>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ProfileSelection.tsx
@@ -184,8 +184,8 @@ function ProfileSelection({
                 <Table>
                     <Thead noWrap>
                         <Tr>
-                            <Th />
-                            <Th />
+                            <Td />
+                            <Td />
                             <Th>Profile</Th>
                             <Th>Rule set</Th>
                             <Th>Applicability</Th>


### PR DESCRIPTION
## Description

During bug bash, I scanned all pages with axe DevTools.

### Problems

1. /main/compliance/coverage/profiles/profile/checks/check?detailsTab=Results

    > ARIA attributes must conform to valid values

        `<button type="button" data-ouia-component-type="PF5/TabButton" data-ouia-safe="true" class="pf-v5-c-tabs__link" id="pf-tab-Results-pf-1718214190870qxggf298ymi" aria-controls="pf-tab-section-Results-pf-1718214190870qxggf298ymi" role="tab" aria-selected="true">Results</button>`

        aria-controls="pf-tab-section-Results-pf-1718214190870qxggf298ymi"

    > ARIA role should be appropriate for element

        `<nav class="pf-v5-c-tabs pf-v5-u-pl-md pf-v5-u-background-color-100 pf-v5-u-flex-shrink-0" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-1" role="region">`

        ARIA role region is not allowed for given element

2. Step 3 Select profiles of compliance schedules wizard

    > Table header text should not be empty

### Solutions

1. Edit CheckDetailsPage.tsx and CheckDetailsTable.tsx files.
    * Add `tabContentId` prop to actual `id` prop in tab section elements.
    * Delete `role="region"` prop.

2. Edit ProfileSelection.tsx file.
    * Because axe DevTools still reports the issue if I add `aria-label` prop to `Th` element, replace `Th` with `Td` as commonly-accepted work-around.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636842 - 4636842
        total 102 = 11727510 - 11727408
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

1. Click **Coverage** under **Compliance (2.0)** in left navigation, and then click a check to visit check details page.

    * After changes without accessibility issues.
        ![coverage_without_issues](https://github.com/stackrox/stackrox/assets/11862657/46ca33e0-ff78-41fe-b4b1-101d61e9fe9d)

2. Visit /main/compliance/schedules, click **Create scan schedule**, and fill in fields until Step 3 Select profiles.

    * Before changes with accessibility issues.
        ![schedules_step_3_with_issues](https://github.com/stackrox/stackrox/assets/11862657/5decdbab-fe7f-4041-a25c-9653872daa5b)

    * After changes without accessibility issues.
        ![schedules_step_3_without_issues](https://github.com/stackrox/stackrox/assets/11862657/6871f168-db4f-4df1-8804-fa8e8e4e8499)
