### PR TITLE
fix(ui): Update query fields used for node component fixability

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -49,11 +49,6 @@ export const nodeVulnerabilityFragment = gql`
         scoreVersion
         nodeComponents(query: $query) {
             ...NodeComponentFragment
-            nodeVulnerabilities(query: $query) {
-                severity
-                isFixable
-                fixedByVersion
-            }
         }
     }
 `;
@@ -63,13 +58,7 @@ export type NodeVulnerability = {
     summary: string;
     cvss: number;
     scoreVersion: string;
-    nodeComponents: (NodeComponent & {
-        nodeVulnerabilities: {
-            severity: string;
-            isFixable: boolean;
-            fixedByVersion: string;
-        }[];
-    })[];
+    nodeComponents: NodeComponent[];
 };
 
 export type CVEsTableProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -58,6 +58,8 @@ export const affectedNodeFragment = gql`
             nodeVulnerabilities(query: $query) {
                 vulnerabilityId: id
                 cve
+                severity
+                fixedByVersion
                 cvss
                 scoreVersion
             }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -58,8 +58,6 @@ export const affectedNodeFragment = gql`
             nodeVulnerabilities(query: $query) {
                 vulnerabilityId: id
                 cve
-                severity
-                fixedByVersion
                 cvss
                 scoreVersion
             }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -29,7 +29,11 @@ export const nodeComponentFragment = gql`
         name
         source
         version
-        fixedIn
+        nodeVulnerabilities(query: $query) {
+            severity
+            isFixable
+            fixedByVersion
+        }
     }
 `;
 
@@ -37,7 +41,11 @@ export type NodeComponent = {
     name: string;
     source: string;
     version: string;
-    fixedIn: string;
+    nodeVulnerabilities: {
+        severity: string;
+        isFixable: boolean;
+        fixedByVersion: string;
+    }[];
 };
 
 const sortFields = ['Component', 'Type'];
@@ -63,20 +71,25 @@ function NodeComponentsTable({ data }: NodeComponentsTableProps) {
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th sort={getSortParams('Type')}>Type</Th>
                     <Th>Version</Th>
-                    <Th>Fixed in</Th>
+                    <Th>CVE fixed in</Th>
                 </Tr>
             </Thead>
             <Tbody>
-                {sortedData.map(({ name, source, version, fixedIn }) => (
-                    <Tr key={name}>
-                        <Td dataLabel="Component">{name}</Td>
-                        <Td dataLabel="Type">{source}</Td>
-                        <Td dataLabel="Version">{version}</Td>
-                        <Td dataLabel="Fixed in">
-                            {fixedIn || <VulnerabilityFixableIconText isFixable={false} />}
-                        </Td>
-                    </Tr>
-                ))}
+                {sortedData.map(({ name, source, version, nodeVulnerabilities }) => {
+                    const fixedByVersion = nodeVulnerabilities?.[0]?.fixedByVersion;
+                    return (
+                        <Tr key={name}>
+                            <Td dataLabel="Component">{name}</Td>
+                            <Td dataLabel="Type">{source}</Td>
+                            <Td dataLabel="Version">{version}</Td>
+                            <Td dataLabel="CVE fixed in">
+                                {fixedByVersion || (
+                                    <VulnerabilityFixableIconText isFixable={false} />
+                                )}
+                            </Td>
+                        </Tr>
+                    );
+                })}
             </Tbody>
         </Table>
     );


### PR DESCRIPTION
### Description

Fixes the query fields used to determine the fixability and fix version of a node component for a given CVE.

### The problem:

Using one example -- in staging the Node `staging-secured-clust-pnltj-worker-d-qd577` has CVE `RHSA-2024:1897` which is declared to be "Fixable". However expanding the node component list shows all affected components as "Not fixable".
![image](https://github.com/stackrox/stackrox/assets/1292638/d502eced-1bd8-41c0-8f84-4796c27224d1)

The VM 1.0 Dashboard lists this as "Fixable" as well, but unfortunately does not show the fixability or fix version on a per component level:
![image](https://github.com/stackrox/stackrox/assets/1292638/0e85e6f4-c9d0-4c08-8ee6-aa8f04fac5dd)
![image](https://github.com/stackrox/stackrox/assets/1292638/0e92167d-d45d-45a4-8c9f-c8eba3cc6135)

It appears the problem is due to the `nodeVulnerabilities.nodeComponents.fixedIn` field of the following query being an empty string:
```graphql
    node(id: $id) {
		id
		nodeVulnerabilities(query: $query, pagination: $pagination) {
			cve
			summary
			cvss
			scoreVersion
			nodeComponents(query: $query) {
				name
				source
				version
				fixedIn
				nodeVulnerabilities(query: $query) {
					cve
					severity
					isFixable
				}
			}
		}
	}
```
Instead, if we used the `nodeVulnerabilities.nodeComponents.nodeVulnerabilities.fixedByVersion` field, we can get the component version that fixes the CVE:
```diff
    node(id: $id) {
		id
		nodeVulnerabilities(query: $query, pagination: $pagination) {
			cve
			summary
			cvss
			scoreVersion
			nodeComponents(query: $query) {
				name
				source
				version
-				fixedIn
				nodeVulnerabilities(query: $query) {
					cve
					severity
					isFixable
+                                       fixedByVersion
				}
			}
		}
	}
```

Verifying the change against staging show each component with it's associated fix version:
![image](https://github.com/stackrox/stackrox/assets/1292638/099e5ff2-d138-4218-8ea6-6cb22377bb0d)


### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing


- [ ] contributed **no automated tests**


#### How I validated my change

See description above for testing on Node page. Perform a similar check on the Node CVE page:
![image](https://github.com/stackrox/stackrox/assets/1292638/5d6c66bb-b0fa-4f95-9849-dbc7c4f0b8a3)
