### PR TITLE
fix(ui): Adjust sorting for Node and Platform CVE tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -22,7 +22,7 @@ import DateDistance from 'Components/DateDistance';
 import {
     aggregateByCVSS,
     aggregateByCreatedTime,
-    aggregateByImageSha,
+    aggregateByDistinctCount,
     getScoreVersionsForTopCVSS,
     sortCveDistroList,
     getWorkloadSortFields,
@@ -104,7 +104,7 @@ function RequestCVEsTable({
                             <Th sort={getSortParams('CVE')}>CVE</Th>
                             <Th>Images by severity</Th>
                             <Th sort={getSortParams('CVSS', aggregateByCVSS)}>CVSS</Th>
-                            <Th sort={getSortParams('Image sha', aggregateByImageSha)}>
+                            <Th sort={getSortParams('Image sha', aggregateByDistinctCount)}>
                                 Affected images
                             </Th>
                             <Th sort={getSortParams('CVE Created Time', aggregateByCreatedTime)}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -39,6 +39,7 @@ import CVESelectionTh from '../../components/CVESelectionTh';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import {
     aggregateByCVSS,
+    aggregateByDistinctCount,
     getScoreVersionsForTopCVSS,
     sortCveDistroList,
 } from '../../utils/sortUtils';
@@ -132,7 +133,10 @@ function CVEsTable({
                     <Th sort={getSortParams(NODE_TOP_CVSS_SORT_FIELD, aggregateByCVSS)}>
                         Top CVSS
                     </Th>
-                    <TooltipTh tooltip="Ratio of the number of nodes affected by this CVE to the total number of nodes">
+                    <TooltipTh
+                        tooltip="Ratio of the number of nodes affected by this CVE to the total number of nodes"
+                        sort={getSortParams('Node ID', aggregateByDistinctCount)}
+                    >
                         Affected nodes
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -46,7 +46,7 @@ export const sortFields = [
     CLUSTER_KUBERNETES_VERSION_SORT_FIELD,
 ];
 
-export const defaultSortOption = { field: CVE_COUNT_SORT_FIELD, direction: 'desc' } as const;
+export const defaultSortOption = { field: CLUSTER_SORT_FIELD, direction: 'asc' } as const;
 
 export type Cluster = {
     id: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -34,7 +34,7 @@ import {
     sortCveDistroList,
     aggregateByCVSS,
     aggregateByCreatedTime,
-    aggregateByImageSha,
+    aggregateByDistinctCount,
 } from '../../utils/sortUtils';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
@@ -166,7 +166,7 @@ function CVEsTable({
                         Top CVSS
                     </TooltipTh>
                     <TooltipTh
-                        sort={getSortParams('Image sha', aggregateByImageSha)}
+                        sort={getSortParams('Image sha', aggregateByDistinctCount)}
                         tooltip="Ratio of total images affected by this CVE"
                     >
                         Affected images

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -7,7 +7,7 @@ export const aggregateByCVSS: SortAggregate = {
     aggregateFunc: 'max',
 };
 
-export const aggregateByImageSha: SortAggregate = {
+export const aggregateByDistinctCount: SortAggregate = {
     aggregateFunc: 'count',
     distinct: 'true',
 };


### PR DESCRIPTION
### Description

Two more, hopefully final, sorting fixes for Node and Platform CVEs:

- Re-add the ability to sort the "Affected nodes" column, using alternative sort parameters (thanks @charmik-redhat )
- Change default sort of Platform CVEs => Clusters table to sort on "Cluster" instead of "CVEs"

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

Visit Node CVEs and sort by "Affected nodes":
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/a321f0ec-a3e3-4422-aea0-d41f2bb13a97">

Sort ascending:
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/240b1cfd-dcc9-46e0-9757-87dbd67dda17">

Visit Platform CVEs => Clusters and observe the first column, clusters, is the default sort:
![image](https://github.com/stackrox/stackrox/assets/1292638/9f6bbdd3-f0a0-4e59-878d-5173d5af928e)
