### PR TITLE
ROX-24737: Fix validation in compliance schedules wizard step 1

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -63,7 +63,7 @@ describe('Compliance Schedules', () => {
             .type('Mare eats oats, and does eat oats, and little lambs eat ivy.')
             .blur();
 
-        getHelperElementByLabel('Name').contains('Scan name is required');
+        getHelperElementByLabel('Name').contains('Name is required');
         getHelperElementByLabel('Time').contains('Time is required');
 
         getInputByLabel('Frequency').click();

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -18,10 +18,9 @@ import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
 
-import {
-    ScanConfigFormValues,
-    getHourMinuteStringFromScheduleBase,
-} from '../compliance.scanConfigs.utils';
+import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
+
+import { helperTextForName, helperTextForTime } from './useFormikScanConfig';
 
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
@@ -31,20 +30,8 @@ function ScanConfigOptions(): ReactElement {
         formik.setFieldValue(id, value);
     }
 
-    function handleTimeChange(
-        _event: React.FormEvent<HTMLInputElement>,
-        time: string,
-        hour?: number,
-        minute?: number,
-        _seconds?: number,
-        isValid?: boolean
-    ): void {
-        if (isValid && hour !== undefined) {
-            const timeString = getHourMinuteStringFromScheduleBase({ hour, minute: minute ?? 0 });
-            formik.setFieldValue('parameters.time', timeString);
-        } else {
-            formik.setFieldValue('parameters.time', time);
-        }
+    function handleTimeChange(_event: React.FormEvent<HTMLInputElement>, time: string): void {
+        formik.setFieldValue('parameters.time', time);
     }
 
     function onScheduledDaysChange(id: string, selection: string[]) {
@@ -73,7 +60,7 @@ function ScanConfigOptions(): ReactElement {
                                     fieldId="parameters.name"
                                     errors={formik.errors}
                                     touched={formik.touched}
-                                    helperText="Name can contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character."
+                                    helperText={helperTextForName}
                                 >
                                     <TextInput
                                         isRequired
@@ -81,6 +68,12 @@ function ScanConfigOptions(): ReactElement {
                                         id="parameters.name"
                                         name="parameters.name"
                                         value={formik.values.parameters.name}
+                                        validated={
+                                            formik.errors?.parameters?.name &&
+                                            formik.touched?.parameters?.name
+                                                ? 'error'
+                                                : 'default'
+                                        }
                                         onChange={(event) => formik.handleChange(event)}
                                         onBlur={formik.handleBlur}
                                     />
@@ -196,7 +189,7 @@ function ScanConfigOptions(): ReactElement {
                                             errors={formik.errors}
                                             isRequired
                                             touched={formik.touched}
-                                            helperText="Select scan time in UTC"
+                                            helperText={helperTextForTime}
                                         >
                                             <TimePicker
                                                 time={formik.values.parameters.time}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
@@ -45,6 +45,7 @@ const validationSchema = yup.object().shape({
     parameters: yup.object().shape({
         name: yup
             .string()
+            // omit trim because confusion when RegExp matches trimmed string
             .required('Name is required')
             .matches(/^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$/, helperTextForName),
         description: yup.string(),

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
@@ -24,19 +24,35 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
     },
 };
 
+export const helperTextForName =
+    "Name can contain only lowercase alphanumeric characters, hyphen '-' or period '.', and start and end with an alphanumeric character.";
+export const helperTextForTime = 'Select or enter scan time between 00:00 and 23:59 UTC';
+
+const timeRegExp = /\d\d:\d\d/;
+
+function timeValidator(value: string) {
+    if (!timeRegExp.test(value)) {
+        return false;
+    }
+
+    const [hourString, minuteString] = value.split(':');
+    const hour = parseInt(hourString);
+    const minute = parseInt(minuteString);
+    return hour >= 0 && hour < 24 && minute >= 0 && minute < 60;
+}
+
 const validationSchema = yup.object().shape({
     parameters: yup.object().shape({
         name: yup
             .string()
-            .trim()
-            .required('Scan name is required')
-            .matches(
-                /^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$/,
-                "Name can contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character."
-            ),
+            .required('Name is required')
+            .matches(/^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$/, helperTextForName),
         description: yup.string(),
         intervalType: yup.string().required('Frequency is required'),
-        time: yup.string().required('Time is required'),
+        time: yup
+            .string()
+            .required('Time is required')
+            .test('time', helperTextForTime, timeValidator),
         daysOfWeek: yup
             .array()
             .when('intervalType', (intervalType, schema) =>


### PR DESCRIPTION
## Description

Thank you, David Vail for careful testing to discover the problems.

Thank you, Brad for background info to understand the wizard.

### Problems

1. Validation error does not appear for leading or trailing spaces in **Name**.
2. Even when validation error for **Name**, the only visual feedback is change of text color from black to red.
    Compare to visual feedback that PatternFly `TimePicker` element provides.
3. **Next** button goes to step 2 when **Time** has validation error on step 1.

### Analysis

1. Validation RegExp in `matches` method does not fail, because of `trim` method.
    Although yup `trim` is useful for so `required` fails not just for empty string, it does not trim the string in formik state. Therefore, it hides errors unless either frontend or backend code quietly trims strings.
2. PatternFly `TextInput` element needs `validated` prop to render red ExclamationCircleIcon at the right.
3. PatternFly `TimePicker` element automatically validates time and displays error and icon (in addition to `helperText` prop, by the way). But `proceedToNextStepIfValid` function depends on yup validation.

### Solution

1. Delete `trim` method from yup validation for `name` property.
2. Add `validated` prop to `TextInput` element.
3. Add `test` method to yup validation for `time` property.
    Although I looked at `validateTime` in PatternFly TimePickerUtils.tsx file, it was not easy to extract.
4. Remove obsolete special case for 12-hour time from `handleTimeChange` function.
    It seemed to prevent deleting the last character after I typed an invalid time.

### Residue

As discussed with Brad, there is room for some simplification during 4.6A sprint, if possible. For example, is a hook needed?

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636842 - 4636842
        total 155 = 11727533 - 11727378
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/schedules and click **Create scan schedule**.

2. Type **ROX-24737** in **Name** input box.
    * See black helper text.

3. Press tab key.
    * See red helper text and `validated="error"` icon.
        ![name_blur_invalid](https://github.com/stackrox/stackrox/assets/11862657/aab12c4a-5c87-46c6-bcc0-5929069e3e05)

4. Move back and replace **ROX** with **rox** in **Name** input box.
    * See black helper text and `validated="default"` absence of icon.
        ![name_valid](https://github.com/stackrox/stackrox/assets/11862657/6ac23a8e-9e0a-4d6a-8590-9df1be202f10)

5. Press tab key, enter text in **Description** input box, and then press tab key 2 times.

6. Type **24:00** in **Time** box.
    * See **Invalid time format** from validation in `TimePicker` element.
        ![TimePicker_Invalid_time_format](https://github.com/stackrox/stackrox/assets/11862657/624fdce2-5527-4841-a142-b3eba2fa85f9)

7. Click **Next**.
    * Stay on Step 1 **Set parameters** because of yup validation.
    * See red helper text.
        ![time_invalid](https://github.com/stackrox/stackrox/assets/11862657/4be49b56-cb46-4c84-889c-6fba356e9022)

8. Replace **24:00** with **00:00** in **Time** box.
    * See black helper text.
        ![time_valid](https://github.com/stackrox/stackrox/assets/11862657/c3a13307-20fe-4694-a776-65e7e4a3b6fc)

9. Delete text in **Name** input box.
    * See **Name is required** red helper text and `validated="error"` icon.