### PR TITLE
fix(CI): artifact download/upload retry & failure propagation

### DIFF
--- a/.github/actions/download-artifact-with-retry/action.yaml
+++ b/.github/actions/download-artifact-with-retry/action.yaml
@@ -20,6 +20,7 @@ runs:
       run: |
         echo outcome ${{ steps.download-artifact-try1.outcome }}
         echo object  ${{ steps.download-artifact-try1 }}
+      shell: bash
     - name: download-artifact-try2
       if: steps.download-artifact-try1.outcome == 'failure'
       uses: actions/download-artifact@v4

--- a/.github/actions/download-artifact-with-retry/action.yaml
+++ b/.github/actions/download-artifact-with-retry/action.yaml
@@ -16,11 +16,6 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
       continue-on-error: true
-    - name: check outcome try1
-      run: |
-        echo outcome ${{ steps.download-artifact-try1.outcome }}
-        echo object  ${{ steps.download-artifact-try1 }}
-      shell: bash
     - id: download-artifact-try2
       if: steps.download-artifact-try1.outcome == 'failure'
       uses: actions/download-artifact@v4

--- a/.github/actions/download-artifact-with-retry/action.yaml
+++ b/.github/actions/download-artifact-with-retry/action.yaml
@@ -16,6 +16,10 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
       continue-on-error: true
+    - name: check outcome try1
+      run: |
+        echo outcome ${{ steps.download-artifact-try1.outcome }}
+        echo object  ${{ steps.download-artifact-try1 }}
     - name: download-artifact-try2
       if: steps.download-artifact-try1.outcome == 'failure'
       uses: actions/download-artifact@v4

--- a/.github/actions/download-artifact-with-retry/action.yaml
+++ b/.github/actions/download-artifact-with-retry/action.yaml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: download-artifact-try1
+    - id: download-artifact-try1
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
@@ -21,15 +21,14 @@ runs:
         echo outcome ${{ steps.download-artifact-try1.outcome }}
         echo object  ${{ steps.download-artifact-try1 }}
       shell: bash
-    - name: download-artifact-try2
+    - id: download-artifact-try2
       if: steps.download-artifact-try1.outcome == 'failure'
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
       continue-on-error: true
-    - name: download-artifact-try3
-      if: steps.download-artifact-try2.outcome == 'failure'
+    - if: steps.download-artifact-try2.outcome == 'failure'
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}

--- a/.github/actions/upload-artifact-with-retry/action.yaml
+++ b/.github/actions/upload-artifact-with-retry/action.yaml
@@ -19,14 +19,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: upload-artifact-try1
+    - id: upload-artifact-try1
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
       continue-on-error: true
-    - name: upload-artifact-try2
+    - id: upload-artifact-try2
       if: steps.upload-artifact-try1.outcome == 'failure'
       uses: actions/upload-artifact@v4
       with:
@@ -34,8 +34,7 @@ runs:
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
       continue-on-error: true
-    - name: upload-artifact-try3
-      if: steps.upload-artifact-try2.outcome == 'failure'
+    - if: steps.upload-artifact-try2.outcome == 'failure'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -252,6 +252,7 @@ jobs:
 
   build-and-push-main:
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     needs:
       - define-job-matrix
       - pre-build-ui

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,12 @@ jobs:
         run: make -C ui deps
 
       - name: Build UI
-        run: make -C ui build
+        run: |
+          if [[ ${{env.ROX_PRODUCT_BRANDING}} == "STACKROX_BRANDING" ]]; then
+            make -C ui break-build
+          else
+            make -C ui build
+          fi
 
       - uses: ./.github/actions/upload-artifact-with-retry
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,12 +98,7 @@ jobs:
         run: make -C ui deps
 
       - name: Build UI
-        run: |
-          if [[ ${{env.ROX_PRODUCT_BRANDING}} == "STACKROX_BRANDING" ]]; then
-            make -C ui break-build
-          else
-            make -C ui build
-          fi
+        run: make -C ui build
 
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
@@ -252,7 +247,6 @@ jobs:
 
   build-and-push-main:
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
     needs:
       - define-job-matrix
       - pre-build-ui


### PR DESCRIPTION
## Description

When checking #11593 I noticed that the download-artifact-with-retry action was not retrying and was not propagating error to its users. This was due to the steps using `name:` as the reference for outcome where it should be `id:`. This also causes the propagation error because the `continue-on-error: true` in the first step is propagated to the action user (`build.yaml` in this case).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- The original forced download failure (missing artifact on #11593) https://github.com/stackrox/stackrox/actions/runs/9573456734/job/26395165226#step:10:25
- Repro with debug commits to force a failure and switched to `id` on this PR. Retry is attempted and failure is propagated: https://github.com/stackrox/stackrox/actions/runs/9603709451/job/26487955525#step:10:1

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
