### PR TITLE
ROX-24922: Fix column sorting for node/platform cves

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -37,7 +37,11 @@ import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import CVESelectionTd from '../../components/CVESelectionTd';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
-import { getScoreVersionsForTopCVSS, sortCveDistroList } from '../../utils/sortUtils';
+import {
+    aggregateByCVSS,
+    getScoreVersionsForTopCVSS,
+    sortCveDistroList,
+} from '../../utils/sortUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
 import useNodeCves from './useNodeCves';
@@ -116,11 +120,10 @@ function CVEsTable({
                         Nodes by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
-                    <Th sort={getSortParams(NODE_TOP_CVSS_SORT_FIELD)}>Top CVSS</Th>
-                    <TooltipTh
-                        tooltip="Ratio of the number of nodes affected by this CVE to the total number of nodes"
-                        sort={getSortParams(NODE_COUNT_SORT_FIELD)}
-                    >
+                    <Th sort={getSortParams(NODE_TOP_CVSS_SORT_FIELD, aggregateByCVSS)}>
+                        Top CVSS
+                    </Th>
+                    <TooltipTh tooltip="Ratio of the number of nodes affected by this CVE to the total number of nodes">
                         Affected nodes
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -55,7 +55,14 @@ export const sortFields = [
     // FIRST_DISCOVERED_SORT_FIELD,
 ];
 
-export const defaultSortOption = { field: CVE_SORT_FIELD, direction: 'desc' } as const;
+export const defaultSortOption = {
+    field: NODE_TOP_CVSS_SORT_FIELD,
+    direction: 'desc',
+    aggregateBy: {
+        aggregateFunc: 'max',
+        distinct: 'false',
+    },
+} as const;
 
 export type CVEsTableProps = {
     querySearchFilter: QuerySearchFilter;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -28,12 +28,7 @@ import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 
 import ExpandRowTh from 'Components/ExpandRowTh';
-import {
-    CLUSTER_CVE_STATUS_SORT_FIELD,
-    CVE_SORT_FIELD,
-    CVE_TYPE_SORT_FIELD,
-    CVSS_SORT_FIELD,
-} from '../../utils/sortFields';
+import { CVE_SORT_FIELD, CVE_TYPE_SORT_FIELD, CVSS_SORT_FIELD } from '../../utils/sortFields';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -50,7 +45,6 @@ const totalClusterCountQuery = gql`
 
 export const sortFields = [
     CVE_SORT_FIELD,
-    CLUSTER_CVE_STATUS_SORT_FIELD,
     CVE_TYPE_SORT_FIELD,
     CVSS_SORT_FIELD,
     // TODO - Needs a BE field implementation
@@ -118,7 +112,7 @@ function CVEsTable({
                     <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
-                    <Th sort={getSortParams(CLUSTER_CVE_STATUS_SORT_FIELD)}>CVE status</Th>
+                    <Th>CVE status</Th>
                     <Th sort={getSortParams(CVE_TYPE_SORT_FIELD)}>CVE type</Th>
                     <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
                     <TooltipTh

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -15,6 +15,6 @@ export const CLUSTER_KUBERNETES_VERSION_SORT_FIELD = 'Cluster Kubernetes Version
 
 // Node sort fields
 export const NODE_SORT_FIELD = 'Node';
-export const NODE_TOP_CVSS_SORT_FIELD = 'Node Top CVSS';
+export const NODE_TOP_CVSS_SORT_FIELD = 'CVSS';
 export const NODE_COUNT_SORT_FIELD = 'Node Count';
 export const NODE_SCAN_TIME_SORT_FIELD = 'Node Scan Time';


### PR DESCRIPTION
## Description

Removes the ability to sort columns that are unsupported by the API
- Node CVEs list "Affected Nodes" column
- Platform CVEs list "CVE status" column

Fixes sorting of:
- Node CVEs list "Top CVSS" column

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Sorting no longer available:
![image](https://github.com/stackrox/stackrox/assets/1292638/336b3f35-56a1-4cdd-9739-bc702128aba7)
![image](https://github.com/stackrox/stackrox/assets/1292638/733029db-8b42-4b82-ba89-982860490d92)

Sort Node CVEs by Top CVSS:
![image](https://github.com/stackrox/stackrox/assets/1292638/dca3fa27-1619-46af-99ce-12d4d46f0ef3)
![image](https://github.com/stackrox/stackrox/assets/1292638/12e9ae9a-0d16-4cf2-a63c-53c7a707a9ea)

