### PR TITLE
fix: pass context to retry

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -269,5 +269,5 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 			return fn(listAlert)
 		})
 	}
-	return pgutils.RetryIfPostgres(walkFn)
+	return pgutils.RetryIfPostgres(ctx, walkFn)
 }

--- a/central/apitoken/datastore/datastore_impl.go
+++ b/central/apitoken/datastore/datastore_impl.go
@@ -92,7 +92,7 @@ func (b *datastoreImpl) GetTokens(ctx context.Context, req *v1.GetAPITokensReque
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return tokens, nil

--- a/central/apitoken/datastore/internal/schedulestore/postgres/store.go
+++ b/central/apitoken/datastore/internal/schedulestore/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NotificationSchedul
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.NotificationSchedule, boo
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.NotificationSchedule, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.NotificationSchedule, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -167,7 +167,7 @@ func (ds *datastoreImpl) buildCache(ctx context.Context) error {
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 
@@ -266,7 +266,7 @@ func (ds *datastoreImpl) GetClustersForSAC(ctx context.Context) ([]*storage.Clus
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -301,7 +301,7 @@ func (ds *datastoreImpl) WalkClusters(ctx context.Context, fn func(obj *storage.
 			return fn(clonedCluster)
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 	return nil
@@ -1058,7 +1058,7 @@ func (ds *datastoreImpl) collectClusters(ctx context.Context) ([]*storage.Cluste
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return clusters, nil

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -315,7 +315,7 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/manager/manager.go
+++ b/central/complianceoperator/manager/manager.go
@@ -182,7 +182,7 @@ func (m *managerImpl) addProfileNoLock(profile *storage.ComplianceOperatorProfil
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(context.Background(), walkFn); err != nil {
 		return err
 	}
 
@@ -345,7 +345,7 @@ func (m *managerImpl) IsStandardActive(standardID string) bool {
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil && err != errConditionMet {
+	if err := pgutils.RetryIfPostgres(context.Background(), walkFn); err != nil && err != errConditionMet {
 		log.Errorf("error walking scan setting bindings datastore: %v", err)
 		return false
 	}
@@ -388,7 +388,7 @@ func (m *managerImpl) IsStandardActiveForCluster(standardID, clusterID string) b
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil && err != errConditionMet {
+	if err := pgutils.RetryIfPostgres(context.Background(), walkFn); err != nil && err != errConditionMet {
 		log.Errorf("error walking scan setting bindings datastore: %v", err)
 		return false
 	}
@@ -417,7 +417,8 @@ func (m *managerImpl) GetMachineConfigs(clusterID string) (map[string][]string, 
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	ctx := context.Background()
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -434,7 +435,7 @@ func (m *managerImpl) GetMachineConfigs(clusterID string) (map[string][]string, 
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return profilesToScan, nil
@@ -454,7 +455,7 @@ func (m *managerImpl) findProfilesWithRuleNoLock(ruleName string) ([]*storage.Co
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(context.Background(), walkFn); err != nil {
 		return nil, err
 	}
 	return profiles, nil

--- a/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline.go
@@ -54,7 +54,7 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/pipelines/complianceoperatorresults/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorresults/pipeline.go
@@ -51,7 +51,7 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/pipelines/complianceoperatorrules/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorrules/pipeline.go
@@ -56,7 +56,7 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 	store := storeMap.Get((*central.SensorEvent_ComplianceOperatorRule)(nil))

--- a/central/complianceoperator/pipelines/complianceoperatorscans/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorscans/pipeline.go
@@ -54,7 +54,7 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 	store := storeMap.Get((*central.SensorEvent_ComplianceOperatorScan)(nil))

--- a/central/complianceoperator/pipelines/complianceoperatorscansettingbinding/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorscansettingbinding/pipeline.go
@@ -51,7 +51,7 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return err
 	}
 	store := storeMap.Get((*central.SensorEvent_ComplianceOperatorScanSettingBinding)(nil))

--- a/central/config/store/postgres/store.go
+++ b/central/config/store/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Config) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.Config, bool, error) {
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.Config, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Config, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/declarativeconfig/health/datastore/datastore_impl.go
+++ b/central/declarativeconfig/health/datastore/datastore_impl.go
@@ -26,7 +26,7 @@ func (ds *datastoreImpl) GetDeclarativeConfigs(ctx context.Context) ([]*storage.
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return declarativeConfigHealths, nil

--- a/central/delegatedregistryconfig/store/postgres/store.go
+++ b/central/delegatedregistryconfig/store/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.DelegatedRegistryCo
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.DelegatedRegistryConfig, 
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.DelegatedRegistryConfig, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.DelegatedRegistryConfig, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -119,7 +119,7 @@ func (m *managerImpl) buildIndicatorFilter() {
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		utils.Should(errors.Wrap(err, "error building indicator filter"))
 	}
 

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -115,7 +115,7 @@ func (ds *dataStoreImpl) Walk(ctx context.Context, authProviderID string, attrib
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return groups, nil

--- a/central/group/datastore/filter/filter.go
+++ b/central/group/datastore/filter/filter.go
@@ -36,7 +36,7 @@ func GetFilteredWithStore(ctx context.Context, filter func(*storage.Group) bool,
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return groups, nil

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -753,7 +753,7 @@ func (s *storeImpl) upsert(ctx context.Context, obj *storage.Image) error {
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Image) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Upsert, "Image")
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -762,7 +762,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Image) error {
 func (s *storeImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Count, "Image")
 
-	return pgutils.Retry2(func() (int, error) {
+	return pgutils.Retry2(ctx, func() (int, error) {
 		return pgSearch.RunCountRequestForSchema(ctx, schema, q, s.db)
 	})
 }
@@ -771,7 +771,7 @@ func (s *storeImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 func (s *storeImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Search, "Image")
 
-	return pgutils.Retry2(func() ([]search.Result, error) {
+	return pgutils.Retry2(ctx, func() ([]search.Result, error) {
 		return pgSearch.RunSearchRequestForSchema(ctx, schema, q, s.db)
 	})
 }
@@ -780,7 +780,7 @@ func (s *storeImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, e
 func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "Image")
 
-	return pgutils.Retry2(func() (bool, error) {
+	return pgutils.Retry2(ctx, func() (bool, error) {
 		return s.retryableExists(ctx, id)
 	})
 }
@@ -798,7 +798,7 @@ func (s *storeImpl) retryableExists(ctx context.Context, id string) (bool, error
 func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Image, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "Image")
 
-	return pgutils.Retry3(func() (*storage.Image, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Image, bool, error) {
 		return s.retryableGet(ctx, id)
 	})
 }
@@ -1045,7 +1045,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Image")
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx, id)
 	})
 }
@@ -1093,7 +1093,7 @@ func (s *storeImpl) deleteImageTree(ctx context.Context, tx *postgres.Tx, imageI
 func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "ImageIDs")
 
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		return s.retryableGetIDs(ctx)
 	})
 }
@@ -1114,7 +1114,7 @@ func (s *storeImpl) retryableGetIDs(ctx context.Context) ([]string, error) {
 func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Image")
 
-	return pgutils.Retry3(func() ([]*storage.Image, []int, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.Image, []int, error) {
 		return s.retryableGetMany(ctx, ids)
 	})
 }
@@ -1269,7 +1269,7 @@ func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB
 func (s *storeImpl) GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageMetadata")
 
-	return pgutils.Retry3(func() (*storage.Image, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Image, bool, error) {
 		return s.retryableGetImageMetadata(ctx, id)
 	})
 }
@@ -1298,7 +1298,7 @@ func (s *storeImpl) retryableGetImageMetadata(ctx context.Context, id string) (*
 func (s *storeImpl) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Image")
 
-	return pgutils.Retry3(func() ([]*storage.Image, []int, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.Image, []int, error) {
 		return s.retryableGetManyImageMetadata(ctx, ids)
 	})
 }
@@ -1357,7 +1357,7 @@ func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []str
 func (s *storeImpl) UpdateVulnState(ctx context.Context, cve string, imageIDs []string, state storage.VulnerabilityState) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Update, "UpdateVulnState")
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpdateVulnState(ctx, cve, imageIDs, state)
 	})
 }

--- a/central/installation/store/postgres/store.go
+++ b/central/installation/store/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.InstallationInfo) e
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.InstallationInfo, bool, e
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.InstallationInfo, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.InstallationInfo, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/integrationhealth/datastore/datastore_impl.go
+++ b/central/integrationhealth/datastore/datastore_impl.go
@@ -113,7 +113,7 @@ func (ds *datastoreImpl) getIntegrationsOfType(ctx context.Context, integrationT
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return integrationHealth, nil

--- a/central/namespace/datastore/datastore.go
+++ b/central/namespace/datastore/datastore.go
@@ -96,7 +96,7 @@ func (b *datastoreImpl) GetAllNamespaces(ctx context.Context) ([]*storage.Namesp
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	b.updateNamespacePriority(allowedNamespaces...)
@@ -124,7 +124,7 @@ func (b *datastoreImpl) GetNamespacesForSAC(ctx context.Context) ([]*storage.Nam
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return allowedNamespaces, nil

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -766,7 +766,7 @@ func (m *manager) initFromStore() error {
 			return nil
 		})
 	}
-	return pgutils.RetryIfPostgres(walkFn)
+	return pgutils.RetryIfPostgres(context.Background(), walkFn)
 }
 
 func (m *manager) flushBaselineQueue() {

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -98,7 +98,7 @@ func (ds *dataStoreImpl) initNetworkTrees(ctx context.Context) {
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		log.Errorf("Failed to initialize network tree: %v", err)
 	}
 
@@ -221,7 +221,7 @@ func (ds *dataStoreImpl) GetAllMatchingEntities(ctx context.Context, pred func(e
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, errors.Wrap(err, "fetching network entities from storage")
 	}
 	return entities, nil

--- a/central/networkpolicies/datastore/datastore_impl.go
+++ b/central/networkpolicies/datastore/datastore_impl.go
@@ -77,7 +77,7 @@ func (ds *datastoreImpl) GetNetworkPolicies(ctx context.Context, clusterID, name
 		return ds.storage.GetByQuery(ctx, getQuery(clusterID, namespace))
 	}
 	var netPols []*storage.NetworkPolicy
-	err := pgutils.RetryIfPostgres(
+	err := pgutils.RetryIfPostgres(ctx,
 		func() error {
 			netPols = netPols[:0]
 			return ds.doForMatching(ctx, clusterID, namespace, func(np *storage.NetworkPolicy) {

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -529,7 +529,7 @@ func (s *storeImpl) upsert(ctx context.Context, obj *storage.Node) error {
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Node) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Upsert, "Node")
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -538,7 +538,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Node) error {
 func (s *storeImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Count, "Node")
 
-	return pgutils.Retry2(func() (int, error) {
+	return pgutils.Retry2(ctx, func() (int, error) {
 		return s.retryableCount(ctx, q)
 	})
 }
@@ -551,7 +551,7 @@ func (s *storeImpl) retryableCount(ctx context.Context, q *v1.Query) (int, error
 func (s *storeImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Search, "Node")
 
-	return pgutils.Retry2(func() ([]search.Result, error) {
+	return pgutils.Retry2(ctx, func() ([]search.Result, error) {
 		return s.retryableSearch(ctx, q)
 	})
 }
@@ -564,7 +564,7 @@ func (s *storeImpl) retryableSearch(ctx context.Context, q *v1.Query) ([]search.
 func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "Node")
 
-	return pgutils.Retry2(func() (bool, error) {
+	return pgutils.Retry2(ctx, func() (bool, error) {
 		return s.retryableExists(ctx, id)
 	})
 }
@@ -582,7 +582,7 @@ func (s *storeImpl) retryableExists(ctx context.Context, id string) (bool, error
 func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Node, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "Node")
 
-	return pgutils.Retry3(func() (*storage.Node, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Node, bool, error) {
 		return s.retryableGet(ctx, id)
 	})
 }
@@ -764,7 +764,7 @@ func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*po
 func (s *storeImpl) Delete(ctx context.Context, id string) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "Node")
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx, id)
 	})
 }
@@ -812,7 +812,7 @@ func (s *storeImpl) deleteNodeTree(ctx context.Context, tx *postgres.Tx, nodeID 
 func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Node, []int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Node")
 
-	return pgutils.Retry3(func() ([]*storage.Node, []int, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.Node, []int, error) {
 		return s.retryableGetMany(ctx, ids)
 	})
 }
@@ -914,7 +914,7 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(node *
 func (s *storeImpl) GetNodeMetadata(ctx context.Context, id string) (*storage.Node, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "NodeMetadata")
 
-	return pgutils.Retry3(func() (*storage.Node, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Node, bool, error) {
 		return s.retryableGetNodeMetadata(ctx, id)
 	})
 }
@@ -943,7 +943,7 @@ func (s *storeImpl) retryableGetNodeMetadata(ctx context.Context, id string) (*s
 func (s *storeImpl) GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, []int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Node")
 
-	return pgutils.Retry3(func() ([]*storage.Node, []int, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.Node, []int, error) {
 		return s.retryableGetManyNodeMetadata(ctx, ids)
 	})
 }

--- a/central/notifier/encconfig/datastore/store/postgres/store.go
+++ b/central/notifier/encconfig/datastore/store/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NotifierEncConfig) 
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.NotifierEncConfig, bool, 
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.NotifierEncConfig, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.NotifierEncConfig, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -180,7 +180,7 @@ func (ds *datastoreImpl) GetAllPolicyCategories(ctx context.Context) ([]*storage
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return categories, nil

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -122,7 +122,7 @@ func getOrphanedIDs(ctx context.Context, pool postgres.DB, query string) ([]stri
 
 // GetOrphanedAlertIDs returns the alert IDs for alerts that are orphaned, so they can be resolved.
 func GetOrphanedAlertIDs(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
 		defer cancel()
 
@@ -133,7 +133,7 @@ func GetOrphanedAlertIDs(ctx context.Context, pool postgres.DB, orphanWindow tim
 
 // GetOrphanedPodIDs returns the pod IDs for pods that are orphaned, so they can be removed.
 func GetOrphanedPodIDs(ctx context.Context, pool postgres.DB) ([]string, error) {
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
 		defer cancel()
 
@@ -143,7 +143,7 @@ func GetOrphanedPodIDs(ctx context.Context, pool postgres.DB) ([]string, error) 
 
 // GetOrphanedNodeIDs returns the node ids that have a cluster that has been removed.
 func GetOrphanedNodeIDs(ctx context.Context, pool postgres.DB) ([]string, error) {
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
 		defer cancel()
 
@@ -153,7 +153,7 @@ func GetOrphanedNodeIDs(ctx context.Context, pool postgres.DB) ([]string, error)
 
 // GetOrphanedProcessIDsByDeployment returns the process ids that have a deployment that has been removed.
 func GetOrphanedProcessIDsByDeployment(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
 		defer cancel()
 
@@ -164,7 +164,7 @@ func GetOrphanedProcessIDsByDeployment(ctx context.Context, pool postgres.DB, or
 
 // GetOrphanedProcessIDsByPod returns the process ids that have a pod that has been removed.
 func GetOrphanedProcessIDsByPod(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
-	return pgutils.Retry2(func() ([]string, error) {
+	return pgutils.Retry2(ctx, func() ([]string, error) {
 		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
 		defer cancel()
 

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -57,7 +57,7 @@ func (s *fullStoreImpl) GetProcessListeningOnPort(
 		"ProcessListeningOnPortStorage",
 	)
 
-	allowed, err := pgutils.Retry2(func() (bool, error) {
+	allowed, err := pgutils.Retry2(ctx, func() (bool, error) {
 		return s.checkAccess(ctx, deploymentID)
 	})
 
@@ -69,7 +69,7 @@ func (s *fullStoreImpl) GetProcessListeningOnPort(
 		return nil, nil
 	}
 
-	return pgutils.Retry2(func() ([]*storage.ProcessListeningOnPort, error) {
+	return pgutils.Retry2(ctx, func() ([]*storage.ProcessListeningOnPort, error) {
 		return s.retryableGetPLOP(ctx, deploymentID)
 	})
 }

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -166,7 +166,7 @@ func (ds *dataStoreImpl) GetRolesFiltered(ctx context.Context, filter func(role 
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return filteredRoles, nil
@@ -189,7 +189,7 @@ func (ds *dataStoreImpl) getAllRolesNoScopeCheck(ctx context.Context) ([]*storag
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -301,7 +301,7 @@ func (ds *dataStoreImpl) GetAllPermissionSets(ctx context.Context) ([]*storage.P
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -323,7 +323,7 @@ func (ds *dataStoreImpl) GetPermissionSetsFiltered(ctx context.Context,
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -476,7 +476,7 @@ func (ds *dataStoreImpl) GetAllAccessScopes(ctx context.Context) ([]*storage.Sim
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 
@@ -498,7 +498,7 @@ func (ds *dataStoreImpl) GetAccessScopesFiltered(ctx context.Context,
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -444,7 +444,7 @@ func (c *sensorConnection) getNetworkBaselineSyncMsg(ctx context.Context) (*cent
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, errors.Wrap(err, "could not list network baselines for Sensor connection")
 	}
 	return &central.MsgToSensor{
@@ -471,7 +471,7 @@ func (c *sensorConnection) getBaselineSyncMsg(ctx context.Context) (*central.Msg
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, errors.Wrap(err, "could not list process baselines for Sensor connection")
 	}
 	return &central.MsgToSensor{

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
@@ -77,7 +77,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SensorUpgradeConfig
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -119,7 +119,7 @@ func (s *storeImpl) Get(ctx context.Context) (*storage.SensorUpgradeConfig, bool
 		return nil, false, nil
 	}
 
-	return pgutils.Retry3(func() (*storage.SensorUpgradeConfig, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.SensorUpgradeConfig, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -162,7 +162,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -56,7 +56,7 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return integrations, nil

--- a/central/systeminfo/store/postgres/store.go
+++ b/central/systeminfo/store/postgres/store.go
@@ -45,19 +45,19 @@ func New(db postgres.DB) Store {
 }
 
 func (s *storeImpl) Get(ctx context.Context) (*storage.SystemInfo, bool, error) {
-	return pgutils.Retry3(func() (*storage.SystemInfo, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.SystemInfo, bool, error) {
 		return s.get(ctx)
 	})
 }
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SystemInfo) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
 
 func (s *storeImpl) Delete(ctx context.Context) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/version/postgres/store.go
+++ b/central/version/postgres/store.go
@@ -59,7 +59,7 @@ func insertIntoVersions(ctx context.Context, tx *postgres.Tx, obj *storage.Versi
 }
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Version) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -99,7 +99,7 @@ func (s *storeImpl) retryableUpsert(ctx context.Context, obj *storage.Version) e
 
 // Get returns the object, if it exists from the store
 func (s *storeImpl) Get(ctx context.Context) (*storage.Version, bool, error) {
-	return pgutils.Retry3(func() (*storage.Version, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Version, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -141,7 +141,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Version, bool, e
 // TODO(ROX-18005) -- remove this.  During transition away from serialized version, UpgradeStatus will make this call against
 // the older database.  In that case we will need to process the serialized data.
 func (s *storeImpl) GetPrevious(ctx context.Context) (*storage.Version, bool, error) {
-	return pgutils.Retry3(func() (*storage.Version, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.Version, bool, error) {
 		return s.retryableGetPrevious(ctx)
 	})
 }
@@ -183,7 +183,7 @@ func (s *storeImpl) acquireConn(ctx context.Context, _ ops.Op, _ string) (*postg
 
 // Delete removes the specified ID from the store
 func (s *storeImpl) Delete(ctx context.Context) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/central/watchedimage/datastore/datastore_impl.go
+++ b/central/watchedimage/datastore/datastore_impl.go
@@ -56,7 +56,7 @@ func (d *dataStore) GetAllWatchedImages(ctx context.Context) ([]*storage.Watched
 			return nil
 		})
 	}
-	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+	if err := pgutils.RetryIfPostgres(ctx, walkFn); err != nil {
 		return nil, err
 	}
 	return watchedImages, nil

--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore/postgres_plugin.go
@@ -198,7 +198,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
@@ -196,7 +196,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategoryedgepostgresstore/store.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategoryedgepostgresstore/store.go
@@ -199,7 +199,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategoryE
 }
 
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategoryEdge) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategorypostgresstore/store.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategorypostgresstore/store.go
@@ -113,14 +113,14 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategor
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policypostgresstore/store.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policypostgresstore/store.go
@@ -293,7 +293,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
@@ -315,7 +315,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/accessScopePostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/accessScopePostgresStore/postgres_plugin.go
@@ -213,7 +213,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessSco
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccessScope) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/collectionPostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/collectionPostgresStore/postgres_plugin.go
@@ -305,7 +305,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ResourceCollect
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ResourceCollection) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -316,7 +316,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ResourceCollection)
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceCollection) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
@@ -221,14 +221,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/previous/store.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/previous/store.go
@@ -251,7 +251,7 @@ func (s *flowStoreImpl) upsert(ctx context.Context, objs ...*storage.NetworkFlow
 }
 
 func (s *flowStoreImpl) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsertFlows(ctx, flows, lastUpdateTS)
 	})
 }
@@ -322,7 +322,7 @@ func (s *flowStoreImpl) readRows(rows pgx.Rows, pred func(*storage.NetworkFlowPr
 
 // GetAllFlows returns the object, if it exists from the store, timestamp and error
 func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetAllFlows(ctx, since)
 	})
 }
@@ -354,7 +354,7 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *time.Ti
 
 // GetMatchingFlows iterates over all of the objects in the store and applies the closure
 func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetMatchingFlows(ctx, pred, since)
 	})
 }
@@ -385,7 +385,7 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 
 // GetFlowsForDeployment returns the flows matching the deployment ID
 func (s *flowStoreImpl) GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error) {
-	return pgutils.Retry2(func() ([]*storage.NetworkFlow, error) {
+	return pgutils.Retry2(ctx, func() ([]*storage.NetworkFlow, error) {
 		return s.retryableGetFlowsForDeployment(ctx, deploymentID)
 	})
 }

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
@@ -181,7 +181,7 @@ func (s *flowStoreImpl) readRows(rows pgx.Rows, pred func(*storage.NetworkFlowPr
 
 // GetAllFlows returns the object, if it exists from the store, timestamp and error
 func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetAllFlows(ctx, since)
 	})
 }
@@ -215,7 +215,7 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *time.Ti
 
 // GetMatchingFlows iterates over all of the objects in the store and applies the closure
 func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *time.Time, error) {
+	return pgutils.Retry3(ctx, func() ([]*storage.NetworkFlow, *time.Time, error) {
 		return s.retryableGetMatchingFlows(ctx, pred, since)
 	})
 }
@@ -248,7 +248,7 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 
 // GetFlowsForDeployment returns the flows matching the deployment ID
 func (s *flowStoreImpl) GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error) {
-	return pgutils.Retry2(func() ([]*storage.NetworkFlow, error) {
+	return pgutils.Retry2(ctx, func() ([]*storage.NetworkFlow, error) {
 		return s.retryableGetFlowsForDeployment(ctx, deploymentID)
 	})
 }

--- a/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/previous/postgres_plugin.go
+++ b/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/previous/postgres_plugin.go
@@ -262,7 +262,7 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Group) error)
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/updated/postgres_plugin.go
+++ b/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/updated/postgres_plugin.go
@@ -224,7 +224,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/newapitokenpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/newapitokenpostgresstore/postgres_plugin.go
@@ -224,7 +224,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/oldapitokenpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/oldapitokenpostgresstore/postgres_plugin.go
@@ -210,7 +210,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/notificationschedulestore/postgres_plugin.go
+++ b/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/notificationschedulestore/postgres_plugin.go
@@ -53,7 +53,7 @@ func insertIntoNotificationSchedules(ctx context.Context, tx *postgres.Tx, obj *
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NotificationSchedule) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableUpsert(ctx, obj)
 	})
 }
@@ -88,7 +88,7 @@ func (s *storeImpl) retryableUpsert(ctx context.Context, obj *storage.Notificati
 
 // Get returns the object, if it exists from the store.
 func (s *storeImpl) Get(ctx context.Context) (*storage.NotificationSchedule, bool, error) {
-	return pgutils.Retry3(func() (*storage.NotificationSchedule, bool, error) {
+	return pgutils.Retry3(ctx, func() (*storage.NotificationSchedule, bool, error) {
 		return s.retryableGet(ctx)
 	})
 }
@@ -123,7 +123,7 @@ func (s *storeImpl) acquireConn(ctx context.Context, _ ops.Op, _ string) (*postg
 
 // Delete removes the singleton from the store
 func (s *storeImpl) Delete(ctx context.Context) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.retryableDelete(ctx)
 	})
 }

--- a/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkbaselinestore/postgres_plugin.go
+++ b/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkbaselinestore/postgres_plugin.go
@@ -252,7 +252,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkBaseline
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBaseline) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkentitystore/postgres_plugin.go
+++ b/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkentitystore/postgres_plugin.go
@@ -217,7 +217,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_177_to_m_178_group_permissions/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_177_to_m_178_group_permissions/permissionsetpostgresstore/postgres_plugin.go
@@ -215,7 +215,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/reportconfigstore/postgres_plugin.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/reportconfigstore/postgres_plugin.go
@@ -226,7 +226,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/test/postgres_plugin.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/test/postgres_plugin.go
@@ -219,7 +219,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/store.go
+++ b/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/store.go
@@ -313,7 +313,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
@@ -335,7 +335,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/permissionsetstore/store.go
+++ b/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/permissionsetstore/store.go
@@ -215,7 +215,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/apitokenstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/apitokenstore/postgres_plugin.go
@@ -225,7 +225,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadata) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/groupstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/groupstore/postgres_plugin.go
@@ -230,7 +230,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/permissionsetstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/permissionsetstore/postgres_plugin.go
@@ -217,7 +217,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/rolestore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/rolestore/postgres_plugin.go
@@ -212,7 +212,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_183_to_m_184_move_declarative_config_health/declarativeconfig/store/postgres_plugin.go
+++ b/migrator/migrations/m_183_to_m_184_move_declarative_config_health/declarativeconfig/store/postgres_plugin.go
@@ -104,7 +104,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.DeclarativeConf
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.DeclarativeConfigHealth) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/m_183_to_m_184_move_declarative_config_health/integrationhealth/store/postgres_plugin.go
+++ b/migrator/migrations/m_183_to_m_184_move_declarative_config_health/integrationhealth/store/postgres_plugin.go
@@ -103,7 +103,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHeal
 //// Interface functions
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/permissionsetstore/postgres_plugin.go
+++ b/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/permissionsetstore/postgres_plugin.go
@@ -216,7 +216,7 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/m_185_to_m_186_more_policy_migrations/policypostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_185_to_m_186_more_policy_migrations/policypostgresstore/postgres_plugin.go
@@ -280,14 +280,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
+++ b/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
@@ -38,7 +38,7 @@ type storeImpl struct {
 }
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storeType) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/policymigrationhelper/edgepostgresstorefortest/postgres_policy_category_edge_plugin.go
+++ b/migrator/migrations/policymigrationhelper/edgepostgresstorefortest/postgres_policy_category_edge_plugin.go
@@ -34,7 +34,7 @@ type storeImpl struct {
 }
 
 func (s *storeImpl) Upsert(ctx context.Context, obj *storeType) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_policy_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_policy_plugin.go
@@ -273,14 +273,14 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/migrator/version/version.go
+++ b/migrator/version/version.go
@@ -58,7 +58,7 @@ func ReadVersionGormDB(ctx context.Context, db *gorm.DB) (*migrations.MigrationV
 
 // UpdateVersionPostgres - updates the version allowing for outer transaction
 func UpdateVersionPostgres(ctx context.Context, db postgres.DB, updatedVersion *storage.Version) {
-	err := pgutils.Retry(func() error {
+	err := pgutils.Retry(ctx, func() error {
 		_, err := db.Exec(ctx, "DELETE FROM versions")
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func SetVersionGormDB(ctx context.Context, db *gorm.DB, updatedVersion *storage.
 		pkgSchema.ApplySchemaForTable(ctx, db, pkgSchema.VersionsSchema.Table)
 	}
 
-	err := pgutils.Retry(func() error {
+	err := pgutils.Retry(ctx, func() error {
 		return db.Transaction(func(tx *gorm.DB) error {
 			// Gorm broke Save, so we have to do delete/insert:  https://github.com/go-gorm/gorm/pull/6149/files
 			result := tx.Exec("DELETE FROM versions")

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -270,8 +270,9 @@ func GetPool(postgresConfig *postgres.Config) (postgres.DB, error) {
 	var err error
 	var postgresDB postgres.DB
 
-	err = pgutils.Retry(func() error {
-		postgresDB, err = postgres.New(context.Background(), postgresConfig)
+	ctx := context.Background()
+	err = pgutils.Retry(ctx, func() error {
+		postgresDB, err = postgres.New(ctx, postgresConfig)
 		return err
 	})
 	if err != nil {

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -70,8 +70,9 @@ func IsTransientError(err error) bool {
 	if errox.IsAny(err, pgx.ErrNoRows, pgx.ErrTxClosed, pgx.ErrTxCommitRollback) {
 		return false
 	}
+	// If the parent context expires, we abort the retries explicitly.
 	if errox.IsAny(err, context.Canceled, context.DeadlineExceeded) {
-		return false
+		return true
 	}
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		return true

--- a/pkg/postgres/pgutils/error_test.go
+++ b/pkg/postgres/pgutils/error_test.go
@@ -38,11 +38,11 @@ func TestWrappedErrors(t *testing.T) {
 		},
 		{
 			err:       errors.Wrap(context.Canceled, "hello"),
-			transient: false,
+			transient: true,
 		},
 		{
 			err:       errors.Wrap(context.DeadlineExceeded, "hello"),
-			transient: false,
+			transient: true,
 		},
 		{
 			err:       errors.Wrap(errors.Wrap(io.EOF, "1"), "2"),
@@ -58,15 +58,15 @@ func TestWrappedErrors(t *testing.T) {
 		},
 		{
 			err:       multiError1Error.ToError(),
-			transient: false,
+			transient: true,
 		},
 		{
 			err:       multiErrorCanceled.ToError(),
-			transient: false,
+			transient: true,
 		},
 		{
 			err:       multiErrorDeadlineExceeded.ToError(),
-			transient: false,
+			transient: true,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -74,7 +74,7 @@ func CreateTableFromModel(ctx context.Context, db *gorm.DB, createStmt *postgres
 	// Partitioned tables are not supported by Gorm migration or models
 	// For partitioned tables the necessary DDL will be contained in PartitionCreate.
 	if !createStmt.Partition {
-		err := Retry(func() error {
+		err := Retry(ctx, func() error {
 			return db.WithContext(ctx).AutoMigrate(createStmt.GormModel)
 		})
 		err = errors.Wrapf(err, "Error creating table for %q: %v", reflect.TypeOf(createStmt.GormModel), err)

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -47,7 +47,7 @@ func RunSelectRequestForSchema[T any](ctx context.Context, db postgres.DB, schem
 	if query == nil {
 		return nil, nil
 	}
-	return pgutils.Retry2(func() ([]*T, error) {
+	return pgutils.Retry2(ctx, func() ([]*T, error) {
 		return retryableRunSelectRequestForSchema[T](ctx, db, query)
 	})
 }

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -399,7 +399,7 @@ func (s *genericStore[T, PT]) Upsert(ctx context.Context, obj PT) error {
 		return err
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		return s.upsert(ctx, obj)
 	})
 }
@@ -417,7 +417,7 @@ func (s *genericStore[T, PT]) UpsertMany(ctx context.Context, objs []PT) error {
 		return err
 	}
 
-	return pgutils.Retry(func() error {
+	return pgutils.Retry(ctx, func() error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations

--- a/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
@@ -111,7 +111,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *{{.Type}}) error {
         return sac.ErrResourceAccessDenied
     }
 
-    return pgutils.Retry(func() error {
+    return pgutils.Retry(ctx, func() error {
         return s.retryableUpsert(ctx, obj)
     })
 }
@@ -153,7 +153,7 @@ func (s *storeImpl) Get(ctx context.Context) (*{{.Type}}, bool, error) {
         return nil, false, nil
     }
 
-    return pgutils.Retry3(func()(*{{.Type}}, bool, error) {
+    return pgutils.Retry3(ctx, func()(*{{.Type}}, bool, error) {
         return s.retryableGet(ctx)
     })
 }
@@ -196,7 +196,7 @@ func (s *storeImpl) Delete(ctx context.Context) error {
         return sac.ErrResourceAccessDenied
     }
 
-    return pgutils.Retry(func() error {
+    return pgutils.Retry(ctx, func() error {
         return s.retryableDelete(ctx)
     })
 }


### PR DESCRIPTION
## Description

The goal of this PR is to make our database retries context aware. The reason is that with the current behavior, there is a clash between cases where we want to cancel the retry (external timeout was hit) and where we want to continue to retry (internal / default timeout was hit). This distinction is now made via the parent context passed to `pgutils.Retry` - if it is expired, we stop the retries. If it is still valid, we continue the retries.

The actual changes are in `pkg/postgres/pgutils`, the rest is just passing the contexts. Note that this PR partially reverts the behavior from https://github.com/stackrox/stackrox/pull/11641, since we now handle parent context expirations explicitly.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

```sh
roxcurl "/v1/export/vuln-mgmt/workloads?timeout=1"
```

fails as expected with
```json
{"error":{"grpcCode":4,"httpCode":504,"message":"context deadline exceeded","httpStatus":"Gateway Timeout","details":[]}}
```

without deadlocking despite context exceeded now being classified as transient again.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
