### PR TITLE
ROX-24132: Build manifests if all archs are available per brand

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -253,6 +253,11 @@ jobs:
       - pre-build-cli
       - pre-build-go-binaries
       - pre-build-docs
+    # This step will run even if required pre-* steps failed. By following this
+    # approach as much of the build matrix as possible is completed despite
+    # transient issues e.g. docker pull timeouts. In this way some e2e jobs that
+    # require some part of the build matrix can still proceed.
+    if: ${{ !cancelled() }}
     strategy:
       # Supports four image builds (see Setup build env):
       # STACKROX_BRANDING
@@ -421,6 +426,12 @@ jobs:
     needs:
     - define-job-matrix
     - build-and-push-main
+    # This step will run even if some of the build-and-push-matrix steps failed.
+    # By following this approach as much of the build matrix as possible is
+    # completed despite transient issues e.g. docker pull timeouts. In this way
+    # some e2e jobs that require some part of the build matrix can still
+    # proceed.
+    if: ${{ !cancelled() }}
     strategy:
       # Supports four image builds (see Setup build env):
       # STACKROX_BRANDING

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,12 +99,7 @@ jobs:
         run: make -C ui deps
 
       - name: Build UI
-        run: |
-          if [[ ${{env.ROX_PRODUCT_BRANDING}} == "STACKROX_BRANDING" ]]; then
-            make -C ui break-build
-          else
-            make -C ui build
-          fi
+        run: make -C ui build
 
       - uses: ./.github/actions/upload-artifact-with-retry
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,6 +372,10 @@ jobs:
       - name: Generate OSS notice
         run: make ossls-notice
 
+      - name: Force break
+        if: matrix.name == 'STACKROX_BRANDING' && matrix.arch == 'amd64'
+        run: exit 1
+
       - name: Set build tag for prerelease images
         if: matrix.name == 'prerelease'
         run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
   pre-build-ui:
     strategy:
       matrix:
-        branding: [ RHACS_BRANDING, STACKFOX_BRANDING ]
+        branding: [ RHACS_BRANDING, STACKROX_BRANDING ]
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     runs-on: ubuntu-latest
@@ -98,7 +98,12 @@ jobs:
         run: make -C ui deps
 
       - name: Build UI
-        run: make -C ui build
+        run: |
+          if [[ ${{env.ROX_PRODUCT_BRANDING}} == "STACKROX_BRANDING" ]]; then
+            make -C ui break-build
+          else
+            make -C ui build
+          fi
 
       - uses: ./.github/actions/upload-artifact-with-retry
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,10 +372,6 @@ jobs:
       - name: Generate OSS notice
         run: make ossls-notice
 
-      - name: Force break
-        if: matrix.name == 'STACKROX_BRANDING' && matrix.arch == 'amd64'
-        run: exit 1
-
       - name: Set build tag for prerelease images
         if: matrix.name == 'prerelease'
         run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
 
   pre-build-ui:
     strategy:
+      fail-fast: false
       matrix:
         branding: [ RHACS_BRANDING, STACKROX_BRANDING ]
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
   pre-build-ui:
     strategy:
       matrix:
-        branding: [ RHACS_BRANDING, STACKROX_BRANDING ]
+        branding: [ RHACS_BRANDING, STACKFOX_BRANDING ]
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Per title. See ROX-24132.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

#### Test 1: break pre-build-ui / STACKROX_BRANDING

- [x]
  - should fail build-and-push-main (STACKROX_BRANDING, *)
  - should fail push-main-manifests (STACKROX_BRANDING)
  - should still push RHACS_BRANDING manifest image
  - should slack failure
  - should run e2e tests (requiring RHACS_BRANDING manifest image)

##### Run 1 - break STACKROX_BRANDING

- https://github.com/stackrox/stackrox/actions/runs/9570258114
- https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1718736598588399
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11593/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1803131900773011456

I had expected the `pre-build-ui` step with STACKROX_BRANDING to fail due to [`75dea4a` (#11593)](https://github.com/stackrox/stackrox/pull/11593/commits/75dea4a91eb49f93cabdab0eb41db3f88c17dc00). But the UI artifact is built but with an incorrect artifact name. The downstream image build steps fail as expected. And the manifest fails to push due to missing contents. RHACS_BRANDING is still pushed and e2e tests ran.

##### Run 2 - really break STACKROX_BRANDING

- https://github.com/stackrox/stackrox/actions/runs/9573456734
- https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1718754023747999
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11593/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1803204510814834688

[`dbc36a1` (#11593)](https://github.com/stackrox/stackrox/pull/11593/commits/dbc36a1058840f4c4b2b34c55572a9ef5be74e0b) does the deed.

#### Test 2: break build-and-push-main / STACKROX_BRANDING / amd64

- [x]
  - should still push RHACS_BRANDING manifest image
  - should slack failure
  - should run e2e tests (requiring RHACS_BRANDING manifest image)

##### Run 3 - break build-and-push-main / STACKROX_BRANDING / amd64

- https://github.com/stackrox/stackrox/actions/runs/9573937472
- https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1718757675017579
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11593/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1803219375994441728

[`6377e4b` (#11593)](https://github.com/stackrox/stackrox/pull/11593/commits/6377e4b4e2adc71a8ced20060422de5de9c0dc77)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
