### PR TITLE
ROX-24163: Improve k8s events metrics

### DIFF
--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -146,8 +146,8 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "k8s_event_processing_duration",
-		Help:      "Time taken to fully process an event from Kubernetes",
-		Buckets:   prometheus.ExponentialBuckets(4, 2, 8),
+		Help:      "Time taken in milliseconds to fully process an event from Kubernetes",
+		Buckets:   prometheus.ExponentialBuckets(4, 2, 12),
 	}, []string{"Action", "Resource", "Dispatcher"})
 
 	clusterMetricsNodeCountGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
### Description

When working on ROX-24163, we noticed that many k8s events are being processed longer that the highest bucket of the prometheus metric. It was also unclear what is the time unit for the measurement.

This PR improves this area. I decided to add the unit to the description and not to change the metric name (despite prometheus naming convention suggest that), for backwards compatibility with metrics gathered in the past.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

- No validation - trivial change
