### PR TITLE
ROX-24913: Verify URLs read form dockerconfig secrets

### DIFF
--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -275,7 +275,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	newIntegrationSet := set.NewStringSet()
 	for registry, dce := range dockerConfig {
 		if err := validateRegistryURL(registry); err != nil {
-			log.Errorf("invalid registry URL %q: %v. Check secret %s/%s and sanitize the URLs",
+			log.Errorf("invalid registry URL %q: %v. Check secret %s/%s and sanitize the URLs it contains",
 				registry, err, secret.GetNamespace(), secret.GetName())
 			continue
 		}

--- a/sensor/kubernetes/listener/resources/secrets_test.go
+++ b/sensor/kubernetes/listener/resources/secrets_test.go
@@ -283,8 +283,12 @@ func Test_validateRegistryURL(t *testing.T) {
 		URL              string
 		wantErrToContain string
 	}{
-		"Valid URL": {
+		"Valid URL with scheme, host and port": {
 			URL:              "http://example.com:80/abc",
+			wantErrToContain: "",
+		},
+		"Valid URL with host and port": {
+			URL:              "example.com:80/abc",
 			wantErrToContain: "",
 		},
 		"URL with scheme, port and space in host": {

--- a/sensor/kubernetes/listener/resources/secrets_test.go
+++ b/sensor/kubernetes/listener/resources/secrets_test.go
@@ -299,6 +299,14 @@ func Test_validateRegistryURL(t *testing.T) {
 			URL:              "tcp://exam ple.com/abc",
 			wantErrToContain: `invalid character " " in host name`,
 		},
+		"URL with leading space in host": {
+			URL:              " example.com",
+			wantErrToContain: "contains no hostname",
+		},
+		"URL with trailing space in host": {
+			URL:              "example.com ",
+			wantErrToContain: "contains no hostname",
+		},
 		// The URL pkg treats the 'exam ple.com' here not as hostname, but a relative path
 		"URL with space in host": {
 			URL:              "exam ple.com/abc",


### PR DESCRIPTION
## Description

Dockerconfig secrets contain URLs of container registries. Those secrets are defined by the users on their clusters. Sensor reads those secrets and tries to dial the registries and discover whether they are TLS terminated.

We want to make sure that the URLs are valid and a call to such URL has chances of succeeding before we call it.
This PR adds such validation early in the process. If an invalid URL is found, an error is printed to the logs and processing of such secret is skipped.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Unit tests
- [ ] On a cluster with creation of dockerconfig secret that contains a space in the URL 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
