### PR TITLE
ROX-24843: Unify compliance links in left navigation

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -42,5 +42,5 @@ export function visitComplianceEnhancedScanConfigs(staticResponseMap) {
         staticResponseMap
     );
 
-    cy.get('a.pf-v5-c-nav__link').contains('Schedules').should('have.class', 'pf-m-current');
+    cy.get('a.pf-v5-c-nav__link:contains("Schedules")').should('have.class', 'pf-m-current');
 }

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -18,13 +18,13 @@ const routeMatcherMapForComplianceScanConfigs = {
 };
 
 export function visitComplianceEnhancedCoverageFromLeftNav(staticResponseMap) {
-    visitFromLeftNavExpandable('Compliance (2.0)', 'Coverage', null, staticResponseMap);
+    visitFromLeftNavExpandable('Compliance', 'Coverage', null, staticResponseMap);
 
     cy.get(`h1:contains("Cluster compliance")`); // TODO obsolete but function is not called
 }
 
 export function visitComplianceEnhancedSchedulesFromLeftNav(staticResponseMap) {
-    visitFromLeftNavExpandable('Compliance (2.0)', 'Schedules', null, staticResponseMap);
+    visitFromLeftNavExpandable('Compliance', 'Schedules', null, staticResponseMap);
 
     cy.get(`h1:contains("Schedules")`);
 }

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -57,7 +57,7 @@ type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string | Reac
 const keyForNetwork = 'Network';
 const keyForPlatformConfiguration = 'Platform Configuration';
 const keyForVulnerabilities = 'Vulnerabilities';
-const keyForCompliance2 = 'Compliance (2.0)';
+const keyForCompliance = 'Compliance';
 type IsActiveCallback = (pathname: string) => boolean;
 
 type LinkDescription = {
@@ -124,96 +124,41 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
             path: violationsBasePath,
             routeKey: 'violations',
         },
-        // Compliance with divided navigation.
-        // /*
         {
             type: 'parent',
-            title: (navDescriptionsFiltered) =>
-                navDescriptionsFiltered.some(
-                    (navDescription) =>
-                        navDescription.type === 'link' && navDescription.routeKey === 'compliance'
-                )
-                    ? 'Compliance (2.0)'
-                    : 'Compliance',
-            key: keyForCompliance2,
+            title: 'Compliance',
+            key: keyForCompliance,
             children: [
                 {
                     type: 'link',
-                    content: 'Coverage',
+                    content: <NavigationContent variant="TechPreview">Coverage</NavigationContent>,
                     path: complianceEnhancedCoveragePath,
                     routeKey: 'compliance-enhanced',
                 },
                 {
                     type: 'link',
-                    content: 'Schedules',
+                    content: <NavigationContent variant="TechPreview">Schedules</NavigationContent>,
                     path: complianceEnhancedSchedulesPath,
                     routeKey: 'compliance-enhanced',
                 },
+                {
+                    type: 'separator',
+                    key: 'preceding-classic-compliance',
+                },
+                {
+                    type: 'link',
+                    content: 'Dashboard',
+                    path: complianceBasePath,
+                    routeKey: 'compliance',
+                    isActive: (pathname) =>
+                        Boolean(matchPath(pathname, complianceBasePath)) &&
+                        !matchPath(pathname, [
+                            complianceEnhancedCoveragePath,
+                            complianceEnhancedSchedulesPath,
+                        ]),
+                },
             ],
         },
