### PR TITLE
ROX-22867: Update ApproversV2 on request approval when unified cve deferral is enabled

### DIFF
--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -128,7 +128,9 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 	req.LastUpdated = protocompat.TimestampNow()
 	approver := authn.UserFromContext(ctx)
 	req.Approvers = append(req.Approvers, approver)
-	req.ApproversV2 = append(req.ApproversV2, utils.ApproverV2(approver))
+	if features.UnifiedCVEDeferral.Enabled() {
+		req.ApproversV2 = append(req.ApproversV2, utils.ApproverV2(approver))
+	}
 	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, message))
 
 	// If this was an update whose status is being updated, the request fields must be changed appropriately.

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -126,7 +126,9 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 	}
 
 	req.LastUpdated = protocompat.TimestampNow()
-	req.Approvers = append(req.Approvers, authn.UserFromContext(ctx))
+	approver := authn.UserFromContext(ctx)
+	req.Approvers = append(req.Approvers, approver)
+	req.ApproversV2 = append(req.ApproversV2, utils.ApproverV2(approver))
 	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, message))
 
 	// If this was an update whose status is being updated, the request fields must be changed appropriately.

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -367,10 +367,12 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateStatus_UnifiedCVEDeferral() {
 			s.mockStore.EXPECT().Get(gomock.Any(), c.existingReq.GetId()).Return(c.existingReq, true, nil)
 			s.mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
 
-			resp, err := s.datastore.UpdateRequestStatus(selfApproverAllSac, c.existingReq.GetId(), "status changed", c.status)
+			resp, err := s.datastore.UpdateRequestStatus(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), c.existingReq.GetId(), "status changed", c.status)
 			s.NoError(err)
 			s.Len(resp.Comments, 2)
 			s.Equal("status changed", resp.Comments[1].Message)
+			s.Len(resp.ApproversV2, 1)
+			s.Equal(resp.ApproversV2[0].Name, s.mockIdentity.FullName())
 			s.Equal(c.expectedStatus, resp.Status)
 			s.Equal(c.expectedReqObj, resp.Req)
 			s.Equal(c.expectedCVEs, resp.GetCves().GetCves())

--- a/central/vulnmgmt/vulnerabilityrequest/utils/util.go
+++ b/central/vulnmgmt/vulnerabilityrequest/utils/util.go
@@ -280,6 +280,17 @@ func IsUpdateNoOp(req *storage.VulnerabilityRequest, update *common.UpdateReques
 	return true
 }
 
+// ApproverV2 converts a slim user (v1 Approver type) to the v2 Approver type.
+func ApproverV2(user *storage.SlimUser) *storage.Approver {
+	if user == nil {
+		return nil
+	}
+	return &storage.Approver{
+		Id:   user.GetId(),
+		Name: user.GetName(),
+	}
+}
+
 func equal(a, b []string) bool {
 	sort.SliceStable(a, func(i, j int) bool {
 		return a[i] < a[j]


### PR DESCRIPTION
### Description

On request approval, only v1 approvers were being updated. But when unified cve deferral feature flag is enabled in VM 2.0, v2 approvers list should be updated as well.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [X] CHANGELOG update is not needed
- [X] Documentation is not needed

### Testing

- [X] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [X] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Updated unit tests to check for approversv2 field being updated.
Manually tested to see that list of approved vulnerability requests has approversV2 populated.

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

change me!
