### PR TITLE
ROX-24714: Differentiate between autocomplete and text inputs

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -14,7 +14,7 @@ import {
     Flex,
     debounce,
 } from '@patternfly/react-core';
-import { ArrowRightIcon, TimesIcon } from '@patternfly/react-icons';
+import { ArrowRightIcon, SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import SEARCH_AUTOCOMPLETE_QUERY, {
     SearchAutocompleteQueryResponse,
@@ -216,8 +216,8 @@ function SearchFilterAutocomplete({
                     isExpanded={isOpen}
                     aria-controls="select-typeahead-listbox"
                     aria-label={textLabel}
+                    icon={<SearchIcon />}
                 />
-
                 <TextInputGroupUtilities>
                     {!!value && (
                         <Button


### PR DESCRIPTION
### Description

This PR helps differentiate between autocomplete and text inputs. Alan recommended just adding the search icon and letting the dropdown help differentiate for now. There's no appropriate icon we can use to differentiate right now. This is something we can look into post-release

### Screenshots

<img width="802" alt="Screenshot 2024-06-28 at 10 18 38 AM" src="https://github.com/stackrox/stackrox/assets/4805485/9058a1b9-9656-4d8b-ab7f-951dafb6df53">
<img width="799" alt="Screenshot 2024-06-28 at 10 18 44 AM" src="https://github.com/stackrox/stackrox/assets/4805485/5b36b6cb-1574-4573-b78a-537872815c9a">
