### PR TITLE
fix(ui): Remove Node Top CVSS filter option

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -214,12 +214,6 @@ export const nodeSearchFilterConfig = {
             searchTerm: 'Operating System',
             inputType: 'text',
         },
-        'Top CVSS': {
-            displayName: 'Top CVSS',
-            filterChipLabel: 'Node top CVSS',
-            searchTerm: 'Node Top CVSS',
-            inputType: 'condition-number',
-        },
         Label: {
             displayName: 'Label',
             filterChipLabel: 'Node label',


### PR DESCRIPTION
### Description

Removes the "Node Top CVSS" filter option. This corresponds to the removal of "Image Top CVSS" from Workload CVEs, as it's presence is confusing and can lead to unexpected filter results. Additionally, we do not display the "Node Top CVSS" value anywhere so it is easy to confuse it with regular "Node CVE CVSS".

The "Top CVSS" value on the CVE list page is the highest CVSS value _for that CVE_ across all nodes, but is not necessarily the "Node Top CVSS":
![image](https://github.com/stackrox/stackrox/assets/1292638/459db9ed-42bf-4036-b809-39557b4947a7)

The "CVSS score" value on the Node CVE single page is the CVSS for a particular node _for the selected CVE_ and again does not necessarily equal the "Node Top CVSS" for that node.
![image](https://github.com/stackrox/stackrox/assets/1292638/1b45bae2-4a1f-4b1f-888e-9ade35fbe0b5)

In either case, applying a filter of "Node Top CVSS: < 9" in the below example might seem like it would filter to include all of the nodes, since their listed CVSS for the CVE is less than 9, but it instead removes all results, because each Node that appears in the list actually has a Top CVSS of "9.1". This 9.1 CVSS is data that is not explicitly listed anywhere in the current UI.
![image](https://github.com/stackrox/stackrox/assets/1292638/73cc7caf-7746-4553-a542-ac0a5e2eccbb)
![image](https://github.com/stackrox/stackrox/assets/1292638/26322782-faba-472d-b118-8383a228e333)


### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

Test that the Node Top CVSS filter option no longer appears.