### PR TITLE
test NVD

### DIFF
--- a/.github/workflows/scanner-nvd-update.yaml
+++ b/.github/workflows/scanner-nvd-update.yaml
@@ -1,9 +1,6 @@
 name: Scanner NVD update
 
 on:
-  push:
-    branches:
-    - 'yli3/**'
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -49,7 +49,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 	if err != nil {
 		return fmt.Errorf("initializing updater: rhel: %w", err)
 	}
-	bundles["nvd"] = nvdOpts()
+	//bundles["nvd"] = nvdOpts()
 
 	// ClairCore updaters.
 	for _, uSet := range []string{
@@ -62,6 +62,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 		"rhcc",
 		"ubuntu",
 		"osv",
+		"clair.cvss",
 	} {
 		bundles[uSet] = []updates.ManagerOption{updates.WithEnabled([]string{uSet})}
 	}


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

Use the old NVD API as the current API is currently malfunctioning

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [x] inspected CI results


#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->


```
{"level":"info","updater":"clair.cvss","bundle":"clair.cvss","component":"libvuln/updates/Manager.driveUpdater","time":"2024-07-03T15:56:26Z","message":"starting update"}
{"level":"info","updater":"clair.cvss","bundle":"clair.cvss","component":"libvuln/updates/Manager.driveUpdater","time":"2024-07-03T15:56:26Z","message":"found EnrichmentUpdater"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2002,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.meta","time":"2024-07-03T15:56:26Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2002,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.meta","mod":"2024-07-02T03:02:58-04:00","time":"2024-07-03T15:56:27Z","message":"parsed meta file"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2003,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.meta","time":"2024-07-03T15:56:27Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2003,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.meta","mod":"2024-07-02T03:02:55-04:00","time":"2024-07-03T15:56:27Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2004,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2004.meta","time":"2024-07-03T15:56:27Z","message":"fetching meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2004,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2004.meta","mod":"2024-06-28T03:02:37-04:00","time":"2024-07-03T15:56:28Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2005,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2005.meta","time":"2024-07-03T15:56:28Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2005,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2005.meta","mod":"2024-07-03T03:03:38-04:00","time":"2024-07-03T15:56:29Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2006,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2006.meta","time":"2024-07-03T15:56:29Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2006,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2006.meta","mod":"2024-07-03T03:03:34-04:00","time":"2024-07-03T15:56:30Z","message":"parsed meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2007,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2007.meta","time":"2024-07-03T15:56:30Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2007,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2007.meta","mod":"2024-07-03T03:03:28-04:00","time":"2024-07-03T15:56:31Z","message":"parsed meta file"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2008,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2008.meta","time":"2024-07-03T15:56:31Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2008,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2008.meta","mod":"2024-07-02T03:02:45-04:00","time":"2024-07-03T15:56:32Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2009,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2009.meta","time":"2024-07-03T15:56:32Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2009,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2009.meta","mod":"2024-06-29T03:04:21-04:00","time":"2024-07-03T15:56:33Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2010,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.meta","time":"2024-07-03T15:56:33Z","message":"fetching meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2010,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.meta","mod":"2024-07-03T03:03:22-04:00","time":"2024-07-03T15:56:34Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2011,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2011.meta","time":"2024-07-03T15:56:34Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2011,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2011.meta","mod":"2024-07-03T03:03:16-04:00","time":"2024-07-03T15:56:35Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2012,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2012.meta","time":"2024-07-03T15:56:35Z","message":"fetching meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2012,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2012.meta","mod":"2024-07-03T03:03:09-04:00","time":"2024-07-03T15:56:36Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2013,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2013.meta","time":"2024-07-03T15:56:36Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2013,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2013.meta","mod":"2024-07-03T03:03:02-04:00","time":"2024-07-03T15:56:37Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2014,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2014.meta","time":"2024-07-03T15:56:37Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2014,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2014.meta","mod":"2024-07-03T03:02:54-04:00","time":"2024-07-03T15:56:38Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2015,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.meta","time":"2024-07-03T15:56:38Z","message":"fetching meta file"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2015,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.meta","mod":"2024-07-03T03:02:46-04:00","time":"2024-07-03T15:56:39Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2016,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2016.meta","time":"2024-07-03T15:56:39Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2016,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2016.meta","mod":"2024-07-03T03:02:38-04:00","time":"2024-07-03T15:56:40Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2017,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2017.meta","time":"2024-07-03T15:56:40Z","message":"fetching meta file"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2017,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2017.meta","mod":"2024-07-03T03:02:27-04:00","time":"2024-07-03T15:56:41Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2018,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.meta","time":"2024-07-03T15:56:41Z","message":"fetching meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2018,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.meta","mod":"2024-07-03T03:02:13-04:00","time":"2024-07-03T15:56:42Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2019,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2019.meta","time":"2024-07-03T15:56:42Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2019,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2019.meta","mod":"2024-07-03T03:01:58-04:00","time":"2024-07-03T15:56:43Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2020,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.meta","time":"2024-07-03T15:56:43Z","message":"fetching meta file"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2020,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.meta","mod":"2024-07-03T03:01:40-04:00","time":"2024-07-03T15:56:44Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2021,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.meta","time":"2024-07-03T15:56:44Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2021,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.meta","mod":"2024-07-03T03:01:17-04:00","time":"2024-07-03T15:56:45Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2022,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2022.meta","time":"2024-07-03T15:56:45Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2022,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2022.meta","mod":"2024-07-03T03:00:52-04:00","time":"2024-07-03T15:56:46Z","message":"parsed meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2023,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2023.meta","time":"2024-07-03T15:56:46Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2023,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2023.meta","mod":"2024-07-03T03:00:27-04:00","time":"2024-07-03T15:56:47Z","message":"parsed meta file"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2024,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2024.meta","time":"2024-07-03T15:56:47Z","message":"fetching meta file"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2024,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2024.meta","mod":"2024-07-03T03:00:06-04:00","time":"2024-07-03T15:56:48Z","message":"parsed meta file"}
{"level":"info","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2002,"time":"2024-07-03T15:56:48Z","message":"change detected"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2002,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.json.gz","time":"2024-07-03T15:56:48Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2002,"skip":6654,"wrote":115,"time":"2024-07-03T15:56:50Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2003,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.json.gz","time":"2024-07-03T15:56:50Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2003,"skip":1530,"wrote":23,"time":"2024-07-03T15:56:50Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2004,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2004.json.gz","time":"2024-07-03T15:56:50Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2004,"skip":2665,"wrote":42,"time":"2024-07-03T15:56:52Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2005,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2005.json.gz","time":"2024-07-03T15:56:52Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","updater":"clair.cvss","year":2005,"skip":4703,"wrote":63,"time":"2024-07-03T15:56:53Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2006,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2006.json.gz","time":"2024-07-03T15:56:53Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2006,"skip":7111,"wrote":31,"time":"2024-07-03T15:56:54Z","message":"wrote cvss items"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2007,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2007.json.gz","time":"2024-07-03T15:56:54Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2007,"skip":6533,"wrote":47,"time":"2024-07-03T15:56:55Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2008,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2008.json.gz","time":"2024-07-03T15:56:55Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2008,"skip":7099,"wrote":77,"time":"2024-07-03T15:56:56Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2009,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2009.json.gz","time":"2024-07-03T15:56:56Z","message":"requesting json"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","year":2009,"skip":4913,"wrote":127,"time":"2024-07-03T15:56:57Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2010,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.json.gz","time":"2024-07-03T15:56:57Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2010,"skip":4999,"wrote":218,"time":"2024-07-03T15:56:58Z","message":"wrote cvss items"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2011,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2011.json.gz","time":"2024-07-03T15:56:58Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2011,"skip":4576,"wrote":285,"time":"2024-07-03T15:56:59Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2012,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2012.json.gz","time":"2024-07-03T15:56:59Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2012,"skip":5514,"wrote":378,"time":"2024-07-03T15:57:00Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2013,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2013.json.gz","time":"2024-07-03T15:57:00Z","message":"requesting json"}
{"level":"debug","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","updater":"clair.cvss","year":2013,"skip":6158,"wrote":622,"time":"2024-07-03T15:57:02Z","message":"wrote cvss items"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2014,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2014.json.gz","time":"2024-07-03T15:57:02Z","message":"requesting json"}
{"level":"debug","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","updater":"clair.cvss","year":2014,"skip":7788,"wrote":1194,"time":"2024-07-03T15:57:03Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2015,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.json.gz","time":"2024-07-03T15:57:03Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2015,"skip":6068,"wrote":2679,"time":"2024-07-03T15:57:04Z","message":"wrote cvss items"}
{"level":"debug","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","updater":"clair.cvss","year":2016,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2016.json.gz","time":"2024-07-03T15:57:04Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2016,"skip":1485,"wrote":9064,"time":"2024-07-03T15:57:06Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2017,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2017.json.gz","time":"2024-07-03T15:57:06Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2017,"skip":2336,"wrote":14645,"time":"2024-07-03T15:57:10Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2018,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.json.gz","time":"2024-07-03T15:57:10Z","message":"requesting json"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","year":2018,"skip":1622,"wrote":15730,"time":"2024-07-03T15:57:14Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2019,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2019.json.gz","time":"2024-07-03T15:57:14Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2019,"skip":1478,"wrote":15506,"time":"2024-07-03T15:57:19Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2020,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz","time":"2024-07-03T15:57:19Z","message":"requesting json"}
{"level":"debug","updater":"clair.cvss","bundle":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2020,"skip":1656,"wrote":18830,"time":"2024-07-03T15:57:24Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2021,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.json.gz","time":"2024-07-03T15:57:24Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2021,"skip":1593,"wrote":21282,"time":"2024-07-03T15:57:33Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2022,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2022.json.gz","time":"2024-07-03T15:57:33Z","message":"requesting json"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","year":2022,"skip":1163,"wrote":23693,"time":"2024-07-03T15:57:41Z","message":"wrote cvss items"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","bundle":"clair.cvss","year":2023,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2023.json.gz","time":"2024-07-03T15:57:41Z","message":"requesting json"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","year":2023,"skip":3049,"wrote":25282,"time":"2024-07-03T15:57:51Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/FetchEnrichment","year":2024,"url":"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2024.json.gz","time":"2024-07-03T15:57:51Z","message":"requesting json"}
{"level":"debug","updater":"clair.cvss","component":"enricher/cvss/itemFeed/WriteCVSS","bundle":"clair.cvss","year":2024,"skip":11047,"wrote":4125,"time":"2024-07-03T15:57:55Z","message":"wrote cvss items"}
{"level":"debug","bundle":"clair.cvss","updater":"clair.cvss","component":"enricher/cvss/Enricher/ParseEnrichment","count":154059,"time":"2024-07-03T15:57:56Z","message":"decoded enrichments"}
{"level":"info","component":"libvuln/updates/Manager.driveUpdater","updater":"clair.cvss","bundle":"clair.cvss","ref":"f974365e-2a8e-4216-b795-b75e96d7501f","time":"2024-07-03T15:57:56Z","message":"successful update"}
{"level":"info","component":"libvuln/updates/Manager.driveUpdater","updater":"clair.cvss","bundle":"clair.cvss","time":"2024-07-03T15:57:56Z","message":"finished update"}
```
