### PR TITLE
ROX-24926: Show snoozed CVE count in button toggle when available

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -32,6 +32,7 @@ import {
     nodeCVESearchFilterConfig,
     clusterSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
+import useSnoozedCveCount from 'Containers/Vulnerabilities/hooks/useSnoozedCveCount';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
@@ -80,6 +81,7 @@ function NodeCvesOverviewPage() {
     const hasLegacySnoozeAbility = useHasLegacySnoozeAbility();
     const selectedCves = useMap<string, { cve: string }>();
     const { snoozeModalOptions, setSnoozeModalOptions, snoozeActionCreator } = useSnoozeCveModal();
+    const snoozedCveCount = useSnoozedCveCount('Node');
 
     function onEntityTabChange(entityTab: 'CVE' | 'Node') {
         pagination.setPage(1);
@@ -172,6 +174,7 @@ function NodeCvesOverviewPage() {
                         <SnoozeCveToggleButton
                             searchFilter={searchFilter}
                             setSearchFilter={setSearchFilter}
+                            snoozedCveCount={snoozedCveCount}
                         />
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -31,6 +31,7 @@ import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 
 import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
 import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import useSnoozedCveCount from 'Containers/Vulnerabilities/hooks/useSnoozedCveCount';
 import { clusterSearchFilterConfig, platformCVESearchFilterConfig } from '../../searchFilterConfig';
 import SnoozeCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
@@ -74,6 +75,7 @@ function PlatformCvesOverviewPage() {
     const hasLegacySnoozeAbility = useHasLegacySnoozeAbility();
     const selectedCves = useMap<string, { cve: string }>();
     const { snoozeModalOptions, setSnoozeModalOptions, snoozeActionCreator } = useSnoozeCveModal();
+    const snoozedCveCount = useSnoozedCveCount('Platform');
 
     function onEntityTabChange(entityTab: 'CVE' | 'Cluster') {
         pagination.setPage(1);
@@ -168,6 +170,7 @@ function PlatformCvesOverviewPage() {
                         <SnoozeCveToggleButton
                             searchFilter={searchFilter}
                             setSearchFilter={setSearchFilter}
+                            snoozedCveCount={snoozedCveCount}
                         />
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import SnoozeCveToggleButton from './SnoozedCveToggleButton';
 
-function Wrapper({ startingSearchFilter = {} }) {
+function Wrapper({ startingSearchFilter = {}, snoozedCveCount }) {
     const [searchFilter, setSearchFilter] = useState(startingSearchFilter);
 
     return (
@@ -14,7 +14,11 @@ function Wrapper({ startingSearchFilter = {} }) {
                     </div>
                 ))}
             </div>
-            <SnoozeCveToggleButton searchFilter={searchFilter} setSearchFilter={setSearchFilter} />
+            <SnoozeCveToggleButton
+                searchFilter={searchFilter}
+                setSearchFilter={setSearchFilter}
+                snoozedCveCount={snoozedCveCount}
+            />
         </>
     );
 }
@@ -57,5 +61,23 @@ describe(Cypress.spec.relative, () => {
         cy.findByText('Show observed CVEs').click();
         cy.get(snoozedFilterSelector).should('not.exist');
         cy.get(severityFilterSelector).should('exist');
+    });
+
+    it('should correctly display the current snoozed CVE count', () => {
+        // Badge should not show when no count is provided
+        cy.mount(<Wrapper snoozedCveCount={undefined} />);
+        cy.get('button .pf-v5-c-badge').should('not.exist');
+
+        // Badge should not show when count is 0
+        cy.mount(<Wrapper snoozedCveCount={0} />);
+        cy.get('button .pf-v5-c-badge').should('not.exist');
+
+        // Badge should show when count is > 0
+        cy.mount(<Wrapper snoozedCveCount={1} />);
+        cy.get('button .pf-v5-c-badge').contains('1');
+
+        // Badge should not show when viewing snoozed CVEs
+        cy.findByText('Show snoozed CVEs').click();
+        cy.get('button .pf-v5-c-badge').should('not.exist');
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
@@ -5,11 +5,19 @@ import { SearchFilter } from 'types/search';
 export type SnoozeCveToggleButtonProps = {
     searchFilter: SearchFilter;
     setSearchFilter: (searchFilter: SearchFilter) => void;
+    snoozedCveCount: number | undefined;
 };
 
-function SnoozeCveToggleButton({ searchFilter, setSearchFilter }: SnoozeCveToggleButtonProps) {
+function SnoozeCveToggleButton({
+    searchFilter,
+    setSearchFilter,
+    snoozedCveCount,
+}: SnoozeCveToggleButtonProps) {
     const isSnoozeFilterActive = searchFilter['CVE Snoozed']?.[0] === 'true';
     const buttonText = isSnoozeFilterActive ? 'Show observed CVEs' : 'Show snoozed CVEs';
+    const showCountBadge =
+        snoozedCveCount !== undefined && snoozedCveCount > 0 && !isSnoozeFilterActive;
+    const badgeCount = showCountBadge ? { isRead: true, count: snoozedCveCount } : undefined;
 
     function toggleSnoozeFilter() {
         const nextFilter = { ...searchFilter };
@@ -22,7 +30,7 @@ function SnoozeCveToggleButton({ searchFilter, setSearchFilter }: SnoozeCveToggl
     }
 
     return (
-        <Button variant="secondary" onClick={toggleSnoozeFilter}>
+        <Button variant="secondary" onClick={toggleSnoozeFilter} countOptions={badgeCount}>
             {buttonText}
         </Button>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
@@ -16,7 +16,7 @@ function SnoozeCveToggleButton({
     const isSnoozeFilterActive = searchFilter['CVE Snoozed']?.[0] === 'true';
     const buttonText = isSnoozeFilterActive ? 'Show observed CVEs' : 'Show snoozed CVEs';
     const showCountBadge =
-        snoozedCveCount !== undefined && snoozedCveCount > 0 && !isSnoozeFilterActive;
+        typeof snoozedCveCount === 'number' && snoozedCveCount > 0 && !isSnoozeFilterActive;
     const badgeCount = showCountBadge ? { isRead: true, count: snoozedCveCount } : undefined;
 
     function toggleSnoozeFilter() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useSnoozedCveCount.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useSnoozedCveCount.ts
@@ -1,0 +1,21 @@
+import { gql, useQuery } from '@apollo/client';
+
+const snoozedNodeCveCountQuery = gql`
+    query getSnoozedNodeCveCount {
+        count: nodeCVECount(query: "CVE Snoozed:true")
+    }
+`;
+
+const snoozedPlatformCveCountQuery = gql`
+    query getSnoozedPlatformCveCount {
+        count: platformCVECount(query: "CVE Snoozed:true")
+    }
+`;
+
+export default function useSnoozedCveCount(cveType: 'Node' | 'Platform'): number | undefined {
+    const totalNodeCountRequest = useQuery<{ count: number }>(
+        cveType === 'Node' ? snoozedNodeCveCountQuery : snoozedPlatformCveCountQuery
+    );
+
+    return totalNodeCountRequest.data?.count;
+}


### PR DESCRIPTION
### Description

Adds an indication that there are snoozed cves by displaying the count in the toggle button, if the count is available and greater than zero.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Automated test changes.

Visit Platform CVEs when no CVEs are snoozed:
![image](https://github.com/stackrox/stackrox/assets/1292638/542d45c1-47a9-4749-9168-3b742746a19a)

Snooze a CVE and observe the change in the button:
![image](https://github.com/stackrox/stackrox/assets/1292638/ddab40a9-b5e3-4f7e-9815-a1c8015ce619)

View snoozed CVEs and observe the count is removed:
![image](https://github.com/stackrox/stackrox/assets/1292638/2247c38b-7724-4968-85e6-47331fba2265)

Repeat for the Node CVE page.