### PR TITLE
fix: scale test install prometheus-metric-parser

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -159,7 +159,7 @@ get_central_debug_dump() {
 get_prometheus_metrics_parser() {
     local parserBin
     local parserDir
-    parserBin=$(make prometheus-metric-parser -C "$ROOT" --silent)
+    parserBin=$(make prometheus-metric-parser -C "$ROOT" --silent | tail -1)
     parserDir=$(dirname "${parserBin}")
     export PATH="$parserDir":$PATH
     prometheus-metric-parser help


### PR DESCRIPTION
## Description

First run of make do all other stuff causing a lot of output while we are interested in the last line. 
This PR fixes that with `tail -1`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Scale test.

```
# make prometheus-metric-parser -B -C . --silent | tail -1
/home/janisz/go/src/github.com/stackrox/stackrox/.gotools/bin/prometheus-metric-parser
```
`-B` is used to force rebuild of all required steps
```
 make prometheus-metric-parser -B -C . --silent          
+ tools/test/go.sum
+ prometheus-metric-parser
/home/janisz/go/src/github.com/stackrox/stackrox/.gotools/bin/prometheus-metric-parse
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
