### PR TITLE
ROX-24899: Change all TLS Handshake calls to use context 

### DIFF
--- a/pkg/env/tls_handshake.go
+++ b/pkg/env/tls_handshake.go
@@ -1,0 +1,8 @@
+package env
+
+import "time"
+
+var (
+	// TLSHandshakeTimeout defines time in which TLS handshake must be finished.
+	TLSHandshakeTimeout = registerDurationSetting("ROX_TLS_HANDSHAKE_TIMEOUT", 2*time.Second)
+)

--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -173,7 +173,10 @@ func (c *EndpointConfig) instantiate(httpHandler http.Handler, grpcSrv *grpc.Ser
 				"":                      &httpLis,
 			}
 
-			tlsutils.ALPNDemux(lis, protoMap, tlsutils.ALPNDemuxConfig{OnHandshakeError: tlsHandshakeErrorHandler})
+			tlsutils.ALPNDemux(lis, protoMap, tlsutils.ALPNDemuxConfig{
+				OnHandshakeError:    tlsHandshakeErrorHandler,
+				TLSHandshakeTimeout: env.TLSHandshakeTimeout.DurationSetting(),
+			})
 		}
 	}
 

--- a/pkg/grpc/tls_conn_creds.go
+++ b/pkg/grpc/tls_conn_creds.go
@@ -39,11 +39,8 @@ func (c credsFromConn) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.
 	if tlsConn == nil {
 		return rawConn, nil, nil
 	}
-	if c.tlsHandshakeTimeout == 0 {
-		log.Debugf("TLS handshake timeout not set. Using 2s default")
-		c.tlsHandshakeTimeout = 2 * time.Second
-	}
-	ctx, cancel := context.WithTimeoutCause(context.Background(), c.tlsHandshakeTimeout, errors.New("TLS handshake timeout"))
+	ctx, cancel := context.WithTimeoutCause(context.Background(), c.tlsHandshakeTimeout,
+		errors.New("TLS handshake timeout"))
 	defer cancel()
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		log.Debugf("TLS handshake error from %q: %v", rawConn.RemoteAddr(), err)

--- a/tests/client_ca_test.go
+++ b/tests/client_ca_test.go
@@ -225,7 +225,10 @@ func TestClientCARequested(t *testing.T) {
 
 	conn, err := tls.Dial("tcp", centralgrpc.RoxAPIEndpoint(t), tlsConf)
 	require.NoError(t, err, "could not connect to central")
-	_ = conn.Handshake()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = conn.HandshakeContext(ctx)
 	_ = conn.Close()
 
 	found := false

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -135,9 +135,13 @@ func (c *endpointsTestCase) Run(t *testing.T, testCtx *endpointsTestContext) {
 func (c *endpointsTestCase) verifyDialResult(t *testing.T, conn *tls.Conn, err error) {
 	if conn != nil {
 		defer utils.IgnoreError(conn.Close)
+	} else {
+		t.Error("conn is nil")
 	}
 	if err == nil {
-		err = conn.Handshake()
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 2*time.Second, errors.New("TLS handshake timeout"))
+		defer cancel()
+		err = conn.HandshakeContext(ctx)
 	}
 
 	if !c.expectConnectFailure {


### PR DESCRIPTION
### Description

Calling `tlsConfig.Handshake` may cause the call to block forever - see [ROX-24163](https://issues.redhat.com/browse/ROX-24163). This PR changes all calls to `Handshake()` to `HandshakeContext(ctx)` and applies arbitraty timeout of 2s if no suitable parent context is found.


### User-facing documentation

(*must be* 2 items and both *must be* checked)

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->
- [x] contributed **no automated tests**
- [x] tests are already existing
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

- existing tests in CI
- deployed to cluster and looked at the logs
