### PR TITLE
fix(ui): Ensure CVE ID is used to create link in Cluster single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -33,6 +33,7 @@ export const defaultSortOption = { field: CVSS_SORT_FIELD, direction: 'desc' } a
 
 export const clusterVulnerabilityFragment = gql`
     fragment ClusterVulnerabilityFragment on ClusterVulnerability {
+        id
         cve
         isFixable
         cvss
@@ -43,6 +44,7 @@ export const clusterVulnerabilityFragment = gql`
 `;
 
 export type ClusterVulnerability = {
+    id: string;
     cve: string;
     isFixable: boolean;
     cvss: number;
@@ -85,8 +87,15 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                 filteredEmptyProps={{ onClearFilters }}
                 renderer={({ data }) =>
                     data.map((clusterVulnerability, rowIndex) => {
-                        const { cve, isFixable, vulnerabilityType, cvss, scoreVersion, summary } =
-                            clusterVulnerability;
+                        const {
+                            id,
+                            cve,
+                            isFixable,
+                            vulnerabilityType,
+                            cvss,
+                            scoreVersion,
+                            summary,
+                        } = clusterVulnerability;
                         const isExpanded = expandedRowSet.has(cve);
 
                         return (
@@ -100,9 +109,7 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                                         }}
                                     />
                                     <Td dataLabel="CVE" modifier="nowrap">
-                                        <Link to={getPlatformEntityPagePath('CVE', cve)}>
-                                            {cve}
-                                        </Link>
+                                        <Link to={getPlatformEntityPagePath('CVE', id)}>{cve}</Link>
                                     </Td>
                                     <Td dataLabel="CVE status">
                                         <VulnerabilityFixableIconText isFixable={isFixable} />


### PR DESCRIPTION
### Description

In Platform CVE's only we need to pass the CVE ID instead of the CVE name as the path component in the URL due to requirements in the BE API. This fixes the CVE links from the Cluster single page -> Platform CVE single page.

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

From Platform CVEs navigate to a Cluster single page. In the table, use a CVE link to navigate to the CVE single page. When the page loads, the entirety of the page should render without a perpetual loading component in the header.
![image](https://github.com/stackrox/stackrox/assets/1292638/97b96b70-8d3f-4aa3-b834-a18ba608f71f)
![image](https://github.com/stackrox/stackrox/assets/1292638/32d2166d-3baf-411b-b0ed-d4fdcf68756c)
![image](https://github.com/stackrox/stackrox/assets/1292638/5f30cbf8-91dc-4457-a121-f3d6381fa9ff)

