### PR TITLE
feat(cache): cache payload for query requests

### DIFF
--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/errox"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
@@ -294,13 +295,28 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 }
 
 // WalkByQuery iterates over all the objects scoped by the query applies the closure.
-func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, q *v1.Query, fn func(obj PT) error) error {
-	if q == nil || protocompat.Equal(q, search.EmptyQuery()) {
-		c.cacheLock.RLock()
-		defer c.cacheLock.RUnlock()
-		return c.walkCacheNoLock(ctx, fn)
+func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
+	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
+	// Fallback to the underlying store on error.
+	if err != nil {
+		log.Errorf("Failed to get identifiers by query, falling back to walk results by query: %v", err)
+		return c.underlyingStore.WalkByQuery(ctx, query, fn)
 	}
-	return c.underlyingStore.WalkByQuery(ctx, q, fn)
+	for _, id := range identifiers {
+		obj, found := c.cache[id]
+		if !found {
+			return errox.InvariantViolation.Newf("object %q not found in store cache", id)
+		}
+		if !c.isReadAllowed(ctx, obj) {
+			continue
+		}
+		if err := fn(obj); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Walk iterates over all the objects in the store and applies the closure.
@@ -312,7 +328,27 @@ func (c *cachedStore[T, PT]) Walk(ctx context.Context, fn func(obj PT) error) er
 
 // GetByQuery returns the objects from the store matching the query.
 func (c *cachedStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
-	return c.underlyingStore.GetByQuery(ctx, query)
+	defer c.setCacheOperationDurationTime(time.Now(), ops.GetByQuery)
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
+	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
+	// Fallback to the underlying store on error.
+	if err != nil {
+		log.Errorf("Failed to get identifiers by query, falling back to get results by query: %v", err)
+		return c.underlyingStore.GetByQuery(ctx, query)
+	}
+	results := make([]*T, 0, len(identifiers))
+	for _, id := range identifiers {
+		obj, found := c.cache[id]
+		if !found {
+			return nil, errox.InvariantViolation.Newf("object %q not found in store cache", id)
+		}
+		if !c.isReadAllowed(ctx, obj) {
+			continue
+		}
+		results = append(results, obj.Clone())
+	}
+	return results, nil
 }
 
 // DeleteByQuery removes the objects from the store based on the passed query.
@@ -344,6 +380,11 @@ func (c *cachedStore[T, PT]) GetIDs(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+// GetIDsByQuery returns the IDs for the store matching the query.
+func (c *cachedStore[T, PT]) GetIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {
+	return c.underlyingStore.GetIDsByQuery(ctx, query)
 }
 
 // GetAll retrieves all objects from the store.

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/errox"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
@@ -296,18 +295,25 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 
 // WalkByQuery iterates over all the objects scoped by the query applies the closure.
 func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
-	c.cacheLock.RLock()
-	defer c.cacheLock.RUnlock()
+	if query == nil || protocompat.Equal(query, search.EmptyQuery()) {
+		c.cacheLock.RLock()
+		defer c.cacheLock.RUnlock()
+		return c.walkCacheNoLock(ctx, fn)
+	}
+
 	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
 	// Fallback to the underlying store on error.
 	if err != nil {
 		log.Errorf("Failed to get identifiers by query, falling back to walk results by query: %v", err)
 		return c.underlyingStore.WalkByQuery(ctx, query, fn)
 	}
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
 	for _, id := range identifiers {
 		obj, found := c.cache[id]
 		if !found {
-			return errox.InvariantViolation.Newf("object %q not found in store cache", id)
+			log.Warnf("Object %q not found in store cache", id)
+			continue
 		}
 		if !c.isReadAllowed(ctx, obj) {
 			continue
@@ -329,8 +335,6 @@ func (c *cachedStore[T, PT]) Walk(ctx context.Context, fn func(obj PT) error) er
 // GetByQuery returns the objects from the store matching the query.
 func (c *cachedStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer c.setCacheOperationDurationTime(time.Now(), ops.GetByQuery)
-	c.cacheLock.RLock()
-	defer c.cacheLock.RUnlock()
 	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
 	// Fallback to the underlying store on error.
 	if err != nil {
@@ -338,10 +342,13 @@ func (c *cachedStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([
 		return c.underlyingStore.GetByQuery(ctx, query)
 	}
 	results := make([]*T, 0, len(identifiers))
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
 	for _, id := range identifiers {
 		obj, found := c.cache[id]
 		if !found {
-			return nil, errox.InvariantViolation.Newf("object %q not found in store cache", id)
+			log.Warnf("Object %q not found in store cache", id)
+			continue
 		}
 		if !c.isReadAllowed(ctx, obj) {
 			continue


### PR DESCRIPTION
## Description

This PR adds an optimization to cached datastore stores. Before, we would pass any request with a non-empty `v1.Query` to the underlying store bypassing the cache completely. We do this to let the store evaluate the query. Now, instead of fetching the entire objects from the store, we only fetch the IDs based on the query. The remaining object data is then loaded from the cache. This effectively reduces the network payload between the database and Central when queries are used.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* see tests
* manual testing

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
