### PR TITLE
fix(ui): workload CVE quick fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -86,7 +86,7 @@ function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageRes
                 {deploymentResourcesData && (
                     <ExpandableSection
                         toggleText={`Images (${imageCount})`}
-                        onToggle={() => imageTableToggle.onToggle}
+                        onToggle={() => imageTableToggle.onToggle(!imageTableToggle.isOpen)}
                         isExpanded={imageTableToggle.isOpen}
                         style={
                             {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -289,7 +289,6 @@ function DeploymentPageVulnerabilities({
                             </SplitItem>
                             <SplitItem>
                                 <Pagination
-                                    isCompact
                                     itemCount={totalVulnerabilityCount}
                                     page={page}
                                     perPage={perPage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -89,7 +89,9 @@ function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
                 {imageResourcesData && (
                     <ExpandableSection
                         toggleText={`Deployments (${deploymentCount})`}
-                        onToggle={() => deploymentTableToggle.onToggle}
+                        onToggle={() =>
+                            deploymentTableToggle.onToggle(!deploymentTableToggle.isOpen)
+                        }
                         isExpanded={deploymentTableToggle.isOpen}
                         style={
                             {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -58,7 +58,6 @@ import {
     getVulnStateScopedQueryString,
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
-import { getDefaultWorkloadSortOption } from '../../utils/sortUtils';
 import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
@@ -148,8 +147,8 @@ export const imageCveAffectedDeploymentsQuery = gql`
     }
 `;
 
-const imageSortFields = ['Image', 'Operating System'];
-const imageDefaultSort = { field: 'Image', direction: 'desc' } as const;
+const imageSortFields = ['Image', 'Severity', 'Operating System'];
+const imageDefaultSort = { field: 'Severity', direction: 'desc' } as const;
 
 const deploymentSortFields = ['Deployment', 'Cluster', 'Namespace'];
 const deploymentDefaultSort = { field: 'Deployment', direction: 'desc' } as const;
@@ -218,7 +217,7 @@ function ImageCvePage() {
     const { sortOption, setSortOption, getSortParams } = useURLSort({
         sortFields: getSortFields(entityTab),
         defaultSortOption: getDefaultSortOption(entityTab),
-        onSort: () => setPage(1),
+        onSort: () => setPage(1, 'replace'),
     });
 
     const metadataRequest = useQuery<{ imageCVE: CveMetadata | null }, { cve: string }>(
@@ -312,8 +311,10 @@ function ImageCvePage() {
     }
 
     function onEntityTypeChange(entityTab: WorkloadEntityTab) {
-        setSortOption(getDefaultWorkloadSortOption(entityTab));
         setPage(1);
+        if (entityTab !== 'CVE') {
+            setSortOption(getDefaultSortOption(entityTab), 'replace');
+        }
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
             properties: {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -99,7 +99,7 @@ function AffectedImagesTable({
                 <Tr>
                     <ExpandRowTh />
                     <Th sort={getSortParams('Image')}>Image</Th>
-                    <Th>CVE severity</Th>
+                    <Th sort={getSortParams('Severity')}>CVE severity</Th>
                     <Th>CVSS</Th>
                     <Th>
                         CVE status

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -25,6 +25,7 @@ import DateDistance from 'Components/DateDistance';
 import { TableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import ExpandRowTh from 'Components/ExpandRowTh';
+import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
 import { VulnerabilitySeverityLabel } from '../../types';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
@@ -295,7 +296,7 @@ function CVEsTable({
                                         {createTableActions && (
                                             <Td className="pf-v5-u-px-0">
                                                 <ActionsColumn
-                                                    // menuAppendTo={() => document.body}
+                                                    popperProps={ACTION_COLUMN_POPPER_PROPS}
                                                     items={createTableActions({
                                                         cve,
                                                         summary,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -201,7 +201,7 @@ function ImagesTable({
                                             />
                                         </Td>
                                     )}
-                                    <Td>{operatingSystem}</Td>
+                                    <Td>{operatingSystem || 'unknown'}</Td>
                                     <Td modifier="nowrap">
                                         {deploymentCount > 0 ? (
                                             <>
@@ -215,13 +215,17 @@ function ImagesTable({
                                         )}
                                     </Td>
                                     <Td>
-                                        <DateDistance
-                                            date={metadata?.v1?.created}
-                                            asPhrase={false}
-                                        />
+                                        {metadata?.v1?.created ? (
+                                            <DateDistance
+                                                date={metadata.v1.created}
+                                                asPhrase={false}
+                                            />
+                                        ) : (
+                                            'unknown'
+                                        )}
                                     </Td>
                                     <Td>
-                                        <DateDistance date={scanTime} />
+                                        {scanTime ? <DateDistance date={scanTime} /> : 'unknown'}
                                     </Td>
                                     {hasWriteAccessForWatchedImage && (
                                         <Td isActionCell>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -11,6 +11,7 @@ import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { TableUIState } from 'utils/getTableUIState';
+import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
 import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../../types';
@@ -226,7 +227,7 @@ function ImagesTable({
                                         <Td isActionCell>
                                             {name?.tag && (
                                                 <ActionsColumn
-                                                    // menuAppendTo={() => document.body}
+                                                    popperProps={ACTION_COLUMN_POPPER_PROPS}
                                                     items={[
                                                         {
                                                             title: watchImageMenuText,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -44,7 +44,7 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
             {data.firstDiscoveredInSystem && (
                 <LabelGroup numLabels={1}>
                     <Label>
-                        First discovered in system {getDateTime(data.firstDiscoveredInSystem)}
+                        First discovered in system: {getDateTime(data.firstDiscoveredInSystem)}
                     </Label>
                 </LabelGroup>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
@@ -25,7 +25,7 @@ function getTooltipContent(severity: string, severityCount?: number, entity?: st
     if (entity) {
         return `${severityCount} ${severity} severity cve count across this ${entity}`;
     }
-    return `image count with ${severity} severity`;
+    return `Image count with ${severity} severity`;
 }
 
 function getClassNameForCount(count?: number) {

--- a/ui/apps/platform/src/constants/tables.ts
+++ b/ui/apps/platform/src/constants/tables.ts
@@ -1,0 +1,5 @@
+export const ACTION_COLUMN_POPPER_PROPS = {
+    appendTo: () => document.body,
+    position: 'end',
+    direction: 'down',
+} as const;


### PR DESCRIPTION
## Description

A variety of very small, quick polish fixes from the bug bash. One commit == one fix.

1. Correctly capitalize tooltip for severity counts
![image](https://github.com/stackrox/stackrox/assets/1292638/d87df264-6351-49bd-9890-de5aa4bcbc1c)

3. Make the Pagination on the Deployment page full sized, to match other pages
![image](https://github.com/stackrox/stackrox/assets/1292638/949f8cef-c75b-4c53-aeae-2263c88804fa)

5. Fix the "double-history" bug on the CVE page, and allow Severity to be sortable
Visit Workload CVEs, click a CVE name in the table. Hitting the back button a single time will return you to the Workload CVE list page. Sortable by Severity below:
![image](https://github.com/stackrox/stackrox/assets/1292638/935f7272-a5e4-40c6-9679-a881754529f5)
![image](https://github.com/stackrox/stackrox/assets/1292638/a0371138-65f8-4bb1-a2fb-8ccc0669b600)


7. Fix the action-menu overflow issue that was re-introduced with PF 5
![image](https://github.com/stackrox/stackrox/assets/1292638/f9754acb-270b-41f3-ac89-7fb270dcd9fe)

9. Adds fallback text of "unknown" to Image table columns when values are empty
![image](https://github.com/stackrox/stackrox/assets/1292638/222ae950-5533-425f-9ea3-02b01cb1b155)

11. Fix the toggling of Resource table expandable sections
![image](https://github.com/stackrox/stackrox/assets/1292638/711bfc8a-c52d-47a7-adbb-78907c9720a3)
![image](https://github.com/stackrox/stackrox/assets/1292638/574173ef-f7d3-4f9f-9855-1ba09fe51fd3)

13. Add missing `:` character in CVE page header label :) 
![image](https://github.com/stackrox/stackrox/assets/1292638/27c2a12a-ba25-4389-9bc6-95f536f8b30e)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

See above