### PR TITLE
ROX-24089: Adding acscsEmail type to notifiers filter in reporting

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
@@ -18,7 +18,7 @@ import { NotifierConfiguration } from 'services/ReportsService.types';
 import NotifierMailingLists from './NotifierMailingLists';
 
 function isEmailNotifier(notifier: NotifierIntegrationBase) {
-    return notifier.type === 'email';
+    return notifier.type === 'email' || notifier.type === 'acscsEmail';
 }
 
 function splitAndTrimMailingListsString(mailingListsString: string): string[] {


### PR DESCRIPTION
As title states. The ACSCS email notifier should show up as an option when the feature flag is turned on in both VM and Compliance reporting.