### PR TITLE
chore(ui): Compliance coverage page bugs

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -117,7 +117,7 @@ function CheckDetails() {
         isLoading: isLoadingCheckResults,
         data: checkResultsResponse?.checkResults,
         error: checkResultsError,
-        searchFilter: {},
+        searchFilter,
     });
 
     useEffect(() => {
@@ -129,6 +129,11 @@ function CheckDetails() {
     const onSearch = (payload: OnSearchPayload) => {
         onURLSearch(searchFilter, setSearchFilter, payload);
     };
+
+    function onClearFilters() {
+        setSearchFilter({});
+        setPage(1, 'replace');
+    }
 
     const onCheckStatusSelect = (
         filterType: 'Compliance Check Status',
@@ -208,6 +213,7 @@ function CheckDetails() {
                         searchFilter={searchFilter}
                         onSearch={onSearch}
                         onCheckStatusSelect={onCheckStatusSelect}
+                        onClearFilters={onClearFilters}
                     />
                 )}
                 {activeTabKey === DETAILS_TAB && (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -48,6 +48,7 @@ export type CheckDetailsTableProps = {
         checked: boolean,
         selection: string
     ) => void;
+    onClearFilters: () => void;
 };
 
 function CheckDetailsTable({
@@ -61,6 +62,7 @@ function CheckDetailsTable({
     searchFilter,
     onSearch,
     onCheckStatusSelect,
+    onClearFilters,
 }: CheckDetailsTableProps) {
     const { generatePathWithScanConfig } = useScanConfigRouter();
     const { page, perPage, setPage, setPerPage } = pagination;
@@ -126,10 +128,7 @@ function CheckDetailsTable({
                     emptyProps={{
                         message: 'No results found for this check',
                     }}
-                    filteredEmptyProps={{
-                        title: 'No results found',
-                        message: 'Clear all filters and try again',
-                    }}
+                    filteredEmptyProps={{ onClearFilters }}
                     renderer={({ data }) => (
                         <Tbody>
                             {data.map((clusterInfo) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -98,7 +98,7 @@ function ClusterDetailsPage() {
         isLoading: isLoadingCheckResults,
         data: checkResultsResponse?.checkResults,
         error: checkResultsError,
-        searchFilter: {},
+        searchFilter,
     });
 
     function handleProfilesToggleChange(selectedProfile: string) {
@@ -122,6 +122,11 @@ function ClusterDetailsPage() {
         const value = selection;
         onSearch({ action, category, value });
     };
+
+    function onClearFilters() {
+        setSearchFilter({});
+        setPage(1, 'replace');
+    }
 
     if (scanConfigProfilesError) {
         return (
@@ -228,6 +233,7 @@ function ClusterDetailsPage() {
                             searchFilter={searchFilter}
                             onSearch={onSearch}
                             onCheckStatusSelect={onCheckStatusSelect}
+                            onClearFilters={onClearFilters}
                         />
                     </>
                 )}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -47,6 +47,7 @@ export type ClusterDetailsTableProps = {
         checked: boolean,
         selection: string
     ) => void;
+    onClearFilters: () => void;
 };
 
 function ClusterDetailsTable({
@@ -59,6 +60,7 @@ function ClusterDetailsTable({
     searchFilter,
     onSearch,
     onCheckStatusSelect,
+    onClearFilters,
 }: ClusterDetailsTableProps) {
     /* eslint-disable no-nested-ternary */
     const { page, perPage, setPage, setPerPage } = pagination;
@@ -141,10 +143,7 @@ function ClusterDetailsTable({
                     emptyProps={{
                         message: 'No results found for this cluster',
                     }}
-                    filteredEmptyProps={{
-                        title: 'No results found',
-                        message: 'Clear all filters and try again',
-                    }}
+                    filteredEmptyProps={{ onClearFilters }}
                     renderer={({ data }) => (
                         <>
                             {data.map((checkResult, rowIndex) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
@@ -4,11 +4,14 @@ import { Text, Bullseye, Flex, FlexItem, PageSection } from '@patternfly/react-c
 import { CubesIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import usePermissions from 'hooks/usePermissions';
 import { complianceEnhancedSchedulesPath } from 'routePaths';
 
 import CoveragesPageHeader from './CoveragesPageHeader';
 
 function CoverageEmptyState() {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
     return (
         <>
             <CoveragesPageHeader />
@@ -20,12 +23,14 @@ function CoverageEmptyState() {
                         icon={CubesIcon}
                     >
                         <Flex direction={{ default: 'column' }}>
-                            <FlexItem>
-                                <Text>
-                                    Create a scan schedule to assess profile compliance on selected
-                                    clusters.
-                                </Text>
-                            </FlexItem>
+                            {hasWriteAccessForCompliance && (
+                                <FlexItem>
+                                    <Text>
+                                        Create a scan schedule to assess profile compliance on
+                                        selected clusters.
+                                    </Text>
+                                </FlexItem>
+                            )}
                             <FlexItem>
                                 <Link to={complianceEnhancedSchedulesPath}>
                                     Go to scan schedules

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Text, Bullseye, Flex, FlexItem, PageSection } from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import { complianceEnhancedSchedulesPath } from 'routePaths';
+
+import CoveragesPageHeader from './CoveragesPageHeader';
+
+function CoverageEmptyState() {
+    return (
+        <>
+            <CoveragesPageHeader />
+            <PageSection isFilled>
+                <Bullseye className="pf-v5-u-background-color-100">
+                    <EmptyStateTemplate
+                        title="No scan data available"
+                        headingLevel="h2"
+                        icon={CubesIcon}
+                    >
+                        <Flex direction={{ default: 'column' }}>
+                            <FlexItem>
+                                <Text>
+                                    Create a scan schedule to assess profile compliance on selected
+                                    clusters.
+                                </Text>
+                            </FlexItem>
+                            <FlexItem>
+                                <Link to={complianceEnhancedSchedulesPath}>
+                                    Go to scan schedules
+                                </Link>
+                            </FlexItem>
+                        </Flex>
+                    </EmptyStateTemplate>
+                </Bullseye>
+            </PageSection>
+        </>
+    );
+}
+
+export default CoverageEmptyState;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -16,6 +16,7 @@ import ClusterDetailsPage from './ClusterDetailsPage';
 import ComplianceProfilesProvider, {
     ComplianceProfilesContext,
 } from './ComplianceProfilesProvider';
+import CoverageEmptyState from './CoverageEmptyState';
 import ProfileChecksPage from './ProfileChecksPage';
 import ProfileClustersPage from './ProfileClustersPage';
 import ScanConfigurationsProvider from './ScanConfigurationsProvider';
@@ -42,8 +43,7 @@ function CoverageContent() {
     }
 
     if (!isLoading && scanConfigProfilesResponse.totalCount === 0) {
-        // TODO: Add a message for when there are no profiles
-        return <div>No profiles, create a scan schedule</div>;
+        return <CoverageEmptyState />;
     }
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -88,7 +88,7 @@ function ProfileChecksPage() {
         isLoading,
         data: profileChecks?.profileResults,
         error,
-        searchFilter: {},
+        searchFilter,
     });
 
     const onSearch = (payload: OnSearchPayload) => {
@@ -97,6 +97,11 @@ function ProfileChecksPage() {
 
     function handleProfilesToggleChange(selectedProfile: string) {
         navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });
+    }
+
+    function onClearFilters() {
+        setSearchFilter({});
+        setPage(1, 'replace');
     }
 
     const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
@@ -171,6 +176,7 @@ function ProfileChecksPage() {
                                 pagination={pagination}
                                 tableState={tableState}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         </PageSection>
                     </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -38,6 +38,7 @@ export type ProfileChecksTableProps = {
     pagination: UseURLPaginationResult;
     tableState: TableUIState<ComplianceCheckResultStatusCount>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function ProfileChecksTable({
@@ -46,6 +47,7 @@ function ProfileChecksTable({
     pagination,
     tableState,
     getSortParams,
+    onClearFilters,
 }: ProfileChecksTableProps) {
     /* eslint-disable no-nested-ternary */
     const { generatePathWithScanConfig } = useScanConfigRouter();
@@ -106,10 +108,7 @@ function ProfileChecksTable({
                         message:
                             'If you have recently created a scan schedule, please wait a few minutes for the results to become available.',
                     }}
-                    filteredEmptyProps={{
-                        title: 'No checks found',
-                        message: 'Clear all filters and try again',
-                    }}
+                    filteredEmptyProps={{ onClearFilters }}
                     renderer={({ data }) => (
                         <>
                             {data.map((check, rowIndex) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -90,7 +90,7 @@ function ProfileClustersPage() {
         isLoading,
         data: profileClusters?.scanStats,
         error,
-        searchFilter: {},
+        searchFilter,
     });
 
     useEffect(() => {
@@ -110,6 +110,11 @@ function ProfileClustersPage() {
     const onSearch = (payload: OnSearchPayload) => {
         onURLSearch(searchFilter, setSearchFilter, payload);
     };
+
+    function onClearFilters() {
+        setSearchFilter({});
+        setPage(1, 'replace');
+    }
 
     const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
         (profile) => profile.name === profileName
@@ -184,6 +189,7 @@ function ProfileClustersPage() {
                                 profileName={profileName}
                                 tableState={tableState}
                                 getSortParams={getSortParams}
+                                onClearFilters={onClearFilters}
                             />
                         </PageSection>
                     </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -36,6 +36,7 @@ export type ProfileClustersTableProps = {
     profileName: string;
     tableState: TableUIState<ComplianceClusterOverallStats>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function ProfileClustersTable({
@@ -45,6 +46,7 @@ function ProfileClustersTable({
     profileName,
     tableState,
     getSortParams,
+    onClearFilters,
 }: ProfileClustersTableProps) {
     const { generatePathWithScanConfig } = useScanConfigRouter();
     const { page, perPage, setPage, setPerPage } = pagination;
@@ -92,10 +94,7 @@ function ProfileClustersTable({
                         message:
                             'If you have recently created a scan schedule, please wait a few minutes for the results to become available.',
                     }}
-                    filteredEmptyProps={{
-                        title: 'No clusters found',
-                        message: 'Clear all filters and try again',
-                    }}
+                    filteredEmptyProps={{ onClearFilters }}
                     renderer={({ data }) => (
                         <Tbody>
                             {data.map((clusterInfo) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -42,7 +42,14 @@ function getStatusIcon(status: Status, count: number) {
         case 'manual':
             return <WrenchIcon color={color} />;
         case 'other':
-            return <BarsIcon color={color} />;
+            return (
+                <BarsIcon
+                    color={color}
+                    style={{
+                        transform: 'rotate(90deg)',
+                    }}
+                />
+            );
         default:
             return null;
     }


### PR DESCRIPTION
## Description

Various fixes for issues found during our bug bash
* Add an empty state page for when no scan schedules have been created.
* Rotate the "Other" status icon. Hamburger icon was causing confusion.
* Differentiate between no results and no results due to filters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

#### Empty state
![Screenshot 2024-06-24 at 1 17 23 PM](https://github.com/stackrox/stackrox/assets/61400697/a1f6dabc-344c-45ca-bb5a-562b3c708a00)


#### Other icon
![Screenshot 2024-06-24 at 1 16 54 PM](https://github.com/stackrox/stackrox/assets/61400697/53f6dd9a-5d66-4f1b-a8cd-95e27dd19172)


#### No results due to filter
![Screenshot 2024-06-24 at 1 16 23 PM](https://github.com/stackrox/stackrox/assets/61400697/e1ff7c81-df8f-4825-a8b6-658e8cb155f1)

