### PR TITLE
chore(ui): Fix accessibility issues in Network Graph tabs and button

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
@@ -59,6 +59,7 @@ const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
             <FlexItem className={buttonClassName}>
                 <Button
                     name={`entities.${idx as string}.entity.delete`}
+                    aria-label="Delete CIDR block"
                     onClick={onRemoveRow}
                     variant="plain"
                     icon={<TrashIcon />}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -15,9 +15,8 @@ import {
     LabelGroup,
     Stack,
     StackItem,
-    Text,
     TextContent,
-    TextVariants,
+    Title,
     EmptyStateHeader,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -55,15 +54,14 @@ function DetailSection({ title, children }) {
         setIsExpanded(_isExpanded);
     };
 
+    // TextContent so heading has black instead of blue color.
     return (
         <ExpandableSection
             isExpanded={isExpanded}
             onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
             toggleContent={
                 <TextContent>
-                    <Text component={TextVariants.h1} className="pf-v5-u-font-size-lg">
-                        {title}
-                    </Text>
+                    <Title headingLevel="h2">{title}</Title>
                 </TextContent>
             }
         >
@@ -284,8 +282,8 @@ function DeploymentDetails({
                         </DescriptionList>
                     </DetailSection>
                 </li>
-                <Divider component="li" className="pf-v5-u-mb-sm" />
                 <li>
+                    <Divider className="pf-v5-u-mb-sm" />
                     <DetailSection title="Deployment overview">
                         <Stack hasGutter>
                             <StackItem>
@@ -377,8 +375,8 @@ function DeploymentDetails({
                         </Stack>
                     </DetailSection>
                 </li>
-                <Divider component="li" className="pf-v5-u-mb-sm" />
                 <li>
+                    <Divider className="pf-v5-u-mb-sm" />
                     <DetailSection title="Port configurations">
                         {deployment.ports.length ? (
                             <Stack hasGutter>
@@ -400,8 +398,8 @@ function DeploymentDetails({
                         )}
                     </DetailSection>
                 </li>
-                <Divider component="li" className="pf-v5-u-mb-sm" />
                 <li>
+                    <Divider className="pf-v5-u-mb-sm" />
                     <DetailSection title="Container configurations">
                         {deployment.containers.length ? (
                             <Stack hasGutter>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -188,7 +188,7 @@ function DeploymentSideBar({
                             {hasReadAccessForNetworkPolicy && (
                                 <Tab
                                     eventKey={deploymentTabs.NETWORK_POLICIES}
-                                    tabContentId={deploymentTabs.NETWORK_POLICIES}
+                                    tabContentId="Network_policies"
                                     title={
                                         <TabTitleText>
                                             {deploymentTabs.NETWORK_POLICIES}
@@ -251,7 +251,7 @@ function DeploymentSideBar({
                         {hasReadAccessForNetworkPolicy && (
                             <TabContent
                                 eventKey={deploymentTabs.NETWORK_POLICIES}
-                                id={deploymentTabs.NETWORK_POLICIES}
+                                id="Network_policies"
                                 hidden={activeKeyTab !== deploymentTabs.NETWORK_POLICIES}
                             >
                                 <NetworkPolicies

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -93,7 +93,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                     />
                     <Tab
                         eventKey="Network policies"
-                        tabContentId="Network policies"
+                        tabContentId="Network_policies"
                         title={<TabTitleText>Network policies</TabTitleText>}
                     />
                 </Tabs>
@@ -108,7 +108,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                 </TabContent>
                 <TabContent
                     eventKey="Network policies"
-                    id="Network policies"
+                    id="Network_policies"
                     hidden={activeKeyTab !== 'Network policies'}
                     className="pf-v5-u-h-100"
                 >

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -70,7 +70,7 @@ export type NetworkPolicySimulatorSidePanelProps = {
 const tabs = {
     SIMULATE_NETWORK_POLICIES: 'Simulate network policies',
     VIEW_ACTIVE_YAMLS: 'View active YAMLS',
-};
+}; // space in visible text, but id has underscore!
 
 function NetworkPolicySimulatorSidePanel({
     simulator,
@@ -410,12 +410,12 @@ function NetworkPolicySimulatorSidePanel({
                 <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
                     <Tab
                         eventKey={tabs.SIMULATE_NETWORK_POLICIES}
-                        tabContentId={tabs.SIMULATE_NETWORK_POLICIES}
+                        tabContentId="Simulate_network_policies"
                         title={<TabTitleText>{tabs.SIMULATE_NETWORK_POLICIES}</TabTitleText>}
                     />
                     <Tab
                         eventKey={tabs.VIEW_ACTIVE_YAMLS}
-                        tabContentId={tabs.VIEW_ACTIVE_YAMLS}
+                        tabContentId="View_active_YAMLS"
                         title={<TabTitleText>{tabs.VIEW_ACTIVE_YAMLS}</TabTitleText>}
                     />
                 </Tabs>
@@ -423,7 +423,7 @@ function NetworkPolicySimulatorSidePanel({
             <StackItem isFilled style={{ overflow: 'auto' }}>
                 <TabContent
                     eventKey={tabs.SIMULATE_NETWORK_POLICIES}
-                    id={tabs.SIMULATE_NETWORK_POLICIES}
+                    id="Simulate_network_policies"
                     hidden={activeKeyTab !== tabs.SIMULATE_NETWORK_POLICIES}
                 >
                     <div className="pf-v5-u-p-lg pf-v5-u-h-100">
@@ -508,7 +508,7 @@ function NetworkPolicySimulatorSidePanel({
                 </TabContent>
                 <TabContent
                     eventKey={tabs.VIEW_ACTIVE_YAMLS}
-                    id={tabs.VIEW_ACTIVE_YAMLS}
+                    id="View_active_YAMLS"
                     hidden={activeKeyTab !== tabs.VIEW_ACTIVE_YAMLS}
                 >
                     <ViewActiveYAMLs

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/deploymentUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/deploymentUtils.ts
@@ -2,5 +2,5 @@ export const deploymentTabs = {
     DETAILS: 'Details',
     FLOWS: 'Flows',
     BASELINE: 'Baseline',
-    NETWORK_POLICIES: 'Network policies',
+    NETWORK_POLICIES: 'Network policies', // space in visible text, but id has underscore!
 };


### PR DESCRIPTION
### Description

### Details tab of side panel

**Problem** reported by axe DevTools

**Details** tab of side panel:

> `ul` and `ol` elements must only directly contain `<li>`, `<script>` or `template` elements

Related nodes

```html
<li class="pf-v5-c-divider pf-v5-u-mb-sm" role="separator"></li>
```

**Analysis**

DeploymentDetalis.tsx file:
1. Presentation `<Divider component="li" className="pf-v5-u-mb-sm" />` element is sibling to `DetailSection` items.
2. `DetailSection` items render `h1` instead of `h2` elements.

**Solution**

1. Move `Divider` element into `li` element.
2. Replace `Text` with `Title` and `h1` with `h2` heading level.

**Residue** Investigate why side panel has `role="dialog"` attribute.

### Network policies tab of side panel

**Problem**

> ARIA attributes must conform to valid values

```html
<button type="button" data-ouia-component-type="PF5/TabButton" data-ouia-safe="true" class="pf-v5-c-tabs__link" id="pf-tab-Network policies-pf-1719860480393ssajqkoypjg" aria-controls="Network policies" role="tab" aria-selected="true">
```

Invalid ARIA attribute value: `aria-controls="Network policies"`

**Analysis**

1. DeploymentSideBar.tsx file: Less visible because of import from deploymentUtils.ts file.
2. NamespaceSideBar.tsx file: Both `tabContentId="Network policies"` prop of `Tab` element and corresponding `id="Network policies"` prop of `TabContent` element include space, which is not valid in identifiers.

**Solution**

1. Replace constant with literal string.
2. Replace space with underscore.

### Network policy generator

**Problem**

> ARIA attributes must conform to valid values

Both tabs:

Invalid ARIA attribute value: `aria-controls="Simulate network policies"`

Invalid ARIA attribute value: `aria-controls="View active YAMLS"`

**Analsis** and **Solution**

### Manage CIDR blocks

**Problem**

> Buttons must have discernable text

```html
<button name="entities.0.entity.delete" aria-disabled="false" class="pf-v5-c-button pf-m-plain" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-plain-3">
```

**Analysis** and **Solution**

Add `aria-label` prop to `TrashIcon` element.

**Residue** Investigate landmark issues for modal.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4637358 - 4637358
        total 79 = 11754551 - 11754472
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `yarn start` in ui

### Manual testing

1. Visit /main/network-graph, select cluster, select namespace, and then click deployment in graph to open side panel with **Details** tab.

    * Before changes, see presence of accessibility issue.
        ![Details_presence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/0d3b87a6-9bcc-4a5d-8d58-69bfde13ddd7)

    * After changes, see absence of accessibility issue.
        ![Details_absence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/5bccfa2d-b8d0-4bed-bc70-1703969d97cb)

2. Click **Network policies** tab.

    * After changes, see absence of accessibility issue.
        ![Deployment_Network_policies_absence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/c9969671-f217-4174-ba6c-52a360531114)

3. Close side panel, click namespace in graph, and then click **Network policies** tab. Ditto.

4. Click **Network policy generator** button.

    * Before changes, see presence of accessibility issue.
        ![Network_policy_generator_presence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/e5900b74-88f7-4034-882c-60ad2fb7c156)

    * After changes, see absence of accessibility issue.
        ![Network_policy_generator_absence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/453ab6e2-3088-4dfb-96f0-5e45116351f9)

5. Click **Manage CIDR blocks** button.

    * Before changes, see presence of accessibility issue.
        ![Manage_CIDR_blocks_presence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/24bff463-8b72-4480-8c24-596367e6d528)

    * After changes, see absence of accessibility issue.
        ![Manage_CIDR_blocks_absence_of_issue](https://github.com/stackrox/stackrox/assets/11862657/9fe216fb-832a-47fb-8cc5-a32a5275a863)

### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js