### PR TITLE
tests(qa): enable retry on grpc

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -132,7 +132,7 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 func (s *serviceImpl) GetImage(ctx context.Context, request *v1.GetImageRequest) (*storage.Image, error) {
 	log.Infof("GetImage %q", request.String())
 	log.Warn("Returning error")
-	return nil, status.Error(codes.Unknown, "Unknown error")
+	return nil, status.Error(codes.Unavailable, "Unknown error")
 }
 
 // CountImages counts the number of images that match the input query.

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -130,30 +130,9 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // GetImage returns an image with given sha if it exists.
 func (s *serviceImpl) GetImage(ctx context.Context, request *v1.GetImageRequest) (*storage.Image, error) {
-	if request.GetId() == "" {
-		return nil, errors.Wrap(errox.InvalidArgs, "id must be specified")
-	}
-
-	id := types.NewDigest(request.GetId()).Digest()
-
-	image, exists, err := s.datastore.GetImage(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.Wrapf(errox.NotFound, "image with id %q does not exist", request.GetId())
-	}
-
-	if !request.GetIncludeSnoozed() {
-		// This modifies the image object
-		utils.FilterSuppressedCVEsNoClone(image)
-	}
-	if request.GetStripDescription() {
-		// This modifies the image object
-		utils.StripCVEDescriptionsNoClone(image)
-	}
-
-	return image, nil
+	log.Infof("GetImage %q", request.String())
+	log.Warn("Returning error")
+	return nil, status.Error(codes.Unknown, "Unknown error")
 }
 
 // CountImages counts the number of images that match the input query.

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -15,11 +15,11 @@ repositories {
     mavenCentral()
 }
 
-def grpcVersion = '1.57.2'
+def grpcVersion = '1.65.0'
 // If the proto versions are changed, be sure it is also changed in make/protogen.mk.
 def protocVersion = '3.25.3'
 def protobufVersion = '3.25.3'
