### PR TITLE
fix: generate a valid time in proto initializer

### DIFF
--- a/pkg/testutils/full_init.go
+++ b/pkg/testutils/full_init.go
@@ -16,18 +16,18 @@ import (
 
 // BasicTypeInitializer prescribes how to initialize a struct field with a given type.
 type BasicTypeInitializer interface {
-	Value(ty reflect.Kind, fieldPath []reflect.StructField) interface{}
+	Value(kind reflect.Kind) interface{}
 }
 
 // UniqueTypeInitializer prescribes how to initialize a struct field with a given type.
 type UniqueTypeInitializer interface {
-	ValueUnique(ty reflect.Kind, fieldPath []reflect.StructField) interface{}
+	ValueUnique(kind reflect.Kind) interface{}
 }
 
 type simpleInitializer struct{}
 
-func (simpleInitializer) Value(ty reflect.Kind, _ []reflect.StructField) interface{} {
-	switch ty {
+func (simpleInitializer) Value(kind reflect.Kind) interface{} {
+	switch kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return int32(1)
 	case reflect.Float32, reflect.Float64:
@@ -44,11 +44,11 @@ func (simpleInitializer) Value(ty reflect.Kind, _ []reflect.StructField) interfa
 
 type uniqueInitializer struct{}
 
-func (uniqueInitializer) Value(ty reflect.Kind, _ []reflect.StructField) interface{} {
+func (uniqueInitializer) Value(kind reflect.Kind) interface{} {
 	// seed rand
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	switch ty {
+	switch kind {
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return r.Int31()
 	case reflect.Int8, reflect.Uint8:
@@ -83,7 +83,7 @@ func UniqueInitializer() BasicTypeInitializer {
 type FieldFilter func(field reflect.StructField, ancestors []reflect.StructField) bool
 
 // JSONFieldsFilter is a field filter that includes only JSON fields.
-func JSONFieldsFilter(field reflect.StructField, _ []reflect.StructField) bool {
+func JSONFieldsFilter(field reflect.StructField) bool {
 	if field.Name != "" && unicode.IsLower([]rune(field.Name)[0]) {
 		return false
 	}
@@ -153,13 +153,13 @@ func fullInitRecursive(val reflect.Value, init BasicTypeInitializer, fieldFilter
 		fullInitStruct(val, init, fieldFilter, fieldPath, seenTypes)
 
 	default:
-		val.Set(reflect.ValueOf(init.Value(val.Type().Kind(), fieldPath)).Convert(val.Type()))
+		val.Set(reflect.ValueOf(init.Value(val.Type().Kind())).Convert(val.Type()))
 	}
 }
 
 func initTime(val reflect.Value, init BasicTypeInitializer) {
 	t := time.Unix(1, 0)
-	duration := init.Value(reflect.Int, nil).(int32)
+	duration := init.Value(reflect.Int).(int32)
 	t = t.Add(time.Duration(duration))
 	now, err := types.ConvertTimeToTimestampOrError(t)
 	utils.Must(err)

--- a/pkg/testutils/full_init.go
+++ b/pkg/testutils/full_init.go
@@ -9,36 +9,27 @@ import (
 	"unicode"
 	"unsafe"
 
+	types "github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
 // BasicTypeInitializer prescribes how to initialize a struct field with a given type.
 type BasicTypeInitializer interface {
-	Value(ty reflect.Type, fieldPath []reflect.StructField) interface{}
+	Value(ty reflect.Kind, fieldPath []reflect.StructField) interface{}
 }
 
 // UniqueTypeInitializer prescribes how to initialize a struct field with a given type.
 type UniqueTypeInitializer interface {
-	ValueUnique(ty reflect.Type, fieldPath []reflect.StructField) interface{}
-}
-
-type zeroInitializer struct{}
-
-func (zeroInitializer) Value(ty reflect.Type, _ []reflect.StructField) interface{} {
-	return reflect.Zero(ty).Interface()
-}
-
-// ZeroInitializer returns a BasicTypeInitializer that initializes all fields of basic types with their zero value
-func ZeroInitializer() BasicTypeInitializer {
-	return zeroInitializer{}
+	ValueUnique(ty reflect.Kind, fieldPath []reflect.StructField) interface{}
 }
 
 type simpleInitializer struct{}
 
-func (simpleInitializer) Value(ty reflect.Type, _ []reflect.StructField) interface{} {
-	switch ty.Kind() {
+func (simpleInitializer) Value(ty reflect.Kind, _ []reflect.StructField) interface{} {
+	switch ty {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return 1
+		return int32(1)
 	case reflect.Float32, reflect.Float64:
 		return 1.0
 	case reflect.Complex64, reflect.Complex128:
@@ -53,11 +44,11 @@ func (simpleInitializer) Value(ty reflect.Type, _ []reflect.StructField) interfa
 
 type uniqueInitializer struct{}
 
-func (uniqueInitializer) Value(ty reflect.Type, _ []reflect.StructField) interface{} {
+func (uniqueInitializer) Value(ty reflect.Kind, _ []reflect.StructField) interface{} {
 	// seed rand
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	switch ty.Kind() {
+	switch ty {
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return r.Int31()
 	case reflect.Int8, reflect.Uint8:
@@ -128,8 +119,12 @@ func fullInitRecursive(val reflect.Value, init BasicTypeInitializer, fieldFilter
 
 	case reflect.Ptr:
 		if _, ok := seenTypes[val.Type().Elem()]; !ok {
-			val.Set(reflect.New(val.Type().Elem()))
-			fullInitRecursive(val.Elem(), init, fieldFilter, fieldPath, seenTypes)
+			if val.Type().String() == "*types.Timestamp" {
+				initTime(val, init)
+			} else {
+				val.Set(reflect.New(val.Type().Elem()))
+				fullInitRecursive(val.Elem(), init, fieldFilter, fieldPath, seenTypes)
+			}
 		}
 
 	case reflect.Slice:
@@ -158,8 +153,18 @@ func fullInitRecursive(val reflect.Value, init BasicTypeInitializer, fieldFilter
 		fullInitStruct(val, init, fieldFilter, fieldPath, seenTypes)
 
 	default:
-		val.Set(reflect.ValueOf(init.Value(val.Type(), fieldPath)).Convert(val.Type()))
+		val.Set(reflect.ValueOf(init.Value(val.Type().Kind(), fieldPath)).Convert(val.Type()))
 	}
+}
+
+func initTime(val reflect.Value, init BasicTypeInitializer) {
+	t := time.Unix(1, 0)
+	duration := init.Value(reflect.Int, nil).(int32)
+	t = t.Add(time.Duration(duration))
+	now, err := types.ConvertTimeToTimestampOrError(t)
+	utils.Must(err)
+	v := reflect.ValueOf(now)
+	val.Set(v)
 }
 
 func fullInitStruct(structVal reflect.Value, init BasicTypeInitializer, fieldFilter FieldFilter, fieldPath []reflect.StructField, seenTypes map[reflect.Type]struct{}) {

--- a/pkg/testutils/full_init_test.go
+++ b/pkg/testutils/full_init_test.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,10 @@ type nestedStruct3 struct {
 	x complex64
 }
 
+type times struct {
+	d *protocompat.Timestamp
+}
+
 type testStruct struct {
 	x int
 	y string
@@ -34,6 +39,8 @@ type testStruct struct {
 
 	nestedStruct2
 	*nestedStruct3
+
+	t times
 }
 
 func TestFullInit(t *testing.T) {
@@ -62,6 +69,13 @@ func TestFullInit(t *testing.T) {
 		},
 		nestedStruct3: &nestedStruct3{
 			x: 1.0i,
+		},
+		t: times{
+			//1970-01-01T00:00:01.000000001Z
+			d: &protocompat.Timestamp{
+				Seconds: 1,
+				Nanos:   1,
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR fixes how proto timestamps are generated. Instead of digging deep into a struct and set every field (which may lead to invalid time) we generate duration that will be added to unix epoch. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
