### PR TITLE
ROX-22718: Sort Tokens

### DIFF
--- a/central/apitoken/service/service_impl.go
+++ b/central/apitoken/service/service_impl.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"strings"
-	"sort"
+	"slices"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"

--- a/central/apitoken/service/service_impl.go
+++ b/central/apitoken/service/service_impl.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"strings"
+	"sort"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
@@ -146,6 +147,7 @@ func (s *serviceImpl) ListAllowedTokenRoles(ctx context.Context, _ *v1.Empty) (*
 			result = append(result, role.GetRoleName())
 		}
 	}
+	sort.Strings(result)
 	return &v1.ListAllowedTokenRolesResponse{
 		RoleNames: result,
 	}, nil

--- a/central/apitoken/service/service_impl.go
+++ b/central/apitoken/service/service_impl.go
@@ -147,7 +147,7 @@ func (s *serviceImpl) ListAllowedTokenRoles(ctx context.Context, _ *v1.Empty) (*
 			result = append(result, role.GetRoleName())
 		}
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return &v1.ListAllowedTokenRolesResponse{
 		RoleNames: result,
 	}, nil

--- a/central/apitoken/service/service_impl.go
+++ b/central/apitoken/service/service_impl.go
@@ -2,8 +2,8 @@ package service
 
 import (
 	"context"
-	"strings"
 	"slices"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"

--- a/central/apitoken/service/service_impl_test.go
+++ b/central/apitoken/service/service_impl_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/central/role"
+	roleMock "github.com/stackrox/rox/central/role/datastore/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
+	"github.com/stackrox/rox/pkg/testutils/roletest"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSomethingIsSorted(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIdentity := mocks.NewMockIdentity(mockCtrl)
+
+	mockDatastore := roleMock.NewMockDataStore(mockCtrl)
+	roleOne := roletest.NewResolvedRole("Analyst", map[string]storage.Access{},
+		role.AccessScopeIncludeAll,
+	)
+
+	roleTwo := roletest.NewResolvedRole("Admin", map[string]storage.Access{},
+		role.AccessScopeIncludeAll,
+	)
+
+	roleThree := roletest.NewResolvedRole("Writer", map[string]storage.Access{},
+		role.AccessScopeIncludeAll,
+	)
+
+	mockIdentity.EXPECT().Roles().Return([]permissions.ResolvedRole{roleOne, roleTwo, roleThree}).AnyTimes()
+
+	mockDatastore.EXPECT().GetAllResolvedRoles(gomock.Any()).Return([]permissions.ResolvedRole{roleOne, roleTwo, roleThree}, nil)
+
+	s := &serviceImpl{roles: mockDatastore}
+
+	ctx := context.Background()
+	ctx = authn.ContextWithIdentity(ctx, mockIdentity, t)
+
+	actual, err := s.ListAllowedTokenRoles(ctx, &v1.Empty{})
+
+	assert.NoError(t, err)
+
+	expected := []string{"Admin", "Analyst", "Writer"}
+	assert.Equal(t, expected, actual.RoleNames)
+}

--- a/central/apitoken/service/service_impl_test.go
+++ b/central/apitoken/service/service_impl_test.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestSomethingIsSorted(t *testing.T) {
+func TestServiceImpl_ListAllowedRoles_SortsRoleAlphabetically(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/central/apitoken/service/service_impl_test.go
+++ b/central/apitoken/service/service_impl_test.go
@@ -13,17 +13,12 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/testutils/roletest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
 func TestServiceImpl_ListAllowedRoles_SortsRoleAlphabetically(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockIdentity := mocks.NewMockIdentity(mockCtrl)
-
-	mockDatastore := roleMock.NewMockDataStore(mockCtrl)
-	roleOne := roletest.NewResolvedRole("Analyst", map[string]storage.Access{},
+	roleOne := roletest.NewResolvedRole("Writer", map[string]storage.Access{},
 		role.AccessScopeIncludeAll,
 	)
 
@@ -31,12 +26,17 @@ func TestServiceImpl_ListAllowedRoles_SortsRoleAlphabetically(t *testing.T) {
 		role.AccessScopeIncludeAll,
 	)
 
-	roleThree := roletest.NewResolvedRole("Writer", map[string]storage.Access{},
+	roleThree := roletest.NewResolvedRole("Analyst", map[string]storage.Access{},
 		role.AccessScopeIncludeAll,
 	)
 
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIdentity := mocks.NewMockIdentity(mockCtrl)
 	mockIdentity.EXPECT().Roles().Return([]permissions.ResolvedRole{roleOne, roleTwo, roleThree}).AnyTimes()
 
+	mockDatastore := roleMock.NewMockDataStore(mockCtrl)
 	mockDatastore.EXPECT().GetAllResolvedRoles(gomock.Any()).Return([]permissions.ResolvedRole{roleOne, roleTwo, roleThree}, nil)
 
 	s := &serviceImpl{roles: mockDatastore}
@@ -46,7 +46,7 @@ func TestServiceImpl_ListAllowedRoles_SortsRoleAlphabetically(t *testing.T) {
 
 	actual, err := s.ListAllowedTokenRoles(ctx, &v1.Empty{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := []string{"Admin", "Analyst", "Writer"}
 	assert.Equal(t, expected, actual.RoleNames)


### PR DESCRIPTION
## Description

When creating ROX tokens , the order of roles is randomized based on the insert order in the database. Sort Tokens makes them ordered alphabetically.

Changes:
	→ Updated the ListAllowedTokenRoles function within the service_impl.go, by including : slices.Sort(result) in order to ensure consistent order of the roles listing.
	→ Added a test case: service_impl_test.go to validate the sorting functionality. Utilized mock data and checked that the resulting sorted list matched the expected sorted list.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ]  ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
Confirmed sorting logic by comparing the actual output with an expected result in the test case.




### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
