### PR TITLE
fix(ui): Clarify usage of "Cluster Platform Type" in Platform CVEs

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -175,6 +175,12 @@ export const clusterSearchFilterConfig = {
             searchTerm: 'Cluster Type',
             inputType: 'autocomplete',
         },
+        'Platform Type': {
+            displayName: 'Platform Type',
+            filterChipLabel: 'Platform type',
+            searchTerm: 'Cluster Platform Type',
+            inputType: 'autocomplete',
+        },
     },
 } as const;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -121,7 +121,7 @@ function ClustersTable({
                         CVEs
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th sort={getSortParams(CLUSTER_TYPE_SORT_FIELD)}>Cluster type</Th>
+                    <Th sort={getSortParams(CLUSTER_TYPE_SORT_FIELD)}>Platform type</Th>
                     <Th sort={getSortParams(CLUSTER_KUBERNETES_VERSION_SORT_FIELD)}>
                         Kubernetes version
                     </Th>
@@ -144,7 +144,7 @@ function ClustersTable({
                                 <Td dataLabel="CVEs">
                                     {pluralize(clusterVulnerabilityCount, 'CVE')}
                                 </Td>
-                                <Td dataLabel="Cluster type">{displayClusterType(type)}</Td>
+                                <Td dataLabel="Platform type">{displayClusterType(type)}</Td>
                                 <Td dataLabel="Kubernetes version">
                                     {status?.orchestratorMetadata?.version ?? 'Unavailable'}
                                 </Td>


### PR DESCRIPTION
### Description

1. Changes the column header of the Clusters Table to "Platform Type" to more accurately reflect the displayed data
2. Adds the "Cluster Platform Type" search field in addition to the "Cluster Type" search field


### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

Verify column header change and addition of "Platform Type" search attribute.
![image](https://github.com/stackrox/stackrox/assets/1292638/b4b3a5df-54d7-4519-b0a1-d46831e8f6cf)

