### PR TITLE
fix: Enable debugging builds in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,6 +168,12 @@ jobs:
       - name: PR labels
         uses: joerick/pr-labels-action@v1.0.9
 
+      - name: Setup build env for debugging support
+        run: |
+          if [[ "${GITHUB_HEAD_REF}" =~ -debug ]]; then
+            echo "DEBUG_BUILD=yes" >> "${GITHUB_ENV}"
+          fi
+
       - name: Setup Go build environment for release
         if: |
           contains(github.event.pull_request.labels.*.name, 'ci-release-build')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -296,6 +296,9 @@ jobs:
             echo "GO_BINARIES_BUILD_ARTIFACT=go-binaries-build-${{ matrix.arch }}-${go_binaries}"
             echo "ROX_PRODUCT_BRANDING=${brand}"
           } >> "$GITHUB_ENV"
+          if [[ "${GITHUB_HEAD_REF}" =~ -debug ]]; then
+            echo "DEBUG_BUILD=yes" >> "${GITHUB_ENV}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -302,7 +302,7 @@ jobs:
             echo "GO_BINARIES_BUILD_ARTIFACT=go-binaries-build-${{ matrix.arch }}-${go_binaries}"
             echo "ROX_PRODUCT_BRANDING=${brand}"
           } >> "$GITHUB_ENV"
-          if [[ "${GITHUB_HEAD_REF}" =~ -debug ]]; then
+          if [[ "${GITHUB_HEAD_REF:-}" =~ -debug ]]; then
             echo "DEBUG_BUILD=yes" >> "${GITHUB_ENV}"
           fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Setup build env for debugging support
         run: |
-          if [[ "${GITHUB_HEAD_REF}" =~ -debug ]]; then
+          if [[ "${GITHUB_HEAD_REF:-}" =~ -debug ]]; then
             echo "DEBUG_BUILD=yes" >> "${GITHUB_ENV}"
           fi
 


### PR DESCRIPTION
## Description

The top-level Makefile contains the following code:
```
# If git branch name contains substring "-debug", a debug build will be made, unless overridden by environment variable.
ifneq (,$(findstring -debug,$(shell git rev-parse --abbrev-ref HEAD)))
	DEBUG_BUILD ?= yes
endif
DEBUG_BUILD ?= no
```

This is supposed to activate debugging builds in case the current branch name contains the string `-debug`. This seems to work reliably for local builds. But, [as documented](https://github.com/stackrox/stackrox/blob/1c13091541b4ec6e47a2198a124fd26bbb5108f1/README.md?plain=1#L525), this feature is also supposed to work in CI, which is currently not the case. The reason being that in CI the checkout is in **detached HEAD mode** and hence the call to `git rev-parse` only returns `HEAD`. A quick research has yielded that there are multiple workarounds and semi-solutions for this, but I haven't found anything that I feel really comfortable with.

Instead, what seems to be the preferable solution to me is what I am proposing in this PR: Let's just use the branch name as being injected into our CI environment from GitHub. This seems to be reliable and doesn't increase the complexity within our Makefile while trying to back-resolve a commit ID to some (potentially non-unique) branch name.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~]

This PR only touches GitHub Actions.


