### PR TITLE
ROX-24979: Make compliance bar color consistent with pass status

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -22,11 +22,7 @@ import { TableUIState } from 'utils/getTableUIState';
 
 import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
-import {
-    calculateCompliancePercentage,
-    getCompliancePfClassName,
-    getStatusCounts,
-} from './compliance.coverage.utils';
+import { calculateCompliancePercentage, getStatusCounts } from './compliance.coverage.utils';
 import ControlLabels from './components/ControlLabels';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
@@ -213,9 +209,6 @@ function ProfileChecksTable({
                                                     measureLocation={
                                                         ProgressMeasureLocation.outside
                                                     }
-                                                    className={getCompliancePfClassName(
-                                                        passPercentage
-                                                    )}
                                                     aria-label={`${checkName} compliance percentage`}
                                                 />
                                                 <Tooltip

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -20,11 +20,7 @@ import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
 
 import { coverageClusterDetailsPath } from './compliance.coverage.routes';
-import {
-    calculateCompliancePercentage,
-    getCompliancePfClassName,
-    getStatusCounts,
-} from './compliance.coverage.utils';
+import { calculateCompliancePercentage, getStatusCounts } from './compliance.coverage.utils';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
@@ -169,7 +165,6 @@ function ProfileClustersTable({
                                                 id={progressBarId}
                                                 value={passPercentage}
                                                 measureLocation={ProgressMeasureLocation.outside}
-                                                className={getCompliancePfClassName(passPercentage)}
                                                 aria-label={`${clusterName} compliance percentage`}
                                             />
                                             <Tooltip

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -17,12 +17,6 @@ import { SearchFilter } from 'types/search';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
 
-// Thresholds for compliance status
-const DANGER_THRESHOLD = 50;
-const WARNING_THRESHOLD = 75;
-
-type LabelColor = LabelProps['color'];
-
 export type ClusterStatusObject = {
     icon: ReactElement;
     statusText: string;
@@ -73,48 +67,6 @@ export function getStatusCounts(checkStats: ComplianceCheckStatusCount[]): {
 
 export function calculateCompliancePercentage(passCount: number, totalCount: number): number {
     return totalCount > 0 ? Math.round((passCount / totalCount) * 100) : 0;
-}
-
-function getComplianceStatus(passPercentage: number): ComplianceStatus {
-    let status: ComplianceStatus = ComplianceStatus.SUCCESS;
-
-    if (passPercentage < DANGER_THRESHOLD) {
-        status = ComplianceStatus.DANGER;
-    } else if (passPercentage < WARNING_THRESHOLD) {
-        status = ComplianceStatus.WARNING;
-    }
-
-    return status;
-}
-
-export function getCompliancePfClassName(passPercentage: number): string {
-    const status = getComplianceStatus(passPercentage);
-
-    if (status === ComplianceStatus.DANGER) {
-        return 'pf-m-danger';
-    }
-    if (status === ComplianceStatus.WARNING) {
-        return 'pf-m-warning';
-    }
-    return '';
-}
-
-export function getComplianceLabelGroupColor(
-    passPercentage: number | undefined
-): LabelColor | undefined {
-    if (passPercentage === undefined) {
-        return undefined;
-    }
-
-    const status = getComplianceStatus(passPercentage);
-
-    if (status === ComplianceStatus.DANGER) {
-        return 'red';
-    }
-    if (status === ComplianceStatus.WARNING) {
-        return 'gold';
-    }
-    return 'blue';
 }
 
 export function sortCheckStats(items: ComplianceCheckStatusCount[]): ComplianceCheckStatusCount[] {


### PR DESCRIPTION
### Description

### Information

Colors of icons in status columns and (soon) of bars in chart:
* Pass: primary blue
* Fail: danger red
* Manual: warning yellow
* Other: disabled gray

Colors of bar in **Compliance** column of profiles tables:
* Less than 50% pass: danger red
* Less than 75% pass: warning yellow
* Otherwise: primary blue

### Problems

1. The thresholds themselves:
    * invisible information
    * might not be intuitive from customer viewpoint
    * might conflict with the spirit of the disclaimer
2. Colors **danger red** and **warning yellow** of bars in table:
    * imply incorrect comparison with **Fail** and **Manual** bars in chart
    * but correct comparison is with **Pass** bar in chart and **Pass** column in table

### Analysis

1. Functions in compliance.coverage.utils.tsx file:
    * `getCompliancePfClassName` function is called by profile tables.
    * `getComplianceLabelGroupColor` function in not called.
    * `getComplianceStatus` function is called by the above.
2. The default color of a `Progress` bar is **primary blue** which by happy coincidence is **Pass** color.

### Solution

1. Remove `className` prop from `Profiles` elements in **Compliance** column of profiles table.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance/coverage and select a profile that has different pass percents for checks.

    * Before changes, see color of bar depends on thresholds.
        ![checks_threshold](https://github.com/stackrox/stackrox/assets/11862657/0e877657-48d9-4a22-8a93-637f6b3a1e56)

    * After changes, see color of bar is primary blue.
        ![checks_primary](https://github.com/stackrox/stackrox/assets/11862657/e844a86a-c497-4d1f-980a-73a533fc9a7d)

2. Click **Clusters** toggle.

    * Before changes, see color of bar depends on thresholds.
        ![custers_threshold](https://github.com/stackrox/stackrox/assets/11862657/8f71063f-3e19-4705-a184-f004ab38f04e)

    * After changes, see color of bar is primary blue.
        ![clusters_primary](https://github.com/stackrox/stackrox/assets/11862657/5f7c1e4f-11a6-4416-a9e0-5fcf41b1a4f5)
