### PR TITLE
chore(ui): Refactor coverage page routing

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -17,8 +17,7 @@ import ComplianceProfilesProvider, {
     ComplianceProfilesContext,
 } from './ComplianceProfilesProvider';
 import CoverageEmptyState from './CoverageEmptyState';
-import ProfileChecksPage from './ProfileChecksPage';
-import ProfileClustersPage from './ProfileClustersPage';
+import CoveragesPage from './CoveragesPage';
 import ScanConfigurationsProvider from './ScanConfigurationsProvider';
 
 function CoveragePage() {
@@ -48,8 +47,11 @@ function CoverageContent() {
 
     return (
         <Switch>
-            <Route exact path={coverageProfileChecksPath} component={ProfileChecksPage} />
-            <Route exact path={coverageProfileClustersPath} component={ProfileClustersPage} />
+            <Route
+                exact
+                path={[coverageProfileChecksPath, coverageProfileClustersPath]}
+                component={CoveragesPage}
+            />
             <Route exact path={coverageCheckDetailsPath} component={CheckDetailsPage} />
             <Route exact path={coverageClusterDetailsPath} component={ClusterDetailsPage} />
             <Route

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -62,7 +62,7 @@ function CoveragesPage() {
     };
 
     function handleProfilesToggleChange(selectedProfile: string) {
-        navigateWithScanConfigQuery(coverageProfileClustersPath, { profileName: selectedProfile });
+        navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });
     }
 
     const onSearch = (payload: OnSearchPayload) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -1,0 +1,158 @@
+import React, { useContext } from 'react';
+import { Route, Switch, useParams } from 'react-router-dom';
+import {
+    Bullseye,
+    Divider,
+    PageSection,
+    Spinner,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
+} from '@patternfly/react-core';
+
+import ComplianceUsageDisclaimer, {
+    COMPLIANCE_DISCLAIMER_KEY,
+} from 'Components/ComplianceUsageDisclaimer';
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import {
+    OnSearchPayload,
+    clusterSearchFilterConfig,
+    profileCheckSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import { getFilteredConfig } from 'Components/CompoundSearchFilter/utils/searchFilterConfig';
+import PageTitle from 'Components/PageTitle';
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
+import useURLSearch from 'hooks/useURLSearch';
+
+import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
+import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import {
+    coverageProfileChecksPath,
+    coverageProfileClustersPath,
+} from './compliance.coverage.routes';
+import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
+import ProfileDetailsHeader from './components/ProfileDetailsHeader';
+import ScanConfigurationSelect from './components/ScanConfigurationSelect';
+import CoveragesPageHeader from './CoveragesPageHeader';
+import useScanConfigRouter from './hooks/useScanConfigRouter';
+import ProfilesToggleGroup from './ProfilesToggleGroup';
+import ProfileChecksPage from './ProfileChecksPage';
+import ProfileClustersPage from './ProfileClustersPage';
+import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
+
+function CoveragesPage() {
+    const [isDisclaimerAccepted, setIsDisclaimerAccepted] = useBooleanLocalStorage(
+        COMPLIANCE_DISCLAIMER_KEY,
+        false
+    );
+    const { navigateWithScanConfigQuery } = useScanConfigRouter();
+    const { profileName } = useParams();
+    const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
+        useContext(ComplianceProfilesContext);
+    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
+        useContext(ScanConfigurationsContext);
+
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    const searchFilterConfig = {
+        'Profile Check': profileCheckSearchFilterConfig,
+        Cluster: getFilteredConfig(clusterSearchFilterConfig, ['Name']),
+    };
+
+    function handleProfilesToggleChange(selectedProfile: string) {
+        navigateWithScanConfigQuery(coverageProfileClustersPath, { profileName: selectedProfile });
+    }
+
+    const onSearch = (payload: OnSearchPayload) => {
+        onURLSearch(searchFilter, setSearchFilter, payload);
+    };
+
+    const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
+        (profile) => profile.name === profileName
+    );
+
+    return (
+        <>
+            <PageTitle title="Compliance coverage - Profile clusters" />
+            <CoveragesPageHeader />
+            <Divider component="div" />
+            <ScanConfigurationSelect
+                isLoading={scanConfigurationsQuery.isLoading}
+                scanConfigs={scanConfigurationsQuery.response.configurations}
+                selectedScanConfigName={selectedScanConfigName}
+                setSelectedScanConfigName={setSelectedScanConfigName}
+            />
+            {!isDisclaimerAccepted && (
+                <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
+            )}
+            <PageSection>
+                {isLoadingScanConfigProfiles ? (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                ) : (
+                    <>
+                        <ProfilesToggleGroup
+                            profileName={profileName}
+                            profiles={scanConfigProfilesResponse.profiles}
+                            handleToggleChange={handleProfilesToggleChange}
+                        />
+                        <Divider component="div" />
+                        <ProfileDetailsHeader
+                            isLoading={isLoadingScanConfigProfiles}
+                            profileName={profileName}
+                            profileDetails={selectedProfileDetails}
+                        />
+                        <Divider component="div" />
+                        <PageSection variant="light" className="pf-v5-u-p-0" component="div">
+                            <Toolbar>
+                                <ToolbarContent>
+                                    <ToolbarGroup className="pf-v5-u-w-100">
+                                        <ToolbarItem className="pf-v5-u-flex-1">
+                                            <CompoundSearchFilter
+                                                config={searchFilterConfig}
+                                                searchFilter={searchFilter}
+                                                onSearch={onSearch}
+                                            />
+                                        </ToolbarItem>
+                                    </ToolbarGroup>
+                                    <ToolbarGroup className="pf-v5-u-w-100">
+                                        <SearchFilterChips
+                                            filterChipGroupDescriptors={[
+                                                {
+                                                    displayName: 'Profile Check',
+                                                    searchFilterName: CHECK_NAME_QUERY,
+                                                },
+                                                {
+                                                    displayName: 'Cluster',
+                                                    searchFilterName: CLUSTER_QUERY,
+                                                },
+                                            ]}
+                                        />
+                                    </ToolbarGroup>
+                                </ToolbarContent>
+                            </Toolbar>
+                            <Divider />
+                            <Switch>
+                                <Route
+                                    exact
+                                    path={coverageProfileChecksPath}
+                                    render={() => <ProfileChecksPage />}
+                                />
+                                <Route
+                                    exact
+                                    path={coverageProfileClustersPath}
+                                    render={() => <ProfileClustersPage />}
+                                />
+                            </Switch>
+                        </PageSection>
+                    </>
+                )}
+            </PageSection>
+        </>
+    );
+}
+
+export default CoveragesPage;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,62 +1,24 @@
 import React, { useCallback, useContext } from 'react';
 import { useParams } from 'react-router-dom';
-import {
-    Bullseye,
-    Divider,
-    PageSection,
-    Spinner,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
 
-import PageTitle from 'Components/PageTitle';
-import ComplianceUsageDisclaimer, {
-    COMPLIANCE_DISCLAIMER_KEY,
-} from 'Components/ComplianceUsageDisclaimer';
-import {
-    OnSearchPayload,
-    clusterSearchFilterConfig,
-    profileCheckSearchFilterConfig,
-} from 'Components/CompoundSearchFilter/types';
-import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import { getFilteredConfig } from 'Components/CompoundSearchFilter/utils/searchFilterConfig';
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
-import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
-import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
 import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
-import { coverageProfileChecksPath } from './compliance.coverage.routes';
-import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
-import ProfileDetailsHeader from './components/ProfileDetailsHeader';
-import ScanConfigurationSelect from './components/ScanConfigurationSelect';
-import CoveragesPageHeader from './CoveragesPageHeader';
-import useScanConfigRouter from './hooks/useScanConfigRouter';
-import ProfilesToggleGroup from './ProfilesToggleGroup';
 import ProfileChecksTable from './ProfileChecksTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function ProfileChecksPage() {
-    const [isDisclaimerAccepted, setIsDisclaimerAccepted] = useBooleanLocalStorage(
-        COMPLIANCE_DISCLAIMER_KEY,
-        false
-    );
-    const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
-    const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
-        useContext(ComplianceProfilesContext);
-    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
-        useContext(ScanConfigurationsContext);
+
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -81,11 +43,6 @@ function ProfileChecksPage() {
     }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
     const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
 
-    const searchFilterConfig = {
-        'Profile Check': profileCheckSearchFilterConfig,
-        Cluster: getFilteredConfig(clusterSearchFilterConfig, ['Name']),
-    };
-
     const tableState = getTableUIState({
         isLoading,
         data: profileChecks?.profileResults,
@@ -93,98 +50,20 @@ function ProfileChecksPage() {
         searchFilter,
     });
 
-    const onSearch = (payload: OnSearchPayload) => {
-        onURLSearch(searchFilter, setSearchFilter, payload);
-    };
-
-    function handleProfilesToggleChange(selectedProfile: string) {
-        navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });
-    }
-
     function onClearFilters() {
         setSearchFilter({});
         setPage(1, 'replace');
     }
 
-    const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
-        (profile) => profile.name === profileName
-    );
-
     return (
-        <>
-            <PageTitle title="Compliance coverage - Profile checks" />
-            <CoveragesPageHeader />
-            <Divider component="div" />
-            <ScanConfigurationSelect
-                isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationsQuery.response.configurations}
-                selectedScanConfigName={selectedScanConfigName}
-                setSelectedScanConfigName={setSelectedScanConfigName}
-            />
-            {!isDisclaimerAccepted && (
-                <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
-            )}
-            <PageSection variant="default">
-                {isLoadingScanConfigProfiles ? (
-                    <Bullseye>
-                        <Spinner />
-                    </Bullseye>
-                ) : (
-                    <>
-                        <ProfilesToggleGroup
-                            profileName={profileName}
-                            profiles={scanConfigProfilesResponse.profiles}
-                            handleToggleChange={handleProfilesToggleChange}
-                        />
-                        <Divider component="div" />
-                        <ProfileDetailsHeader
-                            isLoading={isLoadingScanConfigProfiles}
-                            profileName={profileName}
-                            profileDetails={selectedProfileDetails}
-                        />
-                        <Divider component="div" />
-                        <PageSection variant="light" className="pf-v5-u-p-0" component="div">
-                            <Toolbar>
-                                <ToolbarContent>
-                                    <ToolbarGroup className="pf-v5-u-w-100">
-                                        <ToolbarItem className="pf-v5-u-flex-1">
-                                            <CompoundSearchFilter
-                                                config={searchFilterConfig}
-                                                searchFilter={searchFilter}
-                                                onSearch={onSearch}
-                                            />
-                                        </ToolbarItem>
-                                    </ToolbarGroup>
-                                    <ToolbarGroup className="pf-v5-u-w-100">
-                                        <SearchFilterChips
-                                            filterChipGroupDescriptors={[
-                                                {
-                                                    displayName: 'Profile Check',
-                                                    searchFilterName: CHECK_NAME_QUERY,
-                                                },
-                                                {
-                                                    displayName: 'Cluster',
-                                                    searchFilterName: CLUSTER_QUERY,
-                                                },
-                                            ]}
-                                        />
-                                    </ToolbarGroup>
-                                </ToolbarContent>
-                            </Toolbar>
-                            <Divider />
-                            <ProfileChecksTable
-                                profileChecksResultsCount={profileChecks?.totalCount ?? 0}
-                                profileName={profileName}
-                                pagination={pagination}
-                                tableState={tableState}
-                                getSortParams={getSortParams}
-                                onClearFilters={onClearFilters}
-                            />
-                        </PageSection>
-                    </>
-                )}
-            </PageSection>
-        </>
+        <ProfileChecksTable
+            profileChecksResultsCount={profileChecks?.totalCount ?? 0}
+            profileName={profileName}
+            pagination={pagination}
+            tableState={tableState}
+            getSortParams={getSortParams}
+            onClearFilters={onClearFilters}
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -9,7 +9,7 @@ import { getComplianceClusterStats } from 'services/ComplianceResultsStatsServic
 import { getTableUIState } from 'utils/getTableUIState';
 import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
