### PR TITLE
ROX-24924: Implement clearFilters functionality node cve list

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -75,9 +75,10 @@ export type NodeVulnerability = {
 export type CVEsTableProps = {
     tableState: TableUIState<NodeVulnerability>;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
-function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
+function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps) {
     const COL_SPAN = 6;
     const expandedRowSet = useSet<string>();
 
@@ -103,6 +104,7 @@ function CVEsTable({ tableState, getSortParams }: CVEsTableProps) {
                 tableState={tableState}
                 colSpan={COL_SPAN}
                 emptyProps={{ message: 'No CVEs were detected for this node' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((nodeVulnerability, rowIndex) => {
                         const { cve, cvss, scoreVersion, nodeComponents } = nodeVulnerability;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -152,7 +152,14 @@ function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
                             />
                         </SplitItem>
                     </Split>
-                    <CVEsTable tableState={tableState} getSortParams={getSortParams} />
+                    <CVEsTable
+                        tableState={tableState}
+                        getSortParams={getSortParams}
+                        onClearFilters={() => {
+                            setSearchFilter({});
+                            setPage(1, 'replace');
+                        }}
+                    />
                 </div>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -62,6 +62,7 @@ export type CVEsTableProps = {
     canSelectRows?: boolean;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function CVEsTable({
@@ -73,6 +74,7 @@ function CVEsTable({
     canSelectRows,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: CVEsTableProps) {
     const { page, perPage } = pagination;
 
@@ -134,6 +136,7 @@ function CVEsTable({
                 emptyProps={{
                     message: 'No CVEs have been detected for nodes across your secured clusters',
                 }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((nodeCve, rowIndex) => {
                         const {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -84,6 +84,11 @@ function NodeCvesOverviewPage() {
         );
     }
 
+    function onClearFilters() {
+        setSearchFilter({});
+        pagination.setPage(1, 'replace');
+    }
+
     const { data } = useNodeCveEntityCounts(querySearchFilter);
 
     const entityCounts = {
@@ -200,6 +205,7 @@ function NodeCvesOverviewPage() {
                                     )}
                                     sortOption={sortOption}
                                     getSortParams={getSortParams}
+                                    onClearFilters={onClearFilters}
                                 />
                             )}
                             {activeEntityTabKey === 'Node' && (
@@ -209,6 +215,7 @@ function NodeCvesOverviewPage() {
                                     pagination={pagination}
                                     sortOption={sortOption}
                                     getSortParams={getSortParams}
+                                    onClearFilters={onClearFilters}
                                 />
                             )}
                         </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -39,6 +39,7 @@ export type NodesTableProps = {
     pagination: ReturnType<typeof useURLPagination>;
     sortOption: ApiSortOption;
     getSortParams: UseURLSortResult['getSortParams'];
+    onClearFilters: () => void;
 };
 
 function NodesTable({
@@ -47,6 +48,7 @@ function NodesTable({
     pagination,
     sortOption,
     getSortParams,
+    onClearFilters,
 }: NodesTableProps) {
     const { page, perPage } = pagination;
 
@@ -93,6 +95,7 @@ function NodesTable({
                 tableState={tableState}
                 colSpan={5}
                 emptyProps={{ message: 'No CVEs have been reported for your scanned nodes' }}
+                filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((node) => {
                         const {


### PR DESCRIPTION
## Description

Connects the "Clear filters" button in the table empty state for the Node CVE overview page and Node CVE single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Apply a filter on the following pages that causes a response with zero results:
1. Overview page Node list
2. Overview page CVE list
3. Node single page
![image](https://github.com/stackrox/stackrox/assets/1292638/551bedd5-3624-4891-9afb-b57021b3b63e)

Test that "Clear filters" removes the applied filters.
![image](https://github.com/stackrox/stackrox/assets/1292638/175a01d0-d6ec-4797-9076-0d67085cba36)

