### PR TITLE
ROX-24163: Add timeout to TLS handshake

### DIFF
--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	proxyReloadInterval = 5 * time.Second
-	tlsHandshakeTimeout = 2 * time.Second
 )
 
 var (
@@ -155,11 +154,9 @@ func AwareDialContextTLS(ctx context.Context, address string, tlsClientConf *tls
 		tlsClientConf = tlsClientConf.Clone()
 		tlsClientConf.ServerName = host
 	}
-	ctxHandshake, cancel := context.WithTimeout(ctx, tlsHandshakeTimeout)
-	defer cancel()
 	tlsConn := tls.Client(conn, tlsClientConf)
 	// The handshake must be done with a timeout to avoid infinite blocking of Sensor sync.
-	if err := tlsConn.HandshakeContext(ctxHandshake); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		utils.IgnoreError(tlsConn.Close)
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Sensor during its start synchronizes secrets with the orchestrator. Some types of secrets - `kubernetes.io/dockerconfigjson`, `kubernetes.io/dockerconfig` - contain URLs of registries. In the sync process, those URLs are contacted to store the information about their TLS status. To do that, Sensor calls proxy-aware `Dial` and does TLS `Handshake`. In cases when the destination accepts the connection but never does the handshake (hangs forever), the sync of secrets will freeze and never finish. Sensor would appear healthy, but its data stores will be not fully populated and the state will be corrupted.

At the first glimpse, this is not trivial to spot*, but one of the symptoms is that the node scanning feature would not be able to match the k8s node by name in Sensor (cause the stores are not populated). 

*) We will open another PR to make the log analysis easier.

⚠️ This PR solves one (of potentially few) problems reported by customer in case 03814515.

## Checklist
- [x] Investigated and inspected CI test results - ⌛ 
- [ ] Unit test and regression tests added - 🚧 I could craft one or two of unit tests and add them.

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

This has been manually verified using local-sensor and toxiproxy. Here are the reproduction steps.

1. Installation of toxiproxy

```
brew tap shopify/shopify
brew install toxiproxy
```

2. Start the proxy server (one can pipe logs to `jq` as they are in json format) and let it run

```
toxiproxy-server
```

3. Add new proxy to the server - it should listen on port 8989 and forward all traffic to `example.com:443` (any other TLS-terminanted destination would work - it does not need to be a container registry)

```
toxiproxy-cli create -l localhost:8989 -u example.com:443 example-proxy
```

4. Add toxic behavior to the proxy - here add 120s latency on the connection back to Sensor

```
toxiproxy-cli toxic add -n high_latency -t latency -a latency=120000 example-proxy
```

5. (optional) Confirm toxiproxy works as expected - expect a reply in 2 mins (or a timeout)

```
curl -sL localhost:8989
```

6. Create k8s registry secret (you'll need a running cluster for this) that points to the proxy

```
kubectl -n stackrox create secret docker-registry slow-registry-secret \
  --docker-server="http://localhost:8989/v1/" \
  --docker-username=test \
  --docker-password=test \
  --docker-email=ehlo@example.com -o yaml
```

7a. Run local-sensor and observe the logs (symptoms are better visible in debug mode) - the sync of secrets should hang for 2 minutes.

```
ROX_LOCAL_IMAGE_SCANNING_ENABLED=true ROX_DELEGATED_SCANNING_DISABLED=false LOGLEVEL=DEBUG go run tools/local-sensor/main.go -no-mem-prof -no-cpu-prof -central-out /dev/null
```

The following line should appear first after two minutes:

```
 Info: Successfully synced namespaces, secrets, service accounts, roles, and cluster roles
```



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
