### PR TITLE
ROX-23222 + ROX-20245: Disable VM1.0 deferral/snooze services in VM2.0

### DIFF
--- a/central/cve/cluster/service/service_impl.go
+++ b/central/cve/cluster/service/service_impl.go
@@ -81,7 +81,7 @@ func (s *serviceImpl) UnsuppressCVEs(ctx context.Context, request *v1.Unsuppress
 	if !features.VulnMgmtLegacySnooze.Enabled() {
 		return nil, errors.Wrapf(errox.NotFound, "Feature %s is disabled", features.VulnMgmtLegacySnooze.Name())
 	}
-	
+
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to un-snooze")
 	}

--- a/central/cve/cluster/service/service_impl.go
+++ b/central/cve/cluster/service/service_impl.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/cve/cluster/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/and"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -55,6 +57,10 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // SuppressCVEs suppresses CVEs from policy workflow and API endpoints that include cve in the responses.
 func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVERequest) (*v1.Empty, error) {
+	if !features.VulnMgmtLegacySnooze.Enabled() {
+		return nil, errors.Wrapf(errox.NotFound, "Feature %s is disabled", features.VulnMgmtLegacySnooze.Name())
+	}
+
 	createdAt := time.Now()
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to snooze")
@@ -72,6 +78,10 @@ func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVER
 
 // UnsuppressCVEs un-suppresses given cluster CVEs.
 func (s *serviceImpl) UnsuppressCVEs(ctx context.Context, request *v1.UnsuppressCVERequest) (*v1.Empty, error) {
+	if !features.VulnMgmtLegacySnooze.Enabled() {
+		return nil, errors.Wrapf(errox.NotFound, "Feature %s is disabled", features.VulnMgmtLegacySnooze.Name())
+	}
+	
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to un-snooze")
 	}

--- a/central/cve/node/service/service_impl.go
+++ b/central/cve/node/service/service_impl.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/cve/node/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/and"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -55,6 +57,10 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // SuppressCVEs suppresses CVEs from policy workflow and API endpoints that include cve in the responses.
 func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVERequest) (*v1.Empty, error) {
+	if !features.VulnMgmtLegacySnooze.Enabled() {
+		return nil, errors.Wrapf(errox.NotFound, "Feature %s is disabled", features.VulnMgmtLegacySnooze.Name())
+	}
+
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to snooze")
 	}
@@ -72,6 +78,10 @@ func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVER
 
 // UnsuppressCVEs un-suppresses given node CVEs.
 func (s *serviceImpl) UnsuppressCVEs(ctx context.Context, request *v1.UnsuppressCVERequest) (*v1.Empty, error) {
+	if !features.VulnMgmtLegacySnooze.Enabled() {
+		return nil, errors.Wrapf(errox.NotFound, "Feature %s is disabled", features.VulnMgmtLegacySnooze.Name())
+	}
+
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to un-snooze")
 	}

