### PR TITLE
ROX-24978: Compatibility tests should not test eol combinations

### DIFF
--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -130,7 +130,7 @@ def __get_supported_helm_chart_versions():
 
 def get_supported_releases():
     supported_releases = []
-    data = __get_data_from_api(PRODUCT_LIFECYCLES_API)
+    data = __get_data_from_product_lifecycles_api()
     releases = []
     try:
         releases = data["data"][0]["versions"]
@@ -142,9 +142,9 @@ def get_supported_releases():
     return supported_releases
 
 
-def __get_data_from_api(url):
+def __get_data_from_product_lifecycles_api():
     req = Request(
-        url=url,
+        url=PRODUCT_LIFECYCLES_API,
         headers={'User-Agent': 'Mozilla/5.0'}
     )
     try:

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -134,8 +134,9 @@ def get_supported_releases():
     releases = []
     try:
         releases = data["data"][0]["versions"]
-    except Exception as e:
-        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
+    except Exception as exception:
+        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at "
+                      f"{PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
     for release in releases:
         if release["type"] != "End of life":
             supported_releases.append(parse_release(release["name"]))
@@ -155,10 +156,12 @@ def __get_data_from_product_lifecycles_api():
                 response_string = response_bytes.decode('utf-8')
                 data = json.loads(response_string)
                 return data
