### PR TITLE
chore(ui): Disables NetGraph e2e test for GKE clusters

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -13,10 +13,10 @@ import { networkGraphSelectors } from './networkGraph.selectors';
 describe('Network Graph deployment sidebar', () => {
     withAuth();
 
-    it('should render a graph when cluster and namespace are selected', () => {
+    it('should render a graph when cluster and namespace are selected', function () {
         // Skipping this test due to an issue in GKE-latest that is not easily fixable, and will
         // cause failures 100% of the time. See ROX-23907, ROX-22431.
-        // TODO - remove this skip when ROX-22431 is resolved.
+        // TODO - remove this skip https://issues.redhat.com/browse/ROX-25038
         if (!hasOrchestratorFlavor('openshift')) {
             this.skip();
         }

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasOrchestratorFlavor } from '../../helpers/features';
 
 import {
     visitNetworkGraph,
@@ -13,6 +14,13 @@ describe('Network Graph deployment sidebar', () => {
     withAuth();
 
     it('should render a graph when cluster and namespace are selected', () => {
+        // Skipping this test due to an issue in GKE-latest that is not easily fixable, and will
+        // cause failures 100% of the time. See ROX-23907, ROX-22431.
+        // TODO - remove this skip when ROX-22431 is resolved.
+        if (!hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitNetworkGraph();
 
         checkNetworkGraphEmptyState();


### PR DESCRIPTION
### Description

Disables this Network Graph e2e test for **non-openshift** clusters. This is due to an issue with gke-latest that causes a misclassification of an internal traffic flow as external traffic. See https://issues.redhat.com/browse/ROX-23907 and https://issues.redhat.com/browse/ROX-24594.

We should be able to remove this skip once https://issues.redhat.com/browse/ROX-24594 is resolved.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Inspect CI results