### PR TITLE
ROX-24850: Add sorting by severity for Workload CVE Deployment single

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -91,7 +91,7 @@ export const deploymentVulnerabilitiesQuery = gql`
     }
 `;
 
-const defaultSortFields = ['CVE'];
+const defaultSortFields = ['CVE', 'Severity'];
 
 const searchOptions: SearchOption[] = [
     IMAGE_SEARCH_OPTION,
@@ -126,7 +126,7 @@ function DeploymentPageVulnerabilities({
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultSortFields,
         defaultSortOption: {
-            field: 'CVE',
+            field: 'Severity',
             direction: 'desc',
         },
         onSort: () => setPage(1, 'replace'),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -69,7 +69,7 @@ function DeploymentVulnerabilitiesTable({
                     <ExpandRowTh />
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <Th>OS</Th>
-                    <Th>CVE severity</Th>
+                    <Th sort={getSortParams('Severity')}>CVE severity</Th>
                     <Th>
                         CVE status
                         {isFiltered && <DynamicColumnIcon />}


### PR DESCRIPTION
### Description

This PR will add sorting by severity for the Deployment Single CVEs table in Workload CVEs.

### Screenshots

![Screenshot 2024-06-26 at 10 49 43 AM](https://github.com/stackrox/stackrox/assets/4805485/76cd400e-4668-4ae4-b605-c8f4c9ff59c8)
