### PR TITLE
ROX-14208: Do not use `jsonpb.Unmarshal` with default options

### DIFF
--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -109,7 +109,7 @@ func getTestImages() ([]*storage.Image, error) {
 	defer func() { _ = zipReader.Close() }()
 
 	jsonReader := json.NewDecoder(zipReader)
-	unmarshaler := jsonpb.Unmarshaler{}
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
 
 	images := make([]*storage.Image, 0, 500)
 

--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -18,6 +17,7 @@ import (
 	basicAuthProvider "github.com/stackrox/rox/pkg/auth/authproviders/basic"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
@@ -287,7 +287,7 @@ func (l *loginCommand) verifyLoginAuthProviders() error {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var loginAuthProviders v1.GetLoginAuthProvidersResponse
-	if err := jsonpb.Unmarshal(resp.Body, &loginAuthProviders); err != nil {
+	if err := jsonutil.JSONReaderToProto(resp.Body, &loginAuthProviders); err != nil {
 		return errors.Wrap(err, "unmarshalling login auth providers response")
 	}
 

--- a/roxctl/central/m2m/exchange/exchange.go
+++ b/roxctl/central/m2m/exchange/exchange.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -103,7 +104,7 @@ func (e *exchangeCommand) exchange() error {
 		return errors.Wrap(err, "exchange request failed")
 	}
 	var exchangeResp v1.ExchangeAuthMachineToMachineTokenResponse
-	if err := jsonpb.Unmarshal(resp.Body, &exchangeResp); err != nil {
+	if err := jsonutil.JSONReaderToProto(resp.Body, &exchangeResp); err != nil {
 		return errors.Wrap(err, "unmarshalling exchange request response")
 	}
 

--- a/roxctl/central/m2m/exchange/exchange_test.go
+++ b/roxctl/central/m2m/exchange/exchange_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
@@ -119,7 +120,7 @@ func matchesConfig(roxctlConfig *config.RoxctlConfig, key string) gomock.Matcher
 func exchangeHandle(t *testing.T, expectedToken, responseToken string) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		var m2mRequest v1.ExchangeAuthMachineToMachineTokenRequest
-		assert.NoError(t, jsonpb.Unmarshal(request.Body, &m2mRequest))
+		assert.NoError(t, jsonutil.JSONReaderToProto(request.Body, &m2mRequest))
 		assert.Equal(t, expectedToken, m2mRequest.GetIdToken())
 
 		m := jsonpb.Marshaler{Indent: "  "}

--- a/roxctl/scanner/downloaddb/downloaddb.go
+++ b/roxctl/scanner/downloaddb/downloaddb.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/utils"
 	pkgVersion "github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -151,7 +151,7 @@ func (cmd *scannerDownloadDBCommand) versionFromCentral() (string, error) {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var metadata v1.Metadata
-	if err := jsonpb.Unmarshal(resp.Body, &metadata); err != nil {
+	if err := jsonutil.JSONReaderToProto(resp.Body, &metadata); err != nil {
 		cmd.env.Logger().WarnfLn("error reading metadata from central: %v", err)
 		return "", err
 	}

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -324,7 +324,7 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code for ping request")
 	var pong v1.PongMessage
-	assert.NoError(t, jsonpb.Unmarshal(resp.Body, &pong), "expected response for ping request to be unmarshalable into Pong protobuf")
+	assert.NoError(t, jsonutil.JSONReaderToProto(resp.Body, &pong), "expected response for ping request to be unmarshalable into Pong protobuf")
 
 	resp, err = client.Get(fmt.Sprintf("%s://%s/v1/auth/status", scheme, targetHost))
 	if !assert.NoError(t, err, "expected HTTP request to succeed at the transport level") {
@@ -338,7 +338,7 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 	}
 
 	var authStatus v1.AuthStatus
-	if !assert.NoError(t, jsonpb.Unmarshal(resp.Body, &authStatus), "expected response for auth status request to be unmarshalable into auth status PB") {
+	if !assert.NoError(t, jsonutil.JSONReaderToProto(resp.Body, &authStatus), "expected response for auth status request to be unmarshalable into auth status PB") {
 		return
 	}
 	c.verifyAuthStatus(t, testCtx, &authStatus)


### PR DESCRIPTION
### Description

`jsonpb.Unmarshal` must be used with `AllowUnknownFields: true` to ensure backwards compat with older Sensors.
This PR changes all occurrences of the `jsonpb.Unmarshal` into one that has this field set.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

- In CI we trust
