### PR TITLE
chore(ui): Fix accessibility issues in Violation tab

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -8,7 +8,6 @@ import {
     CardExpandableContent,
     CardBody,
     DescriptionList,
-    Divider,
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
@@ -33,16 +32,18 @@ function K8sCard({ message, keyValueAttrs = { attrs: [] }, time }: K8sCardProps)
     }
 
     return (
-        <div className="pf-v5-u-pb-md" key={message}>
-            <Card isExpanded={isExpanded} id={message} isFlat>
-                <CardHeader onExpand={onExpand}>
+        <div className="pf-v5-u-pb-md">
+            <Card isExpanded={isExpanded} isFlat>
+                <CardHeader
+                    onExpand={onExpand}
+                    toggleButtonProps={{ 'aria-expanded': isExpanded, 'aria-label': 'Details' }}
+                >
                     <CardTitle>{message}</CardTitle>
                 </CardHeader>
                 <CardExpandableContent>
                     <CardBody className="pf-v5-u-mt-lg">
                         <DescriptionList isHorizontal>
                             <DescriptionListItem term="Time" desc={format(time, dateTimeFormat)} />
-                            {keyValueAttrs.attrs?.length > 0 && <Divider component="div" />}
                             {keyValueAttrs.attrs.map(({ key, value }) => (
                                 <DescriptionListItem
                                     term={capitalize(key)}

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -27,9 +27,12 @@ function NetworkFlowCard({ networkFlowInfo, message, time }: NetworkFlowCardProp
     }
 
     return (
-        <div className="pf-v5-u-mb-md" key={message}>
-            <Card isExpanded={isExpanded} id={message} isFlat>
-                <CardHeader onExpand={onExpand}>
+        <div className="pf-v5-u-mb-md">
+            <Card isExpanded={isExpanded} isFlat>
+                <CardHeader
+                    onExpand={onExpand}
+                    toggleButtonProps={{ 'aria-expanded': isExpanded, 'aria-label': 'Details' }}
+                >
                     <CardTitle>{message}</CardTitle>
                 </CardHeader>
                 <CardExpandableContent>

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.js
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.js
@@ -33,7 +33,12 @@ function ProcessCard({ processes, message }) {
 
     return (
         <Card isFlat isExpanded={isExpanded}>
-            <CardHeader onExpand={onExpand}>{message}</CardHeader>
+            <CardHeader
+                onExpand={onExpand}
+                toggleButtonProps={{ 'aria-expanded': isExpanded, 'aria-label': 'Details' }}
+            >
+                {message}
+            </CardHeader>
             <CardExpandableContent>
                 <CardBody>
                     <DescriptionList


### PR DESCRIPTION
### Description

### Problems reported by axe DevTools on Violation tab

> Buttons must have discernable text

```html
<button aria-disabled="false" class="pf-v5-c-button pf-m-plain" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-plain-1">
```

To solve this problem, you need to fix at least (1) of the following
* Element does not have inner text that is visible to screen readers
* aria-label attribute does not exist or is empty
* aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
* Element has no title attribute
* Element's default semantics were not overridden with role="none" or role="presentation"

> dl elements must only directly contain properly ordered dt and dd groups, script, template, or div elements

```html
<dl class="pf-v5-c-description-list pf-m-horizontal">
```

To solve this problem, you need to fix the following:
dl element has direct children that are not allowed: [role=separator]

Related Node

```html
<div class="pf-v5-c-divider" role="separator"></div>
```

### Analysis

1. Absence of `toggleButtonProperties` prop which provides `aria-label` attribute.

    https://www.patternfly.org/components/card#expandable-cards

    Expand the code sample (pardon pun) to see an example:

    ```ts
    toggleButtonProps={{
        id: 'toggle-button1',
        'aria-label': 'Details',
        'aria-labelledby': 'expandable-card-title toggle-button1',
        'aria-expanded': isExpanded
    }}
    ```

2. Indeed, `Divider` element within description list of `K8sCard` component.

### Solutions

1. Edit K8sCard.tsx, NetworkFlowCard.tsx, ProcessCard.tsx files.
    * Add `toggleButtonProperties` prop to `CardHeader` element.
    * Delete unneeded `key` props.
    * Delete unneeded and often non-unique `id` props.
    * Although we could replace `<div className="pf-v5-u-pb-md">` in card elements with `spaceItems` prop of `Flex` element, I left well enough alone.

2. Edit K8sCard.tsx file.
    * Delete `Divider` element.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4637065 - 4637065
        total 78 = 11738298 - 11738220
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

### Manual testing

Brad, thank you for compliance instance, because default local deployment has only **Deploy** violations.

1. Visit /main/violations and click a **Runtime** violation to see **Violation** tab of side panel.

    * Before changes, see presence of accessibility issues.
        First issue: one occurrence per card.
        Second issue: one occurrence per card that corresponds to `'K8S_EVENT'` type.
        ![Violation_with_issues](https://github.com/stackrox/stackrox/assets/11862657/e6bf7cd9-819b-480d-9ac9-625ce65c1b62)

    * After changes, see absence of accessibility issues.
        Rhetorical question: do you miss the divider?
        ![Violation_without_issues](https://github.com/stackrox/stackrox/assets/11862657/22de3c2f-c01f-4090-889a-e80e38de180e)

        See `aria-expanded="true"` and `aria-label="Details"` attributes.
        ![Violation_expanded_true](https://github.com/stackrox/stackrox/assets/11862657/ee505ae8-0cfc-446e-9d5d-846fcd7cb638)

        See `aria-expanded="false"` and `aria-label="Details"` attributes.
        ![Violation_expanded_false](https://github.com/stackrox/stackrox/assets/11862657/efe3492a-a0bc-4bc9-b64f-a2b86c5bec1d)
