### PR TITLE
ROX-23972: Fix Operator Network descriptions in UI

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -73,7 +73,7 @@ type CentralSpec struct {
 	Monitoring *GlobalMonitoring `json:"monitoring,omitempty"`
 
 	// Network configuration.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=10,xDescription={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName=Network,order=10,xDescription={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Network *GlobalNetworkSpec `json:"network,omitempty"`
 }
 

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -73,7 +73,7 @@ type CentralSpec struct {
 	Monitoring *GlobalMonitoring `json:"monitoring,omitempty"`
 
 	// Network configuration.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName=Network,order=10,xDescription={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName=Network,order=10,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Network *GlobalNetworkSpec `json:"network,omitempty"`
 }
 

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -325,7 +325,7 @@ func (m *GlobalMonitoring) IsOpenShiftMonitoringDisabled() bool {
 	return m != nil && m.OpenShiftMonitoring != nil && !m.OpenShiftMonitoring.Enabled
 }
 
-// NetworkPolicies is a type for network sub-struct.
+// Set this to Disabled to prevent the operator from creating NetworkPolicy objects.
 // +kubebuilder:validation:Enum=Enabled;Disabled
 type NetworkPolicies string
 
@@ -349,7 +349,7 @@ func (s *GlobalNetworkSpec) IsNetworkPoliciesEnabled() bool {
 // GlobalNetworkSpec defines settings related to Helm chart network parameters. The corresponding Helm flags
 // live in the global scope `.network`.
 type GlobalNetworkSpec struct {
-	// Create NetworkPolicy objects to limit ACS network connectivity.
+	// To provide security at the network level the ACS Operator creates NetworkPolicy resources by default. If you want to manage your own NetworkPolicy objects then set this to "Disabled".
 	//+kubebuilder:default=Enabled
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="Network Policies"
 	Policies *NetworkPolicies `json:"policies,omitempty"`

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -349,7 +349,8 @@ func (s *GlobalNetworkSpec) IsNetworkPoliciesEnabled() bool {
 // GlobalNetworkSpec defines settings related to Helm chart network parameters. The corresponding Helm flags
 // live in the global scope `.network`.
 type GlobalNetworkSpec struct {
+	// Create NetworkPolicy objects to limit ACS network connectivity.
 	//+kubebuilder:default=Enabled
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,displayName="Network Policies"
 	Policies *NetworkPolicies `json:"policies,omitempty"`
 }

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -106,7 +106,7 @@ type SecuredClusterSpec struct {
 	RegistryOverride string `json:"registryOverride,omitempty"`
 
 	// Network configuration.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=15,xDescription={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName=Network,order=15,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Network *GlobalNetworkSpec `json:"network,omitempty"`
 }
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -755,8 +755,10 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: Create NetworkPolicy objects to limit ACS network
-                      connectivity.
+                    description: To provide security at the network level the ACS
+                      Operator creates NetworkPolicy resources by default. If you
+                      want to manage your own NetworkPolicy objects then set this
+                      to "Disabled".
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -755,7 +755,8 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: NetworkPolicies is a type for network sub-struct.
+                    description: Create NetworkPolicy objects to limit ACS network
+                      connectivity.
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -435,7 +435,8 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: NetworkPolicies is a type for network sub-struct.
+                    description: Create NetworkPolicy objects to limit ACS network
+                      connectivity.
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -435,8 +435,10 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: Create NetworkPolicy objects to limit ACS network
-                      connectivity.
+                    description: To provide security at the network level the ACS
+                      Operator creates NetworkPolicy resources by default. If you
+                      want to manage your own NetworkPolicy objects then set this
+                      to "Disabled".
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -755,8 +755,10 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: Create NetworkPolicy objects to limit ACS network
-                      connectivity.
+                    description: To provide security at the network level the ACS
+                      Operator creates NetworkPolicy resources by default. If you
+                      want to manage your own NetworkPolicy objects then set this
+                      to "Disabled".
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -755,7 +755,8 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: NetworkPolicies is a type for network sub-struct.
+                    description: Create NetworkPolicy objects to limit ACS network
+                      connectivity.
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -435,7 +435,8 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: NetworkPolicies is a type for network sub-struct.
+                    description: Create NetworkPolicy objects to limit ACS network
+                      connectivity.
                     enum:
                     - Enabled
                     - Disabled

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -435,8 +435,10 @@ spec:
                 properties:
                   policies:
                     default: Enabled
-                    description: Create NetworkPolicy objects to limit ACS network
-                      connectivity.
+                    description: To provide security at the network level the ACS
+                      Operator creates NetworkPolicy resources by default. If you
+                      want to manage your own NetworkPolicy objects then set this
+                      to "Disabled".
                     enum:
                     - Enabled
                     - Disabled


### PR DESCRIPTION
### Description

The work done in ROX-23972 made the UI look weird; this tries to fix some wording so it looks better.

Before:
![Screenshot from 2024-07-04 09-00-52](https://github.com/stackrox/stackrox/assets/497744/8e197466-2754-450e-b884-716e6fd671f6)
![Screenshot from 2024-07-04 08-59-05](https://github.com/stackrox/stackrox/assets/497744/8edecff0-267f-4bce-afe0-b68171e4452f)

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

TODO - verifying with Marcin best way to validate