### PR TITLE
ROX-21577: remove SQL query from error, reformat `ParseFloat` error message

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -774,7 +774,8 @@ func retryableRunSearchRequestForSchema(ctx context.Context, query *query, schem
 
 	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error executing query %s", queryStr)
+		log.Errorf("Query issue: %s: %v", queryStr, err)
+		return nil, errors.Wrapf(err, "error executing query")
 	}
 	defer rows.Close()
 
@@ -889,7 +890,8 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 		var count int
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		if err := row.Scan(&count); err != nil {
-			return 0, errors.Wrapf(err, "error executing query %s", queryStr)
+			log.Errorf("Query issue: %s: %v", queryStr, err)
+			return 0, errors.Wrapf(err, "error executing query")
 		}
 		return count, nil
 	})
@@ -1015,7 +1017,8 @@ func RunDeleteRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	return pgutils.Retry(func() error {
 		_, err := db.Exec(ctx, queryStr, query.Data...)
 		if err != nil {
-			return errors.Wrapf(err, "could not delete from %q with query %s", schema.Table, queryStr)
+			log.Errorf("Query issue: %s: %v", queryStr, err)
+			return errors.Wrapf(err, "could not delete from database")
 		}
 		return err
 	})
@@ -1050,7 +1053,8 @@ func RunDeleteRequestReturningIDsForSchema(ctx context.Context, schema *walker.S
 	dbErr := pgutils.Retry(func() error {
 		rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 		if err != nil {
-			return errors.Wrapf(err, "could not delete from %q with query %s", schema.Table, queryStr)
+			log.Errorf("Query issue: %s: %v", queryStr, err)
+			return errors.Wrapf(err, "could not delete from database")
 		}
 		defer rows.Close()
 		for rows.Next() {

--- a/pkg/search/postgres/query/numeric_query.go
+++ b/pkg/search/postgres/query/numeric_query.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/readable"
 )
 
@@ -56,7 +57,7 @@ func parseNumericPrefix(value string) (prefix string, trimmedValue string) {
 func parseNumericStringToFloat(s string) (float64, error) {
 	val, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, err
+		return 0, errox.InvalidArgs.Newf("cannot parse %q as number", s)
 	}
 	return val, nil
 }


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

change me!

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

change me!
