### PR TITLE
ROX-23426: Implement central endpoint port defaulting

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
@@ -33,3 +33,26 @@
   {{ end }}
 {{ end }}
 {{ end }}
+
+{{/*
+  srox.ensureCentralEndpointContainsPort .
+
+  Appends a default port to the configured central endpoint based on a very simply heuristic.
+  Specifically, it only checks if the provided endpoint contains a prefix "https://" and
+  the part after that prefix does not contain a double colon.
+  This heuristic is kept simple on purpose and does not correctly add the default ports in
+  case the host part is an IPv6 address.
+*/}}
+{{ define "srox.ensureCentralEndpointContainsPort" }}
+  {{ $ := . }}
+
+  {{ $endpoint := $._rox.centralEndpoint }}
+  {{ if hasPrefix "https://" $endpoint }}
+    {{ $endpoint = trimPrefix "https://" $endpoint }}
+    {{ if not (contains ":" $endpoint) }}
+      {{ include "srox.warn" (list $ (printf "Specified centralEndpoint %s is missing a port, assuming the port is 443. If this is wrong please specify the correct port." $._rox.centralEndpoint)) }}
+      {{ $_ := set $._rox "centralEndpoint" (printf "%s:443" $._rox.centralEndpoint) }}
+    {{ end }}
+  {{ end }}
+
+{{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
@@ -50,7 +50,7 @@
   {{ if hasPrefix "https://" $endpoint }}
     {{ $endpoint = trimPrefix "https://" $endpoint }}
     {{ if not (contains ":" $endpoint) }}
-      {{ include "srox.warn" (list $ (printf "Specified centralEndpoint %s is missing a port, assuming the port is 443. If this is wrong please specify the correct port." $._rox.centralEndpoint)) }}
+      {{ include "srox.note" (list $ (printf "Specified centralEndpoint %s does not contain a port, assuming port 443. If this is incorrect please specify the correct port." $._rox.centralEndpoint)) }}
       {{ $_ := set $._rox "centralEndpoint" (printf "%s:443" $._rox.centralEndpoint) }}
     {{ end }}
   {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -132,6 +132,7 @@
 {{ include "srox.setInstallMethod" (list $) }}
 
 {{ include "srox.applyDefaults" $ }}
+{{ include "srox.ensureCentralEndpointContainsPort" $ }}
 
 {{ include "srox.getStorageClasses" (list $) }}
 {{ include "srox.getPVCs" (list $) }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/base-config.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/base-config.test.yaml
@@ -23,6 +23,12 @@ tests:
     expect: |
       verifySensorEndpoint("sensor.stackrox.svc:443")
       verifyCentralEndpoint("stackrox-central.example.com:8443")
+  - name: central endpoint without explicit port
+    set:
+      centralEndpoint: "https://stackrox-central.example.com"
+    expect: |
+      verifyCentralEndpoint("https://stackrox-central.example.com:443")
+      .notes | assertThat(contains("WARNING: Specified centralEndpoint https://stackrox-central.example.com is missing a port"))
 
 - name: different namespace
   release:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/base-config.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/base-config.test.yaml
@@ -28,7 +28,7 @@ tests:
       centralEndpoint: "https://stackrox-central.example.com"
     expect: |
       verifyCentralEndpoint("https://stackrox-central.example.com:443")
-      .notes | assertThat(contains("WARNING: Specified centralEndpoint https://stackrox-central.example.com is missing a port"))
+      .notes | assertThat(contains("Specified centralEndpoint https://stackrox-central.example.com does not contain a port"))
 
 - name: different namespace
   release:


### PR DESCRIPTION
## Description

This PR extends the secured-cluster Helm chart so that a provided central endpoint prefixed with `https://` but without explicit port is treated as having the port `:443` explicitly attached to it.

## Checklist
- [x] ~~Investigated and inspected CI test results~~
- [x] ~~Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Manually tested by deploying sensor, providing a central endpoint without explicit port, but with https:// prefix.