--- a/central/vulnmgmt/vulnerabilityrequest/service/service_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/service/service_impl.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -77,6 +78,11 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // GetVulnerabilityRequest returns the requested vulnerability request by ID.
 func (s *serviceImpl) GetVulnerabilityRequest(ctx context.Context, req *v1.ResourceByID) (*v1.GetVulnerabilityRequestResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	requestInfo, _, err := s.datastore.Get(ctx, req.GetId())
 	if err != nil {
 		return nil, err
@@ -88,6 +94,11 @@ func (s *serviceImpl) GetVulnerabilityRequest(ctx context.Context, req *v1.Resou
 
 // ListVulnerabilityRequests returns the list of vulnerability requests.
 func (s *serviceImpl) ListVulnerabilityRequests(ctx context.Context, req *v1.RawQuery) (*v1.ListVulnerabilityRequestsResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	parsedQuery, err := search.ParseQuery(req.GetQuery(), search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
@@ -106,6 +117,11 @@ func (s *serviceImpl) ListVulnerabilityRequests(ctx context.Context, req *v1.Raw
 
 // DeferVulnerability starts the deferral process for the specified vulnerability.
 func (s *serviceImpl) DeferVulnerability(ctx context.Context, req *v1.DeferVulnRequest) (*v1.DeferVulnResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	vulnReq := utils.V1DeferVulnRequestToVulnReq(ctx, req)
 	if err := s.manager.Create(ctx, vulnReq); err != nil {
 		return nil, errors.Wrap(err, "could not create deferral request")
@@ -117,6 +133,11 @@ func (s *serviceImpl) DeferVulnerability(ctx context.Context, req *v1.DeferVulnR
 
 // FalsePositiveVulnerability starts the process to mark the specified vulnerability as false-positive.
 func (s *serviceImpl) FalsePositiveVulnerability(ctx context.Context, req *v1.FalsePositiveVulnRequest) (*v1.FalsePositiveVulnResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	vulnReq := utils.V1FalsePositiveRequestToVulnReq(ctx, req)
 	if err := s.manager.Create(ctx, vulnReq); err != nil {
 		return nil, errors.Wrap(err, "could not create false-positive request")
@@ -127,6 +148,11 @@ func (s *serviceImpl) FalsePositiveVulnerability(ctx context.Context, req *v1.Fa
 }
 
 func (s *serviceImpl) ApproveVulnerabilityRequest(ctx context.Context, req *v1.ApproveVulnRequest) (*v1.ApproveVulnRequestResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	requestInfo, err := s.manager.Approve(ctx, req.GetId(), &common.VulnRequestParams{Comment: req.GetComment()})
 	if err != nil {
 		return nil, err
@@ -137,6 +163,11 @@ func (s *serviceImpl) ApproveVulnerabilityRequest(ctx context.Context, req *v1.A
 }
 
 func (s *serviceImpl) DenyVulnerabilityRequest(ctx context.Context, req *v1.DenyVulnRequest) (*v1.DenyVulnRequestResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	requestInfo, err := s.manager.Deny(ctx, req.GetId(), &common.VulnRequestParams{Comment: req.GetComment()})
 	if err != nil {
 		return nil, err
@@ -147,6 +178,11 @@ func (s *serviceImpl) DenyVulnerabilityRequest(ctx context.Context, req *v1.Deny
 }
 
 func (s *serviceImpl) UpdateVulnerabilityRequest(ctx context.Context, req *v1.UpdateVulnRequest) (*v1.UpdateVulnRequestResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	requestInfo, err := s.manager.UpdateExpiry(ctx, req.GetId(),
 		&common.VulnRequestParams{Comment: req.GetComment(), Expiry: req.GetExpiry()})
 	if err != nil {
@@ -162,6 +198,11 @@ func (s *serviceImpl) UpdateVulnerabilityRequest(ctx context.Context, req *v1.Up
 }
 
 func (s *serviceImpl) UndoVulnerabilityRequest(ctx context.Context, req *v1.ResourceByID) (*v1.UndoVulnRequestResponse, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	requestInfo, err := s.manager.Undo(ctx, req.GetId(), &common.VulnRequestParams{})
 	if err != nil {
 		return nil, err
@@ -172,5 +213,10 @@ func (s *serviceImpl) UndoVulnerabilityRequest(ctx context.Context, req *v1.Reso
 }
 
 func (s *serviceImpl) DeleteVulnerabilityRequest(ctx context.Context, req *v1.ResourceByID) (*v1.Empty, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errors.Wrap(errox.NotFound, "Service unavailable. '/v1/cve/requests/*' APIs have been disabled. "+
+			"Use /v2/vulnerability-exceptions/* APIs instead.")
+	}
+
 	return &v1.Empty{}, s.manager.Delete(ctx, req.GetId())
 }

--- a/central/vulnmgmt/vulnerabilityrequest/service/service_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/service/service_impl_test.go
@@ -9,6 +9,7 @@ import (
 	mgrMock "github.com/stackrox/rox/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -22,7 +23,6 @@ var (
 )
 
 func TestVulnRequestService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(VulnRequestServiceTestSuite))
 }
 
@@ -37,6 +37,10 @@ type VulnRequestServiceTestSuite struct {
 }
 
 func (s *VulnRequestServiceTestSuite) SetupTest() {
+	s.T().Setenv(features.UnifiedCVEDeferral.EnvVar(), "false")
+	if features.UnifiedCVEDeferral.Enabled() {
+		s.T().Skipf("%s=true. Skipping test", features.UnifiedCVEDeferral.EnvVar())
+	}
 	s.mockCtrl = gomock.NewController(s.T())
 
 	s.datastore = dsMock.NewMockDataStore(s.mockCtrl)


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

- In VM 2.0, `ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL` is enabled by default. The legacy v1 APIs would no longer be compatible with this flag enabled and users must use newly added v2 APIs for deferring CVEs. This change will send an error if v1 APIs are used to defer CVEs.
- In VM 2.0, we do not want users to snooze Node and Platform CVEs by default. If someone wants to use the snooze feature, they must enable the `ROX_VULN_MGMT_LEGACY_SNOOZE` feature flag . This change will prevent users from using the snooze APIs if the feature flag is disabled.
- CHANGELOG will be updated in a separate PR.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [X] CHANGELOG update is not needed
- [X] Documentation is not needed

### Testing

- [X] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [X] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->
  Manually verified the change by calling the APIs with both feature flags enabled and disabled.

#### How I validated my change

 Manually verified the change by calling the APIs with both feature flags enabled and disabled.

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->
