### PR TITLE
chore(scanner): remove cleanup func from openArchive

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -151,59 +151,6 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
-	// UUID is only used by Scanner V2, if empty we assume this is from V4.
-	if r.URL.Query().Get(`uuid`) == "" {
-		h.getV4(w, r)
-		return
-	}
-	h.getV2(w, r)
-}
-
-func (h *httpHandler) getV2(w http.ResponseWriter, r *http.Request) {
-	uuid := r.URL.Query().Get(`uuid`)
-	fileName := r.URL.Query().Get(`file`)
-
-	if uuid == "" {
-		writeErrorBadRequest(w)
-		return
-	}
-
-	// Open the most recent definitions file for the provided uuid.
-	f, err := h.openMostRecentDefinitions(r.Context(), uuid)
-	if err != nil {
-		writeErrorForFile(w, err, uuid)
-		return
-	}
-
-	// It is possible no offline Scanner definitions were uploaded, Central cannot
-	// reach the definitions object, or there are no definitions for the given
-	// uuid; in any of those cases, f will be nil.
-	if f == nil {
-		writeErrorNotFound(w)
-		return
-	}
-
-	defer utils.IgnoreError(f.Close)
-
-	// No specific file was requested, so return all definitions.
-	if fileName == "" {
-		serveContent(w, r, f.Name(), f.modTime, f)
-		return
-	}
-
-	// A specific file was requested, so extract from definitions bundle to a
-	// temporary file and serve that instead.
-	namedFile, cleanUp, err := openFromArchive(f.Name(), fileName)
-	if err != nil {
-		writeErrorForFile(w, err, fileName)
-		return
-	}
-	defer cleanUp()
-	defer utils.IgnoreError(namedFile.Close)
-	serveContent(w, r, namedFile.Name(), f.modTime, namedFile)
-}
-
 func writeErrorNotFound(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = w.Write([]byte("No scanner definitions found"))
@@ -403,75 +350,28 @@ func (h *httpHandler) openOfflineBlob(ctx context.Context, blobName string) (*vu
 	return &vulDefFile{snap.File, modTime, snap.Close}, nil
 }
 
-// openMostRecentDefinitions opens the latest Scanner Definitions based on
-// modification time. It's either the one selected by `uuid` if present and
-// online, otherwise fallback to the manually uploaded definitions. The file
-// object can be `nil` if the definitions file does not exist, rather than
-// returning an error.
-func (h *httpHandler) openMostRecentDefinitions(ctx context.Context, uuid string) (file *vulDefFile, err error) {
-	// If in offline mode or uuid is not provided, default to the offline file.
-	if !h.online || uuid == "" {
-		file, err = h.openOfflineBlob(ctx, offlineScannerDefinitionBlobName)
-		if err == nil && file == nil {
-			log.Warnf("Blob %s does not exist", offlineScannerDefinitionBlobName)
-		}
-		return
-	}
-
-	// Start the updater, can be called multiple times for the same uuid, but will
-	// only start the updater once. The Start() call blocks if the definitions were
-	// not downloaded yet.
-	u := h.getUpdater(v2UpdaterType, uuid)
-
-	toClose := func(f *vulDefFile) {
-		if file != f && f != nil {
-			utils.IgnoreError(f.Close)
-		}
-	}
-
-	// Open both the "online" and "offline", and save their modification times.
-	var onlineFile *vulDefFile
-	onlineOSFile, onlineTime, err := h.startUpdaterAndOpenFile(u)
-	if err != nil {
-		return
-	}
-	if onlineOSFile != nil {
-		onlineFile = &vulDefFile{File: onlineOSFile, modTime: onlineTime}
-	}
-
-	defer toClose(onlineFile)
-	offlineFile, err := h.openOfflineBlob(ctx, offlineScannerDefinitionBlobName)
-	if err != nil {
-		return
-	}
-	defer toClose(offlineFile)
-
-	// Return the most recent file, notice that if both don't exist, nil is returned
-	// since modification time will be zero.
-	file = onlineFile
-	if offlineFile != nil && offlineFile.modTime.After(onlineTime) {
-		file = offlineFile
-	}
-	return
-}
-
-// v4OpenOpts are options to open most recent V4 definition files.
-type v4OpenOpts struct {
+// openOpts are options to open most recent V4 definition files.
+type openOpts struct {
+	// name is a generic name to refer to the definition bundle and its content.
+	name string
 	// urlPath specifies the update URL path when setting up online updaters.
 	urlPath string
-	// mappingFile specifies the mapping file to open for mappings updaters.
-	mappingFile string
+	// fileName specifies one file from within the scanner definition archive to
+	// open, instead of returning the archive itself.
+	fileName string
 	// vulnVersion specifies the version of the vulnerability bundle for
 	// vulnerability updaters.
 	vulnVersion string
 	// vulnBundle specifies the vulnerability bundle name for vulnerability updaters.
 	vulnBundle string
+	// offlineBlobName is the name of the offline blob to use.
+	offlineBlobName string
 }
 
-func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+func (h *httpHandler) openDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	log.Debugf("Fetching scanner V4 (online: %t): type %s: options: %#v", h.online, t, opts)
 
-	file, err := h.openMostRecentV4OfflineFile(ctx, t, opts)
+	file, err := h.openOfflineDefinitions(ctx, t, opts)
 	if !h.online {
 		return file, err
 	}
@@ -488,7 +388,7 @@ func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, o
 		}
 	}()
 
-	file, err = h.openMostRecentV4OnlineFile(ctx, t, opts)
+	file, err = h.openOnlineDefinitions(ctx, t, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -503,8 +403,9 @@ func (h *httpHandler) openMostRecentV4File(ctx context.Context, t updaterType, o
 	return file, err
 }
 
-// openMostRecentV4OnlineFile gets desired "online" file, which is pulled and managed by the updater.
-func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+// openOnlineDefinitions gets desired "online" file, which is pulled and managed
+// by the updater.
+func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	u := h.getUpdater(t, opts.urlPath)
 	// Ensure the updater is running.
 	u.Start()
@@ -517,8 +418,8 @@ func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterTyp
 	}
 	log.Debugf("Compressed data file is available: %s", openedFile.Name())
 	switch t {
-	case mappingUpdaterType:
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.mappingFile)
+	case mappingUpdaterType, v2UpdaterType:
+		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -530,21 +431,24 @@ func (h *httpHandler) openMostRecentV4OnlineFile(_ context.Context, t updaterTyp
 	return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
 }
 
