### PR TITLE
ROX-25033: Inform about scan on create but not edit in compliance

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -109,8 +109,8 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                     component="div"
                     isInline
                 >
-                    Compliance Operator does run a new scan schedule immediately when you create it,
-                    but does not run an existing scan schedule immediately when you save changes.
+                    Compliance Operator runs a new scan schedule immediately upon creation, but does
+                    not rununtil scheduled time when you save changes to an existing scan schedule.
                 </Alert>
             </Flex>
         </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -110,7 +110,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                     isInline
                 >
                     Compliance Operator runs a new scan schedule immediately upon creation, but does
-                    not rununtil scheduled time when you save changes to an existing scan schedule.
+                    not run until scheduled time when you save changes to an existing scan schedule.
                 </Alert>
             </Flex>
         </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -103,6 +103,15 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                         notifierConfigurations={formikValues.report.notifierConfigurations}
                     />
                 )}
+                <Alert
+                    variant="info"
+                    title="Save for new versus existing scan schedule"
+                    component="div"
+                    isInline
+                >
+                    Compliance Operator does run a new scan schedule immediately when you create it,
+                    but does not run an existing scan schedule immediately when you save changes.
+                </Alert>
             </Flex>
         </>
     );


### PR DESCRIPTION
### Description

Explain both sides of the coin:
* Create: does scan immediately
* Edit: does not scan immediately

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/compliance/schedules, click **Create scan schedule** and move through to **Review** step.

    * Before change, without information.
        ![Review_without](https://github.com/stackrox/stackrox/assets/11862657/294f8f99-6e24-4e8f-bb1e-95ef9fde51e6)

    * After change, with information.

        **Save for new versus existing scan schedule**
        Compliance Operator runs a new scan schedule immediately upon creation, but does not run until scheduled time when you save changes to an existing scan schedule.

        ![Review_with_improvement](https://github.com/stackrox/stackrox/assets/11862657/4797c301-6f1a-472f-b58f-f33b97734e60)
