### PR TITLE
ROX-24557: delegated scanning add no auth error to log

### DIFF
--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -267,7 +267,7 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 		// No registries found thus far, create a no auth registry.
 		reg, err := s.createNoAuthImageRegistry(ctx, imgName, s.regFactory)
 		if err != nil {
-			return nil, pkgErrors.Errorf("unable to create no auth integration for %q", imgName.GetFullName())
+			return nil, pkgErrors.Wrapf(err, "unable to create no auth integration for %q", imgName.GetFullName())
 		}
 		regs = append(regs, reg)
 	}

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -22,6 +22,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+var (
+	errBroken = errors.New("broken")
+)
+
 type fakeImageServiceClient struct {
 	v1.ImageServiceClient
 	fail bool
@@ -451,6 +455,7 @@ func (suite *scanTestSuite) TestEnrichNoRegistriesFailure() {
 	mirrorStore.EXPECT().PullSources(containerImg.GetName().GetFullName())
 	_, err = scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
 	suite.Require().ErrorContains(err, "unable to create no auth integration")
+	suite.Require().ErrorContains(err, errBroken.Error())
 }
 
 func (suite *scanTestSuite) TestGetRegistries() {
@@ -658,7 +663,7 @@ func successCreateNoAuthImageRegistry(context.Context, *storage.ImageName, regis
 }
 
 func failCreateNoAuthImageRegistry(context.Context, *storage.ImageName, registries.Factory) (registryTypes.ImageRegistry, error) {
-	return nil, errors.New("broken")
+	return nil, errBroken
 }
 
 type fakeRegistry struct {


### PR DESCRIPTION
## Description

When Delegated Scanning is being used and no integrations are found for registry authentication, a 'no auth' integration is created. If the creation of the 'no auth' integration fails, the associated error was not logged, this PR adds the error to the log message to aid troubleshooting.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- [X] ~Evaluated and added CHANGELOG entry if required~
- [X] ~Determined and documented upgrade steps~
- [X] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests
