### PR TITLE
ROX-24725: revert names optimization

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -333,10 +333,6 @@ func updateImageFromRequest(existingImg *storage.Image, reqImgName *storage.Imag
 	log.Debugf("Updated existing image name from %q to %q", existingImgName.GetFullName(), reqImgName.GetFullName())
 	existingImg.Name = reqImgName
 
-	// Because there is no metadata for the existing image we assume the existing Names are
-	// invalid and reset them. If this was an incorrect assumption, Names will be re-populated
-	// over time via the various reprocessing workflows.
-	existingImg.Names = []*storage.ImageName{reqImgName}
 	return true
 }
 


### PR DESCRIPTION
## Description

When the [Unqualified Search Registries feature](https://github.com/stackrox/stackrox/pull/10351) was added, an optimization was included that cleared the 'Names' field for an image under the assumption that if metadata for the image was nil then the previous names were invalid.

https://github.com/stackrox/stackrox/blob/0b85615b6c41cf53e4ecc3daf3fc30e0f7479c9e/central/image/service/service_impl.go#L336-L339

Although the assumption is true, as deployments scale, sensors restart, new clusters introduced, the same wrong 'name' may appear for an image in the future - which would result in cache misses.  

This can be considered an edge case because in practice there likely would be no 'ID'  for an image (which is required to save the image to central-db) in this scenario unless the pod spec references a digest directly (because when the ID is obtainable from the container runtime so is the 'correct name').  Or if there are some clusters in the 'fleet' with the unqualified search registries feature enabled and others without, then the wrong names with a correct ID will be sent to Central from the clusters without the featured enabled. 

In the future we should cleanup the names holistically via some other mechanism - as tags change (ie: `latest`) existing image Names become stale.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

CI
