### PR TITLE
ROX-24295: retry http calls in URLHasValidCert

### DIFF
--- a/central/development/service/service_impl.go
+++ b/central/development/service/service_impl.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	riskManager "github.com/stackrox/rox/central/risk/manager"
@@ -43,14 +44,16 @@ var (
 
 // New creates a new Service.
 func New(sensorConnectionManager connection.Manager, imageDatastore imageDatastore.DataStore, riskManager riskManager.Manager) Service {
+	client := retryablehttp.NewClient()
+	client.HTTPClient = &http.Client{
+		Timeout:   20 * time.Second,
+		Transport: proxy.RoundTripper(),
+	}
 	return &serviceImpl{
 		imageDatastore:          imageDatastore,
 		riskManager:             riskManager,
 		sensorConnectionManager: sensorConnectionManager,
-		client: http.Client{
-			Timeout:   20 * time.Second,
-			Transport: proxy.RoundTripper(),
-		},
+		client:                  client,
 	}
 }
 
@@ -60,7 +63,7 @@ type serviceImpl struct {
 	sensorConnectionManager connection.Manager
 	imageDatastore          imageDatastore.DataStore
 	riskManager             riskManager.Manager
-	client                  http.Client
+	client                  *retryablehttp.Client
 }
 
 func (s *serviceImpl) ReplicateImage(ctx context.Context, req *central.ReplicateImageRequest) (*central.Empty, error) {

--- a/central/development/service/service_impl.go
+++ b/central/development/service/service_impl.go
@@ -53,7 +53,7 @@ func New(sensorConnectionManager connection.Manager, imageDatastore imageDatasto
 		imageDatastore:          imageDatastore,
 		riskManager:             riskManager,
 		sensorConnectionManager: sensorConnectionManager,
-		client:                  client,
+		client:                  client.StandardClient(),
 	}
 }
 
@@ -63,7 +63,7 @@ type serviceImpl struct {
 	sensorConnectionManager connection.Manager
 	imageDatastore          imageDatastore.DataStore
 	riskManager             riskManager.Manager
-	client                  *retryablehttp.Client
+	client                  *http.Client
 }
 
 func (s *serviceImpl) ReplicateImage(ctx context.Context, req *central.ReplicateImageRequest) (*central.Empty, error) {


### PR DESCRIPTION
## Description

Use retryable http client in DevelopmentService to fix issues when badssl.com is down.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI (nongroovy tests) 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
