### PR TITLE
chore(ui): remove tech preview label for Scanner V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-24173: A new export API `/v1/export/vuln-mgmt/workloads` for workload vulnerabilities has been added. It provides a performant way of exporting both deployments and images in a single query which will hold all relevant data for vulnerability management.
 - ROX-21768: Scanner V4 may now be configured to return partial Node.js results via `ROX_SCANNER_V4_PARTIAL_NODE_JS_SUPPORT` (default is `false`).
   - Scanner v2 (aka StackRox Scanner) always returned partial results for programming languages such that only packages with known vulnerabilities were returned. This flag allows users to enable this functionality in Scanner V4 for Node.js, only.
+- Scanner V4 is out of Tech Preview and is now Generally Available.
+  - StackRox Scanner (Scanner v2) continues to be the default scanner until a future release, but it is recommended to use Scanner V4 for more accurate image scan results.
 
 ### Removed Features
 

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -27,8 +27,8 @@ function ScannerV4IntegrationBanner() {
 
     const brandedText =
         branding.type === 'RHACS_BRANDING'
-            ? 'New Scanner V4 now available as Technical Preview in RHACS 4.4.'
-            : 'New Scanner V4 now available as Technical Preview in StackRox 4.4.';
+            ? 'New Scanner V4 now generally available in RHACS 4.4.'
+            : 'New Scanner V4 now generally available in StackRox 4.4.';
 
     const docsLink = (
         <a

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -27,8 +27,8 @@ function ScannerV4IntegrationBanner() {
 
     const brandedText =
         branding.type === 'RHACS_BRANDING'
-            ? 'New Scanner V4 now generally available in RHACS 4.4.'
-            : 'New Scanner V4 now generally available in StackRox 4.4.';
+            ? 'New Scanner V4 now generally available in RHACS 4.5.'
+            : 'New Scanner V4 now generally available in StackRox 4.5.';
 
     const docsLink = (
         <a

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -20,7 +20,6 @@ import { Traits } from 'types/traits.proto';
 import { TraitsOriginLabel } from 'Containers/AccessControl/TraitsOriginLabel';
 import { isUserResource } from 'Containers/AccessControl/traits';
 import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import { getIntegrationLabel } from './utils/integrationsList';
 import { getEditDisabledMessage, getIsMachineAccessConfig } from './utils/integrationUtils';
 import usePageState from './hooks/usePageState';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -35,13 +35,13 @@ export type IntegrationPageProps = {
 
 function IntegrationPage({ title, name, traits, children }: IntegrationPageProps): ReactElement {
     const permissions = useIntegrationPermissions();
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const {
         pageState,
         params: { source, type, id },
     } = usePageState();
     const typeLabel = getIntegrationLabel(source, type);
-    const isTechPreview = isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4';
+    // There is currently nothing relevant in Tech Preview.
+    const isTechPreview = false;
 
     const integrationsListPath = `${integrationsPath}/${source}/${type}`;
     const integrationEditPath = `${integrationsPath}/${source}/${type}/edit/${id as string}`;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ImageIntegrationsSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ImageIntegrationsSection.tsx
@@ -33,9 +33,7 @@ function ImageIntegrationsSection(): ReactElement {
                         label={label}
                         linkTo={getIntegrationsListPath(source, type)}
                         numIntegrations={countIntegrations(type)}
-                        isTechPreview={
-                            isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4'
-                        }
+                        isTechPreview={false}
                     />
                 );
             })}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -49,7 +49,6 @@ function IntegrationsListPage({
 }): ReactElement {
     const { source, type } = useParams();
     const integrations = useIntegrations({ source, type });
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const [deletingIntegrationIds, setDeletingIntegrationIds] = useState([]);
 
     const history = useHistory();
@@ -70,7 +69,8 @@ function IntegrationsListPage({
     const isScannerV4 = getIsScannerV4(source, type);
     const isCloudSource = getIsCloudSource(source);
 
-    const isTechPreview = isFeatureFlagEnabled('ROX_SCANNER_V4') && type === 'scannerv4';
+    // There is currently nothing relevant in Tech Preview.
+    const isTechPreview = false;
 
     function onDeleteIntegrations(ids) {
         setDeletingIntegrationIds(ids);

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -22,7 +22,6 @@ import { actions as cloudSourcesActions } from 'reducers/cloudSources';
 import { integrationsPath } from 'routePaths';
 
 import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useIntegrations from '../hooks/useIntegrations';
 import { getIntegrationLabel } from '../utils/integrationsList';
 import {


### PR DESCRIPTION
### Description

Move Scanner V4 into GA by removing UI labels. Somewhat reverts https://github.com/stackrox/stackrox/pull/10519

See 

### User-facing documentation

- [x] CHANGELOG is updated
- [x] Documentation PR is created and linked above - not quite, but there is a ticket which is assigned

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

TODO
