### PR TITLE
ROX-24784: Migrate workspaces to OCI artifacts in Konflux builds

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -146,7 +146,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:734d1dc1ad64c5933df3269585d16b81cb1375d8ef49c8194a222e4069b70fef
+        value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone-oci-ta:0.1@sha256:f1e58dcdb32efa9ca5b6f44e3600814624b9a8cfd59a1701379c789eeb8eef5b
       - name: kind
         value: task
       resolver: bundles
@@ -187,7 +187,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:f7e3a9d65b4a21e3e2b51cd0759c3696ea5b5f0505d47ae143386519c26d4c66
+        value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:a977d1a1b8cb79f29056e20a2e225b1018d84daad8b546de82f30b6326afee22
       - name: kind
         value: task
       resolver: bundles
@@ -223,7 +223,7 @@ spec:
       - name: name
         value: buildah-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.1@sha256:b6721707cbeb4e5f0c5164e3171b5e0c0e6dd597a2c5e094e9d4a8cdf15d85a3
+        value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-oci-ta:0.1@sha256:2a42822363c83b95a84c2f6a10c4d957835431d812b1e4a045b51fab1cca9769
       - name: kind
         value: task
       resolver: bundles
@@ -272,7 +272,7 @@ spec:
       - name: name
         value: source-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:f700119afdb2c184b8b369d9d89dab1a11af571ccd152ba14da13267f6f89009
+        value: quay.io/redhat-appstudio-tekton-catalog/task-source-build-oci-ta:0.1@sha256:eae2e52027120286bcd3c1e3a48bf3f1281d9718549b9cd4098dcf11b06b71b8
       - name: kind
         value: task
       resolver: bundles
@@ -341,7 +341,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:3dbb7fe03431d6e7b102f376d0ac652f3f84838cce152f2f5529bc74790c74b8
+        value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:80f44bd76a16a687681420f04b1d3e5ee974856eee2b5853311660e6fb0422bf
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -136,7 +136,7 @@ spec:
     - name: fetchTags
       value: $(params.clone-fetch-tags)
     - name: ociStorage
-      value: $(params.output-image).git
+      value: $(params.output-image-repo):konflux-$(params.revision).git
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:
@@ -177,7 +177,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
-      value: $(params.output-image).prefetch
+      value: $(params.output-image-repo):konflux-$(params.revision).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -18,28 +18,6 @@ spec:
       - name: kind
         value: task
       resolver: bundles
-  - name: show-summary
-    params:
-    - name: pipelinerun-name
-      value: $(context.pipelineRun.name)
-    - name: git-url
-      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-    - name: image-url
-      value: $(tasks.build-container.results.IMAGE_URL)
-    - name: build-task-status
-      value: $(tasks.build-container.status)
-    workspaces:
-    - name: workspace
-      workspace: workspace
-    taskRef:
-      params:
-      - name: name
-        value: summary
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:51d5aaa4e13e9fb4303f667e38d07e758820040032ed9fb3ab5f6afaaffc60d8
-      - name: kind
-        value: task
-      resolver: bundles
 
   params:
   - description: Source Repository URL
@@ -122,7 +100,6 @@ spec:
     value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
 
   workspaces:
-  - name: workspace
   - name: git-auth
 
   tasks:
@@ -139,14 +116,8 @@ spec:
     - name: skip-checks
       value: $(params.skip-checks)
     taskRef:
-      params:
-      - name: name
-        value: init
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-init:0.2@sha256:b23c7a924f303a67b3a00b32a6713ae1a4fccbc5327daa76a6edd250501ea7a3
-      - name: kind
-        value: task
-      resolver: bundles
+      name: init
+      version: "0.2"
 
   - name: clone-repository
     params:
@@ -158,24 +129,20 @@ spec:
       value: $(params.clone-depth)
     - name: fetchTags
       value: $(params.clone-fetch-tags)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
     runAfter:
     - init
     taskRef:
-      params:
-      - name: name
-        value: git-clone
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:2be7c9c83159c5247f1f9aab8fa1a2cb29d0df66f6c5bb48a012320bdcb03c7d
-      - name: kind
-        value: task
-      resolver: bundles
+      name: git-clone-oci-ta
+      version: "0.1"
     when:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
     workspaces:
-    - name: output
-      workspace: workspace
     - name: basic-auth
       workspace: git-auth
 
@@ -183,33 +150,29 @@ spec:
     params:
     - name: tag-suffix
       value: $(params.output-tag-suffix)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     runAfter:
     # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository
     taskRef:
