### PR TITLE
ROX-24925: Add CVE status column to platform CVE page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -9,6 +9,8 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { TableUIState } from 'utils/getTableUIState';
 import { ClusterType } from 'types/cluster.proto';
 
+import { getIsSomeVulnerabilityFixable } from 'Containers/Vulnerabilities/utils/vulnerabilityUtils';
+import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import {
     CLUSTER_KUBERNETES_VERSION_SORT_FIELD,
     CLUSTER_SORT_FIELD,
@@ -30,6 +32,9 @@ export const affectedClusterFragment = gql`
         id
         name
         type
+        clusterVulnerabilities(query: $query) {
+            fixedByVersion
+        }
         status {
             orchestratorMetadata {
                 version
@@ -42,6 +47,9 @@ export type AffectedCluster = {
     id: string;
     name: string;
     type: ClusterType;
+    clusterVulnerabilities: {
+        fixedByVersion: string;
+    }[];
     status?: {
         orchestratorMetadata?: {
             version: string;
@@ -72,6 +80,7 @@ function AffectedClustersTable({
                 <Tr>
                     <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
                     <Th sort={getSortParams(CLUSTER_TYPE_SORT_FIELD)}>Cluster type</Th>
+                    <Th>CVE status</Th>
                     <Th sort={getSortParams(CLUSTER_KUBERNETES_VERSION_SORT_FIELD)}>
                         Kubernetes version
                     </Th>
@@ -84,21 +93,30 @@ function AffectedClustersTable({
                 filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) => (
                     <Tbody>
-                        {data.map(({ id, name, type, status }) => (
-                            <Tr key={id}>
-                                <Td dataLabel="Cluster">
-                                    <Link to={getPlatformEntityPagePath('Cluster', id)}>
-                                        <Truncate position="middle" content={name} />
-                                    </Link>
-                                </Td>
-                                <Td dataLabel="Cluster type" modifier="nowrap">
-                                    {displayClusterType(type)}
-                                </Td>
-                                <Td dataLabel="Kubernetes version" modifier="nowrap">
-                                    {status?.orchestratorMetadata?.version ?? 'Unavailable'}
-                                </Td>
-                            </Tr>
-                        ))}
+                        {data.map(({ id, name, type, clusterVulnerabilities, status }) => {
+                            const isFixableInCluster =
+                                getIsSomeVulnerabilityFixable(clusterVulnerabilities);
+                            return (
+                                <Tr key={id}>
+                                    <Td dataLabel="Cluster">
+                                        <Link to={getPlatformEntityPagePath('Cluster', id)}>
+                                            <Truncate position="middle" content={name} />
+                                        </Link>
+                                    </Td>
+                                    <Td dataLabel="Cluster type" modifier="nowrap">
+                                        {displayClusterType(type)}
+                                    </Td>
+                                    <Td dataLabel="CVE status">
+                                        <VulnerabilityFixableIconText
+                                            isFixable={isFixableInCluster}
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Kubernetes version" modifier="nowrap">
+                                        {status?.orchestratorMetadata?.version ?? 'Unavailable'}
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                     </Tbody>
                 )}
             />


### PR DESCRIPTION
## Description

__Easier to review with "Hide whitespace" on__

Adds the CVE status column to Platform CVE single page clusters.

This uses the same method that is used in Workload CVEs:
1. For a given CVE, fetch all clusters affected by that CVE
2. For each cluster, fetch all vulnerabilities under that cluster, **filtered by the target CVE**
3. If any CVE under the cluster has a `fixedByVersion` that is not `''`, then the CVE is considered fixable for that cluster

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Visit a Platform CVE page with clusters that are not fixable:
![image](https://github.com/stackrox/stackrox/assets/1292638/c6c00236-efe7-4e3a-b5b8-3e25d16e39f6)

Compared to data in VM 1.0:
![image](https://github.com/stackrox/stackrox/assets/1292638/bd5c4e30-67a4-40c0-8a85-d26d8b59b129)

Visit a Platform CVE page with clusters that are fixable (via mock API request). Verify that `fixedByVersion` returns non-empty values in staging.
![image](https://github.com/stackrox/stackrox/assets/1292638/7e0fe0e3-5235-47d9-be58-cfd3c57e2eb8)



