### PR TITLE
chore(central): cleanup more handlers

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -321,8 +321,6 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		log.Debugf("Offline blob %s does not exist", opts.offlineBlobName)
 		return nil, nil
 	}
-	defer utils.IgnoreError(offlineBlob.Close)
-	archiveName := offlineBlob.Name()
 
 	var offlineFile *vulDefFile
 	switch t {
@@ -336,7 +334,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 		defer utils.IgnoreError(offlineBlob.Close)
 		// search mapping file
 		fileName := filepath.Base(opts.fileName)
-		targetFile, _, err := h.openFromArchive(archiveName, fileName)
+		targetFile, _, err := h.openFromArchive(offlineBlob.Name(), fileName)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +359,7 @@ func (h *httpHandler) openOfflineDefinitions(ctx context.Context, t updaterType,
 			return nil, errors.New(msg)
 		}
 
-		vulns, _, err := h.openFromArchive(archiveName, opts.vulnBundle)
+		vulns, _, err := h.openFromArchive(offlineBlob.Name(), opts.vulnBundle)
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +458,7 @@ func (h *httpHandler) getUpdater(t updaterType, urlPath string) (*requestedUpdat
 		case vulnerabilityUpdaterType:
 			updateURL = scannerUpdateBaseURL.JoinPath(scannerV4VulnSubDir, urlPath)
 		case v2UpdaterType:
-			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DefsFile)
+			updateURL = scannerUpdateBaseURL.JoinPath(urlPath, scannerV2DiffFile)
 		default:
 			return nil, fmt.Errorf("unknown updater type: %s", t)
 		}

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -425,21 +425,21 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
 
 	// Should get dev zstd file from online update.
 	req = s.getRequestVersion("dev")
-	w.Data.Reset()
+	w = mock.NewResponseWriter()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
 
 	// Release version.
 	req = s.getRequestVersion("4.4.0")
-	w.Data.Reset()
+	w = mock.NewResponseWriter()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
 
 	// Should get dev zstd file from online update.
 	req = s.getRequestVersion("4.3.x-nightly-20240106")
-	w.Data.Reset()
+	w = mock.NewResponseWriter()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zstd", w.Header().Get("Content-Type"))
@@ -447,7 +447,7 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Get_V4() {
 	// Multi-bundle ZIP.
 	req = s.getRequestVersion("dev")
 	req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
-	w.Data.Reset()
+	w = mock.NewResponseWriter()
 	h.ServeHTTP(w, req)
 	s.Equal(http.StatusOK, w.Code)
 	s.Equal("application/zip", w.Header().Get("Content-Type"))


### PR DESCRIPTION
### Description

* Add comments and does minor cleanup to `get`
* Clean `openDefinitions` and remove unnecessary logs
* Cleaned `openOfflineDefinitions`
    * updated log message to remove V4 reference
    * Fixed issue where an error can prevent the closing of the manifest file
    * Swapped `s/Errorf/Error` where necessary
* add doc to `openOfflineBlob`
* `s/getOfflineFileVersion/readV4ManifestVersion`
* Clean `openOnlineDefinitions`
    * Fix issue where the online ZIP file is not closed when it's not the returned file
* Simplify `getUpdater`
    * NOTE: MY IDE CLAIMS mappingUpdaterType IS NEVER SET WHEN getUpdater IS CALLED
    * I don't think I believe this, but I'm hoping someone else can try to verify this

* https://github.com/stackrox/stackrox/pull/11212
* https://github.com/stackrox/stackrox/pull/11825
* https://github.com/stackrox/stackrox/pull/11836
* https://github.com/stackrox/stackrox/pull/11837
* https://github.com/stackrox/stackrox/pull/11841
* https://github.com/stackrox/stackrox/pull/11842 <-- This
* https://github.com/stackrox/stackrox/pull/11843

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

CI