### PR TITLE
fix: reprocess when certificates change in signature integration

### DIFF
--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
@@ -165,7 +166,11 @@ func (d *datastoreImpl) verifyIntegrationIDAndUpdates(ctx context.Context,
 	if err != nil {
 		return false, err
 	}
-	return !getPublicKeyPEMSet(existingIntegration).Equal(getPublicKeyPEMSet(updatedIntegration)), nil
+
+	hasUpdates := !getPublicKeyPEMSet(existingIntegration).Equal(getPublicKeyPEMSet(updatedIntegration)) ||
+		!protoutils.SlicesEqual(existingIntegration.GetCosignCertificates(), updatedIntegration.GetCosignCertificates())
+
+	return hasUpdates, nil
 }
 
 func (d *datastoreImpl) verifyIntegrationIDDoesNotExist(ctx context.Context, id string) error {

--- a/central/signatureintegration/service/service_impl.go
+++ b/central/signatureintegration/service/service_impl.go
@@ -99,13 +99,13 @@ func (s *serviceImpl) PostSignatureIntegration(ctx context.Context, requestedInt
 }
 
 func (s *serviceImpl) PutSignatureIntegration(ctx context.Context, integration *storage.SignatureIntegration) (*v1.Empty, error) {
-	hasUpdatedKeys, err := s.datastore.UpdateSignatureIntegration(ctx, integration)
+	hasUpdates, err := s.datastore.UpdateSignatureIntegration(ctx, integration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update signature integration")
 	}
 
-	// Only trigger reprocessing of signature verification results when the keys have been updated.
-	if hasUpdatedKeys {
+	// Only trigger reprocessing of signature verification results when the verification data has been updated.
+	if hasUpdates {
 		s.reprocessingLoop.ReprocessSignatureVerifications(false)
 	}
 	return &v1.Empty{}, nil


### PR DESCRIPTION
### Description

We have the logic to reprocess immediately when signature integrations have changed (i.e. the verification data has changed). Previously this only worked on detecting changes within the
public keys, now that we've added certificate verification we should also reprocess when that is being changed.

Also fixes an issue when using the fulcio roots within a Central container. Fulcio roots are persisted locally, unfortunately in a containerized environment with read-only filesystem this will fail. Again, unfortunately, we will have to set an environment variable to point to a writeable directory, which for the time being is within the `/tmp`.

### User-facing documentation

- [ ] CHANGELOG is updated
- [x] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

1. Create signature integration with certificates which is valid for the image you scan.
```json
        {
            "name": "testing",
            "cosignCertificates": [
                {
                    "certificatePemEnc": "",
                    "certificateChainPemEnc": "-----BEGIN CERTIFICATE-----\nMIIFizCCA3OgAwIBAgIUKUP5Gi0K7c0FwuJ8otDaPaXa5fYwDQYJKoZIhvcNAQEL\nBQAwVDELMAkGA1UEBhMCVVMxEDAOBgNVBAcMB1Rlc3RpbmcxDDAKBgNVBAoMA0RF\nVjEQMA4GA1UECwwHVGVzdGluZzETMBEGA1UEAwwKVGVzdGluZyBDQTAgFw0yNDA2\nMjUwNDE3NDBaGA8yMDUxMTExMDA0MTc0MFowVDELMAkGA1UEBhMCVVMxEDAOBgNV\nBAcMB1Rlc3RpbmcxDDAKBgNVBAoMA0RFVjEQMA4GA1UECwwHVGVzdGluZzETMBEG\nA1UEAwwKVGVzdGluZyBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB\nAMQvEO69CS+dM3bvtFdYxr5imHMLZVyy5drVAFvLKD9SaZzjPQ+VKtZ0zB9TUJrh\nx6sKTlBk+pFg7iY0BYr+FCWRw2QqhT+4fFST2HGlRzSexw7Ah8E67QH+p+1Qypel\n/ae6/4KaH6ijUY5iqySEhMHBVcAdD+s++kbTDQ4MsZCYbt+zdE8KgkI68kAJ6Fpv\npFw+cFZI5wg8thAR+j1U2rfD8O0E9w0xX+2+iIyHPsfFVN5oyK140Wg43ApZQu7e\nFPLjRa22fFbsgoijouj/74FqINWcxc+ZRzv9HNIwnWt/mBfE0nNvoeqYQFr9nLGu\nO/ZUR954IU+br+OAihMrDgAWU5qSFdgXeITTvxSuN+F+3HGmEQWFo+oP/gYAMM28\nZtgiKWtOZigZhn7b1sdl0XMOhaR+wHqPvHRYfqXrdz3ektHA9KlXV/8WzTXLWoUV\nsnpCqJY9i193X+WsVMbF3sp+Zmdu2QXEmJtNkUd6zvwuZ4S4JyePF5DXoAq2IsoM\n+4A4HYisUgAS2ZrWPpvCQ9Z31CO0aMKSgHPSsU1Q9QEg17V420vvg5bqn8Zbedyb\nnzmJ4Vp2Ccc6YIb7QWdr95UJ7JMoNzLzFLoVCa3XFDkeT2stZlzCrKMBhaVYIewr\nOOlTg67Sa77H7JUYfvmE+i9fxqvfs3VZ5S+w4CDy7rLXAgMBAAGjUzBRMB0GA1Ud\nDgQWBBSPppE/33XnVV+YBvL+osCzuD1lHzAfBgNVHSMEGDAWgBSPppE/33XnVV+Y\nBvL+osCzuD1lHzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQCm\nsTJmiwRX6w0kM/erc8aMdCOcIW4ofSfNkQMdaW/S9pwgnipEF8eKvvkblKvrN+kf\nCntWIOGqOgaxkWlC0yOTqKwzN162mjvRaflUCEDkwLhjqFsgn1g1coma3AScBDMf\nHnpghLH3AAtxs/eDsbvJa70Ybg/3l2oHTLe6kxsVs5k/zqmvIIxOmSqvNFa/5kGg\niWBz/1X/mqc2lD5/cgz3UrM7ZMr1r4IhGK095ljKiCA1fTrlQrgSQe/3pGm1ShjP\nmn5LbCiIr+JCrNFRV9ivSL88mLEJqbWx+qLQhwde8C09c7EGxQZKHfCI/QcdE3EG\nUYyRYQzXS4bgpMRBw+l2saGjYWd1EBUl5kj3rCDmtT4u2kln9SwqYMT9ZJ/PMtTQ\nWKQj6qVYXla6XLmED8XWqMY7dDKHoy0XLwgUS5SnD+D68Fqfpt4kzm/RnuuBmQl8\n6+BO9NMNMo0+TOm9ItEouE/GD4TbRu59h0Q+usyidmUF79Cj+6qKLW//KRQyrEKa\nLgH/JNuwVgUip0EnN1wsVXSCVpCIoKKANRkQSIfKJwRzlD0JO5moL225W5gp68Zx\np6K21vDtW3Cmofa6rpV+ZTd60iyTv5YhVd/h/Gunfm2zLhZKb75aJWpEzwn51QvK\nnzTe7BpOmVwmqLkIefEJe5L4PSXtp2KFLZqGO/kY5A==\n-----END CERTIFICATE-----",
                    "certificateOidcIssuer": ".*",
                    "certificateIdentity": ".*"
                }
            ]
        }
```
2. Scan the image via `roxctl image scan`:
```bash
roxctl image scan --image=quay.io/rhacs-eng/qa-signatures@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
```
```json
{
  "signatureVerificationData": {
    "results": [
      {
        "verificationTime": "2024-06-27T19:32:12.003986519Z",
        "verifierId": "io.stackrox.signatureintegration.288485e0-5fb1-47cc-b345-1d59ea90b43e",
        "status": "VERIFIED",
        "verifiedImageReferences": [
          "quay.io/rhacs-eng/qa-signatures@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c"
        ]
      }
    ]
  }
}
```
3. Create an invalid certificate verification data for that particular image
```json
        {
            "name": "testing",
            "cosignCertificates": [
                {
                    "certificatePemEnc": "",
                    "certificateChainPemEnc": "-----BEGIN CERTIFICATE-----\nMIIFizCCA3OgAwIBAgIUKUP5Gi0K7c0FwuJ8otDaPaXa5fYwDQYJKoZIhvcNAQEL\nBQAwVDELMAkGA1UEBhMCVVMxEDAOBgNVBAcMB1Rlc3RpbmcxDDAKBgNVBAoMA0RF\nVjEQMA4GA1UECwwHVGVzdGluZzETMBEGA1UEAwwKVGVzdGluZyBDQTAgFw0yNDA2\nMjUwNDE3NDBaGA8yMDUxMTExMDA0MTc0MFowVDELMAkGA1UEBhMCVVMxEDAOBgNV\nBAcMB1Rlc3RpbmcxDDAKBgNVBAoMA0RFVjEQMA4GA1UECwwHVGVzdGluZzETMBEG\nA1UEAwwKVGVzdGluZyBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB\nAMQvEO69CS+dM3bvtFdYxr5imHMLZVyy5drVAFvLKD9SaZzjPQ+VKtZ0zB9TUJrh\nx6sKTlBk+pFg7iY0BYr+FCWRw2QqhT+4fFST2HGlRzSexw7Ah8E67QH+p+1Qypel\n/ae6/4KaH6ijUY5iqySEhMHBVcAdD+s++kbTDQ4MsZCYbt+zdE8KgkI68kAJ6Fpv\npFw+cFZI5wg8thAR+j1U2rfD8O0E9w0xX+2+iIyHPsfFVN5oyK140Wg43ApZQu7e\nFPLjRa22fFbsgoijouj/74FqINWcxc+ZRzv9HNIwnWt/mBfE0nNvoeqYQFr9nLGu\nO/ZUR954IU+br+OAihMrDgAWU5qSFdgXeITTvxSuN+F+3HGmEQWFo+oP/gYAMM28\nZtgiKWtOZigZhn7b1sdl0XMOhaR+wHqPvHRYfqXrdz3ektHA9KlXV/8WzTXLWoUV\nsnpCqJY9i193X+WsVMbF3sp+Zmdu2QXEmJtNkUd6zvwuZ4S4JyePF5DXoAq2IsoM\n+4A4HYisUgAS2ZrWPpvCQ9Z31CO0aMKSgHPSsU1Q9QEg17V420vvg5bqn8Zbedyb\nnzmJ4Vp2Ccc6YIb7QWdr95UJ7JMoNzLzFLoVCa3XFDkeT2stZlzCrKMBhaVYIewr\nOOlTg67Sa77H7JUYfvmE+i9fxqvfs3VZ5S+w4CDy7rLXAgMBAAGjUzBRMB0GA1Ud\nDgQWBBSPppE/33XnVV+YBvL+osCzuD1lHzAfBgNVHSMEGDAWgBSPppE/33XnVV+Y\nBvL+osCzuD1lHzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQCm\nsTJmiwRX6w0kM/erc8aMdCOcIW4ofSfNkQMdaW/S9pwgnipEF8eKvvkblKvrN+kf\nCntWIOGqOgaxkWlC0yOTqKwzN162mjvRaflUCEDkwLhjqFsgn1g1coma3AScBDMf\nHnpghLH3AAtxs/eDsbvJa70Ybg/3l2oHTLe6kxsVs5k/zqmvIIxOmSqvNFa/5kGg\niWBz/1X/mqc2lD5/cgz3UrM7ZMr1r4IhGK095ljKiCA1fTrlQrgSQe/3pGm1ShjP\nmn5LbCiIr+JCrNFRV9ivSL88mLEJqbWx+qLQhwde8C09c7EGxQZKHfCI/QcdE3EG\nUYyRYQzXS4bgpMRBw+l2saGjYWd1EBUl5kj3rCDmtT4u2kln9SwqYMT9ZJ/PMtTQ\nWKQj6qVYXla6XLmED8XWqMY7dDKHoy0XLwgUS5SnD+D68Fqfpt4kzm/RnuuBmQl8\n6+BO9NMNMo0+TOm9ItEouE/GD4TbRu59h0Q+usyidmUF79Cj+6qKLW//KRQyrEKa\nLgH/JNuwVgUip0EnN1wsVXSCVpCIoKKANRkQSIfKJwRzlD0JO5moL225W5gp68Zx\np6K21vDtW3Cmofa6rpV+ZTd60iyTv5YhVd/h/Gunfm2zLhZKb75aJWpEzwn51QvK\nnzTe7BpOmVwmqLkIefEJe5L4PSXtp2KFLZqGO/kY5A==\n-----END CERTIFICATE-----",
                    "certificateOidcIssuer": "invalid",
                    "certificateIdentity": "invalid"
                }
            ]
        }
```
5. Run the image scan again, see that the verification has now failed:
```bash
roxctl image scan --image=quay.io/rhacs-eng/qa-signatures@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
```
```json
{
"signatureVerificationData": {
    "results": [
      {
        "verificationTime": "2024-06-27T19:35:54.462910568Z",
        "verifierId": "io.stackrox.signatureintegration.288485e0-5fb1-47cc-b345-1d59ea90b43e",
        "status": "FAILED_VERIFICATION",
        "description": "1 error occurred:\n\t* none of the expected identities matched what was in the certificate, got subjects [team-a@testing.org] with issuer https://testing.org\n\n"
      }
    ]
  }
}
```

