### PR TITLE
tests: Add benchmark tests for some GraphQL queries

### DIFF
--- a/central/graphql/handler/handler_benchmark_test.go
+++ b/central/graphql/handler/handler_benchmark_test.go
@@ -1,0 +1,221 @@
+//go:build sql_integration
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/stackrox/rox/central/graphql/resolvers"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	"github.com/stackrox/rox/central/testutils"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/sac"
+)
+
+const (
+	deploymentsQuery = `query listDeployments($query:String){
+	deployments(query: $query) {
+		id
+		name
+		type
+		namespace
+		namespaceId
+		stateTimestamp
+	}
+}`
+
+	imagesQuery = `query listImages($query:String){
+	images(query: $query) {
+		id
+		name {
+			registry
+			remote
+			tag
+			fullName
+		}
+		# scan is required to ensure the full image is pulled
+		# and not just the associated metadata.
+		scan {
+			operatingSystem
+			scanTime
+		}
+	}
+}`
+
+	deploymentsWithImagesQuery = `query listDeploymentsWithImages($query: String) {
+	deployments(query: $query) {
+		id
+		name
+		type
+		namespace
+		namespaceId
+		stateTimestamp
+	}
+	# For the purpose of the test, the plan is to pull the deployments
+	# and images filtered by namespace. The query resolution for images
+	# relies on the relation to the deployment table, so the behaviour
+	# should be similar to the output of "/v1/export/vuln-mgmt/workloads/"
+	images(query: $query) {
+		id
+		name {
+			registry
+			remote
+			tag
+			fullName
+		}
+		# scan is required to ensure the full image is pulled
+		# and not just the associated metadata.
+		scan {
+			operatingSystem
+			scanTime
+		}
+	}
+}`
+)
+
+func BenchmarkDeploymentExport(b *testing.B) {
+	_ = b
+	testHelper := &testutils.ExportServicePostgresTestHelper{}
+	err := testHelper.SetupTest(b)
+	if err != nil {
+		b.Error(err)
+	}
+	defer testHelper.TearDownTest(b)
+
+	testHelper.InjectDataAndRunBenchmark(b, false, getDeploymentBenchmark(testHelper))
+}
+
+func getDeploymentBenchmark(testHelper *testutils.ExportServicePostgresTestHelper) func(b *testing.B) {
+	return getGraphQLBenchmark(testHelper, deploymentsQuery)
+}
+
+func BenchmarkImageExport(b *testing.B) {
+	_ = b
+	testHelper := &testutils.ExportServicePostgresTestHelper{}
+	err := testHelper.SetupTest(b)
+	if err != nil {
+		b.Error(err)
+	}
+	defer testHelper.TearDownTest(b)
+
+	testHelper.InjectDataAndRunBenchmark(b, true, getImageBenchmark(testHelper))
+}
+
+func getImageBenchmark(testHelper *testutils.ExportServicePostgresTestHelper) func(b *testing.B) {
+	return getGraphQLBenchmark(testHelper, imagesQuery)
+}
+
+func BenchmarkDeploymentWithImageExport(b *testing.B) {
+	_ = b
+	testHelper := &testutils.ExportServicePostgresTestHelper{}
+	err := testHelper.SetupTest(b)
+	if err != nil {
+		b.Error(err)
+	}
+	defer testHelper.TearDownTest(b)
+
+	testHelper.InjectDataAndRunBenchmark(b, true, getDeploymentWithImageBenchmark(testHelper))
+}
+
+func getDeploymentWithImageBenchmark(testHelper *testutils.ExportServicePostgresTestHelper) func(b *testing.B) {
+	return getGraphQLBenchmark(testHelper, deploymentsWithImagesQuery)
+}
+
+type wrappedHandler struct {
+	ctx     context.Context
+	handler http.Handler
+}
+
+func (h *wrappedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	wrappedRequest := r.WithContext(h.ctx)
+	h.handler.ServeHTTP(w, wrappedRequest)
+}
+
+func getGraphQLServer(testHelper *testutils.ExportServicePostgresTestHelper) (*httptest.Server, error) {
+	schema := resolvers.Schema()
+	resolver := resolvers.NewMock()
+	resolver.DeploymentDataStore = testHelper.Deployments
+	resolver.ImageDataStore = testHelper.Images
+	// Override Deployment and Image loader to avoid panics
+	deploymentFactory := func() interface{} {
+		return loaders.NewDeploymentLoader(resolver.DeploymentDataStore)
+	}
+	loaders.RegisterTypeFactory(reflect.TypeOf(storage.Deployment{}), deploymentFactory)
+	imageFactory := func() interface{} {
+		return loaders.NewImageLoader(resolver.ImageDataStore)
+	}
+	loaders.RegisterTypeFactory(reflect.TypeOf(storage.Image{}), imageFactory)
+	ourSchema, err := graphql.ParseSchema(schema, resolver)
+	if err != nil {
+		return nil, err
+	}
+	handler := &relayHandler{Schema: ourSchema}
+	ourHandler := &wrappedHandler{
+		ctx: sac.WithAllAccess(
+			loaders.WithLoaderContext(
+				resolvers.SetAuthorizerOverride(
+					context.Background(),
+					allow.Anonymous(),
+				),
+			),
+		),
+		handler: handler,
+	}
+	server := httptest.NewServer(ourHandler)
+	return server, nil
+}
+
+func getGraphQLBenchmark(
+	testHelper *testutils.ExportServicePostgresTestHelper,
+	query string,
+) func(b *testing.B) {
+	return func(b *testing.B) {
+		testCases := testutils.GetExportTestCases()
+		for _, testCase := range testCases {
+			b.Run(testCase.Name, func(ib *testing.B) {
+				vals := map[string]interface{}{"query": query}
+				if testCase.TargetNamespace != "" {
+					query := "Namespace:" + testCase.TargetNamespace
+					vals["variables"] = map[string]interface{}{
+						"query": query,
+					}
+				}
+				jsonBytes, err := json.Marshal(vals)
+				if err != nil {
+					ib.Error(err)
+				}
+				ib.ResetTimer()
+				for i := 0; i < ib.N; i++ {
+					ib.StopTimer()
+					server, err := getGraphQLServer(testHelper)
+					if err != nil {
+						ib.Error(err)
+					}
+					ib.StartTimer()
+					client := server.Client()
+					requestData := bytes.NewBuffer(jsonBytes)
+					req, reqErr := http.NewRequest(http.MethodPost, server.URL, requestData)
+					if reqErr != nil {
+						ib.Error(reqErr)
+					}
+					resp, callErr := client.Do(req)
+					if callErr != nil {
+						ib.Error(callErr)
+					}
+					_ = resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						ib.Error(resp.Status)
+					}
+				}
+			})
+		}
+	}
+}

