### PR TITLE
ROX-24833: Integrate Platform CVE Overview with BE queries

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -20,19 +20,7 @@ import {
 } from '../../utils/sortFields';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
-
-function displayCveType(cveType: string): string {
-    switch (cveType) {
-        case 'K8S_CVE':
-            return 'Kubernetes';
-        case 'ISTIO_CVE':
-            return 'Istio';
-        case 'OPENSHIFT_CVE':
-            return 'Openshift';
-        default:
-            return cveType;
-    }
-}
+import { displayCveType } from '../utils/stringUtils';
 
 export const sortFields = [
     CVE_SORT_FIELD,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -13,7 +13,6 @@ import {
     Td,
 } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';
-import sum from 'lodash/sum';
 
 import useURLPagination from 'hooks/useURLPagination';
 import useMap from 'hooks/useMap';
@@ -38,10 +37,10 @@ import {
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
-import { sortCveDistroList } from '../../utils/sortUtils';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 import { QuerySearchFilter } from '../../types';
 import usePlatformCves from './usePlatformCves';
+import { displayCveType } from '../utils/stringUtils';
 
 const totalClusterCountQuery = gql`
     query getTotalClusterCount {
@@ -150,16 +149,13 @@ function CVEsTable({
                             isFixable,
                             cveType,
                             cvss,
-                            scoreVersion,
-                            distroTuples,
+                            clusterVulnerability: { summary, scoreVersion },
                             clusterCountByType,
                         } = platformCve;
                         const isExpanded = expandedRowSet.has(cve);
 
-                        const prioritizedDistros = sortCveDistroList(distroTuples);
-                        const summary =
-                            prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
-                        const affectedClusterCount = sum(Object.values(clusterCountByType));
+                        const { generic, kubernetes, openshift, openshift4 } = clusterCountByType;
+                        const affectedClusterCount = generic + kubernetes + openshift + openshift4;
 
                         return (
                             <Tbody key={cve} isExpanded={isExpanded}>
@@ -186,7 +182,7 @@ function CVEsTable({
                                     <Td dataLabel="CVE status">
                                         <VulnerabilityFixableIconText isFixable={isFixable} />
                                     </Td>
-                                    <Td dataLabel="CVE type">{cveType}</Td>
+                                    <Td dataLabel="CVE type">{displayCveType(cveType)}</Td>
                                     <Td dataLabel="CVSS">
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -4,19 +4,15 @@ import { ClientPagination, Pagination } from 'services/types';
 import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
-// TODO Validate types with BE implementation
 type PlatformCVE = {
     cve: string;
     isFixable: boolean;
     cveType: string;
     cvss: number;
-    scoreVersion: string;
-    distroTuples: {
-        summary: string;
-        operatingSystem: string;
-        cvss: number;
+    clusterVulnerability: {
         scoreVersion: string;
-    }[];
+        summary: string;
+    };
     clusterCountByType: {
         generic: number;
         kubernetes: number;
@@ -32,10 +28,9 @@ const cveListQuery = gql`
             isFixable
             cveType
             cvss
-            scoreVersion
-            distroTuples {
+            clusterVulnerability {
+                scoreVersion
                 summary
-                operatingSystem
             }
             clusterCountByType {
                 generic

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
@@ -14,3 +14,16 @@ export function displayClusterType(type: ClusterType): string {
             return ensureExhaustive(type);
     }
 }
+
+export function displayCveType(cveType: string): string {
+    switch (cveType) {
+        case 'K8S_CVE':
+            return 'Kubernetes';
+        case 'ISTIO_CVE':
+            return 'Istio';
+        case 'OPENSHIFT_CVE':
+            return 'Openshift';
+        default:
+            return cveType;
+    }
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -96,10 +96,16 @@ function AdvancedFiltersToolbar({
         )
         .concat(
             includeCveStatusFilters && isFixabilityFiltersEnabled
-                ? makeDefaultFilterDescriptor(defaultFilters, {
-                      displayName: 'CVE status',
-                      searchFilterName: 'FIXABLE',
-                  })
+                ? [
+                      makeDefaultFilterDescriptor(defaultFilters, {
+                          displayName: 'CVE status',
+                          searchFilterName: 'FIXABLE',
+                      }),
+                      makeDefaultFilterDescriptor(defaultFilters, {
+                          displayName: 'CVE status',
+                          searchFilterName: 'CLUSTER CVE FIXABLE',
+                      }),
+                  ]
                 : []
         );
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
@@ -63,6 +63,7 @@ function SnoozeCvesModal({ action, cveType, cves, onSuccess, onClose }: SnoozeCv
             variant="small"
             actions={[
                 <Button
+                    key="perform-modal-action"
                     className="pf-v5-u-display-flex pf-v5-u-align-items-center"
                     isLoading={isSubmitting}
                     isDisabled={isSubmitting || isSuccess}
@@ -71,7 +72,12 @@ function SnoozeCvesModal({ action, cveType, cves, onSuccess, onClose }: SnoozeCv
                 >
                     <span>{action === 'SNOOZE' ? 'Snooze CVEs' : 'Unsnooze CVEs'}</span>
                 </Button>,
-                <Button isDisabled={isSubmitting} variant="link" onClick={onClose}>
+                <Button
+                    key="close-modal"
+                    isDisabled={isSubmitting}
+                    variant="link"
+                    onClick={onClose}
+                >
                     {isSuccess ? 'Close' : 'Cancel'}
                 </Button>,
             ]}
@@ -100,6 +106,7 @@ function SnoozeCvesModal({ action, cveType, cves, onSuccess, onClose }: SnoozeCv
                                 {durationOptions.map((option) => (
                                     <Radio
                                         id={`snooze-duration-${option}`}
+                                        key={option}
                                         isDisabled={isSubmitting || isSuccess}
                                         isChecked={values.duration === durations[option]}
                                         name={option}


### PR DESCRIPTION
## Description

Changes required to sync the UI with the production BE GraphQL queries.

Uses build 4.4.x-1011-gd887ad5d6a from https://github.com/stackrox/stackrox/pull/11604 for testing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Remove all Chrome API stubs and visit the Platform CVE page:

![image](https://github.com/stackrox/stackrox/assets/1292638/cb112f58-f5f1-48af-b49d-662666de62b7)

View the Clusters tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/12db92fe-be04-4b45-8b56-1c697faa344b)

View "Snoozed" CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/98f319cb-5d64-4b23-b825-d99cbaabb46f)

Test other filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/d4e74c34-e5f4-4a38-9b5b-622ce601220b)
