### PR TITLE
ROX-24863: Remove now from Run scan and Send report actions

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -68,7 +68,7 @@ function ScanConfigActionDropdown({
         </DropdownItem>,
         <DropdownSeparator key="Separator" />,
         <DropdownItem
-            key="Run scan now"
+            key="Run scan"
             component="button"
             description={isScanning ? 'Run is disabled while scan is already running' : ''}
             isDisabled={isScanning}
@@ -76,7 +76,7 @@ function ScanConfigActionDropdown({
                 handleRunScanConfig(scanConfigResponse);
             }}
         >
-            Run scan now
+            Run scan
         </DropdownItem>,
     ];
 
@@ -84,7 +84,7 @@ function ScanConfigActionDropdown({
         /* eslint-disable no-nested-ternary */
         dropdownItems.push(
             <DropdownItem
-                key="Send report now"
+                key="Send report"
                 component="button"
                 description={
                     notifiers.length === 0
@@ -98,7 +98,7 @@ function ScanConfigActionDropdown({
                     handleSendReport(scanConfigResponse);
                 }}
             >
-                Send report now
+                Send report
             </DropdownItem>
         );
         /* eslint-enable no-nested-ternary */

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -52,7 +52,7 @@ function ScanConfigActionsColumn({
             isSeparator: true,
         },
         {
-            title: 'Run scan now',
+            title: 'Run scan',
             // description: isScanning ? 'Run is disabled while scan is already running' : '',
             // isDisabled: isScanning,
             onClick: (event) => {
@@ -62,7 +62,7 @@ function ScanConfigActionsColumn({
         },
         /* eslint-disable no-nested-ternary */
         {
-            title: 'Send report now',
+            title: 'Send report',
             description:
                 notifiers.length === 0
                     ? 'Send is disabled if no delivery destinations'
@@ -92,7 +92,7 @@ function ScanConfigActionsColumn({
                 handleDeleteScanConfig(scanConfigResponse);
             },
         },
-    ].filter(({ title }) => title !== 'Send report now' || isComplianceReportingEnabled);
+    ].filter(({ title }) => title !== 'Send report' || isComplianceReportingEnabled);
 
     return (
         <ActionsColumn


### PR DESCRIPTION
## Description

Request from Doron after watching screen video from Surabhi.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/compliance/schedules and open a row actions menu.

    * Before changes, see **Run scan now** and **Send report now**
        ![ScanConfigActionsColumn_with_now](https://github.com/stackrox/stackrox/assets/11862657/c5f8e570-a21f-4745-9e1a-d56715a5fe0f)

    * After changes, see **Run scan** and **Send report**
        ![ScanConfigActionsColumn_without_now](https://github.com/stackrox/stackrox/assets/11862657/fec72131-3696-4495-97e5-e613d33c5aeb)

2. Click a link to visit a scan schedule page, and then click **Actions**.

    * Before changes, see **Run scan now** and **Send report now**
        ![ScanConfigActionDropdown_with_now](https://github.com/stackrox/stackrox/assets/11862657/42e6526b-db7b-4eb8-8f51-33596c9d4990)

    * After changes, see **Run scan** and **Send report**
        ![ScanConfigActionDropdown_without_now](https://github.com/stackrox/stackrox/assets/11862657/e3060326-f703-4bfa-bbb5-edb56a7d29fa)
