### PR TITLE
ROX-24834: Integrate Platform CVE single page with GQL queries

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -139,6 +139,7 @@ function CVEsTable({
                 renderer={({ data }) =>
                     data.map((platformCve, rowIndex) => {
                         const {
+                            id,
                             cve,
                             isFixable,
                             cveType,
@@ -152,7 +153,7 @@ function CVEsTable({
                         const affectedClusterCount = generic + kubernetes + openshift + openshift4;
 
                         return (
-                            <Tbody key={cve} isExpanded={isExpanded}>
+                            <Tbody key={id} isExpanded={isExpanded}>
                                 <Tr>
                                     <Td
                                         expand={{
@@ -169,9 +170,7 @@ function CVEsTable({
                                         />
                                     )}
                                     <Td dataLabel="CVE" modifier="nowrap">
-                                        <Link to={getPlatformEntityPagePath('CVE', cve)}>
-                                            {cve}
-                                        </Link>
+                                        <Link to={getPlatformEntityPagePath('CVE', id)}>{cve}</Link>
                                     </Td>
                                     <Td dataLabel="CVE status">
                                         <VulnerabilityFixableIconText isFixable={isFixable} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -5,6 +5,7 @@ import { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
 type PlatformCVE = {
+    id: string;
     cve: string;
     isFixable: boolean;
     cveType: string;
@@ -24,6 +25,7 @@ type PlatformCVE = {
 const cveListQuery = gql`
     query getPlatformCves($query: String, $pagination: Pagination) {
         platformCVEs(query: $query, pagination: $pagination) {
+            id
             cve
             isFixable
             cveType

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
@@ -23,32 +23,43 @@ export type ClustersByType = {
 };
 
 export type ClustersByTypeSummaryCardProps = {
-    clusterCounts: ClustersByType['clusterCountByType'];
+    clusterCounts?: ClustersByType['clusterCountByType'];
 };
 
 function ClustersByTypeSummaryCard({ clusterCounts }: ClustersByTypeSummaryCardProps) {
-    const { generic, kubernetes, openshift, openshift4 } = clusterCounts;
+    const counts = clusterCounts ?? { generic: 0, kubernetes: 0, openshift: 0, openshift4: 0 };
+    const { generic, kubernetes, openshift, openshift4 } = counts;
+    const totalCount = generic + kubernetes + openshift + openshift4;
+
     return (
         <Card isCompact isFlat isFullHeight>
             <CardTitle>Clusters by type</CardTitle>
             <CardBody>
-                <Grid>
-                    {generic > 0 && (
+                {totalCount > 0 ? (
+                    <Grid>
+                        {generic > 0 && (
+                            <GridItem span={12} className="pf-v5-u-pt-xs">
+                                {generic} Generic
+                            </GridItem>
+                        )}
+                        {kubernetes > 0 && (
+                            <GridItem span={12} className="pf-v5-u-pt-xs">
+                                {kubernetes} Kubernetes
+                            </GridItem>
+                        )}
+                        {openshift + openshift4 > 0 && (
+                            <GridItem span={12} className="pf-v5-u-pt-xs">
+                                {openshift + openshift4} OpenShift
+                            </GridItem>
+                        )}
+                    </Grid>
+                ) : (
+                    <Grid>
                         <GridItem span={12} className="pf-v5-u-pt-xs">
-                            {generic} Generic
+                            No affected clusters found
                         </GridItem>
-                    )}
-                    {kubernetes > 0 && (
-                        <GridItem span={12} className="pf-v5-u-pt-xs">
-                            {kubernetes} Kubernetes
-                        </GridItem>
-                    )}
-                    {openshift + openshift4 > 0 && (
-                        <GridItem span={12} className="pf-v5-u-pt-xs">
-                            {openshift + openshift4} OpenShift
-                        </GridItem>
-                    )}
-                </Grid>
+                    </Grid>
+                )}
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
@@ -27,8 +27,7 @@ export type ClustersByTypeSummaryCardProps = {
 };
 
 function ClustersByTypeSummaryCard({ clusterCounts }: ClustersByTypeSummaryCardProps) {
-    const counts = clusterCounts ?? { generic: 0, kubernetes: 0, openshift: 0, openshift4: 0 };
-    const { generic, kubernetes, openshift, openshift4 } = counts;
+    const { generic = 0, kubernetes = 0, openshift = 0, openshift4 = 0 } = clusterCounts ?? {};
     const totalCount = generic + kubernetes + openshift + openshift4;
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -6,9 +6,12 @@ import {
     BreadcrumbItem,
     Skeleton,
     Flex,
+    Label,
+    LabelGroup,
     Pagination,
     Split,
     SplitItem,
+    Text,
     Title,
     pluralize,
 } from '@patternfly/react-core';
@@ -24,11 +27,13 @@ import {
     SummaryCardLayout,
     SummaryCard,
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import useURLSort from 'hooks/useURLSort';
+import { getDateTime } from 'utils/dateUtils';
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
-import CvePageHeader from '../../components/CvePageHeader';
 import {
     getOverviewPagePath,
     getRegexScopedQueryString,
@@ -41,6 +46,7 @@ import ClustersByTypeSummaryCard from './ClustersByTypeSummaryCard';
 import AffectedClustersSummaryCard from './AffectedClustersSummaryCard';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import { clusterSearchFilterConfig } from '../../searchFilterConfig';
+import usePlatformCveSummaryData from './usePlatformCveSummaryData';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Platform', {
     entityTab: 'CVE',
@@ -54,13 +60,13 @@ function PlatformCvePage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
-    // We need to scope all queries to the *exact* CVE name so that we don't accidentally get
-    // data that matches a prefix of the CVE name in the nested fields
-    const { cveId } = useParams() as { cveId: string };
-    const exactCveIdSearchRegex = `^${cveId}$`;
+    const params = useParams() as { cveId: string };
+    // CVE ID needs to be decoded here as it will contain the `#` character
+    const cveId = decodeURIComponent(params.cveId);
+
     const query = getRegexScopedQueryString({
         ...querySearchFilter,
-        CVE: [exactCveIdSearchRegex],
+        'CVE ID': [cveId],
     });
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
@@ -76,8 +82,10 @@ function PlatformCvePage() {
         perPage,
         sortOption,
     });
-    const metadataRequest = usePlatformCveMetadata({ cve: cveId, query, page, perPage });
-    const cveName = metadataRequest.data?.platformCVE?.cve;
+    const metadataRequest = usePlatformCveMetadata(cveId);
+    const summaryDataRequest = usePlatformCveSummaryData({ cveId, query });
+    const cveMetadata = metadataRequest.data?.platformCVE;
+    const cveName = cveMetadata?.cve;
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
     const tableState = getTableUIState({
@@ -102,7 +110,39 @@ function PlatformCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">
-                <CvePageHeader data={metadataRequest.data?.platformCVE} />
+                {cveMetadata ? (
+                    <Flex
+                        direction={{ default: 'column' }}
+                        alignItems={{ default: 'alignItemsFlexStart' }}
+                    >
+                        <Title headingLevel="h1" className="pf-v5-u-mb-sm">
+                            {cveMetadata.cve}
+                        </Title>
+                        {cveMetadata.firstDiscoveredTime && (
+                            <LabelGroup numLabels={1}>
+                                <Label>
+                                    First discovered in system:{' '}
+                                    {getDateTime(cveMetadata.firstDiscoveredTime)}
+                                </Label>
+                            </LabelGroup>
+                        )}
+                        <Text>{cveMetadata.clusterVulnerability.summary}</Text>
+                        <ExternalLink>
+                            <a
+                                href={cveMetadata.clusterVulnerability.link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {cveMetadata.clusterVulnerability.link}
+                            </a>
+                        </ExternalLink>
+                    </Flex>
+                ) : (
+                    <HeaderLoadingSkeleton
+                        nameScreenreaderText="Loading CVE name"
+                        metadataScreenreaderText="Loading CVE metadata"
+                    />
+                )}
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-v5-u-flex-grow-1">
@@ -121,11 +161,11 @@ function PlatformCvePage() {
                     includeCveSeverityFilters={false}
                 />
                 <SummaryCardLayout
-                    error={metadataRequest.error}
-                    isLoading={metadataRequest.loading}
+                    error={summaryDataRequest.error}
+                    isLoading={summaryDataRequest.loading}
                 >
                     <SummaryCard
-                        data={metadataRequest.data}
+                        data={summaryDataRequest.data}
                         loadingText="Loading affected nodes summary"
                         renderer={({ data }) => (
                             <AffectedClustersSummaryCard
@@ -135,11 +175,11 @@ function PlatformCvePage() {
                         )}
                     />
                     <SummaryCard
-                        data={metadataRequest.data}
+                        data={summaryDataRequest.data}
                         loadingText="Loading affected nodes by CVE severity summary"
                         renderer={({ data }) => (
                             <ClustersByTypeSummaryCard
-                                clusterCounts={data.platformCVE.clusterCountByType}
+                                clusterCounts={data.platformCVE?.clusterCountByType}
                             />
                         )}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
@@ -1,23 +1,17 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { getPaginationParams } from 'utils/searchUtils';
-
-import { ClientPagination } from 'services/types';
 import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
 
 const platformCveMetadataQuery = gql`
     ${clustersByTypeFragment}
-    query getPlatformCVEMetadata($cve: String!, $query: String!) {
-        totalClusterCount: clusterCount
-        clusterCount(query: $query)
-        platformCVE(cve: $cve, subfieldScopeQuery: $query) {
+    query getPlatformCVEMetadata($cveID: String!) {
+        platformCVE(cveID: $cveID) {
             cve
-            distroTuples {
+            clusterVulnerability {
                 link
                 summary
-                operatingSystem
             }
-            firstDiscoveredInSystem
+            firstDiscoveredTime
             ...ClustersByType
         }
     }
@@ -25,29 +19,17 @@ const platformCveMetadataQuery = gql`
 
 export type PlatformCveMetadata = {
     cve: string;
-    distroTuples: {
+    clusterVulnerability: {
         link: string;
         summary: string;
-        operatingSystem: string;
-    }[];
-    firstDiscoveredInSystem: string;
+    };
+    firstDiscoveredTime: string; // iso8601
 };
 
-export default function usePlatformCveMetadata({
-    cve,
-    query,
-    page,
-    perPage,
-}: { cve: string; query: string } & ClientPagination) {
+export default function usePlatformCveMetadata(cveId: string) {
     return useQuery<{
-        totalClusterCount: number;
-        clusterCount: number;
-        platformCVE: PlatformCveMetadata & ClustersByType;
+        platformCVE?: PlatformCveMetadata & ClustersByType;
     }>(platformCveMetadataQuery, {
-        variables: {
-            cve,
-            query,
-            pagination: getPaginationParams({ page, perPage }),
-        },
+        variables: { cveID: cveId },
     });
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveSummaryData.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveSummaryData.tsx
@@ -1,0 +1,33 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+
+const platformCveSummaryDataQuery = gql`
+    ${clustersByTypeFragment}
+    query getPlatformCVEMetadata($cveID: String!, $query: String!) {
+        totalClusterCount: clusterCount
+        clusterCount(query: $query)
+        platformCVE(cveID: $cveID, subfieldScopeQuery: $query) {
+            ...ClustersByType
+        }
+    }
+`;
+
+export default function usePlatformCveSummaryData({
+    cveId,
+    query,
+}: {
+    cveId: string;
+    query: string;
+}) {
+    return useQuery<{
+        totalClusterCount: number;
+        clusterCount: number;
+        platformCVE?: ClustersByType;
+    }>(platformCveSummaryDataQuery, {
+        variables: {
+            cveID: cveId,
+            query,
+        },
+    });
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -76,7 +76,8 @@ export function getPlatformEntityPagePath(
     const queryString = getQueryString(queryOptions);
     switch (platformCveEntity) {
         case 'CVE':
-            return `${vulnerabilitiesPlatformCvesPath}/cves/${id}${queryString}`;
+            // We need to encode the id here due to the `#` character literal in Platform CVE IDs
+            return `${vulnerabilitiesPlatformCvesPath}/cves/${encodeURIComponent(id)}${queryString}`;
         case 'Cluster':
             return `${vulnerabilitiesPlatformCvesPath}/clusters/${id}${queryString}`;
         default:


### PR DESCRIPTION
## Description

Changes required to sync the UI with the production BE GraphQL queries for the **Platform CVE Single page**.

Uses build 4.4.x-1011-gd887ad5d6a from https://github.com/stackrox/stackrox/pull/11604 for testing.


### Notes

1. The `usePlatformCveMetadata` hook to fetch page header and summary card data was split into `usePlatformCveMetadata` and `usePlatformCveSummaryData` hooks. Since the summary card data is affected by a change in filters, but the header data isn't, a split here avoids showing more indeterminate loading elements on the page and saves us some additional error handling.
2. Since a Platform CVE's `ID` field is a concatenation of `<CVE Name>`, `#`, `<CVE_TYPE>` we need to encode/decode this value in the URL. Otherwise the browser will interpret the `#` as the fragment identifier of the URL and cause the page to load incorrectly.
3. The fields returned for a Platform CVE are different enough from other CVE types that I didn't think it made sense to complicate the `<CvePageHeader />` component with generic field handling, so I inlined the single-use header directly in the Page component. If we feel it is valuable enough to abstract these into a more common layout we can revisit in a follow up.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a Platform CVE single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/39d025b5-9f9c-4419-bd7d-d7903d123e94)

Test filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/f486659d-7ec2-4e40-8d50-31d2e6f17a67)

