### PR TITLE
chore(fix): Apply gogoprotofunctions roxvet on sql_integration tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,7 +779,7 @@ roxvet: $(ROXVET_BIN)
 	@# TODO(ROX-7574): Add options to ignore specific files or paths in roxvet
 	$(SILENT)go list -e ./... \
 	    | $(foreach d,$(skip-dirs),grep -v '$(d)' |) \
-	    xargs -n 1000 go vet -vettool "$(ROXVET_BIN)" -donotcompareproto -tags "sql_integration"
+	    xargs -n 1000 go vet -vettool "$(ROXVET_BIN)" -donotcompareproto -gogoprotofunctions -tags "sql_integration"
 	$(SILENT)go list -e ./... \
 	    | $(foreach d,$(skip-dirs),grep -v '$(d)' |) \
 	    xargs -n 1000 go vet -vettool "$(ROXVET_BIN)"

--- a/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/migration_test.go
+++ b/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/migration_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	timestamp "github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/schema"
 	"github.com/stackrox/rox/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/store"
@@ -14,6 +13,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	ts               = timestamp.TimestampNow()
+	ts               = protocompat.TimestampNow()
 	globalImageScope = &storage.VulnerabilityRequest_Scope{
 		Info: &storage.VulnerabilityRequest_Scope_ImageScope{
 			ImageScope: &storage.VulnerabilityRequest_Scope_Image{


### PR DESCRIPTION
### Description

This PR is enabling roxvet `gogoprotofunctions` check on go files with `//go:build sql_integration` tag.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Run `make roxvet` - before and after changes.
