### PR TITLE
chore: manually backport #11359 into 4.4 release branch

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -105,4 +105,9 @@ var (
 
 	// UnqualifiedSearchRegistries enables support for unqualified search registries and short name aliases.
 	UnqualifiedSearchRegistries = registerFeature("Enable support for unqualified search registries and short name aliases", "ROX_UNQUALIFIED_SEARCH_REGISTRIES", false)
+
+	// SensorSingleScanPerImage when set to true forces Sensor to allow only a single scan per image to be active at any given
+	// time. Will only have an affect if UnqualifiedSearchRegistries is also enabled.
+	// TODO(ROX-24641): Remove dependency on the UnqualifiedSearchRegistries feature so that this is enabled by default.
+	SensorSingleScanPerImage = registerFeature("Sensor will only allow a single active scan per image", "ROX_SENSOR_SINGLE_SCAN", true)
 )

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common/clusterid"
@@ -226,7 +227,7 @@ func (c *cacheValue) updateImageNoLock(image *storage.Image) {
 		return
 	}
 
-	c.image.Names = protoutils.SliceUnique(append(c.image.GetNames(), existingNames...))
+	c.image.Names = utils.UniqueImageNames(c.image.GetNames(), existingNames)
 }
 
 func newEnricher(cache expiringcache.Cache, serviceAccountStore store.ServiceAccountStore, registryStore *registry.Store, localScan *scan.LocalScan) *enricher {

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
@@ -17,7 +18,6 @@ import (
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
@@ -143,6 +143,12 @@ outer:
 }
 
 func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, req *scanImageRequest) {
+	if features.UnqualifiedSearchRegistries.Enabled() && features.SensorSingleScanPerImage.Enabled() {
+		// TODO(ROX-24641): Remove dependency on the UnqualifiedSearchRegistries feature so that this is enabled by default.
+		c.scanAndSetWithLock(ctx, svc, req)
+		return
+	}
+
 	defer c.signal.Signal()
 
 	// Ask Central to scan the image if the image is not local otherwise scan with local scanner
@@ -168,6 +174,59 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 
 	log.Debugf("Successful image scan for image %s: %d components returned by scanner", req.containerImage.GetName().GetFullName(), len(scannedImage.GetImage().GetScan().GetComponents()))
 	c.image = scannedImage.GetImage()
+}
+
+func (c *cacheValue) scanAndSetWithLock(ctx context.Context, svc v1.ImageServiceClient, req *scanImageRequest) {
+	defer c.signal.Signal()
+
+	// A cacheValue is unique per image, obtain the lock before scanning to avoid sending multiple
+	// scan requests for the same image at the same time.
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check to see if another routine already enriched this name, if so, short circuit.
+	if protoutils.SliceContains(req.containerImage.GetName(), c.image.GetNames()) {
+		log.Debugf("Image scan loaded from cache: %s: Components: (%d) - short circuit", req.containerImage.GetName().GetFullName(), len(c.image.GetScan().GetComponents()))
+		return
+	}
+
+	// Ask Central to scan the image if the image is not local otherwise scan with local scanner
+	scanImageFn := scanImage
+	if c.regStore.IsLocal(req.containerImage.GetName()) {
+		scanImageFn = scanImageLocal
+		log.Debugf("Sending scan to local scanner for image %q", req.containerImage.GetName().GetFullName())
+	} else {
+		log.Debugf("Sending scan to central for image %q", req.containerImage.GetName().GetFullName())
+	}
+
+	scannedImage, err := c.scanWithRetries(ctx, svc, req, scanImageFn)
+	if err != nil {
+		// Ignore the error and set the image to something basic,
+		// so alerting can progress.
+		log.Errorf("Scan request failed for image %q: %s", req.containerImage.GetName().GetFullName(), err)
+		c.updateImageNoLock(types.ToImage(req.containerImage))
+		return
+	}
+
+	log.Debugf("Successful image scan for image %s: %d components returned by scanner", req.containerImage.GetName().GetFullName(), len(scannedImage.GetImage().GetScan().GetComponents()))
+	c.updateImageNoLock(scannedImage.GetImage())
+}
+
+// updateImageNoLock will replace the internal image with the new image
+// while ensuring any existing image names are kept.
+func (c *cacheValue) updateImageNoLock(image *storage.Image) {
+	if c == nil || image == nil {
+		return
+	}
+
+	existingNames := c.image.GetNames()
+	c.image = image
+
+	if len(existingNames) == 0 {
+		return
+	}
+
+	c.image.Names = protoutils.SliceUnique(append(c.image.GetNames(), existingNames...))
 }
 
 func newEnricher(cache expiringcache.Cache, serviceAccountStore store.ServiceAccountStore, registryStore *registry.Store, localScan *scan.LocalScan) *enricher {

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -10,11 +11,15 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/expiringcache"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/types"
+	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/registry"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -77,7 +82,7 @@ func (s *enricherSuite) Test_dataRaceInRunScan() {
 	// bypass getImageFromCache and land to GetOrSet. If that happens, it shouldn't trigger the data race because
 	// forceEnrichImageWithSignatures is false and newValue != value so we shouldn't trigger a scan.
 	req3 := createScanImageRequest(0, "nginx-id", "nginx:1.14.2", false)
-	conn, closeFunc := createMockImageService(s.T())
+	conn, closeFunc := createMockImageService(s.T(), nil)
 	s.enricher.imageSvc = v1.NewImageServiceClient(conn)
 	defer closeFunc()
 	s.mockCache.RemoveAll()
@@ -100,13 +105,17 @@ func (s *enricherSuite) Test_dataRaceInRunScan() {
 	waitGroup.Wait()
 }
 
-func createMockImageService(t *testing.T) (*grpc.ClientConn, func()) {
+func createMockImageService(t *testing.T, imageServiceServer v1.ImageServiceServer) (*grpc.ClientConn, func()) {
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
 
 	server := grpc.NewServer()
-	v1.RegisterImageServiceServer(server,
-		&mockImageServiceServer{})
+	if imageServiceServer == nil {
+		v1.RegisterImageServiceServer(server, &mockImageServiceServer{})
+	} else {
+		v1.RegisterImageServiceServer(server, imageServiceServer)
+	}
+
 	go func() {
 		utils.IgnoreError(func() error {
 			return server.Serve(listener)
@@ -125,10 +134,164 @@ func createMockImageService(t *testing.T) (*grpc.ClientConn, func()) {
 
 type mockImageServiceServer struct {
 	v1.UnimplementedImageServiceServer
+	callCounts     map[string]int
+	callCountsLock sync.Mutex
+	returnError    bool
 }
 
 func (m *mockImageServiceServer) ScanImageInternal(_ context.Context, req *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+	if m.callCounts != nil {
+		m.callCountsLock.Lock()
+		defer m.callCountsLock.Unlock()
+		m.callCounts[req.GetImage().GetName().GetFullName()]++
+	}
+
+	if m.returnError {
+		return nil, errors.New("broken")
+	}
+
 	return &v1.ScanImageInternalResponse{
 		Image: types.ToImage(req.Image),
 	}, nil
+}
+
+func (s *enricherSuite) TestScanAndSetWithLock() {
+	testutils.MustUpdateFeature(s.T(), features.UnqualifiedSearchRegistries, true)
+	testutils.MustUpdateFeature(s.T(), features.SensorSingleScanPerImage, true)
+
+	req := createScanImageRequest(0, "nginx-id", "nginx:latest", false)
+	req2 := createScanImageRequest(0, "nginx-id", "quay.io/nginx:latest", false)
+	req3 := createScanImageRequest(0, "nginx-id", "nginx:1.14.2", false)
+	reqs := []*scanImageRequest{req, req2, req3}
+
+	runScans := func(t *testing.T, imageService *mockImageServiceServer) {
+		conn, closeFunc := createMockImageService(s.T(), imageService)
+		s.enricher.imageSvc = v1.NewImageServiceClient(conn)
+		defer closeFunc()
+		s.mockCache.RemoveAll()
+
+		waitGroup := runAsyncScans(s.enricher, reqs)
+		waitGroup.Wait()
+
+		// Only a single call per image name should have been made.
+		assert.Len(t, imageService.callCounts, 3)
+		assert.Equal(t, 1, imageService.callCounts[req.containerImage.GetName().GetFullName()])
+		assert.Equal(t, 1, imageService.callCounts[req2.containerImage.GetName().GetFullName()])
+		assert.Equal(t, 1, imageService.callCounts[req3.containerImage.GetName().GetFullName()])
+
+		// Simulate a cache expiry.
+		s.mockCache.RemoveAll()
+
+		waitGroup = runAsyncScans(s.enricher, reqs)
+		waitGroup.Wait()
+
+		// Only one more call per image name should have been made.
+		assert.Len(t, imageService.callCounts, 3)
+		assert.Equal(t, 2, imageService.callCounts[req.containerImage.GetName().GetFullName()])
+		assert.Equal(t, 2, imageService.callCounts[req2.containerImage.GetName().GetFullName()])
+		assert.Equal(t, 2, imageService.callCounts[req3.containerImage.GetName().GetFullName()])
+	}
+
+	s.T().Run("succesfully scans", func(t *testing.T) {
+		imageService := &mockImageServiceServer{callCounts: map[string]int{}}
+		runScans(t, imageService)
+	})
+
+	s.T().Run("error scans", func(t *testing.T) {
+		imageService := &mockImageServiceServer{callCounts: map[string]int{}, returnError: true}
+		runScans(t, imageService)
+	})
+}
+
+func runAsyncScans(e *enricher, reqs []*scanImageRequest) *sync.WaitGroup {
+	waitGroup := &sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		for _, req := range reqs {
+			waitGroup.Add(1)
+			go func(req *scanImageRequest) {
+				e.runScan(req)
+				waitGroup.Done()
+			}(req)
+		}
+	}
+
+	return waitGroup
+}
+
+func (s *enricherSuite) TestUpdateImageNoLock() {
+	name1, _, err := imageUtils.GenerateImageNameFromString("nginx:latest")
+	require.NoError(s.T(), err)
+
+	name2, _, err := imageUtils.GenerateImageNameFromString("nginx:1.0")
+	require.NoError(s.T(), err)
+
+	name3, _, err := imageUtils.GenerateImageNameFromString("nginx:1.14.2")
+	require.NoError(s.T(), err)
+
+	s.T().Run("no panics on nils", func(t *testing.T) {
+		var cValue *cacheValue
+		assert.NotPanics(t, func() { cValue.updateImageNoLock(nil) })
+
+		cValue = new(cacheValue)
+		assert.NotPanics(t, func() { cValue.updateImageNoLock(nil) })
+	})
+
+	s.T().Run("do not update cache value on nil image", func(t *testing.T) {
+		genCacheValue := func() *cacheValue { return &cacheValue{image: &storage.Image{Name: name1}} }
+		cValue := genCacheValue()
+		cValue.updateImageNoLock(nil)
+		assert.Equal(t, genCacheValue(), cValue)
+	})
+
+	s.T().Run("keep existing names when name removed", func(t *testing.T) {
+		cValue := &cacheValue{image: &storage.Image{
+			Name:  name1,
+			Names: []*storage.ImageName{name1, name2},
+		}}
+
+		updatedImage := &storage.Image{
+			Name:  name2,
+			Names: []*storage.ImageName{name2},
+		}
+
+		cValue.updateImageNoLock(updatedImage)
+		assert.Len(t, cValue.image.Names, 2)
+		assert.Contains(t, cValue.image.Names, name1)
+		assert.Contains(t, cValue.image.Names, name2)
+	})
+
+	s.T().Run("append to names when new one added", func(t *testing.T) {
+		cValue := &cacheValue{image: &storage.Image{
+			Name:  name1,
+			Names: []*storage.ImageName{name1},
+		}}
+
+		updatedImage := &storage.Image{
+			Name:  name2,
+			Names: []*storage.ImageName{name1, name2},
+		}
+
+		cValue.updateImageNoLock(updatedImage)
+		assert.Len(t, cValue.image.Names, 2)
+		assert.Contains(t, cValue.image.Names, name1)
+		assert.Contains(t, cValue.image.Names, name2)
+	})
+
+	s.T().Run("append to names when new one added and one removed", func(t *testing.T) {
+		cValue := &cacheValue{image: &storage.Image{
+			Name:  name1,
+			Names: []*storage.ImageName{name1, name2},
+		}}
+
+		updatedImage := &storage.Image{
+			Name:  name2,
+			Names: []*storage.ImageName{name1, name3},
+		}
+
+		cValue.updateImageNoLock(updatedImage)
+		assert.Len(t, cValue.image.Names, 3)
+		assert.Contains(t, cValue.image.Names, name1)
+		assert.Contains(t, cValue.image.Names, name2)
+		assert.Contains(t, cValue.image.Names, name3)
+	})
 }

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -66,7 +66,7 @@ var (
 				// The cacheValue lock used while images are being scanned
 				// is expected to be held longer then 10s, to avoid panics in
 				// dev builds using stdlib sync in the detector instead.
-				"github.com/stackrox/rox/sensor/common/detectorgithub.com/stackrox/rox/pkg/bolthelper/crud/proto",
+				"github.com/stackrox/rox/sensor/common/detector",
 			),
 		},
 		"github.com/magiconair/properties/assert": {

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -63,6 +63,10 @@ var (
 			replacement: "github.com/stackrox/rox/pkg/sync",
 			allowlist: set.NewStringSet(
 				"github.com/stackrox/rox/pkg/bolthelper/crud/proto",
+				// The cacheValue lock used while images are being scanned
+				// is expected to be held longer then 10s, to avoid panics in
+				// dev builds using stdlib sync in the detector instead.
+				"github.com/stackrox/rox/sensor/common/detectorgithub.com/stackrox/rox/pkg/bolthelper/crud/proto",
 			),
 		},
 		"github.com/magiconair/properties/assert": {


### PR DESCRIPTION
## Description

Backporting https://github.com/stackrox/stackrox/pull/11359 into the `4.4` release branch

Required manual backport due to merge conflicts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI / Unit tests
