### PR TITLE
ROX-23386: Add PlatformCVECountByType and PlatformCVECountByFixability; rename ClusterCountByPlatformType to match UI implementation

### DIFF
--- a/central/graphql/resolvers/cluster_count_by_type.go
+++ b/central/graphql/resolvers/cluster_count_by_type.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	schema := getBuilder()
 	utils.Must(
-		schema.AddType("ClusterCountByPlatformType", []string{
+		schema.AddType("ClusterCountByType", []string{
 			"generic: Int!",
 			"kubernetes: Int!",
 			"openshift: Int!",
@@ -19,38 +19,38 @@ func init() {
 	)
 }
 
-type clusterCountByPlatformTypeResolver struct {
+type clusterCountByTypeResolver struct {
 	ctx  context.Context
 	root *Resolver
 	data platformcve.ClusterCountByPlatformType
 }
 
-func (resolver *Resolver) wrapClusterCountByPlatformTypeWithContext(ctx context.Context, value platformcve.ClusterCountByPlatformType, err error) (*clusterCountByPlatformTypeResolver, error) {
+func (resolver *Resolver) wrapClusterCountByTypeWithContext(ctx context.Context, value platformcve.ClusterCountByPlatformType, err error) (*clusterCountByTypeResolver, error) {
 	if err != nil {
 		return nil, err
 	}
 	if value == nil {
-		return &clusterCountByPlatformTypeResolver{ctx: ctx, root: resolver, data: platformcve.NewEmptyClusterCountByPlatformType()}, nil
+		return &clusterCountByTypeResolver{ctx: ctx, root: resolver, data: platformcve.NewEmptyClusterCountByPlatformType()}, nil
 	}
-	return &clusterCountByPlatformTypeResolver{ctx: ctx, root: resolver, data: value}, nil
+	return &clusterCountByTypeResolver{ctx: ctx, root: resolver, data: value}, nil
 }
 
 // Generic returns number of clusters of type GENERIC
-func (resolver *clusterCountByPlatformTypeResolver) Generic(_ context.Context) int32 {
+func (resolver *clusterCountByTypeResolver) Generic(_ context.Context) int32 {
 	return int32(resolver.data.GetGenericClusterCount())
 }
 
 // Kubernetes returns the number of clusters of type KUBERNETES
-func (resolver *clusterCountByPlatformTypeResolver) Kubernetes(_ context.Context) int32 {
+func (resolver *clusterCountByTypeResolver) Kubernetes(_ context.Context) int32 {
 	return int32(resolver.data.GetKubernetesClusterCount())
 }
 
 // Openshift returns the number of clusters of type OPENSHIFT
-func (resolver *clusterCountByPlatformTypeResolver) Openshift(_ context.Context) int32 {
+func (resolver *clusterCountByTypeResolver) Openshift(_ context.Context) int32 {
 	return int32(resolver.data.GetOpenshiftClusterCount())
 }
 
 // Openshift4 retruns the number of clusters of type OPENSHIFT4
-func (resolver *clusterCountByPlatformTypeResolver) Openshift4(_ context.Context) int32 {
+func (resolver *clusterCountByTypeResolver) Openshift4(_ context.Context) int32 {
 	return int32(resolver.data.GetOpenshift4ClusterCount())
 }

--- a/central/graphql/resolvers/platform_cve_core.go
+++ b/central/graphql/resolvers/platform_cve_core.go
@@ -27,7 +27,7 @@ func init() {
 		// NOTE: This list is and should remain alphabetically ordered
 		schema.AddType("PlatformCVECore",
 			[]string{
-				"clusterCountByPlatformType: ClusterCountByPlatformType!",
+				"clusterCountByType: ClusterCountByType!",
 				"clusterCount: Int!",
 				"clusters(pagination: Pagination): [Cluster!]!",
 				"clusterVulnerability: ClusterVulnerability!",
@@ -185,9 +185,9 @@ func (resolver *platformCVECoreResolver) CVSS(_ context.Context) float64 {
 	return float64(resolver.data.GetCVSS())
 }
 
-// ClusterCountByPlatformType returns the number of clusters of each type affected by the given platform cve
-func (resolver *platformCVECoreResolver) ClusterCountByPlatformType(ctx context.Context) (*clusterCountByPlatformTypeResolver, error) {
-	return resolver.root.wrapClusterCountByPlatformTypeWithContext(ctx, resolver.data.GetClusterCountByPlatformType(), nil)
+// ClusterCountByType returns the number of clusters of each type affected by the given platform cve
+func (resolver *platformCVECoreResolver) ClusterCountByType(ctx context.Context) (*clusterCountByTypeResolver, error) {
+	return resolver.root.wrapClusterCountByTypeWithContext(ctx, resolver.data.GetClusterCountByPlatformType(), nil)
 }
 
 // ClusterCount returns the number of clusters affected by the given platform cve

--- a/central/graphql/resolvers/platform_cve_count_by_fixability.go
+++ b/central/graphql/resolvers/platform_cve_count_by_fixability.go
@@ -1,0 +1,45 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/views/platformcve"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("PlatformCVECountByFixability", []string{
+			"total: Int!",
+			"fixable: Int!",
+		}),
+	)
+}
+
+type platformCVECountByFixabilityResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data platformcve.CVECountByFixability
+}
+
+func (resolver *Resolver) wrapPlatformCVECountByFixabilityWithContext(ctx context.Context,
+	value platformcve.CVECountByFixability, err error) (*platformCVECountByFixabilityResolver, error) {
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return &platformCVECountByFixabilityResolver{ctx: ctx, root: resolver, data: platformcve.NewEmptyCVECountByFixability()}, nil
+	}
+	return &platformCVECountByFixabilityResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+// Total returns the total number of platform CVEs
+func (resolver *platformCVECountByFixabilityResolver) Total(_ context.Context) int32 {
+	return int32(resolver.data.GetTotal())
+}
+
+// Fixable returns the number of fixable platform CVEs
+func (resolver *platformCVECountByFixabilityResolver) Fixable(_ context.Context) int32 {
+	return int32(resolver.data.GetFixable())
+}

--- a/central/graphql/resolvers/platform_cve_count_by_fixability.go
+++ b/central/graphql/resolvers/platform_cve_count_by_fixability.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/views/common"
 	"github.com/stackrox/rox/central/views/platformcve"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -20,11 +21,11 @@ func init() {
 type platformCVECountByFixabilityResolver struct {
 	ctx  context.Context
 	root *Resolver
-	data platformcve.CVECountByFixability
+	data common.ResourceCountByFixability
 }
 
 func (resolver *Resolver) wrapPlatformCVECountByFixabilityWithContext(ctx context.Context,
-	value platformcve.CVECountByFixability, err error) (*platformCVECountByFixabilityResolver, error) {
+	value common.ResourceCountByFixability, err error) (*platformCVECountByFixabilityResolver, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/platform_cve_count_by_type.go
+++ b/central/graphql/resolvers/platform_cve_count_by_type.go
@@ -1,0 +1,50 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/views/platformcve"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("PlatformCVECountByType", []string{
+			"kubernetes: Int!",
+			"openshift: Int!",
+			"istio: Int!",
+		}),
+	)
+}
+
+type platformCVECountByTypeResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data platformcve.CVECountByType
+}
+
+func (resolver *Resolver) wrapPlatformCVECountByTypeWithContext(ctx context.Context, value platformcve.CVECountByType, err error) (*platformCVECountByTypeResolver, error) {
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return &platformCVECountByTypeResolver{ctx: ctx, root: resolver, data: platformcve.NewEmptyCVECountByType()}, nil
+	}
+	return &platformCVECountByTypeResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+// Kubernetes returns the number of platform CVEs of type K8S_CVE
+func (resolver *platformCVECountByTypeResolver) Kubernetes(_ context.Context) int32 {
+	return int32(resolver.data.GetKubernetesCVECount())
+}
+
+// Openshift returns the number of platform CVEs of type OPENSHIFT_CVE
+func (resolver *platformCVECountByTypeResolver) Openshift(_ context.Context) int32 {
+	return int32(resolver.data.GetOpenshiftCVECount())
+}
+
+// Istio returns the number of platform CVEs of type ISTIO_CVE
+func (resolver *platformCVECountByTypeResolver) Istio(_ context.Context) int32 {
+	return int32(resolver.data.GetIstioCVECount())
+}

--- a/central/views/platformcve/db_response.go
+++ b/central/views/platformcve/db_response.go
@@ -129,5 +129,5 @@ func (c *cveCountByFixabilityResponse) GetTotal() int {
 }
 
 func (c *cveCountByFixabilityResponse) GetFixable() int {
-	return c.CVECount
+	return c.FixableCount
 }

--- a/central/views/platformcve/db_response.go
+++ b/central/views/platformcve/db_response.go
@@ -100,3 +100,34 @@ type clusterResponse struct {
 	ClusterType       storage.ClusterType `db:"cluster_platform_type"`
 	KubernetesVersion string              `db:"cluster_kubernetes_version"`
 }
+
+type cveCountByTypeResponse struct {
+	KubernetesCVECount int `db:"k8s_cve_count"`
+	OpenshiftCVECount  int `db:"openshift_cve_count"`
+	IstioCVECount      int `db:"istio_cve_count"`
+}
+
+func (c *cveCountByTypeResponse) GetKubernetesCVECount() int {
+	return c.KubernetesCVECount
+}
+
+func (c *cveCountByTypeResponse) GetOpenshiftCVECount() int {
+	return c.OpenshiftCVECount
+}
+
+func (c *cveCountByTypeResponse) GetIstioCVECount() int {
+	return c.IstioCVECount
+}
+
+type cveCountByFixabilityResponse struct {
+	CVECount     int `db:"cve_id_count"`
+	FixableCount int `db:"fixable_cve_id_count"`
+}
+
+func (c *cveCountByFixabilityResponse) GetTotal() int {
+	return c.CVECount
+}
+
+func (c *cveCountByFixabilityResponse) GetFixable() int {
+	return c.CVECount
+}

--- a/central/views/platformcve/empty.go
+++ b/central/views/platformcve/empty.go
@@ -22,3 +22,35 @@ func (e *emptyClusterCountByPlatformType) GetOpenshiftClusterCount() int {
 func (e *emptyClusterCountByPlatformType) GetOpenshift4ClusterCount() int {
 	return 0
 }
+
+func NewEmptyCVECountByType() CVECountByType {
+	return &emptyCVECountByType{}
+}
+
+type emptyCVECountByType struct{}
+
+func (e *emptyCVECountByType) GetKubernetesCVECount() int {
+	return 0
+}
+
+func (e *emptyCVECountByType) GetOpenshiftCVECount() int {
+	return 0
+}
+
+func (e *emptyCVECountByType) GetIstioCVECount() int {
+	return 0
+}
+
+func NewEmptyCVECountByFixability() CVECountByFixability {
+	return &emptyCVECountByFixability{}
+}
+
+type emptyCVECountByFixability struct{}
+
+func (e *emptyCVECountByFixability) GetTotal() int {
+	return 0
+}
+
+func (e *emptyCVECountByFixability) GetFixable() int {
+	return 0
+}

--- a/central/views/platformcve/empty.go
+++ b/central/views/platformcve/empty.go
@@ -1,5 +1,7 @@
 package platformcve
 
+import "github.com/stackrox/rox/central/views/common"
+
 // NewEmptyClusterCountByPlatformType creates an empty instance of type ClusterCountByPlatformType.
 func NewEmptyClusterCountByPlatformType() ClusterCountByPlatformType {
 	return &emptyClusterCountByPlatformType{}
@@ -41,7 +43,7 @@ func (e *emptyCVECountByType) GetIstioCVECount() int {
 	return 0
 }
 
-func NewEmptyCVECountByFixability() CVECountByFixability {
+func NewEmptyCVECountByFixability() common.ResourceCountByFixability {
 	return &emptyCVECountByFixability{}
 }
 

--- a/central/views/platformcve/mocks/types.go
+++ b/central/views/platformcve/mocks/types.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	common "github.com/stackrox/rox/central/views/common"
 	platformcve "github.com/stackrox/rox/central/views/platformcve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
@@ -179,10 +180,10 @@ func (m *MockCveView) EXPECT() *MockCveViewMockRecorder {
 }
 
 // CVECountByFixability mocks base method.
-func (m *MockCveView) CVECountByFixability(ctx context.Context, q *v1.Query) (platformcve.CVECountByFixability, error) {
+func (m *MockCveView) CVECountByFixability(ctx context.Context, q *v1.Query) (common.ResourceCountByFixability, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CVECountByFixability", ctx, q)
-	ret0, _ := ret[0].(platformcve.CVECountByFixability)
+	ret0, _ := ret[0].(common.ResourceCountByFixability)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -395,55 +396,4 @@ func (m *MockCVECountByType) GetOpenshiftCVECount() int {
 func (mr *MockCVECountByTypeMockRecorder) GetOpenshiftCVECount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftCVECount", reflect.TypeOf((*MockCVECountByType)(nil).GetOpenshiftCVECount))
-}
-
-// MockCVECountByFixability is a mock of CVECountByFixability interface.
-type MockCVECountByFixability struct {
-	ctrl     *gomock.Controller
-	recorder *MockCVECountByFixabilityMockRecorder
-}
-
-// MockCVECountByFixabilityMockRecorder is the mock recorder for MockCVECountByFixability.
-type MockCVECountByFixabilityMockRecorder struct {
-	mock *MockCVECountByFixability
-}
-
-// NewMockCVECountByFixability creates a new mock instance.
-func NewMockCVECountByFixability(ctrl *gomock.Controller) *MockCVECountByFixability {
-	mock := &MockCVECountByFixability{ctrl: ctrl}
-	mock.recorder = &MockCVECountByFixabilityMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockCVECountByFixability) EXPECT() *MockCVECountByFixabilityMockRecorder {
-	return m.recorder
-}
-
-// GetFixable mocks base method.
-func (m *MockCVECountByFixability) GetFixable() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFixable")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// GetFixable indicates an expected call of GetFixable.
-func (mr *MockCVECountByFixabilityMockRecorder) GetFixable() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFixable", reflect.TypeOf((*MockCVECountByFixability)(nil).GetFixable))
-}
-
-// GetTotal mocks base method.
-func (m *MockCVECountByFixability) GetTotal() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTotal")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// GetTotal indicates an expected call of GetTotal.
-func (mr *MockCVECountByFixabilityMockRecorder) GetTotal() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotal", reflect.TypeOf((*MockCVECountByFixability)(nil).GetTotal))
 }

--- a/central/views/platformcve/mocks/types.go
+++ b/central/views/platformcve/mocks/types.go
@@ -178,6 +178,36 @@ func (m *MockCveView) EXPECT() *MockCveViewMockRecorder {
 	return m.recorder
 }
 
+// CVECountByFixability mocks base method.
+func (m *MockCveView) CVECountByFixability(ctx context.Context, q *v1.Query) (platformcve.CVECountByFixability, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CVECountByFixability", ctx, q)
+	ret0, _ := ret[0].(platformcve.CVECountByFixability)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CVECountByFixability indicates an expected call of CVECountByFixability.
+func (mr *MockCveViewMockRecorder) CVECountByFixability(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CVECountByFixability", reflect.TypeOf((*MockCveView)(nil).CVECountByFixability), ctx, q)
+}
+
+// CVECountByType mocks base method.
+func (m *MockCveView) CVECountByType(ctx context.Context, q *v1.Query) (platformcve.CVECountByType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CVECountByType", ctx, q)
+	ret0, _ := ret[0].(platformcve.CVECountByType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CVECountByType indicates an expected call of CVECountByType.
+func (mr *MockCveViewMockRecorder) CVECountByType(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CVECountByType", reflect.TypeOf((*MockCveView)(nil).CVECountByType), ctx, q)
+}
+
 // Count mocks base method.
 func (m *MockCveView) Count(ctx context.Context, q *v1.Query) (int, error) {
 	m.ctrl.T.Helper()
@@ -300,4 +330,120 @@ func (m *MockClusterCountByPlatformType) GetOpenshiftClusterCount() int {
 func (mr *MockClusterCountByPlatformTypeMockRecorder) GetOpenshiftClusterCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftClusterCount", reflect.TypeOf((*MockClusterCountByPlatformType)(nil).GetOpenshiftClusterCount))
+}
+
+// MockCVECountByType is a mock of CVECountByType interface.
+type MockCVECountByType struct {
+	ctrl     *gomock.Controller
+	recorder *MockCVECountByTypeMockRecorder
+}
+
+// MockCVECountByTypeMockRecorder is the mock recorder for MockCVECountByType.
+type MockCVECountByTypeMockRecorder struct {
+	mock *MockCVECountByType
+}
+
+// NewMockCVECountByType creates a new mock instance.
+func NewMockCVECountByType(ctrl *gomock.Controller) *MockCVECountByType {
+	mock := &MockCVECountByType{ctrl: ctrl}
+	mock.recorder = &MockCVECountByTypeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCVECountByType) EXPECT() *MockCVECountByTypeMockRecorder {
+	return m.recorder
+}
+
+// GetIstioCVECount mocks base method.
+func (m *MockCVECountByType) GetIstioCVECount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIstioCVECount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetIstioCVECount indicates an expected call of GetIstioCVECount.
+func (mr *MockCVECountByTypeMockRecorder) GetIstioCVECount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIstioCVECount", reflect.TypeOf((*MockCVECountByType)(nil).GetIstioCVECount))
+}
+
+// GetKubernetesCVECount mocks base method.
+func (m *MockCVECountByType) GetKubernetesCVECount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKubernetesCVECount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetKubernetesCVECount indicates an expected call of GetKubernetesCVECount.
+func (mr *MockCVECountByTypeMockRecorder) GetKubernetesCVECount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubernetesCVECount", reflect.TypeOf((*MockCVECountByType)(nil).GetKubernetesCVECount))
+}
+
+// GetOpenshiftCVECount mocks base method.
+func (m *MockCVECountByType) GetOpenshiftCVECount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOpenshiftCVECount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetOpenshiftCVECount indicates an expected call of GetOpenshiftCVECount.
+func (mr *MockCVECountByTypeMockRecorder) GetOpenshiftCVECount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftCVECount", reflect.TypeOf((*MockCVECountByType)(nil).GetOpenshiftCVECount))
+}
+
+// MockCVECountByFixability is a mock of CVECountByFixability interface.
+type MockCVECountByFixability struct {
+	ctrl     *gomock.Controller
+	recorder *MockCVECountByFixabilityMockRecorder
+}
+
+// MockCVECountByFixabilityMockRecorder is the mock recorder for MockCVECountByFixability.
+type MockCVECountByFixabilityMockRecorder struct {
+	mock *MockCVECountByFixability
+}
+
+// NewMockCVECountByFixability creates a new mock instance.
+func NewMockCVECountByFixability(ctrl *gomock.Controller) *MockCVECountByFixability {
+	mock := &MockCVECountByFixability{ctrl: ctrl}
+	mock.recorder = &MockCVECountByFixabilityMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCVECountByFixability) EXPECT() *MockCVECountByFixabilityMockRecorder {
+	return m.recorder
+}
+
+// GetFixable mocks base method.
+func (m *MockCVECountByFixability) GetFixable() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFixable")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetFixable indicates an expected call of GetFixable.
+func (mr *MockCVECountByFixabilityMockRecorder) GetFixable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFixable", reflect.TypeOf((*MockCVECountByFixability)(nil).GetFixable))
+}
+
+// GetTotal mocks base method.
+func (m *MockCVECountByFixability) GetTotal() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTotal")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetTotal indicates an expected call of GetTotal.
+func (mr *MockCVECountByFixabilityMockRecorder) GetTotal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotal", reflect.TypeOf((*MockCVECountByFixability)(nil).GetTotal))
 }

--- a/central/views/platformcve/types.go
+++ b/central/views/platformcve/types.go
@@ -29,6 +29,8 @@ type CveView interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetClusterIDs(ctx context.Context, q *v1.Query) ([]string, error)
+	CVECountByType(ctx context.Context, q *v1.Query) (CVECountByType, error)
+	CVECountByFixability(ctx context.Context, q *v1.Query) (CVECountByFixability, error)
 }
 
 // ClusterCountByPlatformType provides ability to retrieve number of clusters of each platform type
@@ -37,4 +39,17 @@ type ClusterCountByPlatformType interface {
 	GetKubernetesClusterCount() int
 	GetOpenshiftClusterCount() int
 	GetOpenshift4ClusterCount() int
+}
+
+// CVECountByType provides the number of platform CVEs of each type
+type CVECountByType interface {
+	GetKubernetesCVECount() int
+	GetOpenshiftCVECount() int
+	GetIstioCVECount() int
+}
+
+// CVECountByFixability provides the number of fixable and total platform CVEs
+type CVECountByFixability interface {
+	GetTotal() int
+	GetFixable() int
 }

--- a/central/views/platformcve/types.go
+++ b/central/views/platformcve/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -30,7 +31,7 @@ type CveView interface {
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetClusterIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	CVECountByType(ctx context.Context, q *v1.Query) (CVECountByType, error)
-	CVECountByFixability(ctx context.Context, q *v1.Query) (CVECountByFixability, error)
+	CVECountByFixability(ctx context.Context, q *v1.Query) (common.ResourceCountByFixability, error)
 }
 
 // ClusterCountByPlatformType provides ability to retrieve number of clusters of each platform type
@@ -46,10 +47,4 @@ type CVECountByType interface {
 	GetKubernetesCVECount() int
 	GetOpenshiftCVECount() int
 	GetIstioCVECount() int
-}
-
-// CVECountByFixability provides the number of fixable and total platform CVEs
-type CVECountByFixability interface {
-	GetTotal() int
-	GetFixable() int
 }

--- a/central/views/platformcve/view_impl.go
+++ b/central/views/platformcve/view_impl.go
@@ -124,7 +124,7 @@ func (v *platformCVECoreViewImpl) CVECountByType(ctx context.Context, q *v1.Quer
 	return results[0], nil
 }
 
-func (v *platformCVECoreViewImpl) CVECountByFixability(ctx context.Context, q *v1.Query) (CVECountByFixability, error) {
+func (v *platformCVECoreViewImpl) CVECountByFixability(ctx context.Context, q *v1.Query) (common.ResourceCountByFixability, error) {
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err
 	}

--- a/central/views/platformcve/view_impl.go
+++ b/central/views/platformcve/view_impl.go
@@ -96,6 +96,62 @@ func (v *platformCVECoreViewImpl) GetClusterIDs(ctx context.Context, q *v1.Query
 	return ret, nil
 }
 
+func (v *platformCVECoreViewImpl) CVECountByType(ctx context.Context, q *v1.Query) (CVECountByType, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	var err error
+	q, err = common.WithSACFilter(ctx, resources.Cluster, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*cveCountByTypeResponse
+	results, err = pgSearch.RunSelectRequestForSchema[cveCountByTypeResponse](ctx, v.db, v.schema, withCVECountByTypeQuery(q))
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return NewEmptyCVECountByType(), nil
+	}
+	if len(results) > 1 {
+		err = errors.Errorf("Retrieved multiple rows when only one row is expected for count query %q", q.String())
+		utils.Should(err)
+		return NewEmptyCVECountByType(), nil
+	}
+
+	return results[0], nil
+}
+
+func (v *platformCVECoreViewImpl) CVECountByFixability(ctx context.Context, q *v1.Query) (CVECountByFixability, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	var err error
+	q, err = common.WithSACFilter(ctx, resources.Cluster, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*cveCountByFixabilityResponse
+	results, err = pgSearch.RunSelectRequestForSchema[cveCountByFixabilityResponse](ctx, v.db, v.schema, withCVECountByFixabilityQuery(q))
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return NewEmptyCVECountByFixability(), nil
+	}
+	if len(results) > 1 {
+		err = errors.Errorf("Retrieved multiple rows when only one row is expected for count query %q", q.String())
+		utils.Should(err)
+		return NewEmptyCVECountByFixability(), nil
+	}
+
+	return results[0], nil
+}
+
 func withSelectQuery(q *v1.Query) *v1.Query {
 	cloned := q.Clone()
 	cloned.Selects = []*v1.QuerySelect{
@@ -161,6 +217,60 @@ func withCountByPlatformTypeSelectQuery(q *v1.Query) *v1.Query {
 						search.ClusterPlatformType,
 						storage.ClusterType_OPENSHIFT4_CLUSTER.String(),
 					).ProtoQuery(),
+			).Proto(),
+	)
+	return cloned
+}
+
+func withCVECountByTypeQuery(q *v1.Query) *v1.Query {
+	cloned := q.Clone()
+	cloned.Selects = append(cloned.Selects,
+		search.NewQuerySelect(search.CVEID).
+			Distinct().
+			AggrFunc(aggregatefunc.Count).
+			Filter("k8s_cve_count",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.CVEType,
+						storage.CVE_K8S_CVE.String(),
+					).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.CVEID).
+			Distinct().
+			AggrFunc(aggregatefunc.Count).
+			Filter("openshift_cve_count",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.CVEType,
+						storage.CVE_OPENSHIFT_CVE.String(),
+					).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.CVEID).
+			Distinct().
+			AggrFunc(aggregatefunc.Count).
+			Filter("istio_cve_count",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.CVEType,
+						storage.CVE_ISTIO_CVE.String(),
+					).ProtoQuery(),
+			).Proto(),
+	)
+	return cloned
+}
+
+func withCVECountByFixabilityQuery(q *v1.Query) *v1.Query {
+	cloned := q.Clone()
+	cloned.Selects = append(cloned.Selects,
+		search.NewQuerySelect(search.CVEID).
+			Distinct().
+			AggrFunc(aggregatefunc.Count).
+			Proto(),
+		search.NewQuerySelect(search.CVEID).
+			Distinct().
+			AggrFunc(aggregatefunc.Count).
+			Filter("fixable_cve_id_count",
+				search.NewQueryBuilder().AddBools(search.ClusterCVEFixable, true).ProtoQuery(),
 			).Proto(),
 	)
 	return cloned

--- a/central/views/platformcve/view_test.go
+++ b/central/views/platformcve/view_test.go
@@ -13,6 +13,7 @@ import (
 	clusterCVEDS "github.com/stackrox/rox/central/cve/cluster/datastore"
 	"github.com/stackrox/rox/central/cve/converter/v2"
 	converterV2 "github.com/stackrox/rox/central/cve/converter/v2"
+	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgCVE "github.com/stackrox/rox/pkg/cve"
@@ -860,7 +861,7 @@ func (s *PlatformCVEViewTestSuite) compileExpectedCVECountByType(filter *filterI
 	}
 }
 
-func (s *PlatformCVEViewTestSuite) compileExpectedCVECountByFixability(filter *filterImpl) CVECountByFixability {
+func (s *PlatformCVEViewTestSuite) compileExpectedCVECountByFixability(filter *filterImpl) common.ResourceCountByFixability {
 	totalCVECount := 0
 	fixableCVECount := 0
 

--- a/central/views/platformcve/view_test.go
+++ b/central/views/platformcve/view_test.go
@@ -325,6 +325,92 @@ func (s *PlatformCVEViewTestSuite) TestCountPlatformCVECoreSAC() {
 	}
 }
 
+func (s *PlatformCVEViewTestSuite) TestCVECountByType() {
+	for _, tc := range s.testCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.CVECountByType(sac.WithAllAccess(tc.ctx), tc.q)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpectedCVECountByType(tc.matchFilter)
+			assert.EqualValues(t, expected, actual)
+		})
+	}
+}
+
+func (s *PlatformCVEViewTestSuite) TestCVECountByTypeSAC() {
+	for _, tc := range s.testCases() {
+		for _, sacTC := range s.sacTestCases(tc.ctx) {
+			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
+				actual, err := s.cveView.CVECountByType(sacTC.ctx, tc.q)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				// Wrap cluster filter with sac filter.
+				filterWithSAC := matchAllFilter().withClusterFilter(func(cluster *storage.Cluster) bool {
+					if sacTC.visibleClusters.Contains(cluster.GetId()) {
+						return tc.matchFilter.matchCluster(cluster)
+					}
+					return false
+				})
+				filterWithSAC.matchCVEParts = tc.matchFilter.matchCVEParts
+
+				expected := s.compileExpectedCVECountByType(filterWithSAC)
+				assert.EqualValues(t, expected, actual)
+			})
+		}
+	}
+}
+
+func (s *PlatformCVEViewTestSuite) TestCVECountByFixability() {
+	for _, tc := range s.testCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.CVECountByFixability(sac.WithAllAccess(tc.ctx), tc.q)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpectedCVECountByFixability(tc.matchFilter)
+			assert.EqualValues(t, expected, actual)
+		})
+	}
+}
+
+func (s *PlatformCVEViewTestSuite) TestCVECountByFixabilitySAC() {
+	for _, tc := range s.testCases() {
+		for _, sacTC := range s.sacTestCases(tc.ctx) {
+			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
+				actual, err := s.cveView.CVECountByFixability(sacTC.ctx, tc.q)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				// Wrap cluster filter with sac filter.
+				filterWithSAC := matchAllFilter().withClusterFilter(func(cluster *storage.Cluster) bool {
+					if sacTC.visibleClusters.Contains(cluster.GetId()) {
+						return tc.matchFilter.matchCluster(cluster)
+					}
+					return false
+				})
+				filterWithSAC.matchCVEParts = tc.matchFilter.matchCVEParts
+
+				expected := s.compileExpectedCVECountByFixability(filterWithSAC)
+				assert.EqualValues(t, expected, actual)
+			})
+		}
+	}
+}
+
 func (s *PlatformCVEViewTestSuite) testCases() []testCase {
 	return []testCase{
 		{
@@ -734,6 +820,84 @@ func (s *PlatformCVEViewTestSuite) compileExpectedAffectedClusterIDs(filter *fil
 	return affectedClusterIDs.AsSlice()
 }
 
+func (s *PlatformCVEViewTestSuite) compileExpectedCVECountByType(filter *filterImpl) CVECountByType {
+	k8sCVECount := 0
+	openshiftCVECount := 0
+	istioCVECount := 0
+
+	for _, cveParts := range s.cvePartsList {
+		if !filter.matchCVEParts(cveParts) {
+			continue
+		}
+		clusterCount := 0
+
+		for _, child := range cveParts.Children {
+			cluster, exists := s.clusterMap[child.ClusterID]
+			if !exists || !filter.matchCluster(cluster) {
+				continue
+			}
+			clusterCount++
+		}
+		if clusterCount == 0 {
+			// if no clusters matched, then cve is not included in results
+			continue
+		}
+
+		switch cveParts.CVE.GetType() {
+		case storage.CVE_K8S_CVE:
+			k8sCVECount++
+		case storage.CVE_OPENSHIFT_CVE:
+			openshiftCVECount++
+		case storage.CVE_ISTIO_CVE:
+			istioCVECount++
+		}
+	}
+
+	return &cveCountByTypeResponse{
+		KubernetesCVECount: k8sCVECount,
+		OpenshiftCVECount:  openshiftCVECount,
+		IstioCVECount:      istioCVECount,
+	}
+}
+
+func (s *PlatformCVEViewTestSuite) compileExpectedCVECountByFixability(filter *filterImpl) CVECountByFixability {
+	totalCVECount := 0
+	fixableCVECount := 0
+
+	for _, cveParts := range s.cvePartsList {
+		if !filter.matchCVEParts(cveParts) {
+			continue
+		}
+		clusterCount := 0
+		fixable := false
+
+		for _, child := range cveParts.Children {
+			cluster, exists := s.clusterMap[child.ClusterID]
+			if !exists || !filter.matchCluster(cluster) {
+				continue
+			}
+			clusterCount++
+			if child.Edge.GetIsFixable() {
+				fixable = true
+			}
+		}
+		if clusterCount == 0 {
+			// if no clusters matched, then cve is not included in results
+			continue
+		}
+
+		totalCVECount++
+		if fixable {
+			fixableCVECount++
+		}
+	}
+
+	return &cveCountByFixabilityResponse{
+		CVECount:     totalCVECount,
+		FixableCount: fixableCVECount,
+	}
+}
+
 func applyPaginationProps(baseTc *testCase, paginationTc paginationTestCase) {
 	baseTc.desc = fmt.Sprintf("%s %s", baseTc.desc, paginationTc.desc)
 	baseTc.q.Pagination = paginationTc.q.GetPagination()
@@ -832,6 +996,8 @@ func getTestData() (map[string]*storage.Cluster, map[storage.CVE_CVEType][]conve
 	cve2Openshift := generateTestCVE("cve-2", storage.CVE_OPENSHIFT_CVE, 6.3)
 	cve4Openshift := generateTestCVE("cve-4", storage.CVE_OPENSHIFT_CVE, 4.9)
 	cve5Openshift := generateTestCVE("cve-5", storage.CVE_OPENSHIFT_CVE, 7.0)
+	cve1Istio := generateTestCVE("cve-1", storage.CVE_ISTIO_CVE, 7.2)
+	cve5Istio := generateTestCVE("cve-5", storage.CVE_ISTIO_CVE, 4.8)
 
 	// CVEParts
 	cvePartsByType := make(map[storage.CVE_CVEType][]converter.ClusterCVEParts)
@@ -845,6 +1011,8 @@ func getTestData() (map[string]*storage.Cluster, map[storage.CVE_CVEType][]conve
 		converterV2.NewClusterCVEParts(cve2Openshift, []*storage.Cluster{openshift1, openshift2, openshift42}, "4.15"),
 		converterV2.NewClusterCVEParts(cve4Openshift, []*storage.Cluster{openshift2, openshift42}, "4.13"),
 		converterV2.NewClusterCVEParts(cve5Openshift, []*storage.Cluster{openshift41, openshift42}, "4.15"),
+		converterV2.NewClusterCVEParts(cve1Istio, []*storage.Cluster{generic1}, ""),
+		converterV2.NewClusterCVEParts(cve5Istio, []*storage.Cluster{openshift41}, "4.15"),
 	} {
 		cvePartsByType[cveParts.CVE.GetType()] = append(cvePartsByType[cveParts.CVE.GetType()], cveParts)
 	}


### PR DESCRIPTION
## Description

- Rename ClusterCountByPlatformType resolver to ClusterCountByType so that it matches the query called by UI implementation
- Add PlatformCVECountByType resolver
- Add PlatformCVECountByFixability resolver

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Unit tests
- Manual tests by calling the newly added queries

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
