### PR TITLE
ROX-22019: Change string comparison for proto generated structs

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -29,6 +29,11 @@ const (
 	mockScanID   = "mockScanID"
 )
 
+var expectedComplianceOperatorScanConfigurationV2 = &storage.ComplianceOperatorScanConfigurationV2{
+	ScanConfigName: mockScanName,
+	Profiles:       []*storage.ComplianceOperatorScanConfigurationV2_ProfileName{{ProfileName: "ocp4-cis"}},
+}
+
 type pipelineTestCase struct {
 	desc                         string
 	setMocksAndGetComplianceInfo func()
@@ -423,7 +428,7 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 			},
 			isErrorTest: true,
-			expectedErr: fmt.Sprintf("Scan Configuration ID is required for an update, scan_config_name:%q profiles:<profile_name:\"ocp4-cis\" > ", mockScanName),
+			expectedErr: fmt.Sprintf("Scan Configuration ID is required for an update, %+v", expectedComplianceOperatorScanConfigurationV2),
 		},
 		{
 			desc:        "Error due to only having write access to one of the clusters",
@@ -433,7 +438,7 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 			},
 			isErrorTest: true,
-			expectedErr: fmt.Sprintf("Scan Configuration ID is required for an update, scan_config_name:%q profiles:<profile_name:\"ocp4-cis\" > ", mockScanName),
+			expectedErr: fmt.Sprintf("Scan Configuration ID is required for an update, %+v", expectedComplianceOperatorScanConfigurationV2),
 		},
 		{
 			desc:        "Successful update of scan configuration",

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -72,7 +72,7 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 8)
 	assert.Contains(t, fields, logging.String("userID", ""))
-	assert.Contains(t, fields, logging.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}"))
+	assert.Contains(t, fields, logging.String("serviceID", protoToJSON(user.GetServiceId())))
 	assert.Contains(t, fields, logging.Any("expires", user.GetExpires()))
 	assert.Contains(t, fields, logging.String("username", ""))
 	assert.Contains(t, fields, logging.String("friendlyName", ""))


### PR DESCRIPTION
### Description

Replace string comparison for proto generated structs.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

CI pipeline
