### PR TITLE
fix(ui): Advanced Filters bug fixes and improvements

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -303,9 +303,9 @@ describe(Cypress.spec.relative, () => {
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
             category: 'Image Created Time',
-            value: '2034-01-15',
+            value: '01/15/2034',
         });
-        cy.get('input[aria-label="Filter by date"]').should('have.value', '2034-01-15');
+        cy.get('input[aria-label="Filter by date"]').should('have.value', '01/15/2034');
     });
 
     it('should display the condition-number input and correctly search for image cvss', () => {
@@ -394,8 +394,6 @@ describe(Cypress.spec.relative, () => {
             'div[aria-labelledby="Filter results menu toggle"] button[aria-label="Menu toggle"]';
         const autocompleteMenuItems = 'div[aria-label="Filter results select menu"] ul li';
         const autocompleteInput = 'input[aria-label="Filter results by image name"]';
-        const autocompleteClearInputButton =
-            'div[aria-labelledby="Filter results menu toggle"] button[aria-label="Clear input value"]';
         const autocompleteSearchButton = 'button[aria-label="Apply autocomplete input to search"]';
 
         setup(config, searchFilter, onSearch);
@@ -416,9 +414,6 @@ describe(Cypress.spec.relative, () => {
             category: 'Image',
             value: 'docker.io/library/centos:7',
         });
-        cy.get(autocompleteInput).should('have.value', 'docker.io/library/centos:7');
-
-        cy.get(autocompleteClearInputButton).click();
 
         cy.get(autocompleteInput).should('have.value', '');
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -96,12 +96,11 @@ function CompoundSearchFilter({
                 onSearch={(payload) => {
                     // If the search value is non-empty and not in the searchFilter, trigger onSearch
                     if (
-                        !searchFilter[payload.category]?.includes(payload.value) &&
+                        !searchFilter?.[payload.category]?.includes(payload.value) &&
                         payload.value !== ''
                     ) {
                         onSearch(payload);
                     }
-                    setInputValue('');
                 }}
                 config={config}
             />

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -93,7 +93,16 @@ function CompoundSearchFilter({
                     setInputValue(value);
                 }}
                 searchFilter={searchFilter}
-                onSearch={onSearch}
+                onSearch={(payload) => {
+                    // If the search value is non-empty and not in the searchFilter, trigger onSearch
+                    if (
+                        !searchFilter[payload.category]?.includes(payload.value) &&
+                        payload.value !== ''
+                    ) {
+                        onSearch(payload);
+                    }
+                    setInputValue('');
+                }}
                 config={config}
             />
         </Split>

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DatePicker, SearchInput, SelectOption } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
+import { formatDate } from 'utils/dateUtils';
 import { SelectedEntity } from './EntitySelector';
 import { SelectedAttribute } from './AttributeSelector';
 import {
@@ -68,13 +69,14 @@ function CompoundSearchFilterInputField({
                 placeholder={textLabel}
                 value={ensureString(value)}
                 onChange={(_event, _value) => onChange(_value)}
-                onSearch={(_event, _value) =>
+                onSearch={(_event, _value) => {
                     onSearch({
                         action: 'ADD',
                         category: attributeObject.searchTerm,
                         value: _value,
-                    })
-                }
+                    });
+                    onChange('');
+                }}
                 onClear={() => onChange('')}
                 submitSearchButtonLabel="Apply text input to search"
             />
@@ -87,13 +89,16 @@ function CompoundSearchFilterInputField({
                 buttonAriaLabel="Filter by date toggle"
                 value={ensureString(value)}
                 onChange={(_event, _value) => {
+                    const formattedValue = _value ? formatDate(new Date(_value)) : '';
                     onChange(_value);
                     onSearch({
                         action: 'ADD',
                         category: attributeObject.searchTerm,
-                        value: _value,
+                        value: formattedValue,
                     });
                 }}
+                dateFormat={formatDate}
+                placeholder="MM/DD/YYYY"
             />
         );
     }
@@ -133,12 +138,12 @@ function CompoundSearchFilterInputField({
                     onChange(newValue);
                 }}
                 onSearch={(newValue) => {
-                    onChange(newValue);
                     onSearch({
                         action: 'ADD',
                         category: attributeObject.searchTerm,
                         value: newValue,
                     });
+                    onChange('');
                 }}
                 textLabel={textLabel}
             />

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { DatePicker, SearchInput, SelectOption } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
-import { formatDate } from 'utils/dateUtils';
+import { getDate } from 'utils/dateUtils';
+import { dateFormat } from 'constants/dateTimeFormat';
 import { SelectedEntity } from './EntitySelector';
 import { SelectedAttribute } from './AttributeSelector';
 import {
@@ -89,7 +90,7 @@ function CompoundSearchFilterInputField({
                 buttonAriaLabel="Filter by date toggle"
                 value={ensureString(value)}
                 onChange={(_event, _value) => {
-                    const formattedValue = _value ? formatDate(new Date(_value)) : '';
+                    const formattedValue = _value ? getDate(_value) : '';
                     onChange(_value);
                     onSearch({
                         action: 'ADD',
@@ -97,8 +98,8 @@ function CompoundSearchFilterInputField({
                         value: formattedValue,
                     });
                 }}
-                dateFormat={formatDate}
-                placeholder="MM/DD/YYYY"
+                dateFormat={getDate}
+                placeholder={dateFormat}
             />
         );
     }

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -293,15 +293,6 @@ export const imageCVESearchFilterConfig = {
             searchTerm: 'CVSS',
             inputType: 'condition-number',
         },
-        Type: {
-            displayName: 'Type',
-            filterChipLabel: 'Image CVE Type',
-            searchTerm: 'CVE Type',
-            inputType: 'select',
-            inputProps: {
-                options: [{ label: 'Image CVE', value: 'IMAGE_CVE' }],
-            },
-        },
     },
 } as const;
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -56,15 +56,6 @@ describe('utils', () => {
                     searchTerm: 'CVSS',
                     inputType: 'condition-number',
                 },
-                {
-                    displayName: 'Type',
-                    filterChipLabel: 'Image CVE Type',
-                    searchTerm: 'CVE Type',
-                    inputType: 'select',
-                    inputProps: {
-                        options: [{ label: 'Image CVE', value: 'IMAGE_CVE' }],
-                    },
-                },
             ]);
         });
     });
@@ -131,10 +122,6 @@ describe('utils', () => {
                 {
                     displayName: 'Image CVE CVSS',
                     searchFilterName: 'CVSS',
-                },
-                {
-                    displayName: 'Image CVE Type',
-                    searchFilterName: 'CVE Type',
                 },
             ]);
         });

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
@@ -1,4 +1,4 @@
 // searchable and sortable query parameter fields
 export const CLUSTER_QUERY = 'Cluster';
 export const CHECK_NAME_QUERY = 'Compliance Check Name';
