### PR TITLE
ROX-24873: Add deprecation notice for error field in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - Slim/Full Collector images have been deprecated and will be removed in a
   future release. The two image flavors are now functionally identical (neither contain any kernel drivers.)
-- The field `error` returned for failed API calls has been deprecated, and it will be removed in a future release. Instead of using the `error` field, the `message` field should be used. The `message` field contains the same information as the `error` field.
+- The field `error` returned for failed API calls has been deprecated, and it will be removed in a future release. Instead of using the `error` field, use the `message` field. The `message` field contains the same information as the `error` field.
 
 ### Technical Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - Slim/Full Collector images have been deprecated and will be removed in a
   future release. The two image flavors are now functionally identical (neither contain any kernel drivers.)
+- The field `error` returned for failed API calls has been deprecated, and it will be removed in a future release. Instead of using the `error` field, the `message` field should be used. The `message` field contains the same information as the `error` field.
 
 ### Technical Changes
 


### PR DESCRIPTION
## Description

The current tool used to handle gRPC requests and generate code keeps backward compatibility to return the "error" field next to the "message" field for error messages.

The fields contain the same value: https://github.com/grpc-ecosystem/grpc-gateway/blob/26318a510414ca4d63a664faab34ec717e77d97b/runtime/errors.go#L135

With the new version of gRPC Gateway (v2) this field is dropped. Since we are migrating to a new version of the protobuf framework, we want to also drop this field from responses.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

No testing is performed because the change is only for the `md` file.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
