### PR TITLE
chore: add force flag to check image vulns workflow

### DIFF
--- a/.github/workflows/check-image-vulnerabilities.yml
+++ b/.github/workflows/check-image-vulnerabilities.yml
@@ -70,7 +70,7 @@ jobs:
             # We need a monospaced font for the table layout, and `terraform` has
             # nicer color highlighting than the default language agnostic code block.
             echo '```terraform'
-            roxctl image scan --output=table \
+            roxctl image scan --output=table --force \
               --image="quay.io/rhacs-eng/${{ matrix.image }}:${{ inputs.version }}" \
               --severity="MODERATE,IMPORTANT,CRITICAL" \
               --headers="COMPONENT,VERSION,CVE,SEVERITY,FIXED_VERSION,LINK" \
@@ -81,7 +81,7 @@ jobs:
 
       - name: Fail if critical or important vulnerabilities have been found
         run: |
-          RESULT=$(roxctl image scan --output=json \
+          RESULT=$(roxctl image scan --output=json --force \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${{ inputs.version }}")
           CRITICAL_CNT=$(jq ".result.summary.CRITICAL" <<< "$RESULT")
           IMPORTANT_CNT=$(jq ".result.summary.IMPORTANT" <<< "$RESULT")


### PR DESCRIPTION
### Description

The workflow `RELEASE: Check image vulnerabilities` executes scans using `roxctl`, it was recently observed that the results were 'flapping' for a particular vulnerability.  This could be related to a know discrepancy issue when scan data is saved to central DB.  

<img width="1135" alt="image" src="https://github.com/stackrox/stackrox/assets/119438707/4a55d632-ec39-4d8f-8b66-bd0f3ee202c7">


To reduce the likelihood of this happening, adding the `--force` flag which causes the scan to 'skip' central DB and data pulled directly from Scanner.

### User-facing documentation

- [X] CHANGELOG update is not needed
- [X] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

It is itself a test

#### How I validated my change

Manually dispatched job from branch: https://github.com/stackrox/stackrox/actions/runs/9715822082