### PR TITLE
chore(fix): Pass the correct obj to the update function

### DIFF
--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -257,7 +257,7 @@ func (m *handlerImpl) processUpdateScanRequest(requestID string, request *centra
 	var updatedScanSettingBinding *unstructured.Unstructured
 	// It is possible that we successfully created the scan setting but had issues on the binding.
 	if ssbObj != nil {
-		updatedScanSettingBinding, err = updateScanSettingBindingFromUpdateRequest(ssObj, request)
+		updatedScanSettingBinding, err = updateScanSettingBindingFromUpdateRequest(ssbObj, request)
 		if err != nil {
 			return m.composeAndSendApplyScanConfigResponse(requestID, err)
 		}


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

We were passing the ScanSetting to the ScanSettingBinding update function. This led to failures in the updates of ScanSettingBindings.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

- [x] Manual tested with local-sensor
- [x] Manual tested

I'll open a follow-up PR with the automatic tests
