### PR TITLE
ROX-23073: Add advanced filters to Platform CVE cluster page

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -366,10 +366,10 @@ export const platformCVESearchFilterConfig = {
     displayName: 'Platform CVE',
     searchCategory: 'CLUSTER_VULNERABILITIES',
     attributes: {
-        ID: {
-            displayName: 'ID',
-            filterChipLabel: 'Platform CVE ID',
-            searchTerm: 'CVE ID',
+        Name: {
+            displayName: 'Name',
+            filterChipLabel: 'Platform CVE',
+            searchTerm: 'CVE',
             inputType: 'autocomplete',
         },
         'Discovered Time': {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -66,9 +66,10 @@ export type ClusterVulnerability = {
 export type CVEsTableProps = {
     tableState: TableUIState<ClusterVulnerability>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
-function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
+function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps) {
     const COL_SPAN = 5;
     const expandedRowSet = useSet<string>();
 
@@ -93,6 +94,7 @@ function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
                 tableState={tableState}
                 colSpan={COL_SPAN}
                 emptyProps={{ message: 'No CVEs were detected for this cluster' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((clusterVulnerability, rowIndex) => {
                         const { cve, isFixable, vulnerabilityType, cvss, scoreVersion, summary } =

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -14,7 +14,7 @@ import {
 
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
-import { getHasSearchApplied, getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
@@ -42,7 +42,7 @@ export type ClusterPageVulnerabilitiesProps = {
 function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
-    const query = getUrlQueryStringForSearchFilter(querySearchFilter);
+    const query = getRequestQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
@@ -137,7 +137,14 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                             />
                         </SplitItem>
                     </Split>
-                    <CVEsTable tableState={tableState} getSortParams={getSortParams} />
+                    <CVEsTable
+                        tableState={tableState}
+                        getSortParams={getSortParams}
+                        onClearFilters={() => {
+                            setSearchFilter({});
+                            setPage(1, 'replace');
+                        }}
+                    />
                 </div>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Divider,
     Flex,
     PageSection,
     Pagination,
@@ -21,6 +22,8 @@ import useURLSort from 'hooks/useURLSort';
 import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import { getHiddenStatuses, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import { platformCVESearchFilterConfig } from '../../searchFilterConfig';
 
 import useClusterVulnerabilities from './useClusterVulnerabilities';
 import useClusterSummaryData from './useClusterSummaryData';
@@ -28,12 +31,16 @@ import CVEsTable, { defaultSortOption, sortFields } from './CVEsTable';
 import PlatformCvesByStatusSummaryCard from './PlatformCvesByStatusSummaryCard';
 import PlatformCvesByTypeSummaryCard from './PlatformCvesByTypeSummaryCard';
 
+const searchFilterConfig = {
+    'Platform CVE': platformCVESearchFilterConfig,
+};
+
 export type ClusterPageVulnerabilitiesProps = {
     clusterId: string;
 };
 
 function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesProps) {
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getUrlQueryStringForSearchFilter(querySearchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -69,6 +76,19 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                 <Text>Review and triage vulnerability data scanned on this cluster</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">
+                <AdvancedFiltersToolbar
+                    className="pf-v5-u-pb-0 pf-v5-u-px-sm"
+                    searchFilter={searchFilter}
+                    searchFilterConfig={searchFilterConfig}
+                    onFilterChange={(newFilter, { action }) => {
+                        setSearchFilter(newFilter);
+
+                        if (action === 'ADD') {
+                            // TODO - Add analytics tracking ROX-24509
+                        }
+                    }}
+                    includeCveSeverityFilters={false}
+                />
                 <SummaryCardLayout isLoading={summaryRequest.loading} error={summaryRequest.error}>
                     <SummaryCard
                         loadingText={'Loading platform CVEs by status summary'}
@@ -90,6 +110,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                         )}
                     />
                 </SummaryCardLayout>
+                <Divider component="div" />
                 <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100 pf-v5-u-p-lg">
                     <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
                         <SplitItem isFilled>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -69,6 +69,7 @@ export type CVEsTableProps = {
     canSelectRows?: boolean;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function CVEsTable({
@@ -80,6 +81,7 @@ function CVEsTable({
     createRowActions,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: CVEsTableProps) {
     const { page, perPage } = pagination;
 
@@ -140,6 +142,7 @@ function CVEsTable({
                 emptyProps={{
                     message: 'No CVEs have been detected for your secured clusters',
                 }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((platformCve, rowIndex) => {
                         const {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -66,6 +66,7 @@ export type ClustersTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function ClustersTable({
@@ -74,6 +75,7 @@ function ClustersTable({
     pagination,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: ClustersTableProps) {
     const { page, perPage } = pagination;
     const { data, previousData, error, loading } = useQuery<
@@ -129,6 +131,7 @@ function ClustersTable({
                 tableState={tableState}
                 colSpan={colSpan}
                 emptyProps={{ message: 'No secured clusters have been detected' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map(({ id, name, clusterVulnerabilityCount, type, status }) => (
                         <Tbody key={id}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -26,6 +26,8 @@ import SnoozeCvesModal from 'Containers/Vulnerabilities/components/SnoozeCvesMod
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 
 import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
+import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import { clusterSearchFilterConfig, platformCVESearchFilterConfig } from '../../searchFilterConfig';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
@@ -41,6 +43,11 @@ import CVEsTable, {
     sortFields as cveSortFields,
 } from './CVEsTable';
 import { usePlatformCveEntityCounts } from './usePlatformCveEntityCounts';
+
+const searchFilterConfig = {
+    Cluster: clusterSearchFilterConfig,
+    PlatformCVE: platformCVESearchFilterConfig,
+};
 
 function PlatformCvesOverviewPage() {
     const apolloClient = useApolloClient();
@@ -78,7 +85,20 @@ function PlatformCvesOverviewPage() {
         Cluster: data?.clusterCount ?? 0,
     };
 
-    const filterToolbar = <></>;
+    const filterToolbar = (
+        <AdvancedFiltersToolbar
+            searchFilter={searchFilter}
+            searchFilterConfig={searchFilterConfig}
+            onFilterChange={(newFilter, { action }) => {
+                setSearchFilter(newFilter);
+
+                if (action === 'ADD') {
+                    // TODO - Add analytics tracking ROX-24509
+                }
+            }}
+            includeCveSeverityFilters={false}
+        />
+    );
 
     const entityToggleGroup = (
         <EntityTypeToggleGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -85,6 +85,11 @@ function PlatformCvesOverviewPage() {
         Cluster: data?.clusterCount ?? 0,
     };
 
+    function onClearFilters() {
+        setSearchFilter({});
+        pagination.setPage(1, 'replace');
+    }
+
     const filterToolbar = (
         <AdvancedFiltersToolbar
             searchFilter={searchFilter}
@@ -192,6 +197,7 @@ function PlatformCvesOverviewPage() {
                                 )}
                                 sortOption={sortOption}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         )}
                         {activeEntityTabKey === 'Cluster' && (
@@ -201,6 +207,7 @@ function PlatformCvesOverviewPage() {
                                 pagination={pagination}
                                 sortOption={sortOption}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         )}
                     </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -322,7 +322,8 @@ function WorkloadCvesOverviewPage() {
                     // TODO - Add analytics tracking ROX-24532
                 }
             }}
-            includeCveFilters={isViewingWithCves}
+            includeCveSeverityFilters={isViewingWithCves}
+            includeCveStatusFilters={isViewingWithCves}
         />
     ) : (
         <WorkloadCveFilterToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -63,7 +63,8 @@ type AdvancedFiltersToolbarProps = {
     onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
     className?: string;
     defaultFilters?: DefaultFilters;
-    includeCveFilters?: boolean;
+    includeCveSeverityFilters?: boolean;
+    includeCveStatusFilters?: boolean;
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
     // autocompleteSearchContext?: unknown;
 };
@@ -74,7 +75,8 @@ function AdvancedFiltersToolbar({
     onFilterChange,
     className = '',
     defaultFilters = emptyDefaultFilters,
-    includeCveFilters = true,
+    includeCveSeverityFilters = true,
+    includeCveStatusFilters = true,
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component
     // autocompleteSearchContext,
 }: AdvancedFiltersToolbarProps) {
@@ -83,7 +85,7 @@ function AdvancedFiltersToolbar({
 
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
         .concat(
-            includeCveFilters
+            includeCveSeverityFilters
                 ? makeDefaultFilterDescriptor(defaultFilters, {
                       displayName: 'CVE severity',
                       searchFilterName: 'SEVERITY',
@@ -91,7 +93,7 @@ function AdvancedFiltersToolbar({
                 : []
         )
         .concat(
-            includeCveFilters && isFixabilityFiltersEnabled
+            includeCveStatusFilters && isFixabilityFiltersEnabled
                 ? makeDefaultFilterDescriptor(defaultFilters, {
                       displayName: 'CVE status',
                       searchFilterName: 'FIXABLE',
@@ -125,19 +127,22 @@ function AdvancedFiltersToolbar({
                         onSearch={onFilterApplied}
                     />
                 </ToolbarGroup>
-                {includeCveFilters && (
+                {(includeCveSeverityFilters ||
+                    (includeCveStatusFilters && isFixabilityFiltersEnabled)) && (
                     <ToolbarGroup>
-                        <CVESeverityDropdown
-                            searchFilter={searchFilter}
-                            onSelect={(category, checked, value) =>
-                                onFilterApplied({
-                                    category,
-                                    value,
-                                    action: checked ? 'ADD' : 'REMOVE',
-                                })
-                            }
-                        />
-                        {isFixabilityFiltersEnabled && (
+                        {includeCveSeverityFilters && (
+                            <CVESeverityDropdown
+                                searchFilter={searchFilter}
+                                onSelect={(category, checked, value) =>
+                                    onFilterApplied({
+                                        category,
+                                        value,
+                                        action: checked ? 'ADD' : 'REMOVE',
+                                    })
+                                }
+                            />
+                        )}
+                        {includeCveStatusFilters && isFixabilityFiltersEnabled && (
                             <CVEStatusDropdown
                                 searchFilter={searchFilter}
                                 onSelect={(category, checked, value) =>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -7,4 +7,5 @@ export {
     deploymentSearchFilterConfig,
     namespaceSearchFilterConfig,
     clusterSearchFilterConfig,
+    platformCVESearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';


### PR DESCRIPTION
## Description

Last one for VM, excluding exception management 🎉 

Follow ups:

It looks like the "Snoozed" filter cannot be removed via the advanced filters dropdown.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![image](https://github.com/stackrox/stackrox/assets/1292638/2d6a81de-d3ac-4972-b5a3-e246a89b7125)
![image](https://github.com/stackrox/stackrox/assets/1292638/2012f590-ed30-4bba-90ac-d2fd6a718d49)
![image](https://github.com/stackrox/stackrox/assets/1292638/da1097e0-cfd8-4850-b09e-f7ee0f5c21cc)
