### PR TITLE
chore(test): Ignore internal proto fields for protoutils clone test

### DIFF
--- a/pkg/protoutils/clone_test.go
+++ b/pkg/protoutils/clone_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/test"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoreflect"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -147,6 +148,9 @@ func checkAliasRecursive(t *testing.T, orig, cloned reflect.Value) {
 		checkAliasRecursive(t, orig.Elem(), cloned.Elem())
 	case reflect.Struct:
 		for i := 0; i < orig.NumField(); i++ {
+			if protoreflect.IsInternalGeneratorField(orig.Type().Field(i)) {
+				continue
+			}
 			checkAliasRecursive(t, orig.Field(i), cloned.Field(i))
 		}
 	case reflect.UnsafePointer:


### PR DESCRIPTION
### Description

This PR is adding safety for protoutils Clone test to ignore internal fields during testing of fields.

This is important for protobuf V2 migration, because internal protobuf framework fields could have different state in cloned proto Message and also they have references that could lead to infinite loops.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Tested on protobuf V2 switch branch and just ported commit to `master`.
