### PR TITLE
ROX-23689: Compliance scan schedule filter

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
@@ -1,11 +1,13 @@
-import React, { createContext, useCallback } from 'react';
+import React, { createContext, useCallback, useContext } from 'react';
 
 import useRestQuery from 'hooks/useRestQuery';
-
 import {
     listComplianceScanConfigProfiles,
     ListComplianceScanConfigsProfileResponse,
 } from 'services/ComplianceScanConfigurationService';
+
+import { createScanConfigFilter } from './compliance.coverage.utils';
+import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 type ComplianceProfilesContextValue = {
     scanConfigProfilesResponse: ListComplianceScanConfigsProfileResponse;
@@ -28,7 +30,12 @@ export const ComplianceProfilesContext =
     createContext<ComplianceProfilesContextValue>(defaultContextValue);
 
 function ComplianceProfilesProvider({ children }: { children: React.ReactNode }) {
-    const fetchProfiles = useCallback(() => listComplianceScanConfigProfiles(), []);
+    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+
+    const fetchProfiles = useCallback(
+        () => listComplianceScanConfigProfiles(createScanConfigFilter(selectedScanConfig)),
+        [selectedScanConfig]
+    );
     const {
         data: scanConfigProfilesResponse,
         loading: isLoading,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
@@ -30,11 +30,11 @@ export const ComplianceProfilesContext =
     createContext<ComplianceProfilesContextValue>(defaultContextValue);
 
 function ComplianceProfilesProvider({ children }: { children: React.ReactNode }) {
-    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
 
     const fetchProfiles = useCallback(
-        () => listComplianceScanConfigProfiles(createScanConfigFilter(selectedScanConfig)),
-        [selectedScanConfig]
+        () => listComplianceScanConfigProfiles(createScanConfigFilter(selectedScanConfigName)),
+        [selectedScanConfigName]
     );
     const {
         data: scanConfigProfilesResponse,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -18,25 +18,20 @@ import ComplianceProfilesProvider, {
 } from './ComplianceProfilesProvider';
 import ProfileChecksPage from './ProfileChecksPage';
 import ProfileClustersPage from './ProfileClustersPage';
+import ScanConfigurationsProvider from './ScanConfigurationsProvider';
 
 function CoveragePage() {
     return (
-        <ComplianceProfilesProvider>
-            <CoverageContent />
-        </ComplianceProfilesProvider>
+        <ScanConfigurationsProvider>
+            <ComplianceProfilesProvider>
+                <CoverageContent />
+            </ComplianceProfilesProvider>
+        </ScanConfigurationsProvider>
     );
 }
 
 function CoverageContent() {
     const { scanConfigProfilesResponse, isLoading, error } = useContext(ComplianceProfilesContext);
-
-    if (isLoading) {
-        return (
-            <Bullseye>
-                <Spinner />
-            </Bullseye>
-        );
-    }
 
     if (error) {
         return (
@@ -46,7 +41,7 @@ function CoverageContent() {
         );
     }
 
-    if (scanConfigProfilesResponse.totalCount === 0) {
+    if (!isLoading && scanConfigProfilesResponse.totalCount === 0) {
         // TODO: Add a message for when there are no profiles
         return <div>No profiles, create a scan schedule</div>;
     }
@@ -70,8 +65,16 @@ function CoverageContent() {
 }
 
 function ProfilesRedirectHandler() {
-    const { scanConfigProfilesResponse } = useContext(ComplianceProfilesContext);
+    const { scanConfigProfilesResponse, isLoading } = useContext(ComplianceProfilesContext);
     const firstProfile = scanConfigProfilesResponse.profiles[0];
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner />
+            </Bullseye>
+        );
+    }
 
     return (
         <Redirect to={`${complianceEnhancedCoveragePath}/profiles/${firstProfile.name}/checks`} />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -1,14 +1,38 @@
-import React from 'react';
-import { PageSection, Text, Title } from '@patternfly/react-core';
+import React, { useContext } from 'react';
+import { Button, Divider, Flex, FlexItem, PageSection, Text, Title } from '@patternfly/react-core';
+import { TimesCircleIcon } from '@patternfly/react-icons';
+
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
+import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function CoveragesPageHeader() {
+    const { setSelectedScanConfig } = useContext(ScanConfigurationsContext);
     return (
         <>
-            <PageSection component="div" variant="light">
-                <Title headingLevel="h1">Coverage</Title>
-                <Text>
-                    Assess profile compliance for nodes and platform resources across clusters
-                </Text>
+            <PageSection component="div" variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
+                    <FlexItem className="pf-v5-u-p-lg">
+                        <Title headingLevel="h1">Coverage</Title>
+                        <Text>
+                            Assess profile compliance for nodes and platform resources across
+                            clusters
+                        </Text>
+                    </FlexItem>
+                    <Divider />
+                    <Flex
+                        className="pf-v5-u-px-lg pf-v5-u-py-sm"
+                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                    >
+                        <ScanConfigurationSelect />
+                        <Button
+                            variant="link"
+                            icon={<TimesCircleIcon />}
+                            onClick={() => setSelectedScanConfig(undefined)}
+                        >
+                            Reset filter
+                        </Button>
+                    </Flex>
+                </Flex>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -6,7 +6,7 @@ import ScanConfigurationSelect from './components/ScanConfigurationSelect';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function CoveragesPageHeader() {
-    const { setSelectedScanConfig } = useContext(ScanConfigurationsContext);
+    const { setSelectedScanConfigName } = useContext(ScanConfigurationsContext);
     return (
         <>
             <PageSection component="div" variant="light" padding={{ default: 'noPadding' }}>
@@ -27,7 +27,7 @@ function CoveragesPageHeader() {
                         <Button
                             variant="link"
                             icon={<TimesCircleIcon />}
-                            onClick={() => setSelectedScanConfig(undefined)}
+                            onClick={() => setSelectedScanConfigName(undefined)}
                         >
                             Reset filter
                         </Button>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -37,7 +37,7 @@ import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
-import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
@@ -52,7 +52,7 @@ function ProfileChecksPage() {
     const { profileName } = useParams();
     const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
         useContext(ComplianceProfilesContext);
-    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -63,14 +63,17 @@ function ProfileChecksPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfileChecks = useCallback(() => {
-        const combinedFilter = combineSearchFilterWithScanConfig(searchFilter, selectedScanConfig);
+        const combinedFilter = combineSearchFilterWithScanConfig(
+            searchFilter,
+            selectedScanConfigName
+        );
         return getComplianceProfileResults(profileName, {
             sortOption,
             page,
             perPage,
             searchFilter: combinedFilter,
         });
-    }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfig]);
+    }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
     const searchFilterConfig = {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useContext } from 'react';
-import { generatePath, useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import {
+    Bullseye,
     Divider,
     PageSection,
+    Spinner,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
@@ -30,23 +32,27 @@ import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
+import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
+import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function ProfileChecksPage() {
     const [isDisclaimerAccepted, setIsDisclaimerAccepted] = useBooleanLocalStorage(
         COMPLIANCE_DISCLAIMER_KEY,
         false
     );
+    const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
-    const history = useHistory();
     const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
         useContext(ComplianceProfilesContext);
+    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -56,10 +62,15 @@ function ProfileChecksPage() {
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
 
-    const fetchProfileChecks = useCallback(
-        () => getComplianceProfileResults(profileName, { sortOption, page, perPage, searchFilter }),
-        [page, perPage, profileName, sortOption, searchFilter]
-    );
+    const fetchProfileChecks = useCallback(() => {
+        const combinedFilter = combineSearchFilterWithScanConfig(searchFilter, selectedScanConfig);
+        return getComplianceProfileResults(profileName, {
+            sortOption,
+            page,
+            perPage,
+            searchFilter: combinedFilter,
+        });
+    }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfig]);
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
     const searchFilterConfig = {
@@ -93,10 +104,7 @@ function ProfileChecksPage() {
     };
 
     function handleProfilesToggleChange(selectedProfile: string) {
-        const path = generatePath(coverageProfileChecksPath, {
-            profileName: selectedProfile,
-        });
-        history.push(path);
+        navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });
     }
 
     const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
@@ -111,55 +119,63 @@ function ProfileChecksPage() {
                 <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
             )}
             <PageSection variant="default">
-                <ProfilesToggleGroup
-                    profileName={profileName}
-                    profiles={scanConfigProfilesResponse.profiles}
-                    handleToggleChange={handleProfilesToggleChange}
-                />
-                <Divider component="div" />
-                <ProfileDetailsHeader
-                    isLoading={isLoadingScanConfigProfiles}
-                    profileName={profileName}
-                    profileDetails={selectedProfileDetails}
-                />
-                <Divider component="div" />
-                <PageSection variant="light" className="pf-v5-u-p-0" component="div">
-                    <Toolbar>
-                        <ToolbarContent>
-                            <ToolbarGroup className="pf-v5-u-w-100">
-                                <ToolbarItem className="pf-v5-u-flex-1">
-                                    <CompoundSearchFilter
-                                        config={searchFilterConfig}
-                                        searchFilter={searchFilter}
-                                        onSearch={onSearch}
-                                    />
-                                </ToolbarItem>
-                            </ToolbarGroup>
-                            <ToolbarGroup className="pf-v5-u-w-100">
-                                <SearchFilterChips
-                                    filterChipGroupDescriptors={[
-                                        {
-                                            displayName: 'Profile Check',
-                                            searchFilterName: CHECK_NAME_QUERY,
-                                        },
-                                        {
-                                            displayName: 'Cluster',
-                                            searchFilterName: CLUSTER_QUERY,
-                                        },
-                                    ]}
-                                />
-                            </ToolbarGroup>
-                        </ToolbarContent>
-                    </Toolbar>
-                    <Divider />
-                    <ProfileChecksTable
-                        profileChecksResultsCount={profileChecks?.totalCount ?? 0}
-                        profileName={profileName}
-                        pagination={pagination}
-                        tableState={tableState}
-                        getSortParams={getSortParams}
-                    />
-                </PageSection>
+                {isLoadingScanConfigProfiles ? (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                ) : (
+                    <>
+                        <ProfilesToggleGroup
+                            profileName={profileName}
+                            profiles={scanConfigProfilesResponse.profiles}
+                            handleToggleChange={handleProfilesToggleChange}
+                        />
+                        <Divider component="div" />
+                        <ProfileDetailsHeader
+                            isLoading={isLoadingScanConfigProfiles}
+                            profileName={profileName}
+                            profileDetails={selectedProfileDetails}
+                        />
+                        <Divider component="div" />
+                        <PageSection variant="light" className="pf-v5-u-p-0" component="div">
+                            <Toolbar>
+                                <ToolbarContent>
+                                    <ToolbarGroup className="pf-v5-u-w-100">
+                                        <ToolbarItem className="pf-v5-u-flex-1">
+                                            <CompoundSearchFilter
+                                                config={searchFilterConfig}
+                                                searchFilter={searchFilter}
+                                                onSearch={onSearch}
+                                            />
+                                        </ToolbarItem>
+                                    </ToolbarGroup>
+                                    <ToolbarGroup className="pf-v5-u-w-100">
+                                        <SearchFilterChips
+                                            filterChipGroupDescriptors={[
+                                                {
+                                                    displayName: 'Profile Check',
+                                                    searchFilterName: CHECK_NAME_QUERY,
+                                                },
+                                                {
+                                                    displayName: 'Cluster',
+                                                    searchFilterName: CLUSTER_QUERY,
+                                                },
+                                            ]}
+                                        />
+                                    </ToolbarGroup>
+                                </ToolbarContent>
+                            </Toolbar>
+                            <Divider />
+                            <ProfileChecksTable
+                                profileChecksResultsCount={profileChecks?.totalCount ?? 0}
+                                profileName={profileName}
+                                pagination={pagination}
+                                tableState={tableState}
+                                getSortParams={getSortParams}
+                            />
+                        </PageSection>
+                    </>
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -30,7 +30,7 @@ import {
 import ControlLabels from './components/ControlLabels';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
-import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 
 export type ProfileChecksTableProps = {
     profileChecksResultsCount: number;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
     Divider,
     Pagination,
@@ -30,6 +30,7 @@ import {
 import ControlLabels from './components/ControlLabels';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
+import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
 
 export type ProfileChecksTableProps = {
     profileChecksResultsCount: number;
@@ -47,6 +48,7 @@ function ProfileChecksTable({
     getSortParams,
 }: ProfileChecksTableProps) {
     /* eslint-disable no-nested-ternary */
+    const { generatePathWithScanConfig } = useScanConfigRouter();
     const [expandedRows, setExpandedRows] = useState<number[]>([]);
     const { page, perPage, setPage, setPerPage } = pagination;
 
@@ -125,10 +127,13 @@ function ProfileChecksTable({
                                         <Tr>
                                             <Td dataLabel="Check">
                                                 <Link
-                                                    to={generatePath(coverageCheckDetailsPath, {
-                                                        checkName,
-                                                        profileName,
-                                                    })}
+                                                    to={generatePathWithScanConfig(
+                                                        coverageCheckDetailsPath,
+                                                        {
+                                                            checkName,
+                                                            profileName,
+                                                        }
+                                                    )}
                                                 >
                                                     {checkName}
                                                 </Link>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -38,7 +38,7 @@ import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
 import CoveragesPageHeader from './CoveragesPageHeader';
-import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
 import ProfileClustersTable from './ProfileClustersTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
@@ -52,7 +52,7 @@ function ProfileClustersPage() {
     const { profileName } = useParams();
     const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
         useContext(ComplianceProfilesContext);
-    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
 
@@ -65,14 +65,17 @@ function ProfileClustersPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfileClusters = useCallback(() => {
-        const combinedFilter = combineSearchFilterWithScanConfig(searchFilter, selectedScanConfig);
+        const combinedFilter = combineSearchFilterWithScanConfig(
+            searchFilter,
+            selectedScanConfigName
+        );
         return getComplianceClusterStats(profileName, {
             sortOption,
             page,
             perPage,
             searchFilter: combinedFilter,
         });
-    }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfig]);
+    }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
     const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);
 
     const searchFilterConfig = {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -27,7 +27,7 @@ import {
 } from './compliance.coverage.utils';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
-import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 
 export type ProfileClustersTableProps = {
     currentDatetime: Date;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
     Divider,
     Pagination,
@@ -27,6 +27,7 @@ import {
 } from './compliance.coverage.utils';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
+import useScanConfigRouter from './hooks/useNavigateWithScanConfig';
 
 export type ProfileClustersTableProps = {
     currentDatetime: Date;
@@ -45,6 +46,7 @@ function ProfileClustersTable({
     tableState,
     getSortParams,
 }: ProfileClustersTableProps) {
+    const { generatePathWithScanConfig } = useScanConfigRouter();
     const { page, perPage, setPage, setPerPage } = pagination;
 
     return (
@@ -115,10 +117,13 @@ function ProfileClustersTable({
                                     <Tr key={clusterId}>
                                         <Td dataLabel="Cluster">
                                             <Link
-                                                to={generatePath(coverageClusterDetailsPath, {
-                                                    clusterId,
-                                                    profileName,
-                                                })}
+                                                to={generatePathWithScanConfig(
+                                                    coverageClusterDetailsPath,
+                                                    {
+                                                        clusterId,
+                                                        profileName,
+                                                    }
+                                                )}
                                             >
                                                 {clusterName}
                                             </Link>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfilesToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfilesToggleGroup.tsx
@@ -10,10 +10,14 @@ function getUniqueStandards(profiles: ComplianceProfileSummary[]): string[] {
     const standards = new Set(
         profiles.flatMap((profile) => profile.standards.map((standard) => standard.shortName))
     );
+
+    const standardsArray = Array.from(standards).sort();
+
     if (profiles.some((profile) => profile.standards.length === 0)) {
-        standards.add(NON_STANDARD_TAB);
+        standardsArray.push(NON_STANDARD_TAB);
     }
-    return Array.from(standards);
+
+    return standardsArray;
 }
 
 function getInitialStandard(profiles: ComplianceProfileSummary[], profileName: string): string {
@@ -24,7 +28,10 @@ function getInitialStandard(profiles: ComplianceProfileSummary[], profileName: s
     return NON_STANDARD_TAB;
 }
 
-function isStandardInProfile(standardShortName: string, profile: ComplianceProfileSummary) {
+function isStandardInProfile(
+    standardShortName: string,
+    profile: ComplianceProfileSummary
+): boolean {
     return (
         profile.standards.some((standard) => standard.shortName === standardShortName) ||
         (standardShortName === NON_STANDARD_TAB && profile.standards.length === 0)
@@ -55,13 +62,18 @@ function ProfilesToggleGroup({
         // Currently picks the first standard found since no profile should have multiple standards, however
         // if this changes in the future, we'll want to find all matches and only update selectedStandard if the
         // current selectedStandard doesn't exist in the match
-        if (profileName) {
+        if (profileName && profiles.some((profile) => profile.name === profileName)) {
             const standardShortName =
                 profiles.find((profile) => profile.name === profileName)?.standards[0]?.shortName ||
                 NON_STANDARD_TAB;
             setSelectedStandard(standardShortName);
+        } else {
+            if (profiles[0]?.name) {
+                // useful when scan schedule filter changes and current profile is not in the list
+                handleToggleChange(profiles[0].name);
+            }
         }
-    }, [profileName, profiles]);
+    }, [profileName, profiles, handleToggleChange]);
 
     function handleStandardSelection(standardShortName) {
         setSelectedStandard(standardShortName);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useCallback } from 'react';
+
+import useRestQuery from 'hooks/useRestQuery';
+import {
+    listComplianceScanConfigurations,
+    ListComplianceScanConfigurationsResponse,
+} from 'services/ComplianceScanConfigurationService';
+import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+
+type ScanConfigurationsContextValue = {
+    scanConfigurationsQuery: {
+        response: ListComplianceScanConfigurationsResponse;
+        isLoading: boolean;
+        error: Error | undefined;
+    };
+    selectedScanConfig: QueryValue;
+    setSelectedScanConfig: (
+        scanConfigName: QueryValue,
+        historyAction?: HistoryAction | undefined
+    ) => void;
+};
+
+const defaultResponse: ListComplianceScanConfigurationsResponse = {
+    configurations: [],
+    totalCount: 0,
+};
+
+const defaultContextValue: ScanConfigurationsContextValue = {
+    scanConfigurationsQuery: {
+        response: defaultResponse,
+        isLoading: true,
+        error: undefined,
+    },
+    selectedScanConfig: undefined,
+    setSelectedScanConfig: () => {},
+};
+
+export const ScanConfigurationsContext =
+    createContext<ScanConfigurationsContextValue>(defaultContextValue);
+
+function ScanConfigurationsProvider({ children }: { children: React.ReactNode }) {
+    const [selectedScanConfig, setSelectedScanConfig] = useURLParameter('scanSchedule', undefined);
+
+    const fetchScanConfigurations = useCallback(() => listComplianceScanConfigurations(), []);
+    const {
+        data: scanConfigurationsResponse,
+        loading: isLoading,
+        error,
+    } = useRestQuery(fetchScanConfigurations);
+
+    const contextValue: ScanConfigurationsContextValue = {
+        scanConfigurationsQuery: {
+            response: scanConfigurationsResponse ?? defaultResponse,
+            isLoading,
+            error,
+        },
+        selectedScanConfig,
+        setSelectedScanConfig,
+    };
+
+    return (
+        <ScanConfigurationsContext.Provider value={contextValue}>
+            {children}
+        </ScanConfigurationsContext.Provider>
+    );
+}
+
+export default ScanConfigurationsProvider;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
@@ -5,7 +5,7 @@ import {
     listComplianceScanConfigurations,
     ListComplianceScanConfigurationsResponse,
 } from 'services/ComplianceScanConfigurationService';
-import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+import useURLParameter, { HistoryAction } from 'hooks/useURLParameter';
 
 type ScanConfigurationsContextValue = {
     scanConfigurationsQuery: {
@@ -13,9 +13,9 @@ type ScanConfigurationsContextValue = {
         isLoading: boolean;
         error: Error | undefined;
     };
-    selectedScanConfig: QueryValue;
-    setSelectedScanConfig: (
-        scanConfigName: QueryValue,
+    selectedScanConfigName: string | undefined;
+    setSelectedScanConfigName: (
+        scanConfigName: string | undefined,
         historyAction?: HistoryAction | undefined
     ) => void;
 };
@@ -31,15 +31,18 @@ const defaultContextValue: ScanConfigurationsContextValue = {
         isLoading: true,
         error: undefined,
     },
-    selectedScanConfig: undefined,
-    setSelectedScanConfig: () => {},
+    selectedScanConfigName: undefined,
+    setSelectedScanConfigName: () => {},
 };
 
 export const ScanConfigurationsContext =
     createContext<ScanConfigurationsContextValue>(defaultContextValue);
 
 function ScanConfigurationsProvider({ children }: { children: React.ReactNode }) {
-    const [selectedScanConfig, setSelectedScanConfig] = useURLParameter('scanSchedule', undefined);
+    const [selectedScanConfigName, setSelectedScanConfigName] = useURLParameter(
+        'scanSchedule',
+        undefined
+    );
 
     const fetchScanConfigurations = useCallback(() => listComplianceScanConfigurations(), []);
     const {
@@ -48,14 +51,24 @@ function ScanConfigurationsProvider({ children }: { children: React.ReactNode })
         error,
     } = useRestQuery(fetchScanConfigurations);
 
+    const selectedScanConfigNameString =
+        typeof selectedScanConfigName === 'string' ? selectedScanConfigName : undefined;
+
+    const wrappedSetSelectedScanConfig = (
+        scanConfigName: string | undefined,
+        historyAction?: HistoryAction | undefined
+    ) => {
+        setSelectedScanConfigName(scanConfigName, historyAction);
+    };
+
     const contextValue: ScanConfigurationsContextValue = {
         scanConfigurationsQuery: {
             response: scanConfigurationsResponse ?? defaultResponse,
             isLoading,
             error,
         },
-        selectedScanConfig,
-        setSelectedScanConfig,
+        selectedScanConfigName: selectedScanConfigNameString,
+        setSelectedScanConfigName: wrappedSetSelectedScanConfig,
     };
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.routes.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.routes.ts
@@ -4,3 +4,7 @@ export const coverageProfileChecksPath = `${complianceEnhancedCoveragePath}/prof
 export const coverageProfileClustersPath = `${complianceEnhancedCoveragePath}/profiles/:profileName/clusters`;
 export const coverageCheckDetailsPath = `${coverageProfileChecksPath}/:checkName`;
 export const coverageClusterDetailsPath = `${coverageProfileClustersPath}/:clusterId`;
+
+export type CoverageProfilePath =
+    | typeof coverageProfileChecksPath
+    | typeof coverageProfileClustersPath;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -11,7 +11,11 @@ import {
     WrenchIcon,
 } from '@patternfly/react-icons';
 
+import { QueryValue } from 'hooks/useURLParameter';
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
+import { SearchFilter } from 'types/search';
+
+import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
 
 // Thresholds for compliance status
 const DANGER_THRESHOLD = 50;
@@ -211,4 +215,20 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
 
 export function getClusterResultsStatusObject(status: ComplianceCheckStatus): ClusterStatusObject {
     return statusIconTextMap[status];
+}
+
+export function createScanConfigFilter(selectedScanConfig: QueryValue) {
+    return typeof selectedScanConfig === 'string'
+        ? { [SCAN_CONFIG_NAME_QUERY]: selectedScanConfig }
+        : {};
+}
+
+export function combineSearchFilterWithScanConfig(
+    searchFilter: SearchFilter,
+    selectedScanConfig: QueryValue
+): SearchFilter {
+    return {
+        ...searchFilter,
+        ...createScanConfigFilter(selectedScanConfig),
+    };
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -11,7 +11,6 @@ import {
     WrenchIcon,
 } from '@patternfly/react-icons';
 
-import { QueryValue } from 'hooks/useURLParameter';
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
 import { SearchFilter } from 'types/search';
 
@@ -217,18 +216,16 @@ export function getClusterResultsStatusObject(status: ComplianceCheckStatus): Cl
     return statusIconTextMap[status];
 }
 
-export function createScanConfigFilter(selectedScanConfig: QueryValue) {
-    return typeof selectedScanConfig === 'string'
-        ? { [SCAN_CONFIG_NAME_QUERY]: selectedScanConfig }
-        : {};
+export function createScanConfigFilter(selectedScanConfigName: string | undefined) {
+    return selectedScanConfigName ? { [SCAN_CONFIG_NAME_QUERY]: selectedScanConfigName } : {};
 }
 
 export function combineSearchFilterWithScanConfig(
     searchFilter: SearchFilter,
-    selectedScanConfig: QueryValue
+    selectedScanConfigName: string | undefined
 ): SearchFilter {
     return {
         ...searchFilter,
-        ...createScanConfigFilter(selectedScanConfig),
+        ...createScanConfigFilter(selectedScanConfigName),
     };
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
-import { complianceEnhancedCoveragePath } from 'routePaths';
+import {
+    coverageProfileChecksPath,
+    coverageProfileClustersPath,
+    CoverageProfilePath,
+} from '../compliance.coverage.routes';
+import useScanConfigRouter from '../hooks/useNavigateWithScanConfig';
 
 export type ProfilesTableToggleGroupProps = {
     activeToggle: 'checks' | 'clusters';
 };
 
 function ProfilesTableToggleGroup({ activeToggle }: ProfilesTableToggleGroupProps) {
+    const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
-    const history = useHistory();
 
     const handleToggleChange = (resultsView) => {
-        history.push(`${complianceEnhancedCoveragePath}/profiles/${profileName}/${resultsView}`);
+        const path: CoverageProfilePath =
+            resultsView === 'checks' ? coverageProfileChecksPath : coverageProfileClustersPath;
+        navigateWithScanConfigQuery(path, { profileName });
     };
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -7,7 +7,7 @@ import {
     coverageProfileClustersPath,
     CoverageProfilePath,
 } from '../compliance.coverage.routes';
-import useScanConfigRouter from '../hooks/useNavigateWithScanConfig';
+import useScanConfigRouter from '../hooks/useScanConfigRouter';
 
 export type ProfilesTableToggleGroupProps = {
     activeToggle: 'checks' | 'clusters';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -1,0 +1,86 @@
+import React, { useContext, useState } from 'react';
+import {
+    Divider,
+    MenuToggle,
+    MenuToggleElement,
+    Select,
+    SelectGroup,
+    SelectList,
+    SelectOption,
+    Spinner,
+} from '@patternfly/react-core';
+
+import { ScanConfigurationsContext } from '../ScanConfigurationsProvider';
+
+const ALL_SCAN_SCHEDULES_OPTION = 'All scan schedules';
+
+function ScanConfigurationSelect() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const { scanConfigurationsQuery, selectedScanConfig, setSelectedScanConfig } =
+        useContext(ScanConfigurationsContext);
+
+    const onToggleClick = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const onSelect = (
+        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        value: string | number | undefined
+    ) => {
+        const selectedValue = value === ALL_SCAN_SCHEDULES_OPTION ? undefined : (value as string);
+        setSelectedScanConfig(selectedValue);
+        setIsOpen(false);
+    };
+
+    const renderToggle = (toggleRef: React.Ref<HTMLButtonElement | MenuToggleElement>) => {
+        return (
+            <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+                {(selectedScanConfig as string) || ALL_SCAN_SCHEDULES_OPTION}
+            </MenuToggle>
+        );
+    };
+
+    return (
+        <Select
+            id="scan-schedules-filter-id"
+            isOpen={isOpen}
+            selected={selectedScanConfig || ALL_SCAN_SCHEDULES_OPTION}
+            onSelect={onSelect}
+            onOpenChange={(isOpen) => setIsOpen(isOpen)}
+            toggle={renderToggle}
+            shouldFocusToggleOnSelect
+        >
+            {scanConfigurationsQuery.isLoading ? (
+                <SelectOption isLoading value="loader">
+                    <Spinner size="lg" />
+                </SelectOption>
+            ) : (
+                <>
+                    <SelectGroup label="View all results">
+                        <SelectList>
+                            <SelectOption
+                                key="key_all-scan-schedules"
+                                value={ALL_SCAN_SCHEDULES_OPTION}
+                            >
+                                {ALL_SCAN_SCHEDULES_OPTION}
+                            </SelectOption>
+                        </SelectList>
+                    </SelectGroup>
+                    <Divider />
+                    <SelectGroup label="Filter results by a schedule">
+                        <SelectList>
+                            {scanConfigurationsQuery.response.configurations.map(({ scanName }) => (
+                                <SelectOption key={scanName} value={scanName}>
+                                    {scanName}
+                                </SelectOption>
+                            ))}
+                        </SelectList>
+                    </SelectGroup>
+                </>
+            )}
+        </Select>
+    );
+}
+
+export default ScanConfigurationSelect;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -17,7 +17,7 @@ const ALL_SCAN_SCHEDULES_OPTION = 'All scan schedules';
 function ScanConfigurationSelect() {
     const [isOpen, setIsOpen] = useState(false);
 
-    const { scanConfigurationsQuery, selectedScanConfig, setSelectedScanConfig } =
+    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
         useContext(ScanConfigurationsContext);
 
     const onToggleClick = () => {
@@ -29,14 +29,14 @@ function ScanConfigurationSelect() {
         value: string | number | undefined
     ) => {
         const selectedValue = value === ALL_SCAN_SCHEDULES_OPTION ? undefined : (value as string);
-        setSelectedScanConfig(selectedValue);
+        setSelectedScanConfigName(selectedValue);
         setIsOpen(false);
     };
 
     const renderToggle = (toggleRef: React.Ref<HTMLButtonElement | MenuToggleElement>) => {
         return (
             <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-                {(selectedScanConfig as string) || ALL_SCAN_SCHEDULES_OPTION}
+                {selectedScanConfigName || ALL_SCAN_SCHEDULES_OPTION}
             </MenuToggle>
         );
     };
@@ -45,40 +45,41 @@ function ScanConfigurationSelect() {
         <Select
             id="scan-schedules-filter-id"
             isOpen={isOpen}
-            selected={selectedScanConfig || ALL_SCAN_SCHEDULES_OPTION}
+            selected={selectedScanConfigName || ALL_SCAN_SCHEDULES_OPTION}
             onSelect={onSelect}
             onOpenChange={(isOpen) => setIsOpen(isOpen)}
             toggle={renderToggle}
             shouldFocusToggleOnSelect
         >
-            {scanConfigurationsQuery.isLoading ? (
-                <SelectOption isLoading value="loader">
-                    <Spinner size="lg" />
-                </SelectOption>
-            ) : (
-                <>
-                    <SelectGroup label="View all results">
-                        <SelectList>
-                            <SelectOption
-                                key="key_all-scan-schedules"
-                                value={ALL_SCAN_SCHEDULES_OPTION}
-                            >
-                                {ALL_SCAN_SCHEDULES_OPTION}
+            <>
+                <SelectGroup label="View all results">
+                    <SelectList>
+                        <SelectOption value={ALL_SCAN_SCHEDULES_OPTION}>
+                            {ALL_SCAN_SCHEDULES_OPTION}
+                        </SelectOption>
+                    </SelectList>
+                </SelectGroup>
+                <Divider />
+                <SelectGroup label="Filter results by a schedule">
+                    <SelectList>
+                        {scanConfigurationsQuery.isLoading ? (
+                            <SelectOption isLoading value="loader" isDisabled>
+                                <Spinner size="lg" />
                             </SelectOption>
-                        </SelectList>
-                    </SelectGroup>
-                    <Divider />
-                    <SelectGroup label="Filter results by a schedule">
-                        <SelectList>
-                            {scanConfigurationsQuery.response.configurations.map(({ scanName }) => (
-                                <SelectOption key={scanName} value={scanName}>
-                                    {scanName}
-                                </SelectOption>
-                            ))}
-                        </SelectList>
-                    </SelectGroup>
-                </>
-            )}
+                        ) : (
+                            <>
+                                {scanConfigurationsQuery.response.configurations.map(
+                                    ({ scanName }) => (
+                                        <SelectOption key={scanName} value={scanName}>
+                                            {scanName}
+                                        </SelectOption>
+                                    )
+                                )}
+                            </>
+                        )}
+                    </SelectList>
+                </SelectGroup>
+            </>
         </Select>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useNavigateWithScanConfig.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useNavigateWithScanConfig.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { generatePathWithQuery } from 'utils/searchUtils';
+
+import { ScanConfigurationsContext } from '../ScanConfigurationsProvider';
+
+const useScanConfigRouter = () => {
+    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+    const history = useHistory();
+
+    function generatePathWithScanConfig(path, pathParams: Partial<Record<string, unknown>> = {}) {
+        return generatePathWithQuery(
+            path,
+            pathParams,
+            selectedScanConfig ? { scanSchedule: selectedScanConfig } : {}
+        );
+    }
+
+    function navigateWithScanConfigQuery(path, pathParams: Partial<Record<string, unknown>> = {}) {
+        const generatedPath = generatePathWithScanConfig(path, pathParams);
+        history.push(generatedPath);
+    }
+
+    return { navigateWithScanConfigQuery, generatePathWithScanConfig };
+};
+
+export default useScanConfigRouter;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
@@ -6,14 +6,14 @@ import { generatePathWithQuery } from 'utils/searchUtils';
 import { ScanConfigurationsContext } from '../ScanConfigurationsProvider';
 
 const useScanConfigRouter = () => {
-    const { selectedScanConfig } = useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const history = useHistory();
 
     function generatePathWithScanConfig(path, pathParams: Partial<Record<string, unknown>> = {}) {
         return generatePathWithQuery(
             path,
             pathParams,
-            selectedScanConfig ? { scanSchedule: selectedScanConfig } : {}
+            selectedScanConfigName ? { scanSchedule: selectedScanConfigName } : {}
         );
     }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -47,8 +47,7 @@ import { SortOption } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { displayOnlyItemOrItemCount } from 'utils/textUtils';
 
-import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
-import { SCAN_CONFIG_NAME_QUERY } from './compliance.scanConfigs.constants';
+import { DEFAULT_COMPLIANCE_PAGE_SIZE, SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
 import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
 import {
     formatScanSchedule,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.constants.ts
@@ -1,2 +1,0 @@
-// searchable and sortable query parameter fields
-export const SCAN_CONFIG_NAME_QUERY = 'Compliance Scan Config Name';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/compliance.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/compliance.constants.ts
@@ -1,1 +1,4 @@
 export const DEFAULT_COMPLIANCE_PAGE_SIZE = 10;
+
+// searchable and sortable query parameter fields
+export const SCAN_CONFIG_NAME_QUERY = 'Compliance Scan Config Name';

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -1,8 +1,9 @@
 import axios from 'services/instance';
 import qs from 'qs';
 
-import { ApiSortOption } from 'types/search';
+import { ApiSortOption, SearchFilter } from 'types/search';
 import { SlimUser } from 'types/user.proto';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import { ComplianceProfileSummary, complianceV2Url } from './ComplianceCommon';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
@@ -99,7 +100,7 @@ export type ListComplianceScanConfigsClusterProfileResponse = {
  * Fetches a list of scan configurations.
  */
 export function listComplianceScanConfigurations(
-    sortOption: ApiSortOption,
+    sortOption?: ApiSortOption,
     page?: number,
     pageSize?: number
 ): Promise<ListComplianceScanConfigurationsResponse> {
@@ -201,10 +202,14 @@ export function runComplianceReport(scanConfigId: string): Promise<ComplianceRun
 /**
  * Fetches all profiles that are included in a scan configuration.
  */
-export function listComplianceScanConfigProfiles(): Promise<ListComplianceScanConfigsProfileResponse> {
+export function listComplianceScanConfigProfiles(
+    searchFilter: SearchFilter
+): Promise<ListComplianceScanConfigsProfileResponse> {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const params = qs.stringify({ query }, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<ListComplianceScanConfigsProfileResponse>(
-            `${complianceScanConfigBaseUrl}/profiles/collection`
+            `${complianceScanConfigBaseUrl}/profiles/collection?${params}`
         )
         .then((response) => response.data);
 }

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -314,7 +314,12 @@ export function addRegexPrefixToFilters(
 }
 
 // Uses the generatePath function from react-router in addition to adding the query params
-export const generatePathWithQuery = (pathTemplate, params, queryParams) => {
+// TODO: Fallback needed?
+export const generatePathWithQuery = (
+    pathTemplate: string,
+    params: Partial<Record<string, unknown>>,
+    queryParams
+) => {
     const path = safeGeneratePath(pathTemplate, params, pathTemplate);
     const searchParams = new URLSearchParams(queryParams).toString();
     return `${path}?${searchParams}`;

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -317,10 +317,10 @@ export function addRegexPrefixToFilters(
 // TODO: Fallback needed?
 export const generatePathWithQuery = (
     pathTemplate: string,
-    params: Partial<Record<string, unknown>>,
+    pathParams: Partial<Record<string, unknown>>,
     queryParams
 ) => {
-    const path = safeGeneratePath(pathTemplate, params, pathTemplate);
+    const path = safeGeneratePath(pathTemplate, pathParams, pathTemplate);
     const searchParams = new URLSearchParams(queryParams).toString();
     return `${path}?${searchParams}`;
 };


### PR DESCRIPTION
## Description

### Adds a Scan Schedule Filter to Compliance Coverage

#### Scan Configurations Context
- Handles fetching, scan schedule selection, and setting.
- Wraps the entire coverage page, including the ComplianceProfilesProvider.
- Uses `useURLParameter` to track selections and manage the `QueryValue`, converting it to a string or undefined.
- Undefined indicates that all scan schedule results are shown.

#### Utility Functions
- **`createScanConfigFilter`**: creates the `SearchFilter` object using the scan config query (`scanSchedule`)
- **`combineSearchFilterWithScanConfig`**: combines `searchFilter` with `selectedScanConfig`

#### Profiles Toggle Group
- **Alphabetized**: Benchmark tabs are now alphabetized with 'Other' remaining at the end

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

#### Default state
![Screenshot 2024-06-20 at 7 40 23 PM](https://github.com/stackrox/stackrox/assets/61400697/978385d2-cbfd-4373-888a-dc5c7dbb4d6c)


#### Filter open
![Screenshot 2024-06-20 at 7 40 31 PM](https://github.com/stackrox/stackrox/assets/61400697/5c228c9c-25e9-4b9e-a8a0-764b99bc68fd)


#### Scan schedule selected
![Screenshot 2024-06-20 at 7 40 59 PM](https://github.com/stackrox/stackrox/assets/61400697/fc43ee18-119c-4377-aa8e-dca46a91f67b)


#### Loading state
![Screenshot 2024-06-21 at 2 40 53 PM](https://github.com/stackrox/stackrox/assets/61400697/4148824d-9315-4a32-b651-bc335bcdbaef)
