### PR TITLE
ROX-24972: Add telemetry for Node/Platform global snooze

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -19,6 +19,7 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
+import useAnalytics, { GLOBAL_SNOOZE_CVE } from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
@@ -57,6 +58,7 @@ const searchFilterConfig = {
 
 function NodeCvesOverviewPage() {
     const apolloClient = useApolloClient();
+    const { analyticsTrack } = useAnalytics();
 
     const [activeEntityTabKey] = useURLStringUnion('entityTab', nodeEntityTabValues);
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -123,7 +125,13 @@ function NodeCvesOverviewPage() {
             {snoozeModalOptions && (
                 <SnoozeCvesModal
                     {...snoozeModalOptions}
-                    onSuccess={() => {
+                    onSuccess={(action, duration) => {
+                        if (action === 'SNOOZE') {
+                            analyticsTrack({
+                                event: GLOBAL_SNOOZE_CVE,
+                                properties: { type: 'NODE', duration },
+                            });
+                        }
                         // Refresh the data after snoozing/unsnoozing CVEs
                         apolloClient.cache.evict({ fieldName: 'nodeCVEs' });
                         apolloClient.cache.evict({ fieldName: 'nodeCVECount' });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -16,6 +16,7 @@ import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
+import useAnalytics, { GLOBAL_SNOOZE_CVE } from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
@@ -51,6 +52,7 @@ const searchFilterConfig = {
 
 function PlatformCvesOverviewPage() {
     const apolloClient = useApolloClient();
+    const { analyticsTrack } = useAnalytics();
 
     const [activeEntityTabKey] = useURLStringUnion('entityTab', platformEntityTabValues);
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -119,7 +121,13 @@ function PlatformCvesOverviewPage() {
             {snoozeModalOptions && (
                 <SnoozeCvesModal
                     {...snoozeModalOptions}
-                    onSuccess={() => {
+                    onSuccess={(action, duration) => {
+                        if (action === 'SNOOZE') {
+                            analyticsTrack({
+                                event: GLOBAL_SNOOZE_CVE,
+                                properties: { type: 'PLATFORM', duration },
+                            });
+                        }
                         // Refresh the data after snoozing/unsnoozing CVEs
                         apolloClient.cache.evict({ fieldName: 'platformCVEs' });
                         apolloClient.cache.evict({ fieldName: 'platformCVECount' });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
@@ -20,7 +20,7 @@ export type SnoozeCvesModalProps = {
     action: SnoozeAction;
     cveType: SnoozeableCveType;
     cves: { cve: string }[];
-    onSuccess: () => void;
+    onSuccess: (action: SnoozeAction, duration: ValueOf<typeof durations>) => void;
     onClose: () => void;
 };
 
@@ -40,7 +40,7 @@ function SnoozeCvesModal({ action, cveType, cves, onSuccess, onClose }: SnoozeCv
         },
         onSubmit: (formValues: FormValues, helpers: FormikHelpers<FormValues>) => {
             const callbackOptions = {
-                onSuccess,
+                onSuccess: () => onSuccess(action, formValues.duration),
                 onSettled: () => helpers.setSubmitting(false),
             };
 


### PR DESCRIPTION
### Description

Adds telemetry event tracking for Node and Platform CVE global snooze functionality.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**

_There are currently no e2e tests for Node and Platform CVEs, nor is there an existing precedent for testing telemetry via the UI in automated tests. This should be remedied as part of the requirements for the upcoming e2e tests._

#### How I validated my change

Snooze CVEs on the Node CVE overview page and observe the sent telemetry event:
![image](https://github.com/stackrox/stackrox/assets/1292638/45a1354d-1cb6-4d13-b85f-ddd0d43b980d)

Snooze CVEs on the Platform CVE overview page and observe the sent telemetry event:
![image](https://github.com/stackrox/stackrox/assets/1292638/edaa9a1d-6e31-465f-a3b9-ce527ae92ad9)
