### PR TITLE
chore: free up GHA disk space for scanner vuln update job

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -49,16 +49,12 @@ jobs:
       run: |
         set +e
         set -x
-
         df -h
-
         docker system prune --force --all
         for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL; do
           rm -rf "/mnt${delete:?}"
         done
-        
         df -h
-        
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -31,6 +31,8 @@ jobs:
       volumes:
         # The updater makes heavy use of /tmp files.
         - /tmp:/tmp
+        - /usr:/mnt/usr
+        - /opt:/mnt/opt
     strategy:
       # If one of the versions fails, it should not stop others from succeeding.
       fail-fast: false
@@ -43,14 +45,24 @@ jobs:
       ROX_PRODUCT_TAG: ${{ matrix.tag }}
     steps:
     - name: Free up disk space
-      run: |
-        df --si /
-        docker system prune --force --all
-        sudo rm -rf /usr/local/lib/android || true
-        sudo rm -rf /usr/share/dotnet || true
-        sudo rm -rf /usr/local/.ghcup || true
-        df --si /
       shell: bash
+      run: |
+        set +e
+        set -x
+
+        df -h
+
+        docker system prune --force --all
+        for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL; do
+          rm -rf "/mnt${delete:?}"
+          df -h "/mnt${delete:?}"
+        done
+        
+        df -h
+        
+        for path in /mnt/usr/share /mnt/usr/local/lib /mnt/opt /mnt/opt/hostedtoolcache; do
+          du --threshold=100 -hs "${path}"/* | sort -nr | tail -10
+        done
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -55,14 +55,10 @@ jobs:
         docker system prune --force --all
         for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL; do
           rm -rf "/mnt${delete:?}"
-          df -h "/mnt${delete:?}"
         done
         
         df -h
         
-        for path in /mnt/usr/share /mnt/usr/local/lib /mnt/opt /mnt/opt/hostedtoolcache; do
-          du --threshold=100 -hs "${path}"/* | sort -nr | tail -10
-        done
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -48,7 +48,6 @@ jobs:
         docker system prune --force --all
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /usr/share/dotnet || true
-        sudo rm -rf /opt/ghc || true
         sudo rm -rf /usr/local/.ghcup || true
         df --si /
       shell: bash

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -42,10 +42,14 @@ jobs:
       ROX_PRODUCT_VERSION: ${{ matrix.version }}
       ROX_PRODUCT_TAG: ${{ matrix.tag }}
     steps:
-    - name: Recover docker image cache space
+    - name: Free up disk space
       run: |
         df --si /
         docker system prune --force --all
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/.ghcup || true
         df --si /
       shell: bash
 


### PR DESCRIPTION
### Description

The `Scanner release vulnerability update` workflow's `upload-release-vulnerabilities` job has been failing due to `No space left on device` or `write /tmp: no space left on device` ([see this one](https://github.com/stackrox/stackrox/actions/runs/9703577065))

This PR removes directories containing 'stuff' that isn't used by the `upload-release-vulnerabilities` job.

The directories were chosen by referencing a few random sources (such as [this](https://github.com/jlumbroso/free-disk-space/blob/main/action.yml) and [this](https://github.com/actions/runner-images/issues/2840#issuecomment-790492173)). Is more cleanup that could be done if more space needed, however these seemed to be the least invasive.

This should, at the time of writing this, free up an additional `~16GB` (almost doubling current avail free space):

```
9.2G	/usr/local/lib/android
1.6G	/usr/share/dotnet
5.5G	/usr/local/.ghcup
```


### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI

