### PR TITLE
fix(ui): Hide VM 2.0 UI items when insufficient permissions

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -36,6 +36,7 @@ import {
 } from 'Components/CompoundSearchFilter/types';
 import { createFilterTracker } from 'Containers/Vulnerabilities/utils/telemetry';
 import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
+import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
 import {
     SearchOption,
     IMAGE_CVE_SEARCH_OPTION,
@@ -121,13 +122,13 @@ function ImagePageVulnerabilities({
     pagination,
 }: ImagePageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
 
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
     const currentVulnerabilityState = useVulnerabilityState();
+    const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -179,7 +180,7 @@ function ImagePageVulnerabilities({
         createExceptionModalActions,
     } = useExceptionRequestModal();
 
-    const showDeferralUI = isUnifiedDeferralsEnabled && currentVulnerabilityState === 'OBSERVED';
+    const showDeferralUI = hasRequestExceptionsAbility && currentVulnerabilityState === 'OBSERVED';
     const canSelectRows = showDeferralUI;
 
     const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -11,6 +11,7 @@ import useMap from 'hooks/useMap';
 import { VulnerabilityState } from 'types/cve.proto';
 
 import { getTableUIState } from 'utils/getTableUIState';
+import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import CVEsTable, { ImageCVE, cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
@@ -31,7 +32,6 @@ export type CVEsTableContainerProps = {
     sort: ReturnType<typeof useURLSort>;
     workloadCvesScopedQueryString: string;
     isFiltered: boolean;
-    isUnifiedDeferralsEnabled: boolean; // TODO Remove this when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
 };
 
 function CVEsTableContainer({
@@ -43,7 +43,6 @@ function CVEsTableContainer({
     sort,
     workloadCvesScopedQueryString,
     isFiltered,
-    isUnifiedDeferralsEnabled,
 }: CVEsTableContainerProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
@@ -67,6 +66,8 @@ function CVEsTableContainer({
 
     const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
 
+    const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
+
     const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
     const {
         exceptionRequestModalOptions,
@@ -75,7 +76,7 @@ function CVEsTableContainer({
         closeModals,
         createExceptionModalActions,
     } = useExceptionRequestModal();
-    const showDeferralUI = isUnifiedDeferralsEnabled && vulnerabilityState === 'OBSERVED';
+    const showDeferralUI = hasRequestExceptionsAbility && vulnerabilityState === 'OBSERVED';
     const canSelectRows = showDeferralUI;
 
     const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -164,7 +164,6 @@ function WorkloadCvesOverviewPage() {
     const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
     const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_ADVANCED_FILTERS');
 
@@ -478,7 +477,6 @@ function WorkloadCvesOverviewPage() {
                                     workloadCvesScopedQueryString={workloadCvesScopedQueryString}
                                     isFiltered={isFiltered}
                                     vulnerabilityState={currentVulnerabilityState}
-                                    isUnifiedDeferralsEnabled={isUnifiedDeferralsEnabled}
                                 />
                             )}
                             {activeEntityTabKey === 'Image' && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -159,9 +159,9 @@ const searchFilterConfig = {
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
 
-    const { hasReadWriteAccess } = usePermissions();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
-    const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
+    const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isFixabilityFiltersEnabled = isFeatureFlagEnabled('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS');

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -28,9 +28,9 @@ const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloa
 
 function WorkloadCvesPage() {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
-    const hasReadAccessForNamespaces = hasReadWriteAccess('Namespace');
+    const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility.ts
@@ -1,0 +1,12 @@
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+
+export default function useHasRequestExceptionsAbility(): boolean {
+    const { hasReadWriteAccess } = usePermissions();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    return (
+        hasReadWriteAccess('VulnerabilityManagementRequests') &&
+        isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+    );
+}

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -265,7 +265,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     'node-cves': {
         featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_NODE_PLATFORM_CVES']),
-        resourceAccessRequirements: everyResource(['Node']),
+        resourceAccessRequirements: everyResource(['Cluster', 'Node']),
     },
     'platform-cves': {
         featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_NODE_PLATFORM_CVES']),


### PR DESCRIPTION
### Description

1. Hides the "Node CVEs" navigation item when the user does not have at least READ_ACCESS to the Cluster resource. Node CVE APIs will return an error when this is the case, making the section unusable
2. Hides UI elements that allow deferring CVEs when the user does not have READ_WRITE_ACCESS on the "VulnerabilityManagementRequests" resource

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**

Sadly we do not yet have a way to test different role/permission sets e2e at this point.

#### How I validated my change

View the Navigation with a user that has READ access on "Cluster".
![image](https://github.com/stackrox/stackrox/assets/1292638/e6dcd4a5-7206-4608-a70d-932da396d6c5)

View the Navigation with a user that has NO access on "Cluster".
![image](https://github.com/stackrox/stackrox/assets/1292638/f625a396-93e8-4b9a-a4f3-f9c61d7d9754)


View the Workload CVE pages with a user that has READ_WRITE access on "VM Requests" and verify exception UI items are present and functional:
![image](https://github.com/stackrox/stackrox/assets/1292638/3d133451-bf6e-41cf-944f-d06ae2c3ee27)
![image](https://github.com/stackrox/stackrox/assets/1292638/cfd51cd2-9e74-46e9-9c02-d413a8045fad)
![image](https://github.com/stackrox/stackrox/assets/1292638/835879c9-754f-4933-8f6c-732cb148dcaf)
![image](https://github.com/stackrox/stackrox/assets/1292638/2075bfc9-04e1-4fc8-9b97-2ca643bcfdea)

View the Workload CVE pages with a user that has less than READ_WRITE access on "VM Requests" and verify exception UI items are *not* present:
![image](https://github.com/stackrox/stackrox/assets/1292638/06fc80d0-0b72-4c74-93d5-4997ba3f93b8)
![image](https://github.com/stackrox/stackrox/assets/1292638/175bc41d-b5e6-432e-b4f1-83afe81975c3)

View the Workload CVE page with a user that has READ access on "Namespaces" and verify that the "Prioritize by NS view" button is present and functional:
![image](https://github.com/stackrox/stackrox/assets/1292638/379e2a7e-ba85-4d78-903d-79dd831bfcaa)
![image](https://github.com/stackrox/stackrox/assets/1292638/637cf0e4-4591-455a-8ade-8e3da4eaa0b0)


View the Workload CVE page with a user that has READ access on "Namespaces" and verify that the "Prioritize by NS view" button is *not* present:

![image](https://github.com/stackrox/stackrox/assets/1292638/cc463d5f-78b0-4df6-998b-08850e28529b)


