### PR TITLE
ROX-24830: Fix passing of CVE filter to exception mgmt list page

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
@@ -3,6 +3,8 @@ import { hasFeatureFlag } from '../../../helpers/features';
 import {
     cancelAllCveExceptions,
     typeAndSelectCustomSearchFilterValue,
+    viewCvesByObservationState,
+    visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
 import {
     deferAndVisitRequestDetails,
@@ -10,6 +12,7 @@ import {
     approveRequest,
 } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
+import { selectors as workloadSelectors } from '../workloadCves/WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 const comment = 'Defer me';
@@ -59,6 +62,22 @@ describe('Exception Management - Approved Deferrals Table', () => {
         cy.get(
             'table tr:first-child td[data-label="Requested action"]:contains("Deferred (when all fixed)")'
         ).should('exist');
+    });
+
+    it('should navigate from Workload CVEs to a request list filtered by the specific CVE', () => {
+        deferAndVisitRequestDetails({ comment, expiry, scope }).then(({ requestName, cveName }) => {
+            approveRequest();
+
+            visitWorkloadCveOverview();
+            viewCvesByObservationState('Deferred');
+
+            // Verify correct CVE filter
+            cy.get('td[data-label="Request details"] a:contains("View")').click();
+            cy.get(workloadSelectors.filterChipGroupItem('CVE', cveName));
+
+            // Verify a link in the table containing the request
+            cy.get('td a').contains(requestName);
+        });
     });
 
     it('should be able to navigate to the Request Details page by clicking on the request name', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
@@ -3,6 +3,8 @@ import { hasFeatureFlag } from '../../../helpers/features';
 import {
     cancelAllCveExceptions,
     typeAndSelectCustomSearchFilterValue,
+    viewCvesByObservationState,
+    visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
 import {
     markFalsePositiveAndVisitRequestDetails,
@@ -10,6 +12,7 @@ import {
     approveRequest,
 } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
+import { selectors as workloadSelectors } from '../workloadCves/WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 const comment = 'False positive!';
@@ -57,6 +60,24 @@ describe('Exception Management - Approved False Positives Table', () => {
         cy.get(
             'table tr:first-child td[data-label="Requested action"]:contains("False positive")'
         ).should('exist');
+    });
+
+    it('should navigate from Workload CVEs to a request list filtered by the specific CVE', () => {
+        markFalsePositiveAndVisitRequestDetails({ comment, scope }).then(
+            ({ requestName, cveName }) => {
+                approveRequest();
+
+                visitWorkloadCveOverview();
+                viewCvesByObservationState('False positives');
+
+                // Verify correct CVE filter
+                cy.get('td[data-label="Request details"] a:contains("View")').click();
+                cy.get(workloadSelectors.filterChipGroupItem('CVE', cveName));
+
+                // Verify a link in the table containing the request
+                cy.get('td a').contains(requestName);
+            }
+        );
     });
 
     it('should be able to navigate to the Request Details page by clicking on the request name', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -470,3 +470,7 @@ export function waitForTableLoadCompleteIndicator() {
 export function visitNamespaceView() {
     cy.get('button:contains("Prioritize by namespace view")').click();
 }
+
+export function viewCvesByObservationState(observationState) {
+    cy.get('button[role="tab"]').contains(observationState).click();
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -12,7 +12,7 @@ function getExceptionManagementURL(
     cve: string,
     vulnerabilityState: Exclude<VulnerabilityState, 'OBSERVED'>
 ): string {
-    const query = getUrlQueryStringForSearchFilter({ cve });
+    const query = getUrlQueryStringForSearchFilter({ CVE: cve });
 
     switch (vulnerabilityState) {
         case 'DEFERRED':


### PR DESCRIPTION
## Description

Fixes the passing of CVE filters from Deferred and FP tabs in Workload CVEs to the Exception Management list page.

This was a simple case of lowercase => uppercase. 💼 

The fix: +5 characters
The tests: +81, -20 lines...

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added e2e tests that cover this functionality.

![image](https://github.com/stackrox/stackrox/assets/1292638/fffbd3ec-ac34-4da4-af4b-ce0325bfa2ef)
