### PR TITLE
ROX-24721: Fix crash when image labels are nil

### DIFF
--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package resolvers
 
 import (

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -1,5 +1,3 @@
-//go:build sql_integration
-
 package resolvers
 
 import (
@@ -16,6 +14,7 @@ import (
 	deploymentMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	imageDS "github.com/stackrox/rox/central/image/datastore"
 	imageMocks "github.com/stackrox/rox/central/image/datastore/mocks"
 	imageComponentMocks "github.com/stackrox/rox/central/imagecomponent/datastore/mocks"
 	namespaceMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
@@ -430,4 +429,47 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			require.ElementsMatch(t, tc.expected, results)
 		})
 	}
+}
+
+func TestImageLabelAutoCompleteSearch(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	testGormDB := testDB.GetGormDB(t)
+	defer pgtest.CloseGormDB(t, testGormDB)
+	defer testDB.Teardown(t)
+
+	imageDatastore := imageDS.GetTestPostgresDataStore(t, testDB.DB)
+	ctx := loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
+
+	resolver, _ := SetupTestResolver(t, imageDatastore)
+	allowAllCtx := SetAuthorizerOverride(ctx, allow.Anonymous())
+
+	// Case: nil labels
+	image := fixtures.GetImage()
+	image.GetMetadata().GetV1().Labels = nil
+
+	require.NoError(t, imageDatastore.UpsertImage(ctx, image))
+
+	request := searchRequest{
+		Query:      fmt.Sprintf("Image Label:"),
+		Categories: &[]string{"IMAGES"},
+	}
+	results, err := resolver.SearchAutocomplete(allowAllCtx, request)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{}, results)
+
+	// Case: Non-empty labels
+	image.GetMetadata().GetV1().Labels = map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+
+	require.NoError(t, imageDatastore.UpsertImage(ctx, image))
+
+	request = searchRequest{
+		Query:      fmt.Sprintf("Image Label:"),
+		Categories: &[]string{"IMAGES"},
+	}
+	results, err = resolver.SearchAutocomplete(allowAllCtx, request)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"k1=v1", "k2=v2"}, results)
 }

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -452,7 +452,7 @@ func TestImageLabelAutoCompleteSearch(t *testing.T) {
 	require.NoError(t, imageDatastore.UpsertImage(ctx, image))
 
 	request := searchRequest{
-		Query:      fmt.Sprintf("Image Label:"),
+		Query:      "Image Label:",
 		Categories: &[]string{"IMAGES"},
 	}
 	results, err := resolver.SearchAutocomplete(allowAllCtx, request)
@@ -468,7 +468,7 @@ func TestImageLabelAutoCompleteSearch(t *testing.T) {
 	require.NoError(t, imageDatastore.UpsertImage(ctx, image))
 
 	request = searchRequest{
-		Query:      fmt.Sprintf("Image Label:"),
+		Query:      "Image Label:",
 		Categories: &[]string{"IMAGES"},
 	}
 	results, err = resolver.SearchAutocomplete(allowAllCtx, request)

--- a/pkg/search/postgres/query/map_query.go
+++ b/pkg/search/postgres/query/map_query.go
@@ -21,8 +21,12 @@ func ParseMapQuery(label string) (string, string, bool) {
 func readMapValue(val interface{}) map[string]string {
 	// Maps are stored in a jsonb column, which we get back as a byte array.
 	// We know that supported maps are only map[string]string, so we unmarshal accordingly.
+	v, ok := val.(*[]byte)
+	if !ok || v == nil || *v == nil {
+		return nil
+	}
 	var mapValue map[string]string
-	if err := json.Unmarshal(*val.(*[]byte), &mapValue); err != nil {
+	if err := json.Unmarshal(*v, &mapValue); err != nil {
 		utils.Should(err)
 		return nil
 	}
@@ -72,6 +76,9 @@ func newMapQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 				return []string(nil)
 			}
 			asMap := readMapValue(i)
+			if asMap == nil {
+				return []string(nil)
+			}
 			return []string{fmt.Sprintf("%s=%s", key, asMap[key])}
 		}), nil
 	}


### PR DESCRIPTION
### Description

The issue occurs when doing a selecting a map type field when all the values of that field are nil. For example, consider that all images in the database have nil labels.  The query `select images.id, images.metadata_v1_labels from images` would return rows where image id is non-empty but labels is nil. The transform function did not handle this case very well and crashed when trying to json unmarshal the nil label. This PR adds some checks to avoid that.

### User-facing documentation

(*must be* 2 items and both *must be* checked)

- [X] CHANGELOG update is not needed
- [X] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)

- [X] added unit tests

#### How I validated my change

Unit test and manual test
