### PR TITLE
chore(test): Add ProtoToJSON OptCompact flag test

### DIFF
--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -3,6 +3,7 @@ package jsonutil
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -120,4 +121,16 @@ func TestNoErrorOnUnknownAttribute(t *testing.T) {
 	err = JSONReaderToProto(bytes.NewReader(jsonBytes), &proto)
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
+}
+
+func TestProtoToJSONOptCompact(t *testing.T) {
+	testResource := &v1.ResourceByID{Id: "test"}
+
+	strRes, err := ProtoToJSON(testResource)
+	assert.NoError(t, err)
+	assert.Len(t, strings.Split(strRes, "\n"), 3)
+
+	strRes, err = ProtoToJSON(testResource, OptCompact)
+	assert.NoError(t, err)
+	assert.Len(t, strings.Split(strRes, "\n"), 1)
 }


### PR DESCRIPTION
### Description

This PR is adding a simple test for the existing `OptCompact` flag used in `jsonutil.ProtoToJSON`.

This is important to avoid regressions in protobuf V2 switch.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] added unit tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

- executed test locally
