### PR TITLE
ROX-24974: Distinguish color of manual status for compliance checks

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -178,13 +178,13 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     MANUAL: {
         icon: (
             <Icon>
-                <WrenchIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <WrenchIcon color="var(--pf-v5-global--warning-color--100)" />
             </Icon>
         ),
         statusText: 'Manual',
         tooltipText:
             'Manual check requires additional organizational or technical knowledge that is not automatable',
-        color: 'grey',
+        color: 'gold',
     },
     NOT_APPLICABLE: {
         icon: (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -24,7 +24,7 @@ function getStatusIcon(status: Status, count: number) {
                 color = 'var(--pf-v5-global--primary-color--100)';
                 break;
             case 'manual':
-                color = 'var(--pf-v5-global--disabled-color--100)';
+                color = 'var(--pf-v5-global--warning-color--100)';
                 break;
             case 'other':
                 color = 'var(--pf-v5-global--disabled-color--100)';


### PR DESCRIPTION
### Description

Provide visual contrast between **Other** statuses and **Manual** status to follow up separate counts in #11669
* in tables
* in labels
* it segmented bars (prepare for the next release)

Especially prepare for potential change to segmented bars.

Thank you, Alan and Brad for timely consensus about color:
* `--pf-v5-global--warning-color--100` for check status in tables
* `'gold'` for check count in labels

### Residue

1. Brainstorm how to reduce duplication of icon and color:
    * compliance.coverage.utils.tsx file seems like source of truth
    * StatusCountIcon.tsx file
2. Brainstorm pro and con of two naming conventions:
    * ComplianceCommon.ts file seems like source of truth: `'PASS'`, `'FAIL'`, `'MANUAL'`, and so on
    * ComplianceEnhanced UI has `'pass'`, `'fail'`, `'manual'`, and `'other'` (the latter is frontend only)

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change


### Manual testing

1. Visit /main/compliance/coverage and select a profile that has non-zero **Manual** status for checks.

    * Before changes, see gray color of icon for both non-zero and zero counts.
        ![ProfileChecksTable_disabled](https://github.com/stackrox/stackrox/assets/11862657/1068cc74-a32d-4e04-a807-36352a9fee96)

    * After changes, see warning color of icon for non-zero counts.
        ![ProfileChecksTable_warning](https://github.com/stackrox/stackrox/assets/11862657/fcdf1cab-11c2-43e9-b81b-59aaf50a03d7)

2. Click link of clusters that has non-zero counts to see cluster details page.

    * Before changes, see gray color of icon for **Manual** status of a check.
        ![ClusterDetailsTable_disabled](https://github.com/stackrox/stackrox/assets/11862657/2b57a5c8-29d6-453c-bbaa-b88b7edf71f9)

    * After changes, see warning color of icon for **Manual** status of a check.
        ![ClusterDetailsTable_warning](https://github.com/stackrox/stackrox/assets/11862657/af34513e-9409-418f-be58-aeb82c3f35fa)

3. Go back, and then click **Clusters** toggle.

    * Before changes, see gray color of icon for non-zero counts.
        ![ProfileClustersTable_disabled](https://github.com/stackrox/stackrox/assets/11862657/e504e496-a1c7-40bd-8e38-6f4a3535ab9d)

    * After changes, see warning color of icon for non-zero counts.
        ![ProfileClustersTable_warning](https://github.com/stackrox/stackrox/assets/11862657/0293b5db-bb1f-43b8-8ba9-d6106157cb47)

4. Click link of check that has non-zero counts to see **Results** tab of check details page.

    * Before changes, see gray color of icon for **Manual** status of a check and gray color of label for **Manual** counts.
        ![CheckDetailsTable_disabled_gray](https://github.com/stackrox/stackrox/assets/11862657/a327bafd-1a61-44ff-a5e6-f7c5a1ed516c)

    * After changes, see warning color of icon for **Manual** status of a check and gold color of label for **Manual** counts.
        ![CheckDetailsTable_warning_gold](https://github.com/stackrox/stackrox/assets/11862657/6ca18005-b5cf-4ee4-8077-5cbb4af3b0ae)
