### PR TITLE
chore(improvement): Make call to http.NewRequest context aware

### DIFF
--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -123,7 +123,7 @@ func AwareDialContext(ctx context.Context, address string) (net.Conn, error) {
 		return defaultDialer.DialContext(ctx, "tcp", address)
 	}
 
-	fakeHTTPReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("tcp://%s", address), nil)
+	fakeHTTPReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("tcp://%s", address), nil)
 	if err != nil {
 		return nil, utils.ShouldErr(errors.Wrapf(err, "failed to instantiate fake HTTP request for address %q", address))
 	}


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

The call to `http.NewRequest` is not context aware. This PR changes the call and uses `NewRequestWithContext`.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

CI should be happy
