### PR TITLE
fix(ui): Add fix for failing tests due to inconsistent dropdown state

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -89,10 +89,6 @@ function SearchFilterAutocomplete({
         () =>
             debounce((newValue: string) => {
                 setFilterValue(newValue);
-                if (newValue && !isOpen) {
-                    // Open the menu when the input value changes and the new value is not empty
-                    setIsOpen(true);
-                }
                 setActiveItem(null);
                 setFocusedItemIndex(null);
                 setIsTyping(false);


### PR DESCRIPTION
## Description

Fixes an occasional test flake due to the dropdown state in the autocomplete filter. Thanks to @pedrottimark for catching this in a PR test run.

The cause:
- During tests, sometimes we would enter text into the autocomplete dropdown and then immediately click the "apply" button
- This caused the suggestion dropdown to close, and then open again in 500ms when the debounce callback fired
- In some cases, we would attempt to click an element that was obscured by this dropdown right when the 500ms threshold had elapsed causing a test failure

Example failure:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11555/pull-ci-stackrox-stackrox-master-ocp-4-12-ui-e2e-tests/1801646444411621376

From the testing I've done, I wasn't able to see a reason for opening the dropdown programmatically at all so assumed it might have been leftover from an earlier implementation. (If we do still need this for some reason, I think we should do it directly in the event handler instead of the debounce callback.)

@sachaudh since I don't have as much context in this, please let me know if there is something I am missing that would make this an inappropriate fix.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual filter testing.

Existing component tests.

Existing e2e tests.