### PR TITLE
tests: prohibit go-cmp.Diff on proto objects

### DIFF
--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -594,9 +594,9 @@ func (m *deploymentMatcher) Matches(target interface{}) bool {
 			return m.acceptableNumberOfMismatches >= 0
 		}
 
-		if !protoutils.SlicesEqual(m.expectedExposureInfos, deployment.GetPorts()[0].GetExposureInfos()) {
-			diff := cmp.Diff(m.expectedExposureInfos, deployment.GetPorts()[0].GetExposureInfos())
-			m.error = fmt.Sprintf("Exposure info differs: %s", diff)
+		infos := deployment.GetPorts()[0].GetExposureInfos()
+		if !protoutils.SlicesEqual(m.expectedExposureInfos, infos) {
+			m.error = fmt.Sprintf("Exposure info differs: %+v %+v", m.expectedExposureInfos, infos)
 			m.acceptableNumberOfMismatches--
 			return m.acceptableNumberOfMismatches >= 0
 		}

--- a/tests/client_ca_test.go
+++ b/tests/client_ca_test.go
@@ -13,13 +13,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
@@ -27,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/tokenbased"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,7 +182,7 @@ func TestClientCAAuthWithMultipleVerifiedChains(t *testing.T) {
 	authStatus, err := getAuthStatus(t, tlsConfWithLeaf, "")
 	require.NoError(t, err)
 	validateAuthStatusResponseForClientCert(t, leafCert, authStatus)
-	assert.Empty(t, cmp.Diff(createdAuthProvider, authStatus.GetAuthProvider(), cmpopts.IgnoreFields(storage.AuthProvider{}, "Config")))
+	validateEqualExceptFields(t, createdAuthProvider, authStatus.GetAuthProvider(), "config")
 
 	// Simulate the flow used in the browser, where the certs are exchanged for a token.
 	token := getTokenForUserPKIAuthProvider(t, createdAuthProvider.GetId(), tlsConfWithLeaf)
@@ -198,9 +198,25 @@ func TestClientCAAuthWithMultipleVerifiedChains(t *testing.T) {
 	// Token plus matching cert => things should work.
 	authStatusWithToken, err := getAuthStatus(t, tlsConfWithLeaf, token)
 	require.NoError(t, err)
-	assert.Empty(t, cmp.Diff(createdAuthProvider, authStatusWithToken.GetAuthProvider(),
-		cmpopts.IgnoreFields(storage.AuthProvider{}, "Config", "Validated", "Active", "LastUpdated")))
+	validateEqualExceptFields(t, createdAuthProvider, authStatusWithToken.GetAuthProvider(),
+		"Config", "Validated", "Active", "LastUpdated")
 	validateAuthStatusResponseForClientCert(t, leafCert, authStatusWithToken)
+}
+
+func validateEqualExceptFields(t *testing.T, a, b *storage.AuthProvider, ignore ...string) bool {
+	t.Helper()
+	x := copyAndResetFields(a, ignore...)
+	y := copyAndResetFields(b, ignore...)
+	return protoassert.Equal(t, x, y)
+}
+
+func copyAndResetFields(a *storage.AuthProvider, fields ...string) *storage.AuthProvider {
+	x := a.Clone()
+	elem := reflect.ValueOf(&x).Elem()
+	for _, f := range fields {
+		elem.FieldByName(f).SetZero()
+	}
+	return x
 }
 
 func TestClientCARequested(t *testing.T) {

--- a/tools/roxvet/analyzers/donotcompareproto/analyzer.go
+++ b/tools/roxvet/analyzers/donotcompareproto/analyzer.go
@@ -40,6 +40,7 @@ var (
 
 	bannedEqualFunctions = set.NewFrozenStringSet(
 		"github.com/google/go-cmp/cmp.Equal",
+		"github.com/google/go-cmp/cmp.Diff",
 		"reflect.DeepEqual",
 	)
 


### PR DESCRIPTION
### Description

This PR prevents usage of `Diff` on proto objects.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

change me!
