### PR TITLE
ROX-23298: support fixedby for Go stdlib

### DIFF
--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -449,6 +449,95 @@ func TestEnrich_Go(t *testing.T) {
 			expected: "v0.0.0-20241102182017-d307bd883b97",
 		},
 		{
+			name: "unfixed basic",
+			report: &claircore.VulnerabilityReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Version: "v0.21.0",
+					},
+				},
+				Distributions: map[string]*claircore.Distribution{
+					"1": {
+						DID: "rhel",
+					},
+				},
+				Repositories: map[string]*claircore.Repository{
+					"1": {
+						Name: "go",
+						URI:  "https://pkg.go.dev/",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {
+						{
+							RepositoryIDs: []string{"1"},
+						},
+					},
+				},
+				Vulnerabilities: map[string]*claircore.Vulnerability{
+					"1": {
+						FixedInVersion: "",
+					},
+					"2": {
+						FixedInVersion: "v0.21.0-alpha",
+					},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"1": {"1", "2"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "fixed basic",
+			report: &claircore.VulnerabilityReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Version: "v0.21.0",
+					},
+				},
+				Distributions: map[string]*claircore.Distribution{
+					"1": {
+						DID: "rhel",
+					},
+				},
+				Repositories: map[string]*claircore.Repository{
+					"1": {
+						Name: "go",
+						URI:  "https://pkg.go.dev/",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {
+						{
+							RepositoryIDs: []string{"1"},
+						},
+					},
+				},
+				Vulnerabilities: map[string]*claircore.Vulnerability{
+					"1": {
+						FixedInVersion: "",
+					},
+					"2": {
+						FixedInVersion: "v0.21.1-beta",
+					},
+					"3": {
+						FixedInVersion: "v0.21.1",
+					},
+					"4": {
+						FixedInVersion: "v0.21.1-beta",
+					},
+					"5": {
+						FixedInVersion: "",
+					},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"1": {"1", "2", "3", "4", "5"},
+				},
+			},
+			expected: "v0.21.1",
+		},
+		{
 			name: "fixed main version",
 			report: &claircore.VulnerabilityReport{
 				Packages: map[string]*claircore.Package{
@@ -497,6 +586,56 @@ func TestEnrich_Go(t *testing.T) {
 				},
 			},
 			expected: "1.20.12",
+		},
+		{
+			name: "unfixed main version",
+			report: &claircore.VulnerabilityReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:    "stdlib",
+						Version: "go1.22.5",
+					},
+				},
+				Distributions: map[string]*claircore.Distribution{
+					"1": {
+						DID: "rhel",
+					},
+				},
+				Repositories: map[string]*claircore.Repository{
+					"1": {
+						Name: "go",
+						URI:  "https://pkg.go.dev/",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {
+						{
+							RepositoryIDs: []string{"1"},
+						},
+					},
+				},
+				Vulnerabilities: map[string]*claircore.Vulnerability{
+					"1": {
+						FixedInVersion: "",
+					},
+					"2": {
+						FixedInVersion: "1.22",
+					},
+					"3": {
+						FixedInVersion: "v0.0.0-20241002182016-d307bd883b97",
+					},
+					"4": {
+						FixedInVersion: "1.22.5-alpha",
+					},
+					"5": {
+						FixedInVersion: "",
+					},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"1": {"1", "2", "3", "4", "5"},
+				},
+			},
+			expected: "",
 		},
 	}
 

--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -448,6 +448,56 @@ func TestEnrich_Go(t *testing.T) {
 			},
 			expected: "v0.0.0-20241102182017-d307bd883b97",
 		},
+		{
+			name: "fixed main version",
+			report: &claircore.VulnerabilityReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:    "stdlib",
+						Version: "go1.20.4",
+					},
+				},
+				Distributions: map[string]*claircore.Distribution{
+					"1": {
+						DID: "rhel",
+					},
+				},
+				Repositories: map[string]*claircore.Repository{
+					"1": {
+						Name: "go",
+						URI:  "https://pkg.go.dev/",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {
+						{
+							RepositoryIDs: []string{"1"},
+						},
+					},
+				},
+				Vulnerabilities: map[string]*claircore.Vulnerability{
+					"1": {
+						FixedInVersion: "",
+					},
+					"2": {
+						FixedInVersion: "1.20.12",
+					},
+					"3": {
+						FixedInVersion: "v0.0.0-20241002182016-d307bd883b97",
+					},
+					"4": {
+						FixedInVersion: "1.20.5",
+					},
+					"5": {
+						FixedInVersion: "",
+					},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"1": {"1", "2", "3", "4", "5"},
+				},
+			},
+			expected: "1.20.12",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/scanner/enricher/fixedby/versiontype_string.go
+++ b/scanner/enricher/fixedby/versiontype_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[normalVersionType-1]
 	_ = x[urlEncodedVersionType-2]
 	_ = x[semverVersionType-3]
+	_ = x[goSemverVersionType-4]
 }
 
-const _versionType_name = "unknownVersionTypenormalVersionTypeurlEncodedVersionTypesemverVersionType"
+const _versionType_name = "unknownVersionTypenormalVersionTypeurlEncodedVersionTypesemverVersionTypegoSemverVersionType"
 
-var _versionType_index = [...]uint8{0, 18, 35, 56, 73}
+var _versionType_index = [...]uint8{0, 18, 35, 56, 73, 92}
 
 func (i versionType) String() string {
 	if i < 0 || i >= versionType(len(_versionType_index)-1) {


### PR DESCRIPTION
## Description

Previously, we did not support "package-level fixed by" for the Go stdlib. That's because it was versioned as something like "go1.21.9" (with the "go" prefix). This was seen as an invalid semver.

This PR just truncates that prefix.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI + tested image quay.io/stackrox-io/scanner:4.2.0 - 

```
{
        "name": "stdlib",
        "version": "go1.20.4",
        "vulns": [
          {
            "cve": "GO-2023-1878",
            "summary": "Insufficient sanitization of Host header in net/http",
            "link": "https://go.dev/issue/60374",
            "fixedBy": "1.20.6",
            "publishedOn": "2023-07-11T19:19:08Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY"
          },
          {
            "cve": "GO-2023-1840",
            "summary": "Unsafe behavior in setuid/setgid binaries in runtime",
            "link": "https://go.dev/issue/60272",
            "fixedBy": "1.20.5",
            "publishedOn": "2023-06-08T20:16:06Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY"
          }
        ],
        "layerIndex": 42,
        "source": "GO",
        "location": "scanner",
        "topCvss": 0,
        "fixedBy": "1.20.6"
      },
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