-import { CLUSTER_QUERY } from './compliance.coverage.constants';
+import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import ProfileClustersTable from './ProfileClustersTable';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -1,29 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import {
-    Bullseye,
-    Divider,
-    PageSection,
-    Spinner,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
 
-import ComplianceUsageDisclaimer, {
-    COMPLIANCE_DISCLAIMER_KEY,
-} from 'Components/ComplianceUsageDisclaimer';
-import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import {
-    OnSearchPayload,
-    clusterSearchFilterConfig,
-    profileCheckSearchFilterConfig,
-} from 'Components/CompoundSearchFilter/types';
-import { getFilteredConfig } from 'Components/CompoundSearchFilter/utils/searchFilterConfig';
-import PageTitle from 'Components/PageTitle';
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -32,31 +9,15 @@ import { getComplianceClusterStats } from 'services/ComplianceResultsStatsServic
 import { getTableUIState } from 'utils/getTableUIState';
 import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
-import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
-import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import { CLUSTER_QUERY } from './compliance.coverage.constants';
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
-import { coverageProfileClustersPath } from './compliance.coverage.routes';
 import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
-import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
-import ProfileDetailsHeader from './components/ProfileDetailsHeader';
-import ScanConfigurationSelect from './components/ScanConfigurationSelect';
-import CoveragesPageHeader from './CoveragesPageHeader';
-import useScanConfigRouter from './hooks/useScanConfigRouter';
-import ProfilesToggleGroup from './ProfilesToggleGroup';
 import ProfileClustersTable from './ProfileClustersTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function ProfileClustersPage() {
-    const [isDisclaimerAccepted, setIsDisclaimerAccepted] = useBooleanLocalStorage(
-        COMPLIANCE_DISCLAIMER_KEY,
-        false
-    );
-    const { navigateWithScanConfigQuery } = useScanConfigRouter();
     const { profileName } = useParams();
-    const { isLoading: isLoadingScanConfigProfiles, scanConfigProfilesResponse } =
-        useContext(ComplianceProfilesContext);
-    const { scanConfigurationsQuery, selectedScanConfigName, setSelectedScanConfigName } =
-        useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const [currentDatetime, setCurrentDatetime] = useState<Date>(new Date());
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
 
@@ -83,11 +44,6 @@ function ProfileClustersPage() {
     }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
     const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);
 
