### PR TITLE
test: Enable more nongroovy tests on OCP.

### DIFF
--- a/tests/cluster_delete_test.go
+++ b/tests/cluster_delete_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -64,6 +65,9 @@ func getAllCounts(t *testing.T) allCounts {
 }
 
 func TestClusterDeletion(t *testing.T) {
+	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
+		t.Skip("temporarily skipped on OCP. TODO(ROX-24688)")
+	}
 	counts := getAllCounts(t)
 	assert.NotZero(t, counts.ClusterCount)
 	// ROX-6391: NodeCount starts at zero

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -72,35 +72,23 @@ test_e2e() {
 
     collect_and_check_stackrox_logs "/tmp/e2e-test-logs" "initial_tests"
 
-    if [[ ${ORCHESTRATOR_FLAVOR:-} == "openshift" ]]; then
-        info "Temporarily skipping E2E destructive tests on OCP. TODO(ROX-24688)"
-    else
-        # Give some time for previous tests to finish up
-        wait_for_api
+    # Give some time for previous tests to finish up
+    wait_for_api
 
-        info "E2E destructive tests"
-        make -C tests destructive-tests || touch FAIL
-        store_test_results "tests/destructive-tests-results" "destructive-tests-results"
-        [[ ! -f FAIL ]] || die "destructive e2e tests failed"
-    fi
+    info "E2E destructive tests"
+    make -C tests destructive-tests || touch FAIL
+    store_test_results "tests/destructive-tests-results" "destructive-tests-results"
+    [[ ! -f FAIL ]] || die "destructive e2e tests failed"
 
-    if [[ ${ORCHESTRATOR_FLAVOR:-} == "openshift" ]]; then
-        info "Temporarily skipping postgres backup restoration test on OCP. TODO(ROX-24688)"
-    else
-        # Give some time for previous tests to finish up
-        wait_for_api
-        restore_4_1_postgres_backup
-    fi
+    # Give some time for previous tests to finish up
+    wait_for_api
+    restore_4_1_postgres_backup
 
-    if [[ ${ORCHESTRATOR_FLAVOR:-} == "openshift" ]]; then
-        info "Temporarily skipping E2E external backup tests on OCP. TODO(ROX-24688)"
-    else
-        wait_for_api
-        info "E2E external backup tests"
-        make -C tests external-backup-tests || touch FAIL
-        store_test_results "tests/external-backup-tests-results" "external-backup-tests-results"
-        [[ ! -f FAIL ]] || die "external backup e2e tests failed"
-    fi
+    wait_for_api
+    info "E2E external backup tests"
+    make -C tests external-backup-tests || touch FAIL
+    store_test_results "tests/external-backup-tests-results" "external-backup-tests-results"
+    [[ ! -f FAIL ]] || die "external backup e2e tests failed"
 }
 
 test_preamble() {


### PR DESCRIPTION
## Description

These were initially skipped because I was running out of time. Turns out they actually work, so do not skip them. Except for `TestClusterDeletion`, where `ViolationCount` stays at 2 for some reason which needs to be investigated.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Re-run tests more times
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI.

FTR the nongroovy job for scanner v4 was already [falilng due to ooms](https://issues.redhat.com/browse/ROX-24727) before this change.

The ocp-preview cluster creation permanently fails, unrelated to this change.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
