### PR TITLE
ROX-25039: Add telemetry for workload cve exception requests

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -8,7 +8,6 @@ import {
     createDeferralVulnerabilityException,
     createFalsePositiveVulnerabilityException,
     isDeferralException,
-    isFalsePositiveException,
     updateVulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
 import useRestMutation from 'hooks/useRestMutation';

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -167,13 +167,8 @@ export type AnalyticsEvent =
     | {
           event: typeof WORKLOAD_CVE_DEFERRAL_EXCEPTION_REQUESTED;
           properties:
-              | {
-                    expiryType: 'TIME';
-                    expiresOn: string | null;
-                }
-              | {
-                    expiryType: 'ALL_CVE_FIXABLE' | 'ANY_CVE_FIXABLE';
-                };
+              | { expiryType: 'CUSTOM_DATE' | 'TIME'; expiryDays: number }
+              | { expiryType: 'ALL_CVE_FIXABLE' | 'ANY_CVE_FIXABLE' | 'INDEFINITE' };
       }
     | {
           event: typeof WORKLOAD_CVE_FALSE_POSITIVE_EXCEPTION_REQUESTED;

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -4,6 +4,7 @@ import { Telemetry } from 'types/config.proto';
 
 import { selectors } from 'reducers';
 import { UnionFrom, tupleTypeGuard } from 'utils/type.utils';
+import { ExceptionExpiry } from 'services/VulnerabilityExceptionService';
 
 // Event Name Constants
 // clusters
@@ -27,6 +28,10 @@ export const WATCH_IMAGE_SUBMITTED = 'Watch Image Submitted';
 export const WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED = 'Workload CVE Entity Context View';
 export const WORKLOAD_CVE_FILTER_APPLIED = 'Workload CVE Filter Applied';
 export const WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED = 'Workload CVE Default Filters Changed';
+export const WORKLOAD_CVE_DEFERRAL_EXCEPTION_REQUESTED =
+    'Workload CVE Deferral Exception Requested';
+export const WORKLOAD_CVE_FALSE_POSITIVE_EXCEPTION_REQUESTED =
+    'Workload CVE False Positive Exception Requested';
 export const COLLECTION_CREATED = 'Collection Created';
 export const VULNERABILITY_REPORT_CREATED = 'Vulnerability Report Created';
 export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Download Generated';
@@ -159,6 +164,21 @@ export type AnalyticsEvent =
               CVE_STATUS_FIXABLE: AnalyticsBoolean;
               CVE_STATUS_NOT_FIXABLE: AnalyticsBoolean;
           };
+      }
+    | {
+          event: typeof WORKLOAD_CVE_DEFERRAL_EXCEPTION_REQUESTED;
+          properties:
+              | {
+                    expiryType: 'TIME';
+                    expiresOn: string | null;
+                }
+              | {
+                    expiryType: 'ALL_CVE_FIXABLE' | 'ANY_CVE_FIXABLE';
+                };
+      }
+    | {
+          event: typeof WORKLOAD_CVE_FALSE_POSITIVE_EXCEPTION_REQUESTED;
+          properties: Record<string, never>;
       }
     /**
      * Tracks each time the user creates a collection.

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -4,7 +4,6 @@ import { Telemetry } from 'types/config.proto';
 
 import { selectors } from 'reducers';
 import { UnionFrom, tupleTypeGuard } from 'utils/type.utils';
-import { ExceptionExpiry } from 'services/VulnerabilityExceptionService';
 
 // Event Name Constants
 // clusters


### PR DESCRIPTION
### Description

Add telemetry events for when a CVE is Deferred or marked as False Positive.

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing
- [ ] contributed **no automated tests**

#### How I validated my change

Defer a CVE and verify that the correct tracking information is sent:
![image](https://github.com/stackrox/stackrox/assets/1292638/c52dc2cd-3822-49cc-9495-0ba5dc2c056a)
![image](https://github.com/stackrox/stackrox/assets/1292638/d343a649-9d99-45b4-a785-1bd945221542)
![image](https://github.com/stackrox/stackrox/assets/1292638/9699bd34-21f9-483b-b323-9f1a46a538c9)
![image](https://github.com/stackrox/stackrox/assets/1292638/0b3ffb72-41ee-45c8-85ae-55f929c94d92)
![image](https://github.com/stackrox/stackrox/assets/1292638/6f78158a-9094-4058-bae8-e2bd87dc9019)


Mark a CVE as False Positive and verify similarly:
![image](https://github.com/stackrox/stackrox/assets/1292638/cbbcd5da-370c-4580-8317-eac8ac4e1e57)