-    const searchFilterConfig = {
-        'Profile Check': profileCheckSearchFilterConfig,
-        Cluster: getFilteredConfig(clusterSearchFilterConfig, ['Name']),
-    };
-
     const tableState = getTableUIState({
         isLoading,
         data: profileClusters?.scanStats,
@@ -101,103 +57,21 @@ function ProfileClustersPage() {
         }
     }, [profileClusters]);
 
-    function handleProfilesToggleChange(selectedProfile: string) {
-        navigateWithScanConfigQuery(
-            coverageProfileClustersPath,
-            { profileName: selectedProfile },
-            searchFilter
-        );
-    }
-
-    const onSearch = (payload: OnSearchPayload) => {
-        onURLSearch(searchFilter, setSearchFilter, payload);
-    };
-
     function onClearFilters() {
         setSearchFilter({});
         setPage(1, 'replace');
     }
 
-    const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
-        (profile) => profile.name === profileName
-    );
-
     return (
-        <>
-            <PageTitle title="Compliance coverage - Profile clusters" />
-            <CoveragesPageHeader />
-            <Divider component="div" />
-            <ScanConfigurationSelect
-                isLoading={scanConfigurationsQuery.isLoading}
-                scanConfigs={scanConfigurationsQuery.response.configurations}
-                selectedScanConfigName={selectedScanConfigName}
-                setSelectedScanConfigName={setSelectedScanConfigName}
-            />
-            {!isDisclaimerAccepted && (
-                <ComplianceUsageDisclaimer onAccept={() => setIsDisclaimerAccepted(true)} />
-            )}
-            <PageSection>
-                {isLoadingScanConfigProfiles ? (
-                    <Bullseye>
-                        <Spinner />
-                    </Bullseye>
-                ) : (
-                    <>
-                        <ProfilesToggleGroup
-                            profileName={profileName}
-                            profiles={scanConfigProfilesResponse.profiles}
-                            handleToggleChange={handleProfilesToggleChange}
-                        />
-                        <Divider component="div" />
-                        <ProfileDetailsHeader
-                            isLoading={isLoadingScanConfigProfiles}
-                            profileName={profileName}
-                            profileDetails={selectedProfileDetails}
-                        />
-                        <Divider component="div" />
-                        <PageSection variant="light" className="pf-v5-u-p-0" component="div">
-                            <Toolbar>
-                                <ToolbarContent>
-                                    <ToolbarGroup className="pf-v5-u-w-100">
-                                        <ToolbarItem className="pf-v5-u-flex-1">
-                                            <CompoundSearchFilter
-                                                config={searchFilterConfig}
-                                                searchFilter={searchFilter}
-                                                onSearch={onSearch}
-                                            />
-                                        </ToolbarItem>
-                                    </ToolbarGroup>
-                                    <ToolbarGroup className="pf-v5-u-w-100">
-                                        <SearchFilterChips
-                                            filterChipGroupDescriptors={[
-                                                {
-                                                    displayName: 'Profile Check',
-                                                    searchFilterName: CHECK_NAME_QUERY,
-                                                },
-                                                {
-                                                    displayName: 'Cluster',
-                                                    searchFilterName: CLUSTER_QUERY,
-                                                },
-                                            ]}
-                                        />
-                                    </ToolbarGroup>
-                                </ToolbarContent>
-                            </Toolbar>
-                            <Divider />
-                            <ProfileClustersTable
-                                currentDatetime={currentDatetime}
-                                pagination={pagination}
-                                profileClustersResultsCount={profileClusters?.totalCount ?? 0}
-                                profileName={profileName}
-                                tableState={tableState}
-                                getSortParams={getSortParams}
-                                onClearFilters={onClearFilters}
-                            />
-                        </PageSection>
-                    </>
-                )}
-            </PageSection>
-        </>
+        <ProfileClustersTable
+            currentDatetime={currentDatetime}
+            pagination={pagination}
+            profileClustersResultsCount={profileClusters?.totalCount ?? 0}
+            profileName={profileName}
+            tableState={tableState}
+            getSortParams={getSortParams}
+            onClearFilters={onClearFilters}
+        />
     );
 }
 


### PR DESCRIPTION
### Description

Update Coverage Page Routing

As `ProfileChecksPage` and `ProfileClustersPage` continue to share increasing amounts of code, it makes sense to create a shared component that uses nested routing for the different tables.

Benefits:
* Easier to maintain the shared layouts and data between the components
* Improved performance, unnecessary reinitialization of shared components

### Testing

* Main page still working as intended.
* Component initialization:
  * Before: Changing `ProfilesTableToggleGroup` caused shared components to reinitialize.
  * After: Only the components below the Advanced Filter section will reinitialize
