### PR TITLE
ROX-23064: advanced filters platform CVE detail page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -69,6 +69,7 @@ export type CVEsTableProps = {
     canSelectRows?: boolean;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function CVEsTable({
@@ -80,6 +81,7 @@ function CVEsTable({
     createRowActions,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: CVEsTableProps) {
     const { page, perPage } = pagination;
 
@@ -140,6 +142,7 @@ function CVEsTable({
                 emptyProps={{
                     message: 'No CVEs have been detected for your secured clusters',
                 }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((platformCve, rowIndex) => {
                         const {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -66,6 +66,7 @@ export type ClustersTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function ClustersTable({
@@ -74,6 +75,7 @@ function ClustersTable({
     pagination,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: ClustersTableProps) {
     const { page, perPage } = pagination;
     const { data, previousData, error, loading } = useQuery<
@@ -129,6 +131,7 @@ function ClustersTable({
                 tableState={tableState}
                 colSpan={colSpan}
                 emptyProps={{ message: 'No secured clusters have been detected' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map(({ id, name, clusterVulnerabilityCount, type, status }) => (
                         <Tbody key={id}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -26,6 +26,8 @@ import SnoozeCvesModal from 'Containers/Vulnerabilities/components/SnoozeCvesMod
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 
 import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
+import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import { clusterSearchFilterConfig, platformCVESearchFilterConfig } from '../../searchFilterConfig';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
@@ -41,6 +43,11 @@ import CVEsTable, {
     sortFields as cveSortFields,
 } from './CVEsTable';
 import { usePlatformCveEntityCounts } from './usePlatformCveEntityCounts';
+
+const searchFilterConfig = {
+    Cluster: clusterSearchFilterConfig,
+    PlatformCVE: platformCVESearchFilterConfig,
+};
 
 function PlatformCvesOverviewPage() {
     const apolloClient = useApolloClient();
@@ -78,7 +85,20 @@ function PlatformCvesOverviewPage() {
         Cluster: data?.clusterCount ?? 0,
     };
 
-    const filterToolbar = <></>;
+    const filterToolbar = (
+        <AdvancedFiltersToolbar
+            searchFilter={searchFilter}
+            searchFilterConfig={searchFilterConfig}
+            onFilterChange={(newFilter, { action }) => {
+                setSearchFilter(newFilter);
+
+                if (action === 'ADD') {
+                    // TODO - Add analytics tracking ROX-24509
+                }
+            }}
+            includeCveSeverityFilters={false}
+        />
+    );
 
     const entityToggleGroup = (
         <EntityTypeToggleGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -85,6 +85,11 @@ function PlatformCvesOverviewPage() {
         Cluster: data?.clusterCount ?? 0,
     };
 
+    function onClearFilters() {
+        setSearchFilter({});
+        pagination.setPage(1, 'replace');
+    }
+
     const filterToolbar = (
         <AdvancedFiltersToolbar
             searchFilter={searchFilter}
@@ -192,6 +197,7 @@ function PlatformCvesOverviewPage() {
                                 )}
                                 sortOption={sortOption}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         )}
                         {activeEntityTabKey === 'Cluster' && (
@@ -201,6 +207,7 @@ function PlatformCvesOverviewPage() {
                                 pagination={pagination}
                                 sortOption={sortOption}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         )}
                     </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -52,9 +52,14 @@ export type AffectedCluster = {
 export type AffectedClustersTableProps = {
     tableState: TableUIState<AffectedCluster>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
-function AffectedClustersTable({ tableState, getSortParams }: AffectedClustersTableProps) {
+function AffectedClustersTable({
+    tableState,
+    getSortParams,
+    onClearFilters,
+}: AffectedClustersTableProps) {
     return (
         <Table
             borders={tableState.type === 'COMPLETE'}
@@ -76,6 +81,7 @@ function AffectedClustersTable({ tableState, getSortParams }: AffectedClustersTa
                 tableState={tableState}
                 colSpan={3}
                 emptyProps={{ message: 'No clusters have been reported for this CVE' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) => (
                     <Tbody>
                         {data.map(({ id, name, type, status }) => (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -322,7 +322,8 @@ function WorkloadCvesOverviewPage() {
                     // TODO - Add analytics tracking ROX-24532
                 }
             }}
-            includeCveFilters={isViewingWithCves}
+            includeCveSeverityFilters={isViewingWithCves}
+            includeCveStatusFilters={isViewingWithCves}
         />
     ) : (
         <WorkloadCveFilterToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -63,7 +63,8 @@ type AdvancedFiltersToolbarProps = {
     onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
     className?: string;
     defaultFilters?: DefaultFilters;
-    includeCveFilters?: boolean;
+    includeCveSeverityFilters?: boolean;
+    includeCveStatusFilters?: boolean;
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
     // autocompleteSearchContext?: unknown;
 };
@@ -74,7 +75,8 @@ function AdvancedFiltersToolbar({
     onFilterChange,
     className = '',
     defaultFilters = emptyDefaultFilters,
-    includeCveFilters = true,
+    includeCveSeverityFilters = true,
+    includeCveStatusFilters = true,
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component
     // autocompleteSearchContext,
 }: AdvancedFiltersToolbarProps) {
@@ -83,7 +85,7 @@ function AdvancedFiltersToolbar({
 
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
         .concat(
-            includeCveFilters
+            includeCveSeverityFilters
                 ? makeDefaultFilterDescriptor(defaultFilters, {
                       displayName: 'CVE severity',
                       searchFilterName: 'SEVERITY',
@@ -91,7 +93,7 @@ function AdvancedFiltersToolbar({
                 : []
         )
         .concat(
-            includeCveFilters && isFixabilityFiltersEnabled
+            includeCveStatusFilters && isFixabilityFiltersEnabled
                 ? makeDefaultFilterDescriptor(defaultFilters, {
                       displayName: 'CVE status',
                       searchFilterName: 'FIXABLE',
@@ -125,19 +127,22 @@ function AdvancedFiltersToolbar({
                         onSearch={onFilterApplied}
                     />
                 </ToolbarGroup>
-                {includeCveFilters && (
+                {(includeCveSeverityFilters ||
+                    (includeCveStatusFilters && isFixabilityFiltersEnabled)) && (
                     <ToolbarGroup>
-                        <CVESeverityDropdown
-                            searchFilter={searchFilter}
-                            onSelect={(category, checked, value) =>
-                                onFilterApplied({
-                                    category,
-                                    value,
-                                    action: checked ? 'ADD' : 'REMOVE',
-                                })
-                            }
-                        />
-                        {isFixabilityFiltersEnabled && (
+                        {includeCveSeverityFilters && (
+                            <CVESeverityDropdown
+                                searchFilter={searchFilter}
+                                onSelect={(category, checked, value) =>
+                                    onFilterApplied({
+                                        category,
+                                        value,
+                                        action: checked ? 'ADD' : 'REMOVE',
+                                    })
+                                }
+                            />
+                        )}
+                        {includeCveStatusFilters && isFixabilityFiltersEnabled && (
                             <CVEStatusDropdown
                                 searchFilter={searchFilter}
                                 onSelect={(category, checked, value) =>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -7,4 +7,5 @@ export {
     deploymentSearchFilterConfig,
     namespaceSearchFilterConfig,
     clusterSearchFilterConfig,
+    platformCVESearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';


### PR DESCRIPTION
## Description

As titled.

Also discovered when working this PR - we need a follow up for fixability filters throughout Platform CVEs: https://issues.redhat.com/browse/ROX-24735

Follow up question for UX and PM - Do we need the status filter here? It seems like if we can filter by fixability status per-cluster, we should also show that information in the table.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![image](https://github.com/stackrox/stackrox/assets/1292638/cf90d7da-bb0b-42f6-b5a9-23ae0c521f2a)
![image](https://github.com/stackrox/stackrox/assets/1292638/483ad748-a51c-4943-a1be-458e55697e94)

Clear filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/4d2ccf26-47ad-43a9-ba35-6500a8569596)
