### PR TITLE
ROX-24735: Customizable CVE status filter field

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -80,6 +80,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                     className="pf-v5-u-pb-0 pf-v5-u-px-sm"
                     searchFilter={searchFilter}
                     searchFilterConfig={searchFilterConfig}
+                    cveStatusFilterField="CLUSTER CVE FIXABLE"
                     onFilterChange={(newFilter, { action }) => {
                         setSearchFilter(newFilter);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -94,6 +94,7 @@ function PlatformCvesOverviewPage() {
         <AdvancedFiltersToolbar
             searchFilter={searchFilter}
             searchFilterConfig={searchFilterConfig}
+            cveStatusFilterField="CLUSTER CVE FIXABLE"
             onFilterChange={(newFilter, { action }) => {
                 setSearchFilter(newFilter);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -110,6 +110,7 @@ function PlatformCvePage() {
                     className="pf-v5-u-pb-0 pf-v5-u-px-sm"
                     searchFilter={searchFilter}
                     searchFilterConfig={searchFilterConfig}
+                    cveStatusFilterField="CLUSTER CVE FIXABLE"
                     onFilterChange={(newFilter, { action }) => {
                         setSearchFilter(newFilter);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -176,7 +176,11 @@ function WorkloadCveFilterToolbar({
                     <ToolbarGroup>
                         <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />
                         {isFixabilityFiltersEnabled && (
-                            <CVEStatusDropdown searchFilter={searchFilter} onSelect={onSelect} />
+                            <CVEStatusDropdown
+                                filterField="FIXABLE"
+                                searchFilter={searchFilter}
+                                onSelect={onSelect}
+                            />
                         )}
                     </ToolbarGroup>
                 )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -61,6 +61,7 @@ type AdvancedFiltersToolbarProps = {
     searchFilterConfig: CompoundSearchFilterProps['config'];
     searchFilter: SearchFilter;
     onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
+    cveStatusFilterField?: 'FIXABLE' | 'CLUSTER CVE FIXABLE';
     className?: string;
     defaultFilters?: DefaultFilters;
     includeCveSeverityFilters?: boolean;
@@ -73,6 +74,7 @@ function AdvancedFiltersToolbar({
     searchFilterConfig,
     searchFilter,
     onFilterChange,
+    cveStatusFilterField = 'FIXABLE',
     className = '',
     defaultFilters = emptyDefaultFilters,
     includeCveSeverityFilters = true,
@@ -144,6 +146,7 @@ function AdvancedFiltersToolbar({
                         )}
                         {includeCveStatusFilters && isFixabilityFiltersEnabled && (
                             <CVEStatusDropdown
+                                filterField={cveStatusFilterField}
                                 searchFilter={searchFilter}
                                 onSelect={(category, checked, value) =>
                                     onFilterApplied({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVEStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVEStatusDropdown.tsx
@@ -5,12 +5,17 @@ import { SearchFilter } from 'types/search';
 
 import './FilterDropdowns.css';
 
-type CVEStatusDropdownProps = {
+type CVEStatusDropdownProps<FilterField> = {
+    filterField: FilterField;
     searchFilter: SearchFilter;
-    onSelect: (filterType: 'FIXABLE', checked: boolean, selection: string) => void;
+    onSelect: (filterType: FilterField, checked: boolean, selection: string) => void;
 };
 
-function CVEStatusDropdown({ searchFilter, onSelect }: CVEStatusDropdownProps) {
+function CVEStatusDropdown<FilterField extends 'FIXABLE' | 'CLUSTER CVE FIXABLE'>({
+    filterField,
+    searchFilter,
+    onSelect,
+}: CVEStatusDropdownProps<FilterField>) {
     const [cveStatusIsOpen, setCveStatusIsOpen] = useState(false);
 
     function onCveStatusToggle(isOpen: boolean) {
@@ -25,14 +30,14 @@ function CVEStatusDropdown({ searchFilter, onSelect }: CVEStatusDropdownProps) {
             toggleAriaLabel="CVE status filter menu toggle"
             onToggle={(_event, isOpen: boolean) => onCveStatusToggle(isOpen)}
             onSelect={(e, selection) => {
-                onSelect('FIXABLE', (e.target as HTMLInputElement).checked, selection as string);
+                onSelect(filterField, (e.target as HTMLInputElement).checked, selection as string);
             }}
-            selections={searchFilter.FIXABLE}
+            selections={searchFilter[filterField]}
             isOpen={cveStatusIsOpen}
             placeholderText="CVE status"
         >
             <SelectOption key="Fixable" value="Fixable" />
-            <SelectOption key="Important" value="Not fixable" />
+            <SelectOption key="NotFixable" value="Not fixable" />
         </Select>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -139,6 +139,14 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
         cleanSearchFilter.FIXABLE = fixable.filter(isFixableStatus).map(fixableStatusToFixability);
     }
 
+    const clusterCveFixable = searchValueAsArray(rawSearchFilter['CLUSTER CVE FIXABLE']);
+
+    if (clusterCveFixable.length > 0) {
+        cleanSearchFilter['CLUSTER CVE FIXABLE'] = clusterCveFixable
+            .filter(isFixableStatus)
+            .map(fixableStatusToFixability);
+    }
+
     const severity = searchValueAsArray(rawSearchFilter.SEVERITY);
 
     if (severity.length > 0) {


### PR DESCRIPTION
## Description

On Platform CVE pages, the CVE status dropdown should filter based on the `Cluster CVE Fixable` field instead of the default `Fixable` field used on Node and Platform CVE pages. This change allows us to specify which field to use as a component prop.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load a Platform CVE page and use the filter, verifying the correct field in the URL and network request. (Disregard the displayed errors due to unfinished query implementation.)
![image](https://github.com/stackrox/stackrox/assets/1292638/b93ed411-54d7-4385-87ff-e1b410b33208)

Load a Workload CVE page and ensure the original "Fixable" filter is visible in the URL and network request:
![image](https://github.com/stackrox/stackrox/assets/1292638/15970be5-0704-4b91-93d5-08587c6e56cf)


