### PR TITLE
ROX-24835: Platform CVE cluster page integration

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
@@ -29,7 +29,7 @@ const statusHiddenText = {
 } as const;
 
 export const platformCveCountByStatusFragment = gql`
-    fragment PlatformCveCountByStatus on PlatformCVECountByStatus {
+    fragment PlatformCveCountByStatusFragment on PlatformCVECountByFixability {
         total
         fixable
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
@@ -18,7 +18,7 @@ const statusDisplays = [
 ] as const;
 
 export const platformCveCountByTypeFragment = gql`
-    fragment PlatformCveCountByType on PlatformCVECountByType {
+    fragment PlatformCveCountByTypeFragment on PlatformCVECountByType {
         kubernetes
         openshift
         istio

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterSummaryData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterSummaryData.ts
@@ -14,11 +14,11 @@ export const clusterSummaryDataQuery = gql`
     query getClusterVulnSummary($id: ID!, $query: String) {
         cluster(id: $id) {
             id
-            platformCVECountByFixability {
-                ...PlatformCveCountByStatus
+            platformCVECountByFixability(query: $query) {
+                ...PlatformCveCountByStatusFragment
             }
-            platformCVECountByType {
-                ...PlatformCveCountByType
+            platformCVECountByType(query: $query) {
+                ...PlatformCveCountByTypeFragment
             }
         }
     }


### PR DESCRIPTION
## Description

Changes required to sync the UI with the production BE GraphQL queries for the Platform CVE Cluster Single page.

Uses build 4.4.x-1011-gd887ad5d6a from https://github.com/stackrox/stackrox/pull/11604 for testing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load a Cluster single page (note there is an API bug causing the mismatch in the counts):
![image](https://github.com/stackrox/stackrox/assets/1292638/7416116e-f1f6-49cc-ac40-f2db6507bf5f)

Applied filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/40f164cf-c34a-442b-8778-304469709948)


