### PR TITLE
ROX-24926: Adjust filter bar categories for Node/Platform CVEs

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -293,40 +293,28 @@ export type ImageCVEAttributeInputType = ValueOf<
 // Node CVE search filter
 
 export const nodeCVESearchFilterConfig = {
-    displayName: 'Node CVE',
+    displayName: 'CVE',
     searchCategory: 'NODE_VULNERABILITIES',
     attributes: {
         Name: {
             displayName: 'Name',
-            filterChipLabel: 'Node CVE',
+            filterChipLabel: 'CVE',
             searchTerm: 'CVE',
             inputType: 'autocomplete',
         },
         'Discovered time': {
             displayName: 'Discovered time',
-            filterChipLabel: 'Node CVE discovered time',
+            filterChipLabel: 'CVE discovered time',
             searchTerm: 'CVE Created Time',
             inputType: 'date-picker',
         },
         CVSS: {
             displayName: 'CVSS',
-            filterChipLabel: 'Node CVE CVSS',
+            filterChipLabel: 'CVE CVSS',
             searchTerm: 'CVSS',
             inputType: 'condition-number',
         },
         // TODO: Add Top CVSS
-        Snoozed: {
-            displayName: 'Snoozed',
-            filterChipLabel: 'Node CVE snoozed',
-            searchTerm: 'CVE Snoozed',
-            inputType: 'select',
-            inputProps: {
-                options: [
-                    { label: 'True', value: 'true' },
-                    { label: 'False', value: 'false' },
-                ],
-            },
-        },
     },
 } as const;
 
@@ -345,42 +333,30 @@ export type NodeCVEAttributeInputType = ValueOf<
 // Platform CVE search filter
 
 export const platformCVESearchFilterConfig = {
-    displayName: 'Platform CVE',
+    displayName: 'CVE',
     searchCategory: 'CLUSTER_VULNERABILITIES',
     attributes: {
         Name: {
             displayName: 'Name',
-            filterChipLabel: 'Platform CVE',
+            filterChipLabel: 'CVE',
             searchTerm: 'CVE',
             inputType: 'autocomplete',
         },
         'Discovered time': {
             displayName: 'Discovered time',
-            filterChipLabel: 'Platform CVE discovered time',
+            filterChipLabel: 'CVE discovered time',
             searchTerm: 'CVE Created Time',
             inputType: 'date-picker',
         },
         CVSS: {
             displayName: 'CVSS',
-            filterChipLabel: 'Platform CVE CVSS',
+            filterChipLabel: 'CVE CVSS',
             searchTerm: 'CVSS',
             inputType: 'condition-number',
         },
-        Snoozed: {
-            displayName: 'Snoozed',
-            filterChipLabel: 'Platform CVE snoozed',
-            searchTerm: 'CVE Snoozed',
-            inputType: 'select',
-            inputProps: {
-                options: [
-                    { label: 'True', value: 'true' },
-                    { label: 'False', value: 'false' },
-                ],
-            },
-        },
         Type: {
             displayName: 'Type',
-            filterChipLabel: 'Platform CVE type',
+            filterChipLabel: 'CVE type',
             searchTerm: 'CVE Type',
             inputType: 'select',
             inputProps: {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -70,6 +70,10 @@ function AdvancedFiltersToolbar({
     const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');
 
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
+        .concat({
+            displayName: 'CVE snoozed',
+            searchFilterName: 'CVE Snoozed',
+        })
         .concat(
             includeCveSeverityFilters
                 ? makeDefaultFilterDescriptor(defaultFilters, {


### PR DESCRIPTION
### Description

Two tweaks to the filters for Node/Platform CVEs:
1. Remove "CVE snoozed" as an option from the filter bar. This will solely be controlled via the button until we are able to move this to a tab based UX.
2. Remove the `Platform` and `Node` prefixes before `CVE` in the search dropdowns.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] modified existing tests (tests exist for this functionality, but did not require a change)

#### How I validated my change

Visit Node and Platform CVEs, and verify via the dropdowns:
![image](https://github.com/stackrox/stackrox/assets/1292638/27deeefc-3ea4-45e6-ae3a-a7d15681cf9c)
![image](https://github.com/stackrox/stackrox/assets/1292638/ec0a3fe5-37df-4c08-91b5-855746ffc1ab)
![image](https://github.com/stackrox/stackrox/assets/1292638/767758c6-90fe-4e8e-8324-fc3b48c52cff)
![image](https://github.com/stackrox/stackrox/assets/1292638/38450120-9f5c-4dba-a282-5b4d559bc620)
![image](https://github.com/stackrox/stackrox/assets/1292638/51f82dd1-f562-43d0-81aa-2568bb84a562)
