### PR TITLE
ROX-25050: Replace temporary null for compliance lastScanTime

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -13,7 +13,6 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { ClusterCheckStatus } from 'services/ComplianceResultsService';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
@@ -25,7 +24,10 @@ import {
 import { SearchFilter } from 'types/search';
 
 import { coverageClusterDetailsPath } from './compliance.coverage.routes';
-import { getClusterResultsStatusObject } from './compliance.coverage.utils';
+import {
+    getClusterResultsStatusObject,
+    getTimeDifferenceAsPhrase,
+} from './compliance.coverage.utils';
 import { CHECK_STATUS_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
 import CheckStatusDropdown from './components/CheckStatusDropdown';
 import StatusIcon from './components/StatusIcon';
@@ -139,7 +141,7 @@ function CheckDetailsTable({
                                     status,
                                 } = clusterInfo;
                                 const clusterStatusObject = getClusterResultsStatusObject(status);
-                                const firstDiscoveredAsPhrase = getDistanceStrictAsPhrase(
+                                const lastScanTimeAsPhrase = getTimeDifferenceAsPhrase(
                                     lastScanTime,
                                     currentDatetime
                                 );
@@ -159,7 +161,7 @@ function CheckDetailsTable({
                                                 {clusterName}
                                             </Link>
                                         </Td>
-                                        <Td dataLabel="Last scanned">{firstDiscoveredAsPhrase}</Td>
+                                        <Td dataLabel="Last scanned">{lastScanTimeAsPhrase}</Td>
                                         <Td dataLabel="Compliance status">
                                             <StatusIcon clusterStatusObject={clusterStatusObject} />
                                         </Td>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -16,11 +16,14 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { ComplianceClusterOverallStats } from 'services/ComplianceCommon';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { TableUIState } from 'utils/getTableUIState';
 
 import { coverageClusterDetailsPath } from './compliance.coverage.routes';
-import { calculateCompliancePercentage, getStatusCounts } from './compliance.coverage.utils';
+import {
+    calculateCompliancePercentage,
+    getStatusCounts,
+    getTimeDifferenceAsPhrase,
+} from './compliance.coverage.utils';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
@@ -114,7 +117,7 @@ function ProfileClustersTable({
                                         totalCount
                                     );
                                     const progressBarId = `progress-bar-${clusterId}`;
-                                    const firstDiscoveredAsPhrase = getDistanceStrictAsPhrase(
+                                    const lastScanTimeAsPhrase = getTimeDifferenceAsPhrase(
                                         lastScanTime,
                                         currentDatetime
                                     );
@@ -135,7 +138,7 @@ function ProfileClustersTable({
                                                 </Link>
                                             </Td>
                                             <Td dataLabel="Last scanned" modifier="fitContent">
-                                                {firstDiscoveredAsPhrase}
+                                                {lastScanTimeAsPhrase}
                                             </Td>
                                             <Td dataLabel="Pass status" modifier="fitContent">
                                                 <StatusCountIcon

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -216,12 +216,6 @@ export function isScanConfigurationDisabled(
     return false;
 }
 
-export function getTimeDifferenceAsPhrase(iso8601: string, date: Date) {
-    // If initial numeric time is zero before initial scan on creation of scan schedule,
-    // return 0 seconds ago instead of 54 years ago (that is, since beginning of Unix epoch).
-    if (iso8601.slice(0, 10) === '1970-01-01') {
-        return '0 seconds ago';
-    }
-
-    return getDistanceStrictAsPhrase(iso8601, date);
+export function getTimeDifferenceAsPhrase(iso8601: string | null, date: Date) {
+    return iso8601 ? getDistanceStrictAsPhrase(iso8601, date) : 'Scanning now';
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
@@ -14,6 +14,7 @@ import {
 import { ComplianceCheckStatus, ComplianceCheckStatusCount } from 'services/ComplianceCommon';
 import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
 import { SearchFilter } from 'types/search';
+import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
 import { SCAN_CONFIG_NAME_QUERY } from '../compliance.constants';
 import {
@@ -213,4 +214,14 @@ export function isScanConfigurationDisabled(
     }
 
     return false;
+}
+
+export function getTimeDifferenceAsPhrase(iso8601: string, date: Date) {
+    // If initial numeric time is zero before initial scan on creation of scan schedule,
+    // return 0 seconds ago instead of 54 years ago (that is, since beginning of Unix epoch).
+    if (iso8601.slice(0, 10) === '1970-01-01') {
+        return '0 seconds ago';
+    }
+
+    return getDistanceStrictAsPhrase(iso8601, date);
 }


### PR DESCRIPTION
### Description

### Problem

Linda observed **54 years ago** in **Last scanned** column.

### Analysis

Thank you Brad, for digging me out of a mental ditch.

1. Several teammates observed that 2024 - 54 - 1970 (that is, ~beginning of Unix epoch~ `null` value).
2. ~It seems like initial numeric time is zero for a short time for initial scan~ Initial `lastScanTime` is `null` like `lastExecutedTime` on creation of scan schedule.
3. ~I tested that `new Date(0).toISOString()` is `1970-01-01T00:00:00Z` but compared with `slice(0, 10)` because central usually returns dates with many decimal places for seconds.~

### Solution

Follow example of conditional rendering for `lastExecutedTime` in compliance schedules

1. Edit getTimeDifferenceAsPhrase file.
    * Factor out `getTimeDifferenceAsPhrase` function to encapsulate details, including edge case.
2. Replace `getDistanceStrictAsPhrase` function call and also rename `lastScanTimeAsPhrase` variable. My bad to miss apparent copy paste before now.
    * CheckDetailsTable.tsx file
    * ProfileClustersTable.tsx file

### Residue

1. Why `lastScanTime: null` in Network panel for testing step 1? See updated **Analysis** for the reason.
    Replace `lastScanTime: string` with `lastScanTime: string | null` like `lastExecutedTime` property.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/compliance/coverage and click a check to visit check details page.

    * See **Last scanned** column but **Residue** item 1.
        ![CheckDetailsTable](https://github.com/stackrox/stackrox/assets/11862657/575bc93e-6b78-4228-ac8b-3d75ddb5465c)

3. Go back and click **Clusters** toggle.

    * See ordinary relative time in **Last scanned** column.
        ![ProfileClustersTable_ordinary](https://github.com/stackrox/stackrox/assets/11862657/b26c7195-b98e-4358-b196-8c020732356f)

    Temporarily edit components to simulate ~Unix epoch~ `null` value and verify what date-utils renders for now.

    * Before changes, see **54 years ago** in **Last scanned** column.
        ![ProfileClustersTable_54_yeara_ago](https://github.com/stackrox/stackrox/assets/11862657/ab7c8113-6aa9-4741-9322-6852b6b05d87)

    * After **obsolete incorrect** changes, see **0 seconds ago** in **Last scanned** column.
        ![ProfileClustersTable_0_seconda_ago](https://github.com/stackrox/stackrox/assets/11862657/4ff64e47-3b89-4137-862b-f48d2fecfc81)

    * After **updated correct** changes, see **Scanning now** in **Last scanned** column.
        ![ProfileClustersTable_Scanning_now](https://github.com/stackrox/stackrox/assets/11862657/08e9b1c1-e443-4ae5-b6cb-284cc2d3db89)
