### PR TITLE
ROX-24532: Update telemetry for Workload CVEs advanced filters

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -27,6 +27,8 @@ import {
 import { getTableUIState } from 'utils/getTableUIState';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import { createFilterTracker } from 'Containers/Vulnerabilities/utils/telemetry';
+import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import {
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
@@ -117,6 +119,10 @@ function DeploymentPageVulnerabilities({
 }: DeploymentPageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
+
+    const { analyticsTrack } = useAnalytics();
+    const trackAppliedFilter = createFilterTracker(analyticsTrack);
+
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -231,13 +237,10 @@ function DeploymentPageVulnerabilities({
                             className="pf-v5-u-pt-lg pf-v5-u-pb-0"
                             searchFilterConfig={searchFilterConfig}
                             searchFilter={searchFilter}
-                            onFilterChange={(newFilter, { action }) => {
+                            onFilterChange={(newFilter, searchPayload) => {
                                 setSearchFilter(newFilter);
                                 setPage(1, 'replace');
-
-                                if (action === 'ADD') {
-                                    // TODO - Add analytics tracking ROX-24532
-                                }
+                                trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -34,6 +34,8 @@ import {
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
+import { createFilterTracker } from 'Containers/Vulnerabilities/utils/telemetry';
+import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import {
     SearchOption,
     IMAGE_CVE_SEARCH_OPTION,
@@ -121,6 +123,9 @@ function ImagePageVulnerabilities({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
+
+    const { analyticsTrack } = useAnalytics();
+    const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
     const currentVulnerabilityState = useVulnerabilityState();
 
@@ -232,13 +237,10 @@ function ImagePageVulnerabilities({
                             className="pf-v5-u-pt-lg pf-v5-u-pb-0"
                             searchFilterConfig={searchFilterConfig}
                             searchFilter={searchFilter}
-                            onFilterChange={(newFilter, { action }) => {
+                            onFilterChange={(newFilter, searchPayload) => {
                                 setSearchFilter(newFilter);
                                 setPage(1, 'replace');
-
-                                if (action === 'ADD') {
-                                    // TODO - Add analytics tracking ROX-24532
-                                }
+                                trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -26,7 +26,10 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 import { Pagination as PaginationParam } from 'services/types';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
-import useAnalytics, { WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED } from 'hooks/useAnalytics';
+import useAnalytics, {
+    WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
+    WORKLOAD_CVE_FILTER_APPLIED,
+} from 'hooks/useAnalytics';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import {
@@ -41,6 +44,7 @@ import {
     namespaceSearchFilterConfig,
     clusterSearchFilterConfig,
 } from 'Components/CompoundSearchFilter/types';
+import { createFilterTracker } from 'Containers/Vulnerabilities/utils/telemetry';
 import {
     SearchOption,
     IMAGE_SEARCH_OPTION,
@@ -196,6 +200,7 @@ function ImageCvePage() {
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
 
     const { analyticsTrack } = useAnalytics();
+    const trackAppliedFilter = createFilterTracker(analyticsTrack);
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
@@ -409,13 +414,10 @@ function ImageCvePage() {
                                 className="pf-v5-u-py-md"
                                 searchFilterConfig={searchFilterConfig}
                                 searchFilter={searchFilter}
-                                onFilterChange={(newFilter, { action }) => {
+                                onFilterChange={(newFilter, searchPayload) => {
                                     setSearchFilter(newFilter);
                                     setPage(1, 'replace');
-
-                                    if (action === 'ADD') {
-                                        // TODO - Add analytics tracking ROX-24532
-                                    }
+                                    trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                                 }}
                             />
                         ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -24,6 +24,7 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useAnalytics, {
     WATCH_IMAGE_MODAL_OPENED,
     WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
+    WORKLOAD_CVE_FILTER_APPLIED,
 } from 'hooks/useAnalytics';
 import useLocalStorage from 'hooks/useLocalStorage';
 import { SearchFilter } from 'types/search';
@@ -50,6 +51,7 @@ import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/Advanc
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { SearchFilterEntityName } from 'Components/CompoundSearchFilter/types';
 
+import { createFilterTracker } from 'Containers/Vulnerabilities/utils/telemetry';
 import {
     DefaultFilters,
     WorkloadEntityTab,
@@ -167,6 +169,7 @@ function WorkloadCvesOverviewPage() {
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
 
     const { analyticsTrack } = useAnalytics();
+    const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
     const currentVulnerabilityState = useVulnerabilityState();
 
@@ -334,13 +337,10 @@ function WorkloadCvesOverviewPage() {
             searchFilterConfig={searchFilterConfig}
             searchFilter={searchFilter}
             defaultFilters={localStorageValue.preferences.defaultFilters}
-            onFilterChange={(newFilter, { action }) => {
+            onFilterChange={(newFilter, searchPayload) => {
                 setSearchFilter(newFilter);
                 pagination.setPage(1, 'replace');
-
-                if (action === 'ADD') {
-                    // TODO - Add analytics tracking ROX-24532
-                }
+                trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
             }}
             includeCveSeverityFilters={isViewingWithCves}
             includeCveStatusFilters={isViewingWithCves}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -12,7 +12,6 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useAnalytics, {
     WORKLOAD_CVE_FILTER_APPLIED,
     isSearchCategoryWithFilter,
-    isSearchCategoryWithoutFilter,
 } from 'hooks/useAnalytics';
 import { searchValueAsArray } from 'utils/searchUtils';
 
@@ -56,7 +55,7 @@ function WorkloadCveFilterToolbar({
                 event: WORKLOAD_CVE_FILTER_APPLIED,
                 properties: { category, filter },
             });
-        } else if (isSearchCategoryWithoutFilter(category)) {
+        } else {
             analyticsTrack({
                 event: WORKLOAD_CVE_FILTER_APPLIED,
                 properties: { category },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
@@ -1,0 +1,25 @@
+import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import {
+    AnalyticsEvent,
+    WORKLOAD_CVE_FILTER_APPLIED,
+    isSearchCategoryWithFilter,
+} from 'hooks/useAnalytics';
+
+type FilterAppliedEvent = typeof WORKLOAD_CVE_FILTER_APPLIED;
+
+export function createFilterTracker(analyticsTrack: (analyticsEvent: AnalyticsEvent) => void) {
+    return function trackAppliedFilter(event: FilterAppliedEvent, payload: OnSearchPayload) {
+        const { action, category, value: filter } = payload;
+
+        if (action !== 'ADD') {
+            // Only track when a filter is applied, not removed
+            return;
+        }
+
+        const telemetryEvent = isSearchCategoryWithFilter(category)
+            ? { event, properties: { category, filter } }
+            : { event, properties: { category } };
+
+        analyticsTrack(telemetryEvent);
+    };
+}

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -54,27 +54,29 @@ export const LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES = 'Legacy Cluster Download Helm
  */
 type AnalyticsBoolean = 0 | 1;
 
-// search categories and type guards for tracking search filters on the Workload CVE pages
-export const searchCategoriesWithFilter = ['COMPONENT SOURCE', 'SEVERITY', 'FIXABLE'] as const;
+/**
+ * A curated list of filters that we would like to track both the filter category and the
+ * filter value. This list should exclude anything that could be considered sensitive or
+ * specific to a customer environment. This items in this list must also match the casing of
+ * the applied filter _exactly_, otherwise it will be tracked without the filter value.
+ */
+export const searchCategoriesWithFilter = [
+    'Component Source',
+    'SEVERITY',
+    'FIXABLE',
+    'CLUSTER CVE FIXABLE',
+    'CVSS',
+    'Node Top CVSS',
+] as const;
+
 export const isSearchCategoryWithFilter = tupleTypeGuard(searchCategoriesWithFilter);
 export type SearchCategoryWithFilter = UnionFrom<typeof searchCategoriesWithFilter>;
-
-export const searchCategoriesWithoutFilter = [
-    'CVE',
-    'IMAGE',
-    'COMPONENT',
-    'DEPLOYMENT',
-    'NAMESPACE',
-    'CLUSTER',
-] as const;
-export const isSearchCategoryWithoutFilter = tupleTypeGuard(searchCategoriesWithoutFilter);
-export type SearchCategoryWithoutFilter = UnionFrom<typeof searchCategoriesWithoutFilter>;
 
 /**
  * An AnalyticsEvent is either a simple string that represents the event name,
  * or an object with an event name and additional properties.
  */
-type AnalyticsEvent =
+export type AnalyticsEvent =
     | typeof CLUSTER_CREATED
     | typeof INVITE_USERS_MODAL_OPENED
     | typeof INVITE_USERS_SUBMITTED
@@ -87,7 +89,7 @@ type AnalyticsEvent =
               deployments: number;
           };
       }
-    /** Tracks each time network policies are genarated on Network Graph */
+    /** Tracks each time network policies are generated on Network Graph */
     | {
           event: typeof GENERATE_NETWORK_POLICIES;
           properties: {
@@ -137,9 +139,7 @@ type AnalyticsEvent =
      */
     | {
           event: typeof WORKLOAD_CVE_FILTER_APPLIED;
-          properties:
-              | { category: SearchCategoryWithFilter; filter: string }
-              | { category: SearchCategoryWithoutFilter };
+          properties: { category: SearchCategoryWithFilter; filter: string } | { category: string };
       }
     /**
      * Tracks each time the user changes the default filters on the Workload CVE overview page.


### PR DESCRIPTION
### Description

Adds telemetry for Workload CVE advanced filters.

This also softens the type requirements for the filter events -- rationale will be commented inline.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

_Support for verification of telemetry in e2e tests coming soon._

#### How I validated my change
Manual application of filters and verification of sent events for each page.

Workload CVE overview page, verify that all filters are tracked and only filters that are allowed to track values contain the value in the payload.
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/32db572f-767d-4d16-95aa-1829ddb205e6">
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/8b5710bb-bb61-4d52-a90c-eb0f79c00df6">
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/8b01a00f-36bf-451a-890f-51e98d9ef066">
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/1d27cc59-f11e-48a1-8630-92cc0a02dc34">
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/cd8739ac-ae99-4a12-a69e-4c8b3684e9c6">

Perform the same manual checks on:
- Namespace view
- Image single
- Image CVE single
- Deployment single