### PR TITLE
fix(ui): Handle widget when stats not available

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { Route, Switch, useParams } from 'react-router-dom';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -76,8 +76,6 @@ function CoveragesPage() {
     const fetchProfilesStats = useCallback(async () => {
         setSelectedProfileStats(undefined);
         const response = await getComplianceProfilesStats();
-        // Prevents a page shift when only relying on the useEffect below. Otherwise, stats will be finished loading
-        // but selectedProfileStats will be undefined for a moment causing the widget container to not render.
         if (response) {
             const profileStats = response.scanStats.find(
                 (profile) => profile.profileName === profileName
@@ -87,16 +85,8 @@ function CoveragesPage() {
         return response;
     }, [profileName]);
 
-    const {
-        loading: isLoadingProfilesStats,
-        error: profilesStatsError,
-        refetch: refetchProfilesStats,
-    } = useRestQuery(fetchProfilesStats);
-
-    // Refetch profiles stats when profileName changes to stay more in sync with the data in the table
-    useEffect(() => {
-        refetchProfilesStats();
-    }, [profileName, refetchProfilesStats]);
+    const { loading: isLoadingProfilesStats, error: profilesStatsError } =
+        useRestQuery(fetchProfilesStats);
 
     function handleProfilesToggleChange(selectedProfile: string) {
         navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -74,6 +74,7 @@ function CoveragesPage() {
     };
 
     const fetchProfilesStats = useCallback(async () => {
+        setSelectedProfileStats(undefined);
         const response = await getComplianceProfilesStats();
         // Prevents a page shift when only relying on the useEffect below. Otherwise, stats will be finished loading
         // but selectedProfileStats will be undefined for a moment causing the widget container to not render.
@@ -87,7 +88,6 @@ function CoveragesPage() {
     }, [profileName]);
 
     const {
-        data: profilesStatsResponse,
         loading: isLoadingProfilesStats,
         error: profilesStatsError,
         refetch: refetchProfilesStats,
@@ -95,18 +95,8 @@ function CoveragesPage() {
 
     // Refetch profiles stats when profileName changes to stay more in sync with the data in the table
     useEffect(() => {
-        setSelectedProfileStats(undefined);
         refetchProfilesStats();
     }, [profileName, refetchProfilesStats]);
-
-    useEffect(() => {
-        if (profilesStatsResponse) {
-            const profileStats = profilesStatsResponse.scanStats.find(
-                (profile) => profile.profileName === profileName
-            );
-            setSelectedProfileStats(profileStats);
-        }
-    }, [profilesStatsResponse, profileName]);
 
     function handleProfilesToggleChange(selectedProfile: string) {
         navigateWithScanConfigQuery(coverageProfileChecksPath, { profileName: selectedProfile });


### PR DESCRIPTION
### Description

The widget should not be displayed when there are no stats yet available to display.

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

#### How I validated my change

After immediately creating a scan schedule, while waiting on stats to be available

https://github.com/stackrox/stackrox/assets/61400697/5e506a33-3bb2-424c-bf84-0f0f28e47ac3


