### PR TITLE
fix(ui): Fix date picker error text placement

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.css
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.css
@@ -1,3 +1,0 @@
-.pf-v5-c-date-picker__helper-text {
-    position: absolute;
-}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Split } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
 import {
@@ -13,8 +13,6 @@ import { getDefaultAttribute, getDefaultEntity } from '../utils/utils';
 import EntitySelector, { SelectedEntity } from './EntitySelector';
 import AttributeSelector, { SelectedAttribute } from './AttributeSelector';
 import CompoundSearchFilterInputField, { InputFieldValue } from './CompoundSearchFilterInputField';
-
-import './CompoundSearchFilter.css';
 
 export type CompoundSearchFilterProps = {
     config: PartialCompoundSearchFilterConfig;
@@ -66,7 +64,12 @@ function CompoundSearchFilter({
     }, [defaultAttribute]);
 
     return (
-        <Split className="pf-v5-u-flex-grow-1">
+        <Flex
+            direction={{ default: 'row' }}
+            spaceItems={{ default: 'spaceItemsNone' }}
+            flexWrap={{ default: 'nowrap' }}
+            className="pf-v5-u-w-100"
+        >
             <EntitySelector
                 menuToggleClassName="pf-v5-u-flex-shrink-0"
                 selectedEntity={selectedEntity}
@@ -114,7 +117,7 @@ function CompoundSearchFilter({
                 }}
                 config={config}
             />
-        </Split>
+        </Flex>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.css
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.css
@@ -1,0 +1,3 @@
+form#scan-schedules-parameters .pf-v5-c-form__group .pf-v5-c-date-picker__helper-text {
+   position: absolute;
+}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -22,6 +22,8 @@ import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 import { helperTextForName, helperTextForTime } from './useFormikScanConfig';
 
+import './ScanConfigOptions.css';
+
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
     function handleSelectChange(id: string, value: string): void {
@@ -49,7 +51,7 @@ function ScanConfigOptions(): ReactElement {
                 </Flex>
             </PageSection>
             <Divider component="div" />
-            <Form className="pf-v5-u-py-lg pf-v5-u-px-lg">
+            <Form className="pf-v5-u-py-lg pf-v5-u-px-lg" id="scan-schedules-parameters">
                 <Stack hasGutter>
                     <StackItem>
                         <Stack hasGutter>


### PR DESCRIPTION
### Description

This PR fixes an issue caught today where the compound search filter will show the date-picker error message positioned absolutely. This initially fixed a different error ([PR](https://github.com/stackrox/stackrox/pull/11578)), but now it seems hidden behind the search filter chips. The following changes were made to resolve the issue:

1. The CSS was removed that set it to position absolutely
2. Thanks to @bradr5 and @pedrottimark for recommending adding a different CSS styling that does fix the previous issue ([PR](https://github.com/stackrox/stackrox/pull/11578))
3. Removing the absolute positioning will undo a fix that @bradr5 made for his Timepicker in Compliance ([PR](https://github.com/stackrox/stackrox/pull/11859)) so we specifically add the absolute positioning for that timepicker. This will prevent the change from propagating to any other components.

### Screenshot

Before
![Screenshot 2024-07-05 at 11 53 04 AM](https://github.com/stackrox/stackrox/assets/4805485/263f602f-2350-4389-a72c-7c94ebd20b52)

After
<img width="476" alt="Screenshot 2024-07-05 at 11 57 27 AM" src="https://github.com/stackrox/stackrox/assets/4805485/61c13d2e-3d67-4b2b-ad73-cf1e55d715fc">
