### PR TITLE
ROX-24889: Fix accessibility issues in compliance coverage

### DIFF
--- a/ui/apps/platform/src/Components/ComplianceUsageDisclaimer.tsx
+++ b/ui/apps/platform/src/Components/ComplianceUsageDisclaimer.tsx
@@ -19,6 +19,7 @@ function ComplianceUsageDisclaimer({ className, onAccept }: ComplianceUsageDiscl
                 variant="info"
                 isInline
                 title="Usage disclaimer"
+                component="div"
                 actionLinks={
                     <>
                         <AlertActionLink onClick={onAccept}>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfilesToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfilesToggleGroup.tsx
@@ -31,6 +31,8 @@ function isStandardInProfile(standardShortName: string, profile: ComplianceProfi
     );
 }
 
+const tabContentId = 'profiles-toggle-group';
+
 type ProfilesToggleGroupProps = {
     profileName: string;
     profiles: ComplianceProfileSummary[];
@@ -91,10 +93,12 @@ function ProfilesToggleGroup({
                         key={standardShortName}
                         eventKey={standardShortName}
                         title={standardShortName}
+                        tabContentId={tabContentId}
                     />
                 ))}
             </Tabs>
             <ToggleGroup
+                id={tabContentId}
                 aria-label="Toggle for selected profile view"
                 className="pf-v5-u-background-color-100 pf-v5-u-p-md"
             >

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -414,7 +414,12 @@ function NavigationSidebar({
                                                 />
                                             );
                                         }
-                                        return <NavItemSeparator key={childDescription.key} />;
+                                        return (
+                                            <NavItemSeparator
+                                                key={childDescription.key}
+                                                role="listitem"
+                                            />
+                                        );
                                     })}
                                 </NavExpandable>
                             );


### PR DESCRIPTION
## Description

### Problems according to axe DevTools

1. Certain ARIA roles must contain particular children
    `<ul class="pf-v5-c-nav__list" role="list">`

    Related node
    `<li class="pf-v5-c-divider" role="separator"></li>`

2. ARIA attributes must conform to valid values
    `<button type="button" data-ouia-component-type="PF5/TabButton" data-ouia-safe="true" class="pf-v5-c-tabs__link" id="pf-tab-E8-pf-1718893766426hxhq5vpnpf7" aria-controls="pf-tab-section-E8-pf-1718893766426hxhq5vpnpf7" role="tab" aria-selected="true">E8</button>`

    Invalid ARIA attribute value
    `aria-controls="pf-tab-section-E8-pf-1718893766426hxhq5vpnpf7"`

3. Heading levels should only increase by one
    `<h4 class="pf-v5-c-alert__title"><span class="pf-v5-screen-reader">Info alert:</span>Usage disclaimer</h4>`

### Analysis

1. This is a generic problem with any divider in left navigation.

    Defaults are inconsistent when we compose PatternFly elements.

    PatternFly `NavList` element renders `ul` with `role="list"` prop:
    https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Nav/NavList.tsx#L160

    Better if it did not, according to MDN:
    https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/list_role#best_practices
    > Only use `role="list"` and `role="listitem"` if you have to

    PatternFly `NavItemSeparator` renders `Divider` with `component="li"` which renders `li` with `role="separator"` prop:
    https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Divider/Divider.tsx#L54

    But `separator` is not a valid role of child if parent has role `list`

    And default `hr` element is not a valid substitute for `li` element in this context.

2. Same as an issue fixed in #11512

    Without `tabContentId` prop, PatternFly renders `aria-controls` prop whose value does not correspond to any `id` prop in the page.

3. Page has `h1` and `h2` headings but `Alert` element renders `h4` heading by default.

### Solutions

1. Add `role="listitem"` prop in `NavItemSeparator` element.

2. Add `tabContentId` prop whose value corresponds to `id` prop of `ToggleGroup` element.

3. Add `component="h4"` prop in `Alert` element.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/compliance/coverage/profiles/profile/checks

    * with issues before changes
        ![coverage_with_issues](https://github.com/stackrox/stackrox/assets/11862657/fbcd79e4-cb62-4cc5-9e0c-64a64aa86515)

    * Solution 1
        ![NavItemSeparator_role_listitem](https://github.com/stackrox/stackrox/assets/11862657/a5ebb71f-ce9b-4447-8ce0-b3c636feff2c)

    * Solution 2
        ![ProfilesToggleGroup_tabContentId](https://github.com/stackrox/stackrox/assets/11862657/50a415e9-6185-485d-aa1c-8d97f2f1f18a)

    * Solution 3
        ![ComplianceUsageDisclaimer_Alert_component_div](https://github.com/stackrox/stackrox/assets/11862657/fa086153-15b6-4502-80ab-87dfa9db8c89)
