### PR TITLE
ROX-24971: Telemetry for entity tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     PageSection,
     Title,
@@ -19,7 +19,10 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
-import useAnalytics, { GLOBAL_SNOOZE_CVE } from 'hooks/useAnalytics';
+import useAnalytics, {
+    GLOBAL_SNOOZE_CVE,
+    NODE_CVE_ENTITY_CONTEXT_VIEWED,
+} from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
@@ -84,7 +87,20 @@ function NodeCvesOverviewPage() {
             entityTab === 'CVE' ? cveDefaultSortOption : nodeDefaultSortOption,
             'replace'
         );
+
+        analyticsTrack({
+            event: NODE_CVE_ENTITY_CONTEXT_VIEWED,
+            properties: {
+                type: entityTab,
+                page: 'Overview',
+            },
+        });
     }
+
+    // Track the current entity tab when the page is initially visited.
+    useEffect(() => {
+        onEntityTabChange(activeEntityTabKey);
+    }, []);
 
     function onClearFilters() {
         setSearchFilter({});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     PageSection,
     Title,
@@ -16,7 +16,10 @@ import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import useAnalytics, { GLOBAL_SNOOZE_CVE } from 'hooks/useAnalytics';
+import useAnalytics, {
+    GLOBAL_SNOOZE_CVE,
+    PLATFORM_CVE_ENTITY_CONTEXT_VIEWED,
+} from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
@@ -78,7 +81,20 @@ function PlatformCvesOverviewPage() {
             entityTab === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
             'replace'
         );
+
+        analyticsTrack({
+            event: PLATFORM_CVE_ENTITY_CONTEXT_VIEWED,
+            properties: {
+                type: entityTab,
+                page: 'Overview',
+            },
+        });
     }
+
+    // Track the current entity tab when the page is initially visited.
+    useEffect(() => {
+        onEntityTabChange(activeEntityTabKey);
+    }, []);
 
     const { data } = usePlatformCveEntityCounts(querySearchFilter);
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -31,7 +31,11 @@ export const COLLECTION_CREATED = 'Collection Created';
 export const VULNERABILITY_REPORT_CREATED = 'Vulnerability Report Created';
 export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Download Generated';
 export const VULNERABILITY_REPORT_SENT_MANUALLY = 'Vulnerability Report Sent Manually';
+
+// Node and Platform CVEs
 export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
+export const NODE_CVE_ENTITY_CONTEXT_VIEWED = 'Node CVE Entity Context View';
+export const PLATFORM_CVE_ENTITY_CONTEXT_VIEWED = 'Platform CVE Entity Context View';
 
 // cluster-init-bundles
 export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
@@ -195,6 +199,28 @@ type AnalyticsEvent =
           properties: {
               type: 'NODE' | 'PLATFORM';
               duration: string;
+          };
+      }
+    /**
+     * Tracks each view of a CVE entity context (CVE or Node). This is
+     * controlled by the entity tabs on the Overview page.
+     */
+    | {
+          event: typeof NODE_CVE_ENTITY_CONTEXT_VIEWED;
+          properties: {
+              type: 'CVE' | 'Node';
+              page: 'Overview';
+          };
+      }
+    /**
+     * Tracks each view of a CVE entity context (CVE or Cluster). This is
+     * controlled by the entity tabs on the Overview page.
+     */
+    | {
+          event: typeof PLATFORM_CVE_ENTITY_CONTEXT_VIEWED;
+          properties: {
+              type: 'CVE' | 'Cluster';
+              page: 'Overview';
           };
       }
     /**


### PR DESCRIPTION
### Description

Adds telemetry event tracking for Node and Platform CVE entity tab buttons.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

_Node and Platform CVE e2e coming in future PRs. e2e testing for analytics tracking has not been established yet but is on the radar._

#### How I validated my change

Visit Node CVEs and view the automatic event tracking for the default entity tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/35b751d0-649d-4318-8e20-a46fe03b32d1)

Click the Node tab and view the event tracking:
![image](https://github.com/stackrox/stackrox/assets/1292638/2385cfec-8a4d-4676-b8c0-b7fb0480a557)

Refresh in-place and view the automatic event tracking for the navigated-to entity tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/384724b5-3549-42ce-a874-e88aee3b1fce)


Repeat the above steps for the Platform CVE page:
![image](https://github.com/stackrox/stackrox/assets/1292638/68f2d3b5-7218-4095-b882-d14b982492a9)
![image](https://github.com/stackrox/stackrox/assets/1292638/f8443d55-f692-47af-8390-16b4e87574ea)
![image](https://github.com/stackrox/stackrox/assets/1292638/6671fb8b-0b9f-43f4-8b88-7f3fb1b80c58)

