### PR TITLE
ROX-24713: Specify default entity

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -130,6 +130,21 @@ function mergeDefaultAndLocalFilters(
     return { ...filter, SEVERITY, FIXABLE };
 }
 
+function getSearchFilterEntityByTab(
+    entityTab: WorkloadEntityTab
+): SearchFilterEntityName | undefined {
+    switch (entityTab) {
+        case 'CVE':
+            return 'Image CVE';
+        case 'Image':
+            return 'Image';
+        case 'Deployment':
+            return 'Deployment';
+        default:
+            return undefined;
+    }
+}
+
 const searchFilterConfig = {
     Image: imageSearchFilterConfig,
     'Image CVE': imageCVESearchFilterConfig,
@@ -141,10 +156,6 @@ const searchFilterConfig = {
 
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
-
-    const [defaultSearchFilter, setDefaultSearchFilter] = useState<
-        SearchFilterEntityName | undefined
-    >();
 
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
@@ -169,6 +180,9 @@ function WorkloadCvesOverviewPage() {
         'observedCveMode',
         observedCveModeValues
     );
+
+    const defaultSearchFilterEntity = getSearchFilterEntityByTab(activeEntityTabKey);
+
     const isViewingWithCves = observedCveMode === 'WITH_CVES';
 
     // If the user is viewing observed CVEs, we need to scope the query based on
@@ -242,8 +256,6 @@ function WorkloadCvesOverviewPage() {
         pagination.setPage(1);
         sort.setSortOption(getDefaultSortOption(entityTab), 'replace');
 
-        setDefaultSearchFilter(entityTab === 'CVE' ? 'Image CVE' : entityTab);
-
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
             properties: {
@@ -261,7 +273,6 @@ function WorkloadCvesOverviewPage() {
         setSearchFilter({}, 'replace');
         if (activeEntityTabKey === 'CVE') {
             setActiveEntityTabKey('Image', 'replace');
-            setDefaultSearchFilter('Image');
             sort.setSortOption(getDefaultSortOption('Image'), 'replace');
         }
 
@@ -274,7 +285,6 @@ function WorkloadCvesOverviewPage() {
     function onVulnerabilityStateChange(vulnerabilityState: VulnerabilityState) {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
-        setDefaultSearchFilter('Image CVE');
         setSearchFilter({}, 'replace');
         sort.setSortOption(getDefaultWorkloadSortOption('CVE'), 'replace');
         pagination.setPage(1, 'replace');
@@ -334,7 +344,7 @@ function WorkloadCvesOverviewPage() {
             }}
             includeCveSeverityFilters={isViewingWithCves}
             includeCveStatusFilters={isViewingWithCves}
-            defaultSearchFilter={defaultSearchFilter}
+            defaultSearchFilterEntity={defaultSearchFilterEntity}
         />
     ) : (
         <WorkloadCveFilterToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -48,6 +48,8 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
 import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
 import LinkShim from 'Components/PatternFly/LinkShim';
+import { SearchFilterEntityName } from 'Components/CompoundSearchFilter/types';
+
 import {
     DefaultFilters,
     WorkloadEntityTab,
@@ -130,8 +132,8 @@ function mergeDefaultAndLocalFilters(
 
 const searchFilterConfig = {
     Image: imageSearchFilterConfig,
-    ImageCVE: imageCVESearchFilterConfig,
-    ImageComponent: imageComponentSearchFilterConfig,
+    'Image CVE': imageCVESearchFilterConfig,
+    'Image Component': imageComponentSearchFilterConfig,
     Deployment: deploymentSearchFilterConfig,
     Namespace: namespaceSearchFilterConfig,
     Cluster: clusterSearchFilterConfig,
@@ -139,6 +141,10 @@ const searchFilterConfig = {
 
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
+
+    const [defaultSearchFilter, setDefaultSearchFilter] = useState<
+        SearchFilterEntityName | undefined
+    >();
 
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
@@ -236,6 +242,8 @@ function WorkloadCvesOverviewPage() {
         pagination.setPage(1);
         sort.setSortOption(getDefaultSortOption(entityTab), 'replace');
 
+        setDefaultSearchFilter(entityTab === 'CVE' ? 'Image CVE' : entityTab);
+
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
             properties: {
@@ -253,6 +261,7 @@ function WorkloadCvesOverviewPage() {
         setSearchFilter({}, 'replace');
         if (activeEntityTabKey === 'CVE') {
             setActiveEntityTabKey('Image', 'replace');
+            setDefaultSearchFilter('Image');
             sort.setSortOption(getDefaultSortOption('Image'), 'replace');
         }
 
@@ -265,6 +274,7 @@ function WorkloadCvesOverviewPage() {
     function onVulnerabilityStateChange(vulnerabilityState: VulnerabilityState) {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
+        setDefaultSearchFilter('Image CVE');
         setSearchFilter({}, 'replace');
         sort.setSortOption(getDefaultWorkloadSortOption('CVE'), 'replace');
         pagination.setPage(1, 'replace');
@@ -324,6 +334,7 @@ function WorkloadCvesOverviewPage() {
             }}
             includeCveSeverityFilters={isViewingWithCves}
             includeCveStatusFilters={isViewingWithCves}
+            defaultSearchFilter={defaultSearchFilter}
         />
     ) : (
         <WorkloadCveFilterToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -6,7 +6,7 @@ import { Globe } from 'react-feather';
 import CompoundSearchFilter, {
     CompoundSearchFilterProps,
 } from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import { OnSearchPayload, SearchFilterEntityName } from 'Components/CompoundSearchFilter/types';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import useFeatureFlags from 'hooks/useFeatureFlags';
@@ -66,6 +66,7 @@ type AdvancedFiltersToolbarProps = {
     defaultFilters?: DefaultFilters;
     includeCveSeverityFilters?: boolean;
     includeCveStatusFilters?: boolean;
+    defaultSearchFilter?: SearchFilterEntityName;
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
     // autocompleteSearchContext?: unknown;
 };
@@ -79,6 +80,7 @@ function AdvancedFiltersToolbar({
     defaultFilters = emptyDefaultFilters,
     includeCveSeverityFilters = true,
     includeCveStatusFilters = true,
+    defaultSearchFilter,
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component
     // autocompleteSearchContext,
 }: AdvancedFiltersToolbarProps) {
@@ -133,6 +135,7 @@ function AdvancedFiltersToolbar({
                         config={searchFilterConfig}
                         searchFilter={searchFilter}
                         onSearch={onFilterApplied}
+                        defaultEntity={defaultSearchFilter}
                     />
                 </ToolbarGroup>
                 {(includeCveSeverityFilters ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -66,7 +66,7 @@ type AdvancedFiltersToolbarProps = {
     defaultFilters?: DefaultFilters;
     includeCveSeverityFilters?: boolean;
     includeCveStatusFilters?: boolean;
-    defaultSearchFilter?: SearchFilterEntityName;
+    defaultSearchFilterEntity?: SearchFilterEntityName;
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
     // autocompleteSearchContext?: unknown;
 };
@@ -80,7 +80,7 @@ function AdvancedFiltersToolbar({
     defaultFilters = emptyDefaultFilters,
     includeCveSeverityFilters = true,
     includeCveStatusFilters = true,
-    defaultSearchFilter,
+    defaultSearchFilterEntity,
     // TODO We need to be able to apply the autocomplete search context to the advanced filters component
     // autocompleteSearchContext,
 }: AdvancedFiltersToolbarProps) {
@@ -135,7 +135,7 @@ function AdvancedFiltersToolbar({
                         config={searchFilterConfig}
                         searchFilter={searchFilter}
                         onSearch={onFilterApplied}
-                        defaultEntity={defaultSearchFilter}
+                        defaultEntity={defaultSearchFilterEntity}
                     />
                 </ToolbarGroup>
                 {(includeCveSeverityFilters ||


### PR DESCRIPTION
## Description

This PR adds the ability to specify a default entity for the compound search filter

1)If you tab over to `CVEs`, it will go to `CVE+Name`
2) If you tab over to `Images`, it will go to `Image+Name`
3) If you tab over to `Deployments`, it will go to `Deployment+Name`

## Screen recording


https://github.com/stackrox/stackrox/assets/4805485/cd3be122-1554-48f6-b0e3-d592b3a14f1d




