### PR TITLE
fix(store): respect context cancelation

### DIFF
--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -70,10 +70,10 @@ func IsTransientError(err error) bool {
 	if errox.IsAny(err, pgx.ErrNoRows, pgx.ErrTxClosed, pgx.ErrTxCommitRollback) {
 		return false
 	}
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return true
+	if errox.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+		return false
 	}
-	if errox.IsAny(err, context.DeadlineExceeded) {
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		return true
 	}
 	if errox.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE) {

--- a/pkg/postgres/pgutils/error_test.go
+++ b/pkg/postgres/pgutils/error_test.go
@@ -16,6 +16,10 @@ func TestWrappedErrors(t *testing.T) {
 	multiError1Error := errorhelpers.NewErrorList("hello")
 	multiError1Error.AddError(context.DeadlineExceeded)
 
+	multiErrorCanceled := errorhelpers.NewErrorList("hello")
+	multiErrorCanceled.AddError(context.Canceled)
+	multiErrorCanceled.AddErrors(errors.New("other error"))
+
 	multiErrorDeadlineExceeded := errorhelpers.NewErrorList("hello")
 	multiErrorDeadlineExceeded.AddError(context.DeadlineExceeded)
 	multiErrorDeadlineExceeded.AddErrors(errors.New("other error"))
@@ -33,8 +37,12 @@ func TestWrappedErrors(t *testing.T) {
 			transient: false,
 		},
 		{
+			err:       errors.Wrap(context.Canceled, "hello"),
+			transient: false,
+		},
+		{
 			err:       errors.Wrap(context.DeadlineExceeded, "hello"),
-			transient: true,
+			transient: false,
 		},
 		{
 			err:       errors.Wrap(errors.Wrap(io.EOF, "1"), "2"),
@@ -50,11 +58,15 @@ func TestWrappedErrors(t *testing.T) {
 		},
 		{
 			err:       multiError1Error.ToError(),
-			transient: true,
+			transient: false,
+		},
+		{
+			err:       multiErrorCanceled.ToError(),
+			transient: false,
 		},
 		{
 			err:       multiErrorDeadlineExceeded.ToError(),
-			transient: true,
+			transient: false,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -310,6 +310,9 @@ func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, f
 	c.cacheLock.RLock()
 	defer c.cacheLock.RUnlock()
 	for _, id := range identifiers {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		obj, found := c.cache[id]
 		if !found {
 			log.Warnf("Object %q not found in store cache", id)
@@ -414,6 +417,9 @@ func (c *cachedStore[T, PT]) GetAll(ctx context.Context) ([]PT, error) {
 
 func (c *cachedStore[T, PT]) walkCacheNoLock(ctx context.Context, fn func(obj PT) error) error {
 	for _, obj := range c.cache {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if !c.isReadAllowed(ctx, obj) {
 			continue
 		}

--- a/pkg/search/postgres/store_cache_test.go
+++ b/pkg/search/postgres/store_cache_test.go
@@ -248,6 +248,25 @@ func TestCachedWalk(t *testing.T) {
 	assert.ElementsMatch(t, testObjects, walkedObjects)
 }
 
+func TestCachedWalkContextCancelation(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	store := newCachedStore(testDB)
+	require.NotNil(t, store)
+
+	testObjects := sampleCachedTestSingleKeyStructArray("Walk")
+	err := store.UpsertMany(cachedStoreCtx, testObjects)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(cachedStoreCtx)
+	cancel()
+	walkFn := func(obj *storage.TestSingleKeyStruct) error {
+		return nil
+	}
+	err = store.Walk(ctx, walkFn)
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestCachedWalkByQuery(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	store := newCachedStore(testDB)
@@ -281,6 +300,25 @@ func TestCachedWalkByQuery(t *testing.T) {
 	}
 	assert.ElementsMatch(t, expectedNames, walkedNames)
 	assert.ElementsMatch(t, expectedObjects, walkedObjects)
+}
+
+func TestCachedWalkByQueryContextCancelation(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	store := newCachedStore(testDB)
+	require.NotNil(t, store)
+
+	testObjects := sampleCachedTestSingleKeyStructArray("WalkByQuery")
+	err := store.UpsertMany(cachedStoreCtx, testObjects)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(cachedStoreCtx)
+	cancel()
+	walkFn := func(obj *storage.TestSingleKeyStruct) error {
+		return nil
+	}
+	err = store.WalkByQuery(ctx, nil, walkFn)
+
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestCachedGetAll(t *testing.T) {


### PR DESCRIPTION
## Description

When walking the store cache, we currently do not respect context cancelations. Since we don't control the callback function, this may lead to unexpected runtimes and disregard of timeouts. This PR adds explicit context checks for the cached store to more closely mimmick the behavior of the underlying postgres store.

Additionally, context errors are now classified as non-transient to prevent retry deadlocks. The reason for this change is that after a context deadline is expired, it won't unexpire and the retry will be fruitless.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

see unit tests

`roxcurl "/v1/export/vuln-mgmt/workloads?timeout=1"` <-- this would previously get stuck in a 5 minute deadlock due to calling `GetImage` with an expired context.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
