### PR TITLE
ROX-24839: Improve clarity of tooltips for compliance status

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -6,11 +6,9 @@ import {
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
-    Tooltip,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import IconText from 'Components/PatternFly/IconText/IconText';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { UseURLSortResult } from 'hooks/useURLSort';
@@ -25,10 +23,12 @@ import {
     PartialCompoundSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
 import { SearchFilter } from 'types/search';
+
 import { coverageClusterDetailsPath } from './compliance.coverage.routes';
 import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import { CHECK_STATUS_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
+import StatusIcon from './components/StatusIcon';
 
 export const tabContentIdForResults = 'check-details-Results-tab-section';
 
@@ -156,12 +156,7 @@ function CheckDetailsTable({
                                         </Td>
                                         <Td dataLabel="Last scanned">{firstDiscoveredAsPhrase}</Td>
                                         <Td dataLabel="Compliance status">
-                                            <Tooltip content={clusterStatusObject.tooltipText}>
-                                                <IconText
-                                                    icon={clusterStatusObject.icon}
-                                                    text={clusterStatusObject.statusText}
-                                                />
-                                            </Tooltip>
+                                            <StatusIcon clusterStatusObject={clusterStatusObject} />
                                         </Td>
                                     </Tr>
                                 );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -8,7 +8,6 @@ import {
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
-    Tooltip,
 } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
@@ -17,7 +16,6 @@ import {
     OnSearchPayload,
     PartialCompoundSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
-import IconText from 'Components/PatternFly/IconText/IconText';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
@@ -32,6 +30,7 @@ import { coverageCheckDetailsPath } from './compliance.coverage.routes';
 import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
 import ControlLabels from './components/ControlLabels';
+import StatusIcon from './components/StatusIcon';
 
 export type ClusterDetailsTableProps = {
     checkResultsCount: number;
@@ -200,12 +199,9 @@ function ClusterDetailsTable({
                                                 )}
                                             </Td>
                                             <Td dataLabel="Compliance status" modifier="fitContent">
-                                                <Tooltip content={clusterStatusObject.tooltipText}>
-                                                    <IconText
-                                                        icon={clusterStatusObject.icon}
-                                                        text={clusterStatusObject.statusText}
-                                                    />
-                                                </Tooltip>
+                                                <StatusIcon
+                                                    clusterStatusObject={clusterStatusObject}
+                                                />
                                             </Td>
                                         </Tr>
                                         {isRowExpanded && (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -19,10 +19,10 @@ const WARNING_THRESHOLD = 75;
 
 type LabelColor = LabelProps['color'];
 
-type ClusterStatusObject = {
+export type ClusterStatusObject = {
     icon: ReactElement;
     statusText: string;
-    tooltipText: string;
+    tooltipText: string | null; // null if tooltip text is redundant with statusText
     color: LabelProps['color'];
 };
 
@@ -132,7 +132,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
             </Icon>
         ),
         statusText: 'Pass',
-        tooltipText: 'Check was successful',
+        tooltipText: null,
         color: 'blue',
     },
     FAIL: {
@@ -142,7 +142,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
             </Icon>
         ),
         statusText: 'Fail',
-        tooltipText: 'Check was unsuccessful',
+        tooltipText: null,
         color: 'red',
     },
     ERROR: {
@@ -173,7 +173,8 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
             </Icon>
         ),
         statusText: 'Manual',
-        tooltipText: 'Check cannot automatically assess the status and manual check is required',
+        tooltipText:
+            'Manual check requires additional organizational or technical knowledge that is not automatable',
         color: 'grey',
     },
     NOT_APPLICABLE: {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusIcon.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
+
+import IconText from 'Components/PatternFly/IconText/IconText';
+
+import { ClusterStatusObject } from '../compliance.coverage.utils';
+
+export type StatusIconProps = {
+    clusterStatusObject: ClusterStatusObject;
+};
+
+function StatusIcon({ clusterStatusObject }: StatusIconProps): ReactElement {
+    const { icon, statusText, tooltipText } = clusterStatusObject;
+
+    const iconText = <IconText icon={icon} text={statusText} />;
+
+    return typeof tooltipText === 'string' ? (
+        <Tooltip content={tooltipText} isContentLeftAligned>
+            {iconText}
+        </Tooltip>
+    ) : (
+        iconText
+    );
+}
+
+export default StatusIcon;


### PR DESCRIPTION
## Description

### Problem

Linda reported distracting first impressions during recent team test:
* Text of tips are redundant for **Pass** and **Fail** status.
* Text of tip for **Manual** status is hard to read with **check** at the beginning and end of the phrase. Especially because **manual check** at the end is the concept to explain.

### Analysis

1. Both `CheckDetailsTable` and `ClusterDetailsTable` render individual status.
2. The `tooltipText` property is required in `statusIconTextMap` object and therefore in **Compliance status** table cell.

### Solution

1. Edit compliance.coverage.utils.tsx file.
    * Replace `tooltipText: string` with `tooltipText: string | null` to make omission of text a visible decision instead of a potentially invisible accident.
    * Replace strings with `null` for `PASS` and `FAIL` status.
    * Rewrite string for `MANUAL` status.
        Thanks to Lance Bragstad for brainstorming on the following:
        > Manual check requires additional organizational or technical knowledge that is not automatable
2. Add StatusIcon.tsx file.
    * Conditionally render with or without `Tooltip` element.
    * Add `isContentLeftAligned` prop to `Tooltip` element for readability (see picture below).
3. Edit CheckDetailsTable.tsx and ClusterDetailsTable.tsx files.
    * Render `StatusIcon` element.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636925 - 4636925
        total 75 = 11716362 - 11716287
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/coverage, click a check link to visit page:
    /main/compliance/coverage/profiles/profiles/checks/check?detailsTab=Results

    * Before changes, see **Manual** has original tip text that is center aligned:
        ![Manual_original](https://github.com/stackrox/stackrox/assets/11862657/54075d02-5374-4540-a25a-7b9314c0284f)

    * After changes, see **Manual** has rewritten tip text that is left aligned:
        ![Manual_rewritten](https://github.com/stackrox/stackrox/assets/11862657/d3161416-9565-40a4-9388-2bcfd9503f43)

2. Go back, click **Clusters** toggle, and then click a cluster link to visit page:
    /main/compliance/coverage/profiles/profile/clusters/id

    * Before changes, see **Pass** has original tip text:
        ![Pass_with](https://github.com/stackrox/stackrox/assets/11862657/7564f95d-977e-4b0f-961c-527e2d320497)

    * After changes, see **Pass** does not have a tip:
        ![Pass_without](https://github.com/stackrox/stackrox/assets/11862657/8b9ac022-1ba8-43b0-bf52-a5e748ad6c7a)

### Integration testing

No tests for coverage.