### PR TITLE
ROX-15348: Fix flaky Splunk integration test

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -137,6 +137,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         }
 
         log.info "Starting conversion of ACS violations to Splunk alerts"
+        // This conversion job is run by the Splunk Cronjob every 5 minutes. We need the created alerts.
+        // This forces an out of schedule run to minimize waiting time for its results.
         postToSplunk(port, "/services/saved/searches/" + SPLUNK_TA_CONVERSION_JOB_NAME +"/dispatch", [
                 "dispatch.now": "true",
                 "force_dispatch": "true",
@@ -165,13 +167,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         }
 
         then:
-        "StackRox violations are in Splunk"
-        assert !results.isEmpty()
+        "StackRox violations are in Splunk and have been converted to alerts"
         assert !alerts.isEmpty()
-        assert hasNetworkViolation
-        assert hasProcessViolation
-        assert hasNetworkAlert
-        assert hasProcessAlert
         log.info "Validating CIM mappings for alerts"
         for (alert in alerts) {
             validateCimMappings(alert)

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -170,7 +170,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
             hasNetworkAlert = alerts.any { isNetworkViolation(it) }
             hasProcessAlert = alerts.any { isProcessViolation(it) }
             log.debug "Found Alerts in Splunk: \n${alerts}"
-            log.info "Current Splunk index contains NetworkAlert: ${hasNetworkAlert} and ProcessAlert: ${hasProcessAlert}"
+            log.info "Current Splunk index contains " +
+                    "NetworkAlert: ${hasNetworkAlert} and ProcessAlert: ${hasProcessAlert}"
             if (hasNetworkAlert && hasProcessAlert) {
                 log.info "Success finding Network and Process Alerts in Splunk!"
                 break

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -166,7 +166,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
             hasNetworkAlert = alerts.any { isNetworkViolation(it) }
             hasProcessAlert = alerts.any { isProcessViolation(it) }
             // TODO: Remove debug log
-            log.info "Found Alerts in Splunk: \n${results}"
+            log.info "Found Alerts in Splunk: \n${alerts}"
             log.info "hasNetworkAlert: ${hasNetworkAlert}\nhasProcessAlert: ${hasProcessAlert}"
             // TODO: /Remove debug log
             if (hasNetworkAlert && hasProcessAlert) {
@@ -184,8 +184,9 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         assert hasProcessViolation
         assert hasNetworkAlert
         assert hasProcessAlert
-        for (result in results) {
-            validateCimMappings(result)
+        log.info "Validating CIM mappings for alerts"
+        for (alert in alerts) {
+            validateCimMappings(alert)
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -21,7 +21,6 @@ import util.SplunkUtil
 import util.SplunkUtil.SplunkDeployment
 import util.Timer
 
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Tag
 
@@ -150,16 +149,18 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         List<Map<String, String>> alerts = Collections.emptyList()
         boolean hasNetworkAlert = false
         boolean hasProcessAlert = false
-        for (int i = 0; i < 41; i++) { // FIXME: We must try for at least 10 minutes, as the conversion cron runs every 5 minutes. Try calling the search manually.
+        // FIXME: We must try for at least 10 minutes, as the conversion cron runs every 5 minutes.
+        //  Try calling the search manually.
+        for (int i = 0; i < 41; i++) {
             log.info "Attempt ${i} to get Alerts from Splunk"
-            def v_searchId = SplunkUtil.createSearch(port, "| from datamodel Alerts.Alerts")
+            def vSearchId = SplunkUtil.createSearch(port, "| from datamodel Alerts.Alerts")
             TimeUnit.SECONDS.sleep(15)
-            Response v_response = SplunkUtil.getSearchResults(port, v_searchId)
+            Response vResponse = SplunkUtil.getSearchResults(port, vSearchId)
             // We should have at least one violation in the response
-            if (v_response == null) {
+            if (vResponse == null) {
                 continue
             }
-            alerts = v_response.getBody().jsonPath().getList("results")
+            alerts = vResponse.getBody().jsonPath().getList("results")
             if (alerts.isEmpty()) {
                 continue
             }
@@ -173,7 +174,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
                 log.info "Success!"
                 break
             }
-
         }
 
         then:

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -96,13 +96,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
                  "api_token": tokenResp.getToken(),])
         // create new input to search violations from
         postToSplunk(port, "/servicesNS/nobody/TA-stackrox/data/inputs/stackrox_violations",
-                ["name": SPLUNK_INPUT_NAME, "interval": "1", "from_checkpoint": "2000-01-01T00:00:00.000Z"])
-        // update saved search of TA to run every minute to create alerts quicker. It also looks further back.
-        postToSplunk(port, "/servicesNS/nobody/TA-stackrox/saved/searches/" +
-                "Threat%20-%20Create%20Notable%20from%20RHACS%20Alert%20-%20Rule", [
-                        "cron_schedule": "* * * * *",
-                        "dispatch.earliest_time": "-15m",
-                ])
+                ["name": SPLUNK_INPUT_NAME, "interval": "5", "from_checkpoint": "2000-01-01T00:00:00.000Z"])
     }
 
     @Tag("Integration")
@@ -123,7 +117,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         boolean hasNetworkViolation = false
         boolean hasProcessViolation = false
         def port = splunkDeployment.splunkPortForward.getLocalPort()
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < 20; i++) {
             log.info "Attempt ${i} to get raw violations from Splunk"
             def searchId = SplunkUtil.createSearch(port, "search sourcetype=stackrox-violations")
             TimeUnit.SECONDS.sleep(15)
@@ -159,7 +153,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         List<Map<String, String>> alerts = Collections.emptyList()
         boolean hasNetworkAlert = false
         boolean hasProcessAlert = false
-        for (int i = 0; i < 41; i++) {
+        for (int i = 0; i < 20; i++) {
             log.info "Attempt ${i} to get Alerts from Splunk"
             // Hint: If this produces no results, evaluate expanding the earliest_time, e.g. to -15m
             def vSearchId = SplunkUtil.createSearch(port, "| from datamodel Alerts.Alerts")

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -149,7 +149,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         }
 
         // After we know that violations arrived, manually kick off search that converts them into alerts
-        postToSplunk(port, "https://localhost:8089/services/saved/searches/" +
+        postToSplunk(port, "/services/saved/searches/" +
                 "Threat%20-%20Create%20Notable%20from%20RHACS%20Alert%20-%20Rule/dispatch", [
                 "dispatch.now": "true",
                 "force_dispatch": "true",


### PR DESCRIPTION
### Description
The `IntegrationsSplunkViolationsTest` has been flaky. 
If we set aside situations where the image pull did not work, most of the flakes can be attributed to missing alerts. 
Splunk Alerts are an integral part of our Splunk TA, therefore we have been asserting on them.
However, we did that in a brittle way.
This PR introduces a more robust way to assert that Splunk generates the required alerts.
 
#### Background  & Dataflow
The dataflow is as follows: 
Splunk queries ACS for all Violations it knows in regular intervals.
The Violations arrive in Splunk as regular events and are being indexed (query `search sourcetype=stackrox-violations`). 
Every 5 minutes, a Splunk Cronjob runs that converts all indexed Violations into Alerts.
Alerts from any source in Splunk can be queried via a specialized query (query `| from datamodel Alerts.Alerts`).

#### Introduced change
Before, we installed the Splunk TA for RHACS and configured it. After generating Violations in ACS, we directly asserted on Alerts, expecting that they exist in Splunk:
`Set up TA -> Generate Violations in ACS -> Assert on Splunk Alerts`

This PR breaks the test up into smaller steps:
`Set up TA -> Generate Violations in ACS -> Assert on Splunk indexed violations -> Trigger conversion cronjob -> Assert on Splunk Alerts`.


### User-facing documentation
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing
- [x] inspected CI results

#### Automated testing
- [x] modified existing tests

#### How I validated my change
Repeated CI tests, plus manual runs of the groovy test against GKE and OpenShift infra clusters