-        {
-            type: 'link',
-            content: (navDescriptionsFiltered) =>
-                navDescriptionsFiltered.some(
-                    (navDescription) =>
-                        navDescription.type === 'parent' && navDescription.key === keyForCompliance2
-                )
-                    ? 'Compliance (1.0)'
-                    : 'Compliance',
-            path: complianceBasePath,
-            routeKey: 'compliance',
-            isActive: (pathname) =>
-                Boolean(matchPath(pathname, complianceBasePath)) &&
-                !matchPath(pathname, [
-                    complianceEnhancedCoveragePath,
-                    complianceEnhancedSchedulesPath,
-                ]),
-        },
-        // */
-        // Compliance with unified navigation.
-        /*
-    {
-        type: 'parent',
-        title: (navDescriptionsFiltered) =>
-            navDescriptionsFiltered.some(
-                (navDescription) =>
-                    navDescription.type === 'link' && navDescription.routeKey === 'compliance'
-            )
-                ? 'Compliance (2.0)'
-                : 'Compliance',
-        key: keyForCompliance2,
-        children: [
-            {
-                type: 'link',
-                content: 'Coverage',
-                path: complianceEnhancedCoveragePath,
-                routeKey: 'compliance-enhanced',
-            },
-            {
-                type: 'link',
-                content: 'Schedules',
-                path: complianceEnhancedSchedulesPath,
-                routeKey: 'compliance-enhanced',
-            },
-            {
-                type: 'separator',
-                key: 'preceding-classic-compliance',
-            },
-            {
-                type: 'link',
-                content: 'Workload Compliance',
-                path: complianceBasePath,
-                routeKey: 'compliance',
-                isActive: (pathname) =>
-                    Boolean(matchPath(pathname, complianceBasePath)) &&
-                    !matchPath(pathname, [
-                        complianceEnhancedCoveragePath,
-                        complianceEnhancedSchedulesPath,
-                    ]),
-            },
-        ],
-    },
-    */
         {
             type: 'parent',
             title: 'Vulnerabilities',


### PR DESCRIPTION
## Description

Visual counterpart to follow up unify routes in #11114

### Problem

Some customers misunderstand relationship between Compliance 1.0 and 2.0 as analogous to Vulnerability Management 1.0 and 2.0 (in which 2.0 supersedes and replaces 1.0).

### Analysis

Because of recent change to unify vulnerabilities links with **Dashboard (Deprecated)** under **Vulnerabilities** if all feature flags are turned on, **Dashboard** under **Compliance** contrasts (we hope) so customers do not misunderstand.

### Solution

1. Edit cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
    * Delete **(2.0)** from item text.
2. Edit src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
    * Delete divided navigation.
    * Comment in initial draft of unified navigation. Sorry about the indentation change!
    * Add **Tech preview** for **Coverage** and **Schedules** links.
    * Replace initial **Workload compliance** with final **Dashboard** text of link to classic compliance pages.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -6 = 4636919 - 4636925
        total -6 = 11716281 - 11716287
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

Pictures do not have benchmark tabs from #11563

1. Visit /main/dashboard

    * See **Compliance 2.0** and **Compliance 1.0** before unification.
        ![main_divided](https://github.com/stackrox/stackrox/assets/11862657/1c186e13-d7a4-491d-94ac-268fd7b85023)

    * See **Compliance** after unification.
        ![main_unified](https://github.com/stackrox/stackrox/assets/11862657/318187d1-7baa-4413-85d7-b6c7907d0f27)

2. Visit /main/compliance/coverage

    * See **Coverage** under **Compliance 2.0** before unification.
        ![coverage_divided](https://github.com/stackrox/stackrox/assets/11862657/f4e4a349-e80b-483d-a118-97f4ef4f8a30)

    * See **Coverage** under **Compliance** after unification.
        ![coverage_unified](https://github.com/stackrox/stackrox/assets/11862657/7106ad68-a0b8-4d27-b218-f0a9e9c7b729)

3. Visit /main/compliance/schedules

    * See **Schedules** under **Compliance 2.0** before unification.
        ![schedules_divided](https://github.com/stackrox/stackrox/assets/11862657/a578b504-82d5-441b-a388-403f6a9c0030)

    * See **Schedules** under **Compliance** after unification.
        ![schedules_unified](https://github.com/stackrox/stackrox/assets/11862657/6f9f29a7-3285-4266-8c2e-60649111186e)

4. Visit /main/compliance

    * See **Compliance 1.0** before unification.
        ![compliance_divided](https://github.com/stackrox/stackrox/assets/11862657/8f9ac3ae-2991-4397-8003-deaa879c2df1)

    * See **Dashboard** under **Compliance** after unification.
        ![compliance_unified](https://github.com/stackrox/stackrox/assets/11862657/a9c23df2-5943-4cc9-a527-fe8a6963c5f7)

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js
* compliance-enhanced/complianceEnhancedScanConfigs.test.js
