### PR TITLE
fix(tests): Fix roxctl PSP tests

### DIFF
--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -88,4 +88,5 @@ assert_number_of_k8s_resources() {
 
   assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
   run -0 grep -q "bats-tests" "${output_dir}/scanner/02-scanner-06-deployment.yaml"
+  assert_number_of_k8s_resources 15
 }

--- a/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
@@ -23,7 +23,7 @@ central_bundle_psp_enabled() {
     shift
     local bundle_dir="${out_dir}/bundle-central-${RANDOM}-${RANDOM}-${RANDOM}"
     roxctl-release central generate "${cluster_type}" pvc "$@" --output-dir="${bundle_dir}"
-    run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
+    run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}/central"
     assert_success
 }
 
@@ -32,13 +32,13 @@ central_bundle_psp_disabled() {
     shift
     local bundle_dir="${out_dir}/bundle-central-${RANDOM}-${RANDOM}-${RANDOM}"
     roxctl-release central generate "${cluster_type}" pvc "$@" --output-dir="${bundle_dir}"
-    run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
+    run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}/central"
     assert_failure
 }
 
 # Testing: central generate k8s
 @test "PodSecurityPolicies can be disabled for central deployment bundle (k8s)" {
-    central_bundle_psp_enabled k8s --enable-pod-security-policies=false
+    central_bundle_psp_disabled k8s --enable-pod-security-policies=false
 }
 
 @test "PodSecurityPolicies can be enabled for central deployment bundle (k8s)" {
@@ -51,7 +51,7 @@ central_bundle_psp_disabled() {
 
 # Testing: central generate openshift
 @test "PodSecurityPolicies can be disabled for central deployment bundle (openshift)" {
-    central_bundle_psp_enabled openshift --enable-pod-security-policies=false
+    central_bundle_psp_disabled openshift --enable-pod-security-policies=false
 }
 
 @test "PodSecurityPolicies can be enabled for central deployment bundle (openshift)" {


### PR DESCRIPTION
## Description

The roxctl bats tests for PSPs contain some bugs. This PR is taking care of them.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
