### PR TITLE
ROX-25256: add GA requirements to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ change me!
 
 ### Quality Assurance
 
-- [ ] This PR meets all [General Availability requirements](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), and the change is ready to be de deployed in production
+- [ ] this PR meets all [General Availability requirements](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), and the change is ready to be de deployed in production
 - [ ] CI results are inspected
 
 #### Automated testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ General Availability requirements: https://github.com/stackrox/stackrox/blob/mas
 Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
 -->
 
-- [ ] the change is ready to be deployed in production: the feature is complete xor gated by a feature flag, and security and performance implications have been considered
+- [ ] the change is production ready: the feature is GA or otherwise gated by a feature flag
 - [ ] CI results are inspected
 
 #### Automated testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ change me!
 - [ ] CHANGELOG is updated **OR** update is not needed
 - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
 
-### Quality Assurance
+### Quality assurance
 
 <!--
 General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,13 @@ about contributing to this project, check "*.md" files under:
 
 change me!
 
+### General Availability
+
+(*must be* one of the items checked)
+
+- [ ] this PR meets all General Availability requirements, including thorough testing, comprehensive documentation, and adherence to performance and security standards
+- [ ] the change is gated by a feature flag, disabled by default
+
 ### User-facing documentation
 
 - [ ] CHANGELOG is updated **OR** update is not needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,14 +14,14 @@ change me!
 - [ ] CHANGELOG is updated **OR** update is not needed
 - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
 
-### Quality assurance
+### Testing and quality
 
 <!--
 General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
 Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
 -->
 
-- [ ] the change is production ready: the feature is GA or otherwise gated by a feature flag
+- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
 - [ ] CI results are inspected
 
 #### Automated testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,21 +9,15 @@ about contributing to this project, check "*.md" files under:
 
 change me!
 
-### General Availability
-
-(*must be* one of the items checked)
-
-- [ ] this PR meets all General Availability requirements, including thorough testing, comprehensive documentation, and adherence to performance and security standards
-- [ ] the change is gated by a feature flag, disabled by default
-
 ### User-facing documentation
 
 - [ ] CHANGELOG is updated **OR** update is not needed
 - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
 
-### Testing
+### Quality Assurance
 
-- [ ] inspected CI results
+- [ ] This PR meets all [General Availability requirements](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), and the change is ready to be de deployed in production
+- [ ] CI results are inspected
 
 #### Automated testing
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,12 @@ change me!
 
 ### Quality Assurance
 
-- [ ] this PR meets all [General Availability requirements](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), and the change is ready to be de deployed in production
+<!--
+General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
+Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
+-->
+
+- [ ] the change is ready to be deployed in production: the feature is complete xor gated by a feature flag, and security and performance implications have been considered
 - [ ] CI results are inspected
 
 #### Automated testing


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

The PR adds the following task to the PR template:

- [x] the change is production ready: the feature is GA or otherwise gated by a feature flag

___

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] CI results are inspected

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->
  PR template change + updated the PR description check script.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

Documentation only.