### PR TITLE
ROX-24871: Remove test assertion for checking violations

### DIFF
--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -1,5 +1,8 @@
 import static util.Helpers.waitForTrue
 import static util.Helpers.withRetry
+
+import com.google.protobuf.Timestamp
+
 import io.stackrox.proto.storage.NodeOuterClass.Node
 
 import common.Constants
@@ -34,6 +37,7 @@ class NodeInventoryTest extends BaseSpecification {
         "given a non-empty list of nodes"
         List<Node> nodes = NodeService.getNodes()
         assert nodes.size() > 0
+        def previousScanTime = [:]
 
         when:
         boolean nodeInventoryContainerAvailable =
@@ -63,6 +67,11 @@ class NodeInventoryTest extends BaseSpecification {
                 }
                 return true
             }
+            // Finally, before starting the test, make note of the current scan time, which should be updated
+            nodes.each { node ->
+                previousScanTime[node.getId()] = node.hasScan() ? node.getScan().getScanTime() : Timestamp.getDefaultInstance()
+                log.info("Previous scan time of node ${node.getId()}: ${previousScanTime[node.getId()]}")
+            }
         }
         log.info("Waiting for scanner deployment to be ready")
         waitForTrue(20, 6) {
@@ -91,6 +100,9 @@ class NodeInventoryTest extends BaseSpecification {
             }
             assert node.getScan().getComponentsList().size() > 4,
                 "Expected to find more than 4 components on RHCOS node"
+
+            assert previousScanTime[node.getId()] != node.getScan().getScanTime(),
+                "Expected the scan time of the node to have changed"
         }
     }
 }

--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -69,7 +69,8 @@ class NodeInventoryTest extends BaseSpecification {
             }
             // Finally, before starting the test, make note of the current scan time, which should be updated
             nodes.each { node ->
-                previousScanTime[node.getId()] = node.hasScan() ? node.getScan().getScanTime() : Timestamp.getDefaultInstance()
+                previousScanTime[node.getId()] = node.hasScan() ?
+                        node.getScan().getScanTime() : Timestamp.getDefaultInstance()
                 log.info("Previous scan time of node ${node.getId()}: ${previousScanTime[node.getId()]}")
             }
         }

--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -91,10 +91,6 @@ class NodeInventoryTest extends BaseSpecification {
             }
             assert node.getScan().getComponentsList().size() > 4,
                 "Expected to find more than 4 components on RHCOS node"
-
-            // assume that there must be at least one vulnerability within all the components
-            assert node.getScan().getComponentsList().sum { it.getVulnerabilitiesList().size() }
-                > 0, "Expected to find at least one vulnerability among the components"
         }
     }
 }


### PR DESCRIPTION
### Description

This assertion has been flaky.
Given that violations for images can change often, based on the base image version and current CVEs, it is enough to verify that we have found components to ensure the Node Inventory is working correctly.

change me!

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [x] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change
Repeated automated CI tests
