### PR TITLE
fix(ui): Swap node cve list from operatingSystem to osImage

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -98,14 +98,8 @@ function NodesTable({
                 filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((node) => {
-                        const {
-                            id,
-                            name,
-                            nodeCVECountBySeverity,
-                            cluster,
-                            operatingSystem,
-                            scanTime,
-                        } = node;
+                        const { id, name, nodeCVECountBySeverity, cluster, osImage, scanTime } =
+                            node;
                         const { critical, important, moderate, low } = nodeCVECountBySeverity;
                         return (
                             <Tr key={id}>
@@ -127,7 +121,7 @@ function NodesTable({
                                     <Truncate position="middle" content={cluster.name} />
                                 </Td>
                                 <Td dataLabel="Operating system" modifier="nowrap">
-                                    {operatingSystem}
+                                    <Truncate position="middle" content={osImage} />
                                 </Td>
                                 <Td dataLabel="Scan time">
                                     <DateDistance date={scanTime} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -26,13 +26,12 @@ const nodeListQuery = gql`
             cluster {
                 name
             }
-            operatingSystem
+            osImage
             scanTime
         }
     }
 `;
 
-// TODO - Verify these types once the BE is implemented
 type Node = {
     id: string;
     name: string;
@@ -53,8 +52,7 @@ type Node = {
     cluster: {
         name: string;
     };
-    // TODO Swap this to the osImage field
-    operatingSystem: string;
+    osImage: string;
     scanTime: string;
 };
 


### PR DESCRIPTION
### Description

Changes the `operatingSystem` field to `osImage` in the Node CVE node list. This shows the actual operating system in use, instead of just "linux", etc.

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

![image](https://github.com/stackrox/stackrox/assets/1292638/b57a2bfc-e5d0-401a-86dd-d368041218bc)
