### PR TITLE
ROX-25017: Make Compliance Coverage and Schedules heading consistent

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPageHeader.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
-import { Flex, Text, Title } from '@patternfly/react-core';
+import { Flex, PageSection, Text, Title } from '@patternfly/react-core';
 
 function CoveragesPageHeader() {
     return (
-        <>
-            <Flex
-                className="pf-v5-u-p-lg"
-                direction={{ default: 'column' }}
-                justifyContent={{ default: 'justifyContentSpaceBetween' }}
-            >
+        <PageSection component="div" variant="light">
+            <Flex direction={{ default: 'column' }}>
                 <Title headingLevel="h1">Coverage</Title>
                 <Text>
                     Assess profile compliance for nodes and platform resources across clusters
                 </Text>
             </Flex>
-        </>
+        </PageSection>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -266,14 +266,14 @@ function ScanConfigsTablePage({
         <>
             <PageTitle title="Compliance - Schedules" />
             <PageSection component="div" variant="light">
-                <Flex direction={{ default: 'row' }}>
-                    <FlexItem>
+                <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>
+                    <Flex direction={{ default: 'column' }}>
                         <Title headingLevel="h1">Schedules</Title>
                         <Text>
                             Configure scan schedules to run profile compliance checks on selected
                             clusters
                         </Text>
-                    </FlexItem>
+                    </Flex>
                     {hasWriteAccessForCompliance && (
                         <FlexItem align={{ default: 'alignRight' }}>
                             <CreateScanConfigButton />


### PR DESCRIPTION
### Description

### Problem

Thank you Linda, for noticing inconsistent heading layout.

### Analysis

1. Because `CoveragesPageHeader` did not render `PageSection` element, the heading matches a classic CSS rule.
2. Because `ScanConfigsTablePage` did not render `Title` and `Text` elements in a `Flex` there was not 8px padding between as in most recent page headings.

### Solution

1. Edit CoveragePageHeader.tsx file.
    * Replace utility class padding with `PageSection` element.
    * Delete `justifyContent` prop which does not seem to be needed.
2. Edit ScanConfigsTablePage.tsx file.
    * Add `Flex` element.
    * As bonus, align button center.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/compliance/coverage

    * Before changes, inconsistent heading layout:
        ![coverage_inconsistent](https://github.com/stackrox/stackrox/assets/11862657/67d51176-e9db-4482-b887-7ca5c5a4174b)

    * After changes, consistent heading layout:
        ![coverage_consistent](https://github.com/stackrox/stackrox/assets/11862657/1e26f879-5ab9-4567-b9c7-27675a465b70)

2. Visit /main/compliance/schedules

    * Before changes, inconsistent heading layout:
        ![schedules_inconsistent](https://github.com/stackrox/stackrox/assets/11862657/0bfff95b-667f-40de-b0d2-12d853f73d20)

    * After changes, consistent heading layout:
        ![schedules_consistent](https://github.com/stackrox/stackrox/assets/11862657/3224fb15-59fa-40b5-a9fc-584681b55253)
