### PR TITLE
ROX-23942: remove duplicate vulns

### DIFF
--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -868,8 +868,7 @@ OUTER:
 //
 // The goal of this function is to make it clear those two CVE-2019-12900 findings are exactly the same.
 func vulnsEqual(a, b *claircore.Vulnerability) bool {
-	return a.Updater == b.Updater &&
-		a.Name == b.Name &&
+	return a.Name == b.Name &&
 		a.Description == b.Description &&
 		a.Issued == b.Issued &&
 		a.Links == b.Links &&

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -102,7 +102,7 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	}
 	return &v4.VulnerabilityReport{
 		Vulnerabilities:        vulnerabilities,
-		PackageVulnerabilities: toProtoV4PackageVulnerabilitiesMap(r.PackageVulnerabilities),
+		PackageVulnerabilities: toProtoV4PackageVulnerabilitiesMap(r.PackageVulnerabilities, r.Vulnerabilities),
 		Contents:               contents,
 	}, nil
 }
@@ -278,7 +278,7 @@ func toProtoV4Environment(e *claircore.Environment) *v4.Environment {
 	}
 }
 
-func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string) map[string]*v4.StringList {
+func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string, ccVulnerabilities map[string]*claircore.Vulnerability) map[string]*v4.StringList {
 	if ccPkgVulnerabilities == nil {
 		return nil
 	}
@@ -286,12 +286,12 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 	if len(ccPkgVulnerabilities) > 0 {
 		pkgVulns = make(map[string]*v4.StringList, len(ccPkgVulnerabilities))
 	}
-	for k, v := range ccPkgVulnerabilities {
-		if v == nil {
+	for id, vulnIDs := range ccPkgVulnerabilities {
+		if vulnIDs == nil {
 			continue
 		}
-		pkgVulns[k] = &v4.StringList{
-			Values: append([]string(nil), v...),
+		pkgVulns[id] = &v4.StringList{
+			Values: filterVulns(vulnIDs, ccVulnerabilities),
 		}
 	}
 	return pkgVulns
@@ -814,4 +814,66 @@ func findName(vuln *claircore.Vulnerability, p *regexp.Regexp) (string, bool) {
 		return v, true
 	}
 	return "", false
+}
+
+// filterVulns filters repeat vulnerabilities out of vulnIDs and returns the result.
+// This function does not guarantee ordering is preserved.
+func filterVulns(vulnIDs []string, vulns map[string]*claircore.Vulnerability) []string {
+	// Group each vulnerability by name.
+	// This maps each name to a slice of vulnerabilities to protect against the possibility
+	// Claircore finds multiple vulnerabilities with the same name for this package from different vulnerability streams.
+	// In that situation, it is not clear which one may be the single, correct option to choose, so just allow for both.
+	vulnsByName := make(map[string][]*claircore.Vulnerability)
+OUTER:
+	for _, vulnID := range vulnIDs {
+		vuln := vulns[vulnID]
+		if vuln == nil {
+			continue
+		}
+
+		// Find the currently tracked vulnerabilities with the same name.
+		// If this entry matches any of those, then ignore this one.
+		matching := vulnsByName[vuln.Name]
+		for _, match := range matching {
+			if vulnsEqual(match, vuln) {
+				continue OUTER
+			}
+		}
+
+		// Add the unique entry to the map.
+		vulnsByName[vuln.Name] = append(vulnsByName[vuln.Name], vuln)
+	}
+
+	filtered := make([]string, 0, len(vulns))
+	for _, vulns := range vulnsByName {
+		for _, vuln := range vulns {
+			filtered = append(filtered, vuln.ID)
+		}
+	}
+	return filtered
+}
+
+// vulnsEqual determines if the vulnerabilities are essentially equal.
+// That is, this function does not check all fields of the vulnerability struct,
+// to prevent consumers from seeing two seemingly identical vulnerabilities
+// for the same package in the same image.
+//
+// For example: Claircore currently returns CVE-2019-12900 twice for the bzip2-libs package
+// in one particular image. The two versions of the CVE are exactly the same
+// except for the repository name (cpe:/a:redhat:enterprise_linux:8::appstream vs cpe:/o:redhat:enterprise_linux:8::baseos).
+// The entry for this vulnerability as it matched this package in this image may be found in
+// https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2.
+// After reading the entry in this file, it is clear Claircore matched this vulnerability to this stream's
+// CVE-2019-12900 entry twice (once per matching repository).
+//
+// The goal of this function is to make it clear those two CVE-2019-12900 findings are exactly the same.
+func vulnsEqual(a, b *claircore.Vulnerability) bool {
+	return a.Updater == b.Updater &&
+		a.Name == b.Name &&
+		a.Description == b.Description &&
+		a.Issued == b.Issued &&
+		a.Links == b.Links &&
+		a.Severity == b.Severity &&
+		a.NormalizedSeverity == b.NormalizedSeverity &&
+		a.FixedInVersion == b.FixedInVersion
 }

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -291,7 +291,7 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 			continue
 		}
 		pkgVulns[id] = &v4.StringList{
-			Values: filterVulns(vulnIDs, ccVulnerabilities),
+			Values: filterRepeatedVulns(vulnIDs, ccVulnerabilities),
 		}
 	}
 	return pkgVulns
@@ -816,9 +816,9 @@ func findName(vuln *claircore.Vulnerability, p *regexp.Regexp) (string, bool) {
 	return "", false
 }
 
-// filterVulns filters repeat vulnerabilities out of vulnIDs and returns the result.
+// filterRepeatedVulns filters repeat vulnerabilities out of vulnIDs and returns the result.
 // This function does not guarantee ordering is preserved.
-func filterVulns(vulnIDs []string, vulns map[string]*claircore.Vulnerability) []string {
+func filterRepeatedVulns(vulnIDs []string, ccVulnerabilities map[string]*claircore.Vulnerability) []string {
 	// Group each vulnerability by name.
 	// This maps each name to a slice of vulnerabilities to protect against the possibility
 	// Claircore finds multiple vulnerabilities with the same name for this package from different vulnerability streams.
@@ -826,7 +826,7 @@ func filterVulns(vulnIDs []string, vulns map[string]*claircore.Vulnerability) []
 	vulnsByName := make(map[string][]*claircore.Vulnerability)
 OUTER:
 	for _, vulnID := range vulnIDs {
-		vuln := vulns[vulnID]
+		vuln := ccVulnerabilities[vulnID]
 		if vuln == nil {
 			continue
 		}
@@ -844,7 +844,7 @@ OUTER:
 		vulnsByName[vuln.Name] = append(vulnsByName[vuln.Name], vuln)
 	}
 
-	filtered := make([]string, 0, len(vulns))
+	filtered := make([]string, 0, len(vulnIDs))
 	for _, vulns := range vulnsByName {
 		for _, vuln := range vulns {
 			filtered = append(filtered, vuln.ID)


### PR DESCRIPTION
## Description

Scanner V4 will sometimes return duplicate vulnerabilities for a given package in a given image. This may happen when Claircore matches the same vulnerability entry in a vulnerability data stream twice (for example: matches against two repository names which are associated with the same entry).

This PR is meant to remove those duplicates.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI + Deployed to an OpenShift cluster:

```
$ roxctl -e <central endpoint> --insecure-skip-tls-verify image scan --image=quay.io/stackrox-io/main:4.4.x-553-gcf5e7f5481 | jq '.scan.components[] | select(.name == "bzip2-libs")'
WARN:	Flag --format has been deprecated, please use --output/-o to specify the output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.
{
  "name": "bzip2-libs",
  "version": "1.0.6-26.el8",
  "vulns": [
    {
      "cve": "CVE-2019-12900",
      "cvss": 4,
      "summary": "DOCUMENTATION: The MITRE CVE dictionary describes this issue as: BZ2_decompress in decompress.c in bzip2 through 1.0.6 has an out-of-bounds write when there are many selectors. \n            STATEMENT: This issue affects the versions of bzip2 as shipped with Red Hat Enterprise Linux 5, 6, 7, and 8.\n\nRed Hat Enterprise Linux 5 is now in Extended Life Phase of the support and maintenance life cycle. This issue is not currently planned to be addressed in future updates. For additional information, refer to the Red Hat Enterprise Linux Life Cycle: https://access.redhat.com/support/policy/updates/errata/.\n\nRed Hat Enterprise Linux 6 is now in Maintenance Support 2 Phase of the support and maintenance life cycle. This has been rated as having a security impact of Low, and is not currently planned to be addressed in future updates. For additional information, refer to the Red Hat Enterprise Linux Life Cycle: https://access.redhat.com/support/policy/updates/errata/.\n\nRed Hat JBoss Fuse 7 uses a Java implemntation of bzip2, this is different to the bzip2 this vulnerability exists in.",
      "link": "https://access.redhat.com/security/cve/CVE-2019-12900",
      "scoreVersion": "V3",
      "cvssV3": {
        "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
        "exploitabilityScore": 2.5,
        "impactScore": 1.4,
        "availability": "IMPACT_LOW",
        "score": 4,
        "severity": "MEDIUM"
      },
      "publishedOn": "0001-01-01T00:00:00Z",
      "vulnerabilityType": "IMAGE_VULNERABILITY",
      "vulnerabilityTypes": [
        "IMAGE_VULNERABILITY"
      ],
      "firstSystemOccurrence": "2024-06-12T22:50:45.227652948Z",
      "firstImageOccurrence": "2024-06-12T22:50:45.227652948Z",
      "severity": "LOW_VULNERABILITY_SEVERITY"
    }
  ],
  "layerIndex": 22,
  "priority": "15",
  "location": "var/lib/rpm",
  "topCvss": 4,
  "riskScore": 1.012
}

$ roxctl -e <central endpoint> --insecure-skip-tls-verify image scan --force --image=quay.io/stackrox-io/main:4.4.x-553-gcf5e7f5481 | jq '.scan.components[] | select(.name == "bzip2-libs")'
WARN:	Flag --format has been deprecated, please use --output/-o to specify the output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.
{
  "name": "bzip2-libs",
  "version": "1.0.6-26.el8",
  "vulns": [
    {
      "cve": "CVE-2019-12900",
      "cvss": 4,
      "summary": "DOCUMENTATION: The MITRE CVE dictionary describes this issue as: BZ2_decompress in decompress.c in bzip2 through 1.0.6 has an out-of-bounds write when there are many selectors. \n            STATEMENT: This issue affects the versions of bzip2 as shipped with Red Hat Enterprise Linux 5, 6, 7, and 8.\n\nRed Hat Enterprise Linux 5 is now in Extended Life Phase of the support and maintenance life cycle. This issue is not currently planned to be addressed in future updates. For additional information, refer to the Red Hat Enterprise Linux Life Cycle: https://access.redhat.com/support/policy/updates/errata/.\n\nRed Hat Enterprise Linux 6 is now in Maintenance Support 2 Phase of the support and maintenance life cycle. This has been rated as having a security impact of Low, and is not currently planned to be addressed in future updates. For additional information, refer to the Red Hat Enterprise Linux Life Cycle: https://access.redhat.com/support/policy/updates/errata/.\n\nRed Hat JBoss Fuse 7 uses a Java implemntation of bzip2, this is different to the bzip2 this vulnerability exists in.",
      "link": "https://access.redhat.com/security/cve/CVE-2019-12900",
      "scoreVersion": "V3",
      "cvssV3": {
        "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
        "exploitabilityScore": 2.5,
        "impactScore": 1.4,
        "availability": "IMPACT_LOW",
        "score": 4,
        "severity": "MEDIUM"
      },
      "publishedOn": "0001-01-01T00:00:00Z",
      "vulnerabilityType": "IMAGE_VULNERABILITY",
      "severity": "LOW_VULNERABILITY_SEVERITY"
    }
  ],
  "layerIndex": 22,
  "location": "var/lib/rpm",
  "topCvss": 4,
  "riskScore": 1.012
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
