### PR TITLE
ROX-24851: Filters should not persist between tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -224,7 +224,13 @@ function DeploymentPageVulnerabilities({
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                 component="div"
             >
-                <VulnerabilityStateTabs isBox onChange={() => setPage(1)} />
+                <VulnerabilityStateTabs
+                    isBox
+                    onChange={() => {
+                        setSearchFilter({});
+                        setPage(1);
+                    }}
+                />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">
                     {isAdvancedFiltersEnabled ? (
                         <AdvancedFiltersToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -228,7 +228,7 @@ function DeploymentPageVulnerabilities({
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1);
+                        setPage(1, 'replace');
                     }}
                 />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -229,7 +229,7 @@ function ImagePageVulnerabilities({
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1);
+                        setPage(1, 'replace');
                     }}
                 />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -225,7 +225,13 @@ function ImagePageVulnerabilities({
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                 component="div"
             >
-                <VulnerabilityStateTabs isBox onChange={() => setPage(1)} />
+                <VulnerabilityStateTabs
+                    isBox
+                    onChange={() => {
+                        setSearchFilter({});
+                        setPage(1);
+                    }}
+                />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">
                     {isAdvancedFiltersEnabled ? (
                         <AdvancedFiltersToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -402,7 +402,7 @@ function ImageCvePage() {
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1);
+                        setPage(1, 'replace');
                     }}
                 />
                 <div className="pf-v5-u-background-color-100">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -400,7 +400,10 @@ function ImageCvePage() {
                 <VulnerabilityStateTabs
                     titleOverrides={{ observed: 'Workloads' }}
                     isBox
-                    onChange={() => setPage(1)}
+                    onChange={() => {
+                        setSearchFilter({});
+                        setPage(1);
+                    }}
                 />
                 <div className="pf-v5-u-background-color-100">
                     <div className="pf-v5-u-px-sm">


### PR DESCRIPTION
### Description

This PR should clear the filters when switching between `Workloads`, `Deferred`, and `False positives` tabs in Workload CVEs single pages (Image CVE, Image, Deployment)