### PR TITLE
ROX-25031: Correct default body and subject of compliance report

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -33,7 +33,7 @@ import {
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import {
-    customBodyDefault,
+    getBodyDefault,
     getSubjectDefault,
     getTimeWithHourMinuteFromISO8601,
 } from './compliance.scanConfigs.utils';
@@ -218,9 +218,12 @@ function ViewScanConfigDetail({
                                 />
                                 {isComplianceReportingEnabled && (
                                     <NotifierConfigurationView
-                                        customBodyDefault={customBodyDefault}
+                                        customBodyDefault={getBodyDefault(
+                                            scanConfig.scanConfig.profiles
+                                        )}
                                         customSubjectDefault={getSubjectDefault(
-                                            scanConfig.scanName
+                                            scanConfig.scanName,
+                                            scanConfig.scanConfig.profiles
                                         )}
                                         notifierConfigurations={scanConfig.scanConfig.notifiers}
                                     />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
@@ -7,7 +7,7 @@ import usePermissions from 'hooks/usePermissions';
 
 import {
     ScanConfigFormValues,
-    customBodyDefault,
+    getBodyDefault,
     getSubjectDefault,
 } from '../compliance.scanConfigs.utils';
 
@@ -32,8 +32,11 @@ function ReportConfiguration(): ReactElement {
             <Divider component="div" />
             <Form className="pf-v5-u-py-lg pf-v5-u-px-lg">
                 <NotifierConfigurationForm
-                    customBodyDefault={customBodyDefault}
-                    customSubjectDefault={getSubjectDefault(formik.values.parameters.name)}
+                    customBodyDefault={getBodyDefault(formik.values.profiles)}
+                    customSubjectDefault={getSubjectDefault(
+                        formik.values.parameters.name,
+                        formik.values.profiles
+                    )}
                     errors={formik.errors}
                     fieldIdPrefixForFormikAndPatternFly="report.notifierConfigurations"
                     hasWriteAccessForIntegration={hasWriteAccessForIntegration}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -18,7 +18,7 @@ import { ComplianceIntegration } from 'services/ComplianceIntegrationService';
 
 import {
     convertFormikParametersToSchedule,
-    customBodyDefault,
+    getBodyDefault,
     getSubjectDefault,
     ScanConfigFormValues,
 } from '../compliance.scanConfigs.utils';
@@ -95,8 +95,11 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                 />
                 {isComplianceReportingEnabled && (
                     <NotifierConfigurationView
-                        customBodyDefault={customBodyDefault}
-                        customSubjectDefault={getSubjectDefault(formikValues.parameters.name)}
+                        customBodyDefault={getBodyDefault(formikValues.profiles)}
+                        customSubjectDefault={getSubjectDefault(
+                            formikValues.parameters.name,
+                            formikValues.profiles
+                        )}
                         notifierConfigurations={formikValues.report.notifierConfigurations}
                     />
                 )}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
@@ -223,10 +223,12 @@ export function formatScanSchedule(schedule: Schedule) {
 
 // report
 
-const { basePageTitle, shortName } = getProductBranding();
+const { reportName } = getProductBranding();
 
-export const customBodyDefault = `${basePageTitle} for Kubernetes has identified non-compliant profile checks for the clusters scanned by your schedule configuration parameters. The attached report lists those checks and associated details to help with remediation.`;
+export function getBodyDefault(profiles: string[]) {
+    return `${reportName} has scanned your clusters for compliance with the profiles in your scan configuration. The attached report lists those checks and associated details to help with remediation. Profiles: ${profiles.join(',')}`;
+}
 
-export function getSubjectDefault(scanName: string) {
-    return `${shortName} Compliance Report for ${scanName}`;
+export function getSubjectDefault(scanName: string, profiles: string[]) {
+    return `${reportName} Compliance Report for ${scanName} with ${profiles.length} Profiles`;
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/emailTemplateFormUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/emailTemplateFormUtils.ts
@@ -2,9 +2,10 @@ import { getProductBranding } from 'constants/productBranding';
 
 // Helper functions
 
-const { shortName, type: productBrand } = getProductBranding();
+const { type: productBrand } = getProductBranding();
 const productBrandText =
     productBrand === 'RHACS_BRANDING' ? 'Red Hat Advanced Cluster Security (RHACS)' : 'StackRox';
+const shortName = productBrand === 'RHACS_BRANDING' ? 'RHACS' : 'StackRox';
 
 export const defaultEmailSubjectTemplate = `${shortName} Workload CVE Report for <Config name>; Scope: <Collection name>`;
 

--- a/ui/apps/platform/src/constants/productBranding.ts
+++ b/ui/apps/platform/src/constants/productBranding.ts
@@ -15,7 +15,7 @@ export interface BrandingAssets {
     /** Value to use as the base in the <title> element */
     basePageTitle: string;
     /** Value for default subject of report e-mail */
-    shortName: string;
+    reportName: string;
     /** Absolute path to the page favicon */
     favicon: string;
 }
@@ -25,7 +25,7 @@ const rhacsBranding: BrandingAssets = {
     logoSvg: rhacsLogoSvg,
     logoAltText: 'Red Hat Advanced Cluster Security Logo',
     basePageTitle: 'Red Hat Advanced Cluster Security',
-    shortName: 'RHACS',
+    reportName: 'Red Hat Advanced Cluster Security (RHACS)',
     favicon: rhacsFavicon,
 };
 
@@ -34,7 +34,7 @@ const stackroxBranding: BrandingAssets = {
     logoSvg: stackroxLogoSvg,
     logoAltText: 'StackRox Logo',
     basePageTitle: 'StackRox',
-    shortName: 'StackRox',
+    reportName: 'StackRox',
     favicon: stackroxFavicon,
 };
 


### PR DESCRIPTION
### Description

Thank you, Surabhi seeing the incorrect text and providing the correct backend templates, which are source of truth for frontend.

### Changes

1. Edit compliance.scanConfigs.utils.tsx file.
    * Replace different names with `reportName` from product branding.
    * Replace `customBodyDefault` with `getBodyDefault` function.
    * Add `profiles` argument to `getSubjectDefault` function.

https://github.com/stackrox/stackrox/blob/1e6cf12ca1926da6f68e5d933a77cf911bc0d888/central/complianceoperator/v2/report/manager/complianceReportgenerator/consts.go

2. Edit 3 files that need default body for Compliance Report.
    * Replace `customBodyDefault` with `getBodyDefault` function.

3. Edit file for Vulnerability Report.
    * Revert some of the changes from refactoring, pending investigation whether short name for subject and long name for body is correct. It seems inconsistent with Compliance Report.

    https://github.com/stackrox/stackrox/pull/11146/files#diff-b65c53c09fd4101cb3383d4b0954efe10d10fceb7cd17c1be6869a74ece91fbdL5-L10

4. Edit productBranding.ts file.
    * Replace `shortName` with `reportName` based on backend
        
https://github.com/stackrox/stackrox/blob/1e6cf12ca1926da6f68e5d933a77cf911bc0d888/central/complianceoperator/v2/report/manager/complianceReportgenerator/report_gen_impl.go#L118

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/compliance/schedules, click **Create scan schedule**, and then in Step 4 Report, click **Default template applied**.

    * Before changes, with incorrect body and subject for Stackrox product branding.
        ![incorrect](https://github.com/stackrox/stackrox/assets/11862657/fe7a6460-7d91-4ded-942f-5aa3a04573f2)

    * After changes, with correct body and subject for Stackrox product branding.
        ![correct](https://github.com/stackrox/stackrox/assets/11862657/4f728a90-8dbe-4853-aadd-d1dbc6cbfb76)
