### PR TITLE
feat(sync-message): Publish resource sync message

### DIFF
--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -23,6 +23,9 @@ const (
 
 	// SensorComponentEventSyncFinished denotes that Sensor finished initial sync.
 	SensorComponentEventSyncFinished SensorComponentEvent = "sync-finished"
+
+	// SensorComponentEventResourceSyncFinished denotes that Sensor finished the k8s resource sync
+	SensorComponentEventResourceSyncFinished SensorComponentEvent = "resource-sync-finished"
 )
 
 // LogSensorComponentEvent returns a unified string for logging the transition between component states/
@@ -42,6 +45,8 @@ func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string)
 		mode = "Offline"
 	case SensorComponentEventSyncFinished:
 		return fmt.Sprintf("%s has received the SyncFinished notification", name)
+	case SensorComponentEventResourceSyncFinished:
+		return fmt.Sprintf("%s has received the ResourceSyncFinished notification", name)
 	}
 	return fmt.Sprintf("%s runs now in %s mode", name, mode)
 

--- a/sensor/common/internalmessage/internal_message_pubsub.go
+++ b/sensor/common/internalmessage/internal_message_pubsub.go
@@ -8,6 +8,9 @@ import (
 const (
 	// SensorMessageSoftRestart is a message kind where components require sensor-central connection to restart.
 	SensorMessageSoftRestart = "SensorMessage_SoftRestart"
+
+	// SensorMessageResourceSyncFinished is a message kind where components require the resource sync to be finished.
+	SensorMessageResourceSyncFinished = "SensorMessage_ResourceSyncFinished"
 )
 
 // SensorInternalMessageCallback is the callback used by subscribers.
@@ -17,7 +20,8 @@ type SensorInternalMessageCallback func(message *SensorInternalMessage)
 func NewMessageSubscriber() *MessageSubscriber {
 	return &MessageSubscriber{
 		subscribers: map[string][]SensorInternalMessageCallback{
-			SensorMessageSoftRestart: {},
+			SensorMessageSoftRestart:          {},
+			SensorMessageResourceSyncFinished: {},
 		},
 		lock: &sync.RWMutex{},
 	}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
+	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
@@ -238,6 +239,7 @@ func NewManager(
 	clusterEntities EntityStore,
 	externalSrcs externalsrcs.Store,
 	policyDetector detector.Detector,
+	pubSub *internalmessage.MessageSubscriber,
 ) Manager {
 	enricherTicker := time.NewTicker(tickerTime)
 	mgr := &networkFlowManager{
@@ -251,6 +253,7 @@ func NewManager(
 		activeConnections: make(map[connection]*networkConnIndicator),
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicator),
 		stopper:           concurrency.NewStopper(),
+		pubSub:            pubSub,
 	}
 
 	enricherTicker.Stop()
@@ -258,6 +261,17 @@ func NewManager(
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.NetworkFlowBufferSize))
 	} else {
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage)
+	}
+
+	if err := mgr.pubSub.Subscribe(internalmessage.SensorMessageResourceSyncFinished, func(msg *internalmessage.SensorInternalMessage) {
+		if msg.IsExpired() {
+			return
+		}
+		// Since we need to have the logic to transition to offline mode if `SensorCapturesIntermediateEvents` is disabled.
+		// We call `Notify` here to keep the logic to transition offline/online in the same place.
+		mgr.Notify(common.SensorComponentEventResourceSyncFinished)
+	}); err != nil {
+		log.Errorf("unable to subscribe to %s: %+v", internalmessage.SensorMessageResourceSyncFinished, err)
 	}
 
 	return mgr
@@ -293,6 +307,7 @@ type networkFlowManager struct {
 	policyDetector detector.Detector
 
 	stopper concurrency.Stopper
+	pubSub  *internalmessage.MessageSubscriber
 }
 
 func (m *networkFlowManager) ProcessMessage(_ *central.MsgToSensor) error {
@@ -321,7 +336,7 @@ func (m *networkFlowManager) Capabilities() []centralsensor.SensorCapability {
 func (m *networkFlowManager) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
 	switch e {
-	case common.SensorComponentEventSyncFinished:
+	case common.SensorComponentEventResourceSyncFinished:
 		if features.SensorCapturesIntermediateEvents.Enabled() {
 			if m.initialSync.CompareAndSwap(false, true) {
 				m.enricherTicker.Reset(tickerTime)

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -537,7 +537,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connection",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: expectEntityLookupContainerHelper(mockEntity, 1, clusterentities.ContainerMetadata{
 				DeploymentID: srcID,
 			}, true),
@@ -560,7 +560,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received connections",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -607,7 +607,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		},
 		{
 			testName: "In online mode we should enrich and send the previously received endpoints",
-			notify:   common.SensorComponentEventSyncFinished,
+			notify:   common.SensorComponentEventResourceSyncFinished,
 			expectEntityLookupContainer: func() {
 				gomock.InOrder(
 					mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool) {
@@ -696,7 +696,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(1)
 	mockEntity.EXPECT().RecordTick().AnyTimes()
 	addHostConnection(m, createHostnameConnections(hostname).withConnectionPair(createConnectionPair()))
-	m.Notify(common.SensorComponentEventSyncFinished)
+	m.Notify(common.SensorComponentEventResourceSyncFinished)
 	fakeTicker <- time.Now()
 	select {
 	case <-time.After(10 * time.Second):
@@ -704,7 +704,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	case msg, ok := <-m.sensorUpdates:
 		s.Require().True(ok, "the sensorUpdates channel should not be closed")
 		m.Notify(common.SensorComponentEventOfflineMode)
-		m.Notify(common.SensorComponentEventSyncFinished)
+		m.Notify(common.SensorComponentEventResourceSyncFinished)
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -327,6 +327,11 @@ func (k *listenerImpl) handleAllEvents() {
 		},
 		Context: k.context,
 	})
+	utils.Should(k.pubSub.Publish(&internalmessage.SensorInternalMessage{
+		Kind:     internalmessage.SensorMessageResourceSyncFinished,
+		Text:     "Finished the k8s resource sync",
+		Validity: k.context,
+	}))
 }
 
 // Helper function that creates and adds a handler to an informer.

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -141,7 +141,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		processSignals = signalService.New(processPipeline, indicators, signalService.WithTraceWriter(cfg.processIndicatorWriter))
 	}
 	networkFlowManager :=
-		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector)
+		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector, pubSub)
 	enhancer := deploymentenhancer.CreateEnhancer(storeProvider)
 	components := []common.SensorComponent{
 		admCtrlMsgForwarder,


### PR DESCRIPTION
## Description

Some components don't need to start processing until the k8s resources are done syncing. This PR:

- Enables components to subscribe to a `ResourceSyncFinished` message that will be published when the k8s listeners are done with the initial sync.
- Subscribes the network flows manager to this new message.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI
- [x] Manually tested the network flows manager still work as expected

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
