### PR TITLE
feat(sensor): Log cluster name and install method

### DIFF
--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -93,8 +93,11 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		if centralsensor.IsInitCertClusterID(certClusterID) {
 			return nil, errors.New("a sensor that uses certificates from an init bundle must have a cluster name specified")
 		}
+	} else {
+		log.Infof("Cluster name from Helm configuration: %q", helmManagedConfig.GetClusterName())
 	}
 
+	log.Infof("Install method: %q", helmManagedConfig.GetManagedBy())
 	installmethod.Set(helmManagedConfig.GetManagedBy())
 
 	deploymentIdentification := fetchDeploymentIdentification(context.Background(), cfg.k8sClient.Kubernetes())


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

This information tends to be precious when investigating installation-related customer issues.
Having this directly in the log will improve turnaround times.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests** - would require significant work to test log output

#### How I validated my change

Created an OpenShift cluster and deployed sensor to it. Logs contain:

```
kubernetes/sensor: 2024/07/04 07:28:01.501673 sensor.go:81: Info: Loaded Helm cluster configuration with fingerprint "97664b32f9bf952c4680609a2f7d071dd9c76d489573396bb9ec80564d7419b1"
kubernetes/sensor: 2024/07/04 07:28:01.501769 sensor.go:97: Info: Cluster name from Helm configuration: "manual"
kubernetes/sensor: 2024/07/04 07:28:01.501800 sensor.go:100: Info: Install method: "MANAGER_TYPE_KUBERNETES_OPERATOR"
```

Which is as expected.