### PR TITLE
ROX-24399: Disable PSP generation for roxctl deployment bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Scanner V4 may now be accessed anonymously for debugging purposes by enabling `ROX_SCANNER_V4_ALLOW_ANONYMOUS_AUTH`.
   - This was already enabled for development builds of StackRox, but now it may be configured for release builds, too.
   - This defaults to `true` for development builds, and `false` for release builds.
+- Deployment bundles created with roxctl do not contain PodSecurityPolicies (PSPs) anymore by default. When deploying to pre-1.25 Kubernetes clusters with PSPs enabled the --enable-pod-security-policies flag needs to be specified when invoking roxctl for generating deployment bundles.
 
 ## [4.4.0]
 

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -376,7 +376,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	if !buildinfo.ReleaseBuild {
 		flags.AddHelmChartDebugSetting(c)
 	}
-	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	c.AddCommand(centralGenerateCmd.interactive())
 	c.AddCommand(k8s(cliEnvironment))

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -114,7 +114,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		fmt.Sprintf(
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
-	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	flags.AddTimeout(c)
 	flags.AddRetryTimeout(c)

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -230,7 +230,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionController, "admission-controller-listen-on-creates", false, "Whether or not to configure the admission controller webhook to listen on deployment creates")
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerUpdates, "admission-controller-listen-on-updates", false, "Whether or not to configure the admission controller webhook to listen on deployment updates")
-	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
 	// Admission controller config
 	ac := generateCmd.cluster.DynamicConfig.AdmissionControllerConfig

--- a/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
@@ -50,8 +50,8 @@ sensor_bundle_psp_disabled() {
     sensor_bundle_psp_enabled k8s --enable-pod-security-policies=true
 }
 
-@test "PodSecurityPolicies enabled by default for sensor deployment bundle (k8s)" {
-    sensor_bundle_psp_enabled k8s
+@test "PodSecurityPolicies are disabled by default for sensor deployment bundle (k8s)" {
+    sensor_bundle_psp_disabled k8s
 }
 
 # Testing: sensor generate openshift
@@ -63,6 +63,6 @@ sensor_bundle_psp_disabled() {
     sensor_bundle_psp_enabled openshift --enable-pod-security-policies=true
 }
 
-@test "PodSecurityPolicies enabled by default for sensor deployment bundle (openshift)" {
-    sensor_bundle_psp_enabled openshift
+@test "PodSecurityPolicies are disabled by default for sensor deployment bundle (openshift)" {
+    sensor_bundle_psp_disabled openshift
 }

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -51,7 +51,7 @@ assert_number_of_k8s_resources() {
   # additional mounted volume. It's called "trusted-ca-volume" and we use it to identify OpenShift 4 configuration.
   run -0 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 17
+  assert_number_of_k8s_resources 14
 }
 
 @test "[openshift] roxctl scanner generate" {
@@ -60,7 +60,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 17
+  assert_number_of_k8s_resources 14
 }
 
 @test "[k8s] roxctl scanner generate" {
@@ -72,7 +72,7 @@ assert_number_of_k8s_resources() {
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -1 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
 
-  assert_number_of_k8s_resources 15
+  assert_number_of_k8s_resources 12
 }
 
 @test "[k8s istio-support] roxctl scanner generate" {
@@ -80,7 +80,7 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-07-service.yaml"
   run -0 grep -q "^apiVersion: networking.istio.io/v1alpha3" "${output_dir}/scanner/02-scanner-07-service.yaml"
-  assert_number_of_k8s_resources 17
+  assert_number_of_k8s_resources 14
 }
 
 @test "[k8s scanner-image] roxctl scanner generate" {
@@ -88,5 +88,5 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q "bats-tests" "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 15
+  assert_number_of_k8s_resources 12
 }

--- a/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
@@ -45,8 +45,8 @@ central_bundle_psp_disabled() {
     central_bundle_psp_enabled k8s --enable-pod-security-policies=true
 }
 
-@test "PodSecurityPolicies are enabled by default for central deployment bundle (k8s)" {
-    central_bundle_psp_enabled k8s
+@test "PodSecurityPolicies are disabled by default for central deployment bundle (k8s)" {
+    central_bundle_psp_disabled k8s
 }
 
 # Testing: central generate openshift
@@ -58,6 +58,6 @@ central_bundle_psp_disabled() {
     central_bundle_psp_enabled openshift --enable-pod-security-policies=true
 }
 
-@test "PodSecurityPolicies are enabled by default for central deployment bundle (openshift)" {
-    central_bundle_psp_enabled openshift
+@test "PodSecurityPolicies are disabled by default for central deployment bundle (openshift)" {
+    central_bundle_psp_disabled openshift
 }


### PR DESCRIPTION
## Description

Within the roxctl the different subcommands for generating deployment bundles were defaulting to generate the bundles including PSPs, which is not a reasonable choice anymore.

This PR:
* flips the defaults of these toggles.
* updates the CHANGELOG
* updates the bats tests for roxctl deployment bundles

**Update:** Now depends on https://github.com/stackrox/stackrox/pull/11584.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] ~~Determined and documented upgrade steps~~
- [x] Documented user facing changes

## Testing Performed

CI + manually (invoking the different `roxctl generate` commands).
