### PR TITLE
ROX-12993: Junitify the upgrade test

### DIFF
--- a/scripts/ci/bats/lib_junit.bats
+++ b/scripts/ci/bats/lib_junit.bats
@@ -160,7 +160,6 @@ _EO_DETAILS_
 
 @test "JUNIT wrapping functionality - propagates failure" {
     wrapped_functionality() {
-        echo "This bit of fn() will have a JUNIT record \o/"
         not_a_valid_command
     }
     run -127 junit_wrap "Suite" "Test" "failure message" "wrapped_functionality"
@@ -168,6 +167,15 @@ _EO_DETAILS_
     run cat "${junit_dir}/junit-Suite.xml"
     assert_output --partial 'tests="1"'
     assert_output --partial 'failures="1"'
+}
+
+@test "JUNIT wrapping functionality - propagates exports" {
+    BEFORE="before"
+    wrapped_functionality() {
+        export BEFORE="after"
+    }
+    junit_wrap "Suite" "Test" "failure message" "wrapped_functionality"
+    assert_equal "${BEFORE}" "after"
 }
 
 @test "JUNIT wrapping functionality - includes output on failure" {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1916,11 +1916,14 @@ junit_wrap() {
     local command_output_file
     command_output_file="$(mktemp)"
 
-    if "$@" 2>&1 | tee "${command_output_file}"; then
+    start_tee "${command_output_file}"
+    if "$@"; then
+        stop_tee
         save_junit_success "${class}" "${description}"
         rm -f "${command_output_file}"
     else
         local ret_code="$?"
+        stop_tee
         local failure_body=""
         if [[ -n "$failure_message" ]]; then
             failure_body="${failure_message}

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1916,6 +1916,9 @@ junit_wrap() {
     local command_output_file
     command_output_file="$(mktemp)"
 
+    # The desired command is wrapped with a `{start,stop}_tee` for inline tee
+    # behavior. This is required because `if "$@" | tee;` runs `$@` in a
+    # subshell that will lose any variables exported by `$@`.
     start_tee "${command_output_file}"
     if "$@"; then
         stop_tee

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1916,18 +1916,13 @@ junit_wrap() {
     local command_output_file
     command_output_file="$(mktemp)"
 
-    # The desired command is wrapped with a `{start,stop}_tee` for inline tee
-    # behavior. This is required because `if "$@" | tee;` runs `$@` in a
-    # subshell that will lose any variables exported by `$@`.
-
-    start_tee "${command_output_file}"
-    if "$@"; then
-        stop_tee
+    if "$@" > "${command_output_file}" 2>&1; then
+        cat "${command_output_file}"
         save_junit_success "${class}" "${description}"
         rm -f "${command_output_file}"
     else
         local ret_code="$?"
-        stop_tee
+        cat "${command_output_file}"
         local failure_body=""
         if [[ -n "$failure_message" ]]; then
             failure_body="${failure_message}

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1919,6 +1919,7 @@ junit_wrap() {
     # The desired command is wrapped with a `{start,stop}_tee` for inline tee
     # behavior. This is required because `if "$@" | tee;` runs `$@` in a
     # subshell that will lose any variables exported by `$@`.
+
     start_tee "${command_output_file}"
     if "$@"; then
         stop_tee

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1916,13 +1916,15 @@ junit_wrap() {
     local command_output_file
     command_output_file="$(mktemp)"
 
-    if "$@" > "${command_output_file}" 2>&1; then
-        cat "${command_output_file}"
+    local ret_code=0
+    "$@" > "${command_output_file}" 2>&1
+    ret_code="$?"
+    cat "${command_output_file}"
+
+    if [[ "${ret_code}" == "0" ]]; then
         save_junit_success "${class}" "${description}"
         rm -f "${command_output_file}"
     else
-        local ret_code="$?"
-        cat "${command_output_file}"
         local failure_body=""
         if [[ -n "$failure_message" ]]; then
             failure_body="${failure_message}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -182,32 +182,6 @@ retry() {
     return 0
 }
 
-# Function to turn on tee behavior
-start_tee() {
-    # Save original file descriptors
-    exec 3>&1  # Save stdout to file descriptor 3
-    exec 4>&2  # Save stderr to file descriptor 4
-
-    # Open a file for writing if specified
-    if [ -n "$1" ]; then
-        exec 1> >(tee -a "$1")  # Redirect stdout to file and tee
-    else
-        exec 1> >(tee /dev/stderr)  # Redirect stdout to tee
-    fi
-
-    exec 2>&1  # Redirect stderr to stdout
-}
-
-# Function to turn off tee behavior
-stop_tee() {
-    exec 1>&3  # Restore stdout from file descriptor 3
-    exec 2>&4  # Restore stderr from file descriptor 4
-
-    # Close file descriptors
-    exec 3>&-  # Close file descriptor 3
-    exec 4>&-  # Close file descriptor 4
-}
-
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         usage

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -182,6 +182,32 @@ retry() {
     return 0
 }
 
+# Function to turn on tee behavior
+start_tee() {
+    # Save original file descriptors
+    exec 3>&1  # Save stdout to file descriptor 3
+    exec 4>&2  # Save stderr to file descriptor 4
+
+    # Open a file for writing if specified
+    if [ -n "$1" ]; then
+        exec 1> >(tee -a "$1")  # Redirect stdout to file and tee
+    else
+        exec 1> >(tee /dev/stderr)  # Redirect stdout to tee
+    fi
+
+    exec 2>&1  # Redirect stderr to stdout
+}
+
+# Function to turn off tee behavior
+stop_tee() {
+    exec 1>&3  # Restore stdout from file descriptor 3
+    exec 2>&4  # Restore stderr from file descriptor 4
+
+    # Close file descriptors
+    exec 3>&-  # Close file descriptor 3
+    exec 4>&-  # Close file descriptor 4
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         usage

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -77,105 +77,123 @@ test_upgrade_paths() {
 
     local log_output_dir="$1"
 
-    EARLIER_TAG="3.74.0"
-    FORCE_ROLLBACK_VERSION="$EARLIER_TAG"
+    _test_upgrade_paths__initial_deployment() {
+        EARLIER_TAG="3.74.0"
+        FORCE_ROLLBACK_VERSION="$EARLIER_TAG"
 
-    ########################################################################################
-    # Use roxctl to generate helm files and deploy older central backed by RocksDB         #
-    ########################################################################################
-    deploy_earlier_rocks_central
-    wait_for_api
-    setup_client_TLS_certs
+        ########################################################################################
+        # Use roxctl to generate helm files and deploy older central backed by RocksDB         #
+        ########################################################################################
+        deploy_earlier_rocks_central
+        wait_for_api
+        setup_client_TLS_certs
 
-    restore_3_56_1_backup
-    wait_for_api
+        restore_3_56_1_backup
+        wait_for_api
 
-    # Add some access scopes and see that they survive the upgrade and rollback process
-    createRocksDBScopes
-    checkForRocksAccessScopes
+        # Add some access scopes and see that they survive the upgrade and rollback process
+        createRocksDBScopes
+        checkForRocksAccessScopes
 
-    # Get the API_TOKEN for the upgrades
-    API_TOKEN="$(roxcurl /v1/apitokens/generate -d '{"name": "helm-upgrade-test", "role": "Admin"}' | jq -r '.token')"
-    export API_TOKEN
+        # Get the API_TOKEN for the upgrades
+        API_TOKEN="$(roxcurl /v1/apitokens/generate -d '{"name": "helm-upgrade-test", "role": "Admin"}' | jq -r '.token')"
+        export API_TOKEN
 
-    cd "$TEST_ROOT"
-    download_roxctl "${LAST_POSTGRES_TAG}"
+        cd "$TEST_ROOT"
+        download_roxctl "${LAST_POSTGRES_TAG}"
+    }
+    junit_wrap "legacy_upgrade_paths" \
+               "A deployment of an older central backed by RocksDB" \
+               "See log for error details." \
+               _test_upgrade_paths__initial_deployment
 
-    ########################################################################################
-    # Use helm to upgrade to current Postgres release.                                     #
-    ########################################################################################
-    info "Upgrade to ${LAST_POSTGRES_TAG} via helm"
-    helm_upgrade_to_last_postgres
-    wait_for_api
-    wait_for_scanner_to_be_ready
+    _test_upgrade_paths__upgrade_to_current() {
+        ########################################################################################
+        # Use helm to upgrade to current Postgres release.                                     #
+        ########################################################################################
+        info "Upgrade to ${LAST_POSTGRES_TAG} via helm"
+        helm_upgrade_to_last_postgres
+        wait_for_api
+        wait_for_scanner_to_be_ready
 
-    # Upgraded to Postgres via helm.  Validate the upgrade.
-    validate_upgrade "00_upgrade" "central upgrade to postgres" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+        # Upgraded to Postgres via helm.  Validate the upgrade.
+        validate_upgrade "00_upgrade" "central upgrade to postgres" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
-    # Ensure the access scopes added to rocks still exist after the upgrade
-    checkForRocksAccessScopes
+        # Ensure the access scopes added to rocks still exist after the upgrade
+        checkForRocksAccessScopes
 
-    collect_and_check_stackrox_logs "$log_output_dir" "00_initial_check"
+        collect_and_check_stackrox_logs "$log_output_dir" "00_initial_check"
 
-    # Add some Postgres Access Scopes.  These should not survive a rollback.
-    createPostgresScopes
-    checkForPostgresAccessScopes
+        # Add some Postgres Access Scopes.  These should not survive a rollback.
+        createPostgresScopes
+        checkForPostgresAccessScopes
+    }
+    junit_wrap "legacy_upgrade_paths" \
+               "Upgrade to current Postgres release" \
+               "See log for error details." \
+               _test_upgrade_paths__upgrade_to_current
 
-    ########################################################################################
-    # Flip the Postgres flag to go back to RocksDB                                         #
-    ########################################################################################
+    _test_upgrade_paths__flip_flag_to_downgrade() {
+        ########################################################################################
+        # Flip the Postgres flag to go back to RocksDB                                         #
+        ########################################################################################
 
-    # Need to push the flag to ci so that the collect scripts pull from
-    # Postgres and not Rocks
-    ci_export ROX_POSTGRES_DATASTORE "false"
-    LAST_ROCKS_TAG="3.74.0-1-gfe924fce30"
-    kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:${LAST_ROCKS_TAG}"; kubectl -n stackrox set env deploy/central ROX_POSTGRES_DATASTORE=false
-    wait_for_api
-    wait_for_scanner_to_be_ready
+        # Need to push the flag to ci so that the collect scripts pull from
+        # Postgres and not Rocks
+        ci_export ROX_POSTGRES_DATASTORE "false"
+        LAST_ROCKS_TAG="3.74.0-1-gfe924fce30"
+        kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:${LAST_ROCKS_TAG}"; kubectl -n stackrox set env deploy/central ROX_POSTGRES_DATASTORE=false
+        wait_for_api
+        wait_for_scanner_to_be_ready
 
-    # Check the database status to ensure it is using RocksDB
-    check_legacy_db_status
+        # Check the database status to ensure it is using RocksDB
+        check_legacy_db_status
 
-    # Ensure we still have the access scopes added to Rocks
-    checkForRocksAccessScopes
-    # The scopes added after the initial upgrade to Postgres should no longer exist.
-    verifyNoPostgresAccessScopes
+        # Ensure we still have the access scopes added to Rocks
+        checkForRocksAccessScopes
+        # The scopes added after the initial upgrade to Postgres should no longer exist.
+        verifyNoPostgresAccessScopes
 
-    # Returned to Rocks by flipping the flag.  Validate that RocksDB backed central functions.
-    validate_upgrade "01_to_rocks" "central upgrade postgres down to rocks" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+        # Returned to Rocks by flipping the flag.  Validate that RocksDB backed central functions.
+        validate_upgrade "01_to_rocks" "central upgrade postgres down to rocks" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
-    info "Fetching a sensor bundle for cluster 'remote'"
-    roxctl version
-    rm -rf sensor-remote
-    roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
-    [[ -d sensor-remote ]]
+        info "Fetching a sensor bundle for cluster 'remote'"
+        roxctl version
+        rm -rf sensor-remote
+        roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor get-bundle remote
+        [[ -d sensor-remote ]]
 
-    info "Installing sensor"
-    # This old software version doesn't remove PSP from the bundle so we have to do it.
-    info "Removing pod-security files"
-    rm ./sensor-remote/*pod-security.yaml
-    ./sensor-remote/sensor.sh
-    kubectl -n stackrox set image deploy/sensor "*=$REGISTRY/main:$LAST_ROCKS_TAG"
-    kubectl -n stackrox set image deploy/admission-control "*=$REGISTRY/main:$LAST_ROCKS_TAG"
-    kubectl -n stackrox set image ds/collector "collector=$REGISTRY/collector:$(make collector-tag)" \
-        "compliance=$REGISTRY/main:$LAST_ROCKS_TAG"
+        info "Installing sensor"
+        # This old software version doesn't remove PSP from the bundle so we have to do it.
+        info "Removing pod-security files"
+        rm ./sensor-remote/*pod-security.yaml
+        ./sensor-remote/sensor.sh
+        kubectl -n stackrox set image deploy/sensor "*=$REGISTRY/main:$LAST_ROCKS_TAG"
+        kubectl -n stackrox set image deploy/admission-control "*=$REGISTRY/main:$LAST_ROCKS_TAG"
+        kubectl -n stackrox set image ds/collector "collector=$REGISTRY/collector:$(make collector-tag)" \
+            "compliance=$REGISTRY/main:$LAST_ROCKS_TAG"
 
-    sensor_wait
+        sensor_wait
 
-    # Bounce collectors to avoid restarts on initial module pull
-    kubectl -n stackrox delete pod -l app=collector --grace-period=0
+        # Bounce collectors to avoid restarts on initial module pull
+        kubectl -n stackrox delete pod -l app=collector --grace-period=0
 
-    wait_for_central_reconciliation
+        wait_for_central_reconciliation
 
-    rm -f FAIL
-    remove_qa_test_results
+        rm -f FAIL
+        remove_qa_test_results
 
-    info "Running smoke tests"
-    CLUSTER="$CLUSTER_TYPE_FOR_TEST" make -C qa-tests-backend smoke-test || touch FAIL
-    store_qa_test_results "upgrade-paths-smoke-tests"
-    [[ ! -f FAIL ]] || die "Smoke tests failed"
+        info "Running smoke tests"
+        CLUSTER="$CLUSTER_TYPE_FOR_TEST" make -C qa-tests-backend smoke-test || touch FAIL
+        store_qa_test_results "upgrade-paths-smoke-tests"
+        [[ ! -f FAIL ]] || die "Smoke tests failed"
 
-    collect_and_check_stackrox_logs "$log_output_dir" "02_final_back_to_Rocks"
+        collect_and_check_stackrox_logs "$log_output_dir" "02_final_back_to_Rocks"
+    }
+    junit_wrap "legacy_upgrade_paths" \
+               "Flip the Postgres flag to go back to RocksDB" \
+               "See log for error details." \
+               _test_upgrade_paths__flip_flag_to_downgrade
 }
 
 helm_upgrade_to_last_postgres() {

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 LAST_POSTGRES_TAG="4.4.0"
-CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -69,7 +69,7 @@ test_upgrade() {
 }
 
 test_upgrade_paths() {
-    info "Testing various upgrade paths"
+    info "Testing various legacy upgrade paths"
 
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade_paths <log-output-dir>"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -223,6 +223,8 @@ test_upgrade_paths() {
         ########################################################################################
         # Upgrade back to latest to run the smoke tests                                        #
         ########################################################################################
+        shopt -o
+        info "Upgrade back to latest to run the smoke tests"
         kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
         kubectl -n stackfox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -224,7 +224,7 @@ test_upgrade_paths() {
         # Upgrade back to latest to run the smoke tests                                        #
         ########################################################################################
         kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
-        kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
+        kubectl -n stackfox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
 
         wait_for_api
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -227,6 +227,8 @@ test_upgrade_paths() {
         info "Upgrade back to latest to run the smoke tests"
         kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
         kubectl -n stackfox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
+        echo "$?"
+        ls -l /noexisto
 
         wait_for_api
 

--- a/tests/upgrade/postgres_sensor_run.sh
+++ b/tests/upgrade/postgres_sensor_run.sh
@@ -74,8 +74,16 @@ test_upgrade() {
 
     touch "${STATE_DEPLOYED}"
 
-    test_sensor_bundle
-    test_upgrader
+    junit_wrap test_sensor_bundle \
+               "roxctl sensor get-bundle test" \
+               "See log for error details." \
+               test_sensor_bundle
+
+    junit_wrap test_upgrader \
+               "bin/upgrader tests" \
+               "See log for error details." \
+               test_upgrader
+
     remove_existing_stackrox_resources
 }
 

--- a/tests/upgrade/postgres_sensor_run.sh
+++ b/tests/upgrade/postgres_sensor_run.sh
@@ -30,7 +30,7 @@ test_upgrade() {
     # Need to push the flag to ci so that is where it needs to be for the part
     # of the test.
     ci_export ROX_POSTGRES_DATASTORE "true"
-    export ROX_POSTGRES_DATASTORE "true"
+    export ROX_POSTGRES_DATASTORE
 
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade <log-output-dir>"

--- a/tests/upgrade/postgres_sensor_run.sh
+++ b/tests/upgrade/postgres_sensor_run.sh
@@ -30,7 +30,6 @@ test_upgrade() {
     # Need to push the flag to ci so that is where it needs to be for the part
     # of the test.
     ci_export ROX_POSTGRES_DATASTORE "true"
-    export ROX_POSTGRES_DATASTORE
 
     if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: test_upgrade <log-output-dir>"


### PR DESCRIPTION
## Description

This PR wraps the main gke-upgrade-test functionality with `junit_wrap()` to get more granular pass/fail results for this job. As a side effect, `junit_wrap()` removed the `"$@" | tee` approach to command execution so that variables exported in functions are not lost over `junit_wrap()` calls as required by the upgrade test [e.g.](https://github.com/stackrox/stackrox/blob/3eb41ccf0f2082bfcfe829b27b9ce95580bf7529/tests/upgrade/legacy_to_postgres_run.sh#L298)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

### Here I tell how I validated my change

Forced a failure of one of the pieces of test functionality. 
- [ ] verified that a failure JUNIT is created. 
- [ ] success JUNITs are generated for tests before the failure.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
