### PR TITLE
fix: Operator: Reduce defaultwebhook timeout to 10 seconds

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -139,7 +139,8 @@ type AdmissionControlComponentSpec struct {
 	// Maximum timeout period for admission review, upon which admission review will fail open.
 	// Use it to set request timeouts when you enable inline image scanning.
 	// The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-	//+kubebuilder:default=20
+	// On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
+	//+kubebuilder:default=10
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:validation:Maximum=25
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=5

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -172,11 +172,12 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 20
+                    default: 10
                     description: |-
                       Maximum timeout period for admission review, upon which admission review will fail open.
                       Use it to set request timeouts when you enable inline image scanning.
                       The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
+                      On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
                     format: int32
                     maximum: 25
                     minimum: 1

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -172,11 +172,12 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 20
+                    default: 10
                     description: |-
                       Maximum timeout period for admission review, upon which admission review will fail open.
                       Use it to set request timeouts when you enable inline image scanning.
                       The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
+                      On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
                     format: int32
                     maximum: 25
                     minimum: 1


### PR DESCRIPTION
### Description

Reduce default admission controller webhook timeout within operator to 10 seconds
This has been overlooked in a previous PR.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG is updated (was done in [PR#11807](https://github.com/stackrox/stackrox/pull/11807)

Documentation will be covered in a separate PR.

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)

- [x] contributed **no automated tests**

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

change me!
