### PR TITLE
tests(sensor): ignore unexported fields

### DIFF
--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -622,8 +623,9 @@ func (m *detectionObjectMatcher) Matches(target interface{}) bool {
 		return false
 	}
 
-	if !cmp.Equal(m.expected, event.DetectorMessages) {
-		m.error = fmt.Sprintf("received detection deployment doesn't match expected: %s", cmp.Diff(m.expected, event.ReprocessDeployments))
+	diff := cmp.Diff(m.expected, event.DetectorMessages, cmpopts.IgnoreUnexported(storage.Deployment{}))
+	if len(diff) != 0 {
+		m.error = fmt.Sprintf("received detection deployment doesn't match expected: %s", diff)
 		m.acceptableNumberOfMismatches--
 		return m.acceptableNumberOfMismatches >= 0
 	}


### PR DESCRIPTION
### Description

Ignore unexported fields as in proto v2 there are some that are different in every object e.g. internal mutex.
This PR also extracts `diff` and use it instead of `cmp.Equal` to compare same objects as current code compares different types slices of structs and strings.

- https://github.com/stackrox/stackrox/pull/3895/files#r1662409083

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->


