### PR TITLE
ROX-25189: Export evidence for compliance operator standards

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/List/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import lowerCase from 'lodash/lowerCase';
 import startCase from 'lodash/startCase';
-import findKey from 'lodash/findKey';
 
 import PageHeader from 'Components/PageHeader';
 import ExportButton from 'Components/ExportButton';
@@ -16,10 +15,15 @@ const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsE
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
 
-    const standardId = findKey(standardLabels, (key) => key === standard);
+    // ROX-25189: Comment out, because standardLabels prevents Download Evidence as CSV for compliance operator standards.
+    // const standardId = findKey(standardLabels, (key) => key === standard);
+    const standardId = standard;
 
+    // ROX-25189: Add nullish coalescing to include compliance operator standard id:
+    // in page header
+    // in file name
     const headerText = standardId
-        ? standardLabels[standardId]
+        ? standardLabels[standardId] ?? standardId
         : `${startCase(lowerCase(entityType))}s`;
 
     // If standardId is truthy, then standard page entity is CONTROL for address controls?s[standard]=WHAT_EVER&s[groupBy]=CATEGORY


### PR DESCRIPTION
### Description

### Problem

Inconsistent behavior:
* /main/compliance has export options which include **Download Evidence as CSV** button.
    The data exists, because CSV file includes rows for compliance operator standards.
* /main/compliance/controls for standard has export options include **Download Evidence as CSV** button only for 5 built-in standards.

### Analysis

Header.js file assumes only built-in standards in `standardLabel` object.

1. Because `standardId` has `undefined` value:
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L19

    Therefore,

    * Page header lacks standard name:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L38

    * Export button lacks option:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L47
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/ExportButton.js#L34-L36

2. Even if `standardId` has compliance operator standard, `headerText` has `undefined` value:
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L22

    Therefore,

    * Page header lacks standard name:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L38
    * Report file name lacks standard name:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L45

Baseline to evaluate `findKey` method, if I mangle a standard id in query string of page address, there is not validation in Standard.js
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/Entity/Standard.js#L19-L21

Therefore, **No data matched your search.**

If, after I make changes described below, I click **Export** and then **Download Evidence as CSV** button, invisible 400 Bad Request status for request:

GET /api/compliance/export/csv?standardId=bogus-standard

### Solution

1. Remove `findKey(standardLabels, …)` limitation.
2. Add nullish coalescing for `headerText` if `standardId` is truthy.

### User-facing documentation

If engineering management decides to cherry pick from master, CHANGELOG update will probably **on release branch**.

- [x] CHANGELOG update is not needed **in this contribution**
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/compliance and then click a built-in standard.

    * See standard name at left of header and **Download Evidence as CSV** button at right.
        ![built-in](https://github.com/stackrox/stackrox/assets/11862657/f956828b-7822-4898-a876-e88cae4b37e0)

2. Click back, and then click a compliance operator standard.

    * Without changes, see absence of standard id and button at right. This picture of staging.
        ![compliance_operator_without_changes](https://github.com/stackrox/stackrox/assets/11862657/dc3245bd-3528-425f-8fcd-994749854e91)

    * With changes, see presence of standard id and button at right. This picture is of team compliance instance.
        ![compliance_operator_with_changes](https://github.com/stackrox/stackrox/assets/11862657/df3be6bb-f7c5-42da-bf0e-b65fc678d83d)

3. Click **Download Evidence as CSV** button.

    * With partial changes, see `undefined` in report file name.

    * With changes, see standard id in report file name.

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