-def nettyTcNativeVersion = '2.0.61.Final'
+def nettyTcNativeVersion = '2.0.65.Final'
 def fabric8Version = '6.12.1'
 def jacksonVersion = '2.14.2'
 

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -151,7 +151,6 @@ class BaseService {
         return ["methodConfig": [
                 [
                         "name"       : [["service": ""]],
-                        "timeout"    : "30.0s",
                         "retryPolicy": [
                                 "maxAttempts"         : "3",
                                 "initialBackoff"      : "1s",
@@ -164,7 +163,6 @@ class BaseService {
                                         "INTERNAL",
                                         "RESOURCE_EXHAUSTED",
                                         "UNAVAILABLE",
-                                        "UNAUTHENTICATED",
                                         "UNKNOWN",
                                 ]
                         ]

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -163,7 +163,15 @@ class BaseService {
                                 "initialBackoff"      : "1s",
                                 "maxBackoff"          : "10s",
                                 "backoffMultiplier"   : "2",
-                                "retryableStatusCodes": ["UNAVAILABLE", "UNKNOWN"]
+                                "retryableStatusCodes": [
+                                        "ABORTED",
+                                        "CANCELLED",
+                                        "DEADLINE_EXCEEDED",
+                                        "INTERNAL",
+                                        "RESOURCE_EXHAUSTED",
+                                        "UNAVAILABLE",
+                                        "UNKNOWN",
+                                ]
                         ]
                 ]
         ]]

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -25,6 +25,7 @@ import objects.Secret
 import services.BaseService
 import services.ClusterService
 import services.ImageIntegrationService
+import services.ImageService
 import services.MetadataService
 import services.RoleService
 import util.Env
@@ -236,6 +237,8 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
+
+        ImageService.getImage("some digest ")
     }
 
     static setupCoreImageIntegration() {


### PR DESCRIPTION
## Description

This PR enables retrying in grpc as described in https://stackoverflow.com/a/76784188/1387612

- #4921
- https://github.com/stackrox/stackrox/pull/7636

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```diff
index 818499cd31..3356470f92 100644
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -28,8 +28,8 @@ import util.Keys
 @Slf4j
 class BaseService {
 
-    static final String BASIC_AUTH_USERNAME = Env.mustGetUsername()
-    static final String BASIC_AUTH_PASSWORD = Env.mustGetPassword()
+    static final String BASIC_AUTH_USERNAME = "admin"
+    static final String BASIC_AUTH_PASSWORD = "pass"
 
     static final EMPTY = EmptyOuterClass.Empty.newBuilder().build()
 
@@ -130,7 +130,7 @@ class BaseService {
             def sslContext = sslContextBuilder.build()
 
             transportChannel = NettyChannelBuilder
-                    .forAddress(Env.mustGetHostname(), Env.mustGetPort())
+                    .forAddress("localhost", 8000)
                     .defaultServiceConfig(getServiceConfig())
                     .maxRetryAttempts(3)
                     .enableRetry()
@@ -153,14 +153,14 @@ class BaseService {
         return ["methodConfig": [
                 [
                         "name"       : [
-                                ["service": "$AuthProviderServiceGrpc.SERVICE_NAME"],
+                                ["service": "$AuthProviderServiceGrpc.SERVICE_NAME".toString()],
                         ],
                         "timeout"    : "30.0s",
                         "retryPolicy": [
                                 "maxAttempts"         : "3",
                                 "initialBackoff"      : "1s",
                                 "maxBackoff"          : "10s",
-                                "backoffMultiplier"   : 2,
+                                "backoffMultiplier"   : "1",
                                 "retryableStatusCodes": ["UNAVAILABLE", "UNKNOWN"]
                         ]
                 ]
diff --git a/qa-tests-backend/src/main/groovy/util/Env.groovy b/qa-tests-backend/src/main/groovy/util/Env.groovy
index a04a71cf6b..0016cf1543 100644
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -35,7 +35,7 @@ class Env {
     // only has secured-cluster deployed and connects to a remote central
     static final ONLY_SECURED_CLUSTER = System.getenv("ONLY_SECURED_CLUSTER") ?: "false"
 
-    private static final Env INSTANCE = new Env()
+    private static final Env INSTANCE = null
 
     static String get(String key, String defVal = null) {
         return INSTANCE.getInternal(key, defVal)
diff --git a/qa-tests-backend/src/test/groovy/GrpcRetryTest.groovy b/qa-tests-backend/src/test/groovy/GrpcRetryTest.groovy
index a09b9650aa..1dd702c5b7 100644
--- a/qa-tests-backend/src/test/groovy/GrpcRetryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GrpcRetryTest.groovy
@@ -1,2 +1,15 @@
-class GrpcRetryTest {
+import io.stackrox.proto.api.v1.AuthProviderServiceGrpc
+import io.stackrox.proto.storage.AuthProviderOuterClass
+
+import services.AuthProviderService
+
+import spock.lang.Specification
+
+class GrpcRetryTest extends Specification {
+    def "will it retry"() {
+        when:
+        def provider = AuthProviderService.getAuthProvider("admin")
+        then:
+        provider
+    
```

I used above code to hit 
```
python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
127.0.0.1 - - [24/Jun/2024 19:24:59] code 400, message Bad request syntax ('\x16\x03\x03\x01\x89\x01\x00\x01\x85\x03\x03jG¡oqÎÝ\x08\x04özÂ\x9f9\rø:0Ò`ÙµYFKì^¯8;}Ñ j\x9eÛ¿\x9b®\x8b½\x04\x0b\x9b¨\x08i\x88=÷ãvs8n\x88ÎB¹Ë')
127.0.0.1 - - [24/Jun/2024 19:24:59] "
ø:0Ò`ÙµYFKì^¯8;}Ñ jÛ¿®½
                           i=÷ãvs8nÎB¹Ë" 400 -
127.0.0.1 - - [24/Jun/2024 19:25:00] code 400, message Bad request version ('Ó@A\x97\x129\x82Í\x9c\x03ò\x88T£¸gf©!dÂä×Þ\x93ôº\x07a]¯\x86\x00\x12À+À/À,À0Ì©Ì¨\x13\x01\x13\x02\x13\x03\x01\x00\x01*\x00\x05\x00\x05\x01\x00\x00\x00\x00\x00')
127.0.0.1 - - [24/Jun/2024 19:25:00] "
=YÔ,&FwýZKìstÜÕÝ({)çJÙÛØ Ó@A9ÍòT£¸gf©!dÂä×Þôºa]¯À+À/À,À0Ì©Ì¨*" 400 -
^[[?62;c^C
Keyboard interrupt received, exiting.
```
Without config it looks like this an takes
```
python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
127.0.0.1 - - [24/Jun/2024 19:27:11] code 400, message Bad request syntax ('\x16\x03\x03\x01\x89\x01\x00\x01\x85\x03\x03¦µ)\\ul\x9fD£Ù\x07¢xî2Å\x0e\x93´s\x9cDIf«âR"Þ`\x1c\x9d ge\x0b\x9dózO\x90Ù»èÒþó~³Ó\x11\x9b¶_uw¶mµ\x0cÎ¬\x89M\x7f\x00\x12À+À/À,À0Ì©Ì¨\x13\x01\x13\x02\x13\x03\x01\x00\x01*\x00\x05\x00\x05\x01\x00\x00\x00\x00\x00')
127.0.0.1 - - [24/Jun/2024 19:27:11] "
¦µ)\ulD£Ù¢xî2Å´sDIf«âR"Þ` ge
                                   ózOÙ»èÒþó~³Ó¶_uw¶mµ
                                                          Î¬MÀ+À/À,À0Ì©Ì¨*" 400 -
^C

```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
