### PR TITLE
chore(ui): Fix accessibility issue of color contrast in system health

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
@@ -1,5 +1,5 @@
-import React, { ElementType, ReactElement } from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import React, { ReactElement } from 'react';
+import { Flex, FlexItem, Icon } from '@patternfly/react-core';
 import {
     BanIcon,
     CheckIcon,
@@ -8,30 +8,29 @@ import {
 } from '@patternfly/react-icons';
 import { distanceInWordsStrict } from 'date-fns';
 
-type Style = {
-    Icon: ElementType;
-    fgColor: string;
-};
+const iconDefault = (
+    <Icon>
+        <InfoCircleIcon color="var(--pf-v5-global--info-color--100)" />
+    </Icon>
+);
 
-const styleDefault: Style = {
-    Icon: InfoCircleIcon,
-    fgColor: 'pf-v5-u-info-color-100',
-};
+const iconValid = (
+    <Icon>
+        <CheckIcon color="var(--pf-v5-global--success-color--100)" />
+    </Icon>
+);
 
-const styleValid: Style = {
-    Icon: CheckIcon,
-    fgColor: 'pf-v5-u-success-color-100',
-};
+const iconFuture = (
+    <Icon>
+        <BanIcon color="var(--pf-v5-global--danger-color--100)" />
+    </Icon>
+);
 
-const styleFuture: Style = {
-    Icon: BanIcon,
-    fgColor: 'pf-v5-u-danger-color-100', // alert because it time is complete and incorrect
-};
-
-const styleInvalid: Style = {
-    Icon: ExclamationTriangleIcon,
-    fgColor: 'pf-v5-u-warning-color-100', // warning because time might be incomplete
-};
+const iconInvalid = (
+    <Icon>
+        <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
+    </Icon>
+);
 
 type FilterByStartingTimeValidationMessageProps = {
     currentTimeObject: Date | null;
@@ -47,7 +46,7 @@ const FilterByStartingTimeValidationMessage = ({
     startingTimeFormat,
     startingTimeObject,
 }: FilterByStartingTimeValidationMessageProps): ReactElement => {
-    let style = styleDefault;
+    let icon: ReactElement = iconDefault;
     let message = 'default time: 20 minutes ago';
 
     if (currentTimeObject && startingTimeObject) {
@@ -56,22 +55,20 @@ const FilterByStartingTimeValidationMessage = ({
         });
 
         if (isStartingTimeValid) {
-            style = styleValid;
+            icon = iconValid;
             message = `about ${timeDifference} ago`;
         } else {
-            style = styleFuture;
+            icon = iconFuture;
             message = `future time: in about ${timeDifference}`;
         }
     } else if (!isStartingTimeValid) {
-        style = styleInvalid;
+        icon = iconInvalid;
         message = `expected format: ${startingTimeFormat}`;
     }
 
-    const { Icon, fgColor } = style;
-
     return (
-        <Flex alignItems={{ default: 'alignItemsCenter' }} className={fgColor}>
-            <Icon />
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            {icon}
             <FlexItem data-testid="starting-time-message">{message}</FlexItem>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
@@ -24,13 +24,13 @@ const iconFuture = (
     <Icon>
         <BanIcon color="var(--pf-v5-global--danger-color--100)" />
     </Icon>
-);
+); // danger because it time is complete and incorrect
 
 const iconInvalid = (
     <Icon>
         <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
     </Icon>
-);
+); // warning because time might be incomplete
 
 type FilterByStartingTimeValidationMessageProps = {
     currentTimeObject: Date | null;

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -104,7 +104,8 @@ function GenerateDiagnosticBundle(): ReactElement {
     return (
         <Popover
             aria-label="Choose options to generate a diagnostic bundle"
-            headerContent={<h2>Diagnostic bundle</h2>}
+            headerComponent="h2"
+            headerContent="Diagnostic bundle"
             bodyContent={
                 <DiagnosticBundleForm
                     values={values}


### PR DESCRIPTION
## Description

Remove a left over color contrast issue and solve a unique heading issue as bonus.

### Problems according to axe DevTools

> Elements must meet minimum color contrast ratio thresholds

> Element has insufficient color contrast of 2.99 (foreground color: #2b9af3, background color: #ffffff, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1

```html
<div data-testid="starting-time-message" class="">default time: 20 minutes ago</div>
```

> Heading levels should only increase by one

```html
<h6 class="pf-v5-c-popover__title-text"><h2>Diagnostic bundle</h2></h6>
```

### Analysis

1. Info icon color does not have sufficient color contrast ratio for text.

2. Default value of `headerComponent` prop is incorrect for heading hierarchy of page and `h2` element in `headerContent` prop is inconsistently redundant.
    https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Popover/Popover.tsx#L237

### Solution

1. Render color only for icon.

2. Add `headerComponent="h2"` prop and remove redundant `h2` element from `headerContent` prop.

### Residue

1. Investigate 2 accessibility issues apparently because popover renders a `header` element.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/system-health and click **Generate diagnostic bundle** to open the popover.

    * Before changes, see 4 accessibility issues.
        ![DiagnosticBundleForm_with_4_issues](https://github.com/stackrox/stackrox/assets/11862657/771bae4a-73a0-4e56-aef2-015c00b475a4)

    * After changes, solve 2 accessibility issues. 
        ![DiagnosticBundleForm_with_2_issues](https://github.com/stackrox/stackrox/assets/11862657/3020fac9-fbfc-43ca-97fd-0d05dcf7b8e4)

### Integration testing

* systemHealth/bundle.test.js
