### PR TITLE
ROX-24928: Fix duplicated benchmark ids

### DIFF
--- a/pkg/defaults/complianceoperator/files/nist-high-benchmark-revision-4.json
+++ b/pkg/defaults/complianceoperator/files/nist-high-benchmark-revision-4.json
@@ -1,5 +1,5 @@
 {
-  "id": "13d6b465-1467-4bfd-af0f-a3e2205048f1",
+  "id": "f5859d89-1a5a-4876-9ddc-fbcc52b79fe5",
   "name": "NIST 800-53 High-Impact Baseline",
   "version": "Revision 4",
   "description": "",


### PR DESCRIPTION
## Description

The NIST high and moderate had the same id making it so high was overwritten when we insert the benchmark on startup. This PR fixes this issue by changing the id of NIST high.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Deploy ACS and verify that all benchmarks are inserted properly on startup
  - These are the benchmarks in centraldb:
![Screenshot 2024-06-25 at 10 42 15](https://github.com/stackrox/stackrox/assets/2685670/898418ca-a8ad-40a5-bcdd-dc384a147f40)
![Screenshot 2024-06-25 at 10 42 51](https://github.com/stackrox/stackrox/assets/2685670/dfce0f51-624b-4349-998c-39aeb6d0ae34)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
