### PR TITLE
ROX-21577: return only well-cooked errors from API or generic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,7 @@ linters-settings:
       - errox\.MakeSensitive
       - retry\.MakeRetryable
       - policy\.NewErr.*
+      - status\.Error[f]?
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/central/main.go
+++ b/central/main.go
@@ -593,7 +593,7 @@ func startGRPCServer() {
 		Endpoints:          endpointCfgs,
 	}
 
-	if env.EnableErrorConcealement.BooleanSetting() {
+	if env.EnableErrorConcealment.BooleanSetting() {
 		config.UnaryInterceptors = append(config.UnaryInterceptors,
 			errors.ConcealErrorInterceptor)
 		config.StreamInterceptors = append(config.StreamInterceptors,

--- a/central/main.go
+++ b/central/main.go
@@ -593,6 +593,13 @@ func startGRPCServer() {
 		Endpoints:          endpointCfgs,
 	}
 
+	if env.EnableErrorConcealement.BooleanSetting() {
+		config.UnaryInterceptors = append(config.UnaryInterceptors,
+			errors.ConcealErrorInterceptor)
+		config.StreamInterceptors = append(config.StreamInterceptors,
+			errors.ConcealErrorStreamInterceptor)
+	}
+
 	if devbuild.IsEnabled() {
 		config.UnaryInterceptors = append(config.UnaryInterceptors,
 			errors.LogInternalErrorInterceptor,

--- a/pkg/env/error_concealement.go
+++ b/pkg/env/error_concealement.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// EnableErrorConcealement configures central to drop messages of errors, not
+	// wrapped with errox.SensitiveError.
+	EnableErrorConcealement = RegisterBooleanSetting("ROX_ENABLE_ERROR_CONCEALEMENT", false)
+)

--- a/pkg/env/error_concealement.go
+++ b/pkg/env/error_concealement.go
@@ -1,7 +1,7 @@
 package env
 
 var (
-	// EnableErrorConcealement configures central to drop messages of errors, not
+	// EnableErrorConcealment configures central to drop messages of errors, not
 	// wrapped with errox.SensitiveError.
-	EnableErrorConcealement = RegisterBooleanSetting("ROX_ENABLE_ERROR_CONCEALEMENT", false)
+	EnableErrorConcealment = RegisterBooleanSetting("ROX_ENABLE_ERROR_CONCEALMENT", false)
 )

--- a/pkg/errox/roxerror_test.go
+++ b/pkg/errox/roxerror_test.go
@@ -86,3 +86,13 @@ func TestCausedBy(t *testing.T) {
 		assert.ErrorIs(t, err, NotFound)
 	}
 }
+
+func TestSentinelMessage(t *testing.T) {
+	assert.Equal(t, "not found", GetBaseSentinelMessage(NotFound))
+	assert.Equal(t, "not found", GetBaseSentinelMessage(NotFound.CausedBy(InvalidArgs)))
+	assert.Equal(t, "not found", GetBaseSentinelMessage(NotFound.CausedBy("secret")))
+	assert.Equal(t, "not found", GetBaseSentinelMessage(errors.WithMessage(NotFound, "secret")))
+	assert.Equal(t, "not found", GetBaseSentinelMessage(errors.WithMessage(NotFound.New("secret"), "secret")))
+	assert.Equal(t, "not found", GetBaseSentinelMessage(NotFound.New("secret")))
+	assert.Equal(t, "", GetBaseSentinelMessage(errors.New("abc")))
+}

--- a/pkg/errox/utils.go
+++ b/pkg/errox/utils.go
@@ -14,3 +14,16 @@ func IsAny(err error, targets ...error) bool {
 	}
 	return false
 }
+
+// GetBaseSentinelMessage returns the error message of the lowest found
+// sentinel error.
+func GetBaseSentinelMessage(err error) string {
+	var re Error
+	for errors.As(err, &re) {
+		err = errors.Unwrap(re)
+	}
+	if re, ok := (re).(*RoxError); ok && re != nil {
+		return re.message
+	}
+	return ""
+}

--- a/pkg/errox/utils.go
+++ b/pkg/errox/utils.go
@@ -15,15 +15,13 @@ func IsAny(err error, targets ...error) bool {
 	return false
 }
 
-// GetBaseSentinelMessage returns the error message of the lowest found
-// sentinel error.
-func GetBaseSentinelMessage(err error) string {
+// GetBaseSentinelError returns the lowest found sentinel error, and the flag
+// that tells whether the error has been found.
+func GetBaseSentinelError(err error) (error, bool) {
 	var re Error
 	for errors.As(err, &re) {
 		err = errors.Unwrap(re)
 	}
-	if re, ok := (re).(*RoxError); ok && re != nil {
-		return re.message
-	}
-	return ""
+	re, ok := (re).(*RoxError)
+	return re, ok
 }

--- a/pkg/grpc/errors/interceptor.go
+++ b/pkg/grpc/errors/interceptor.go
@@ -62,9 +62,11 @@ func logErrorIfInternal(err error) {
 }
 
 func concealError(err error) error {
-	var serr errox.SensitiveError
-	if _, ok := status.FromError(err); ok || errors.As(err, &serr) {
+	if serr := (errox.SensitiveError)(nil); errors.As(err, &serr) {
 		return err
+	}
+	if s, ok := status.FromError(err); ok {
+		return status.Error(s.Code(), s.Code().String())
 	}
 	if message := errox.GetBaseSentinelMessage(err); message != "" {
 		return errors.New(message)

--- a/pkg/grpc/errors/interceptor.go
+++ b/pkg/grpc/errors/interceptor.go
@@ -68,8 +68,8 @@ func concealError(err error) error {
 	if s, ok := status.FromError(err); ok {
 		return status.Error(s.Code(), s.Code().String())
 	}
-	if message := errox.GetBaseSentinelMessage(err); message != "" {
-		return errors.New(message)
+	if err, ok := errox.GetBaseSentinelError(err); ok {
+		return err
 	}
 	return errox.ServerError
 }

--- a/pkg/grpc/errors/interceptor.go
+++ b/pkg/grpc/errors/interceptor.go
@@ -63,7 +63,7 @@ func logErrorIfInternal(err error) {
 
 func concealError(err error) error {
 	var serr errox.SensitiveError
-	if err == nil || errors.As(err, &serr) {
+	if _, ok := status.FromError(err); ok || errors.As(err, &serr) {
 		return err
 	}
 	if message := errox.GetBaseSentinelMessage(err); message != "" {
@@ -78,9 +78,7 @@ func ConcealErrorInterceptor(ctx context.Context, req interface{}, _ *grpc.Unary
 }
 
 func ConcealErrorStreamInterceptor(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	err := handler(srv, ss)
-	logErrorIfInternal(err)
-	return concealError(err)
+	return concealError(handler(srv, ss))
 }
 
 // ErrorToGrpcCodeInterceptor translates common errors defined in errorhelpers to GRPC codes.

--- a/pkg/grpc/errors/interceptor_test.go
+++ b/pkg/grpc/errors/interceptor_test.go
@@ -316,9 +316,10 @@ func Test_concealError(t *testing.T) {
 			"invalid arguments",
 		},
 		"http status": {
-			status.Error(codes.NotFound, "not found"),
-			"rpc error: code = NotFound desc = not found",
-			"rpc error: code = NotFound desc = not found",
+			// gRPC status message is dropped.
+			status.Error(codes.NotFound, "absent"),
+			"rpc error: code = NotFound desc = NotFound",
+			"rpc error: code = NotFound desc = NotFound",
 		},
 	}
 

--- a/pkg/grpc/errors/interceptor_test.go
+++ b/pkg/grpc/errors/interceptor_test.go
@@ -315,6 +315,12 @@ func Test_concealError(t *testing.T) {
 			"invalid arguments",
 			"invalid arguments",
 		},
+		"custom sentinel": {
+			// Only the bottom sentinel error never contains sensitive messages.
+			errors.WithMessage(errox.InvalidArgs.New("secret"), "hidden"),
+			"invalid arguments",
+			"invalid arguments",
+		},
 		"http status": {
 			// gRPC status message is dropped.
 			status.Error(codes.NotFound, "absent"),

--- a/pkg/grpc/errors/interceptor_test.go
+++ b/pkg/grpc/errors/interceptor_test.go
@@ -315,6 +315,11 @@ func Test_concealError(t *testing.T) {
 			"invalid arguments",
 			"invalid arguments",
 		},
+		"http status": {
+			status.Error(codes.NotFound, "not found"),
+			"rpc error: code = NotFound desc = not found",
+			"rpc error: code = NotFound desc = not found",
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -206,7 +206,6 @@ func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 	// to gRPC status codes.
 	u = append(u, grpc_prometheus.UnaryServerInterceptor)
 	u = append(u, grpc_errors.ErrorToGrpcCodeInterceptor)
-	u = append(u, grpc_errors.ConcealErrorInterceptor)
 
 	if a.config.RateLimiter != nil {
 		u = append(u, a.config.RateLimiter.GetUnaryServerInterceptor())
@@ -254,7 +253,6 @@ func (a *apiImpl) streamInterceptors() []grpc.StreamServerInterceptor {
 	// to gRPC status codes.
 	s = append(s, grpc_prometheus.StreamServerInterceptor)
 	s = append(s, grpc_errors.ErrorToGrpcCodeStreamInterceptor)
-	s = append(s, grpc_errors.ConcealErrorStreamInterceptor)
 
 	if a.config.RateLimiter != nil {
 		s = append(s, a.config.RateLimiter.GetStreamServerInterceptor())

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -201,6 +201,9 @@ func (a *apiImpl) Stop() bool {
 func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 	var u []grpc.UnaryServerInterceptor
 
+	// Conceal errors out of the metrics interceptor to not break the stats.
+	u = append(u, grpc_errors.ConcealErrorInterceptor)
+
 	// The metrics and error interceptors are first in line, i.e., outermost, to
 	// make sure all requests are registered in Prometheus with errors converted
 	// to gRPC status codes.
@@ -247,6 +250,9 @@ func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 
 func (a *apiImpl) streamInterceptors() []grpc.StreamServerInterceptor {
 	var s []grpc.StreamServerInterceptor
+
+	// Conceal errors out of the metrics interceptor to not break the stats.
+	s = append(s, grpc_errors.ConcealErrorStreamInterceptor)
 
 	// The metrics and error interceptors are first in line, i.e., outermost, to
 	// make sure all requests are registered in Prometheus with errors converted

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -201,14 +201,12 @@ func (a *apiImpl) Stop() bool {
 func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 	var u []grpc.UnaryServerInterceptor
 
-	// Conceal errors out of the metrics interceptor to not break the stats.
-	u = append(u, grpc_errors.ConcealErrorInterceptor)
-
 	// The metrics and error interceptors are first in line, i.e., outermost, to
 	// make sure all requests are registered in Prometheus with errors converted
 	// to gRPC status codes.
 	u = append(u, grpc_prometheus.UnaryServerInterceptor)
 	u = append(u, grpc_errors.ErrorToGrpcCodeInterceptor)
+	u = append(u, grpc_errors.ConcealErrorInterceptor)
 
 	if a.config.RateLimiter != nil {
 		u = append(u, a.config.RateLimiter.GetUnaryServerInterceptor())
@@ -251,14 +249,12 @@ func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 func (a *apiImpl) streamInterceptors() []grpc.StreamServerInterceptor {
 	var s []grpc.StreamServerInterceptor
 
-	// Conceal errors out of the metrics interceptor to not break the stats.
-	s = append(s, grpc_errors.ConcealErrorStreamInterceptor)
-
 	// The metrics and error interceptors are first in line, i.e., outermost, to
 	// make sure all requests are registered in Prometheus with errors converted
 	// to gRPC status codes.
 	s = append(s, grpc_prometheus.StreamServerInterceptor)
 	s = append(s, grpc_errors.ErrorToGrpcCodeStreamInterceptor)
+	s = append(s, grpc_errors.ConcealErrorStreamInterceptor)
 
 	if a.config.RateLimiter != nil {
 		s = append(s, a.config.RateLimiter.GetStreamServerInterceptor())


### PR DESCRIPTION
Added `ROX_ENABLE_ERROR_CONCEALMENT` variable that enables error concealment gRPC interceptor.

The gRPC interceptor removes all error details from the service error, except if:

* `errox.SensitiveError` is found in the chain — passed as is;
* `errox.Error` is found in the chain — only the generic sentinel message is passed;
* the error is a `status.Status` — error message replaced with the generic status message.

## Testing Performed

### Command
```console
me@work$ curl -u admin:password -k -i -X POST https://localhost:8443/v1/db/interruptrestore/0/0
```

#### With `ROX_ENABLE_ERROR_CONCEALMENT=false`

```http
HTTP/2 400 
content-type: application/json
vary: Accept-Encoding
content-length: 133
date: Fri, 21 Jun 2024 10:00:22 GMT

{"error":"no restore process is currently in progress","code":9,"message":"no restore process is currently in progress","details":[]}
```

#### With `ROX_ENABLE_ERROR_CONCEALMENT=true`

```http
HTTP/2 400 
content-type: application/json
vary: Accept-Encoding
content-length: 83
date: Fri, 21 Jun 2024 09:56:26 GMT

{"error":"FailedPrecondition","code":9,"message":"FailedPrecondition","details":[]}
```

### Command

```console
me@work$ bin/linux_amd64/roxctl --use-current-k8s-context image scan --image ubuntu -p password
```

#### With either `ROX_ENABLE_ERROR_CONCEALMENT`

`ERROR:	Scanning image failed: retrieving image scan result: could not scan image: "ubuntu": rpc error: code = Internal desc = image enrichment error: error scanning image: docker.io/library/ubuntu:latest error: scanning "docker.io/library/ubuntu:latest" with scanner "Stackrox Scanner": dial tcp: connect: connection refused. Retrying after 3 seconds...`

### Command

```console
me@work$ curl -u admin:password -k https://localhost:8443/v1/administration/events/$(uuid) -i
```

#### With `ROX_ENABLE_ERROR_CONCEALMENT=false`

```http
HTTP/2 404 
content-type: application/json
vary: Accept-Encoding
content-length: 343
date: Fri, 21 Jun 2024 11:42:20 GMT

{"error":"failed to get administration event \"51a99626-2fc3-11ef-a4c6-8c8caaddc7a9\": administration event \"51a99626-2fc3-11ef-a4c6-8c8caaddc7a9\" not found","code":5,"message":"failed to get administration event \"51a99626-2fc3-11ef-a4c6-8c8caaddc7a9\": administration event \"51a99626-2fc3-11ef-a4c6-8c8caaddc7a9\" not found","details":[]}
```

#### With `ROX_ENABLE_ERROR_CONCEALMENT=true`

```http
HTTP/2 404 
content-type: application/json
vary: Accept-Encoding
content-length: 65
date: Fri, 21 Jun 2024 11:42:52 GMT

{"error":"not found","code":5,"message":"not found","details":[]}
```