### PR TITLE
ROX-24857: Use substring matching for checks/cluster names

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -31,6 +31,7 @@ import useURLSort from 'hooks/useURLSort';
 import { getComplianceProfileResults } from 'services/ComplianceResultsService';
 import { getTableUIState } from 'utils/getTableUIState';
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
+import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
@@ -66,8 +67,9 @@ function ProfileChecksPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfileChecks = useCallback(() => {
+        const regexSearchFilter = addRegexPrefixToFilters(searchFilter, [CHECK_NAME_QUERY]);
         const combinedFilter = combineSearchFilterWithScanConfig(
-            searchFilter,
+            regexSearchFilter,
             selectedScanConfigName
         );
         return getComplianceProfileResults(profileName, {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -30,6 +30,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { getComplianceClusterStats } from 'services/ComplianceResultsStatsService';
 import { getTableUIState } from 'utils/getTableUIState';
+import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
@@ -68,8 +69,9 @@ function ProfileClustersPage() {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const fetchProfileClusters = useCallback(() => {
+        const regexSearchFilter = addRegexPrefixToFilters(searchFilter, [CHECK_NAME_QUERY]);
         const combinedFilter = combineSearchFilterWithScanConfig(
-            searchFilter,
+            regexSearchFilter,
             selectedScanConfigName
         );
         return getComplianceClusterStats(profileName, {


### PR DESCRIPTION
### Description

This PR will filter the results for profile checks and clusters using substring matching

### Screenshots

![Screenshot 2024-06-26 at 10 38 09 AM](https://github.com/stackrox/stackrox/assets/4805485/23b1d452-a8f7-49e9-b4e6-4897a0cd7ef1)
![Screenshot 2024-06-26 at 10 38 34 AM](https://github.com/stackrox/stackrox/assets/4805485/f0678562-41aa-4bac-a15c-5e96a350d694)
