### PR TITLE
ROX-22019: Add protomock to check expected proto structs

### DIFF
--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/protomock"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -303,7 +304,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlerts() {
 	expectedMergedAlert.Violations = append(expectedMergedAlert.Violations, alerts[0].Violations...)
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should notify
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
@@ -331,7 +332,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsNoNotify() {
 	expectedMergedAlert.Violations = append(expectedMergedAlert.Violations, alerts[0].Violations...)
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should not notify
 
@@ -389,7 +390,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsKeepsNewViolationsIfM
 	expectedMergedAlert.Violations = expectedMergedAlert.Violations[:maxRunTimeViolationsPerAlert]
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should notify if set to
 	if env.NotifyOnEveryRuntimeEvent() {
@@ -423,7 +424,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsKeepsNewViolationsIfM
 	expectedMergedAlert.Violations = expectedMergedAlert.Violations[:maxRunTimeViolationsPerAlert]
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should not notify
 
@@ -452,7 +453,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsOnlyKeepsMaxViolation
 	expectedMergedAlert := newAlert.Clone()
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should notify if set to
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
@@ -483,7 +484,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsOnlyKeepsMaxViolation
 	expectedMergedAlert := newAlert.Clone()
 
 	// Only the merged alert will be updated.
-	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, expectedMergedAlert).Return(nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, protomock.GoMockMatcherEqualMessage(expectedMergedAlert)).Return(nil)
 
 	// Updated alert should not notify
 

--- a/central/serviceaccount/service/service_impl_test.go
+++ b/central/serviceaccount/service/service_impl_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protomock"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -206,7 +207,7 @@ func (suite *ServiceAccountServiceTestSuite) setupMocks() {
 		AddExactMatches(search.SubjectName, expectedSA.Name).
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		ProtoQuery()
-	suite.mockBindingStore.EXPECT().Search(gomock.Any(), clusterScopeQuery).AnyTimes().
+	suite.mockBindingStore.EXPECT().Search(gomock.Any(), protomock.GoMockMatcherEqualMessage(clusterScopeQuery)).AnyTimes().
 		Return([]search.Result{
 			{
 				ID: clusterRoleBinding.GetId(),
@@ -226,7 +227,7 @@ func (suite *ServiceAccountServiceTestSuite) setupMocks() {
 		AddExactMatches(search.SubjectName, expectedSA.Name).
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		ProtoQuery()
-	suite.mockBindingStore.EXPECT().Search(gomock.Any(), namespaceScopeQuery).AnyTimes().
+	suite.mockBindingStore.EXPECT().Search(gomock.Any(), protomock.GoMockMatcherEqualMessage(namespaceScopeQuery)).AnyTimes().
 		Return([]search.Result{
 			{
 				ID: rolebinding.GetId(),

--- a/pkg/protomock/mock_matcher.go
+++ b/pkg/protomock/mock_matcher.go
@@ -1,0 +1,12 @@
+package protomock
+
+import (
+	"github.com/stackrox/rox/pkg/protocompat"
+	"go.uber.org/mock/gomock"
+)
+
+func GoMockMatcherEqualMessage(expectedMsg protocompat.Message) gomock.Matcher {
+	return gomock.Cond(func(msg any) bool {
+		return protocompat.Equal(expectedMsg, msg.(protocompat.Message))
+	})
+}


### PR DESCRIPTION
### Description

This PR is adding a helper function for matching expected `proto.Message` arguments in mock calls.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Unit tests in our CI pipeline.
