### PR TITLE
chore(ui): Fix accessiblility issues for heading in access control

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -137,7 +137,7 @@ export function assertAccessControlEntitiesPage(entitiesKey) {
 export function assertAccessControlEntityPage(entitiesKey) {
     // Positive assertions.
 
-    // Caller is responsible to assert h2 element.
+    // Caller is responsible to assert h1 element.
 
     cy.title().should(
         'match',
@@ -161,7 +161,6 @@ export function assertAccessControlEntityPage(entitiesKey) {
 }
 
 export function assertAccessControlEntityDoesNotExist(entitiesKey) {
-    cy.get('h2').should('not.exist');
     cy.get('li.pf-v5-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
     cy.get('.pf-v5-c-empty-state h1').should(

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -56,7 +56,7 @@ describe('Access Control Access scopes', () => {
         const entityName = 'Deny All';
         clickEntityNameInTable(entitiesKey, entityName);
 
-        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`h1:contains("${entityName}")`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get(selectors.form.notEditableLabel).should('exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -71,7 +71,7 @@ describe('Access Control Auth providers', () => {
 
         assertAccessControlEntityPage(entitiesKey);
 
-        cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get('h1').should('have.text', `Create ${type} provider`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
@@ -102,7 +102,7 @@ describe('Access Control Auth providers', () => {
 
         assertAccessControlEntityPage(entitiesKey);
 
-        cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get('h1').should('have.text', `Create ${type} provider`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
@@ -251,7 +251,7 @@ describe('Access Control Auth providers', () => {
 
         assertAccessControlEntityPage(entitiesKey);
 
-        cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get('h1').should('have.text', `Create ${type} provider`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
@@ -302,7 +302,7 @@ describe('Access Control Auth providers', () => {
 
         assertAccessControlEntityPage(entitiesKey);
 
-        cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get('h1').should('have.text', `Create ${type} provider`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         getInputByLabel('Name').should('be.enabled').should('have.attr', 'required');
@@ -346,7 +346,7 @@ describe('Access Control Auth providers', () => {
 
         assertAccessControlEntityPage(entitiesKey);
 
-        cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get('h1').should('have.text', `Create ${type} provider`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlOrigin.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlOrigin.test.js
@@ -42,7 +42,7 @@ describe('Access Control declarative resources', () => {
         const entityName = 'access-scope-test-name';
         clickEntityNameInTable(accessScopesKey, entityName);
 
-        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`h1:contains("${entityName}")`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get('.pf-v5-c-label:contains("Declarative")').should('exist');
@@ -87,7 +87,7 @@ describe('Access Control declarative resources', () => {
         const entityName = 'auth-provider-1';
         clickEntityNameInTable(authProvidersKey, entityName);
 
-        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`h1:contains("${entityName}")`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get('.pf-v5-c-label:contains("Declarative")').should('exist');
@@ -128,7 +128,7 @@ describe('Access Control declarative resources', () => {
         const entityName = 'permission-set-test-name';
         clickEntityNameInTable(permissionSetsKey, entityName);
 
-        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`h1:contains("${entityName}")`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get('.pf-v5-c-label:contains("Declarative")').should('exist');
@@ -164,7 +164,7 @@ describe('Access Control declarative resources', () => {
         const entityName = 'test-role-name';
         clickEntityNameInTable(rolesKey, entityName);
 
-        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`h1:contains("${entityName}")`);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get('.pf-v5-c-label:contains("Declarative")').should('exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -56,7 +56,7 @@ describe('Access Control Permission sets', () => {
         const entityName = 'Admin';
         clickEntityNameInTable(entitiesKey, entityName);
 
-        cy.get('h2').should('have.text', entityName);
+        cy.get('h1').should('have.text', entityName);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get(selectors.form.notEditableLabel).should('exist');

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -66,7 +66,7 @@ describe('Access Control Roles', () => {
         const entityName = 'Admin';
         clickEntityNameInTable(entitiesKey, entityName);
 
-        cy.get('h2').should('have.text', entityName);
+        cy.get('h1').should('have.text', entityName);
         cy.get(`li.pf-v5-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
         cy.get(selectors.form.notEditableLabel).should('exist');
@@ -109,7 +109,7 @@ describe('Access Control Roles', () => {
 
         cy.get('button:contains("Create role")').click();
 
-        cy.get('h2').should('have.text', 'Create role');
+        cy.get('h1').should('have.text', 'Create role');
         cy.get(selectors.form.notEditableLabel).should('not.exist');
         cy.get(selectors.form.editButton).should('not.exist');
         cy.get(selectors.form.saveButton).should('be.disabled');
@@ -136,7 +136,7 @@ describe('Access Control Roles', () => {
         cy.contains('h2', /^\d+ results? found$/).should('exist');
         cy.get(`td[data-label="Name"] a:contains("${name}")`).click();
 
-        cy.get('h2').should('have.text', name);
+        cy.get('h1').should('have.text', name);
         cy.get(selectors.form.inputName).should('be.disabled').should('have.value', name);
         cy.get(selectors.form.notEditableLabel).should('not.exist');
         cy.get(selectors.form.editButton).should('exist');

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlDescription.tsx
@@ -5,7 +5,7 @@ export type AccessControlDescriptionProps = {
 };
 
 /*
- * Render description following AccessControlNav and preceding Title h2 in list or form element.
+ * Render description following AccessControlNav and preceding Title h2 in list or h1 in form element.
  */
 function AccessControlDescription({ children }: AccessControlDescriptionProps): ReactElement {
     return <div className="pf-v5-u-font-size-sm pf-v5-u-pt-sm">{children}</div>;

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -123,7 +123,7 @@ function AccessScopeFormWrapper({
             <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pt-0">
                 <ToolbarContent>
                     <ToolbarItem>
-                        <Title headingLevel="h2">
+                        <Title headingLevel="h1">
                             {action === 'create' ? 'Create access scope' : accessScope.name}
                         </Title>
                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -291,7 +291,7 @@ function AuthProviderForm({
             <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pt-0">
                 <ToolbarContent>
                     <ToolbarItem>
-                        <Title headingLevel="h2">{formTitle}</Title>
+                        <Title headingLevel="h1">{formTitle}</Title>
                     </ToolbarItem>
                     {action !== 'create' && (
                         <ToolbarItem>
@@ -416,7 +416,7 @@ function AuthProviderForm({
                 />
             )}
             <FormikProvider value={formik}>
-                <FormSection title="Configuration" titleElement="h3" className="pf-v5-u-mt-0">
+                <FormSection title="Configuration" titleElement="h2" className="pf-v5-u-mt-0">
                     <Grid hasGutter>
                         <GridItem span={12} lg={6}>
                             <FormGroup label="Name" fieldId="name" isRequired>
@@ -475,7 +475,7 @@ function AuthProviderForm({
                 </FormSection>
                 <FormSection
                     title={`Assign roles to your ${selectedAuthProvider.type} users`}
-                    titleElement="h3"
+                    titleElement="h2"
                 >
                     <FormGroup
                         className="pf-v5-u-w-100 pf-v5-u-w-75-on-md pf-v5-u-w-50-on-lg"
@@ -514,7 +514,7 @@ function AuthProviderForm({
                     {selectedAuthProvider.type === 'oidc' && (
                         <FormSection
                             title="Required attributes for the authentication provider"
-                            titleElement="h3"
+                            titleElement="h2"
                         >
                             <Alert
                                 isInline
@@ -631,7 +631,7 @@ function AuthProviderForm({
                     {selectedAuthProvider.type === 'oidc' && (
                         <FormSection
                             title="Claim mappings for the authentication provider"
-                            titleElement="h3"
+                            titleElement="h2"
                         >
                             <Alert
                                 isInline
@@ -735,7 +735,7 @@ function AuthProviderForm({
                             />
                         </FormSection>
                     )}
-                    <FormSection title="Rules" titleElement="h3" className="pf-v5-u-mt-0">
+                    <FormSection title="Rules" titleElement="h2" className="pf-v5-u-mt-0">
                         <RuleGroups
                             authProviderId={selectedAuthProvider.id}
                             groups={values.groups}

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -124,7 +124,7 @@ function PermissionSetForm({
             <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pt-0">
                 <ToolbarContent>
                     <ToolbarItem>
-                        <Title headingLevel="h2">
+                        <Title headingLevel="h1">
                             {action === 'create' ? 'Create permission set' : permissionSet.name}
                         </Title>
                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -118,7 +118,7 @@ function RoleForm({
             <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pt-0">
                 <ToolbarContent>
                     <ToolbarItem>
-                        <Title headingLevel="h2">
+                        <Title headingLevel="h1">
                             {action === 'create' ? 'Create role' : role.name}
                         </Title>
                     </ToolbarItem>


### PR DESCRIPTION
## Description

### Problem according to axe DevTools

> Page should contain a level-one heading

### Analysis

Apparently `h2` is left over from initial attempt to build side panel in PatternFly.

### Solution

1. Replace `h2` with `h1` element:
    * integration test assertions
    * entity page components
2. Replace `h3` with `h2` element in auth provider form.

### Residue

1. Fix **Heading levels should only increase by one** issues for `Alert` element in a separate contribution.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/access-control, click **Create auth provider**, and then click **OpenID Connect**.

    * Before changes, see accessibility issue.
        ![auth-providers_h2](https://github.com/stackrox/stackrox/assets/11862657/8c7bf2c4-e695-4394-aac5-50332ece27bd)

    * After changes, see `h1` instead of `h2` and `h2` element instead of `h3` element.
        ![auth-providers_h1_h2](https://github.com/stackrox/stackrox/assets/11862657/9de62880-81a6-49d4-95e8-41d49793f39b)

2. Go back, click **Roles**, and then click a link to visit an entity page.

    * After changes, see `h1` instead of `h2` element.
        ![roles_h1](https://github.com/stackrox/stackrox/assets/11862657/d0bca381-bbab-45ee-92a8-5a18bc4467f4)

3. Go back, click **Permission sets**, and then click a link to visit an entity page.

    * After changes, see `h1` instead of `h2` element.
        ![permission-sets_h1](https://github.com/stackrox/stackrox/assets/11862657/f37fdf76-8cc6-4e51-8bcd-e9fe7f912b71)

3. Go back, click **Access scopes**, and then click a link to visit an entity page.

    * After changes, see `h1` instead of `h2` element.
        ![access-scopes_h1](https://github.com/stackrox/stackrox/assets/11862657/4aed4771-d70c-45a7-a261-44a496716207)

### Integration testing

See tests fail, and then update the assertions.

* accessControl/accessControlAccessScopes.test.js
* accessControl/accessControlAuthProviders.test.js
* accessControl/accessControlOrigin.test.js
* accessControl/accessControlPermissionSets.test.js
* accessControl/accessControlRoles.test.js