--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -199,6 +199,20 @@ func (h *ExportServicePostgresTestHelper) InjectDeployments(
 				IsClusterLocal: false,
 			}
 			container.Image = containerImage
+			for _, v := range container.Volumes {
+				v.MountPropagation = storage.Volume_NONE
+			}
+			if container.Config != nil {
+				for _, e := range container.Config.Env {
+					e.EnvVarSource = storage.ContainerConfig_EnvironmentConfig_UNKNOWN
+				}
+			}
+			for _, portConfig := range container.Ports {
+				portConfig.Exposure = storage.PortConfig_INTERNAL
+				for _, exposureInfo := range portConfig.ExposureInfos {
+					exposureInfo.Level = storage.PortConfig_INTERNAL
+				}
+			}
 			containers = append(containers, container)
 		}
 		deployment.Containers = containers
@@ -206,6 +220,12 @@ func (h *ExportServicePostgresTestHelper) InjectDeployments(
 			deployment.Namespace = namespace10pct
 		} else {
 			deployment.Namespace = namepsace90pct
+		}
+		for _, portConfig := range deployment.Ports {
+			portConfig.Exposure = storage.PortConfig_INTERNAL
+			for _, exposureInfo := range portConfig.ExposureInfos {
+				exposureInfo.Level = storage.PortConfig_INTERNAL
+			}
 		}
 		err = h.Deployments.UpsertDeployment(upsertCtx, deployment)
 		if err != nil {

--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -198,6 +198,11 @@ func (h *ExportServicePostgresTestHelper) InjectDeployments(
 				NotPullable:    false,
 				IsClusterLocal: false,
 			}
+			// region ensure enum values are valid
+			// Note: the unique initializer considers enum fields as int32
+			// and fills them with values that are mostly out of the valid
+			// range. These get reverted to fixed valid values so decoders
+			// do not break.
 			container.Image = containerImage
 			for _, v := range container.Volumes {
 				v.MountPropagation = storage.Volume_NONE
@@ -213,6 +218,7 @@ func (h *ExportServicePostgresTestHelper) InjectDeployments(
 					exposureInfo.Level = storage.PortConfig_INTERNAL
 				}
 			}
+			// endregion ensure enum values are valid
 			containers = append(containers, container)
 		}
 		deployment.Containers = containers
@@ -221,6 +227,7 @@ func (h *ExportServicePostgresTestHelper) InjectDeployments(
 		} else {
 			deployment.Namespace = namepsace90pct
 		}
+		// Set the enum values to valid data.
 		for _, portConfig := range deployment.Ports {
 			portConfig.Exposure = storage.PortConfig_INTERNAL
 			for _, exposureInfo := range portConfig.ExposureInfos {


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

See the title

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] added unit tests
- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

Manual run of `ROX_SCALE_TEST=true go test -v -tags sql_integration -bench . -timeout 7200s` in:
- `central/graphql/handler`
- `central/deployment/service`
- `central/image/service`
- `central/vulnmgmt/service`