### PR TITLE
ROX-24892: Fix accessibility issues in compliance clusters

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -56,16 +56,13 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
                 const headerTextComponent = (
                     <div className="w-full flex items-center">
                         <div className="flex items-center" data-testid="side-panel-header">
-                            <Link
-                                to={headerUrl}
-                                className="w-full flex text-primary-700 hover:text-primary-800 focus:text-primary-700"
-                            >
+                            <Link to={headerUrl} className="w-full flex pf-v5-u-link-color">
                                 <div className="flex flex-1 items-center pl-4 leading-normal font-700">
                                     {linkText}
                                 </div>
                             </Link>
                             <Link
-                                className="mx-2 text-primary-700 hover:text-primary-800 p-1 bg-primary-300 rounded flex"
+                                className="mx-2 pf-v5-u-link-color p-1 rounded flex"
                                 to={headerUrl}
                                 target="_blank"
                                 aria-label="External link"

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -12,7 +12,6 @@ import Table from 'Components/Table';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
 import Loader from 'Components/Loader';
 import TablePagination from 'Components/TablePagination';
-import TableGroup from 'Components/TableGroup';
 import { getColumnsByEntity, getColumnsByStandard } from 'constants/tableColumns';
 import Query from 'Components/CacheFirstQuery';
 import NoResultsMessage from 'Components/NoResultsMessage';
@@ -23,6 +22,7 @@ import { LIST_STANDARD, STANDARDS_QUERY } from 'queries/standard';
 import queryService from 'utils/queryService';
 
 import { complianceEntityTypes, entityCountNounOrdinaryCase } from '../entitiesForCompliance';
+import TableGroup from './TableGroup';
 
 function getQuery(entityType) {
     switch (entityType) {

--- a/ui/apps/platform/src/Containers/Compliance/List/TableGroup.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/TableGroup.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Table from 'Components/Table';
 import Collapsible from 'react-collapsible';
 import * as Icon from 'react-feather';
-import pluralize from 'pluralize';
+
+import { entityCountNounOrdinaryCase } from '../entitiesForCompliance';
 
 const icons = {
     opened: <Icon.ChevronUp size="14" />,
@@ -63,9 +64,9 @@ class TableGroup extends Component {
                     </div>
                     <h1 className="p-3 pl-0 font-700 text-lg leading-normal">{name}</h1>
                 </div>
-                <div className="flex items-center flex-shrink-0 font-700 text-sm p-3 pr-4 opacity-50">{`${
-                    rows.length
-                } ${pluralize(this.props.entityType, rows.length)}`}</div>
+                <div className="flex items-center flex-shrink-0 p-3 pr-4">
+                    {entityCountNounOrdinaryCase(rows.length, this.props.entityType)}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description

### Problems according to axe DevTools

1. /main/compliance/clusters/id

    > Elements must meet minimum color contrast ratio thresholds

    `<div class="flex flex-1 items-center pl-4 leading-normal font-700">remote</div>`

2. /main/compliance/clusters/id/controls

    > Elements must meet minimum color contrast ratio thresholds
    `<div class="flex items-center flex-shrink-0 font-700 text-sm p-3 pr-4 opacity-50">122 CONTROLS</div>`

### Analysis

1. Classic `text-primary-700` has insufficient 3.65 color contrast ratio.

2. Small, heavy, and dim: `font-700` `text-sm` `opacity-50`
    Was also unique combination of size, weight, and opacity.

### Solutions

1. Replace `text-primary-700` with `pf-v5-u-link-color` utility class.

2. Move and edit TableGroup.js file.
    * Render as ordinary text.
    * Because `TableGroup` is only for compliance standards, replace generic pluralize of UPPERCASE entity type with container-specific `entityCountNounOrdinaryCase` function.

### Residue

1. Replace other occurrences of `text-primary-700` class?
2. Investigate accessibility issue on many classic pages:
    > Scrollable region must have keyboard access

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636952 - 4636952
        total -128 = 11719417 - 11719545
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/clusters and click a row to display side panel.

    * Before change without sufficient color contrast ratio
        ![compliance_clusters_id_without_contrast](https://github.com/stackrox/stackrox/assets/11862657/5c6e5b4d-dd60-42e1-8783-d5da34a97062)

    * After change with sufficient color contrast ratio
        ![compliance_clusters_id_with_contrast](https://github.com/stackrox/stackrox/assets/11862657/b72ac71a-6321-4434-aa9d-a260503b9c06)

2. Click cluster link in side panel, and then click **Controls** tab in single page.

    * Before change without sufficient color contrast ratio
        ![compliance_cluster_id_controls_without_contrast lpng](https://github.com/stackrox/stackrox/assets/11862657/ee2be7a6-6e72-49fc-b5e3-b625cdc12718)

    * After change with sufficient color contrast ratio
        ![compliance_cluster_id_controls_with_contrast lpng](https://github.com/stackrox/stackrox/assets/11862657/642e6668-546d-45d2-9212-e87e7f14b68c)