-      name: determine-image-tag
-    workspaces:
-    - name: source
-      workspace: workspace
+      name: determine-image-tag-oci-ta
 
   - name: prefetch-dependencies
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
     runAfter:
     - determine-image-tag
     taskRef:
-      params:
-      - name: name
-        value: prefetch-dependencies
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:9aec3ae9f0f50a05abdc739faf4cbc82832cff16c77ac74e1d54072a882c0503
-      - name: kind
-        value: task
-      resolver: bundles
-    workspaces:
-    - name: source
-      workspace: workspace
+      name: prefetch-dependencies-oci-ta
+      version: "0.1"
 
   - name: build-container
     params:
@@ -231,24 +194,19 @@ spec:
       value:
       - VERSIONS_SUFFIX=$(params.output-tag-suffix)
       - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.image-tag)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
     - prefetch-dependencies
     taskRef:
-      params:
-      - name: name
-        value: buildah
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:102500165339bc08791775cf2c4dcae3dd4bde557a9009d44dc590ef66dde384
-      - name: kind
-        value: task
-      resolver: bundles
+      name: buildah-oci-ta
+      version: "0.1"
     when:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    workspaces:
-    - name: source
-      workspace: workspace
 
   - name: apply-tags
     params:
@@ -257,17 +215,15 @@ spec:
     - name: ADDITIONAL_TAGS
       value:
       - konflux-$(params.revision)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
     - build-container
     taskRef:
-      params:
-      - name: name
-        value: apply-tags
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-apply-tags:0.1@sha256:29add9a49a2281a3755a9b580d2b9c5cb110231b14cccf8ade2fd7895a9b4b4a
-      - name: kind
-        value: task
-      resolver: bundles
+      name: apply-tags-oci-ta
+      version: "0.1"
 
   - name: build-source-image
     params:
@@ -275,17 +231,15 @@ spec:
       value: $(tasks.build-container.results.IMAGE_URL)
     - name: BASE_IMAGES
       value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
     - build-container
     taskRef:
-      params:
-      - name: name
-        value: source-build
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:1a976a35adee9163e455d0c5aee5d9bf9cb3c6a770656ae347558f8c54977709
-      - name: kind
-        value: task
-      resolver: bundles
+      name: source-build-oci-ta
+      version: "0.1"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -293,9 +247,6 @@ spec:
     - input: $(params.build-source-image)
       operator: in
       values: [ "true" ]
-    workspaces:
-    - name: workspace
-      workspace: workspace
 
   - name: deprecated-base-image-check
     params:
@@ -344,24 +295,18 @@ spec:
       values: [ "false" ]
 
   - name: sast-snyk-check
+    params:
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:
     - clone-repository
     taskRef:
-      params:
-      - name: name
-        value: sast-snyk-check
-      - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:242acc527a06a11fac9dd6524467f62f3a086c186c5f885973e5780a04d4289c
-      - name: kind
-        value: task
-      resolver: bundles
+      name: sast-snyk-check-oci-ta
+      version: "0.1"
     when:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
-    workspaces:
-    - name: workspace
-      workspace: workspace
 
   - name: clamav-scan
     params:

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -143,8 +143,6 @@ spec:
       value: $(params.output-image-repo):konflux-$(params.revision).git
     - name: ociArtifactExpiresAfter
       value: $(params.oci-artifact-expires-after)
-    runAfter:
-    - init
     taskRef:
       params:
       - name: name
@@ -168,8 +166,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    runAfter:
-    - clone-repository
     taskRef:
       name: determine-image-tag-oci-ta
 
@@ -183,8 +179,6 @@ spec:
       value: $(params.output-image-repo):konflux-$(params.revision).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.oci-artifact-expires-after)
-    runAfter:
-    - clone-repository
     taskRef:
       params:
       - name: name
@@ -219,9 +213,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - determine-image-tag
-    - prefetch-dependencies
     taskRef:
       params:
       - name: name
@@ -243,8 +234,6 @@ spec:
     - name: ADDITIONAL_TAGS
       value:
       - konflux-$(params.revision)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name
@@ -265,8 +254,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name
@@ -292,8 +279,6 @@ spec:
       value: $(tasks.build-container.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-container.results.IMAGE_DIGEST)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name
@@ -314,8 +299,6 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-container.results.IMAGE_URL)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name
@@ -334,8 +317,6 @@ spec:
     params:
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    runAfter:
-    - prefetch-dependencies
     taskRef:
       params:
       - name: name
@@ -356,8 +337,6 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-container.results.IMAGE_URL)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name
@@ -378,8 +357,6 @@ spec:
       value: $(tasks.build-container.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-container.results.IMAGE_DIGEST)
