### PR TITLE
ROX-24837: Integrate node CVE single page with BE

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -43,7 +43,11 @@ function mockNode(fields) {
 function setup(tableState) {
     cy.mount(
         <ComponentTestProviders>
-            <AffectedNodesTable tableState={tableState} getSortParams={() => {}} />
+            <AffectedNodesTable
+                tableState={tableState}
+                getSortParams={() => {}}
+                onClearFilters={() => {}}
+            />
         </ComponentTestProviders>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -89,10 +89,15 @@ export type AffectedNode = {
 export type AffectedNodesTableProps = {
     tableState: TableUIState<AffectedNode>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 // TODO Add filter icon to dynamic table columns
-function AffectedNodesTable({ tableState, getSortParams }: AffectedNodesTableProps) {
+function AffectedNodesTable({
+    tableState,
+    getSortParams,
+    onClearFilters,
+}: AffectedNodesTableProps) {
     const colSpan = 8;
     const expandedRowSet = useSet<string>();
 
@@ -122,6 +127,7 @@ function AffectedNodesTable({ tableState, getSortParams }: AffectedNodesTablePro
                 emptyProps={{
                     message: 'There are no nodes that are affected by this CVE',
                 }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((node, rowIndex) => {
                         const { id, name, nodeComponents } = node;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveMetadata.ts
@@ -1,13 +1,10 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
 import { CveMetadata } from '../../components/CvePageHeader';
 
 const metadataQuery = gql`
-    query getNodeCVEMetadata($cve: String!, $query: String!) {
-        totalNodeCount: nodeCount
-        nodeCount(query: $query)
-        nodeCVE(cve: $cve, subfieldScopeQuery: $query) {
+    query getNodeCVEMetadata($cve: String!) {
+        nodeCVE(cve: $cve) {
             cve
             distroTuples {
                 summary
@@ -15,51 +12,25 @@ const metadataQuery = gql`
                 operatingSystem
             }
             firstDiscoveredInSystem
-            nodeCountBySeverity {
-                critical {
-                    total
-                }
-                important {
-                    total
-                }
-                moderate {
-                    total
-                }
-                low {
-                    total
-                }
-            }
         }
     }
 `;
 
-export default function useNodeCveMetadata(cveId: string, query: string) {
+export default function useNodeCveMetadata(cveId: string) {
     const metadataRequest = useQuery<
         {
-            totalNodeCount: number;
-            nodeCount: number;
-            nodeCVE: CveMetadata & {
-                nodeCountBySeverity: ResourceCountsByCveSeverity;
-            };
+            nodeCVE?: CveMetadata;
         },
-        {
-            cve: string;
-            query: string;
-        }
+        { cve: string }
     >(metadataQuery, {
-        variables: {
-            cve: cveId,
-            query,
-        },
+        variables: { cve: cveId },
     });
 
     const { data, previousData } = metadataRequest;
-    const nodeCount = data?.nodeCount ?? previousData?.nodeCount ?? 0;
     const cveData = data?.nodeCVE ?? previousData?.nodeCVE;
 
     return {
         metadataRequest,
-        nodeCount,
         cveData,
     };
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
@@ -1,0 +1,61 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
+
+const summaryDataQuery = gql`
+    query getNodeCVESummaryData($cve: String!, $query: String!) {
+        totalNodeCount: nodeCount
+        nodeCount(query: $query)
+        nodeCVE(cve: $cve, subfieldScopeQuery: $query) {
+            distroTuples {
+                operatingSystem
+            }
+            affectedNodeCountBySeverity {
+                critical {
+                    total
+                }
+                important {
+                    total
+                }
+                moderate {
+                    total
+                }
+                low {
+                    total
+                }
+            }
+        }
+    }
+`;
+
+export default function useNodeCveSummaryData(cveId: string, query: string) {
+    const summaryDataRequest = useQuery<
+        {
+            totalNodeCount: number;
+            nodeCount: number;
+            nodeCVE?: {
+                distroTuples: {
+                    operatingSystem: string;
+                }[];
+                affectedNodeCountBySeverity: ResourceCountsByCveSeverity;
+            };
+        },
+        {
+            cve: string;
+            query: string;
+        }
+    >(summaryDataQuery, {
+        variables: {
+            cve: cveId,
+            query,
+        },
+    });
+
+    const { data, previousData } = summaryDataRequest;
+    const nodeCount = data?.nodeCount ?? previousData?.nodeCount ?? 0;
+
+    return {
+        summaryDataRequest,
+        nodeCount,
+    };
+}


### PR DESCRIPTION
## Description

Changes required to sync the UI with the production BE GraphQL queries on the Node CVE Single page.

Uses build 4.4.x-1054-g98250e1bd8 from https://github.com/stackrox/stackrox/pull/11623 for testing.

## Of note

1. This PR splits the metadata hook into two hooks, like done in Platform CVEs, in order to only re-fetch data that is reliant on query filters.
2. This also hooks up the `onClearFilters` button of `<TbodyUnified />` to allow proper clearing of filters via the table.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Visit a Node CVE single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/9ce9cfe6-74b9-4feb-a78c-fa8e3001cc9c)

Filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/744493cd-dc8f-432f-a29a-4e2e903ee050)
![image](https://github.com/stackrox/stackrox/assets/1292638/b8db3840-df02-49e9-bc63-a62812b0d278)

