### PR TITLE
ROX-24836: Integrate Node CVE overview page with API

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -27,6 +27,7 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { ApiSortOption } from 'types/search';
 
 import ExpandRowTh from 'Components/ExpandRowTh';
+import { vulnerabilitySeverityLabels } from 'messages/common';
 import {
     CVE_SORT_FIELD,
     NODE_COUNT_SORT_FIELD,
@@ -38,7 +39,7 @@ import CVESelectionTh from '../../components/CVESelectionTh';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { getScoreVersionsForTopCVSS, sortCveDistroList } from '../../utils/sortUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { QuerySearchFilter } from '../../types';
+import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
 import useNodeCves from './useNodeCves';
 import useTotalNodeCount from './useTotalNodeCount';
 
@@ -50,7 +51,7 @@ export const sortFields = [
     // FIRST_DISCOVERED_SORT_FIELD,
 ];
 
-export const defaultSortOption = { field: NODE_TOP_CVSS_SORT_FIELD, direction: 'desc' } as const;
+export const defaultSortOption = { field: CVE_SORT_FIELD, direction: 'desc' } as const;
 
 export type CVEsTableProps = {
     querySearchFilter: QuerySearchFilter;
@@ -94,6 +95,10 @@ function CVEsTable({
     const expandedRowSet = useSet<string>();
     const colSpan = canSelectRows ? 8 : 6;
 
+    const filteredSeverities = querySearchFilter.SEVERITY?.map(
+        (s) => vulnerabilitySeverityLabels[s]
+    ).filter(isVulnerabilitySeverityLabel);
+
     return (
         <Table
             borders={tableState.type === 'COMPLETE'}
@@ -133,7 +138,7 @@ function CVEsTable({
                     data.map((nodeCve, rowIndex) => {
                         const {
                             cve,
-                            nodeCountBySeverity: { critical, important, moderate, low },
+                            affectedNodeCountBySeverity: { critical, important, moderate, low },
                             distroTuples,
                             topCVSS,
                             affectedNodeCount,
@@ -172,7 +177,7 @@ function CVEsTable({
                                             importantCount={important.total}
                                             moderateCount={moderate.total}
                                             lowCount={low.total}
-                                            // TODO - Add filtered severities once filter toolbar is in place
+                                            filteredSeverities={filteredSeverities}
                                         />
                                     </Td>
                                     <Td dataLabel="Top CVSS">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -8,7 +8,7 @@ const cvesListQuery = gql`
     query getNodeCVEs($query: String, $pagination: Pagination) {
         nodeCVEs(query: $query, pagination: $pagination) {
             cve
-            nodeCountBySeverity {
+            affectedNodeCountBySeverity {
                 critical {
                     total
                 }
@@ -35,10 +35,9 @@ const cvesListQuery = gql`
     }
 `;
 
-// TODO Need to verify these types with the BE implementation
 export type NodeCVE = {
     cve: string;
-    nodeCountBySeverity: {
+    affectedNodeCountBySeverity: {
         critical: { total: number };
         important: { total: number };
         moderate: { total: number };


### PR DESCRIPTION
## Description

Changes required to sync the UI with the production BE GraphQL queries on the Node CVE Overview page.

Uses build 4.4.x-1054-g98250e1bd8 from https://github.com/stackrox/stackrox/pull/11623 for testing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Node CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/86a98fbd-f5c8-4ebe-a26e-c21d51a1a5a9)

Nodes tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/6b378b01-f680-4eda-8638-b7e2a735b94b)

Filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/b88739bd-b1d1-42d8-8977-058a8b5cd92b)

Snoozed CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/3d87d222-9502-4df9-a9ff-e62d0d2e0268)

