### PR TITLE
ROX-24916: use prune option the store has

### DIFF
--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -39,6 +39,7 @@ type DataStore interface {
 	MarkAlertsResolvedBatch(ctx context.Context, id ...string) ([]*storage.Alert, error)
 
 	DeleteAlerts(ctx context.Context, ids ...string) error
+	PruneAlerts(ctx context.Context, ids ...string) error
 }
 
 // New returns a new soleInstance of DataStore using the input store, and searcher.

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -219,6 +219,21 @@ func (ds *datastoreImpl) DeleteAlerts(ctx context.Context, ids ...string) error 
 	return nil
 }
 
+func (ds *datastoreImpl) PruneAlerts(ctx context.Context, ids ...string) error {
+	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "PruneAlerts")
+
+	if ok, err := alertSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	if err := ds.storage.PruneMany(ctx, ids); err != nil {
+		return errors.Wrap(err, "pruning alert")
+	}
+	return nil
+}
+
 func sacKeyForAlert(alert *storage.Alert) []sac.ScopeKey {
 	scopedObj := getNSScopedObjectFromAlert(alert)
 	if scopedObj == nil {

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -147,6 +147,20 @@ func (mr *MockStoreMockRecorder) GetMany(ctx, ids any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
 }
 
+// PruneMany mocks base method.
+func (m *MockStore) PruneMany(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PruneMany", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PruneMany indicates an expected call of PruneMany.
+func (mr *MockStoreMockRecorder) PruneMany(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneMany", reflect.TypeOf((*MockStore)(nil).PruneMany), ctx, ids)
+}
+
 // Search mocks base method.
 func (m *MockStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -24,4 +24,5 @@ type Store interface {
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error
 	Delete(ctx context.Context, id string) error
 	DeleteMany(ctx context.Context, ids []string) error
+	PruneMany(ctx context.Context, ids []string) error
 }

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -127,6 +127,25 @@ func (mr *MockDataStoreMockRecorder) MarkAlertsResolvedBatch(ctx any, id ...any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlertsResolvedBatch", reflect.TypeOf((*MockDataStore)(nil).MarkAlertsResolvedBatch), varargs...)
 }
 
+// PruneAlerts mocks base method.
+func (m *MockDataStore) PruneAlerts(ctx context.Context, ids ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range ids {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PruneAlerts", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PruneAlerts indicates an expected call of PruneAlerts.
+func (mr *MockDataStoreMockRecorder) PruneAlerts(ctx any, ids ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, ids...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneAlerts", reflect.TypeOf((*MockDataStore)(nil).PruneAlerts), varargs...)
+}
+
 // Search mocks base method.
 func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -639,7 +639,7 @@ func (ds *datastoreImpl) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx con
 	ds.mutex.Lock()
 	defer ds.mutex.Unlock()
 
-	err = ds.storage.DeleteMany(ctx, plopsToDelete)
+	err = ds.storage.PruneMany(ctx, plopsToDelete)
 	if err != nil {
 		return 0, err
 	}

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1299,7 +1299,7 @@ func (s *PruningTestSuite) TestRemoveOrphanedProcesses() {
 			s.Nil(err)
 			s.NoError(actualProcessDatastore.AddProcessIndicators(s.ctx, c.initialProcesses...))
 
-			processes.EXPECT().PruneProcessIndicators(pruningCtx, c.expectedDeletions).AnyTimes()
+			processes.EXPECT().PruneProcessIndicators(gomock.Any(), c.expectedDeletions).AnyTimes()
 			gci.removeOrphanedProcesses()
 
 			db.Teardown(t)

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -512,6 +512,8 @@ func (s *genericStore[T, PT]) copyFrom(ctx context.Context, objs ...PT) error {
 func (s *genericStore[T, PT]) deleteMany(ctx context.Context, identifiers []string, initialBatchSize int, continueOnError bool) error {
 	// Batch the deletes
 	localBatchSize := initialBatchSize
+	deletedCount := 0
+	numberToDelete := len(identifiers)
 
 	for {
 		if len(identifiers) == 0 {
@@ -532,10 +534,14 @@ func (s *genericStore[T, PT]) deleteMany(ctx context.Context, identifiers []stri
 			}
 			log.Errorf("unable to prune the records: %v", err)
 		}
+		deletedCount = deletedCount + len(identifierBatch)
+		log.Debugf("deleted batch of %d records", len(identifierBatch))
 
 		// Move the slice forward to start the next batch
 		identifiers = identifiers[localBatchSize:]
 	}
+
+	log.Debugf("successfully deleted %d of %d records", deletedCount, numberToDelete)
 
 	return nil
 }


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

Follow on to #11886 to use the new `PruneMany` that will prune outside of a transaction as we aren't as worried about semantics with Prune.  We just want the data gone.  So if one batch fails we will continue onto the next one instead of failing the entire prune job which is what was happening when we used `DeleteMany`.  Pruning is a different animal where we just want to purge as much as we can and move along

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [x] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

Had to do a lot of this manually.  

- spin up a scale test environment
- Hook up 4 fake workload sensors that slam alerts
- change the alert retention configs to by 1 day-ish
- Verify in the logs and the database that alerts are being deleted per the updated retention configs.
- delete the 4 fake workload clusters
- wait for the orphaned deployment retention config to hit
- verify in the logs and the database that alerts orphaned by deployments were pruning based on the config
