### PR TITLE
fix(ui): Prevent filter dropdowns from shrinking below min size

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
@@ -15,6 +15,7 @@ export type AttributeSelectorProps = {
     selectedAttribute: SelectedAttribute;
     onChange: AttributeSelectorOnChange;
     config: PartialCompoundSearchFilterConfig;
+    menuToggleClassName?: string;
 };
 
 function AttributeSelector({
@@ -22,6 +23,7 @@ function AttributeSelector({
     selectedAttribute,
     onChange,
     config,
+    menuToggleClassName,
 }: AttributeSelectorProps) {
     if (!selectedEntity) {
         return null;
@@ -35,6 +37,7 @@ function AttributeSelector({
 
     return (
         <SimpleSelect
+            menuToggleClassName={menuToggleClassName}
             value={selectedAttribute}
             onChange={onChange}
             ariaLabelMenu="compound search filter attribute selector menu"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -66,6 +66,7 @@ function CompoundSearchFilter({
     return (
         <Split className="pf-v5-u-flex-grow-1">
             <EntitySelector
+                menuToggleClassName="pf-v5-u-flex-shrink-0"
                 selectedEntity={selectedEntity}
                 onChange={(value) => {
                     setSelectedEntity(value as SearchFilterEntityName);
@@ -79,6 +80,7 @@ function CompoundSearchFilter({
                 config={config}
             />
             <AttributeSelector
+                menuToggleClassName="pf-v5-u-flex-shrink-0"
                 selectedEntity={selectedEntity}
                 selectedAttribute={selectedAttribute}
                 onChange={(value) => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
@@ -16,9 +16,15 @@ export type EntitySelectorProps = {
     selectedEntity: SelectedEntity;
     onChange: EntitySelectorOnChange;
     config: PartialCompoundSearchFilterConfig;
+    menuToggleClassName?: string;
 };
 
-function EntitySelector({ selectedEntity, onChange, config }: EntitySelectorProps) {
+function EntitySelector({
+    selectedEntity,
+    onChange,
+    config,
+    menuToggleClassName,
+}: EntitySelectorProps) {
     const entities = getEntities(config);
 
     if (entities.length === 0) {
@@ -29,6 +35,7 @@ function EntitySelector({ selectedEntity, onChange, config }: EntitySelectorProp
 
     return (
         <SimpleSelect
+            menuToggleClassName={menuToggleClassName}
             value={displayName}
             onChange={onChange}
             ariaLabelMenu="compound search filter entity selector menu"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
@@ -14,6 +14,7 @@ export type SimpleSelectProps = {
     isDisabled?: boolean;
     ariaLabelMenu?: string;
     ariaLabelToggle?: string;
+    menuToggleClassName?: string;
 };
 
 function SimpleSelect({
@@ -23,6 +24,7 @@ function SimpleSelect({
     isDisabled = false,
     ariaLabelMenu,
     ariaLabelToggle,
+    menuToggleClassName,
 }: SimpleSelectProps) {
     const [isOpen, setIsOpen] = React.useState(false);
 
@@ -40,6 +42,7 @@ function SimpleSelect({
 
     const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
+            className={menuToggleClassName}
             aria-label={ariaLabelToggle}
             ref={toggleRef}
             onClick={onToggleClick}


### PR DESCRIPTION
### Description

Fixes the layout of the new compound filter bar to prevent the initial dropdowns from shrinking to a width that is less than the width of the displayed text. This cause text truncation and poor UX. The fix is done with `flex-shrink: 0`, to prevent these items from shrinking to accommodate the negative free space of the flex parent.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

Visual change that is not something that is typically covered by automated UI tests.

#### How I validated my change

Tested in Firefox and Safari.

Before the change:
![image](https://github.com/stackrox/stackrox/assets/1292638/d3ef930f-da10-4429-a8f8-1920bc57b4b4)

![image](https://github.com/stackrox/stackrox/assets/1292638/547b54fb-f05b-4065-873c-8e5352b0e0d7)

![image](https://github.com/stackrox/stackrox/assets/1292638/3e138e16-0128-406e-9041-cc4104951144)


After the change:
![image](https://github.com/stackrox/stackrox/assets/1292638/53869fde-6e54-44fa-8a83-8949b0ac4bb4)
![image](https://github.com/stackrox/stackrox/assets/1292638/b0ccf65a-0f0c-42f8-85f4-f3febdf89226)
![image](https://github.com/stackrox/stackrox/assets/1292638/cd36abf5-9d4d-4406-90d8-97cdd727b04a)
