### PR TITLE
ROX-23789: ScanConfig sync in Central

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -55,7 +55,7 @@ var (
 		},
 	})
 
-	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
+	configNameRegexp = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`)
 
 	reservedConfigNames = []string{"default", "default-auto-apply"}
 )

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -343,7 +343,11 @@ func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 		return errors.Wrap(errox.InvalidArgs, "At least one cluster is required for a scan configuration")
 	}
 
-	if req.GetScanConfig() == nil || len(req.GetScanConfig().GetProfiles()) == 0 {
+	if req.GetScanConfig() == nil {
+		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil.")
+	}
+
+	if len(req.GetScanConfig().GetProfiles()) == 0 {
 		return errors.Wrap(errox.InvalidArgs, "At least one profile is required for a scan configuration")
 	}
 

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -55,7 +55,7 @@ var (
 		},
 	})
 
-	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*[a-z0-9]?$`)
+	configNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
 
 	reservedConfigNames = []string{"default", "default-auto-apply"}
 )

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -177,7 +177,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	request.ScanConfig = nil
 	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 	s.Require().Nil(config)
 
 	request = getTestAPIRec()
@@ -220,7 +220,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	request.ScanConfig = nil
 	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 
 	// Test Case 4: No clusters
 	request = getTestAPIRec()

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -520,7 +520,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 		return nil, err
 	}
 
-	var reformatedConfigs []*central.ApplyComplianceScanConfigRequest
+	var reformattedConfigs []*central.ApplyComplianceScanConfigRequest
 	for _, scanConfig := range scanConfigs {
 		var profiles []string
 		for _, profile := range scanConfig.GetProfiles() {
@@ -542,7 +542,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 				},
 			},
 		}
-		reformatedConfigs = append(reformatedConfigs, &scanConfigRequest)
+		reformattedConfigs = append(reformattedConfigs, &scanConfigRequest)
 	}
 
 	return &central.MsgToSensor{
@@ -550,7 +550,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 			ComplianceRequest: &central.ComplianceRequest{
 				Request: &central.ComplianceRequest_SyncScanConfigs{
 					SyncScanConfigs: &central.SyncComplianceScanConfigRequest{
-						ScanConfigs: reformatedConfigs,
+						ScanConfigs: reformattedConfigs,
 					},
 				},
 			},
@@ -753,8 +753,6 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		}
 	}
 
-	metrics.IncrementSensorConnect(c.clusterID, c.sensorHello.GetSensorState().String())
-
 	scanMsg, err := c.getScanConfigurationMsg(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get scan config for %q", c.clusterID)
@@ -762,6 +760,8 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 	if err := server.Send(scanMsg); err != nil {
 		return errors.Wrapf(err, "unable to sync config to cluster %q", c.clusterID)
 	}
+
+	metrics.IncrementSensorConnect(c.clusterID, c.sensorHello.GetSensorState().String())
 
 	c.runRecv(ctx, server)
 	return c.stopSig.Err()

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -755,7 +755,7 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		}
 	}
 
-	if features.ComplianceEnhancements.Enabled() {
+	if features.ComplianceEnhancements.Enabled() && connectionCapabilities.Contains(centralsensor.ComplianceV2ScanConfigSync) {
 		log.Infof("Sensor (%s) can sync scan configuration: sending sending scan configuration", c.clusterID)
 		scanMsg, err := c.getScanConfigurationMsg(ctx)
 		if err != nil {

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -757,10 +757,12 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 	}
 
 	if features.ComplianceEnhancements.Enabled() && connectionCapabilities.Contains(centralsensor.ComplianceV2Integrations) {
+		log.Infof("Sensor (%s) can sync scan configuration: sending sending scan configuration", c.clusterID)
 		scanMsg, err := c.getScanConfigurationMsg(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get scan config for %q", c.clusterID)
 		}
+		log.Infof("sending %d scan configs to sensor", len(scanMsg.GetComplianceRequest().GetSyncScanConfigs().GetScanConfigs()))
 		if err := server.Send(scanMsg); err != nil {
 			return errors.Wrapf(err, "unable to sync config to cluster %q", c.clusterID)
 		}

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -532,6 +532,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 						StrictNodeScan: true,
 						Profiles:       profiles,
 					},
+					Cron: scanConfig.Schedule.String(),
 				},
 			},
 		}

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -756,7 +756,7 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		}
 	}
 
