### PR TITLE
ROX-24915: Add manual column in compliance checks and clusters tables

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -89,15 +89,16 @@ function ProfileChecksTable({
                             Check
                         </Th>
                         <Th modifier="fitContent">Controls</Th>
-                        <Th modifier="fitContent">Fail status</Th>
                         <Th modifier="fitContent">Pass status</Th>
+                        <Th modifier="fitContent">Fail status</Th>
+                        <Th modifier="fitContent">Manual status</Th>
                         <Th modifier="fitContent">Other status</Th>
                         <Th width={40}>Compliance</Th>
                     </Tr>
                 </Thead>
                 <TbodyUnified
                     tableState={tableState}
-                    colSpan={6}
+                    colSpan={7}
                     errorProps={{
                         title: 'There was an error loading profile checks',
                     }}
@@ -113,8 +114,13 @@ function ProfileChecksTable({
                         <>
                             {data.map((check, rowIndex) => {
                                 const { checkName, rationale, checkStats, controls } = check;
-                                const { passCount, failCount, otherCount, totalCount } =
-                                    getStatusCounts(checkStats);
+                                const {
+                                    passCount,
+                                    failCount,
+                                    manualCount,
+                                    otherCount,
+                                    totalCount,
+                                } = getStatusCounts(checkStats);
                                 const passPercentage = calculateCompliancePercentage(
                                     passCount,
                                     totalCount
@@ -173,6 +179,13 @@ function ProfileChecksTable({
                                                     '-'
                                                 )}
                                             </Td>
+                                            <Td dataLabel="Pass status" modifier="fitContent">
+                                                <StatusCountIcon
+                                                    text="cluster"
+                                                    status="pass"
+                                                    count={passCount}
+                                                />
+                                            </Td>
                                             <Td dataLabel="Fail status" modifier="fitContent">
                                                 <StatusCountIcon
                                                     text="cluster"
@@ -180,11 +193,11 @@ function ProfileChecksTable({
                                                     count={failCount}
                                                 />
                                             </Td>
-                                            <Td dataLabel="Pass status" modifier="fitContent">
+                                            <Td dataLabel="Manual status" modifier="fitContent">
                                                 <StatusCountIcon
                                                     text="cluster"
-                                                    status="pass"
-                                                    count={passCount}
+                                                    status="manual"
+                                                    count={manualCount}
                                                 />
                                             </Td>
                                             <Td dataLabel="Other status" modifier="fitContent">
@@ -222,7 +235,7 @@ function ProfileChecksTable({
                                         </Tr>
                                         {isRowExpanded && (
                                             <Tr isExpanded={isRowExpanded}>
-                                                <Td colSpan={6}>
+                                                <Td colSpan={7}>
                                                     <ExpandableRowContent>
                                                         <ControlLabels controls={controls} />
                                                     </ExpandableRowContent>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -71,13 +71,15 @@ function ProfileClustersTable({
             <Table>
                 <Thead>
                     <Tr>
-                        <Th sort={getSortParams('Cluster')}>Cluster</Th>
-                        <Th>Last scanned</Th>
-                        <Th>Pass status</Th>
-                        <Th>Fail status</Th>
-                        <Th>Manual status</Th>
-                        <Th>Other status</Th>
-                        <Th width={30}>Compliance</Th>
+                        <Th sort={getSortParams('Cluster')} width={50}>
+                            Cluster
+                        </Th>
+                        <Th modifier="fitContent">Last scanned</Th>
+                        <Th modifier="fitContent">Pass status</Th>
+                        <Th modifier="fitContent">Fail status</Th>
+                        <Th modifier="fitContent">Manual status</Th>
+                        <Th modifier="fitContent">Other status</Th>
+                        <Th width={50}>Compliance</Th>
                     </Tr>
                 </Thead>
                 <TbodyUnified

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -73,15 +73,16 @@ function ProfileClustersTable({
                     <Tr>
                         <Th sort={getSortParams('Cluster')}>Cluster</Th>
                         <Th>Last scanned</Th>
-                        <Th>Fail status</Th>
                         <Th>Pass status</Th>
+                        <Th>Fail status</Th>
+                        <Th>Manual status</Th>
                         <Th>Other status</Th>
                         <Th width={30}>Compliance</Th>
                     </Tr>
                 </Thead>
                 <TbodyUnified
                     tableState={tableState}
-                    colSpan={6}
+                    colSpan={7}
                     errorProps={{
                         title: 'There was an error loading profile clusters',
                     }}
@@ -101,8 +102,13 @@ function ProfileClustersTable({
                                     lastScanTime,
                                     checkStats,
                                 } = clusterInfo;
-                                const { passCount, failCount, otherCount, totalCount } =
-                                    getStatusCounts(checkStats);
+                                const {
+                                    passCount,
+                                    failCount,
+                                    manualCount,
+                                    otherCount,
+                                    totalCount,
+                                } = getStatusCounts(checkStats);
                                 const passPercentage = calculateCompliancePercentage(
                                     passCount,
                                     totalCount
@@ -129,6 +135,13 @@ function ProfileClustersTable({
                                             </Link>
                                         </Td>
                                         <Td dataLabel="Last scanned">{firstDiscoveredAsPhrase}</Td>
+                                        <Td dataLabel="Pass status">
+                                            <StatusCountIcon
+                                                text="check"
+                                                status="pass"
+                                                count={passCount}
+                                            />
+                                        </Td>
                                         <Td dataLabel="Fail status">
                                             <StatusCountIcon
                                                 text="check"
@@ -136,11 +149,11 @@ function ProfileClustersTable({
                                                 count={failCount}
                                             />
                                         </Td>
-                                        <Td dataLabel="Pass status">
+                                        <Td dataLabel="Manual status" modifier="fitContent">
                                             <StatusCountIcon
                                                 text="check"
-                                                status="pass"
-                                                count={passCount}
+                                                status="manual"
+                                                count={manualCount}
                                             />
                                         </Td>
                                         <Td dataLabel="Other status">

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -40,11 +40,13 @@ export type ComplianceStatus = (typeof ComplianceStatus)[keyof typeof Compliance
 export function getStatusCounts(checkStats: ComplianceCheckStatusCount[]): {
     passCount: number;
     failCount: number;
+    manualCount: number;
     otherCount: number;
     totalCount: number;
 } {
     let passCount = 0;
     let failCount = 0;
+    let manualCount = 0;
     let otherCount = 0;
     let totalCount = 0;
 
@@ -57,12 +59,15 @@ export function getStatusCounts(checkStats: ComplianceCheckStatusCount[]): {
             case 'FAIL':
                 failCount += statusInfo.count;
                 break;
+            case 'MANUAL':
+                manualCount += statusInfo.count;
+                break;
             default:
                 otherCount += statusInfo.count;
         }
     });
 
-    return { passCount, failCount, otherCount, totalCount };
+    return { passCount, failCount, manualCount, otherCount, totalCount };
 }
 
 export function calculateCompliancePercentage(passCount: number, totalCount: number): number {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Icon } from '@patternfly/react-core';
-import { BarsIcon, CheckCircleIcon, SecurityIcon } from '@patternfly/react-icons';
+import { BarsIcon, CheckCircleIcon, SecurityIcon, WrenchIcon } from '@patternfly/react-icons';
 import pluralize from 'pluralize';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 
-type Status = 'pass' | 'fail' | 'other';
+type Status = 'pass' | 'fail' | 'manual' | 'other';
 
 type StatusCountIconProps = {
     text: string;
@@ -23,6 +23,9 @@ function getStatusIcon(status: Status, count: number) {
             case 'pass':
                 color = 'var(--pf-v5-global--primary-color--100)';
                 break;
+            case 'manual':
+                color = 'var(--pf-v5-global--disabled-color--100)';
+                break;
             case 'other':
                 color = 'var(--pf-v5-global--disabled-color--100)';
                 break;
@@ -36,6 +39,8 @@ function getStatusIcon(status: Status, count: number) {
             return <SecurityIcon color={color} />;
         case 'pass':
             return <CheckCircleIcon color={color} />;
+        case 'manual':
+            return <WrenchIcon color={color} />;
         case 'other':
             return <BarsIcon color={color} />;
         default:


### PR DESCRIPTION
## Description

Follow up discussion with Maria to display **Manual** counts as bar in graph and column in tables.

* **Pass**: glass full viewpoint
* **Fail** and **Manual**: glass empty viewpoint and indicator of effort
* **Other**: rare

Reorder columns in table consistent with bars in graph.

### Residue

1. Brainstorm how to reduce duplication of icon and color:
    * compliance.coverage.utils.tsx file seems like source of truth
    * StatusCountIcon.tsx file
2. Brainstorm pro and con of two naming conventions:
    * ComplianceCommon.ts file seems like source of truth: `'PASS'`, `'FAIL'`, `'MANUAL'`, and so on
    * ComplianceEnhanced UI has `'pass'`, `'fail'`, `'manual'`, and `'other'` (the latter is frontend only)
3. Limit width of compliance bar in last column?

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4636952 - 4636952
        total 508 = 11724222 - 11723714
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

Pictures at 1440px width.

1. Visit /main/compliance/coverage

    * Before changes, see 3 status columns for **Fail**, **Pass**, and **Other**
        ![checks_3_status](https://github.com/stackrox/stackrox/assets/11862657/99fdaa52-2cc9-43ae-a300-c9cd98128699)

    * After changes, see 4 status columns for **Pass**, **Fail**, **Manual**, and **Other**
        ![checks_4_status](https://github.com/stackrox/stackrox/assets/11862657/9a86404c-36b7-44e2-aea8-7e3b0d0cb9ed)

2. Click **Clusters** toggle.

    * Before changes, see 3 status columns for **Fail**, **Pass**, and **Other**
        ![clusters_3_status](https://github.com/stackrox/stackrox/assets/11862657/d34aba13-e8f9-45f6-b4c4-55cbc9ab5f6c)

    * After changes, see 4 status columns for **Pass**, **Fail**, **Manual**, and **Other**
        ![clusters_4_status](https://github.com/stackrox/stackrox/assets/11862657/1938dd79-7450-4d4a-8000-ac1a710ac09f)
