### PR TITLE
ROX-24757: Fix date picker issues

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.css
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.css
@@ -1,0 +1,3 @@
+.pf-v5-c-date-picker__helper-text {
+    position: absolute;
+}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -32,10 +32,10 @@ const imageNameResponseMock = {
     },
 };
 
-function Wrapper({ config, onSearch }) {
+function Wrapper({ config, searchFilter, onSearch }) {
     return (
         <div className="pf-v5-u-p-md">
-            <CompoundSearchFilter config={config} onSearch={onSearch} />
+            <CompoundSearchFilter config={config} searchFilter={searchFilter} onSearch={onSearch} />
         </div>
     );
 }
@@ -65,6 +65,33 @@ function mockAutocompleteResponse() {
 
         req.reply(response);
     }).as('autocomplete');
+}
+
+/**
+ * Selects a date in a date-picker component.
+ *
+ * @param {string} month - The full name of the month to select (e.g., "January", "February").
+ * @param {string} day - The day of the month to select (e.g., "01", "15").
+ * @param {string} year - The four-digit year to select (e.g., "2023").
+ *
+ */
+function selectDatePickerDate(month, day, year) {
+    // The date-picker input should be present
+    cy.get('input[aria-label="Filter by date"]').should('exist');
+
+    // Click on the date-picker toggle
+    cy.get('button[aria-label="Filter by date toggle"]').click();
+
+    // Select a month
+    cy.get('div.pf-v5-c-calendar-month__header-month button').click();
+    cy.get(`button.pf-v5-c-menu__item:contains("${month}")`).click();
+
+    // Select a year
+    cy.get('input[aria-label="Select year"]').clear();
+    cy.get('input[aria-label="Select year"]').type(year);
+
+    // Select a day
+    cy.get(`button.pf-v5-c-calendar-month__date:contains("${day}")`).click();
 }
 
 describe(Cypress.spec.relative, () => {
@@ -255,22 +282,9 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.attributeSelectToggle).click();
         cy.get(selectors.attributeSelectItem('Discovered Time')).click();
 
-        // The date-picker input should be present
-        cy.get('input[aria-label="Filter by date"]').should('exist');
+        selectDatePickerDate('January', '15', '2034');
 
-        // Click on the date-picker toggle
-        cy.get('button[aria-label="Filter by date toggle"]').click();
-
-        // Select a month
-        cy.get('div.pf-v5-c-calendar-month__header-month button').click();
-        cy.get('button.pf-v5-c-menu__item:contains("January")').click();
-
-        // Select a year
-        cy.get('input[aria-label="Select year"]').clear();
-        cy.get('input[aria-label="Select year"]').type('2034');
-
-        // Select a day
-        cy.get('button.pf-v5-c-calendar-month__date:contains("15")').click();
+        cy.get('button[aria-label="Apply date input to search"]').click();
 
         // Check updated date value
         cy.get('@onSearch').should('have.been.calledWithExactly', {
@@ -278,7 +292,8 @@ describe(Cypress.spec.relative, () => {
             category: 'CVE Created Time',
             value: '01/15/2034',
         });
-        cy.get('input[aria-label="Filter by date"]').should('have.value', '01/15/2034');
+
+        cy.get('input[aria-label="Filter by date"]').should('have.value', '');
     });
 
     it('should display the condition-number input and correctly search for image cvss', () => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -14,6 +14,8 @@ import EntitySelector, { SelectedEntity } from './EntitySelector';
 import AttributeSelector, { SelectedAttribute } from './AttributeSelector';
 import CompoundSearchFilterInputField, { InputFieldValue } from './CompoundSearchFilterInputField';
 
+import './CompoundSearchFilter.css';
+
 export type CompoundSearchFilterProps = {
     config: PartialCompoundSearchFilterConfig;
     defaultEntity?: SearchFilterEntityName;


### PR DESCRIPTION
## Description

This PR makes a few fixes to the CompoundSearchFilter's date-picker input:

1.  Fixes an issue with the "invalid date" error text causing a visual bug
<img width="493" alt="Screenshot 2024-06-13 at 2 08 18 PM" src="https://github.com/stackrox/stackrox/assets/4805485/e5954d8c-2e6c-48b1-a44c-a8e02fbad561">
<img width="464" alt="Screenshot 2024-06-18 at 10 03 53 AM" src="https://github.com/stackrox/stackrox/assets/4805485/45e75fa3-9155-4cda-8933-282056f5fe82">

2. Fixes an issue with the "invalid date" error text persisting even after changing the input field value to be the correct format

3. Adding a button to trigger the "onSearch". This fixes an issue where it was searching on every character change while typing into the input field. This is why the button is needed because we need to differentiate between the value in the input field and the value we search on.

<img width="460" alt="Screenshot 2024-06-17 at 5 57 42 PM" src="https://github.com/stackrox/stackrox/assets/4805485/5bcf6f3e-13e2-41ff-a4c4-c5b9c0905977">




