### PR TITLE
chore(ui): Add scan config select to details pages

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -32,15 +32,13 @@ import CheckDetailsTable, { tabContentIdForResults } from './CheckDetailsTable';
 import {
     combineSearchFilterWithScanConfig,
     createScanConfigFilter,
-    getScanConfigurationSelectData,
+    isScanConfigurationDisabled,
 } from './compliance.coverage.utils';
 import CheckDetailsInfo from './components/CheckDetailsInfo';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
-import ScanConfigurationSelect, {
-    ScanConfigurationSelectData,
-} from './components/ScanConfigurationSelect';
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
@@ -143,11 +141,6 @@ function CheckDetails() {
         onSearch({ action, category, value });
     };
 
-    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
-        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations, {
-            profileName,
-        });
-
     return (
         <>
             <PageTitle title="Compliance coverage - Check" />
@@ -166,8 +159,11 @@ function CheckDetails() {
             <Divider component="div" />
             <ScanConfigurationSelect
                 isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationSelectData}
+                scanConfigs={scanConfigurationsQuery.response.configurations}
                 selectedScanConfigName={selectedScanConfigName}
+                isScanConfigDisabled={(config) =>
+                    isScanConfigurationDisabled(config, { profileName })
+                }
                 setSelectedScanConfigName={setSelectedScanConfigName}
             />
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
     Pagination,
     Toolbar,
@@ -29,6 +29,7 @@ import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import { CHECK_STATUS_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
 import StatusIcon from './components/StatusIcon';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 
 export const tabContentIdForResults = 'check-details-Results-tab-section';
 
@@ -61,6 +62,7 @@ function CheckDetailsTable({
     onSearch,
     onCheckStatusSelect,
 }: CheckDetailsTableProps) {
+    const { generatePathWithScanConfig } = useScanConfigRouter();
     const { page, perPage, setPage, setPerPage } = pagination;
 
     return (
@@ -146,10 +148,13 @@ function CheckDetailsTable({
                                     <Tr key={clusterId}>
                                         <Td dataLabel="Cluster">
                                             <Link
-                                                to={generatePath(coverageClusterDetailsPath, {
-                                                    clusterId,
-                                                    profileName,
-                                                })}
+                                                to={generatePathWithScanConfig(
+                                                    coverageClusterDetailsPath,
+                                                    {
+                                                        clusterId,
+                                                        profileName,
+                                                    }
+                                                )}
                                             >
                                                 {clusterName}
                                             </Link>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -1,15 +1,17 @@
-import React, { useCallback } from 'react';
-import { generatePath, useHistory, useParams } from 'react-router-dom';
+import React, { useCallback, useContext } from 'react';
+import { useParams } from 'react-router-dom';
 import {
     Alert,
     Breadcrumb,
     BreadcrumbItem,
+    Bullseye,
     Divider,
     Flex,
     Label,
     LabelGroup,
     PageSection,
     Skeleton,
+    Spinner,
     Title,
 } from '@patternfly/react-core';
 
@@ -38,11 +40,22 @@ import {
     coverageProfileClustersPath,
     coverageClusterDetailsPath,
 } from './compliance.coverage.routes';
+import {
+    createScanConfigFilter,
+    getScanConfigurationSelectData,
+} from './compliance.coverage.utils';
+import ScanConfigurationSelect, {
+    ScanConfigurationSelectData,
+} from './components/ScanConfigurationSelect';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
+import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
 
 function ClusterDetailsPage() {
-    const history = useHistory();
+    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
+        useContext(ScanConfigurationsContext);
     const { clusterId, profileName } = useParams();
+    const { generatePathWithScanConfig, navigateWithScanConfigQuery } = useScanConfigRouter();
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -53,8 +66,12 @@ function ClusterDetailsPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfilesStats = useCallback(
-        () => listComplianceScanConfigClusterProfiles(clusterId),
-        [clusterId]
+        () =>
+            listComplianceScanConfigClusterProfiles(
+                clusterId,
+                createScanConfigFilter(selectedScanConfigName)
+            ),
+        [clusterId, selectedScanConfigName]
     );
     const {
         data: scanConfigProfilesResponse,
@@ -90,11 +107,10 @@ function ClusterDetailsPage() {
     });
 
     function handleProfilesToggleChange(selectedProfile: string) {
-        const path = generatePath(coverageClusterDetailsPath, {
+        navigateWithScanConfigQuery(coverageClusterDetailsPath, {
             profileName: selectedProfile,
             clusterId,
         });
-        history.push(path);
     }
 
     const onSearch = (payload: OnSearchPayload) => {
@@ -129,14 +145,18 @@ function ClusterDetailsPage() {
         (profile) => profile.name === profileName
     );
 
+    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
+        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations, {
+            clusterId,
+        });
+
     return (
         <>
             <PageTitle title="Compliance coverage - Cluster" />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItem>Compliance coverage</BreadcrumbItem>
                     <BreadcrumbItemLink
-                        to={generatePath(coverageProfileClustersPath, {
+                        to={generatePathWithScanConfig(coverageProfileClustersPath, {
                             profileName,
                         })}
                     >
@@ -151,6 +171,13 @@ function ClusterDetailsPage() {
                     </BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
+            <Divider component="div" />
+            <ScanConfigurationSelect
+                isLoading={scanConfigurationsQuery.isLoading}
+                scanConfigs={scanConfigurationSelectData}
+                selectedScanConfigName={selectedScanConfigName}
+                setSelectedScanConfigName={setSelectedScanConfigName}
+            />
             <Divider component="div" />
             <PageSection variant="light">
                 <Flex
@@ -180,29 +207,37 @@ function ClusterDetailsPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection>
-                <ProfilesToggleGroup
-                    profileName={profileName}
-                    profiles={scanConfigProfilesResponse?.profiles ?? []}
-                    handleToggleChange={handleProfilesToggleChange}
-                />
-                <Divider component="div" />
-                <ProfileDetailsHeader
-                    isLoading={isLoadingScanConfigProfiles}
-                    profileName={profileName}
-                    profileDetails={selectedProfileDetails}
-                />
-                <Divider component="div" />
-                <ClusterDetailsTable
-                    checkResultsCount={checkResultsResponse?.totalCount ?? 0}
-                    profileName={profileName}
-                    tableState={tableState}
-                    pagination={pagination}
-                    getSortParams={getSortParams}
-                    searchFilterConfig={searchFilterConfig}
-                    searchFilter={searchFilter}
-                    onSearch={onSearch}
-                    onCheckStatusSelect={onCheckStatusSelect}
-                />
+                {isLoadingScanConfigProfiles ? (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                ) : (
+                    <>
+                        <ProfilesToggleGroup
+                            profileName={profileName}
+                            profiles={scanConfigProfilesResponse?.profiles ?? []}
+                            handleToggleChange={handleProfilesToggleChange}
+                        />
+                        <Divider component="div" />
+                        <ProfileDetailsHeader
+                            isLoading={isLoadingScanConfigProfiles}
+                            profileName={profileName}
+                            profileDetails={selectedProfileDetails}
+                        />
+                        <Divider component="div" />
+                        <ClusterDetailsTable
+                            checkResultsCount={checkResultsResponse?.totalCount ?? 0}
+                            profileName={profileName}
+                            tableState={tableState}
+                            pagination={pagination}
+                            getSortParams={getSortParams}
+                            searchFilterConfig={searchFilterConfig}
+                            searchFilter={searchFilter}
+                            onSearch={onSearch}
+                            onCheckStatusSelect={onCheckStatusSelect}
+                        />
+                    </>
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -40,13 +40,8 @@ import {
     coverageProfileClustersPath,
     coverageClusterDetailsPath,
 } from './compliance.coverage.routes';
-import {
-    createScanConfigFilter,
-    getScanConfigurationSelectData,
-} from './compliance.coverage.utils';
-import ScanConfigurationSelect, {
-    ScanConfigurationSelectData,
-} from './components/ScanConfigurationSelect';
+import { createScanConfigFilter, isScanConfigurationDisabled } from './compliance.coverage.utils';
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
@@ -145,11 +140,6 @@ function ClusterDetailsPage() {
         (profile) => profile.name === profileName
     );
 
-    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
-        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations, {
-            clusterId,
-        });
-
     return (
         <>
             <PageTitle title="Compliance coverage - Cluster" />
@@ -174,8 +164,11 @@ function ClusterDetailsPage() {
             <Divider component="div" />
             <ScanConfigurationSelect
                 isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationSelectData}
+                scanConfigs={scanConfigurationsQuery.response.configurations}
                 selectedScanConfigName={selectedScanConfigName}
+                isScanConfigDisabled={(config) =>
+                    isScanConfigurationDisabled(config, { clusterId })
+                }
                 setSelectedScanConfigName={setSelectedScanConfigName}
             />
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { generatePath, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
     Pagination,
     Text,
@@ -31,6 +31,7 @@ import { getClusterResultsStatusObject } from './compliance.coverage.utils';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
 import ControlLabels from './components/ControlLabels';
 import StatusIcon from './components/StatusIcon';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
 
 export type ClusterDetailsTableProps = {
     checkResultsCount: number;
@@ -61,6 +62,7 @@ function ClusterDetailsTable({
 }: ClusterDetailsTableProps) {
     /* eslint-disable no-nested-ternary */
     const { page, perPage, setPage, setPerPage } = pagination;
+    const { generatePathWithScanConfig } = useScanConfigRouter();
     const [expandedRows, setExpandedRows] = useState<number[]>([]);
 
     function toggleRow(selectedRowIndex: number) {
@@ -155,10 +157,18 @@ function ClusterDetailsTable({
                                         <Tr>
                                             <Td dataLabel="Check">
                                                 <Link
-                                                    to={`${generatePath(coverageCheckDetailsPath, {
-                                                        checkName,
-                                                        profileName,
-                                                    })}?${TAB_NAV_QUERY}=${DETAILS_TAB}`}
+                                                    to={`${generatePathWithScanConfig(
+                                                        coverageCheckDetailsPath,
+                                                        {
+                                                            checkName,
+                                                            profileName,
+                                                        },
+                                                        {
+                                                            customParams: {
+                                                                [TAB_NAV_QUERY]: DETAILS_TAB,
+                                                            },
+                                                        }
+                                                    )}`}
                                                 >
                                                     {checkName}
                                                 </Link>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -1,39 +1,19 @@
-import React, { useContext } from 'react';
-import { Button, Divider, Flex, FlexItem, PageSection, Text, Title } from '@patternfly/react-core';
-import { TimesCircleIcon } from '@patternfly/react-icons';
-
-import ScanConfigurationSelect from './components/ScanConfigurationSelect';
-import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
+import React from 'react';
+import { Flex, Text, Title } from '@patternfly/react-core';
 
 function CoveragesPageHeader() {
-    const { setSelectedScanConfigName } = useContext(ScanConfigurationsContext);
     return (
         <>
-            <PageSection component="div" variant="light" padding={{ default: 'noPadding' }}>
-                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
-                    <FlexItem className="pf-v5-u-p-lg">
-                        <Title headingLevel="h1">Coverage</Title>
-                        <Text>
-                            Assess profile compliance for nodes and platform resources across
-                            clusters
-                        </Text>
-                    </FlexItem>
-                    <Divider />
-                    <Flex
-                        className="pf-v5-u-px-lg pf-v5-u-py-sm"
-                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
-                    >
-                        <ScanConfigurationSelect />
-                        <Button
-                            variant="link"
-                            icon={<TimesCircleIcon />}
-                            onClick={() => setSelectedScanConfigName(undefined)}
-                        >
-                            Reset filter
-                        </Button>
-                    </Flex>
-                </Flex>
-            </PageSection>
+            <Flex
+                className="pf-v5-u-p-lg"
+                direction={{ default: 'column' }}
+                justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            >
+                <Title headingLevel="h1">Coverage</Title>
+                <Text>
+                    Assess profile compliance for nodes and platform resources across clusters
+                </Text>
+            </Flex>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -32,15 +32,21 @@ import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 
-import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
-import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
+import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import {
+    combineSearchFilterWithScanConfig,
+    getScanConfigurationSelectData,
+} from './compliance.coverage.utils';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
+import ScanConfigurationSelect, {
+    ScanConfigurationSelectData,
+} from './components/ScanConfigurationSelect';
+import CoveragesPageHeader from './CoveragesPageHeader';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
-import CoveragesPageHeader from './CoveragesPageHeader';
 import ProfileChecksTable from './ProfileChecksTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
@@ -53,7 +59,8 @@ function ProfileChecksPage() {
     const { profileName } = useParams();
     const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
         useContext(ComplianceProfilesContext);
-    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
+    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
+        useContext(ScanConfigurationsContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -101,10 +108,20 @@ function ProfileChecksPage() {
         (profile) => profile.name === profileName
     );
 
+    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
+        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations);
+
     return (
         <>
             <PageTitle title="Compliance coverage - Profile checks" />
             <CoveragesPageHeader />
+            <Divider component="div" />
+            <ScanConfigurationSelect
+                isLoading={scanConfigurationsQuery.isLoading}
+                scanConfigs={scanConfigurationSelectData}
+                selectedScanConfigName={selectedScanConfigName}
+                setSelectedScanConfigName={setSelectedScanConfigName}
+            />
             {!isDisclaimerAccepted && (
                 <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
             )}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -34,16 +34,11 @@ import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
-import {
-    combineSearchFilterWithScanConfig,
-    getScanConfigurationSelectData,
-} from './compliance.coverage.utils';
+import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import { coverageProfileChecksPath } from './compliance.coverage.routes';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
-import ScanConfigurationSelect, {
-    ScanConfigurationSelectData,
-} from './components/ScanConfigurationSelect';
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
@@ -108,9 +103,6 @@ function ProfileChecksPage() {
         (profile) => profile.name === profileName
     );
 
-    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
-        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations);
-
     return (
         <>
             <PageTitle title="Compliance coverage - Profile checks" />
@@ -118,7 +110,7 @@ function ProfileChecksPage() {
             <Divider component="div" />
             <ScanConfigurationSelect
                 isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationSelectData}
+                scanConfigs={scanConfigurationsQuery.response.configurations}
                 selectedScanConfigName={selectedScanConfigName}
                 setSelectedScanConfigName={setSelectedScanConfigName}
             />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -35,9 +35,15 @@ import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { coverageProfileClustersPath } from './compliance.coverage.routes';
-import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
+import {
+    combineSearchFilterWithScanConfig,
+    getScanConfigurationSelectData,
+} from './compliance.coverage.utils';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
+import ScanConfigurationSelect, {
+    ScanConfigurationSelectData,
+} from './components/ScanConfigurationSelect';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
@@ -53,7 +59,8 @@ function ProfileClustersPage() {
     const { profileName } = useParams();
     const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
         useContext(ComplianceProfilesContext);
-    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
+    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
+        useContext(ScanConfigurationsContext);
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
 
@@ -113,10 +120,20 @@ function ProfileClustersPage() {
         (profile) => profile.name === profileName
     );
 
+    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
+        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations);
+
     return (
         <>
             <PageTitle title="Compliance coverage - Profile clusters" />
             <CoveragesPageHeader />
+            <Divider component="div" />
+            <ScanConfigurationSelect
+                isLoading={scanConfigurationsQuery.isLoading}
+                scanConfigs={scanConfigurationSelectData}
+                selectedScanConfigName={selectedScanConfigName}
+                setSelectedScanConfigName={setSelectedScanConfigName}
+            />
             {!isDisclaimerAccepted && (
                 <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
             )}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -35,15 +35,10 @@ import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { coverageProfileClustersPath } from './compliance.coverage.routes';
-import {
-    combineSearchFilterWithScanConfig,
-    getScanConfigurationSelectData,
-} from './compliance.coverage.utils';
+import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
-import ScanConfigurationSelect, {
-    ScanConfigurationSelectData,
-} from './components/ScanConfigurationSelect';
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
 import CoveragesPageHeader from './CoveragesPageHeader';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
 import ProfilesToggleGroup from './ProfilesToggleGroup';
@@ -120,9 +115,6 @@ function ProfileClustersPage() {
         (profile) => profile.name === profileName
     );
 
-    const scanConfigurationSelectData: ScanConfigurationSelectData[] =
-        getScanConfigurationSelectData(scanConfigurationsQuery.response.configurations);
-
     return (
         <>
             <PageTitle title="Compliance coverage - Profile clusters" />
@@ -130,7 +122,7 @@ function ProfileClustersPage() {
             <Divider component="div" />
             <ScanConfigurationSelect
                 isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationSelectData}
+                scanConfigs={scanConfigurationsQuery.response.configurations}
                 selectedScanConfigName={selectedScanConfigName}
                 setSelectedScanConfigName={setSelectedScanConfigName}
             />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
@@ -61,9 +61,20 @@ function ScanConfigurationsProvider({ children }: { children: React.ReactNode })
         setSelectedScanConfigName(scanConfigName, historyAction);
     };
 
+    const effectiveScanConfigurationsResponse = scanConfigurationsResponse ?? defaultResponse;
+
+    const { configurations } = effectiveScanConfigurationsResponse;
+
+    const sortedScanConfigurations = configurations.sort((a, b) =>
+        a.scanName.localeCompare(b.scanName)
+    );
+
     const contextValue: ScanConfigurationsContextValue = {
         scanConfigurationsQuery: {
-            response: scanConfigurationsResponse ?? defaultResponse,
+            response: {
+                configurations: sortedScanConfigurations,
+                totalCount: effectiveScanConfigurationsResponse.totalCount,
+            },
             isLoading,
             error,
         },

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -12,9 +12,11 @@ import {
 } from '@patternfly/react-icons';
 
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
 import { SearchFilter } from 'types/search';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
+import { ScanConfigurationSelectData } from './components/ScanConfigurationSelect';
 
 // Thresholds for compliance status
 const DANGER_THRESHOLD = 50;
@@ -233,4 +235,27 @@ export function combineSearchFilterWithScanConfig(
         ...searchFilter,
         ...createScanConfigFilter(selectedScanConfigName),
     };
+}
+
+export function getScanConfigurationSelectData(
+    configurations: ComplianceScanConfigurationStatus[],
+    disabledCriteria: { profileName?: string; clusterId?: string } = {}
+): ScanConfigurationSelectData[] {
+    return configurations.map((config) => {
+        const { profileName, clusterId } = disabledCriteria;
+        let isDisabled = false;
+
+        if (profileName && !config.scanConfig.profiles.includes(profileName)) {
+            isDisabled = true;
+        }
+        if (clusterId && !config.clusterStatus.some((cluster) => cluster.clusterId === clusterId)) {
+            isDisabled = true;
+        }
+
+        return {
+            id: config.id,
+            isDisabled,
+            name: config.scanName,
+        };
+    });
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -16,7 +16,6 @@ import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfig
 import { SearchFilter } from 'types/search';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
-import { ScanConfigurationSelectData } from './components/ScanConfigurationSelect';
 
 // Thresholds for compliance status
 const DANGER_THRESHOLD = 50;
@@ -237,25 +236,19 @@ export function combineSearchFilterWithScanConfig(
     };
 }
 
-export function getScanConfigurationSelectData(
-    configurations: ComplianceScanConfigurationStatus[],
+export function isScanConfigurationDisabled(
+    config: ComplianceScanConfigurationStatus,
     disabledCriteria: { profileName?: string; clusterId?: string } = {}
-): ScanConfigurationSelectData[] {
-    return configurations.map((config) => {
-        const { profileName, clusterId } = disabledCriteria;
-        let isDisabled = false;
+): boolean {
+    const { profileName, clusterId } = disabledCriteria;
 
-        if (profileName && !config.scanConfig.profiles.includes(profileName)) {
-            isDisabled = true;
-        }
-        if (clusterId && !config.clusterStatus.some((cluster) => cluster.clusterId === clusterId)) {
-            isDisabled = true;
-        }
+    if (profileName && !config.scanConfig.profiles.includes(profileName)) {
+        return true;
+    }
 
-        return {
-            id: config.id,
-            isDisabled,
-            name: config.scanName,
-        };
-    });
+    if (clusterId && !config.clusterStatus.some((cluster) => cluster.clusterId === clusterId)) {
+        return true;
+    }
+
+    return false;
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -22,7 +22,7 @@ function ProfilesTableToggleGroup({ activeToggle }: ProfilesTableToggleGroupProp
     const handleToggleChange = (resultsView) => {
         const path: CoverageProfilePath =
             resultsView === 'checks' ? coverageProfileChecksPath : coverageProfileClustersPath;
-        navigateWithScanConfigQuery(path, { profileName }, searchFilter);
+        navigateWithScanConfigQuery(path, { profileName }, { searchFilter });
     };
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -13,18 +13,15 @@ import {
 } from '@patternfly/react-core';
 import { TimesCircleIcon } from '@patternfly/react-icons';
 
-const ALL_SCAN_SCHEDULES_OPTION = 'All scan schedules';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
 
-export type ScanConfigurationSelectData = {
-    id: string;
-    isDisabled: boolean;
-    name: string;
-};
+const ALL_SCAN_SCHEDULES_OPTION = 'All scan schedules';
 
 type ScanConfigurationSelectProps = {
     isLoading: boolean;
-    scanConfigs: ScanConfigurationSelectData[];
+    scanConfigs: ComplianceScanConfigurationStatus[];
     selectedScanConfigName: string | undefined;
+    isScanConfigDisabled?: (config: ComplianceScanConfigurationStatus) => boolean;
     setSelectedScanConfigName: (value: string | undefined) => void;
 };
 
@@ -32,6 +29,7 @@ function ScanConfigurationSelect({
     isLoading,
     scanConfigs,
     selectedScanConfigName,
+    isScanConfigDisabled = () => false,
     setSelectedScanConfigName,
 }: ScanConfigurationSelectProps) {
     const [isOpen, setIsOpen] = useState(false);
@@ -92,10 +90,10 @@ function ScanConfigurationSelect({
                                         return (
                                             <SelectOption
                                                 key={config.id}
-                                                value={config.name}
-                                                isDisabled={config.isDisabled}
+                                                value={config.scanName}
+                                                isDisabled={isScanConfigDisabled(config)}
                                             >
-                                                {config.name}
+                                                {config.scanName}
                                             </SelectOption>
                                         );
                                     })}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -1,6 +1,8 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import {
+    Button,
     Divider,
+    Flex,
     MenuToggle,
     MenuToggleElement,
     Select,
@@ -9,16 +11,30 @@ import {
     SelectOption,
     Spinner,
 } from '@patternfly/react-core';
-
-import { ScanConfigurationsContext } from '../ScanConfigurationsProvider';
+import { TimesCircleIcon } from '@patternfly/react-icons';
 
 const ALL_SCAN_SCHEDULES_OPTION = 'All scan schedules';
 
-function ScanConfigurationSelect() {
-    const [isOpen, setIsOpen] = useState(false);
+export type ScanConfigurationSelectData = {
+    id: string;
+    isDisabled: boolean;
+    name: string;
+};
 
-    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
-        useContext(ScanConfigurationsContext);
+type ScanConfigurationSelectProps = {
+    isLoading: boolean;
+    scanConfigs: ScanConfigurationSelectData[];
+    selectedScanConfigName: string | undefined;
+    setSelectedScanConfigName: (value: string | undefined) => void;
+};
+
+function ScanConfigurationSelect({
+    isLoading,
+    scanConfigs,
+    selectedScanConfigName,
+    setSelectedScanConfigName,
+}: ScanConfigurationSelectProps) {
+    const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
         setIsOpen(!isOpen);
@@ -42,45 +58,61 @@ function ScanConfigurationSelect() {
     };
 
     return (
-        <Select
-            id="scan-schedules-filter-id"
-            isOpen={isOpen}
-            selected={selectedScanConfigName || ALL_SCAN_SCHEDULES_OPTION}
-            onSelect={onSelect}
-            onOpenChange={(isOpen) => setIsOpen(isOpen)}
-            toggle={renderToggle}
-            shouldFocusToggleOnSelect
+        <Flex
+            className="pf-v5-u-px-lg pf-v5-u-py-sm"
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
         >
-            <>
-                <SelectGroup label="View all results">
-                    <SelectList>
-                        <SelectOption value={ALL_SCAN_SCHEDULES_OPTION}>
-                            {ALL_SCAN_SCHEDULES_OPTION}
-                        </SelectOption>
-                    </SelectList>
-                </SelectGroup>
-                <Divider />
-                <SelectGroup label="Filter results by a schedule">
-                    <SelectList>
-                        {scanConfigurationsQuery.isLoading ? (
-                            <SelectOption isLoading value="loader" isDisabled>
-                                <Spinner size="lg" />
+            <Select
+                id="scan-schedules-filter-id"
+                isOpen={isOpen}
+                selected={selectedScanConfigName || ALL_SCAN_SCHEDULES_OPTION}
+                onSelect={onSelect}
+                onOpenChange={(isOpen) => setIsOpen(isOpen)}
+                toggle={renderToggle}
+                shouldFocusToggleOnSelect
+            >
+                <>
+                    <SelectGroup label="View all results">
+                        <SelectList>
+                            <SelectOption value={ALL_SCAN_SCHEDULES_OPTION}>
+                                {ALL_SCAN_SCHEDULES_OPTION}
                             </SelectOption>
-                        ) : (
-                            <>
-                                {scanConfigurationsQuery.response.configurations.map(
-                                    ({ scanName }) => (
-                                        <SelectOption key={scanName} value={scanName}>
-                                            {scanName}
-                                        </SelectOption>
-                                    )
-                                )}
-                            </>
-                        )}
-                    </SelectList>
-                </SelectGroup>
-            </>
-        </Select>
+                        </SelectList>
+                    </SelectGroup>
+                    <Divider />
+                    <SelectGroup label="Filter results by a schedule">
+                        <SelectList>
+                            {isLoading ? (
+                                <SelectOption isLoading value="loader" isDisabled>
+                                    <Spinner size="lg" />
+                                </SelectOption>
+                            ) : (
+                                <>
+                                    {scanConfigs.map((config) => {
+                                        return (
+                                            <SelectOption
+                                                key={config.id}
+                                                value={config.name}
+                                                isDisabled={config.isDisabled}
+                                            >
+                                                {config.name}
+                                            </SelectOption>
+                                        );
+                                    })}
+                                </>
+                            )}
+                        </SelectList>
+                    </SelectGroup>
+                </>
+            </Select>
+            <Button
+                variant="link"
+                icon={<TimesCircleIcon />}
+                onClick={() => setSelectedScanConfigName(undefined)}
+            >
+                Reset filter
+            </Button>
+        </Flex>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { generatePathWithQuery } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 
 import { ScanConfigurationsContext } from '../ScanConfigurationsProvider';
 
@@ -12,11 +13,18 @@ const useScanConfigRouter = () => {
     function generatePathWithScanConfig(
         path,
         pathParams: Partial<Record<string, unknown>> = {},
-        searchFilter = {}
+        options: {
+            customParams?: Record<string, string>;
+            searchFilter?: SearchFilter;
+        } = {}
     ) {
+        const queryParams = selectedScanConfigName
+            ? { ...options.customParams, scanSchedule: selectedScanConfigName }
+            : options.customParams;
+
         return generatePathWithQuery(path, pathParams, {
-            customParams: selectedScanConfigName ? { scanSchedule: selectedScanConfigName } : {},
-            searchFilter,
+            customParams: queryParams,
+            searchFilter: options.searchFilter,
         });
     }
 

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -1,5 +1,8 @@
 import axios from 'services/instance';
-import { SearchQueryOptions } from 'types/search';
+import { SearchFilter, SearchQueryOptions } from 'types/search';
+import qs from 'qs';
+
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import {
     buildNestedRawQueryParams,
@@ -73,11 +76,14 @@ export function getComplianceClusterStats(
  */
 export function getComplianceProfileCheckStats(
     profileName: string,
-    checkName: string
+    checkName: string,
+    scanConfigSearchFilter: SearchFilter
 ): Promise<ComplianceCheckResultStatusCount> {
+    const query = getRequestQueryStringForSearchFilter(scanConfigSearchFilter);
+    const params = qs.stringify({ query: { query } }, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<ListComplianceProfileResults>(
-            `${complianceResultsStatsBaseUrl}/profiles/${profileName}/checks/${checkName}`
+            `${complianceResultsStatsBaseUrl}/profiles/${profileName}/checks/${checkName}?${params}`
         )
         .then((response) => response.data?.profileResults?.[0]);
 }

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -203,9 +203,9 @@ export function runComplianceReport(scanConfigId: string): Promise<ComplianceRun
  * Fetches all profiles that are included in a scan configuration.
  */
 export function listComplianceScanConfigProfiles(
-    searchFilter: SearchFilter
+    scanConfigSearchFilter: SearchFilter
 ): Promise<ListComplianceScanConfigsProfileResponse> {
-    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const query = getRequestQueryStringForSearchFilter(scanConfigSearchFilter);
     const params = qs.stringify({ query }, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<ListComplianceScanConfigsProfileResponse>(
@@ -218,11 +218,14 @@ export function listComplianceScanConfigProfiles(
  * Fetches all profiles that are included in a scan configuration on a specific cluster.
  */
 export function listComplianceScanConfigClusterProfiles(
-    clusterId: string
+    clusterId: string,
+    scanConfigSearchFilter: SearchFilter
 ): Promise<ListComplianceScanConfigsClusterProfileResponse> {
+    const query = getRequestQueryStringForSearchFilter(scanConfigSearchFilter);
+    const params = qs.stringify({ query: { query } }, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<ListComplianceScanConfigsClusterProfileResponse>(
-            `${complianceScanConfigBaseUrl}/clusters/${clusterId}/profiles/collection`
+            `${complianceScanConfigBaseUrl}/clusters/${clusterId}/profiles/collection?${params}`
         )
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

Add the scan configurations select component to the compliance details pages.

Notes:

- Scan configurations are now alphabetized in the select component.
- Formatting and filter reset have been added directly to the ScanConfigurationsSelect component.
- Scan configurations unrelated to the current details page will be disabled.
- State has been lifted out of the ScanConfigurationsSelect component.
  - A utility function has been created to handle the disabled state.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Check Details Page

#### All schedules
![Screenshot 2024-06-24 at 11 12 58 AM](https://github.com/stackrox/stackrox/assets/61400697/0683bd0b-f5cb-4f07-8233-358bdb525e2c)

#### Dropdown open with disabled schedules
![Screenshot 2024-06-24 at 11 13 08 AM](https://github.com/stackrox/stackrox/assets/61400697/cf2b9ab0-356d-4f16-9f24-d9e58aef6dcd)

#### Filtered by schedule
![Screenshot 2024-06-24 at 11 13 11 AM](https://github.com/stackrox/stackrox/assets/61400697/3c08b29d-d9f1-4ff8-8d1c-f2af12e6cfc4)

### Cluster Details Page

#### All schedules
![Screenshot 2024-06-24 at 11 25 19 AM](https://github.com/stackrox/stackrox/assets/61400697/d2cb562c-bb7c-442a-955e-3623a0edb59b)

#### Dropdown open with disabled schedules
![Screenshot 2024-06-24 at 11 13 27 AM](https://github.com/stackrox/stackrox/assets/61400697/2e9d6113-f5a8-4e75-aa0d-03dde7830b73)

#### Filtered by schedule
![Screenshot 2024-06-24 at 11 13 38 AM](https://github.com/stackrox/stackrox/assets/61400697/88bc7c45-854d-4da1-9f18-7f037e72c944)