-// openMostRecentV4OfflineFile gets desired offline file from compressed bundle: offlineScannerV4DefinitionBlobName
-func (h *httpHandler) openMostRecentV4OfflineFile(ctx context.Context, t updaterType, opts v4OpenOpts) (*vulDefFile, error) {
+// openOfflineDefinitions gets desired offline file from compressed bundle.
+func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
 	log.Debugf("Getting v4 offline data for updater: type %s: options: %#v", t, opts)
-	openedFile, err := h.openOfflineBlob(ctx, offlineScannerV4DefinitionBlobName)
-	if err == nil && openedFile == nil {
-		log.Warnf("Blob %s does not exist", offlineScannerV4DefinitionBlobName)
-		return nil, errors.New("No valid scanner V4 file in offline mode")
+	openedFile, err := h.openOfflineBlob(ctx, opts.offlineBlobName)
+	if err != nil {
+		return nil, fmt.Errorf("opening offline definitions: %s: %w",
+			opts.offlineBlobName, err)
 	}
-
+	if openedFile == nil {
+		log.Warnf("Blob %s does not exist", opts.offlineBlobName)
+		return nil, nil
+	}
 	var offlineFile *vulDefFile
 	defer utils.IgnoreError(openedFile.Close)
 	switch t {
-	case mappingUpdaterType:
+	case mappingUpdaterType, v2UpdaterType:
 		// search mapping file
-		fileName := filepath.Base(opts.mappingFile)
+		fileName := filepath.Base(opts.fileName)
 		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), fileName)
 		if err != nil {
 			return nil, err
@@ -577,7 +481,7 @@ func (h *httpHandler) openMostRecentV4OfflineFile(ctx context.Context, t updater
 		defer cleanUp()
 		offlineFile = &vulDefFile{File: vulns, modTime: openedFile.modTime}
 	default:
-		return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
+		return nil, fmt.Errorf("unknown updater type: %s", t)
 	}
 
 	return offlineFile, nil
@@ -637,13 +541,16 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	return tmpFile, cleanup, nil
 }
 
-func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
+func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
+	// URL parameters.
+	uuid := r.URL.Query().Get(`uuid`)
 	fileName := r.URL.Query().Get(`file`)
 	v := r.URL.Query().Get(`version`)
+
 	ctx := r.Context()
 
 	var uType updaterType
-	var opts v4OpenOpts
+	var opts openOpts
 	var contentType string
 
 	switch {
@@ -655,7 +562,9 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		uType = mappingUpdaterType
-		opts.mappingFile = v4FileName
+		opts.name = fileName
+		opts.fileName = v4FileName
+		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
 	case fileName == "" && v != "":
 		// If only version is provided, this is for Scanner V4 vuln file
 		if version.GetVersionKind(v) == version.NightlyKind {
@@ -669,19 +578,31 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 			bundle = "vulnerabilities.zip"
 			contentType = "application/zip"
 		}
+		opts.name = v
 		opts.urlPath = path.Join(v, bundle)
 		opts.vulnVersion = v
 		opts.vulnBundle = bundle
+		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
+	case uuid != "":
+		// Scanner V2 definitions.
+		uType = v2UpdaterType
+		opts.name = uuid
+		opts.urlPath = uuid
+		opts.fileName = fileName
+		opts.offlineBlobName = offlineScannerDefinitionBlobName
 	default:
 		writeErrorBadRequest(w)
 		return
 	}
 
-	f, err := h.openMostRecentV4File(ctx, uType, opts)
+	f, err := h.openDefinitions(ctx, uType, opts)
 	if err != nil {
-		errMsg := fmt.Sprintf("could not read: %s", err)
-		log.Error(errMsg)
-		httputil.WriteGRPCStyleErrorf(w, codes.Internal, errMsg)
+		writeErrorForFile(w, err, opts.name)
+		return
+	}
+
+	if f == nil {
+		writeErrorNotFound(w)
 		return
 	}
 
@@ -691,18 +612,6 @@ func (h *httpHandler) getV4(w http.ResponseWriter, r *http.Request) {
 
 	defer utils.IgnoreError(f.Close)
 	serveContent(w, r, f.Name(), f.modTime, f)
-}
-
-func (h *httpHandler) startUpdaterAndOpenFile(u *requestedUpdater) (*os.File, time.Time, error) {
-	u.Start()
-	osFile, modTime, err := u.file.Open()
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	if osFile == nil {
-		return nil, time.Time{}, nil
-	}
-	return osFile, modTime, nil
 }
 
 func getOfflineFileVersion(mf *os.File) (string, error) {

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -418,7 +418,13 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 	}
 	log.Debugf("Compressed data file is available: %s", openedFile.Name())
 	switch t {
-	case mappingUpdaterType, v2UpdaterType:
+	case v2UpdaterType:
+		if opts.fileName == "" {
+			return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
+		}
+		fallthrough
+	case mappingUpdaterType:
+		defer utils.IgnoreError(openedFile.Close)
 		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
@@ -446,7 +452,11 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 	var offlineFile *vulDefFile
 	switch t {
 	case v2UpdaterType:
-		offlineFile = openedFile
+		if opts.fileName == "" {
+			offlineFile = openedFile
+			break
+		}
+		fallthrough
 	case mappingUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
 		// search mapping file

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -600,7 +600,14 @@ func (h *httpHandler) openFromArchive(archiveFile string, fileName string) (*os.
 
 	// Create a temporary file and remove it for the OS to clean up once the
 	// struct is closed.
-	tmpFile, err := os.CreateTemp(h.dataDir, fileName)
+	//
+	// Ensure the file extension stays intact (via the *- prefix) so the HTTP server
+	// can automatically pick up the Content-Type.
+	//
+	// Also, replace / with - to account for the mapping files, as
+	// forward slash is invalid in the pattern accepted by os.CreateTemp.
+	tmpFilePattern := "*-" + strings.ReplaceAll(fileName, "/", "-")
+	tmpFile, err := os.CreateTemp(h.dataDir, tmpFilePattern)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "opening temporary file")
 	}

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -327,20 +327,18 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		defer utils.IgnoreError(openedFile.Close)
 		// search mapping file
 		fileName := filepath.Base(opts.fileName)
-		targetFile, cleanUp, err := h.openFromArchive(openedFile.Name(), fileName)
+		targetFile, err := h.openFromArchive(openedFile.Name(), fileName)
 		if err != nil {
 			return nil, err
 		}
-		defer cleanUp()
 		offlineFile = &vulDefFile{File: targetFile, modTime: openedFile.modTime}
 	case vulnerabilityUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
 		// check version information in manifest
-		mf, cleanUp, err := h.openFromArchive(openedFile.Name(), scannerV4ManifestFile)
+		mf, err := h.openFromArchive(openedFile.Name(), scannerV4ManifestFile)
 		if err != nil {
 			return nil, err
 		}
-		defer cleanUp()
 		offlineV, err := getOfflineFileVersion(mf)
 		if err != nil {
 			return nil, err
@@ -353,11 +351,10 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 			return nil, errors.New(msg)
 		}
 
-		vulns, cleanUp, err := h.openFromArchive(openedFile.Name(), opts.vulnBundle)
+		vulns, err := h.openFromArchive(openedFile.Name(), opts.vulnBundle)
 		if err != nil {
 			return nil, err
 		}
-		defer cleanUp()
 		offlineFile = &vulDefFile{File: vulns, modTime: openedFile.modTime}
 	default:
 		return nil, fmt.Errorf("unknown updater type: %s", t)
@@ -405,11 +402,10 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 		fallthrough
 	case mappingUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
-		targetFile, cleanUp, err := h.openFromArchive(openedFile.Name(), opts.fileName)
+		targetFile, err := h.openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
 		}
-		defer cleanUp()
 		return &vulDefFile{File: targetFile, modTime: onlineTime}, nil
 	case vulnerabilityUpdaterType:
 		return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
@@ -497,18 +493,17 @@ func (h *httpHandler) validateV4DefsVersion(zipPath string) error {
 
 	for _, zipF := range zipR.File {
 		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
-			defs, _, err := h.openFromArchive(zipPath, zipF.Name)
+			defs, err := h.openFromArchive(zipPath, zipF.Name)
 			if err != nil {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
 			utils.IgnoreError(defs.Close)
-			mf, removeDefs, err := h.openFromArchive(defs.Name(), scannerV4ManifestFile)
+			mf, err := h.openFromArchive(defs.Name(), scannerV4ManifestFile)
 			if err != nil {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
 			offlineV, err := getOfflineFileVersion(mf)
 			utils.IgnoreError(mf.Close)
-			removeDefs()
 			if err != nil {
 				return errors.Wrap(err, "couldn't get v4 offline defs version")
 			}
@@ -585,18 +580,18 @@ func (h *httpHandler) handleScannerDefsFile(ctx context.Context, zipF *zip.File,
 // The returned file struct has a file descriptor allocated on the filesystem outside the ZIP, but
 // its name is removed. Meaning: as soon as the file struct is closed, the data will be
 // freed in filesystem by the OS.
-func (h *httpHandler) openFromArchive(archiveFile string, fileName string) (*os.File, func(), error) {
+func (h *httpHandler) openFromArchive(archiveFile string, fileName string) (*os.File, error) {
 	// Open zip archive and extract the fileName.
 	zipReader, err := zip.OpenReader(archiveFile)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "opening zip archive")
+		return nil, errors.Wrap(err, "opening zip archive")
 	}
 	defer utils.IgnoreError(zipReader.Close)
-	fileReader, err := zipReader.Open(fileName)
+	zipFile, err := zipReader.Open(fileName)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "extracting")
+		return nil, errors.Wrap(err, "extracting")
 	}
-	defer utils.IgnoreError(fileReader.Close)
+	defer utils.IgnoreError(zipFile.Close)
 
 	// Create a temporary file and remove it for the OS to clean up once the
 	// struct is closed.
@@ -609,29 +604,34 @@ func (h *httpHandler) openFromArchive(archiveFile string, fileName string) (*os.
 	tmpFilePattern := "*-" + strings.ReplaceAll(fileName, "/", "-")
 	tmpFile, err := os.CreateTemp(h.dataDir, tmpFilePattern)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "opening temporary file")
+		return nil, errors.Wrap(err, "opening temporary file")
 	}
-	// TODO: There is no real purpose to this, as we can just remove this upon finishing this function.
-	// Delete this in a future commit.
-	cleanup := func() {
+	defer func() {
 		_ = os.Remove(tmpFile.Name())
-	}
+	}()
+	var success bool
+	defer func() {
+		// If this function is unsuccessful, then close the struct.
+		if !success {
+			utils.IgnoreError(tmpFile.Close)
+		}
+	}()
 
 	// Extract the file and copy contents to the temporary file, notice we
 	// intentionally don't Sync(), to benefit from filesystem caching.
-	_, err = io.Copy(tmpFile, fileReader)
+	_, err = io.Copy(tmpFile, zipFile)
 	if err != nil {
-		_ = os.Remove(tmpFile.Name())
-		return nil, nil, errors.Wrap(err, "writing to temporary file")
+		return nil, errors.Wrap(err, "writing to temporary file")
 	}
 
 	// Reset for caller's convenience.
 	_, err = tmpFile.Seek(0, io.SeekStart)
 	if err != nil {
-		_ = os.Remove(tmpFile.Name())
-		return nil, nil, errors.Wrap(err, "writing to temporary file")
+		return nil, errors.Wrap(err, "setting offset for temporary file")
 	}
-	return tmpFile, cleanup, nil
+
+	success = true
+	return tmpFile, nil
 }
 
 func getOfflineFileVersion(mf *os.File) (string, error) {

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -41,8 +41,10 @@ const (
 	// tmpDirPattern is the pattern for the directory in which all Scanner data is written.
 	tmpDirPattern = "scannerdefinitions-*"
 
-	// scannerV2DefsFile is the name of the file which contains Scanner v2 data.
-	scannerV2DefsFile = "diff.zip"
+	// scannerV2DiffFile is the name of the file which contains Scanner v2 diff data.
+	scannerV2DiffFile = "diff.zip"
+	// scannerV2DefsFileis the name of the file which contains offline Scanner v2 data.
+	scannerV2DefsFile = "scanner-defs.zip"
 	// offlineScannerV2DefsBlobName represents the blob name of offline/fallback data file for Scanner v2.
 	offlineScannerV2DefsBlobName = "/offline/scanner/scanner-defs.zip"
 
@@ -420,7 +422,7 @@ func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdate
 			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4VulnSubDir, urlPath)
 			ext = ".json.zst"
 		default: // uuid
-			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DefsFile)
+			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DiffFile)
 			ext = ".zip"
 		}
 		filePath := filepath.Join(h.onlineVulnDir, fileName)

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -111,12 +112,27 @@ type manifest struct {
 
 // httpHandler handles HTTP GET and POST requests for vulnerability data.
 type httpHandler struct {
-	online        bool
-	interval      time.Duration
-	lock          sync.Mutex
-	updaters      map[string]*requestedUpdater
-	onlineVulnDir string
-	blobStore     blob.Datastore
+	// online indicates if we are in online or offline mode.
+	online bool
+	// updaterInterval specifies the time period between subsequent updates, in online-mode.
+	updaterInterval time.Duration
+	// updatersLock protects updaters.
+	updatersLock sync.Mutex
+	// updaters stores the various updaters which may be required.
+	updaters map[string]*requestedUpdater
+	// dataDir is the root directory into which all data is downloaded.
+	dataDir string
+	// uploadPath is the file path to which "offline data" is uploaded prior to storing in blobStore.
+	// This file will be under the dataDir directory.
+	uploadPath string
+	// blobStore provides access to the blob storage which stores the uploaded "offline data".
+	blobStore blob.Datastore
+
+	// uploadInProgress indicates when there is
+	// a scanner definitions upload (POST) already in progress.
+	// This is meant to protect from concurrent uploads which may overwrite each other.
+	// Concurrent uploads are not expected nor supported.
+	uploadInProgress atomic.Bool
 }
 
 func init() {
@@ -127,28 +143,27 @@ func init() {
 
 // New creates a new http.Handler to handle vulnerability data.
 func New(blobStore blob.Datastore, opts handlerOpts) http.Handler {
-	h := &httpHandler{
-		online:    !env.OfflineModeEnv.BooleanSetting(),
-		interval:  env.ScannerVulnUpdateInterval.DurationSetting(),
-		blobStore: blobStore,
-	}
-
-	if h.online {
-		h.initializeUpdaters(opts.cleanupInterval, opts.cleanupAge)
-	} else {
-		log.Info("In offline mode: scanner definitions will not be updated automatically")
-	}
-
-	return h
-}
-
-func (h *httpHandler) initializeUpdaters(cleanupInterval, cleanupAge *time.Duration) {
-	var err error
-	h.onlineVulnDir, err = os.MkdirTemp("", tmpDirPattern)
+	dataDir, err := os.MkdirTemp("", tmpDirPattern)
 	utils.CrashOnError(err) // Fundamental problem if we cannot create a temp directory.
 
+	h := &httpHandler{
+		online:          !env.OfflineModeEnv.BooleanSetting(),
+		updaterInterval: env.ScannerVulnUpdateInterval.DurationSetting(),
+		dataDir:         dataDir,
+		uploadPath:      filepath.Join(dataDir, offlineDefsFile),
+		blobStore:       blobStore,
+	}
+
+	if !h.online {
+		log.Info("In offline mode: scanner definitions will not be updated automatically")
+		return h
+	}
+
+	log.Info("In online mode: scanner definitions will be updated automatically")
 	h.updaters = make(map[string]*requestedUpdater)
-	go h.cleanUpdatersPeriodic(cleanupInterval, cleanupAge)
+	go h.cleanUpdatersPeriodic(opts.cleanupInterval, opts.cleanupAge)
+
+	return h
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -312,7 +327,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		defer utils.IgnoreError(openedFile.Close)
 		// search mapping file
 		fileName := filepath.Base(opts.fileName)
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), fileName)
+		targetFile, cleanUp, err := h.openFromArchive(openedFile.Name(), fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +336,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 	case vulnerabilityUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
 		// check version information in manifest
-		mf, cleanUp, err := openFromArchive(openedFile.Name(), scannerV4ManifestFile)
+		mf, cleanUp, err := h.openFromArchive(openedFile.Name(), scannerV4ManifestFile)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +353,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 			return nil, errors.New(msg)
 		}
 
-		vulns, cleanUp, err := openFromArchive(openedFile.Name(), opts.vulnBundle)
+		vulns, cleanUp, err := h.openFromArchive(openedFile.Name(), opts.vulnBundle)
 		if err != nil {
 			return nil, err
 		}
@@ -390,7 +405,7 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 		fallthrough
 	case mappingUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
+		targetFile, cleanUp, err := h.openFromArchive(openedFile.Name(), opts.fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -406,8 +421,8 @@ func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, op
 // by the given updater type and a URL path to the definitions file. If the
 // updater was created, it is no started here, callers are expected to start it.
 func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdater {
-	h.lock.Lock()
-	defer h.lock.Unlock()
+	h.updatersLock.Lock()
+	defer h.updatersLock.Unlock()
 
 	fileName := strings.ReplaceAll(filepath.Join(t.String(), urlPath), "/", "-")
 	updater, exists := h.updaters[fileName]
@@ -425,13 +440,13 @@ func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdate
 			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DiffFile)
 			ext = ".zip"
 		}
-		filePath := filepath.Join(h.onlineVulnDir, fileName)
+		filePath := filepath.Join(h.dataDir, fileName)
 		// Use a default extension if the URL path does not contain one.
 		if filepath.Ext(fileName) == "" {
 			filePath += ext
 		}
 		updater = &requestedUpdater{
-			updater: newUpdater(file.New(filePath), client, updateURL.String(), h.interval),
+			updater: newUpdater(file.New(filePath), client, updateURL.String(), h.updaterInterval),
 		}
 		h.updaters[fileName] = updater
 	}
@@ -441,37 +456,39 @@ func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdate
 }
 
 func (h *httpHandler) post(w http.ResponseWriter, r *http.Request) {
-	tempDir, err := os.MkdirTemp("", "scanner-definitions-handler")
-	if err != nil {
-		httputil.WriteGRPCStyleErrorf(w, codes.Internal, "failed to create temp dir: %v", err)
+	// Swap will set h.uploadInProgress to true and return the previous value.
+	// If it was previously true, then there is already an upload in progress,
+	// so we should abort the operation.
+	if h.uploadInProgress.Swap(true) {
+		httputil.WriteGRPCStyleError(w, codes.Aborted, errors.New("scanner definitions upload already in progress"))
 		return
 	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			log.Warnf("Failed to remove temp dir for scanner defs: %v", err)
-		}
-	}()
+	// There are no other uploads in progress at this point.
+	// Once we exit this function, the upload is no longer in progress.
+	defer h.uploadInProgress.Store(false)
 
-	tempFile := filepath.Join(tempDir, offlineDefsFile)
-	if err := fileutils.CopySrcToFile(tempFile, r.Body); err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrapf(err, "copying HTTP POST body to %s", tempFile))
+	// Copy the request body into the filesystem.
+	// If the file at h.uploadPath doesn't exist yet, it will be created.
+	if err := fileutils.CopySrcToFile(h.uploadPath, r.Body); err != nil {
+		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "copying uploaded scanner definitions"))
 		return
 	}