-	if features.ComplianceEnhancements.Enabled() && connectionCapabilities.Contains(centralsensor.ComplianceV2Integrations) {
+	if features.ComplianceEnhancements.Enabled() {
 		log.Infof("Sensor (%s) can sync scan configuration: sending sending scan configuration", c.clusterID)
 		scanMsg, err := c.getScanConfigurationMsg(ctx)
 		if err != nil {

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -526,8 +526,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 		for _, profile := range scanConfig.GetProfiles() {
 			profiles = append(profiles, profile.GetProfileName())
 		}
-		var cron string
-		cron, err = schedule.ConvertToCronTab(scanConfig.GetSchedule())
+		cron, err := schedule.ConvertToCronTab(scanConfig.GetSchedule())
 		if err != nil {
 			return nil, err
 		}

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -123,7 +123,7 @@ func (s *testSuite) TestSendsScanConfigurationMsgOnRun() {
 		sentList: make([]*central.MsgToSensor, 0),
 	}
 
-	err := sensorMockConn.Run(ctx, server, set.NewSet[centralsensor.SensorCapability](centralsensor.ComplianceV2Integrations))
+	err := sensorMockConn.Run(ctx, server, set.NewSet[centralsensor.SensorCapability](centralsensor.ComplianceV2ScanConfigSync))
 	s.NoError(err)
 
 	var complianceRequests []*central.ComplianceRequest

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -112,7 +112,7 @@ func (s *testSuite) TestSendsScanConfigurationMsgOnRun() {
 		sendC:              make(chan *central.MsgToSensor),
 	}
 
-	mgrMock.EXPECT().GetCluster(ctx, gomock.Any()).Return(&storage.Cluster{}, true, nil).AnyTimes()
+	mgrMock.EXPECT().GetCluster(ctx, gomock.Any()).Return(&storage.Cluster{}, true, nil).Times(2)
 	s.scanConfigDS.EXPECT().GetScanConfigurations(ctx, gomock.Any()).Return(scanConfigs, nil).Times(1)
 
 	server := &mockServer{

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -54,4 +54,7 @@ const (
 
 	// NetworkGraphInternalEntitiesSupported identifies the capability of Central (UI) to display internal entities in the network graph.
 	NetworkGraphInternalEntitiesSupported = "NetworkGraphInternalEntitiesSupported"
+
+	// ComplianceV2ScanConfigSync identifies the capability of sensor to support scan configuration sync when connecting to central.
+	ComplianceV2ScanConfigSync SensorCapability = "ComplianceV2ScanConfigSync"
 )

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -52,5 +52,11 @@
         "job": "upgrade",
         "logfile": "sensor-previous",
         "logline": "checking central status failed after"
+    },
+    {
+        "comment": "collector restart due to sensor bounce in compliance test",
+        "job": "compliance-e2e-tests",
+        "logfile": "collector-previous",
+        "logline": "Socket closed"
     }
 ]

--- a/sensor/kubernetes/complianceoperator/env.go
+++ b/sensor/kubernetes/complianceoperator/env.go
@@ -1,0 +1,7 @@
+package complianceoperator
+
+import "github.com/stackrox/rox/pkg/env"
+
+var (
+	syncScanConfigsOnStartup = env.RegisterBooleanSetting("ROX_SYNC_SCAN_CONFIGS_ON_STARTUP", true)
+)

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -77,7 +77,7 @@ func (m *handlerImpl) Stop(_ error) {
 func (m *handlerImpl) Notify(_ common.SensorComponentEvent) {}
 
 func (m *handlerImpl) Capabilities() []centralsensor.SensorCapability {
-	return nil
+	return []centralsensor.SensorCapability{centralsensor.ComplianceV2ScanConfigSync}
 }
 
 func (m *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -77,7 +77,10 @@ func (m *handlerImpl) Stop(_ error) {
 func (m *handlerImpl) Notify(_ common.SensorComponentEvent) {}
 
 func (m *handlerImpl) Capabilities() []centralsensor.SensorCapability {
-	return []centralsensor.SensorCapability{centralsensor.ComplianceV2ScanConfigSync}
+	if syncScanConfigsOnStartup.BooleanSetting() {
+		return []centralsensor.SensorCapability{centralsensor.ComplianceV2ScanConfigSync}
+	}
+	return nil
 }
 
 func (m *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -87,6 +87,7 @@ func (m *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
 	}
 	// Sync Scan Configs is done during the syncing process between Sensor and Central
 	if _, ok := req.GetRequest().(*central.ComplianceRequest_SyncScanConfigs); ok {
+		log.Info("received scan config sync from central")
 		return m.handleSyncScanCfgRequest(req.GetSyncScanConfigs())
 	}
 
@@ -472,6 +473,7 @@ func (m *handlerImpl) handleSyncScanCfgRequest(request *central.SyncComplianceSc
 		case <-m.stopSignal.Done():
 			return
 		case <-m.complianceIsReady.Done():
+			log.Debugf("compliance is ready. Starting the reconciliation of %d scan configs", len(request.GetScanConfigs()))
 			if err := m.processSyncScanCfg(request); err != nil {
 				log.Error(err)
 				return

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -256,7 +256,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 			Id: res.GetId(),
 		}
 		_, _ = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
-		cleanUpResourcesAndWait(ctx, t, scanName, coNamespace)
+		cleanUpResources(ctx, t, scanName, coNamespace)
 	})
 
 	// Scale up Sensor

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -230,7 +230,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	// Create the ScanConfiguration service
-	service := v2.NewComplianceScanConfigurationServiceClient(conn)
+	scanConfigService := v2.NewComplianceScanConfigurationServiceClient(conn)
 
 	// Get cluster ID
 	serviceCluster := v1.NewClustersServiceClient(conn)
@@ -247,7 +247,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	waitForDeploymentReady(ctx, t, "sensor", stackroxNamespace, 0)
 
 	// Create ScanConfig in Central
-	res, err := service.CreateComplianceScanConfiguration(ctx, &scanConfig)
+	res, err := scanConfigService.CreateComplianceScanConfiguration(ctx, &scanConfig)
 	assert.NoError(t, err)
 
 	// Cleanup just in case the test fails
@@ -255,7 +255,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 		reqDelete := &v2.ResourceByID{
 			Id: res.GetId(),
 		}
-		_, _ = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
+		_, _ = scanConfigService.DeleteComplianceScanConfiguration(ctx, reqDelete)
 		cleanUpResources(ctx, t, scanName, coNamespace)
 	})
 
@@ -279,7 +279,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	scanConfig.Id = res.GetId()
 	scanConfig.ScanConfig.Profiles = updatedProfiles
 	scanConfig.ScanConfig.ScanSchedule = updatedSchedule
-	_, err = service.UpdateComplianceScanConfiguration(ctx, &scanConfig)
+	_, err = scanConfigService.UpdateComplianceScanConfiguration(ctx, &scanConfig)
 	assert.NoError(t, err)
 
 	// Scale up Sensor
@@ -300,7 +300,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	reqDelete := &v2.ResourceByID{
 		Id: res.GetId(),
 	}
-	_, err = service.DeleteComplianceScanConfiguration(ctx, reqDelete)
+	_, err = scanConfigService.DeleteComplianceScanConfiguration(ctx, reqDelete)
 
 	// Scale up Sensor
 	assert.NoError(t, scaleToN(ctx, k8sClient, "sensor", stackroxNamespace, 1))


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

Central sends the scan configuration to Sensor on startup (if any).

This feature can be disabled by setting the environment variable`ROX_SYNC_SCAN_CONFIGS_ON_STARTUP` to `false` in sensor.

Note: Since this test scales down sensor, it could happen that collector pods restart. In order to prevent the test for failing due to unexpected collector restarts, I've added an exception for the compliance-e2e tests.

- [1808518704468594688](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11827/pull-ci-stackrox-stackrox-master-ocp-4-12-compliance-e2e-tests/1808518704468594688) [1808518720402755584](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11827/pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/1808518720402755584) runs that failed before the exception.
- [1808560523524968448](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11827/pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/1808560523524968448) [1808754867989123072](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11827/pull-ci-stackrox-stackrox-master-ocp-4-12-compliance-e2e-tests/1808754867989123072) [1808754868026871808](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11827/pull-ci-stackrox-stackrox-master-ocp-4-15-compliance-e2e-tests/1808754868026871808) runs that passed even though collector pods restarted.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] added unit tests
- [x] added e2e tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

- [x] Unit tests pass manually
- [x] Unit tests pass in CI
- [x] Compliance e2e test pass manually
- [x] Compliance e2e test pass in CI
- [x] Manual test in an OCP cluster: creating, updating, and deleting scan configurations while sensor is disconnected from central.
