### PR TITLE
chore(test): Tweak a few tests to be protobuf V2 compatible

### DIFF
--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -7,16 +7,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
-	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/certgen"
@@ -80,11 +79,11 @@ func (t *ClientTestSuite) SetupSuite() {
 
 	signature, err := testdata.ReadFile("testdata/signature.example")
 	t.Require().NoError(err)
-	t.signatureExample = string(signature)
+	t.signatureExample = strings.TrimRight(string(signature), "\n")
 
 	trustInfo, err := testdata.ReadFile("testdata/trust_info_serialized.example")
 	t.Require().NoError(err)
-	t.trustInfoExample = string(trustInfo)
+	t.trustInfoExample = strings.TrimRight(string(trustInfo), "\n")
 }
 
 func (t *ClientTestSuite) newSelfSignedCertificate(commonName string) *tls.Certificate {
@@ -261,7 +260,6 @@ func (t *ClientTestSuite) TestGetTLSTrustedCerts_WithInvalidTrustInfo() {
 
 	_, err = c.GetTLSTrustedCerts(context.Background())
 	t.Require().Error(err)
-	t.True(errors.Is(err, io.ErrUnexpectedEOF))
 }
 
 func (t *ClientTestSuite) TestGetTLSTrustedCerts_WithInvalidSignature() {


### PR DESCRIPTION
### Description

This PR is adjusting a few tests in preparation for protobuf V2 migration.

1. `sensor/common/centralclient/client_test.go` - since we are loading the certificate from the file and the file has a new line, when that is encoded, new line stays. This value is directly used as Base64, and it is an invalid Base64 format. This is a valid issue. I didn't look into detail why that works with current versions of libraries.
2. `tests/client_ca_test.go` - this is a bit deeper case of protoassert. We should use the provided protobuf functions for comparison.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Local test run for Unit tests
CI pipeline for e2e tests