-    runAfter:
-    - build-container
     taskRef:
       params:
       - name: name

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -169,7 +169,6 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     runAfter:
-    # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
     - clone-repository
     taskRef:
       name: determine-image-tag-oci-ta
@@ -185,7 +184,7 @@ spec:
     - name: ociArtifactExpiresAfter
       value: $(params.oci-artifact-expires-after)
     runAfter:
-    - determine-image-tag
+    - clone-repository
     taskRef:
       params:
       - name: name
@@ -221,6 +220,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
+    - determine-image-tag
     - prefetch-dependencies
     taskRef:
       params:
@@ -335,7 +335,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:
-    - clone-repository
+    - prefetch-dependencies
     taskRef:
       params:
       - name: name

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -82,7 +82,7 @@ spec:
     name: clone-fetch-tags
     type: string
   - default: "1d"
-    description: OCI Artifact (workspace) expiration time.
+    description: This sets the expiration time for intermediate OCI artifacts produced and used during builds after which they can be garbage collected.
     name: oci-artifact-expires-after
     type: string
 
@@ -192,7 +192,7 @@ spec:
   - name: build-container
     params:
     - name: IMAGE
-      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: DOCKERFILE
       value: $(params.dockerfile)
     - name: CONTEXT
@@ -208,7 +208,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - VERSIONS_SUFFIX=$(params.output-tag-suffix)
-      - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.image-tag)
+      - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -81,6 +81,10 @@ spec:
     description: Fetch tags with git clone
     name: clone-fetch-tags
     type: string
+  - default: "1d"
+    description: OCI Artifact (workspace) expiration time.
+    name: oci-artifact-expires-after
+    type: string
 
   results:
   - description: ""
@@ -138,7 +142,7 @@ spec:
     - name: ociStorage
       value: $(params.output-image-repo):konflux-$(params.revision).git
     - name: ociArtifactExpiresAfter
-      value: $(params.image-expires-after)
+      value: $(params.oci-artifact-expires-after)
     runAfter:
     - init
     taskRef:
@@ -160,7 +164,7 @@ spec:
 
   - name: determine-image-tag
     params:
-    - name: tag-suffix
+    - name: TAG_SUFFIX
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
@@ -179,7 +183,7 @@ spec:
     - name: ociStorage
       value: $(params.output-image-repo):konflux-$(params.revision).prefetch
     - name: ociArtifactExpiresAfter
-      value: $(params.image-expires-after)
+      value: $(params.oci-artifact-expires-after)
     runAfter:
     - determine-image-tag
     taskRef:
@@ -239,10 +243,6 @@ spec:
     - name: ADDITIONAL_TAGS
       value:
       - konflux-$(params.revision)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
     - build-container
     taskRef:

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -116,8 +116,14 @@ spec:
     - name: skip-checks
       value: $(params.skip-checks)
     taskRef:
-      name: init
-      version: "0.2"
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/redhat-appstudio-tekton-catalog/task-init:0.2@sha256:b23c7a924f303a67b3a00b32a6713ae1a4fccbc5327daa76a6edd250501ea7a3
+      - name: kind
+        value: task
+      resolver: bundles
 
   - name: clone-repository
     params:
@@ -136,8 +142,14 @@ spec:
     runAfter:
     - init
     taskRef:
-      name: git-clone-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: git-clone-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:734d1dc1ad64c5933df3269585d16b81cb1375d8ef49c8194a222e4069b70fef
+      - name: kind
+        value: task
+      resolver: bundles
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -171,8 +183,14 @@ spec:
     runAfter:
     - determine-image-tag
     taskRef:
-      name: prefetch-dependencies-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: prefetch-dependencies-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:f7e3a9d65b4a21e3e2b51cd0759c3696ea5b5f0505d47ae143386519c26d4c66
+      - name: kind
+        value: task
+      resolver: bundles
 
   - name: build-container
     params:
@@ -201,8 +219,14 @@ spec:
     runAfter:
     - prefetch-dependencies
     taskRef:
-      name: buildah-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: buildah-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.1@sha256:b6721707cbeb4e5f0c5164e3171b5e0c0e6dd597a2c5e094e9d4a8cdf15d85a3
+      - name: kind
+        value: task
+      resolver: bundles
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -222,8 +246,14 @@ spec:
     runAfter:
     - build-container
     taskRef:
