### PR TITLE
fix(gke-latest): Use private IP range for GKE service ips

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -133,6 +133,7 @@ create_cluster() {
     # The "cluster" secondary range is for pods ("--cluster-ipv4-cidr").
     # The "services" secondary range is for ClusterIP services ("--services-ipv4-cidr").
     # See https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips#cluster_sizing.
+    # We specify secondary subnet IP so that GKE default (34.118.224.0) is not used. (ROX-22431)
 
     REGION=us-central1
     NUM_NODES="${NUM_NODES:-3}"
@@ -172,7 +173,7 @@ create_cluster() {
             --disk-size="${DISK_SIZE_GB}GB" \
             --create-subnetwork range=/28 \
             --cluster-ipv4-cidr=/20 \
-            --services-ipv4-cidr=/24 \
+            --services-ipv4-cidr=10.0.0.0/24 \
             --enable-ip-alias \
             --enable-network-policy \
             --no-enable-autorepair \

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -173,7 +173,7 @@ create_cluster() {
             --disk-size="${DISK_SIZE_GB}GB" \
             --create-subnetwork range=/28 \
             --cluster-ipv4-cidr=/20 \
-            --services-ipv4-cidr=10.0.0.0/24 \
+            --services-ipv4-cidr=192.168.0.0/24 \
             --enable-ip-alias \
             --enable-network-policy \
             --no-enable-autorepair \


### PR DESCRIPTION
### Description
On [May 10, 2024](https://cloud.google.com/kubernetes-engine/docs/release-notes#May_10_2024), GKE versions 1.29 and later, began to use a GKE managed IP range 34.118.224.0/20 for services by default -- this eliminates the need for a secondary services [subnet](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing_secondary_range_svcs). If only a range size is given to the `--services-ipv4-cidr` flag, GKE still uses the GKE-managed range to obtain the sub-range of addresses.

This PR specifies the subnet IP range so that ACS networking doesn't consider 34.118.224.X ips as external.

### User-facing documentation


- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

/pragma: gke_cluster_version:latest