### PR TITLE
ROX-25032: Fix overlapping time picker validation

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -199,6 +199,8 @@ function ScanConfigOptions(): ReactElement {
                                                     onBlur: formik.handleBlur,
                                                     name: 'parameters.time',
                                                 }}
+                                                invalidFormatErrorMessage="" // error messaging is handled by FormLabelGroup
+                                                invalidMinMaxErrorMessage=""
                                             />
                                         </FormLabelGroup>
                                     </FlexItem>


### PR DESCRIPTION
### Description

Fixes overlapping error text on the time picker component

The `TimePicker` component currently displays error messages using `position: absolute`. Since we already display helper text under the input field that turns red when there is a Formik error, we can disable the `TimePicker` invalid messages to prevent overlapping. The `TimePicker` component will still display an error status icon when there is an issue with the formatting.

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### How I validated my change

#### Before
Overlapping text:
<img src="https://private-user-images.githubusercontent.com/61400697/345574425-371a5d9c-eb65-46b3-86eb-92e07714621b.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwMzI3NjgsIm5iZiI6MTcyMDAzMjQ2OCwicGF0aCI6Ii82MTQwMDY5Ny8zNDU1NzQ0MjUtMzcxYTVkOWMtZWI2NS00NmIzLTg2ZWItOTJlMDc3MTQ2MjFiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzAzVDE4NDc0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWEyMjFmYjMxNGM4NjdhYTk5YjdjMWUyYTExM2Q5NWZlNTZiNDY4MmE3MTU2MDFjMGE4MzhlM2U1Zjc0ZGM4MzEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.Mc0bo7-kTF1kPkEH6cXxgJAVfCWPCrx28Lhv3PsW_-Q" width="400">


#### After
Initial view:
<img src="https://private-user-images.githubusercontent.com/61400697/345574779-b06157a6-a5d1-4727-97dd-c9907e0d018d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwMzI3ODksIm5iZiI6MTcyMDAzMjQ4OSwicGF0aCI6Ii82MTQwMDY5Ny8zNDU1NzQ3NzktYjA2MTU3YTYtYTVkMS00NzI3LTk3ZGQtYzk5MDdlMGQwMThkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzAzVDE4NDgwOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTRlZGVkOGZlMDVhMWNmOGY0ZTcwYmUwZjQwMjA3NWIyYjVjNWJiZThhMjE3MjI3MGYyYjI0M2Y0OTNjNjY0ZmYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.H_4sQXDsZbZ2Y7-3ndZUnOOxPvAdrXZY8gESRwn5IeM" width="400">


After clicking next:
<img src="https://private-user-images.githubusercontent.com/61400697/345574813-e67d42e8-3048-4be1-aaa3-5c89726b436f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwMzI3ODksIm5iZiI6MTcyMDAzMjQ4OSwicGF0aCI6Ii82MTQwMDY5Ny8zNDU1NzQ4MTMtZTY3ZDQyZTgtMzA0OC00YmUxLWFhYTMtNWM4OTcyNmI0MzZmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzAzVDE4NDgwOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTljNjljOTU5MzMzNzA4M2ZkYmE5N2UzYzY2NmE5N2VmZjUzNjhjMWYyMDM4M2Q5OTEzYjQxYzZmNDI1M2ViZDkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.66kCBoYI3Rc67Qtr72geoysr8cBS_f-bpUHxxGZxUzY" width="400">


Entering an invalid time:
<img src="https://private-user-images.githubusercontent.com/61400697/345574897-4f975ce6-538b-4a6c-b537-547fd414f7a9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwMzI3ODksIm5iZiI6MTcyMDAzMjQ4OSwicGF0aCI6Ii82MTQwMDY5Ny8zNDU1NzQ4OTctNGY5NzVjZTYtNTM4Yi00YTZjLWI1MzctNTQ3ZmQ0MTRmN2E5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzAzVDE4NDgwOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWJmMzRiOTgwZGRmMGM0ZjZkZmEyYzMwZDQ1ZjIyMGEzMjVjYjUwZTY3ZGRmZWM1YTU3NzhlYzAzYTczNTAyYTgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.JSU8gSiV86qhcnNaivHAaQgj8acsROzcfYFl9rQvNPs" width="400">


Entering a valid time:
<img src="https://private-user-images.githubusercontent.com/61400697/345574946-0316a9a8-d6f4-4b6f-814e-bd9a9e6ef872.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwMzI3ODksIm5iZiI6MTcyMDAzMjQ4OSwicGF0aCI6Ii82MTQwMDY5Ny8zNDU1NzQ5NDYtMDMxNmE5YTgtZDZmNC00YjZmLTgxNGUtYmQ5YTllNmVmODcyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzAzVDE4NDgwOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNiZWEzYTVhOTU1ZWI5NmE1NmE3Y2M0NmFlMjU3YjUxNWIxNDE3M2VhYzhjZjQ1OGYwOWFiNzJhODE5OTIwY2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.rMOCH6vV54pmD3__a2oHJ78VeuTA2DWW32ptArhTVPs" width="400">



