### PR TITLE
chore(UI): Revert VM nagivation title change

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -127,7 +127,7 @@ function getEntityPath(entitiesKey, entityId) {
 
 export function visitVulnerabilityManagementDashboardFromLeftNav() {
     visitFromLeftNavExpandable(
-        'Vulnerabilities',
+        'Vulnerability Management',
         'Dashboard',
         routeMatcherMapForVulnerabilityManagementDashboard
     );

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -56,8 +56,8 @@ type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string | Reac
 // Parent conditional title finds key to decide presence or absence of counterpart parent.
 const keyForNetwork = 'Network';
 const keyForPlatformConfiguration = 'Platform Configuration';
-const keyForVulnerabilities = 'Vulnerabilities';
 const keyForCompliance = 'Compliance';
+const keyForVulnerabilities = 'Vulnerability Management';
 type IsActiveCallback = (pathname: string) => boolean;
 
 type LinkDescription = {
@@ -161,7 +161,7 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         },
         {
             type: 'parent',
-            title: 'Vulnerabilities',
+            title: 'Vulnerability Management',
             key: keyForVulnerabilities,
             children: [
                 {


### PR DESCRIPTION
## Description

Reverts the navigation title from "Vulnerabilities" back to "Vulnerability Management".

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Existing e2e tests.

Visual inspection:
![image](https://github.com/stackrox/stackrox/assets/1292638/1f2e3676-2168-4c9f-a792-59b91f65b048)
