### PR TITLE
Jv remove get info about osci jobs

### DIFF
--- a/scripts/ci/tools/get-info-about-osci-jobs/get-info-about-osci-jobs.sh
+++ b/scripts/ci/tools/get-info-about-osci-jobs/get-info-about-osci-jobs.sh
@@ -2,8 +2,7 @@
 set -eou pipefail
 
 # Given a directory with multiple artifacts for OSCI jobs looks through all of the collector logs
-# and produces output for a csv file with the name of the job, the kernel version used in the job,
-# and the collection method used by collector.
+# and produces output for a csv file with the name of the job and the kernel version used in the job.
 
 log_dir=$1
 
@@ -12,20 +11,13 @@ get_info_from_collector_log_file() {
 
     dir_name=$(dirname "$log_file" | grep -oP ".*ci-stackrox-stackrox-\K.*")
     kernel_version=$(grep "Kernel Version" "$log_file" | grep -oP 'Kernel Version: \K.*')
-    probe_type=""
-
-    if grep -q "Driver loaded into kernel: CO.RE eBPF probe" "$log_file"; then
-        probe_type="core_bpf"
-    elif grep -q "Driver loaded into kernel: collector-ebpf" "$log_file"; then
-        probe_type="ebpf"
-    fi
 
     pattern="^([^/]+)/"
     [[ $dir_name =~ $pattern ]] && extracted="${BASH_REMATCH[1]}"
 
 
-    if [ -n "$dir_name" ] && [ -n "$kernel_version" ] && [ -n "$probe_type" ]; then
-        echo "$extracted,$kernel_version,$probe_type"
+    if [ -n "$dir_name" ] && [ -n "$kernel_version" ]; then
+        echo "$extracted,$kernel_version"
     fi
 }
 
@@ -38,5 +30,5 @@ collector_infos="$(find . -name '*collector.log' -exec bash -c 'get_info_from_co
 
 collector_infos="$(echo "$collector_infos" | sort -u)"
 
-echo "OSCI Job, Kernel Version, Collection method"
+echo "OSCI Job, Kernel Version"
 echo "$collector_infos"

--- a/scripts/ci/tools/get-info-about-osci-jobs/get-info-for-shas.sh
+++ b/scripts/ci/tools/get-info-about-osci-jobs/get-info-for-shas.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-# Runs the script get-info-about-osci-jobs.sh to get infromation about which kernel versions and
-# collection methods were used for OSCI jobs, from artifacts for multiple CI runs. The artifacts
-# are obtained by downloading them from gcp buckets. The buckets are specified with commit shas.
+# Runs the script get-info-about-osci-jobs.sh to get infromation about which kernel versions
+# were used for OSCI jobs, from artifacts for multiple CI runs. The artifacts are obtained
+# by downloading them from gcp buckets. The buckets are specified with commit shas.
 #
 # The output is a set of csv files and stdout with only unique lines from the set of csv files
 #


### PR DESCRIPTION
### Description

Removes the check for the collection method used in CI tests.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

~~- [ ] CHANGELOG is updated~~
- [x] CHANGELOG update is not needed
~~- [ ] Documentation PR is created and linked above~~
- [x] Documentation is not needed

### Testing

- [x] inspected CI results
       Two failures but they don't use the scripts that were modified

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

~~- [ ] added unit tests~~
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~
- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Ran 

```
./get-info-for-shas.sh ncommit=4 sha=3c7bc3b7e08d11eeef2122c7b3ea801db4e07599
```