### PR TITLE
fix(ui): Add GO component source to UI types

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -241,14 +241,15 @@ describe(Cypress.spec.relative, () => {
         const imageComponenSourceSelectItems =
             'div[aria-label="Filter by source select menu"] ul li';
 
-        cy.get(imageComponenSourceSelectItems).should('have.length', 7);
+        cy.get(imageComponenSourceSelectItems).should('have.length', 8);
         cy.get(imageComponenSourceSelectItems).eq(0).should('have.text', 'OS');
         cy.get(imageComponenSourceSelectItems).eq(1).should('have.text', 'Python');
         cy.get(imageComponenSourceSelectItems).eq(2).should('have.text', 'Java');
         cy.get(imageComponenSourceSelectItems).eq(3).should('have.text', 'Ruby');
         cy.get(imageComponenSourceSelectItems).eq(4).should('have.text', 'Node js');
-        cy.get(imageComponenSourceSelectItems).eq(5).should('have.text', 'Dotnet Core Runtime');
-        cy.get(imageComponenSourceSelectItems).eq(6).should('have.text', 'Infrastructure');
+        cy.get(imageComponenSourceSelectItems).eq(5).should('have.text', 'Go');
+        cy.get(imageComponenSourceSelectItems).eq(6).should('have.text', 'Dotnet Core Runtime');
+        cy.get(imageComponenSourceSelectItems).eq(7).should('have.text', 'Infrastructure');
 
         cy.get(imageComponenSourceSelectItems).eq(1).click();
         cy.get('@onSearch').should('have.been.calledWithExactly', {

--- a/ui/apps/platform/src/types/image.proto.ts
+++ b/ui/apps/platform/src/types/image.proto.ts
@@ -26,6 +26,7 @@ export const sourceTypes = [
     'JAVA',
     'RUBY',
     'NODEJS',
+    'GO',
     'DOTNETCORERUNTIME',
     'INFRASTRUCTURE',
 ] as const;
@@ -36,6 +37,7 @@ export const sourceTypeLabels: Record<SourceType, string> = {
     JAVA: 'Java',
     RUBY: 'Ruby',
     NODEJS: 'Node js',
+    GO: 'Go',
     DOTNETCORERUNTIME: 'Dotnet Core Runtime',
     INFRASTRUCTURE: 'Infrastructure',
 };


### PR DESCRIPTION
### Description

As titled, UI counterpart to https://github.com/stackrox/stackrox/blob/718bbe5634201802d2d696296e114cf835fb7085/proto/storage/image.proto#L150

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] contributed **no automated tests**


#### How I validated my change

Allows the UI to use the newly supported Go-lang component source as a filter type:
![image](https://github.com/stackrox/stackrox/assets/1292638/e803187e-7e02-4fa7-beef-2bfb541a6ba8)
![image](https://github.com/stackrox/stackrox/assets/1292638/f77298ce-49ed-4804-ac7f-d19116017b68)
![image](https://github.com/stackrox/stackrox/assets/1292638/5e8d1f52-526f-4f5e-b2c8-02b17db3cab0)

