### PR TITLE
fix(ui): Adjust VM 1.0 logic to only allow snooze when FF is enabled

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -299,6 +299,7 @@ const VulnMgmtCves = ({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
+    const isLegacySnoozeEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_LEGACY_SNOOZE');
 
     const [selectedCveIds, setSelectedCveIds] = useState([]);
     const [bulkActionCveIds, setBulkActionCveIds] = useState([]);
@@ -307,7 +308,18 @@ const VulnMgmtCves = ({
 
     const cveType = workflowState.getCurrentEntityType();
 
-    const shouldRenderGlobalSnooze = !isUnifiedDeferralEnabled || cveType !== entityTypes.IMAGE_CVE;
+    // Only allow snooze mutations when:
+    // 1. Unified deferrals is disabled, and the CVE is an image CVE, or
+    // 2. Legacy snooze is enabled, and the CVE is a Node or Platform CVE
+    const shouldRenderGlobalSnoozeAction =
+        (!isUnifiedDeferralEnabled && cveType === entityTypes.IMAGE_CVE) ||
+        (isLegacySnoozeEnabled && cveType !== entityTypes.IMAGE_CVE);
+
+    // Allow the ability to toggle the snoozed/unsnoozed view when:
+    // 1. Unified deferrals is disabled and the CVE is an image CVE, or
+    // 2. Always when the CVE is a Node or Platform CVE
+    const shouldRenderGlobalSnoozeView =
+        !isUnifiedDeferralEnabled || cveType !== entityTypes.IMAGE_CVE;
 
     let cveQuery = '';
 
@@ -496,7 +508,7 @@ const VulnMgmtCves = ({
                       )}
                       {hasWriteAccessForRiskAcceptance &&
                           !viewingSuppressed &&
-                          shouldRenderGlobalSnooze && (
+                          shouldRenderGlobalSnoozeAction && (
                               <RowActionMenu
                                   className="h-full min-w-30"
                                   border="border-l-2 border-base-400"
@@ -507,7 +519,7 @@ const VulnMgmtCves = ({
                           )}
                       {hasWriteAccessForRiskAcceptance &&
                           viewingSuppressed &&
-                          shouldRenderGlobalSnooze && (
+                          shouldRenderGlobalSnoozeAction && (
                               <RowActionButton
                                   text="Reobserve CVE"
                                   border="border-l-2 border-base-400"
@@ -534,33 +546,37 @@ const VulnMgmtCves = ({
                     Add to policy
                 </PanelButton>
             )}
-            {hasWriteAccessForRiskAcceptance && !viewingSuppressed && shouldRenderGlobalSnooze && (
-                <Menu
-                    className="h-full min-w-30 ml-2"
-                    menuClassName="bg-base-100 min-w-28"
-                    buttonClass="btn-icon btn-tertiary"
-                    buttonText="Defer and approve"
-                    buttonIcon={<Icon.BellOff className="h-4 w-4 mr-2" />}
-                    options={snoozeOptions()}
-                    disabled={selectedCveIds.length === 0}
-                    tooltip="Defer and approve selected CVEs"
-                />
-            )}
+            {hasWriteAccessForRiskAcceptance &&
+                !viewingSuppressed &&
+                shouldRenderGlobalSnoozeAction && (
+                    <Menu
+                        className="h-full min-w-30 ml-2"
+                        menuClassName="bg-base-100 min-w-28"
+                        buttonClass="btn-icon btn-tertiary"
+                        buttonText="Defer and approve"
+                        buttonIcon={<Icon.BellOff className="h-4 w-4 mr-2" />}
+                        options={snoozeOptions()}
+                        disabled={selectedCveIds.length === 0}
+                        tooltip="Defer and approve selected CVEs"
+                    />
+                )}
 
-            {hasWriteAccessForRiskAcceptance && viewingSuppressed && shouldRenderGlobalSnooze && (
-                <PanelButton
-                    icon={<Icon.Bell className="h-4 w-4" />}
-                    className="btn-icon btn-tertiary ml-2"
-                    onClick={unsuppressCves()}
-                    disabled={selectedCveIds.length === 0}
-                    tooltip="Reobserve selected CVEs"
-                >
-                    Reobserve
-                </PanelButton>
-            )}
+            {hasWriteAccessForRiskAcceptance &&
+                viewingSuppressed &&
+                shouldRenderGlobalSnoozeAction && (
+                    <PanelButton
+                        icon={<Icon.Bell className="h-4 w-4" />}
+                        className="btn-icon btn-tertiary ml-2"
+                        onClick={unsuppressCves()}
+                        disabled={selectedCveIds.length === 0}
+                        tooltip="Reobserve selected CVEs"
+                    >
+                        Reobserve
+                    </PanelButton>
+                )}
 
             <span className="w-px bg-base-400 ml-2" />
-            {shouldRenderGlobalSnooze && (
+            {shouldRenderGlobalSnoozeView && (
                 <PanelButton
                     icon={
                         viewingSuppressed ? (


### PR DESCRIPTION
### Description

Counterpart to https://github.com/stackrox/stackrox/pull/11759 to avoid API error responses via allowed UI actions.

This updates the support matrix of the UNIFIED_DEFERRALS flag, LEGACY_SNOOZE flag, Image CVEs, and Node/Platform CVEs in the following ways in the deprecated VM 1.0 section:

*Ability to View Snoozed CVEs*
- For Image CVEs, only when UNIFIED_DEFERRALS is `false` (same as before this PR)
- For Node/Platform CVEs, _always_ (same as before this PR)

*Ability to mutate Snoozed/Unsnoozed CVEs*
- For Image CVEs, only when UNIFIED_DEFERRALS is `false` (same as before this PR)
- For Node/Platform CVEs, only when LEGACY_SNOOZE is `true` (The only functional change in this PR)

### User-facing documentation

TODO - Which of these do we need for this change?
- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

Image CVEs with
UNIFIED_DEFERRALS enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/f71d71a1-3c8f-464a-a990-32c013e8f54c)

UNIFIED_DEFERRALS disabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/f75abdca-f036-43c1-a1d1-4fe2b552416d)

Node/Platform CVEs with
LEGACY_SNOOZE disabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/181fe792-9620-4c27-bbff-903bb2734d60)
LEGACY_SNOOZE enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/679529a5-2ac5-49e9-b01f-d487c7dd6f32)



