### PR TITLE
ROX-24910: Set ROX_POSTGRES_DATASTORE to true by default in e2e tests

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -18,6 +18,7 @@ class Env {
             "API_HOSTNAME": "localhost",
             "API_PORT": "8000",
             "ROX_USERNAME": "admin",
+            "ROX_POSTGRES_DATASTORE": "true",
     ]
 
     static final IN_CI = (System.getenv("CI") == "true")


### PR DESCRIPTION
## Description

Sets ROX_POSTGRES_DATASTORE to true by default in the groovy code of the e2e tests, so that it doesn't have to be set manually before running e2e tests locally.

## Checklist
- [x] Investigated and inspected CI test results
      ocp-4-12-nongroovy-e2e-tests fails, but is unrelated to the changes here
- [x] Checked that e2e test fails locally in master when ROX_POSTGRES_DATASTORE is not set
- [x] e2e test passes locally in this branch when ROX_POSTGRES_DATASTORE is not set
- [x] e2e test passes locally in this branch when ROX_POSTGRES_DATASTORE is set to true
- [x] e2e test fails locally in this branch when ROX_POSTGRES_DATASTORE is set to false
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

This is a change to how tests are done, so there is no need for unit tests. This is a change for internal testing so no user facing documentation is needed. There is no change to the upgrade steps.

## Testing Performed

### This branch

```
$ ./gradlew test --tests=NetworkFlowTest

...

BUILD SUCCESSFUL in 8m 13s
11 actionable tasks: 1 executed, 10 up-to-date
```

### Master

This is what happens when ROX_POSTGRES_DATASTORE is not set when running e2e tests locally in master

```
$ ./gradlew test --tests=NetworkFlowTest

> Task :test

NetworkFlowTest STANDARD_OUT
    09:08:36 | INFO  | NetworkFlowTest           | NetworkFlowTest           | Starting testsuite
    09:08:36 | INFO  | NetworkFlowTest           | BaseSpecification         | Performing global setup
    09:08:36 | INFO  | NetworkFlowTest           | BaseSpecification         | Will perform strict integration testing (if any is required)
    09:08:38 | DEBUG | NetworkFlowTest           | Kubernetes                | quay: secret created.
    09:08:38 | DEBUG | NetworkFlowTest           | Kubernetes                | public-dockerhub: secret created.
    09:08:38 | WARN  | NetworkFlowTest           | BaseSpecification         | The GOOGLE_CREDENTIALS_GCR_SCANNER_V2 env var is missing. (this is ok if your test does not use images on us.gcr.io)
    09:08:38 | DEBUG | NetworkFlowTest           | BaseService               | The gRPC channel to central was opened (useClientCert: false)
    09:08:39 | INFO  | NetworkFlowTest           | BaseSpecification         | Testing against:
    09:08:40 | INFO  | NetworkFlowTest           | BaseSpecification         | version: "4.4.x-1067-gb5cb591df3"
    build_flavor: "development"
    license_status: VALID

    09:08:40 | INFO  | NetworkFlowTest           | BaseSpecification         | isGKE: true
    09:08:40 | INFO  | NetworkFlowTest           | BaseSpecification         | isEKS: false
    09:08:40 | INFO  | NetworkFlowTest           | BaseSpecification         | isOpenShift4: false
    09:08:40 | INFO  | NetworkFlowTest           | BaseSpecification         | testTarget: 
    09:08:41 | DEBUG | NetworkFlowTest           | Helpers                   | Caught exception. Retrying in 1s (attempt 0 of 30): io.grpc.StatusRuntimeException: INVALID_ARGUMENT: referenced access scope io.stackrox.authz.accessscope.unrestricted does not exist: invalid arguments
    09:08:42 | DEBUG | NetworkFlowTest           | Helpers                   | Caught exception. Retrying in 1s (attempt 1 of 30): io.grpc.StatusRuntimeException: INVALID_ARGUMENT: referenced access scope io.stackrox.authz.accessscope.unrestricted does not exist: invalid arguments
    09:08:43 | DEBUG | NetworkFlowTest           | Helpers 

...

    09:09:19 | DEBUG | NetworkFlowTest           | Helpers                   | Caught exception. Retrying in 1s (attempt 29 of 30): io.grpc.StatusRuntimeException: INVALID_ARGUMENT: referenced access scope io.stackrox.authz.accessscope.unrestricted does not exist: invalid arguments
    09:09:21 | WARN  | NetworkFlowTest           | Helpers                   | Debug collection will be skipped. [CI: false, GATHER_QA_TEST_DEBUG_LOGS: false, QA_TEST_DEBUG_LOGS: ]
    09:09:21 | DEBUG | NetworkFlowTest           | Kubernetes                | Waiting for namespace qa2 to be deleted
    09:09:21 | DEBUG | NetworkFlowTest           | Kubernetes                | K8s found that namespace qa2 was deleted
    09:09:21 | DEBUG | NetworkFlowTest           | Kubernetes                | Waiting for namespace qa2 to be deleted
    09:09:21 | DEBUG | NetworkFlowTest           | Kubernetes                | K8s found that namespace qa2 was deleted
    09:09:21 | INFO  | NetworkFlowTest           | NetworkFlowTest           | Ending testsuite

NetworkFlowTest > initializationError FAILED
    io.grpc.StatusRuntimeException: INVALID_ARGUMENT: referenced access scope io.stackrox.authz.accessscope.unrestricted does not exist: invalid arguments
        at app//io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:275)
        at app//io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:256)
        at app//io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:169)
        at app//io.stackrox.proto.api.v1.RoleServiceGrpc$RoleServiceBlockingStub.createRole(RoleServiceGrpc.java:1161)
        at app//services.RoleService.createRoleWithScopeAndPermissionSet(RoleService.groovy:57)
        at BaseSpecification.globalSetup_closure3(BaseSpecification.groovy:150)
        at BaseSpecification.globalSetup_closure3(BaseSpecification.groovy)
        at app//util.Helpers.evaluateWithRetry(Helpers.groovy:29)
        at app//util.Helpers.withRetry(Helpers.groovy:33)
        at app//BaseSpecification.globalSetup(BaseSpecification.groovy:139)
        at app//BaseSpecification.synchronizedGlobalSetup(BaseSpecification.groovy:78)
        at app//BaseSpecification.setupSpec(BaseSpecification.groovy:235)

1 test completed, 1 failed

> Task :test FAILED

FAILURE: Build failed with an exception.

```



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
