### PR TITLE
ROX-25030: Disable reset for all schedules in compliance coverage

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -106,6 +106,7 @@ function ScanConfigurationSelect({
             <Button
                 variant="link"
                 icon={<TimesCircleIcon />}
+                isDisabled={!selectedScanConfigName}
                 onClick={() => setSelectedScanConfigName(undefined)}
             >
                 Reset filter


### PR DESCRIPTION
### Description

Linda observed that **Reset filter** is enabled for default **All scan schedules**

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

### Manual testing

1. Visit /main/compliance/coverage

    * Before changes, see **Reset filter** is enabled (unexpected).

    * After changes, see **Reset filter** is disabled (expected).

2. Select a specific scan schedule.

    * Before or after changes, see **Reset filter** is enabled (expected).
