### PR TITLE
fix(ui): More Advanced Filters Fixes

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.js
@@ -32,7 +32,7 @@ describe('Workload CVE Deployment Single page', () => {
         if (isAdvancedFiltersEnabled) {
             cy.get(selectors.searchEntityDropdown).click();
             cy.get(selectors.searchEntityMenuItem).contains('Image');
-            cy.get(selectors.searchEntityMenuItem).contains('Image CVE');
+            cy.get(selectors.searchEntityMenuItem).contains('CVE');
             cy.get(selectors.searchEntityMenuItem).contains('Image Component');
             cy.get(selectors.searchEntityDropdown).click();
         } else {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -31,7 +31,7 @@ describe('Workload CVE Image Single page', () => {
         // have CVEs, so we apply a wildcard filter to ensure only images with CVEs are visible
         if (!hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')) {
             if (isAdvancedFiltersEnabled) {
-                typeAndEnterCustomSearchFilterValue('Image CVE', 'Name', '.*');
+                typeAndEnterCustomSearchFilterValue('CVE', 'Name', '.*');
             } else {
                 typeAndSelectCustomSearchFilterValue('CVE', '.*');
             }
@@ -49,7 +49,7 @@ describe('Workload CVE Image Single page', () => {
         // Check that only applicable resource menu items are present in the toolbar
         if (isAdvancedFiltersEnabled) {
             cy.get(selectors.searchEntityDropdown).click();
-            cy.get(selectors.searchEntityMenuItem).contains('Image CVE');
+            cy.get(selectors.searchEntityMenuItem).contains('Image');
             cy.get(selectors.searchEntityMenuItem).contains('Image Component');
             cy.get(selectors.searchEntityDropdown).click();
         } else {
@@ -151,7 +151,7 @@ describe('Workload CVE Image Single page', () => {
                 const cveName = $cveNameCell.innerText;
                 // Enter the CVE name into the CVE filter
                 if (isAdvancedFiltersEnabled) {
-                    typeAndEnterSearchFilterValue('Image CVE', 'Name', cveName);
+                    typeAndEnterSearchFilterValue('CVE', 'Name', cveName);
                 } else {
                     typeAndSelectSearchFilterValue('CVE', cveName);
                 }

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -7,6 +7,7 @@ import CompoundSearchFilter from './CompoundSearchFilter';
 import {
     clusterSearchFilterConfig,
     deploymentSearchFilterConfig,
+    imageCVESearchFilterConfig,
     imageComponentSearchFilterConfig,
     imageSearchFilterConfig,
     nodeComponentSearchFilterConfig,
@@ -131,15 +132,12 @@ describe(Cypress.spec.relative, () => {
 
         cy.get(selectors.attributeSelectToggle).click();
 
-        cy.get(selectors.attributeSelectItems).should('have.length', 8);
+        cy.get(selectors.attributeSelectItems).should('have.length', 5);
         cy.get(selectors.attributeSelectItems).eq(0).should('have.text', 'Name');
         cy.get(selectors.attributeSelectItems).eq(1).should('have.text', 'Operating System');
         cy.get(selectors.attributeSelectItems).eq(2).should('have.text', 'Tag');
-        cy.get(selectors.attributeSelectItems).eq(3).should('have.text', 'CVSS');
-        cy.get(selectors.attributeSelectItems).eq(4).should('have.text', 'Label');
-        cy.get(selectors.attributeSelectItems).eq(5).should('have.text', 'Created Time');
-        cy.get(selectors.attributeSelectItems).eq(6).should('have.text', 'Scan Time');
-        cy.get(selectors.attributeSelectItems).eq(7).should('have.text', 'Registry');
+        cy.get(selectors.attributeSelectItems).eq(3).should('have.text', 'Label');
+        cy.get(selectors.attributeSelectItems).eq(4).should('have.text', 'Registry');
     });
 
     it('should display Deployment attributes in the attribute selector', () => {
@@ -240,17 +238,22 @@ describe(Cypress.spec.relative, () => {
         });
     });
 
-    it('should display the date-picker input and correctly search for image create time', () => {
+    it('should display the date-picker input and correctly search for image cve discovered time', () => {
         const config = {
-            Image: imageSearchFilterConfig,
+            'Image CVE': imageCVESearchFilterConfig,
         };
         const onSearch = cy.stub().as('onSearch');
         const searchFilter = {};
 
         setup(config, searchFilter, onSearch);
 
+        cy.get(selectors.entitySelectToggle).click();
+        cy.get(selectors.entitySelectItem('CVE')).click();
+
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
+
         cy.get(selectors.attributeSelectToggle).click();
-        cy.get(selectors.attributeSelectItem('Created Time')).click();
+        cy.get(selectors.attributeSelectItem('Discovered Time')).click();
 
         // The date-picker input should be present
         cy.get('input[aria-label="Filter by date"]').should('exist');
@@ -272,7 +275,7 @@ describe(Cypress.spec.relative, () => {
         // Check updated date value
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
-            category: 'Image Created Time',
+            category: 'CVE Created Time',
             value: '01/15/2034',
         });
         cy.get('input[aria-label="Filter by date"]').should('have.value', '01/15/2034');
@@ -280,12 +283,15 @@ describe(Cypress.spec.relative, () => {
 
     it('should display the condition-number input and correctly search for image cvss', () => {
         const config = {
-            Image: imageSearchFilterConfig,
+            'Image CVE': imageCVESearchFilterConfig,
         };
         const onSearch = cy.stub().as('onSearch');
         const searchFilter = {};
 
         setup(config, searchFilter, onSearch);
+
+        cy.get(selectors.entitySelectToggle).click();
+        cy.get(selectors.entitySelectItem('CVE')).click();
 
         cy.get(selectors.attributeSelectToggle).click();
         cy.get(selectors.attributeSelectItem('CVSS')).click();
@@ -313,7 +319,7 @@ describe(Cypress.spec.relative, () => {
         cy.get('button[aria-label="Apply condition and number input to search"]').click();
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
-            category: 'Image Top CVSS',
+            category: 'CVSS',
             value: '<9.9',
         });
 
@@ -332,7 +338,7 @@ describe(Cypress.spec.relative, () => {
         cy.get('button[aria-label="Apply condition and number input to search"]').click();
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
-            category: 'Image Top CVSS',
+            category: 'CVSS',
             value: '<10',
         });
 
@@ -346,7 +352,7 @@ describe(Cypress.spec.relative, () => {
         cy.get('button[aria-label="Apply condition and number input to search"]').click();
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
-            category: 'Image Top CVSS',
+            category: 'CVSS',
             value: '<0',
         });
     });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -94,11 +94,14 @@ function CompoundSearchFilter({
                 }}
                 searchFilter={searchFilter}
                 onSearch={(payload) => {
-                    // If the search value is non-empty and not in the searchFilter, trigger onSearch
-                    if (
-                        !searchFilter?.[payload.category]?.includes(payload.value) &&
-                        payload.value !== ''
-                    ) {
+                    const { action, category, value } = payload;
+                    const shouldSearch =
+                        (action === 'ADD' &&
+                            value !== '' &&
+                            !searchFilter?.[category]?.includes(value)) ||
+                        (action === 'REMOVE' && value !== '');
+
+                    if (shouldSearch) {
                         onSearch(payload);
                     }
                 }}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -12,10 +12,15 @@ import {
     SearchFilterAttribute,
     SelectSearchFilterAttribute,
 } from '../types';
-import { ensureConditionNumber, ensureString, ensureStringArray } from '../utils/utils';
+import {
+    conditionMap,
+    ensureConditionNumber,
+    ensureString,
+    ensureStringArray,
+} from '../utils/utils';
 
 import CheckboxSelect from './CheckboxSelect';
-import ConditionNumber, { conditionMap } from './ConditionNumber';
+import ConditionNumber from './ConditionNumber';
 import SearchFilterAutocomplete from './SearchFilterAutocomplete';
 
 export type InputFieldValue =

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
@@ -3,28 +3,17 @@ import { Button, NumberInput, SelectOption } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 import clamp from 'lodash/clamp';
 
-import { ensureString } from '../utils/utils';
+import { conditions, ensureString } from '../utils/utils';
 
 import SimpleSelect from './SimpleSelect';
 
+export type ConditionNumber = { condition: string; number: number };
+
 export type ConditionNumberProps = {
-    value: {
-        condition: string;
-        number: number;
-    };
+    value: ConditionNumber;
     onChange: (value: { condition: string; number: number }) => void;
     onSearch: (value: { condition: string; number: number }) => void;
 };
-
-export const conditionMap = {
-    'Is greater than': '>',
-    'Is greater than or equal to': '>=',
-    'Is equal to': '=',
-    'Is less than or equal to': '<=',
-    'Is less than': '<',
-};
-
-const conditions = Object.keys(conditionMap);
 
 const minValue = 0;
 const maxValue = 10;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -40,7 +40,7 @@ export const imageSearchFilterConfig = {
             displayName: 'Operating System',
             filterChipLabel: 'Image Operating System',
             searchTerm: 'Image OS',
-            inputType: 'text',
+            inputType: 'autocomplete',
         },
         Tag: {
             displayName: 'Tag',
@@ -48,29 +48,11 @@ export const imageSearchFilterConfig = {
             searchTerm: 'Image Tag',
             inputType: 'text',
         },
-        CVSS: {
-            displayName: 'CVSS',
-            filterChipLabel: 'Image CVSS',
-            searchTerm: 'Image Top CVSS',
-            inputType: 'condition-number',
-        },
         Label: {
             displayName: 'Label',
             filterChipLabel: 'Image Label',
             searchTerm: 'Image Label',
             inputType: 'autocomplete',
-        },
-        'Created Time': {
-            displayName: 'Created Time',
-            filterChipLabel: 'Image Created Time',
-            searchTerm: 'Image Created Time',
-            inputType: 'date-picker',
-        },
-        'Scan Time': {
-            displayName: 'Scan Time',
-            filterChipLabel: 'Image Scan Time',
-            searchTerm: 'Image Scan Time',
-            inputType: 'date-picker',
         },
         Registry: {
             displayName: 'Registry',
@@ -272,7 +254,7 @@ export type NodeAttributeInputType = ValueOf<NodeSearchFilterConfig['attributes'
 // Image CVE search filter
 
 export const imageCVESearchFilterConfig = {
-    displayName: 'Image CVE',
+    displayName: 'CVE',
     searchCategory: 'IMAGE_VULNERABILITIES',
     attributes: {
         Name: {
@@ -289,7 +271,7 @@ export const imageCVESearchFilterConfig = {
         },
         CVSS: {
             displayName: 'CVSS',
-            filterChipLabel: 'Image CVE CVSS',
+            filterChipLabel: 'CVSS',
             searchTerm: 'CVSS',
             inputType: 'condition-number',
         },

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -52,7 +52,7 @@ describe('utils', () => {
                 },
                 {
                     displayName: 'CVSS',
-                    filterChipLabel: 'Image CVE CVSS',
+                    filterChipLabel: 'CVSS',
                     searchTerm: 'CVSS',
                     inputType: 'condition-number',
                 },
@@ -120,7 +120,7 @@ describe('utils', () => {
                     searchFilterName: 'CVE Created Time',
                 },
                 {
-                    displayName: 'Image CVE CVSS',
+                    displayName: 'CVSS',
                     searchFilterName: 'CVSS',
                 },
             ]);

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.ts
@@ -11,6 +11,16 @@ import {
     compoundSearchEntityNames,
 } from '../types';
 
+export const conditionMap = {
+    'Is greater than': '>',
+    'Is greater than or equal to': '>=',
+    'Is equal to': '=',
+    'Is less than or equal to': '<=',
+    'Is less than': '<',
+};
+
+export const conditions = Object.keys(conditionMap);
+
 export function getEntities(config: PartialCompoundSearchFilterConfig): SearchFilterEntityName[] {
     const entities = Object.keys(config) as SearchFilterEntityName[];
     return entities;
@@ -83,7 +93,7 @@ export function ensureConditionNumber(value: unknown): { condition: string; numb
         };
     }
     return {
-        condition: '',
+        condition: conditions[0],
         number: 0,
     };
 }


### PR DESCRIPTION
## Description

This PR fixes a few Advanced Filters bugs:

1. Change `text` to `autocomplete` for Image Operating System ([jira](https://issues.redhat.com/browse/ROX-24762))
2. Remove `Image Created Time` and `Image Scan Time` ([jira](https://issues.redhat.com/browse/ROX-24758))
3. Remove the term `Image` from `Image CVE` ([jira](https://issues.redhat.com/browse/ROX-24754))
4. Fix issue with unchecking an option in the Checkbox Select ([jira](https://issues.redhat.com/browse/ROX-24753))
5. When using the `condition-number` type for a search, it should not display `undefined` if the condition is not changed at least once ([jira 1](https://issues.redhat.com/browse/ROX-24752)) ([jira 2](https://issues.redhat.com/browse/ROX-24705))
6. Should be able to clear `CVE Snoozed` values from dropdown ([jira](https://issues.redhat.com/browse/ROX-24738))

Also, the tests needed to be updated because of a few changes.