-      name: apply-tags-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/redhat-appstudio-tekton-catalog/task-apply-tags:0.1@sha256:29add9a49a2281a3755a9b580d2b9c5cb110231b14cccf8ade2fd7895a9b4b4a
+      - name: kind
+        value: task
+      resolver: bundles
 
   - name: build-source-image
     params:
@@ -238,8 +268,14 @@ spec:
     runAfter:
     - build-container
     taskRef:
-      name: source-build-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: source-build-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:f700119afdb2c184b8b369d9d89dab1a11af571ccd152ba14da13267f6f89009
+      - name: kind
+        value: task
+      resolver: bundles
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -301,8 +337,14 @@ spec:
     runAfter:
     - clone-repository
     taskRef:
-      name: sast-snyk-check-oci-ta
-      version: "0.1"
+      params:
+      - name: name
+        value: sast-snyk-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.1@sha256:3dbb7fe03431d6e7b102f376d0ac652f3f84838cce152f2f5529bc74790c74b8
+      - name: kind
+        value: task
+      resolver: bundles
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -50,16 +50,6 @@ spec:
     value: 'true'
 
   workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: determine-image-tag-oci-ta
+  namespace: rh-acs-tenant
+# TODO(ROX-23812): Refactor to a task bundle
+spec:
+  description: Determines the tag for the output image using the StackRox convention from 'make tag' output.
+  params:
+  - name: tag-suffix
+    description: Suffix to append to generated image tag.
+    type: string
+  - name: SOURCE_ARTIFACT
+    description: The Trusted Artifact URI pointing to the artifact with
+      the application source code.
+    type: string
+  results:
+  - name: image-tag
+    description: Image Tag determined by custom logic.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+    args:
+      - use
+      - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+  - name: determine-image-tag
+    image: registry.access.redhat.com/ubi8:latest
+    workingDir: /var/workdir/source
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      dnf -y upgrade --nobest
+      dnf -y install git make
+
+      .konflux/scripts/fail-build-if-git-is-dirty.sh
+      echo -n "$(make --quiet --no-print-directory tag)$(params.tag-suffix)" | tee "$(results.image-tag.path)"

--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   description: Determines the tag for the output image using the StackRox convention from 'make tag' output.
   params:
-  - name: tag-suffix
+  - name: TAG_SUFFIX
     description: Suffix to append to generated image tag.
     type: string
   - name: SOURCE_ARTIFACT
@@ -40,4 +40,4 @@ spec:
       dnf -y install git make
 
       .konflux/scripts/fail-build-if-git-is-dirty.sh
-      echo -n "$(make --quiet --no-print-directory tag)$(params.tag-suffix)" | tee "$(results.image-tag.path)"
+      echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.image-tag.path)"

--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -12,7 +12,8 @@ spec:
     type: string
   - name: SOURCE_ARTIFACT
     description: The Trusted Artifact URI pointing to the artifact with
-      the application source code.
+      the application source code. This should be the result of the git-clone task,
+      results from other tasks might fail as dirty.
     type: string
   results:
   - name: image-tag

--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -16,7 +16,7 @@ spec:
       results from other tasks might fail as dirty.
     type: string
   results:
-  - name: image-tag
+  - name: IMAGE_TAG
     description: Image Tag determined by custom logic.
   volumes:
     - name: workdir
@@ -41,4 +41,4 @@ spec:
       dnf -y install git make
 
       .konflux/scripts/fail-build-if-git-is-dirty.sh
-      echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.image-tag.path)"
+      echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -49,16 +49,6 @@ spec:
     value: 'true'
 
   workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 3Gi
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -49,16 +49,6 @@ spec:
     value: 'true'
 
   workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 3Gi
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -50,16 +50,6 @@ spec:
     value: 'true'
 
   workspaces:
-  - name: workspace
-    volumeClaimTemplate:
-      metadata:
-        creationTimestamp: null
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Description

Pipeline adapted based on https://github.com/konflux-ci/build-definitions/blob/main/pipelines/docker-build-oci-ta/patch.yaml.

This pipeline is used by `central-db`, `operator`, `roxctl`, `scanner-v4-db` - other builds still use the PVC workspace until migrated. 

### Notes

- `show-summary` removed per https://github.com/konflux-ci/build-definitions/blob/main/pipelines/docker-build-oci-ta/patch.yaml#L120-L126
- added a second custom task that supports OCI TA
- the `.git` & `.prefetch` images will be placed in the same Quay repository as the image (e.g. `quay.io/rhacs-eng/central-db`) and expire at the same time, controlled by `params.image-expires-after`

## Checklist
- [x] Investigated and inspected CI test results (Konflux)
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Passing Konflux CI is sufficient.