+
 	if features.ScannerV4.Enabled() {
-		if err := validateV4DefsVersion(tempFile); err != nil {
+		if err := h.validateV4DefsVersion(h.uploadPath); err != nil {
 			httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
 			return
 		}
 	}
-	if err := h.handleZipContentsFromVulnDump(r.Context(), tempFile); err != nil {
+	if err := h.handleZipContentsFromVulnDump(r.Context(), h.uploadPath); err != nil {
 		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
 		return
 	}
 
-	_, _ = w.Write([]byte("Successfully stored the offline vulnerability definitions"))
+	_, _ = w.Write([]byte("Successfully stored scanner vulnerability definitions"))
 }
 
-func validateV4DefsVersion(zipPath string) error {
+func (h *httpHandler) validateV4DefsVersion(zipPath string) error {
 	zipR, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return errors.Wrap(err, "couldn't open file as zip")
@@ -480,12 +497,12 @@ func validateV4DefsVersion(zipPath string) error {
 
 	for _, zipF := range zipR.File {
 		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
-			defs, _, err := openFromArchive(zipPath, zipF.Name)
+			defs, _, err := h.openFromArchive(zipPath, zipF.Name)
 			if err != nil {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
 			utils.IgnoreError(defs.Close)
-			mf, removeDefs, err := openFromArchive(defs.Name(), scannerV4ManifestFile)
+			mf, removeDefs, err := h.openFromArchive(defs.Name(), scannerV4ManifestFile)
 			if err != nil {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
@@ -564,11 +581,11 @@ func (h *httpHandler) handleScannerDefsFile(ctx context.Context, zipF *zip.File,
 	return nil
 }
 
-// openFromArchive returns a file object for a name within the definitions
-// bundle. The file object has a file descriptor allocated on the filesystem, but
-// its name is removed. Meaning once the file object is closed, the data will be
+// openFromArchive returns the associated file for the given name within the ZIP archiveFile.
+// The returned file struct has a file descriptor allocated on the filesystem outside the ZIP, but
+// its name is removed. Meaning: as soon as the file struct is closed, the data will be
 // freed in filesystem by the OS.
-func openFromArchive(archiveFile string, fileName string) (*os.File, func(), error) {
+func (h *httpHandler) openFromArchive(archiveFile string, fileName string) (*os.File, func(), error) {
 	// Open zip archive and extract the fileName.
 	zipReader, err := zip.OpenReader(archiveFile)
 	if err != nil {
@@ -581,38 +598,30 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	}
 	defer utils.IgnoreError(fileReader.Close)
 
-	// Create a temporary file and remove it, keeping the file descriptor.
-	tmpDir, err := os.MkdirTemp("", tmpDirPattern)
+	// Create a temporary file and remove it for the OS to clean up once the
+	// struct is closed.
+	tmpFile, err := os.CreateTemp(h.dataDir, fileName)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating temporary directory")
-	}
-	tmpFile, err := os.Create(filepath.Join(tmpDir, path.Base(fileName)))
-	if err != nil {
-		// Best effort to clean.
-		_ = os.RemoveAll(tmpDir)
 		return nil, nil, errors.Wrap(err, "opening temporary file")
 	}
-	defer func() {
-		if err != nil {
-			_ = tmpFile.Close()
-		}
-	}()
+	// TODO: There is no real purpose to this, as we can just remove this upon finishing this function.
+	// Delete this in a future commit.
 	cleanup := func() {
-		_ = os.RemoveAll(tmpDir)
+		_ = os.Remove(tmpFile.Name())
 	}
 
 	// Extract the file and copy contents to the temporary file, notice we
 	// intentionally don't Sync(), to benefit from filesystem caching.
 	_, err = io.Copy(tmpFile, fileReader)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = os.Remove(tmpFile.Name())
 		return nil, nil, errors.Wrap(err, "writing to temporary file")
 	}
 
 	// Reset for caller's convenience.
 	_, err = tmpFile.Seek(0, io.SeekStart)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
+		_ = os.Remove(tmpFile.Name())
 		return nil, nil, errors.Wrap(err, "writing to temporary file")
 	}
 	return tmpFile, cleanup, nil
@@ -670,8 +679,8 @@ func (h *httpHandler) cleanUpdatersPeriodic(cleanupInterval, cleanupAge *time.Du
 func (h *httpHandler) cleanupUpdaters(cleanupAge time.Duration) {
 	now := time.Now()
 
-	h.lock.Lock()
-	defer h.lock.Unlock()
+	h.updatersLock.Lock()
+	defer h.updatersLock.Unlock()
 
 	for id, updatingHandler := range h.updaters {
 		if now.Sub(updatingHandler.lastRequestedTime) > cleanupAge {

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -38,24 +38,31 @@ import (
 )
 
 const (
-	definitionsBaseDir = "scannerdefinitions"
+	// tmpDirPattern is the pattern for the directory in which all Scanner data is written.
+	tmpDirPattern = "scannerdefinitions-*"
 
-	// scannerDefsSubZipName represents the offline zip bundle for CVEs for Scanner.
-	scannerDefsSubZipName  = "scanner-defs.zip"
-	scannerUpdateURLSuffix = "diff.zip"
+	// scannerV2DefsFile is the name of the file which contains Scanner v2 data.
+	scannerV2DefsFile = "diff.zip"
+	// offlineScannerV2DefsBlobName represents the blob name of offline/fallback data file for Scanner v2.
+	offlineScannerV2DefsBlobName = "/offline/scanner/scanner-defs.zip"
 
-	scannerV4DefsSubZipName = "scanner-v4-defs.zip"
 	// scannerV4DefsPrefix helps to search the v4 offline zip bundle for CVEs
 	scannerV4DefsPrefix    = "scanner-v4-defs"
+	scannerV4ManifestFile  = "manifest.json"
 	scannerV4VulnSubDir    = "v4/vulnerability-bundles"
 	scannerV4MappingSubDir = "v4/redhat-repository-mappings"
 	scannerV4MappingFile   = "mapping.zip"
+	// offlineScannerV4DefsBlobName represents the blob name of offline/fallback data file for Scanner V4.
+	offlineScannerV4DefsBlobName = "/offline/scanner/v4/scanner-v4-defs.zip"
 
-	// offlineScannerDefinitionBlobName represents the blob name of offline/fallback zip bundle for CVEs for Scanner.
-	offlineScannerDefinitionBlobName = "/offline/scanner/" + scannerDefsSubZipName
+	// scannerV4AcceptHeader defines the custom HTTP header to identify the content type Scanner V4 desires.
+	// This is used instead of Accept, as we do not map this 1:1 with the returned content type.
+	scannerV4AcceptHeader = "X-Scanner-V4-Accept"
+	// scannerV4MultiBundleContentType is the custom content type representing Scanner V4 wants
+	// the "multi-bundle" ZIP data returned.
+	scannerV4MultiBundleContentType = "application/vnd.stackrox.scanner-v4.multi-bundle+zip"
 
-	// offlineScannerV4DefinitionBlobName represents the blob name of offline/fallback zip bundle for CVEs for Scanner V4.
-	offlineScannerV4DefinitionBlobName = "/offline/scanner/v4/" + scannerV4DefsSubZipName
+	offlineDefsFile = "offline-defs.zip"
 
 	defaultCleanupInterval = 4 * time.Hour
 	defaultCleanupAge      = 1 * time.Hour
@@ -80,6 +87,8 @@ var (
 
 	log = logging.LoggerForModule()
 
+	// v4FileMapping maps a URL query parameter to its associated
+	// Scanner V4 map file.
 	v4FileMapping = map[string]string{
 		"name2repos": "repomapping/container-name-repos-map.json",
 		"repo2cpe":   "repomapping/repository-to-cpe.json",
@@ -92,6 +101,8 @@ type requestedUpdater struct {
 	lastRequestedTime time.Time
 }
 
+// manifest represents the manifest.json file
+// containing Scanner V4 related metadata.
 type manifest struct {
 	Version string `json:"version"`
 }
@@ -109,9 +120,7 @@ type httpHandler struct {
 func init() {
 	var err error
 	scannerUpdateBaseURL, err = url.Parse("https://definitions.stackrox.io")
-	if err != nil {
-		panic(err)
-	}
+	utils.CrashOnError(err) // This is very unexpected.
 }
 
 // New creates a new http.Handler to handle vulnerability data.
@@ -133,11 +142,11 @@ func New(blobStore blob.Datastore, opts handlerOpts) http.Handler {
 
 func (h *httpHandler) initializeUpdaters(cleanupInterval, cleanupAge *time.Duration) {
 	var err error
-	h.onlineVulnDir, err = os.MkdirTemp("", definitionsBaseDir)
+	h.onlineVulnDir, err = os.MkdirTemp("", tmpDirPattern)
 	utils.CrashOnError(err) // Fundamental problem if we cannot create a temp directory.
 
 	h.updaters = make(map[string]*requestedUpdater)
-	go h.runCleanupUpdaters(cleanupInterval, cleanupAge)
+	go h.cleanUpdatersPeriodic(cleanupInterval, cleanupAge)
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +197,7 @@ func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
 		opts.name = uuid
 		opts.urlPath = uuid
 		opts.fileName = fileName
-		opts.offlineBlobName = offlineScannerDefinitionBlobName
+		opts.offlineBlobName = offlineScannerV2DefsBlobName
 	case fileName != "" && v == "":
 		// If only file is requested, then this is request for Scanner v4 mapping file.
 		v4FileName, exists := v4FileMapping[fileName]
@@ -199,7 +208,7 @@ func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
 		uType = mappingUpdaterType
 		opts.name = fileName
 		opts.fileName = v4FileName
-		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
+		opts.offlineBlobName = offlineScannerV4DefsBlobName
 	case fileName == "" && v != "":
 		// If only version is provided, this is for Scanner V4 vuln file
 		if version.GetVersionKind(v) == version.NightlyKind {
@@ -209,7 +218,7 @@ func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
 		uType = vulnerabilityUpdaterType
 		bundle := "vulns.json.zst"
 		contentType = "application/zstd"
-		if r.Header.Get("X-Scanner-V4-Accept") == "application/vnd.stackrox.scanner-v4.multi-bundle+zip" {
+		if r.Header.Get(scannerV4AcceptHeader) == scannerV4MultiBundleContentType {
 			bundle = "vulnerabilities.zip"
 			contentType = "application/zip"
 		}
@@ -217,7 +226,7 @@ func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
 		opts.urlPath = path.Join(v, bundle)
 		opts.vulnVersion = v
 		opts.vulnBundle = bundle
-		opts.offlineBlobName = offlineScannerV4DefinitionBlobName
+		opts.offlineBlobName = offlineScannerV4DefsBlobName
 	default:
 		writeErrorBadRequest(w)
 		return
@@ -310,7 +319,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 	case vulnerabilityUpdaterType:
 		defer utils.IgnoreError(openedFile.Close)
 		// check version information in manifest
-		mf, cleanUp, err := openFromArchive(openedFile.Name(), "manifest.json")
+		mf, cleanUp, err := openFromArchive(openedFile.Name(), scannerV4ManifestFile)
 		if err != nil {
 			return nil, err
 		}
@@ -411,7 +420,7 @@ func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdate
 			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4VulnSubDir, urlPath)
 			ext = ".json.zst"
 		default: // uuid
-			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerUpdateURLSuffix)
+			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DefsFile)
 			ext = ".zip"
 		}
 		filePath := filepath.Join(h.onlineVulnDir, fileName)
@@ -441,7 +450,7 @@ func (h *httpHandler) post(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	tempFile := filepath.Join(tempDir, "tempfile.zip")
+	tempFile := filepath.Join(tempDir, offlineDefsFile)
 	if err := fileutils.CopySrcToFile(tempFile, r.Body); err != nil {
 		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrapf(err, "copying HTTP POST body to %s", tempFile))
 		return
@@ -474,7 +483,7 @@ func validateV4DefsVersion(zipPath string) error {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
 			utils.IgnoreError(defs.Close)
-			mf, removeDefs, err := openFromArchive(defs.Name(), "manifest.json")
+			mf, removeDefs, err := openFromArchive(defs.Name(), scannerV4ManifestFile)
 			if err != nil {
 				return errors.Wrap(err, "couldn't open v4 offline defs manifest.json")
 			}
@@ -509,15 +518,15 @@ func (h *httpHandler) handleZipContentsFromVulnDump(ctx context.Context, zipPath
 	// In the future, we may decide to support other files (like we have in the past), which is why we
 	// expect this ZIP of a single ZIP.
 	for _, zipF := range zipR.File {
-		if zipF.Name == scannerDefsSubZipName {
-			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerDefinitionBlobName); err != nil {
+		if zipF.Name == scannerV2DefsFile {
+			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerV2DefsBlobName); err != nil {
 				return errors.Wrap(err, "couldn't handle scanner-defs sub file")
 			}
 			count++
 			continue
 		}
 		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
-			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerV4DefinitionBlobName); err != nil {
+			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerV4DefsBlobName); err != nil {
 				return errors.Wrap(err, "couldn't handle scanner-v4-defs sub file")
 			}
 			log.Debugf("Successfully processed file: %s", zipF.Name)
@@ -571,7 +580,7 @@ func openFromArchive(archiveFile string, fileName string) (*os.File, func(), err
 	defer utils.IgnoreError(fileReader.Close)
 
 	// Create a temporary file and remove it, keeping the file descriptor.
-	tmpDir, err := os.MkdirTemp("", definitionsBaseDir)
+	tmpDir, err := os.MkdirTemp("", tmpDirPattern)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating temporary directory")
 	}
@@ -640,7 +649,7 @@ func writeErrorForFile(w http.ResponseWriter, err error, path string) {
 	httputil.WriteGRPCStyleErrorf(w, codes.Internal, "could not read vulnerability definition %s: %v", filepath.Base(path), err)
 }
 
-func (h *httpHandler) runCleanupUpdaters(cleanupInterval, cleanupAge *time.Duration) {
+func (h *httpHandler) cleanUpdatersPeriodic(cleanupInterval, cleanupAge *time.Duration) {
 	interval := defaultCleanupInterval
 	if cleanupInterval != nil {
 		interval = *cleanupInterval

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -151,205 +151,6 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func writeErrorNotFound(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusNotFound)
-	_, _ = w.Write([]byte("No scanner definitions found"))
-}
-
-func writeErrorBadRequest(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusBadRequest)
-	_, _ = w.Write([]byte("at least one of file or uuid must be specified"))
-}
-
-func writeErrorForFile(w http.ResponseWriter, err error, path string) {
-	if errox.IsAny(err, fs.ErrNotExist, snapshot.ErrBlobNotExist) {
-		writeErrorNotFound(w)
-		return
-	}
-
-	httputil.WriteGRPCStyleErrorf(w, codes.Internal, "could not read vulnerability definition %s: %v", filepath.Base(path), err)
-}
-
-func serveContent(w http.ResponseWriter, r *http.Request, name string, modTime time.Time, content io.ReadSeeker) {
-	log.Debugf("Serving vulnerability definitions from %s", filepath.Base(name))
-	http.ServeContent(w, r, name, modTime, content)
-}
-
-// getUpdater gets or creates an updater for the scanner definitions identified
-// by the given updater type and a URL path to the definitions file. If the
-// updater was created, it is no started here, callers are expected to start it.
-func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdater {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	fileName := strings.ReplaceAll(filepath.Join(t.String(), urlPath), "/", "-")
-	updater, exists := h.updaters[fileName]
-	if !exists {
-		var updateURL *url.URL
-		var ext string
-		switch t {
-		case mappingUpdaterType:
-			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4MappingSubDir, scannerV4MappingFile)
-			ext = ".zip"
-		case vulnerabilityUpdaterType:
-			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4VulnSubDir, urlPath)
-			ext = ".json.zst"
-		default: // uuid
-			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerUpdateURLSuffix)
-			ext = ".zip"
-		}
-		filePath := filepath.Join(h.onlineVulnDir, fileName)
-		// Use a default extension if the URL path does not contain one.
-		if filepath.Ext(fileName) == "" {
-			filePath += ext
-		}
-		updater = &requestedUpdater{
-			updater: newUpdater(file.New(filePath), client, updateURL.String(), h.interval),
-		}
-		h.updaters[fileName] = updater
-	}
-
-	updater.lastRequestedTime = time.Now()
-	return updater
-}
-
-func (h *httpHandler) handleScannerDefsFile(ctx context.Context, zipF *zip.File, blobName string) error {
-	r, err := zipF.Open()
-	if err != nil {
-		return errors.Wrap(err, "opening ZIP reader")
-	}
-	defer utils.IgnoreError(r.Close)
-
-	// POST requests only update the offline feed.
-	b := &storage.Blob{
-		Name:         blobName,
-		LastUpdated:  protocompat.TimestampNow(),
-		ModifiedTime: protocompat.TimestampNow(),
-		Length:       zipF.FileInfo().Size(),
-	}
-
-	if err := h.blobStore.Upsert(sac.WithAllAccess(ctx), b, r); err != nil {
-		return errors.Wrap(err, "writing scanner definitions")
-	}
-
-	return nil
-}
-
-func (h *httpHandler) handleZipContentsFromVulnDump(ctx context.Context, zipPath string) error {
-	zipR, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return errors.Wrap(err, "couldn't open file as zip")
-	}
-	defer utils.IgnoreError(zipR.Close)
-	var count int
-	// It is expected a ZIP file be uploaded with both Scanner V2 and V4 vulnerability definitions.
-	// scanner-defs.zip contains data required by Scanner V2.
-	// scanner-v4-defs-*.zip contains data required by Scanner v4.
-	// In the future, we may decide to support other files (like we have in the past), which is why we
-	// expect this ZIP of a single ZIP.
-	for _, zipF := range zipR.File {
-		if zipF.Name == scannerDefsSubZipName {
-			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerDefinitionBlobName); err != nil {
-				return errors.Wrap(err, "couldn't handle scanner-defs sub file")
-			}
-			count++
-			continue
-		}
-		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
-			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerV4DefinitionBlobName); err != nil {
-				return errors.Wrap(err, "couldn't handle scanner-v4-defs sub file")
-			}
-			log.Debugf("Successfully processed file: %s", zipF.Name)
-			count++
-		}
-		// Ignore any other files which may be in the ZIP.
-	}
-	if count > 0 {
-		return nil
-	}
-	return errors.New("scanner defs file not found in upload zip; wrong zip uploaded?")
-}
-
-func (h *httpHandler) post(w http.ResponseWriter, r *http.Request) {
-	tempDir, err := os.MkdirTemp("", "scanner-definitions-handler")
-	if err != nil {
-		httputil.WriteGRPCStyleErrorf(w, codes.Internal, "failed to create temp dir: %v", err)
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			log.Warnf("Failed to remove temp dir for scanner defs: %v", err)
-		}
-	}()
-
-	tempFile := filepath.Join(tempDir, "tempfile.zip")
-	if err := fileutils.CopySrcToFile(tempFile, r.Body); err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrapf(err, "copying HTTP POST body to %s", tempFile))
-		return
-	}
-	if features.ScannerV4.Enabled() {
-		if err := validateV4DefsVersion(tempFile); err != nil {
-			httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
-			return
-		}
-	}
-	if err := h.handleZipContentsFromVulnDump(r.Context(), tempFile); err != nil {
-		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
-		return
-	}
-
-	_, _ = w.Write([]byte("Successfully stored the offline vulnerability definitions"))
-}
-
-func (h *httpHandler) runCleanupUpdaters(cleanupInterval, cleanupAge *time.Duration) {
-	interval := defaultCleanupInterval
-	if cleanupInterval != nil {
-		interval = *cleanupInterval
-	}
-	age := defaultCleanupAge
-	if cleanupAge != nil {
-		age = *cleanupAge
-	}
-
-	t := time.NewTicker(interval)
-	for range t.C {
-		h.cleanupUpdaters(age)
-	}
-}
-
-func (h *httpHandler) cleanupUpdaters(cleanupAge time.Duration) {
-	now := time.Now()
-
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	for id, updatingHandler := range h.updaters {
-		if now.Sub(updatingHandler.lastRequestedTime) > cleanupAge {
-			// Updater has not been requested for a long time.
-			// Clean it up.
-			updatingHandler.Stop()
-			delete(h.updaters, id)
-		}
-	}
-}
-
-func (h *httpHandler) openOfflineBlob(ctx context.Context, blobName string) (*vulDefFile, error) {
-	snap, err := snapshot.TakeBlobSnapshot(sac.WithAllAccess(ctx), h.blobStore, blobName)
-	if err != nil {
-		// If the blob does not exist, return no reader.
-		if errors.Is(err, snapshot.ErrBlobNotExist) {
-			return nil, nil
-		}
-		log.Warnf("Cannnot take a snapshot of Blob %q: %v", blobName, err)
-		return nil, err
-	}
-	modTime := time.Time{}
-	if t := protocompat.NilOrTime(snap.GetBlob().ModifiedTime); t != nil {
-		modTime = *t
-	}
-	return &vulDefFile{snap.File, modTime, snap.Close}, nil
-}
-
 // openOpts are options to open most recent V4 definition files.
 type openOpts struct {
 	// name is a generic name to refer to the definition bundle and its content.
@@ -366,192 +167,6 @@ type openOpts struct {
 	vulnBundle string
 	// offlineBlobName is the name of the offline blob to use.
 	offlineBlobName string
-}
-
-func (h *httpHandler) openDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
-	log.Debugf("Fetching scanner V4 (online: %t): type %s: options: %#v", h.online, t, opts)
-
-	file, err := h.openOfflineDefinitions(ctx, t, opts)
-	if !h.online {
-		return file, err
-	}
-	if err != nil {
-		log.Debugf("Failed to access offline file (ignore the message if no "+
-			"offline bundle has been uploaded): %v", err)
-	}
-
-	offlineFile := file
-
-	defer func() {
-		if offlineFile != nil {
-			_ = offlineFile.Close()
-		}
-	}()
-
-	file, err = h.openOnlineDefinitions(ctx, t, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the offline files are newer, return them instead.
-	if offlineFile != nil && offlineFile.modTime.After(file.modTime) {
-		_ = file.Close()
-		// Set nil to protect the deferred close.
-		file, offlineFile = offlineFile, nil
-	}
-
-	return file, err
-}
-
-// openOnlineDefinitions gets desired "online" file, which is pulled and managed
-// by the updater.
-func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
-	u := h.getUpdater(t, opts.urlPath)
-	// Ensure the updater is running.
-	u.Start()
-	openedFile, onlineTime, err := u.file.Open()
-	if err != nil {
-		return nil, err
-	}
-	if openedFile == nil {
-		return nil, fmt.Errorf("scanner V4 %s file %s not found", t, opts.urlPath)
-	}
-	log.Debugf("Compressed data file is available: %s", openedFile.Name())
-	switch t {
-	case v2UpdaterType:
-		if opts.fileName == "" {
-			return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
-		}
-		fallthrough
-	case mappingUpdaterType:
-		defer utils.IgnoreError(openedFile.Close)
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
-		if err != nil {
-			return nil, err
-		}
-		defer cleanUp()
-		return &vulDefFile{File: targetFile, modTime: onlineTime}, nil
-	case vulnerabilityUpdaterType:
-		return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
-	}
-	return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
-}
-
-// openOfflineDefinitions gets desired offline file from compressed bundle.
-func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
-	log.Debugf("Getting v4 offline data for updater: type %s: options: %#v", t, opts)
-	openedFile, err := h.openOfflineBlob(ctx, opts.offlineBlobName)
-	if err != nil {
-		return nil, fmt.Errorf("opening offline definitions: %s: %w",
-			opts.offlineBlobName, err)
-	}
-	if openedFile == nil {
-		log.Warnf("Blob %s does not exist", opts.offlineBlobName)
-		return nil, nil
-	}
-	var offlineFile *vulDefFile
-	switch t {
-	case v2UpdaterType:
-		if opts.fileName == "" {
-			offlineFile = openedFile
-			break
-		}
-		fallthrough
-	case mappingUpdaterType:
-		defer utils.IgnoreError(openedFile.Close)
-		// search mapping file
-		fileName := filepath.Base(opts.fileName)
-		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), fileName)
-		if err != nil {
-			return nil, err
-		}
-		defer cleanUp()
-		offlineFile = &vulDefFile{File: targetFile, modTime: openedFile.modTime}
-	case vulnerabilityUpdaterType:
-		defer utils.IgnoreError(openedFile.Close)
-		// check version information in manifest
-		mf, cleanUp, err := openFromArchive(openedFile.Name(), "manifest.json")
-		if err != nil {
-			return nil, err
-		}
-		defer cleanUp()
-		offlineV, err := getOfflineFileVersion(mf)
-		if err != nil {
-			return nil, err
-		}
-		defer utils.IgnoreError(mf.Close)
-
-		if offlineV != minorVersionPattern.FindString(opts.vulnVersion) && (opts.vulnVersion != "dev" || buildinfo.ReleaseBuild) {
-			msg := fmt.Sprintf("failed to get offline vuln file, uploaded file is version: %s and requested file version is: %s", offlineV, opts.vulnVersion)
-			log.Errorf(msg)
-			return nil, errors.New(msg)
-		}
-
-		vulns, cleanUp, err := openFromArchive(openedFile.Name(), opts.vulnBundle)
-		if err != nil {
-			return nil, err
-		}
-		defer cleanUp()
-		offlineFile = &vulDefFile{File: vulns, modTime: openedFile.modTime}
-	default:
-		return nil, fmt.Errorf("unknown updater type: %s", t)
-	}
-
-	return offlineFile, nil
-}
-
-// openFromArchive returns a file object for a name within the definitions
-// bundle. The file object has a file descriptor allocated on the filesystem, but
-// its name is removed. Meaning once the file object is closed, the data will be
-// freed in filesystem by the OS.
-func openFromArchive(archiveFile string, fileName string) (*os.File, func(), error) {
-	// Open zip archive and extract the fileName.
-	zipReader, err := zip.OpenReader(archiveFile)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "opening zip archive")
-	}
-	defer utils.IgnoreError(zipReader.Close)
-	fileReader, err := zipReader.Open(fileName)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "extracting")
-	}
-	defer utils.IgnoreError(fileReader.Close)
-
-	// Create a temporary file and remove it, keeping the file descriptor.
-	tmpDir, err := os.MkdirTemp("", definitionsBaseDir)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating temporary directory")
-	}
-	tmpFile, err := os.Create(filepath.Join(tmpDir, path.Base(fileName)))
-	if err != nil {
-		// Best effort to clean.
-		_ = os.RemoveAll(tmpDir)
-		return nil, nil, errors.Wrap(err, "opening temporary file")
-	}
-	defer func() {
-		if err != nil {
-			_ = tmpFile.Close()
-		}
-	}()
-	cleanup := func() {
-		_ = os.RemoveAll(tmpDir)
-	}
-
-	// Extract the file and copy contents to the temporary file, notice we
-	// intentionally don't Sync(), to benefit from filesystem caching.
-	_, err = io.Copy(tmpFile, fileReader)
-	if err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return nil, nil, errors.Wrap(err, "writing to temporary file")
-	}
-
-	// Reset for caller's convenience.
-	_, err = tmpFile.Seek(0, io.SeekStart)
-	if err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return nil, nil, errors.Wrap(err, "writing to temporary file")
-	}
-	return tmpFile, cleanup, nil
 }
 
 func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
