### PR TITLE
fix(vm): Loosen restriction on GET exception config

### DIFF
--- a/central/config/datastore/mocks/datastore.go
+++ b/central/config/datastore/mocks/datastore.go
@@ -85,6 +85,21 @@ func (mr *MockDataStoreMockRecorder) GetPublicConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetPublicConfig))
 }
 
+// GetVulnerabilityExceptionConfig mocks base method.
+func (m *MockDataStore) GetVulnerabilityExceptionConfig(ctx context.Context) (*storage.VulnerabilityExceptionConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVulnerabilityExceptionConfig", ctx)
+	ret0, _ := ret[0].(*storage.VulnerabilityExceptionConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVulnerabilityExceptionConfig indicates an expected call of GetVulnerabilityExceptionConfig.
+func (mr *MockDataStoreMockRecorder) GetVulnerabilityExceptionConfig(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVulnerabilityExceptionConfig", reflect.TypeOf((*MockDataStore)(nil).GetVulnerabilityExceptionConfig), ctx)
+}
+
 // UpsertConfig mocks base method.
 func (m *MockDataStore) UpsertConfig(arg0 context.Context, arg1 *storage.Config) error {
 	m.ctrl.T.Helper()

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -157,12 +157,12 @@ func (s *serviceImpl) GetVulnerabilityExceptionConfig(ctx context.Context, _ *v1
 	if !features.UnifiedCVEDeferral.Enabled() {
 		return nil, errors.Errorf("Cannot fulfill request. Environment variable %s=false", features.UnifiedCVEDeferral.EnvVar())
 	}
-	privateConfig, err := s.datastore.GetPrivateConfig(ctx)
+	vmExceptionConfig, err := s.datastore.GetVulnerabilityExceptionConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &v1.GetVulnerabilityExceptionConfigResponse{
-		Config: storagetov1.VulnerabilityExceptionConfig(privateConfig.GetVulnerabilityExceptionConfig()),
+		Config: storagetov1.VulnerabilityExceptionConfig(vmExceptionConfig),
 	}, nil
 }
 

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -33,10 +33,12 @@ var (
 			// This endpoint should therefore remain public.
 			"/v1.ConfigService/GetPublicConfig",
 		},
+		user.With(permissions.View(resources.VulnerabilityManagementRequests)): {
+			"/v1.ConfigService/GetVulnerabilityExceptionConfig",
+		},
 		user.With(permissions.View(resources.Administration)): {
 			"/v1.ConfigService/GetConfig",
 			"/v1.ConfigService/GetPrivateConfig",
-			"/v1.ConfigService/GetVulnerabilityExceptionConfig",
 		},
 		user.With(permissions.Modify(resources.Administration)): {
 			"/v1.ConfigService/PutConfig",

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -17,7 +17,7 @@ import (
 	pkgGRPC "github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
-	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/set"
@@ -33,9 +33,9 @@ var (
 			// This endpoint should therefore remain public.
 			"/v1.ConfigService/GetPublicConfig",
 		},
-               or.Or(
-                   user.With(permissions.View(resources.VulnerabilityManagementRequests)),
-                   user.With(permissions.View(resources.Administration))): {
+		or.Or(
+			user.With(permissions.View(resources.VulnerabilityManagementRequests)),
+			user.With(permissions.View(resources.Administration))): {
 			"/v1.ConfigService/GetVulnerabilityExceptionConfig",
 		},
 		user.With(permissions.View(resources.Administration)): {

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -33,7 +33,9 @@ var (
 			// This endpoint should therefore remain public.
 			"/v1.ConfigService/GetPublicConfig",
 		},
-		user.With(permissions.View(resources.VulnerabilityManagementRequests)): {
+               or.Or(
+                   user.With(permissions.View(resources.VulnerabilityManagementRequests)),
+                   user.With(permissions.View(resources.Administration))): {
 			"/v1.ConfigService/GetVulnerabilityExceptionConfig",
 		},
 		user.With(permissions.View(resources.Administration)): {

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/set"


### PR DESCRIPTION
### Description

Allow users with read access on VulnerabilityManagementRequests to access /v1/config/private/exception/vulnerabilities API

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests** (fix is for an edge case of limited permissions that requires manual testing at this time)
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Bug reporter on UI team deployed PR image twice. First time, they uncovered another problem; second time, issue was finally fixed.
