### PR TITLE
fix(CI): cache images tagged :latest

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2323,7 +2323,7 @@ class Kubernetes implements OrchestratorMain {
         Container container = new Container(
                 name: deployment.containerName ? deployment.containerName : deployment.name,
                 image: deployment.image,
-                imagePullPolicy: "ifNotPresent",
+                imagePullPolicy: "IfNotPresent",
                 command: deployment.command,
                 args: deployment.args,
                 ports: depPorts,

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2323,6 +2323,7 @@ class Kubernetes implements OrchestratorMain {
         Container container = new Container(
                 name: deployment.containerName ? deployment.containerName : deployment.name,
                 image: deployment.image,
+                imagePullPolicy: "ifNotPresent",
                 command: deployment.command,
                 args: deployment.args,
                 ports: depPorts,


### PR DESCRIPTION
### Description

Per [spec](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting) these default to `Always` which we do not want with image prefetching. https://issues.redhat.com/browse/ROX-24962 is a case where this caused a test failure. This PR sets the default to `IfNotPresent` for qa-e2e-tests.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

 CI with all-qa label and extra cluster flavors.

Note: because there are no failures there are no pod events captured showing that `:latest` images are not fetched at deploy time but I have faith.