### PR TITLE
chore: backport 11642 to release 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Entries in this file should be limited to:
 - Obscure side-effects that are not obviously apparent based on the JIRA associated with the changes.
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
+## [4.4.4]
+
+### Added Features
+
+### Removed Features
+
+### Deprecated Features
+
+### Technical Changes
+- ROX-24725: Enhances Sensor's image scan event handling when `ROX_UNQUALIFIED_SEARCH_REGISTRIES` is `true` so only one simultaneous scan request is allowed per unique image.
+  - Also increases the chances of scan cache hits when multiple names for the same image have been observed.
+  - This enhancement is enabled by default when `ROX_UNQUALIFIED_SEARCH_REGISTRIES` is `true` on Sensor, it can be disabled by setting `ROX_SENSOR_SINGLE_SCAN` to `false` on Sensor.
+
 ## [4.4.1]
 
 ### Added Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ## [4.4.4]
 
-### Added Features
-
-### Removed Features
-
-### Deprecated Features
-
 ### Technical Changes
 - ROX-24725: Enhances Sensor's image scan event handling when `ROX_UNQUALIFIED_SEARCH_REGISTRIES` is `true` so only one simultaneous scan request is allowed per unique image.
   - Also increases the chances of scan cache hits when multiple names for the same image have been observed.


### PR DESCRIPTION
### Description

Due to merge conflicts manually backporting https://github.com/stackrox/stackrox/pull/11642 into the 4.4 release branch

### User-facing documentation

- [x] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] contributed **no automated tests**

#### How I validated my change

👀 📖 