### PR TITLE
ROX-24944: Improve crdwatcher unit test

### DIFF
--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
@@ -86,20 +86,14 @@ func (s *watcherSuite) waitForResourcesCreation(resources ...string) {
 	s.Eventually(func() bool {
 		// The context is ignored in the fake client, so we can simply pass context.Background
 		list, err := s.dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
-		if err != nil || len(list.Items) != len(resources) {
-			return false
-		}
-		return true
+		return err == nil && len(list.Items) == len(resources)
 	}, defaultTimeout, time.Millisecond, "the expected resources were not created on time: %v", resources)
 }
 
 func (s *watcherSuite) waitForResourcesRemoval() {
 	s.Eventually(func() bool {
 		list, err := s.dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
-		if err != nil || len(list.Items) > 0 {
-			return false
-		}
-		return true
+		return err == nil && len(list.Items) == 0
 	}, defaultTimeout, time.Millisecond, "the resources were not removed on time")
 }
 

--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
@@ -69,15 +69,35 @@ func newFakeCRD(name string) *unstructured.Unstructured {
 func (s *watcherSuite) createFakeCRDs(ctx context.Context, names ...string) {
 	for _, name := range names {
 		_, err := s.dynamicClient.Resource(gvr).Create(ctx, newFakeCRD(name), metav1.CreateOptions{})
-		s.Assert().NoError(err)
+		s.Require().NoError(err)
 	}
 }
 
 func (s *watcherSuite) removeFakeCRDs(ctx context.Context, names ...string) {
 	for _, name := range names {
 		err := s.dynamicClient.Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
-		s.Assert().NoError(err)
+		s.Require().NoError(err)
 	}
+}
+
+func (s *watcherSuite) waitForResourcesCreation(resources ...string) {
+	s.Eventually(func() bool {
+		list, err := s.dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
+		if err != nil || len(list.Items) != len(resources) {
+			return false
+		}
+		return true
+	}, defaultTimeout, time.Millisecond, "the expected resources were not created on time: %v", resources)
+}
+
+func (s *watcherSuite) waitForResourcesRemoval() {
+	s.Eventually(func() bool {
+		list, err := s.dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
+		if err != nil || len(list.Items) > 0 {
+			return false
+		}
+		return true
+	}, defaultTimeout, time.Millisecond, "the resources were not removed on time")
 }
 
 func (s *watcherSuite) Test_CreateDeleteCRD() {
@@ -124,6 +144,8 @@ func (s *watcherSuite) Test_CreateDeleteCRD() {
 
 			// Create fake CRDs after starting the watcher
 			s.createFakeCRDs(context.Background(), tCase.resourcesToCreateAfterWatch...)
+			// Wait for all resources to be created
+			s.waitForResourcesCreation(append(tCase.resourcesToCreateBeforeWatch, tCase.resourcesToCreateAfterWatch...)...)
 
 			select {
 			case <-time.NewTimer(defaultTimeout).C:
@@ -141,6 +163,8 @@ func (s *watcherSuite) Test_CreateDeleteCRD() {
 
 			s.removeFakeCRDs(context.Background(), tCase.resourcesToCreateBeforeWatch...)
 			s.removeFakeCRDs(context.Background(), tCase.resourcesToCreateAfterWatch...)
+			// Wait for all resources to be removed
+			s.waitForResourcesRemoval()
 
 			select {
 			case <-time.NewTimer(defaultTimeout).C:

--- a/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
+++ b/sensor/kubernetes/listener/watcher/crd/crdwatcher_test.go
@@ -66,22 +66,25 @@ func newFakeCRD(name string) *unstructured.Unstructured {
 	}
 }
 
-func (s *watcherSuite) createFakeCRDs(ctx context.Context, names ...string) {
+func (s *watcherSuite) createFakeCRDs(names ...string) {
 	for _, name := range names {
-		_, err := s.dynamicClient.Resource(gvr).Create(ctx, newFakeCRD(name), metav1.CreateOptions{})
+		// The context is ignored in the fake client, so we can simply pass context.Background
+		_, err := s.dynamicClient.Resource(gvr).Create(context.Background(), newFakeCRD(name), metav1.CreateOptions{})
 		s.Require().NoError(err)
 	}
 }
 
-func (s *watcherSuite) removeFakeCRDs(ctx context.Context, names ...string) {
+func (s *watcherSuite) removeFakeCRDs(names ...string) {
 	for _, name := range names {
-		err := s.dynamicClient.Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
+		// The context is ignored in the fake client, so we can simply pass context.Background
+		err := s.dynamicClient.Resource(gvr).Delete(context.Background(), name, metav1.DeleteOptions{})
 		s.Require().NoError(err)
 	}
 }
 
 func (s *watcherSuite) waitForResourcesCreation(resources ...string) {
 	s.Eventually(func() bool {
+		// The context is ignored in the fake client, so we can simply pass context.Background
 		list, err := s.dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
 		if err != nil || len(list.Items) != len(resources) {
 			return false
@@ -132,7 +135,7 @@ func (s *watcherSuite) Test_CreateDeleteCRD() {
 				close(callbackC)
 			}()
 			// Create fake CRDs before starting the watcher
-			s.createFakeCRDs(context.Background(), tCase.resourcesToCreateBeforeWatch...)
+			s.createFakeCRDs(tCase.resourcesToCreateBeforeWatch...)
 			w := s.createWatcher(&stopSig)
 			for _, rName := range tCase.resourcesToCreateBeforeWatch {
 				s.Assert().NoError(w.AddResourceToWatch(rName))
@@ -143,7 +146,7 @@ func (s *watcherSuite) Test_CreateDeleteCRD() {
 			s.Assert().NoError(w.Watch(callbackC))
 
 			// Create fake CRDs after starting the watcher
-			s.createFakeCRDs(context.Background(), tCase.resourcesToCreateAfterWatch...)
+			s.createFakeCRDs(tCase.resourcesToCreateAfterWatch...)
 			// Wait for all resources to be created
 			s.waitForResourcesCreation(append(tCase.resourcesToCreateBeforeWatch, tCase.resourcesToCreateAfterWatch...)...)
 
@@ -161,8 +164,8 @@ func (s *watcherSuite) Test_CreateDeleteCRD() {
 				}
 			}
 
-			s.removeFakeCRDs(context.Background(), tCase.resourcesToCreateBeforeWatch...)
-			s.removeFakeCRDs(context.Background(), tCase.resourcesToCreateAfterWatch...)
+			s.removeFakeCRDs(tCase.resourcesToCreateBeforeWatch...)
+			s.removeFakeCRDs(tCase.resourcesToCreateAfterWatch...)
 			// Wait for all resources to be removed
 			s.waitForResourcesRemoval()
 


### PR DESCRIPTION
### Description

Wait for resources to be created before asserting to avoid possible races.

### User-facing documentation

<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

I've run the tests multiple times locally.
