### PR TITLE
chore(e2e): Update cypress 13.12.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -136,7 +136,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "autoprefixer": "^10.2.5",
-        "cypress": "^13.11.0",
+        "cypress": "^13.12.0",
         "eslint": "^8.56.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-cypress": "^2.15.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6443,10 +6443,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^13.11.0:
-  version "13.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.11.0.tgz#17097366390424cba5db6bf0ee5e97503f036e07"
-  integrity sha512-NXXogbAxVlVje4XHX+Cx5eMFZv4Dho/2rIcdBHg9CNPFUGZdM4cRdgIgM7USmNYsC12XY0bZENEQ+KBk72fl+A==
+cypress@^13.12.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.12.0.tgz#1a4ea89b7fa6855e32bc02eaf5e25fc45b9e273f"
+  integrity sha512-udzS2JilmI9ApO/UuqurEwOvThclin5ntz7K0BtnHBs+tg2Bl9QShLISXpSEMDv/u8b6mqdoAdyKeZiSqKWL8g==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

Update with 1 week before 4.5 release.

https://docs.cypress.io/guides/references/changelog#13-12-0

Bug fixes

* We now trigger `input` and `change` events when typing `{upArrow}` and `{downArrow}` via `.type()` on `input[type=number]` elements.
* Fixed an issue where `inlineSourceMaps` was still being used when `sourceMaps` was provided in a user's TypeScript config for TypeScript version 5.
* Fixed an issue where receiving HTTP responses with invalid headers raised an error. Now Cypress removes the invalid headers and gives a warning in the console with debug mode on.

Dependency updates

* Updated firefox-profile from 4.3.1 to 4.6.0.
* Updated typescript from 4.7.4 to 5.3.3.
* Updated url-parse from 1.5.9 to 1.5.10.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js

### Component testing

* src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
* src/Components/TableStateTemplates/TbodyUnified.cy.jsx