### PR TITLE
ROX-24855: Preserve search query params in Compliance Coverage

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -98,7 +98,11 @@ function ProfileClustersPage() {
     }, [profileClusters]);
 
     function handleProfilesToggleChange(selectedProfile: string) {
-        navigateWithScanConfigQuery(coverageProfileClustersPath, { profileName: selectedProfile });
+        navigateWithScanConfigQuery(
+            coverageProfileClustersPath,
+            { profileName: selectedProfile },
+            searchFilter
+        );
     }
 
     const onSearch = (payload: OnSearchPayload) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import qs from 'qs';
 
 import {
     coverageProfileChecksPath,
@@ -16,11 +17,13 @@ export type ProfilesTableToggleGroupProps = {
 function ProfilesTableToggleGroup({ activeToggle }: ProfilesTableToggleGroupProps) {
     const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
+    const location = useLocation();
 
     const handleToggleChange = (resultsView) => {
+        const searchParams = qs.parse(location.search, { ignoreQueryPrefix: true });
         const path: CoverageProfilePath =
             resultsView === 'checks' ? coverageProfileChecksPath : coverageProfileClustersPath;
-        navigateWithScanConfigQuery(path, { profileName });
+        navigateWithScanConfigQuery(path, { profileName }, searchParams);
     };
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
-import qs from 'qs';
 
+import useURLSearch from 'hooks/useURLSearch';
 import {
     coverageProfileChecksPath,
     coverageProfileClustersPath,
@@ -17,13 +17,12 @@ export type ProfilesTableToggleGroupProps = {
 function ProfilesTableToggleGroup({ activeToggle }: ProfilesTableToggleGroupProps) {
     const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
-    const location = useLocation();
+    const { searchFilter } = useURLSearch();
 
     const handleToggleChange = (resultsView) => {
-        const searchParams = qs.parse(location.search, { ignoreQueryPrefix: true });
         const path: CoverageProfilePath =
             resultsView === 'checks' ? coverageProfileChecksPath : coverageProfileClustersPath;
-        navigateWithScanConfigQuery(path, { profileName }, searchParams);
+        navigateWithScanConfigQuery(path, { profileName }, searchFilter);
     };
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
@@ -9,16 +9,26 @@ const useScanConfigRouter = () => {
     const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const history = useHistory();
 
-    function generatePathWithScanConfig(path, pathParams: Partial<Record<string, unknown>> = {}) {
+    function generatePathWithScanConfig(
+        path,
+        pathParams: Partial<Record<string, unknown>> = {},
+        searchParams = {}
+    ) {
         return generatePathWithQuery(
             path,
             pathParams,
-            selectedScanConfigName ? { scanSchedule: selectedScanConfigName } : {}
+            selectedScanConfigName
+                ? { ...searchParams, scanSchedule: selectedScanConfigName }
+                : searchParams
         );
     }
 
-    function navigateWithScanConfigQuery(path, pathParams: Partial<Record<string, unknown>> = {}) {
-        const generatedPath = generatePathWithScanConfig(path, pathParams);
+    function navigateWithScanConfigQuery(
+        path,
+        pathParams: Partial<Record<string, unknown>> = {},
+        searchParams = {}
+    ) {
+        const generatedPath = generatePathWithScanConfig(path, pathParams, searchParams);
         history.push(generatedPath);
     }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
@@ -12,23 +12,20 @@ const useScanConfigRouter = () => {
     function generatePathWithScanConfig(
         path,
         pathParams: Partial<Record<string, unknown>> = {},
-        searchParams = {}
+        searchFilter = {}
     ) {
-        return generatePathWithQuery(
-            path,
-            pathParams,
-            selectedScanConfigName
-                ? { ...searchParams, scanSchedule: selectedScanConfigName }
-                : searchParams
-        );
+        return generatePathWithQuery(path, pathParams, {
+            customParams: selectedScanConfigName ? { scanSchedule: selectedScanConfigName } : {},
+            searchFilter,
+        });
     }
 
     function navigateWithScanConfigQuery(
         path,
         pathParams: Partial<Record<string, unknown>> = {},
-        searchParams = {}
+        searchFilter = {}
     ) {
-        const generatedPath = generatePathWithScanConfig(path, pathParams, searchParams);
+        const generatedPath = generatePathWithScanConfig(path, pathParams, searchFilter);
         history.push(generatedPath);
     }
 

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -66,7 +66,11 @@ function SummaryCounts({ hasReadAccessForResource }: SummaryCountsProps): ReactE
         Alert: violationsBasePath,
         Deployment: `${configManagementPath}/${urlEntityListTypes[resourceTypes.DEPLOYMENT]}`,
         Image: areVMMiscImprovementsEnabled
-            ? generatePathWithQuery(vulnerabilitiesWorkloadCvesPath, {}, { entityTab: 'Image' })
+            ? generatePathWithQuery(
+                  vulnerabilitiesWorkloadCvesPath,
+                  {},
+                  { customParams: { entityTab: 'Image' } }
+              )
             : vulnManagementImagesPath,
         Secret: `${configManagementPath}/${urlEntityListTypes[resourceTypes.SECRET]}`,
     };

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -321,6 +321,6 @@ export const generatePathWithQuery = (
     queryParams
 ) => {
     const path = safeGeneratePath(pathTemplate, pathParams, pathTemplate);
-    const searchParams = new URLSearchParams(queryParams).toString();
-    return `${path}?${searchParams}`;
+    const searchParams = qs.stringify(queryParams, { encode: false, arrayFormat: 'indices' });
+    return `${path}${searchParams !== '' ? `?${searchParams}` : ''}`;
 };

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -318,9 +318,16 @@ export function addRegexPrefixToFilters(
 export const generatePathWithQuery = (
     pathTemplate: string,
     pathParams: Partial<Record<string, unknown>>,
-    queryParams
-) => {
+    options: {
+        customParams?: string | URLSearchParams | string[][] | Record<string, string>;
+        searchFilter?: SearchFilter;
+    } = {}
+): string => {
+    const { customParams = {}, searchFilter = {} } = options;
     const path = safeGeneratePath(pathTemplate, pathParams, pathTemplate);
-    const searchParams = qs.stringify(queryParams, { encode: false, arrayFormat: 'indices' });
-    return `${path}${searchParams !== '' ? `?${searchParams}` : ''}`;
+    const customParamsString = new URLSearchParams(customParams).toString();
+    const searchFilterString = getUrlQueryStringForSearchFilter(searchFilter);
+    const queryParams = [customParamsString, searchFilterString].filter(Boolean).join('&');
+
+    return queryParams ? `${path}?${queryParams}` : path;
 };


### PR DESCRIPTION
## Description

This PR preserves the search query params when switching between the "Checks" and "Clusters" view in Compliance Coverage

## Screen recording

https://github.com/stackrox/stackrox/assets/4805485/f80d34b7-1667-4dcb-b4b2-5b432c44d37b