-export const CHECK_STATUS_QUERY = 'Compliance Status';
+export const CHECK_STATUS_QUERY = 'Compliance Check Status';

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -165,6 +165,13 @@ export function getDayOfMonthWithOrdinal(num: number): string {
     }
 }
 
+export const formatDate = (date: Date) => {
+    const day = `0${date.getDate()}`.slice(-2);
+    const month = `0${date.getMonth() + 1}`.slice(-2);
+    const year = date.getFullYear();
+    return `${month}/${day}/${year}`;
+};
+
 export default {
     getLatestDatedItemByKey,
     addBrandedTimestampToString,

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -165,13 +165,6 @@ export function getDayOfMonthWithOrdinal(num: number): string {
     }
 }
 
-export const formatDate = (date: Date) => {
-    const day = `0${date.getDate()}`.slice(-2);
-    const month = `0${date.getMonth() + 1}`.slice(-2);
-    const year = date.getFullYear();
-    return `${month}/${day}/${year}`;
-};
-
 export default {
     getLatestDatedItemByKey,
     addBrandedTimestampToString,


### PR DESCRIPTION
## Description

The following are fixed:

1. Removed the unnecessary Image CVE Type option
2. Duplicate values can't be added to searchFilter
3. Empty values can't be added to searchFilter
4. Applying a search value for the text and autocomplete inputs will clear the input field
5. The date picker should use the format `MM/DD/YYYY` instead of `YYYY-MM-DD` so it aligns with what the backend expects
6. Updating tests


