### PR TITLE
ROX-23690: Profile stats bar chart

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
@@ -2,3 +2,9 @@
 export const CLUSTER_QUERY = 'Cluster';
 export const CHECK_NAME_QUERY = 'Compliance Check Name';
 export const CHECK_STATUS_QUERY = 'Compliance Check Status';
+
+// status colors
+export const PASSING_COLOR = 'var(--pf-v5-global--primary-color--100)';
+export const FAILING_COLOR = 'var(--pf-v5-global--danger-color--100)';
+export const MANUAL_COLOR = 'var(--pf-v5-global--warning-color--100)';
+export const OTHER_COLOR = 'var(--pf-v5-global--disabled-color--100)';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.constants.ts
@@ -4,7 +4,11 @@ export const CHECK_NAME_QUERY = 'Compliance Check Name';
 export const CHECK_STATUS_QUERY = 'Compliance Check Status';
 
 // status colors
-export const PASSING_COLOR = 'var(--pf-v5-global--primary-color--100)';
-export const FAILING_COLOR = 'var(--pf-v5-global--danger-color--100)';
-export const MANUAL_COLOR = 'var(--pf-v5-global--warning-color--100)';
-export const OTHER_COLOR = 'var(--pf-v5-global--disabled-color--100)';
+export const FAILING_VAR_COLOR = 'var(--pf-v5-global--danger-color--100)';
+export const FAILING_LABEL_COLOR = 'red';
+export const MANUAL_VAR_COLOR = 'var(--pf-v5-global--warning-color--100)';
+export const MANUAL_LABEL_COLOR = 'grey';
+export const OTHER_VAR_COLOR = 'var(--pf-v5-global--disabled-color--100)';
+export const OTHER_LABEL_COLOR = 'gold';
+export const PASSING_VAR_COLOR = 'var(--pf-v5-global--primary-color--100)';
+export const PASSING_LABEL_COLOR = 'blue';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -17,10 +17,14 @@ import { SearchFilter } from 'types/search';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
 import {
-    FAILING_COLOR,
-    MANUAL_COLOR,
-    OTHER_COLOR,
-    PASSING_COLOR,
+    FAILING_LABEL_COLOR,
+    FAILING_VAR_COLOR,
+    MANUAL_LABEL_COLOR,
+    MANUAL_VAR_COLOR,
+    OTHER_LABEL_COLOR,
+    OTHER_VAR_COLOR,
+    PASSING_LABEL_COLOR,
+    PASSING_VAR_COLOR,
 } from './compliance.coverage.constants';
 
 export type ClusterStatusObject = {
@@ -95,84 +99,84 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     PASS: {
         icon: (
             <Icon>
-                <CheckCircleIcon color={PASSING_COLOR} />
+                <CheckCircleIcon color={PASSING_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Pass',
         tooltipText: null,
-        color: 'blue',
+        color: PASSING_LABEL_COLOR,
     },
     FAIL: {
         icon: (
             <Icon>
-                <SecurityIcon color={FAILING_COLOR} />
+                <SecurityIcon color={FAILING_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Fail',
         tooltipText: null,
-        color: 'red',
+        color: FAILING_LABEL_COLOR,
     },
     ERROR: {
         icon: (
             <Icon>
-                <ExclamationTriangleIcon color={OTHER_COLOR} />
+                <ExclamationTriangleIcon color={OTHER_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Error',
         tooltipText: 'Check ran successfully, but could not complete',
-        color: 'grey',
+        color: OTHER_LABEL_COLOR,
     },
     INFO: {
         icon: (
             <Icon>
-                <ExclamationCircleIcon color={OTHER_COLOR} />
+                <ExclamationCircleIcon color={OTHER_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Info',
         tooltipText:
             'Check was successful and found something not severe enough to be considered an error',
-        color: 'grey',
+        color: OTHER_LABEL_COLOR,
     },
     MANUAL: {
         icon: (
             <Icon>
-                <WrenchIcon color={MANUAL_COLOR} />
+                <WrenchIcon color={MANUAL_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Manual',
         tooltipText:
             'Manual check requires additional organizational or technical knowledge that is not automatable',
-        color: 'gold',
+        color: MANUAL_LABEL_COLOR,
     },
     NOT_APPLICABLE: {
         icon: (
             <Icon>
-                <BanIcon color={OTHER_COLOR} />
+                <BanIcon color={OTHER_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Not Applicable',
         tooltipText: 'Check did not run as it is not applicable',
-        color: 'grey',
+        color: OTHER_LABEL_COLOR,
     },
     INCONSISTENT: {
         icon: (
             <Icon>
-                <UnknownIcon color={OTHER_COLOR} />
+                <UnknownIcon color={OTHER_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Inconsistent',
         tooltipText: 'Different nodes report different results',
-        color: 'grey',
+        color: OTHER_LABEL_COLOR,
     },
     UNSET_CHECK_STATUS: {
         icon: (
             <Icon>
-                <ResourcesEmptyIcon color={OTHER_COLOR} />
+                <ResourcesEmptyIcon color={OTHER_VAR_COLOR} />
             </Icon>
         ),
         statusText: 'Unset',
         tooltipText: '',
-        color: 'grey',
+        color: OTHER_LABEL_COLOR,
     },
 };
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -16,6 +16,12 @@ import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfig
 import { SearchFilter } from 'types/search';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
+import {
+    FAILING_COLOR,
+    MANUAL_COLOR,
+    OTHER_COLOR,
+    PASSING_COLOR,
+} from './compliance.coverage.constants';
 
 export type ClusterStatusObject = {
     icon: ReactElement;
@@ -89,7 +95,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     PASS: {
         icon: (
             <Icon>
-                <CheckCircleIcon color="var(--pf-v5-global--primary-color--100)" />
+                <CheckCircleIcon color={PASSING_COLOR} />
             </Icon>
         ),
         statusText: 'Pass',
@@ -99,7 +105,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     FAIL: {
         icon: (
             <Icon>
-                <SecurityIcon color="var(--pf-v5-global--danger-color--100)" />
+                <SecurityIcon color={FAILING_COLOR} />
             </Icon>
         ),
         statusText: 'Fail',
@@ -109,7 +115,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     ERROR: {
         icon: (
             <Icon>
-                <ExclamationTriangleIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <ExclamationTriangleIcon color={OTHER_COLOR} />
             </Icon>
         ),
         statusText: 'Error',
@@ -119,7 +125,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     INFO: {
         icon: (
             <Icon>
-                <ExclamationCircleIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <ExclamationCircleIcon color={OTHER_COLOR} />
             </Icon>
         ),
         statusText: 'Info',
@@ -130,7 +136,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     MANUAL: {
         icon: (
             <Icon>
-                <WrenchIcon color="var(--pf-v5-global--warning-color--100)" />
+                <WrenchIcon color={MANUAL_COLOR} />
             </Icon>
         ),
         statusText: 'Manual',
@@ -141,7 +147,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     NOT_APPLICABLE: {
         icon: (
             <Icon>
-                <BanIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <BanIcon color={OTHER_COLOR} />
             </Icon>
         ),
         statusText: 'Not Applicable',
@@ -151,7 +157,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     INCONSISTENT: {
         icon: (
             <Icon>
-                <UnknownIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <UnknownIcon color={OTHER_COLOR} />
             </Icon>
         ),
         statusText: 'Inconsistent',
@@ -161,7 +167,7 @@ const statusIconTextMap: Record<ComplianceCheckStatus, ClusterStatusObject> = {
     UNSET_CHECK_STATUS: {
         icon: (
             <Icon>
-                <ResourcesEmptyIcon color="var(--pf-v5-global--disabled-color--100)" />
+                <ResourcesEmptyIcon color={OTHER_COLOR} />
             </Icon>
         ),
         statusText: 'Unset',

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
@@ -46,7 +46,10 @@ function ProfileDetailsHeader({
         const { description, productType, profileVersion, title } = profileDetails;
 
         return (
-            <Flex className="pf-v5-u-p-md" direction={{ default: 'column' }}>
+            <Flex
+                className="pf-v5-u-p-md pf-v5-u-background-color-100"
+                direction={{ default: 'column' }}
+            >
                 <Flex
                     alignItems={{ default: 'alignItemsFlexStart' }}
                     justifyContent={{ default: 'justifyContentSpaceBetween' }}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
@@ -1,17 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
+    ExpandableSectionVariant,
+    ExpandableSection,
     Flex,
     FlexItem,
-    Title,
-    Text,
-    LabelGroup,
     Label,
-    Modal,
-    ModalVariant,
-    Button,
+    LabelGroup,
+    Text,
+    Title,
     Skeleton,
 } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { ComplianceProfileSummary } from 'services/ComplianceCommon';
 
@@ -26,12 +24,16 @@ function ProfileDetailsHeader({
     profileDetails,
     profileName,
 }: ProfileDetailsHeaderProps) {
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isExpanded, setIsExpanded] = React.useState(false);
+
+    function onToggleDescription(_event: React.MouseEvent, isExpanded: boolean) {
+        setIsExpanded(isExpanded);
+    }
 
     if (isLoading) {
         return (
             <Flex
-                className="pf-v5-u-p-lg pf-v5-u-background-color-100"
+                className="pf-v5-u-p-md pf-v5-u-background-color-100"
                 direction={{ default: 'column' }}
             >
                 <Title headingLevel="h2">{profileName}</Title>
@@ -44,59 +46,39 @@ function ProfileDetailsHeader({
         const { description, productType, profileVersion, title } = profileDetails;
 
         return (
-            <>
+            <Flex className="pf-v5-u-p-md" direction={{ default: 'column' }}>
                 <Flex
-                    className="pf-v5-u-p-lg pf-v5-u-background-color-100"
-                    direction={{ default: 'column' }}
+                    alignItems={{ default: 'alignItemsFlexStart' }}
+                    justifyContent={{ default: 'justifyContentSpaceBetween' }}
                 >
-                    <Flex
-                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
-                        alignItems={{ default: 'alignItemsFlexStart' }}
-                    >
-                        <FlexItem>
-                            <Title headingLevel="h2">{profileName}</Title>
-                        </FlexItem>
-                        <FlexItem>
-                            <LabelGroup numLabels={4}>
-                                {profileVersion ? (
-                                    <Label variant="filled">
-                                        Profile version: {profileVersion}
-                                    </Label>
-                                ) : null}
-                                <Label variant="filled">Applicability: {productType}</Label>
-                                <Label
-                                    color="blue"
-                                    icon={<InfoCircleIcon />}
-                                    onClick={() => setIsModalOpen(!isModalOpen)}
-                                >
-                                    View description
-                                </Label>
-                            </LabelGroup>
-                        </FlexItem>
-                    </Flex>
                     <FlexItem>
-                        <Text className="pf-v5-u-font-size-sm">{title}</Text>
+                        <Title headingLevel="h2">{profileName}</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <LabelGroup numLabels={4}>
+                            {profileVersion ? (
+                                <Label variant="filled">Profile version: {profileVersion}</Label>
+                            ) : null}
+                            <Label variant="filled">Applicability: {productType}</Label>
+                        </LabelGroup>
                     </FlexItem>
                 </Flex>
-
-                <Modal
-                    variant={ModalVariant.medium}
-                    title={profileName}
-                    isOpen={isModalOpen}
-                    onClose={() => setIsModalOpen(!isModalOpen)}
-                    actions={[
-                        <Button
-                            key="close"
-                            variant="primary"
-                            onClick={() => setIsModalOpen(!isModalOpen)}
-                        >
-                            Close
-                        </Button>,
-                    ]}
-                >
-                    {description}
-                </Modal>
-            </>
+                <FlexItem>
+                    <Text className="pf-v5-u-font-size-sm">{title}</Text>
+                </FlexItem>
+                <FlexItem>
+                    <ExpandableSection
+                        className="pf-v5-u-font-size-sm"
+                        isExpanded={isExpanded}
+                        toggleText={isExpanded ? 'Show less' : 'Show more'}
+                        truncateMaxLines={5}
+                        variant={ExpandableSectionVariant.truncate}
+                        onToggle={onToggleDescription}
+                    >
+                        {description}
+                    </ExpandableSection>
+                </FlexItem>
+            </Flex>
         );
     }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
@@ -9,7 +9,23 @@ import { ComplianceProfileScanStats } from 'services/ComplianceResultsStatsServi
 import { defaultChartHeight, defaultChartBarWidth } from 'utils/chartUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import {
+    FAILING_COLOR,
+    MANUAL_COLOR,
+    OTHER_COLOR,
+    PASSING_COLOR,
+} from '../compliance.coverage.constants';
 import { getStatusCounts } from '../compliance.coverage.utils';
+
+type ChartData = {
+    x: string;
+    y: number;
+    color: string;
+};
+
+type DatumArgs = {
+    datum?: ChartData;
+};
 
 export type ProfileStatsWidgetProps = {
     isLoading: boolean;
@@ -49,37 +65,38 @@ function ProfileStatsWidget({ error, isLoading, profileScanStats }: ProfileStats
             profileScanStats.checkStats
         );
 
-        const data = [
+        const data: ChartData[] = [
             {
                 x: 'Passing',
                 y: passCount / totalCount,
-                color: 'var(--pf-v5-global--primary-color--100)',
+                color: PASSING_COLOR,
             },
             {
                 x: 'Failing',
                 y: failCount / totalCount,
-                color: 'var(--pf-v5-global--danger-color--100)',
+                color: FAILING_COLOR,
             },
             {
                 x: 'Manual',
                 y: manualCount / totalCount,
-                color: 'var(--pf-v5-global--warning-color--100)',
+                color: MANUAL_COLOR,
             },
             {
-                x: 'Mixed',
+                x: 'Other',
                 y: otherCount / totalCount,
-                color: 'var(--pf-v5-global--disabled-color--100)',
+                color: OTHER_COLOR,
             },
         ];
+
         return (
             <div ref={setWidgetContainer}>
                 <Chart
                     ariaDesc="Aging images grouped by date of last update"
                     ariaTitle="Aging images"
                     domainPadding={{ x: [50, 50] }}
-                    padding={{ top: 25, bottom: 65, left: 65, right: 20 }}
+                    padding={{ top: 30, bottom: 65, left: 65, right: 20 }}
                     height={defaultChartHeight}
-                    width={widgetContainerResizeEntry?.contentRect.width}
+                    width={widgetContainerResizeEntry?.contentRect.width ?? 0}
                     containerComponent={<ChartContainer responsive />}
                 >
                     <ChartAxis label="Check status" />
@@ -95,10 +112,12 @@ function ProfileStatsWidget({ error, isLoading, profileScanStats }: ProfileStats
                         data={data}
                         style={{
                             data: {
-                                fill: ({ datum }) => datum.color,
+                                fill: ({ datum }: DatumArgs) => (datum ? datum.color : 'gray'),
                             },
                         }}
-                        labels={({ datum }) => `${Math.round(datum.y * 100)}%`}
+                        labels={({ datum }: DatumArgs) =>
+                            datum ? `${Math.round(datum.y * 100)}%` : ''
+                        }
                         labelComponent={<ChartLabel dy={-10} />}
                     />
                 </Chart>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { Chart, ChartAxis, ChartBar, ChartContainer, ChartLabel } from '@patternfly/react-charts';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import useResizeObserver from 'hooks/useResizeObserver';
+import { ComplianceProfileScanStats } from 'services/ComplianceResultsStatsService';
+import { defaultChartHeight, defaultChartBarWidth } from 'utils/chartUtils';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import { getStatusCounts } from '../compliance.coverage.utils';
+
+export type ProfileStatsWidgetProps = {
+    isLoading: boolean;
+    error: Error | undefined;
+    profileScanStats: ComplianceProfileScanStats | undefined;
+};
+
+function ProfileStatsWidget({ error, isLoading, profileScanStats }: ProfileStatsWidgetProps) {
+    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
+    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <Bullseye>
+                <EmptyStateTemplate
+                    title="Error loading profile stats"
+                    headingLevel="h3"
+                    icon={ExclamationCircleIcon}
+                    iconClassName="pf-v5-u-danger-color-100"
+                >
+                    {getAxiosErrorMessage(error.message)}
+                </EmptyStateTemplate>
+            </Bullseye>
+        );
+    }
+
+    if (profileScanStats) {
+        const { passCount, failCount, manualCount, otherCount, totalCount } = getStatusCounts(
+            profileScanStats.checkStats
+        );
+
+        const data = [
+            {
+                x: 'Passing',
+                y: passCount / totalCount,
+                color: 'var(--pf-v5-global--primary-color--100)',
+            },
+            {
+                x: 'Failing',
+                y: failCount / totalCount,
+                color: 'var(--pf-v5-global--danger-color--100)',
+            },
+            {
+                x: 'Manual',
+                y: manualCount / totalCount,
+                color: 'var(--pf-v5-global--warning-color--100)',
+            },
+            {
+                x: 'Mixed',
+                y: otherCount / totalCount,
+                color: 'var(--pf-v5-global--disabled-color--100)',
+            },
+        ];
+        return (
+            <div ref={setWidgetContainer}>
+                <Chart
+                    ariaDesc="Aging images grouped by date of last update"
+                    ariaTitle="Aging images"
+                    domainPadding={{ x: [50, 50] }}
+                    padding={{ top: 25, bottom: 65, left: 65, right: 20 }}
+                    height={defaultChartHeight}
+                    width={widgetContainerResizeEntry?.contentRect.width}
+                    containerComponent={<ChartContainer responsive />}
+                >
+                    <ChartAxis label="Check status" />
+                    <ChartAxis
+                        tickFormat={(t) => `${Math.round(t * 100)}%`}
+                        domain={[0, 1]}
+                        dependentAxis
+                        showGrid
+                    />
+                    <ChartBar
+                        key="testing"
+                        barWidth={defaultChartBarWidth}
+                        data={data}
+                        style={{
+                            data: {
+                                fill: ({ datum }) => datum.color,
+                            },
+                        }}
+                        labels={({ datum }) => `${Math.round(datum.y * 100)}%`}
+                        labelComponent={<ChartLabel dy={-10} />}
+                    />
+                </Chart>
+            </div>
+        );
+    }
+}
+
+export default ProfileStatsWidget;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileStatsWidget.tsx
@@ -10,10 +10,10 @@ import { defaultChartHeight, defaultChartBarWidth } from 'utils/chartUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import {
-    FAILING_COLOR,
-    MANUAL_COLOR,
-    OTHER_COLOR,
-    PASSING_COLOR,
+    FAILING_VAR_COLOR,
+    MANUAL_VAR_COLOR,
+    OTHER_VAR_COLOR,
+    PASSING_VAR_COLOR,
 } from '../compliance.coverage.constants';
 import { getStatusCounts } from '../compliance.coverage.utils';
 
@@ -69,30 +69,30 @@ function ProfileStatsWidget({ error, isLoading, profileScanStats }: ProfileStats
             {
                 x: 'Passing',
                 y: passCount / totalCount,
-                color: PASSING_COLOR,
+                color: PASSING_VAR_COLOR,
             },
             {
                 x: 'Failing',
                 y: failCount / totalCount,
-                color: FAILING_COLOR,
+                color: FAILING_VAR_COLOR,
             },
             {
                 x: 'Manual',
                 y: manualCount / totalCount,
-                color: MANUAL_COLOR,
+                color: MANUAL_VAR_COLOR,
             },
             {
                 x: 'Other',
                 y: otherCount / totalCount,
-                color: OTHER_COLOR,
+                color: OTHER_VAR_COLOR,
             },
         ];
 
         return (
             <div ref={setWidgetContainer}>
                 <Chart
-                    ariaDesc="Aging images grouped by date of last update"
-                    ariaTitle="Aging images"
+                    ariaDesc="Percentage of total checks by status"
+                    ariaTitle="Check stats by status"
                     domainPadding={{ x: [50, 50] }}
                     padding={{ top: 30, bottom: 65, left: 65, right: 20 }}
                     height={defaultChartHeight}
@@ -107,12 +107,12 @@ function ProfileStatsWidget({ error, isLoading, profileScanStats }: ProfileStats
                         showGrid
                     />
                     <ChartBar
-                        key="testing"
                         barWidth={defaultChartBarWidth}
                         data={data}
                         style={{
                             data: {
-                                fill: ({ datum }: DatumArgs) => (datum ? datum.color : 'gray'),
+                                fill: ({ datum }: DatumArgs) =>
+                                    datum ? datum.color : OTHER_VAR_COLOR,
                             },
                         }}
                         labels={({ datum }: DatumArgs) =>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -6,10 +6,10 @@ import pluralize from 'pluralize';
 import IconText from 'Components/PatternFly/IconText/IconText';
 
 import {
-    FAILING_COLOR,
-    MANUAL_COLOR,
-    OTHER_COLOR,
-    PASSING_COLOR,
+    FAILING_VAR_COLOR,
+    MANUAL_VAR_COLOR,
+    OTHER_VAR_COLOR,
+    PASSING_VAR_COLOR,
 } from '../compliance.coverage.constants';
 
 type Status = 'pass' | 'fail' | 'manual' | 'other';
@@ -25,16 +25,16 @@ function getStatusIcon(status: Status, count: number) {
     if (count > 0) {
         switch (status) {
             case 'fail':
-                color = FAILING_COLOR;
+                color = FAILING_VAR_COLOR;
                 break;
             case 'pass':
-                color = PASSING_COLOR;
+                color = PASSING_VAR_COLOR;
                 break;
             case 'manual':
-                color = MANUAL_COLOR;
+                color = MANUAL_VAR_COLOR;
                 break;
             case 'other':
-                color = OTHER_COLOR;
+                color = OTHER_VAR_COLOR;
                 break;
             default:
                 break;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -5,6 +5,13 @@ import pluralize from 'pluralize';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 
+import {
+    FAILING_COLOR,
+    MANUAL_COLOR,
+    OTHER_COLOR,
+    PASSING_COLOR,
+} from '../compliance.coverage.constants';
+
 type Status = 'pass' | 'fail' | 'manual' | 'other';
 
 type StatusCountIconProps = {
@@ -18,16 +25,16 @@ function getStatusIcon(status: Status, count: number) {
     if (count > 0) {
         switch (status) {
             case 'fail':
-                color = 'var(--pf-v5-global--danger-color--100)';
+                color = FAILING_COLOR;
                 break;
             case 'pass':
-                color = 'var(--pf-v5-global--primary-color--100)';
+                color = PASSING_COLOR;
                 break;
             case 'manual':
-                color = 'var(--pf-v5-global--warning-color--100)';
+                color = MANUAL_COLOR;
                 break;
             case 'other':
-                color = 'var(--pf-v5-global--disabled-color--100)';
+                color = OTHER_COLOR;
                 break;
             default:
                 break;


### PR DESCRIPTION
### Description

Adds Profile Stats Widget to Coverage Page

* Uses `getComplianceProfilesStats` to fetch check stats on all profiles
* Displays a bar chart for passing, failing, manual, and other check stat percentages
* Heavily resembles widgets from the main dashboard page


### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

#### How I validated my change

#### Loading
![Screenshot 2024-06-26 at 1 40 32 PM](https://github.com/stackrox/stackrox/assets/61400697/57ad493c-8ae1-4755-9187-14db77d542e7)


#### Error
![Screenshot 2024-06-26 at 1 40 56 PM](https://github.com/stackrox/stackrox/assets/61400697/78db5e5f-5a47-488c-b144-b952ea3b3942)


#### Bar Chart
![Screenshot 2024-06-26 at 1 40 42 PM](https://github.com/stackrox/stackrox/assets/61400697/0cfdb1ba-a599-40a8-a36c-8f9f11d21a60)


#### Expandable Description
Before:
![Screenshot 2024-06-26 at 1 52 29 PM](https://github.com/stackrox/stackrox/assets/61400697/26ba04e6-568e-43ac-9bf7-f68a5f775153)
After:
![Screenshot 2024-06-26 at 1 52 35 PM](https://github.com/stackrox/stackrox/assets/61400697/9eb492d7-471b-4701-a8d2-204c29e1be5e)


#### Responsive
![Screenshot 2024-06-26 at 1 52 52 PM](https://github.com/stackrox/stackrox/assets/61400697/4b587105-f067-4a02-be6f-573b12ab06a8)



