### PR TITLE
chore(performance): Add container memory WSS to kube-burner metrics

### DIFF
--- a/tests/performance/scale/tests/kube-burner/cluster-density/metrics.yml
+++ b/tests/performance/scale/tests/kube-burner/cluster-density/metrics.yml
@@ -918,3 +918,6 @@
 
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace="stackrox"}) by (container, pod, namespace))
   metricName: stackrox_container_memory
+
+- query: (sum(container_memory_working_set_bytes{name!="",container!="POD",namespace="stackrox"}) by (container, pod, namespace))
+  metricName: stackrox_container_memory_working_set_bytes


### PR DESCRIPTION
## Description

Add gathering of `container_memory_working_set_bytes` during kube-burner tests.

We are currently gathering memory RSS. That can be pretty low compared to the threshold where a container will be OOMKilled. WSS is a better representation of this threshold, and we should gather that metric because we can use that value to define Kubernetes container resource requirements/limits.

## Checklist
- ~[ ] Investigated and inspected CI test results~ - changes are not relevant for CI
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

I didn't perform any testing.

I just copied the query for `container_memory_rss` and replaced the metric name with `container_memory_working_set_bytes`.
Renamed `metricName` - and verified that there is no such metric in the file and that length is smaller than any existing `metricName` (ensure it will be gathered).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
