### PR TITLE
chore(test): Fix protoassert for custom structs with proto-generated field types

### DIFF
--- a/compliance/collection/compliance/compliance_checks_test.go
+++ b/compliance/collection/compliance/compliance_checks_test.go
@@ -174,7 +174,7 @@ func (s *ComplianceResultsBuilderTestSuite) TestSend() {
 	zippedEvidence := complianceReturn.GetEvidence()
 	s.Require().NotNil(zippedEvidence)
 	unzippedEvidence := s.decompressEvidence(zippedEvidence)
-	s.Equal(mockData, unzippedEvidence)
+	protoassert.MapEqual(s.T(), mockData.ResultMap, unzippedEvidence.ResultMap)
 }
 
 type dummyNodeNameProvider struct{}


### PR DESCRIPTION
### Description

This PR fixes an `assert` that uses custom structs with nested proto-generated structs.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

- executed it locally on the V2 switch branch (just ported changes to master without testing)
- let CI pipeline
- run `roxvet` after using `ResultMap` - to be sure it would catch such case
