### PR TITLE
ROX-24923: Fix filter handling when toggling snoozed cves

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -141,7 +141,7 @@ function NodeCvesOverviewPage() {
                     </Flex>
                     <FlexItem>
                         <SnoozeCveToggleButton
-                            searchFilter={querySearchFilter}
+                            searchFilter={searchFilter}
                             setSearchFilter={setSearchFilter}
                         />
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -142,7 +142,7 @@ function PlatformCvesOverviewPage() {
                     </Flex>
                     <FlexItem>
                         <SnoozeCveToggleButton
-                            searchFilter={querySearchFilter}
+                            searchFilter={searchFilter}
                             setSearchFilter={setSearchFilter}
                         />
                     </FlexItem>


### PR DESCRIPTION
## Description

Fixes an issue where invalid Severity and Status values we applied to the filter chips, and then removed entirely when toggling Snoozed CVEs.

This is due to passing a `QuerySearchFilter` to the toggle button instead of a `SearchFilter`. The former is an object type that represents filter values as they are passed to the API, while the latter is a more general type that represents any user created search object. Since the first is a subset of the second, it is allowed to be passed to this component and is subsequently parsed into a `QuerySearchFilter` a second time, causing the invalid filter chips.

Although this SnoozeButton component is planned for removal, this is an issue that could reappear so we should evaluate alternatives to avoid this happening again in the future.
- Branded, "nominal" typing?
- More restricted data flow for search filters?
- Something else?

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Apply a Severity and/or Status filter on the Node and Platform CVE pages. Toggle the Snooze filter on, and then off, via the button.

Node:
![image](https://github.com/stackrox/stackrox/assets/1292638/4041857b-79b1-461d-97ac-cef949964e34)
![image](https://github.com/stackrox/stackrox/assets/1292638/e993c272-4923-418e-b45e-70bfacbb984b)
![image](https://github.com/stackrox/stackrox/assets/1292638/e3cd9f07-4a03-4c4e-ba4f-7da6b57fc70a)

Platform:
![image](https://github.com/stackrox/stackrox/assets/1292638/f00266ae-bcf3-4a2b-ba42-efb3256bb514)
![image](https://github.com/stackrox/stackrox/assets/1292638/ab310804-f56b-4f45-b735-211be8023cda)
![image](https://github.com/stackrox/stackrox/assets/1292638/5dbfdbb9-3367-4444-be0a-7280d561a0ce)