@@ -627,13 +242,222 @@ func (h *httpHandler) get(w http.ResponseWriter, r *http.Request) {
 	serveContent(w, r, f.Name(), f.modTime, f)
 }
 
-func getOfflineFileVersion(mf *os.File) (string, error) {
-	var m manifest
-	err := json.NewDecoder(mf).Decode(&m)
-	if err != nil {
-		return "", err
+func (h *httpHandler) openDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
+	log.Debugf("Fetching scanner V4 (online: %t): type %s: options: %#v", h.online, t, opts)
+
+	file, err := h.openOfflineDefinitions(ctx, t, opts)
+	if !h.online {
+		return file, err
 	}
-	return m.Version, nil
+	if err != nil {
+		log.Debugf("Failed to access offline file (ignore the message if no "+
+			"offline bundle has been uploaded): %v", err)
+	}
+
+	offlineFile := file
+
+	defer func() {
+		if offlineFile != nil {
+			_ = offlineFile.Close()
+		}
+	}()
+
+	file, err = h.openOnlineDefinitions(ctx, t, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the offline files are newer, return them instead.
+	if offlineFile != nil && offlineFile.modTime.After(file.modTime) {
+		_ = file.Close()
+		// Set nil to protect the deferred close.
+		file, offlineFile = offlineFile, nil
+	}
+
+	return file, err
+}
+
+// openOfflineDefinitions gets desired offline file from compressed bundle.
+func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
+	log.Debugf("Getting v4 offline data for updater: type %s: options: %#v", t, opts)
+	openedFile, err := h.openOfflineBlob(ctx, opts.offlineBlobName)
+	if err != nil {
+		return nil, fmt.Errorf("opening offline definitions: %s: %w",
+			opts.offlineBlobName, err)
+	}
+	if openedFile == nil {
+		log.Warnf("Blob %s does not exist", opts.offlineBlobName)
+		return nil, nil
+	}
+	var offlineFile *vulDefFile
+	switch t {
+	case v2UpdaterType:
+		if opts.fileName == "" {
+			offlineFile = openedFile
+			break
+		}
+		fallthrough
+	case mappingUpdaterType:
+		defer utils.IgnoreError(openedFile.Close)
+		// search mapping file
+		fileName := filepath.Base(opts.fileName)
+		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), fileName)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanUp()
+		offlineFile = &vulDefFile{File: targetFile, modTime: openedFile.modTime}
+	case vulnerabilityUpdaterType:
+		defer utils.IgnoreError(openedFile.Close)
+		// check version information in manifest
+		mf, cleanUp, err := openFromArchive(openedFile.Name(), "manifest.json")
+		if err != nil {
+			return nil, err
+		}
+		defer cleanUp()
+		offlineV, err := getOfflineFileVersion(mf)
+		if err != nil {
+			return nil, err
+		}
+		defer utils.IgnoreError(mf.Close)
+
+		if offlineV != minorVersionPattern.FindString(opts.vulnVersion) && (opts.vulnVersion != "dev" || buildinfo.ReleaseBuild) {
+			msg := fmt.Sprintf("failed to get offline vuln file, uploaded file is version: %s and requested file version is: %s", offlineV, opts.vulnVersion)
+			log.Errorf(msg)
+			return nil, errors.New(msg)
+		}
+
+		vulns, cleanUp, err := openFromArchive(openedFile.Name(), opts.vulnBundle)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanUp()
+		offlineFile = &vulDefFile{File: vulns, modTime: openedFile.modTime}
+	default:
+		return nil, fmt.Errorf("unknown updater type: %s", t)
+	}
+
+	return offlineFile, nil
+}
+
+func (h *httpHandler) openOfflineBlob(ctx context.Context, blobName string) (*vulDefFile, error) {
+	snap, err := snapshot.TakeBlobSnapshot(sac.WithAllAccess(ctx), h.blobStore, blobName)
+	if err != nil {
+		// If the blob does not exist, return no reader.
+		if errors.Is(err, snapshot.ErrBlobNotExist) {
+			return nil, nil
+		}
+		log.Warnf("Cannnot take a snapshot of Blob %q: %v", blobName, err)
+		return nil, err
+	}
+	modTime := time.Time{}
+	if t := protocompat.NilOrTime(snap.GetBlob().ModifiedTime); t != nil {
+		modTime = *t
+	}
+	return &vulDefFile{snap.File, modTime, snap.Close}, nil
+}
+
+// openOnlineDefinitions gets desired "online" file, which is pulled and managed
+// by the updater.
+func (h *httpHandler) openOnlineDefinitions(_ context.Context, t updaterType, opts openOpts) (*vulDefFile, error) {
+	u := h.getUpdater(t, opts.urlPath)
+	// Ensure the updater is running.
+	u.Start()
+	openedFile, onlineTime, err := u.file.Open()
+	if err != nil {
+		return nil, err
+	}
+	if openedFile == nil {
+		return nil, fmt.Errorf("scanner V4 %s file %s not found", t, opts.urlPath)
+	}
+	log.Debugf("Compressed data file is available: %s", openedFile.Name())
+	switch t {
+	case v2UpdaterType:
+		if opts.fileName == "" {
+			return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
+		}
+		fallthrough
+	case mappingUpdaterType:
+		defer utils.IgnoreError(openedFile.Close)
+		targetFile, cleanUp, err := openFromArchive(openedFile.Name(), opts.fileName)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanUp()
+		return &vulDefFile{File: targetFile, modTime: onlineTime}, nil
+	case vulnerabilityUpdaterType:
+		return &vulDefFile{File: openedFile, modTime: onlineTime}, nil
+	}
+	return nil, fmt.Errorf("unknown Scanner V4 updater type: %s", t)
+}
+
+// getUpdater gets or creates an updater for the scanner definitions identified
+// by the given updater type and a URL path to the definitions file. If the
+// updater was created, it is no started here, callers are expected to start it.
+func (h *httpHandler) getUpdater(t updaterType, urlPath string) *requestedUpdater {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	fileName := strings.ReplaceAll(filepath.Join(t.String(), urlPath), "/", "-")
+	updater, exists := h.updaters[fileName]
+	if !exists {
+		var updateURL *url.URL
+		var ext string
+		switch t {
+		case mappingUpdaterType:
+			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4MappingSubDir, scannerV4MappingFile)
+			ext = ".zip"
+		case vulnerabilityUpdaterType:
+			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4VulnSubDir, urlPath)
+			ext = ".json.zst"
+		default: // uuid
+			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerUpdateURLSuffix)
+			ext = ".zip"
+		}
+		filePath := filepath.Join(h.onlineVulnDir, fileName)
+		// Use a default extension if the URL path does not contain one.
+		if filepath.Ext(fileName) == "" {
+			filePath += ext
+		}
+		updater = &requestedUpdater{
+			updater: newUpdater(file.New(filePath), client, updateURL.String(), h.interval),
+		}
+		h.updaters[fileName] = updater
+	}
+
+	updater.lastRequestedTime = time.Now()
+	return updater
+}
+
+func (h *httpHandler) post(w http.ResponseWriter, r *http.Request) {
+	tempDir, err := os.MkdirTemp("", "scanner-definitions-handler")
+	if err != nil {
+		httputil.WriteGRPCStyleErrorf(w, codes.Internal, "failed to create temp dir: %v", err)
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			log.Warnf("Failed to remove temp dir for scanner defs: %v", err)
+		}
+	}()
+
+	tempFile := filepath.Join(tempDir, "tempfile.zip")
+	if err := fileutils.CopySrcToFile(tempFile, r.Body); err != nil {
+		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrapf(err, "copying HTTP POST body to %s", tempFile))
+		return
+	}
+	if features.ScannerV4.Enabled() {
+		if err := validateV4DefsVersion(tempFile); err != nil {
+			httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
+			return
+		}
+	}
+	if err := h.handleZipContentsFromVulnDump(r.Context(), tempFile); err != nil {
+		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
+		return
+	}
+
+	_, _ = w.Write([]byte("Successfully stored the offline vulnerability definitions"))
 }
 
 func validateV4DefsVersion(zipPath string) error {
@@ -670,4 +494,180 @@ func validateV4DefsVersion(zipPath string) error {
 		}
 	}
 	return nil
