### PR TITLE
ROX-24858: Replace "No results" text in summary cards

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
@@ -105,18 +105,17 @@ describe('Workload CVE Deployment Single page', () => {
 
         // Check that no severities are hidden by default
         cy.get(selectors.summaryCard('CVEs by severity'))
-            .find("*:contains('Results hidden')")
+            .find('p')
+            .contains(new RegExp('(Critical|Important|Moderate|Low) hidden'))
             .should('not.exist');
 
         applyLocalSeverityFilters('Critical');
 
         // Check that summary card severities are hidden correctly
-        cy.get(`${selectors.severityIcon('Critical')} + *:contains("Results hidden")`).should(
-            'not.exist'
-        );
-        cy.get(`${selectors.severityIcon('Important')} + *:contains("Results hidden")`);
-        cy.get(`${selectors.severityIcon('Moderate')} + *:contains("Results hidden")`);
-        cy.get(`${selectors.severityIcon('Low')} + *:contains("Results hidden")`);
+        cy.get(`*:contains("Critical hidden")`).should('not.exist');
+        cy.get(`*:contains("Important hidden")`);
+        cy.get(`*:contains("Moderate hidden")`);
+        cy.get(`*:contains("Low hidden")`);
 
         // Check that table rows are filtered
         cy.get(selectors.filteredViewLabel);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -106,7 +106,8 @@ describe('Workload CVE Image Single page', () => {
         visitFirstImage();
         // Check that no severities are hidden by default
         cy.get(selectors.summaryCard('CVEs by severity'))
-            .find("*:contains('Results hidden')")
+            .find('p')
+            .contains(new RegExp('(Critical|Important|Moderate|Low) hidden'))
             .should('not.exist');
 
         const severityFilter = 'Critical';
@@ -114,12 +115,10 @@ describe('Workload CVE Image Single page', () => {
         applyLocalSeverityFilters(severityFilter);
 
         // Check that summary card severities are hidden correctly
-        cy.get(`${selectors.severityIcon('Critical')} + *:contains("Results hidden")`).should(
-            'not.exist'
-        );
-        cy.get(`${selectors.severityIcon('Important')} + *:contains("Results hidden")`);
-        cy.get(`${selectors.severityIcon('Moderate')} + *:contains("Results hidden")`);
-        cy.get(`${selectors.severityIcon('Low')} + *:contains("Results hidden")`);
+        cy.get(`*:contains("Critical hidden")`).should('not.exist');
+        cy.get(`*:contains("Important hidden")`);
+        cy.get(`*:contains("Moderate hidden")`);
+        cy.get(`*:contains("Low hidden")`);
 
         // Check that table rows are filtered
         cy.get(selectors.filteredViewLabel);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
@@ -23,6 +23,11 @@ const statusDisplays = [
     },
 ] as const;
 
+const statusHiddenText = {
+    Fixable: 'Fixable hidden',
+    'Not fixable': 'Not fixable hidden',
+} as const;
+
 export const platformCveCountByStatusFragment = gql`
     fragment PlatformCveCountByStatus on PlatformCVECountByStatus {
         total
@@ -59,7 +64,7 @@ function PlatformCvesByStatusSummaryCard({
                             >
                                 <Icon />
                                 <Text style={{ color: isHidden ? disabledColor100 : 'inherit' }}>
-                                    {isHidden ? 'Results hidden' : text(data)}
+                                    {isHidden ? statusHiddenText[status] : text(data)}
                                 </Text>
                             </Flex>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -66,6 +66,11 @@ const statusDisplays = [
 
 const disabledColor100 = 'var(--pf-v5-global--disabled-color--100)';
 
+const statusHiddenText = {
+    Fixable: 'Fixable hidden',
+    'Not fixable': 'Not fixable hidden',
+} as const;
+
 export type CvesByStatusSummaryCardProps = {
     cveStatusCounts: ResourceCountByCveSeverityAndStatus;
     hiddenStatuses: Set<FixableStatus>;
@@ -103,7 +108,9 @@ function CvesByStatusSummaryCard({
                                             color: isHidden ? disabledColor100 : 'inherit',
                                         }}
                                     >
-                                        {isHidden ? 'Results hidden' : text(cveStatusCounts)}
+                                        {isHidden
+                                            ? statusHiddenText[status]
+                                            : text(cveStatusCounts)}
                                     </Text>
                                 </Flex>
                             </GridItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
@@ -20,6 +20,13 @@ const severityToQuerySeverityKeys = {
     LOW_VULNERABILITY_SEVERITY: 'low',
 } as const;
 
+const severityToHiddenText = {
+    CRITICAL_VULNERABILITY_SEVERITY: 'Critical hidden',
+    IMPORTANT_VULNERABILITY_SEVERITY: 'Important hidden',
+    MODERATE_VULNERABILITY_SEVERITY: 'Moderate hidden',
+    LOW_VULNERABILITY_SEVERITY: 'Low hidden',
+} as const;
+
 const fadedTextColor = 'var(--pf-v5-global--Color--200)';
 
 export type ResourceCountsByCveSeverity = {
@@ -50,20 +57,11 @@ function BySeveritySummaryCard({
                     {severitiesCriticalToLow.map((severity) => {
                         const querySeverityKey = severityToQuerySeverityKeys[severity];
                         const count = severityCounts[querySeverityKey];
-                        const hasNoResults = count.total === 0;
                         const isHidden = hiddenSeverities.has(severity);
-
-                        let textColor = '';
-                        let text = `${count.total} ${vulnerabilitySeverityLabels[severity]}`;
-
-                        if (isHidden) {
-                            textColor = fadedTextColor;
-                            text = 'Results hidden';
-                        } else if (hasNoResults) {
-                            textColor = fadedTextColor;
-                            text = 'No results';
-                        }
-
+                        const textColor = isHidden ? fadedTextColor : '';
+                        const text = isHidden
+                            ? severityToHiddenText[severity]
+                            : `${count.total} ${vulnerabilitySeverityLabels[severity]}`;
                         const Icon = SeverityIcons[severity];
 
                         return (
@@ -73,12 +71,10 @@ function BySeveritySummaryCard({
                                     spaceItems={{ default: 'spaceItemsSm' }}
                                     alignItems={{ default: 'alignItemsCenter' }}
                                 >
-                                    {Icon && (
-                                        <Icon
-                                            title={vulnerabilitySeverityLabels[severity]}
-                                            color={hasNoResults ? textColor : undefined}
-                                        />
-                                    )}
+                                    <Icon
+                                        title={vulnerabilitySeverityLabels[severity]}
+                                        color={isHidden ? textColor : undefined}
+                                    />
                                     <Text style={{ color: textColor }}>{text}</Text>
                                 </Flex>
                             </GridItem>


### PR DESCRIPTION
## Description

Updates the text for severity and status summary cards to be less cryptic and to explicitly describe what type of results are hidden, or have a zero count.

e.g.

"Results hidden" => "Critical hidden"
"Results hidden" => "Fixable hidden"
"No results" => "0 Important"

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Results with values == 0 and values > 0:
<img width="1305" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/830874a5-5478-4f62-8480-aa524a9a8836">

Results with values hidden via filters:
<img width="1305" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/6dcfaec4-418c-4ab9-af61-842a5a5b60b8">
