### PR TITLE
ROX-25099: Relax restriction on profile name duplication

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -434,7 +434,7 @@ func (s *complianceScanConfigDataStoreTestSuite) TestScanConfigurationProfileExi
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"ocp4-cis-1-4-0"},
 			clusters:    []string{s.clusterID1},
-			isErrorTest: true,
+			isErrorTest: false,
 		},
 		{
 			desc:        "Successful get - updating existing config",
@@ -448,7 +448,7 @@ func (s *complianceScanConfigDataStoreTestSuite) TestScanConfigurationProfileExi
 			configID:    configID,
 			profiles:    []string{"no-match-profile", "ocp4-cis", "ocp4-cis-1-4-0"},
 			clusters:    []string{s.clusterID1},
-			isErrorTest: true,
+			isErrorTest: false,
 		},
 	}
 


### PR DESCRIPTION

### Description
Let's relax the restriction on having a duplicate profile with a different version, previously we made sure no same profile was run at the same time, even if they have different name, ex. ocp-cis, and ocp-cis-1-5 is not allowed to run at the same time. 

However, the Compliance Operator does not require this, as long as the same name profile is only used once. So we can run ocp-cis with ocp-cis-1-5 and ocp-cis-1-5, but we should not reference ocp-cis in two scans.


### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

change me!
