### PR TITLE
Make requester nullable in response type and handle nulls

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -156,10 +156,11 @@ function ExceptionRequestDetailsPage() {
         hasWriteAccessForApproving &&
         !expired &&
         (status === 'PENDING' || status === 'APPROVED_PENDING_UPDATE');
-    const showCancelButton = !expired && currentUser.userId === requester.id && status !== 'DENIED';
+    const showCancelButton =
+        !expired && currentUser.userId === requester?.id && status !== 'DENIED';
     const showUpdateButton =
         !expired &&
-        currentUser.userId === requester.id &&
+        currentUser.userId === requester?.id &&
         (status === 'PENDING' || 'APPROVED' || status === 'APPROVED_PENDING_UPDATE');
 
     const relevantCVEs =

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -50,7 +50,7 @@ export type BaseVulnerabilityException = {
     name: string;
     status: ExceptionStatus;
     expired: boolean;
-    requester: SlimUser;
+    requester?: SlimUser;
     approvers: SlimUser[];
     createdAt: string; // ISO 8601
     lastUpdated: string; // ISO 8601


### PR DESCRIPTION
## Description

Fixes page crashes in Exception Management when the `requester` field is null.

This problem occurs when a system with very old exception requests is migrated to the unified deferral flow and the requester information is not attached to the request. In this case, the field will be `null` when it reaches the UI and could cause a page crash when accessing that information.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Pointed towards staging, visit the MD-240322-16 request that contains a request created earlier this year.

With this change:
![image](https://github.com/stackrox/stackrox/assets/1292638/23f34e3d-5765-40a6-ae28-eee0ded6efef)
![image](https://github.com/stackrox/stackrox/assets/1292638/1f12de95-9531-42bf-be68-370bdc9bfb4b)

Before this change:
![image](https://github.com/stackrox/stackrox/assets/1292638/2c0efb9d-b16b-47ad-a69d-a25b0ad25e78)
