### PR TITLE
ROX-24760: Search filter chips for select dropdowns should use labels

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -10,13 +10,13 @@ import {
     OnSearchPayload,
     PartialCompoundSearchFilterConfig,
     SearchFilterAttribute,
-    SelectSearchFilterAttribute,
 } from '../types';
 import {
     conditionMap,
     ensureConditionNumber,
     ensureString,
     ensureStringArray,
+    isSelectType,
 } from '../utils/utils';
 
 import CheckboxSelect from './CheckboxSelect';
@@ -40,12 +40,6 @@ export type CompoundSearchFilterInputFieldProps = {
     onChange: InputFieldOnChange;
     config: PartialCompoundSearchFilterConfig;
 };
-
-function isSelectType(
-    attributeObject: SearchFilterAttribute
-): attributeObject is SelectSearchFilterAttribute {
-    return attributeObject.inputType === 'select';
-}
 
 function dateParse(date: string): Date {
     const split = date.split('/');

--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -1,12 +1,30 @@
 import React from 'react';
 import { Button, ChipGroup, Chip, Flex, FlexItem, ToolbarChip } from '@patternfly/react-core';
 import noop from 'lodash/noop';
+import { Globe } from 'react-feather';
 
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import { searchValueAsArray } from 'utils/searchUtils';
 
 import './SearchFilterChips.css';
+
+export type FilterChipProps = {
+    isGlobal?: boolean;
+    name: string;
+};
+
+export function FilterChip({ isGlobal, name }: FilterChipProps) {
+    if (isGlobal) {
+        return (
+            <Flex alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
+                <Globe height="15px" />
+                {name}
+            </Flex>
+        );
+    }
+    return <Flex>{name}</Flex>;
+}
 
 export type FilterChipGroupDescriptor = {
     /** The name of the chip category that will be displayed in the toolbar */

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import noop from 'lodash/noop';
-import { Toolbar, ToolbarGroup, ToolbarContent, Flex } from '@patternfly/react-core';
+import { Toolbar, ToolbarGroup, ToolbarContent } from '@patternfly/react-core';
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
-import { Globe } from 'react-feather';
 
-import SearchFilterChips, { SearchFilterChipsProps } from 'Components/PatternFly/SearchFilterChips';
+import SearchFilterChips, {
+    FilterChip,
+    SearchFilterChipsProps,
+} from 'Components/PatternFly/SearchFilterChips';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useAnalytics, {
     WORKLOAD_CVE_FILTER_APPLIED,
@@ -21,23 +23,6 @@ import FilterAutocomplete, {
 } from '../../components/FilterAutocomplete';
 import CVESeverityDropdown from '../../components/CVESeverityDropdown';
 import CVEStatusDropdown from '../../components/CVEStatusDropdown';
-
-type FilterChipProps = {
-    isGlobal?: boolean;
-    name: string;
-};
-
-function FilterChip({ isGlobal, name }: FilterChipProps) {
-    if (isGlobal) {
-        return (
-            <Flex alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
-                <Globe height="15px" />
-                {name}
-            </Flex>
-        );
-    }
-    return <Flex>{name}</Flex>;
-}
 
 const emptyDefaultFilters = {
     SEVERITY: [],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { Toolbar, ToolbarGroup, ToolbarContent, Flex } from '@patternfly/react-core';
+import { Toolbar, ToolbarGroup, ToolbarContent } from '@patternfly/react-core';
 import { uniq } from 'lodash';
-import { Globe } from 'react-feather';
 
 import CompoundSearchFilter, {
     CompoundSearchFilterProps,
 } from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import SearchFilterChips, { FilterChip } from 'Components/PatternFly/SearchFilterChips';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { SearchFilter } from 'types/search';
 import { searchValueAsArray } from 'utils/searchUtils';
@@ -18,23 +17,6 @@ import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
 
 import './AdvancedFiltersToolbar.css';
-
-type FilterChipProps = {
-    isGlobal?: boolean;
-    name: string;
-};
-
-function FilterChip({ isGlobal, name }: FilterChipProps) {
-    if (isGlobal) {
-        return (
-            <Flex alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
-                <Globe height="15px" />
-                {name}
-            </Flex>
-        );
-    }
-    return <Flex>{name}</Flex>;
-}
 
 function makeDefaultFilterDescriptor(
     defaultFilters: DefaultFilters,


### PR DESCRIPTION
## Description

This PR fixes an issue where the search filter chips displayed the compound search filter's select option value rather than the option label

<img width="1440" alt="Screenshot 2024-06-24 at 2 21 15 PM" src="https://github.com/stackrox/stackrox/assets/4805485/62904022-8e93-4a5d-ad83-345fa6d4f43a">
<img width="1440" alt="Screenshot 2024-06-24 at 2 21 03 PM" src="https://github.com/stackrox/stackrox/assets/4805485/9d32303e-7305-4388-82a1-8c7db8f7a2dc">