-            except Exception as e:
-                logging.debug(f"Failed to read data from PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
-    except Exception as e:
-        logging.debug(f"Failed to access PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
+            except Exception as exception:
+                logging.debug(f"Failed to read data from PRODUCT_LIFECYCLES_API at "
+                              f"{PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
+    except Exception as exception:
+        logging.debug(f"Failed to access PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
+    return []
 
 
 def __does_chart_exist(chart_name, release):

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -149,24 +149,19 @@ def __get_data_from_product_lifecycles_api():
         headers={'User-Agent': 'Mozilla/5.0'}
     )
     try:
-        response = urlopen(req)
-    except URLError as exception:
-        logging.debug(f"Failed to open URL {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
-        return []
-    with response:
-        try:
+        with urlopen(req) as response:
             response_bytes = response.read()
             response_string = response_bytes.decode('utf-8')
-        except ValueError as exception:
-            logging.debug(f"Failed to decode API response from {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
-            return []
-        try:
             data = json.loads(response_string)
-        except json.JSONDecodeError as exception:
-            logging.debug(f"Failed to load JSON from API response from {PRODUCT_LIFECYCLES_API} with error:"
-                          f"\n{repr(exception)}")
-            return []
-        return data
+            return data
+    except URLError as exception:
+        logging.debug(f"Failed to open URL {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
+    except json.JSONDecodeError as exception:
+        logging.debug(f"Failed to load JSON from API response from {PRODUCT_LIFECYCLES_API} with error:"
+                      f"\n{repr(exception)}")
+    except ValueError as exception:
+        logging.debug(f"Failed to decode API response from {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
+    return []
 
 
 def __does_chart_exist(chart_name, release):

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -61,7 +61,7 @@ def main(argv):
     logging.info(
         f"Helm chart versions for the latest {num_releases} releases:")
 
-    print("\n".join(helm_versions))
+    logging.info("\n".join(helm_versions))
     helm_version_specific = get_latest_helm_chart_version_for_specific_release(
         "stackrox-secured-cluster-services", sample_support_exception
     )
@@ -131,7 +131,11 @@ def __get_supported_helm_chart_versions():
 def get_supported_releases():
     supported_releases = []
     data = __get_data_from_api(PRODUCT_LIFECYCLES_API)
-    releases = data["data"][0]["versions"]
+    releases = []
+    try:
+        releases = data["data"][0]["versions"]
+    except Exception as e:
+        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}.\n{repr(e)}")
     for release in releases:
         if release["type"] != "End of life":
             supported_releases.append(parse_release(release["name"]))

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -13,6 +13,7 @@ import pathlib
 import re
 import subprocess
 import sys
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from collections import namedtuple
@@ -131,14 +132,13 @@ def __get_supported_helm_chart_versions():
 def get_supported_releases():
     supported_releases = []
     data = __get_data_from_product_lifecycles_api()
-    releases = []
-    try:
-        releases = data["data"][0]["versions"]
-    except Exception as exception:
-        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at "
-                      f"{PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
+    if "data" not in data or len(data["data"]) == 0 or "versions" not in data["data"][0]:
+        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API")
+        return []
+    releases = data["data"][0]["versions"]
+
     for release in releases:
-        if release["type"] != "End of life":
+        if "type" in release and release["type"] != "End of life":
             supported_releases.append(parse_release(release["name"]))
     return supported_releases
 
@@ -150,18 +150,22 @@ def __get_data_from_product_lifecycles_api():
     )
     try:
         response = urlopen(req)
-        with response:
-            try:
-                response_bytes = response.read()
-                response_string = response_bytes.decode('utf-8')
-                data = json.loads(response_string)
-                return data
-            except Exception as exception:
-                logging.debug(f"Failed to read data from PRODUCT_LIFECYCLES_API at "
-                              f"{PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
-    except Exception as exception:
-        logging.debug(f"Failed to access PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(exception)}")
-    return []
+    except URLError as exception:
+        logging.debug(f"Failed to open URL {req.url} with error:\n{repr(exception)}")
+        return []
+    with response:
+        try:
+            response_bytes = response.read()
+            response_string = response_bytes.decode('utf-8')
+        except ValueError as exception:
+            logging.debug(f"Failed to decode API response from {req.url} with error:\n{repr(exception)}")
+            return []
+        try:
+            data = json.loads(response_string)
+        except json.JSONDecodeError as exception:
+            logging.debug(f"Failed to load JSON from API response from {req.url} with error:\n{repr(exception)}")
+            return []
+        return data
 
 
 def __does_chart_exist(chart_name, release):

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -69,7 +69,7 @@ def main(argv):
         f"Latest chart version for the {sample_support_exception} "
         f"releases is {helm_version_specific}"
     )
-    supported_versions_string = [[f"{version.major}.{version.minor}"] for version in get_supported_versions()]
+    supported_versions_string = [[f"{version.major}.{version.minor}"] for version in get_supported_releases()]
     supported_central_versions_from_api, supported_sensor_versions_from_api = get_supported_helm_chart_versions()
     logging.info(
         f"\nThe product lifecycles API denotes support for the following versions: {supported_versions_string}\n"

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -133,7 +133,7 @@ def get_supported_releases():
     supported_releases = []
     data = __get_data_from_product_lifecycles_api()
     if "data" not in data or len(data["data"]) == 0 or "versions" not in data["data"][0]:
-        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API")
+        logging.debug("Found no RHACS releases in PRODUCT_LIFECYCLES_API")
         return []
     releases = data["data"][0]["versions"]
 
@@ -151,19 +151,20 @@ def __get_data_from_product_lifecycles_api():
     try:
         response = urlopen(req)
     except URLError as exception:
-        logging.debug(f"Failed to open URL {req.url} with error:\n{repr(exception)}")
+        logging.debug(f"Failed to open URL {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
         return []
     with response:
         try:
             response_bytes = response.read()
             response_string = response_bytes.decode('utf-8')
         except ValueError as exception:
-            logging.debug(f"Failed to decode API response from {req.url} with error:\n{repr(exception)}")
+            logging.debug(f"Failed to decode API response from {PRODUCT_LIFECYCLES_API} with error:\n{repr(exception)}")
             return []
         try:
             data = json.loads(response_string)
         except json.JSONDecodeError as exception:
-            logging.debug(f"Failed to load JSON from API response from {req.url} with error:\n{repr(exception)}")
+            logging.debug(f"Failed to load JSON from API response from {PRODUCT_LIFECYCLES_API} with error:"
+                          f"\n{repr(exception)}")
             return []
         return data
 

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -135,7 +135,7 @@ def get_supported_releases():
     try:
         releases = data["data"][0]["versions"]
     except Exception as e:
-        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}.\n{repr(e)}")
+        logging.debug(f"Found no RHACS releases in PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
     for release in releases:
         if release["type"] != "End of life":
             supported_releases.append(parse_release(release["name"]))
@@ -147,11 +147,18 @@ def __get_data_from_api(url):
         url=url,
         headers={'User-Agent': 'Mozilla/5.0'}
     )
-    with urlopen(req) as response:
-        response_bytes = response.read()
-        response_string = response_bytes.decode('utf-8')
-        data = json.loads(response_string)
-        return data
+    try:
+        response = urlopen(req)
+        with response:
+            try:
+                response_bytes = response.read()
+                response_string = response_bytes.decode('utf-8')
+                data = json.loads(response_string)
+                return data
+            except Exception as e:
+                logging.debug(f"Failed to read data from PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
+    except Exception as e:
+        logging.debug(f"Failed to access PRODUCT_LIFECYCLES_API at {PRODUCT_LIFECYCLES_API}\n{repr(e)}")
 
 
 def __does_chart_exist(chart_name, release):

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,6 +20,7 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
+    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])
@@ -63,7 +64,14 @@ test_tuples.extend(
 
 # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
 # https://issues.redhat.com/browse/ROX-18223
+# however a new support exception is being negotiated, add it here when it's ready
 support_exceptions = [
+    ChartVersions(
+        central_version=latest_tag,
+        sensor_version=get_latest_helm_chart_version_for_specific_release(
+            "stackrox-secured-cluster-services", Release(major=3, minor=74)
+        ),
+    )
 ]
 
 test_tuples.extend(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,7 +20,6 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
-    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])
@@ -64,14 +63,7 @@ test_tuples.extend(
 
 # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
 # https://issues.redhat.com/browse/ROX-18223
-# Remove it after confirming the support exception has not been extended
 support_exceptions = [
-    ChartVersions(
-        central_version=latest_tag,
-        sensor_version=get_latest_helm_chart_version_for_specific_release(
-            "stackrox-secured-cluster-services", Release(major=3, minor=74)
-        ),
-    )
 ]
 
 test_tuples.extend(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -62,16 +62,9 @@ test_tuples.extend(
     ]
 )
 
-# Support exception for latest central and sensor 3.74 as per
+# Currently there are no support exceptions, the last one expired on 2024-06-30, see:
 # https://issues.redhat.com/browse/ROX-18223
-support_exceptions = [
-    ChartVersions(
-        central_version=latest_tag,
-        sensor_version=get_latest_helm_chart_version_for_specific_release(
-            "stackrox-secured-cluster-services", Release(major=3, minor=74)
-        ),
-    )
-]
+support_exceptions = []
 
 test_tuples.extend(
     support_exception

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -51,9 +51,8 @@ def get_data_from_api(url):
 def get_supported_versions():
     supported_central = []
     supported_sensor = []
-    response = get_data_from_api(PRODUCT_LIFECYCLES_API)
+    data = get_data_from_api(PRODUCT_LIFECYCLES_API)
 
-    data = json.loads(response.text)
     versions = data["data"][0]["versions"]
     for version in versions:
         if version["type"] != "End of life":

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -59,7 +59,7 @@ def get_supported_versions():
     data = json.loads(response.text)
     versions = data["data"][0]["versions"]
     for version in versions:
-        if version["type"] == "Full Support":
+        if version["type"] != "End of life":
             major = version["name"].split('.')[0]
             minor = version["name"].split('.')[1]
             supported_central.append(get_latest_helm_chart_version_for_specific_release(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -113,5 +113,4 @@ if len(test_tuples) > 0:
     ).run()
 else:
     logging.info("There are currently no supported older versions or support exceptions that require compatibility "
-             "testing.")
-
+                 "testing.")

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,6 +20,7 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
+    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -64,7 +64,7 @@ test_tuples.extend(
 
 # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
 # https://issues.redhat.com/browse/ROX-18223
-# TODO: remove this after confirming that it has not been extended
+# Remove it after confirming the support exception has not been extended
 support_exceptions = [
     ChartVersions(
         central_version=latest_tag,

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,6 +20,7 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
+    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])
@@ -63,7 +64,15 @@ test_tuples.extend(
 
 # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
 # https://issues.redhat.com/browse/ROX-18223
-support_exceptions = []
+# TODO: remove this after confirming that it has not been extended
+support_exceptions = [
+    ChartVersions(
+        central_version=latest_tag,
+        sensor_version=get_latest_helm_chart_version_for_specific_release(
+            "stackrox-secured-cluster-services", Release(major=3, minor=74)
+        ),
+    )
+]
 
 test_tuples.extend(
     support_exception

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,7 +20,6 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
-    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -112,6 +112,6 @@ if len(test_tuples) > 0:
         ),
     ).run()
 else:
-logging.info("There are currently no supported older versions or support exceptions that require compatibility "
+    logging.info("There are currently no supported older versions or support exceptions that require compatibility "
              "testing.")
 

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -41,11 +41,11 @@ def get_data_from_api(url):
         url=url,
         headers={'User-Agent': 'Mozilla/5.0'}
     )
-    response = urlopen(req)
-    response_bytes = response.read()
-    response_string = response_bytes.decode('utf-8')
-    data = json.loads(response_string)
-    return data
+    with urlopen(req) as response:
+        response_bytes = response.read()
+        response_string = response_bytes.decode('utf-8')
+        data = json.loads(response_string)
+        return data
 
 
 def get_supported_versions():

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -21,7 +21,6 @@ from post_tests import PostClusterTest, FinalPost
 from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
-    get_latest_helm_chart_versions,
     get_latest_helm_chart_version_for_specific_release,
 )
 
@@ -33,28 +32,12 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
-'''
-get_supported_versions() {
-
-    mapfile -t supported_versions < <(
-        curl -fsS "https://access.redhat.com/product-life-cycles/api/v1/products?name=Red%20Hat%20Advanced%20Cluster%20Security%20for%20Kubernetes" |
-jq -r '.data[0].versions[] | select(.type == "Full Support") | .name'
-)
-
-nversions="${#supported_versions[@]}"
-for ((i = nversions - 1; i >= 0; i = i - 1)); do
-echo "${supported_versions[$i]}"
-done
-
-echo "$release"
-}
-'''
-
 
 def get_supported_versions():
     supported_central = []
     supported_sensor = []
-    response = requests.get("https://access.redhat.com/product-life-cycles/api/v1/products?name=Red%20Hat%20Advanced%20Cluster%20Security%20for%20Kubernetes")
+    response = requests.get("https://access.redhat.com/product-life-cycles/api/v1/products?name="
+                            "Red%20Hat%20Advanced%20Cluster%20Security%20for%20Kubernetes")
     data = json.loads(response.text)
     versions = data["data"][0]["versions"]
     for version in versions:

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -6,12 +6,11 @@ Run version compatibility tests
 import json
 import logging
 import os
-import requests
 import subprocess
 import sys
-
 from collections import namedtuple
 from pathlib import Path
+import requests
 
 from pre_tests import (
     PreSystemTests,

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -40,9 +40,12 @@ latest_tag = subprocess.check_output(
     encoding="utf-8",
 ).strip()
 
-if len(central_chart_versions) == 0 and len(sensor_chart_versions) == 0:
-    logging.info("Found no older versions to test against according to the product lifecycles API. \n"
-                 "However versions with support exceptions will still be tested against.")
+if len(central_chart_versions) == 0:
+    logging.info("Found no older central chart versions to test against according to the product lifecycles API.")
+if len(sensor_chart_versions) == 0:
+    logging.info("Found no older sensor chart versions to test against according to the product lifecycles API.")
+if len(central_chart_versions) == 0 or len(sensor_chart_versions) == 0:
+    logging.info("However versions with support exceptions will still be tested against.")
 
 ChartVersions = namedtuple(
     "Chart_versions", ["central_version", "sensor_version"])


### PR DESCRIPTION
### Description

We now use an API call to figure out which versions are supported instead of testing against the last n in our gke-version-compatibility-tests

### User-facing documentation
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] added compatibility tests

#### How I validated my change

I manually ran the new python function and confirmed that it returned the correct versions (only 4.4 right now)

Compatibility tests are now testing nothing, this is intended. Refer to the product lifecycles API here:
https://access.redhat.com/product-life-cycles/api/v1/products?name=Red%20Hat%20Advanced%20Cluster%20Security%20for%20Kubernetes
Maintenance support is a new category introduced in 4.4 so once we release 4.5 OR add a support exception compatibility tests will have versions to test against again.