+}
+
+func (h *httpHandler) handleZipContentsFromVulnDump(ctx context.Context, zipPath string) error {
+	zipR, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "couldn't open file as zip")
+	}
+	defer utils.IgnoreError(zipR.Close)
+	var count int
+	// It is expected a ZIP file be uploaded with both Scanner V2 and V4 vulnerability definitions.
+	// scanner-defs.zip contains data required by Scanner V2.
+	// scanner-v4-defs-*.zip contains data required by Scanner v4.
+	// In the future, we may decide to support other files (like we have in the past), which is why we
+	// expect this ZIP of a single ZIP.
+	for _, zipF := range zipR.File {
+		if zipF.Name == scannerDefsSubZipName {
+			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerDefinitionBlobName); err != nil {
+				return errors.Wrap(err, "couldn't handle scanner-defs sub file")
+			}
+			count++
+			continue
+		}
+		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
+			if err := h.handleScannerDefsFile(ctx, zipF, offlineScannerV4DefinitionBlobName); err != nil {
+				return errors.Wrap(err, "couldn't handle scanner-v4-defs sub file")
+			}
+			log.Debugf("Successfully processed file: %s", zipF.Name)
+			count++
+		}
+		// Ignore any other files which may be in the ZIP.
+	}
+	if count > 0 {
+		return nil
+	}
+	return errors.New("scanner defs file not found in upload zip; wrong zip uploaded?")
+}
+
+func (h *httpHandler) handleScannerDefsFile(ctx context.Context, zipF *zip.File, blobName string) error {
+	r, err := zipF.Open()
+	if err != nil {
+		return errors.Wrap(err, "opening ZIP reader")
+	}
+	defer utils.IgnoreError(r.Close)
+
+	// POST requests only update the offline feed.
+	b := &storage.Blob{
+		Name:         blobName,
+		LastUpdated:  protocompat.TimestampNow(),
+		ModifiedTime: protocompat.TimestampNow(),
+		Length:       zipF.FileInfo().Size(),
+	}
+
+	if err := h.blobStore.Upsert(sac.WithAllAccess(ctx), b, r); err != nil {
+		return errors.Wrap(err, "writing scanner definitions")
+	}
+
+	return nil
+}
+
+// openFromArchive returns a file object for a name within the definitions
+// bundle. The file object has a file descriptor allocated on the filesystem, but
+// its name is removed. Meaning once the file object is closed, the data will be
+// freed in filesystem by the OS.
+func openFromArchive(archiveFile string, fileName string) (*os.File, func(), error) {
+	// Open zip archive and extract the fileName.
+	zipReader, err := zip.OpenReader(archiveFile)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "opening zip archive")
+	}
+	defer utils.IgnoreError(zipReader.Close)
+	fileReader, err := zipReader.Open(fileName)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "extracting")
+	}
+	defer utils.IgnoreError(fileReader.Close)
+
+	// Create a temporary file and remove it, keeping the file descriptor.
+	tmpDir, err := os.MkdirTemp("", definitionsBaseDir)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating temporary directory")
+	}
+	tmpFile, err := os.Create(filepath.Join(tmpDir, path.Base(fileName)))
+	if err != nil {
+		// Best effort to clean.
+		_ = os.RemoveAll(tmpDir)
+		return nil, nil, errors.Wrap(err, "opening temporary file")
+	}
+	defer func() {
+		if err != nil {
+			_ = tmpFile.Close()
+		}
+	}()
+	cleanup := func() {
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	// Extract the file and copy contents to the temporary file, notice we
+	// intentionally don't Sync(), to benefit from filesystem caching.
+	_, err = io.Copy(tmpFile, fileReader)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, nil, errors.Wrap(err, "writing to temporary file")
+	}
+
+	// Reset for caller's convenience.
+	_, err = tmpFile.Seek(0, io.SeekStart)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, nil, errors.Wrap(err, "writing to temporary file")
+	}
+	return tmpFile, cleanup, nil
+}
+
+func getOfflineFileVersion(mf *os.File) (string, error) {
+	var m manifest
+	err := json.NewDecoder(mf).Decode(&m)
+	if err != nil {
+		return "", err
+	}
+	return m.Version, nil
+}
+
+func serveContent(w http.ResponseWriter, r *http.Request, name string, modTime time.Time, content io.ReadSeeker) {
+	log.Debugf("Serving vulnerability definitions from %s", filepath.Base(name))
+	http.ServeContent(w, r, name, modTime, content)
+}
+
+func writeErrorNotFound(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte("No scanner definitions found"))
+}
+
+func writeErrorBadRequest(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_, _ = w.Write([]byte("at least one of file or uuid must be specified"))
+}
+
+func writeErrorForFile(w http.ResponseWriter, err error, path string) {
+	if errox.IsAny(err, fs.ErrNotExist, snapshot.ErrBlobNotExist) {
+		writeErrorNotFound(w)
+		return
+	}
+
+	httputil.WriteGRPCStyleErrorf(w, codes.Internal, "could not read vulnerability definition %s: %v", filepath.Base(path), err)
+}
+
+func (h *httpHandler) runCleanupUpdaters(cleanupInterval, cleanupAge *time.Duration) {
+	interval := defaultCleanupInterval
+	if cleanupInterval != nil {
+		interval = *cleanupInterval
+	}
+	age := defaultCleanupAge
+	if cleanupAge != nil {
+		age = *cleanupAge
+	}
+
+	t := time.NewTicker(interval)
+	for range t.C {
+		h.cleanupUpdaters(age)
+	}
+}
+
+func (h *httpHandler) cleanupUpdaters(cleanupAge time.Duration) {
+	now := time.Now()
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	for id, updatingHandler := range h.updaters {
+		if now.Sub(updatingHandler.lastRequestedTime) > cleanupAge {
+			// Updater has not been requested for a long time.
+			// Clean it up.
+			updatingHandler.Stop()
+			delete(h.updaters, id)
+		}
+	}
 }

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -270,17 +270,17 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	// No scanner defs found.
 	req := s.getRequestWithVersionedFile(t, "4.3.0")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// No mapping json file
 	req = s.getRequestWithJSONFile(t, "name2repos")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// No mapping json file
 	req = s.getRequestWithJSONFile(t, "repo2cpe")
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	tempDir := t.TempDir()
 	filePath := tempDir + "/test.zip"

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,19 +20,22 @@ import (
 	"github.com/stackrox/rox/central/blob/datastore/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/httputil/mock"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 const (
 	content1 = "Hello, world!"
 	content2 = "Papaya"
+
+	v4ManifestContent = `{
+  "version": "dev"
+}`
 )
 
 type handlerTestSuite struct {
@@ -77,179 +81,70 @@ func (s *handlerTestSuite) TearDownSuite() {
 	utils.IgnoreError(func() error { return os.RemoveAll(s.tmpDir) })
 }
 
-func (s *handlerTestSuite) mustGetRequest(t *testing.T) *http.Request {
-	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe"
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+func (s *handlerTestSuite) postRequestV2() *http.Request {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	file, err := zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-defs.zip",
+		Comment:            "Scanner V2 content",
+		UncompressedSize64: uint64(len(content1)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(content1))
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
 
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) getRequestWithJSONFile(t *testing.T, file string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?file=%s", file)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) getRequestWithVersionedFile(t *testing.T, v string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?version=%s", v)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, "https://central.stackrox.svc/scannerdefinitions", &buf)
+	s.Require().NoError(err)
 
 	return req
 }
 
-func (s *handlerTestSuite) mustGetRequestWithFile(t *testing.T, file string) *http.Request {
-	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe&file=%s", file)
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
+func (s *handlerTestSuite) postRequestV4() *http.Request {
+	// V4 ZIP file contents.
+	var v4Buf bytes.Buffer
+	zw := zip.NewWriter(&v4Buf)
+	file, err := zw.CreateHeader(&zip.FileHeader{
+		Name:               "manifest.json",
+		Comment:            "Scanner V4 manifest",
+		UncompressedSize64: uint64(len(v4ManifestContent)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(v4ManifestContent))
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
+
+	var buf bytes.Buffer
+	zw = zip.NewWriter(&buf)
+
+	// Currently, we need both V2 and V4 files when Scanner V4 is enabled.
+	file, err = zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-defs.zip",
+		Comment:            "Scanner V2 content",
+		UncompressedSize64: uint64(len(content1)),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write([]byte(content1))
+	s.Require().NoError(err)
+
+	file, err = zw.CreateHeader(&zip.FileHeader{
+		Name:               "scanner-v4-defs.zip",
+		Comment:            "Scanner V4 content",
+		UncompressedSize64: uint64(v4Buf.Len()),
+	})
+	s.Require().NoError(err)
+	_, err = file.Write(v4Buf.Bytes())
+	s.Require().NoError(err)
+
+	s.Require().NoError(zw.Close())
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, "https://central.stackrox.svc/scannerdefinitions", &buf)
+	s.Require().NoError(err)
 
 	return req
 }
 
-func (s *handlerTestSuite) mustGetBadRequest(t *testing.T) *http.Request {
-	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=fail"
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
-	require.NoError(t, err)
-
-	return req
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Offline_Get() {
-	t := s.T()
-	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
-
-	h := New(s.datastore, handlerOpts{})
-
-	// No scanner defs found.
-	req := s.mustGetRequest(t)
-	w := mock.NewResponseWriter()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Add scanner defs.
-	s.mustWriteOffline(content1, time.Now())
-
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, content1, w.Data.String())
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	w := mock.NewResponseWriter()
-
-	// Should not get anything.
-	req := s.mustGetBadRequest(t)
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Should get file from online update.
-	req = s.mustGetRequestWithFile(t, "manifest.json")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	assert.Regexpf(t, `{"since":".*","until":".*"}`, w.Data.String(), "content1 did not match")
-	// Should get online update.
-	req = s.mustGetRequest(t)
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	// Write offline definitions.
-	s.mustWriteOffline(content1, time.Now())
-
-	// Set the offline dump's modified time to later than the online update's.
-	s.mustWriteOffline(content1, time.Now().Add(time.Hour))
-
-	// Served the offline dump, as it is more recent.
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, content1, w.Data.String())
-
-	// Set the offline dump's modified time to earlier than the online update's.
-	s.mustWriteOffline(content2, nov23)
-
-	// Serve the online dump, as it is now more recent.
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.NotEqual(t, content2, w.Data.String())
-
-	// File is unmodified.
-	req.Header.Set(ifModifiedSinceHeader, time.Now().UTC().Format(http.TimeFormat))
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotModified, w.Code)
-	assert.Empty(t, w.Data.String())
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_ZSTD_Bundle_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	w := mock.NewResponseWriter()
-
-	req := s.getRequestWithVersionedFile(t, "randomName")
-	h.ServeHTTP(w, req)
-	// If the version is invalid or versioned bundle cannot be found, it's a 500
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-
-	// Should get dev zstd file from online update.
-	req = s.getRequestWithVersionedFile(t, "dev")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-
-	req = s.getRequestWithVersionedFile(t, "4.3.x-173-g6bbb2e07dc")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-
-	// Should get dev zstd file from online update.
-	req = s.getRequestWithVersionedFile(t, "4.3.x-nightly-20240106")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
-}
-
-func (s *handlerTestSuite) TestServeHTTP_Online_Mappings_Get() {
-	t := s.T()
-	h := New(s.datastore, handlerOpts{})
-
-	w := mock.NewResponseWriter()
-
-	// Nothing should be found
-	req := s.getRequestWithJSONFile(t, "randomName")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// Should get mapping json file from online update.
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-
-	// Should get mapping json file from online update.
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	w.Data.Reset()
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-}
-
-func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
+func (s *handlerTestSuite) mustWriteBlob(content string, modTime time.Time) {
 	modifiedTime, err := protocompat.ConvertTimeToTimestampOrError(modTime)
 	s.Require().NoError(err)
 	blob := &storage.Blob{
@@ -261,67 +156,44 @@ func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
 	s.Require().NoError(s.datastore.Upsert(s.ctx, blob, bytes.NewBuffer([]byte(content))))
 }
 
-func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
-	t := s.T()
-	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
-	h := New(s.datastore, handlerOpts{})
-	w := mock.NewResponseWriter()
-
-	// No scanner defs found.
-	req := s.getRequestWithVersionedFile(t, "4.3.0")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// No mapping json file
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	// No mapping json file
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-
-	tempDir := t.TempDir()
-	filePath := tempDir + "/test.zip"
-
-	url := "https://storage.googleapis.com/scanner-support-public/offline/v1/4.3/scanner-vulns-4.3.zip"
-	resp, err := http.Get(url)
-	// Skip the test if file cannot be downloaded or status code is not OK.
-	if err != nil {
-		return
-	}
-	defer utils.IgnoreError(resp.Body.Close)
-	if resp.StatusCode != http.StatusOK {
-		return
-	}
-
-	outFile, err := os.Create(filePath)
+func (s *handlerTestSuite) getRequestUUID() *http.Request {
+	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
 
-	_, err = io.Copy(outFile, resp.Body)
+	return req
+}
+
+func (s *handlerTestSuite) getRequestFile(file string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?file=%s", file)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
-	utils.IgnoreError(outFile.Close)
 
-	err = s.mockHandleZipContents(filePath)
+	return req
+}
+
+func (s *handlerTestSuite) getRequestVersion(v string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?version=%s", v)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
 	s.Require().NoError(err)
 
-	req = s.getRequestWithVersionedFile(t, "4.3.0")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
+	return req
+}
 
-	w = mock.NewResponseWriter()
-	req = s.getRequestWithJSONFile(t, "repo2cpe")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+func (s *handlerTestSuite) getRequestUUIDAndFile(file string) *http.Request {
+	centralURL := fmt.Sprintf("https://central.stackrox.svc/scannerdefinitions?uuid=e799c68a-671f-44db-9682-f24248cd0ffe&file=%s", file)
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+	s.Require().NoError(err)
 
-	w = mock.NewResponseWriter()
-	req = s.getRequestWithJSONFile(t, "name2repos")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	return req
+}
+
+func (s *handlerTestSuite) getRequestBadUUID() *http.Request {
+	centralURL := "https://central.stackrox.svc/scannerdefinitions?uuid=fail"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, centralURL, nil)
+	s.Require().NoError(err)
+
+	return req
 }
 
 func (s *handlerTestSuite) mockHandleDefsFile(zipF *zip.File, blobName string) error {
@@ -351,4 +223,238 @@ func (s *handlerTestSuite) mockHandleZipContents(zipPath string) error {
 		}
 	}
 	return errors.New("test failed")
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Post_V2() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "false")
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	req := s.postRequestV2()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Get_V2() {
+	s.T().Skip("TODO: fix in followup PRs")
+
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "false")
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	// No scanner-defs found.
+	getReq := s.getRequestUUID()
+	w.Data.Reset()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Post scanner-defs.
+	postReq := s.postRequestV2()
+	w = mock.NewResponseWriter()
+	h.ServeHTTP(w, postReq)
+	s.Require().Equal(http.StatusOK, w.Code)
+
+	// Bad request after data is uploaded.
+	getReq = s.getRequestBadUUID()
+	w.Data.Reset()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Get scanner-defs again.
+	getReq = s.getRequestUUID()
+	w.Data.Reset()
+	h.ServeHTTP(w, getReq)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal(content1, w.Data.String())
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V2() {
+	s.T().Skip("TODO: fix in followup PRs")
+
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	// Should not get anything with bad UUID.
+	req := s.getRequestBadUUID()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Should get file from online update.
+	req = s.getRequestUUIDAndFile("manifest.json")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+	s.Regexpf(`{"since":".*","until":".*"}`, w.Data.String(), "content1 did not match")
+
+	// Should get online vulns.
+	req = s.getRequestUUID()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+
+	// Write offline definitions, directly.
+	// Set the offline dump's modified time to later than the online update's.
+	s.mustWriteBlob(content1, time.Now().Add(time.Hour))
+
+	// Serve the offline dump, as it is more recent.
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal(content1, w.Data.String())
+
+	// Set the offline dump's modified time to earlier than the online update's.
+	s.mustWriteBlob(content2, nov23)
+
+	// Serve the online dump, as it is now more recent.
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.NotEqual(content2, w.Data.String())
+
+	// File is unmodified.
+	req.Header.Set(ifModifiedSinceHeader, time.Now().UTC().Format(http.TimeFormat))
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotModified, w.Code)
+	s.Empty(w.Data.String())
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Post_V4() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "true")
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	req := s.postRequestV4()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Offline_Get_V4() {
+	s.T().Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	s.T().Setenv(features.ScannerV4.EnvVar(), "true")
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	// No scanner defs found.
+	req := s.getRequestVersion("4.5.0")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// No mapping json file
+	req = s.getRequestFile("name2repos")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// No mapping json file
+	req = s.getRequestFile("repo2cpe")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	url := "https://storage.googleapis.com/scanner-support-public/offline/v1/4.5/scanner-vulns-4.5.zip"
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, url, nil)
+	s.Require().NoError(err)
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer utils.IgnoreError(resp.Body.Close)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	filePath := filepath.Join(s.T().TempDir(), "test.zip")
+	outFile, err := os.Create(filePath)
+	s.Require().NoError(err)
+
+	_, err = io.Copy(outFile, resp.Body)
+	s.Require().NoError(err)
+	utils.IgnoreError(outFile.Close)
+
+	err = s.mockHandleZipContents(filePath)
+	s.Require().NoError(err)
+
+	// This will fail because 4.5.0 uses the multi-bundle ZIP format.
+	req = s.getRequestVersion("4.5.0")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Set the header properly.
+	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+
+	w = mock.NewResponseWriter()
+	req = s.getRequestFile("repo2cpe")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+
+	w = mock.NewResponseWriter()
+	req = s.getRequestFile("name2repos")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	req := s.getRequestVersion("randomName")
+	h.ServeHTTP(w, req)
+	// If the version is invalid or versioned bundle cannot be found, it's a 500
+	s.Equal(http.StatusInternalServerError, w.Code)
+
+	// Should get dev zstd file from online update.
+	req = s.getRequestVersion("dev")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Release version.
+	req = s.getRequestVersion("4.4.0")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Should get dev zstd file from online update.
+	req = s.getRequestVersion("4.3.x-nightly-20240106")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zstd", w.Header().Get("Content-Type"))
+
+	// Multi-bundle ZIP.
+	req = s.getRequestVersion("dev")
+	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/zip", w.Header().Get("Content-Type"))
+}
+
+func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4_Mappings() {
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	// Nothing should be found
+	req := s.getRequestFile("randomName")
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusNotFound, w.Code)
+
+	// Should get mapping json file from online update.
+	req = s.getRequestFile("name2repos")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
+
+	// Should get mapping json file from online update.
+	req = s.getRequestFile("repo2cpe")
+	w.Data.Reset()
+	h.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/json", w.Header().Get("Content-Type"))
 }


### PR DESCRIPTION
### Description

* Remove the returned clean func from `openFromArchive`, as there is no purpose for it
* Close access to file upon failure - was previously a potential memory leak

* https://github.com/stackrox/stackrox/pull/11212
* https://github.com/stackrox/stackrox/pull/11825
* https://github.com/stackrox/stackrox/pull/11836
* https://github.com/stackrox/stackrox/pull/11837
* https://github.com/stackrox/stackrox/pull/11841 <-- This
* https://github.com/stackrox/stackrox/pull/11842
* https://github.com/stackrox/stackrox/pull/11843

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

CI