### PR TITLE
Stress test the Secrets Dispatcher initial sync

### DIFF
--- a/pkg/buildinfo/buildinfo_dev.go
+++ b/pkg/buildinfo/buildinfo_dev.go
@@ -3,6 +3,6 @@
 package buildinfo
 
 const (
-	releaseBuild = false
+	releaseBuild = true
 	buildFlavor  = "development"
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -1,6 +1,8 @@
 package env
 
-import "time"
+import (
+	"time"
+)
 
 // These environment variables are used in the deployment file.
 // Please check the files before deleting.
@@ -78,4 +80,9 @@ var (
 	// DiagnosticDataCollectionTimeout defines the timeout for the diagnostic data collection on Sensor side.
 	DiagnosticDataCollectionTimeout = registerDurationSetting("ROX_DIAGNOSTIC_DATA_COLLECTION_TIMEOUT",
 		2*time.Minute)
+
+	// FakeDelay just for testing
+	FakeDelay = RegisterSetting("FAKE_DELAY")
+	// FakeDelayTime just for testing
+	FakeDelayTime = registerDurationSetting("FAKE_DELAY_TIME", 5*time.Minute)
 )

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -193,6 +193,8 @@ func (w *WorkloadManager) initializePreexistingResources() {
 
 	labelsPool.matchLabels = w.workload.MatchLabels
 
+	objects = append(objects, w.getSecrets(w.workload.SecretWorkload, w.getIDsForPrefix(dockerConfigJSONSecretPrefix))...)
+
 	objects = append(objects, w.getRBAC(w.workload.RBACWorkload, w.getIDsForPrefix(serviceAccountPrefix), w.getIDsForPrefix(rolesPrefix), w.getIDsForPrefix(rolebindingsPrefix))...)
 	var resources []*deploymentResourcesToBeManaged
 

--- a/sensor/kubernetes/fake/pebble.go
+++ b/sensor/kubernetes/fake/pebble.go
@@ -11,16 +11,17 @@ import (
 const (
 	idSeparator = "\x00"
 
-	namespacePrefix      = "namespaces"
-	podPrefix            = "pods"
-	deploymentPrefix     = "deployments"
-	replicaSetPrefix     = "replicasets"
-	nodePrefix           = "nodes"
-	serviceAccountPrefix = "serviceaccount"
-	rolesPrefix          = "roles"
-	rolebindingsPrefix   = "rolebindings"
-	servicePrefix        = "services"
-	networkPolicyPrefix  = "networkpolicies"
+	namespacePrefix              = "namespaces"
+	podPrefix                    = "pods"
+	deploymentPrefix             = "deployments"
+	replicaSetPrefix             = "replicasets"
+	nodePrefix                   = "nodes"
+	serviceAccountPrefix         = "serviceaccount"
+	rolesPrefix                  = "roles"
+	rolebindingsPrefix           = "rolebindings"
+	servicePrefix                = "services"
+	dockerConfigJSONSecretPrefix = "dockerconfigjsonsecrets"
+	networkPolicyPrefix          = "networkpolicies"
 )
 
 func idOrNewUID(id string) types.UID {

--- a/sensor/kubernetes/fake/secret.go
+++ b/sensor/kubernetes/fake/secret.go
@@ -1,0 +1,32 @@
+package fake
+
+import (
+	"encoding/base64"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func getDockerConfigJSONSecret(id string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randStringWithLength(16),
+			Namespace: namespacePool.mustGetRandomElem(),
+			UID:       idOrNewUID(id),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{".dockerconfigjson": []byte(base64.StdEncoding.EncodeToString([]byte(randStringWithLength(16))))},
+	}
+}
+
+func (w *WorkloadManager) getSecrets(workload SecretWorkload, dockerConfigJSONIDs []string) []runtime.Object {
+	secrets := make([]runtime.Object, 0, workload.NumDockerConfigJSON)
+	for i := 0; i < workload.NumDockerConfigJSON; i++ {
+		log.Info("fake secret")
+		secret := getDockerConfigJSONSecret(getID(dockerConfigJSONIDs, i))
+		w.writeID(dockerConfigJSONSecretPrefix, secret.UID)
+		secrets = append(secrets, secret)
+	}
+	return secrets
+}

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -75,6 +75,11 @@ type ServiceWorkload struct {
 	NumLoadBalancers int `yaml:"numLoadBalancers"`
 }
 
+// SecretWorkload defines the workload of secrets
+type SecretWorkload struct {
+	NumDockerConfigJSON int `yaml:"numDockerConfigJSON"`
+}
+
 // Workload is the definition of a scale workload
 type Workload struct {
 	DeploymentWorkload    []DeploymentWorkload    `yaml:"deploymentWorkload"`
@@ -83,6 +88,7 @@ type Workload struct {
 	NetworkWorkload       NetworkWorkload         `yaml:"networkWorkload"`
 	RBACWorkload          RBACWorkload            `yaml:"rbacWorkload"`
 	ServiceWorkload       ServiceWorkload         `yaml:"serviceWorkload"`
+	SecretWorkload        SecretWorkload          `yaml:"secretWorkload"`
 	NumNamespaces         int                     `yaml:"numNamespaces"`
 	MatchLabels           bool                    `yaml:"matchLabels"`
 }


### PR DESCRIPTION
## Description

The go-client documentation recommends to [process the events promptly](https://github.com/kubernetes/client-go/blob/592d891671b2a09e5f81781b28ebe078d8115e41/tools/cache/shared_informer.go#L128-L132).
In order to determine if we could be losing events on the secrets dispatcher's initial sync, we decided to test the creation of a lot of resources and artificially slow down the processing to see if eventually sensor recovers and continues.
We tested this both with the fake workloads and in a real scenario.

#### The fake workloads

Using the code in this PR we created 100.000 fake secrets, blocked for an hour, and observed that after that, sensor finishes the initial sync and recovers.

**Steps taken:**

- Create a fake workload (`default.yaml`) that defines 100k secrets:
```yaml
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 10m0s
  numDeployments: 2500
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 2m0s
    numContainers: 3
    numPods: 5
    processWorkload:
      alertRate: 0.001
      processInterval: 30s
  updateInterval: 100s
networkWorkload:
  batchSize: 100
  flowInterval: 1s
nodeWorkload:
  numNodes: 1000
rbacWorkload:
  numBindings: 1000
  numRoles: 1000
  numServiceAccounts: 1000
secretWorkload:
  numDockerConfigJSON: 100000 # 100k secrets
```
- Run local-sensor with the environment variables `FAKE_DELAY` and `FAKE_DELAY_TIMEOUT` set to `once` and `1h`, respectively, and `ROX_LOCAL_IMAGE_SCANNING_ENABLED` set to `true`: 
```
FAKE_DELAY=once FAKE_DELAY_TIMEOUT=1h ROX_LOCAL_IMAGE_SCANNING_ENABLED=true go run tools/local-sensor/main.go -no-cpu-prof -no-mem-prof -with-fakeworkload default.yaml
```
- Observe that after the initial delay, sensor recovers and finishes the sync.

#### The real scenario

Using the code in this PR and [kube-burner](https://github.com/kube-burner/kube-burner) we created 70.000 secrets, blocked for an hour, and observed that after that, sensor finishes the initial sync and recovers.

**Steps taken:**

- Create an `openshift-4-perf-scale` cluster
- Create the following `kube-burner` config (`template.yaml`):
```yaml
---
global:
  gc: true
jobs:
  - name: lvm-test 
    namespace: lvm-test
    jobType: create 
    jobIterations: 16
    jobPause: 2h
    qps: 20
    burst: 20
    namespacedIterations: true
    podWait: false
    waitWhenFinished: true
    preLoadImages: true
    preLoadPeriod: 30s
    churn: false
    namespaceLabels:
      security.openshift.io/scc.podSecurityLabelSync: false
      pod-security.kubernetes.io/enforce: privileged
      pod-security.kubernetes.io/audit: privileged
      pod-security.kubernetes.io/warn: privileged
    objects:
      - objectTemplate: templates/secret.yml
        replicas: 4375 
        inputVars:
          resourceName: lvm-secret
```
☝️ This assumes you have a `secret.yml` file in the `templates/` folder:
```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: {{.resourceName}}-{{.Replica}}
data:
  top-secret: "{{randAlphaNum 2048}}"
```
- Run `kube-burner` to create the 70k secrets:
```
kube-burner init -c template.yaml --timeout 48h
```
- Deploy ACS using the image created in this PR:
- Wait for `kube-burner` to finish creating the secrets:
```
time="2024-06-26 09:12:11" level=info msg="Verifying created objects" file="utils.go:85"
time="2024-06-26 09:12:40" level=info msg="secrets found: 70000 Expected: 70000" file="utils.go:118"
time="2024-06-26 09:12:40" level=info msg="Pausing for 10h0m0s before finishing job" file="job.go:189"
```
- Set the environment variables `FAKE_DELAY` and `FAKE_DELAY_TIMEOUT` to `once` and `1h`, respectively, in sensor:
```
kubectl -n stackrox set env deploy/sensor FAKE_DELAY=once FAKE_DELAY_TIMEOUT=1h
```
- Observe that after the initial delay, sensor recovers and finishes the sync.