### PR TITLE
ROX-24952: Add cloud provider to Platform CVE cluster details

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -20,8 +20,25 @@ import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import ExpandableLabelSection from '../../components/ExpandableLabelSection';
-import useClusterExtendedDetails from './useClusterExtendedDetails';
+import useClusterExtendedDetails, { ProviderMetadata } from './useClusterExtendedDetails';
 import { displayClusterType } from '../utils/stringUtils';
+
+function getCloudProviderText(providerMetadata: ProviderMetadata | undefined): string | null {
+    if (!providerMetadata) {
+        return null;
+    }
+    const { region } = providerMetadata;
+    if (providerMetadata.aws) {
+        return `AWS ${region}`;
+    }
+    if (providerMetadata.azure) {
+        return `Azure ${region}`;
+    }
+    if (providerMetadata.google) {
+        return `GCP ${region}`;
+    }
+    return null;
+}
 
 export type ClusterPageDetailsProps = {
     clusterId: string;
@@ -66,18 +83,20 @@ function ClusterPageDetails({ clusterId }: ClusterPageDetailsProps) {
                                                 {displayClusterType(data.cluster.type)}
                                             </DescriptionListDescription>
                                         </DescriptionListGroup>
-                                        {/*
-                                        {data.cluster.cloudProvider && (
+                                        {getCloudProviderText(
+                                            data.cluster.status?.providerMetadata
+                                        ) && (
                                             <DescriptionListGroup>
                                                 <DescriptionListTerm>
                                                     Cloud provider
                                                 </DescriptionListTerm>
                                                 <DescriptionListDescription>
-                                                    {data.cluster.cloudProvider}
+                                                    {getCloudProviderText(
+                                                        data.cluster.status?.providerMetadata
+                                                    )}
                                                 </DescriptionListDescription>
                                             </DescriptionListGroup>
                                         )}
-                                        */}
                                         {data.cluster.status?.orchestratorMetadata?.buildDate && (
                                             <DescriptionListGroup>
                                                 <DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
@@ -6,14 +6,24 @@ const clusterExtendedDetailsQuery = gql`
         cluster(id: $id) {
             id
             status {
+                providerMetadata {
+                    aws {
+                        __typename
+                    }
+                    azure {
+                        __typename
+                    }
+                    google {
+                        __typename
+                    }
+                    region
+                }
                 orchestratorMetadata {
                     version
                     buildDate
                 }
             }
             type
-            # TODO - Need to add the following fields to the query
-            # cloudProvider
             labels {
                 key
                 value
@@ -22,17 +32,23 @@ const clusterExtendedDetailsQuery = gql`
     }
 `;
 
+export type ProviderMetadata = {
+    aws: Record<string, unknown> | null;
+    azure: Record<string, unknown> | null;
+    google: Record<string, unknown> | null;
+    region: string;
+};
+
 export type ClusterExtendedDetails = {
     id: string;
     status?: {
+        providerMetadata?: ProviderMetadata;
         orchestratorMetadata?: {
             version: string;
             buildDate: string;
         };
     };
     type: ClusterType;
-    // TODO - Need to add the following fields to the type
-    // cloudProvider: string;
     labels: {
         key: string;
         value: string;

--- a/ui/apps/platform/src/configureApolloClient.js
+++ b/ui/apps/platform/src/configureApolloClient.js
@@ -60,6 +60,13 @@ const cache = new InMemoryCache({
         ImageCVECore: {
             keyFields: ['cve'],
         },
+        Cluster: {
+            fields: {
+                status: {
+                    merge: (existing, incoming) => merge({}, existing, incoming),
+                },
+            },
+        },
     },
 });
 


### PR DESCRIPTION
## Description

Found one item from the mocks/requirements that was not implemented. This adds the "Cloud provider" to the Cluster details tab if a known cloud provider is detected for the cluster.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Visit Cluster details and see the addition of the cloud provider field.
![image](https://github.com/stackrox/stackrox/assets/1292638/27fa10f2-f281-4616-903c-801bdcb3368f)

