### PR TITLE
chore(ui): Add permission tests for Node CVE pages

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getAffectedNodes.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getAffectedNodes.json
@@ -1,0 +1,66 @@
+{
+    "data": {
+        "nodes": [
+            {
+                "id": "1",
+                "name": "cypress-node-1",
+                "osImage": "Red Hat Enterprise Linux CoreOS 414.92.202402010350-0 (Plow)",
+                "cluster": {
+                    "name": "control-cluster",
+                    "__typename": "Cluster"
+                },
+                "nodeComponents": [
+                    {
+                        "name": "openshift-clients",
+                        "source": "INFRASTRUCTURE",
+                        "version": "4.14.0-202401111553.p0.g286cfa5.assembly.stream.el9.x86_64",
+                        "nodeVulnerabilities": [
+                            {
+                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                "isFixable": false,
+                                "fixedByVersion": "",
+                                "__typename": "NodeVulnerability",
+                                "vulnerabilityId": "CVE-2022-1996#rhcos:4.14",
+                                "cve": "CVE-2022-1996",
+                                "cvss": 9.100000381469727,
+                                "scoreVersion": "V3"
+                            }
+                        ],
+                        "__typename": "NodeComponent"
+                    }
+                ],
+                "__typename": "Node"
+            },
+            {
+                "id": "2",
+                "name": "cypress-node-2",
+                "osImage": "Red Hat Enterprise Linux CoreOS 415.92.202402201450-0 (Plow)",
+                "cluster": {
+                    "name": "my-cluster",
+                    "__typename": "Cluster"
+                },
+                "nodeComponents": [
+                    {
+                        "name": "openshift-clients",
+                        "source": "INFRASTRUCTURE",
+                        "version": "4.15.0-202402070507.p0.g48dcf59.assembly.stream.el9.x86_64",
+                        "nodeVulnerabilities": [
+                            {
+                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                "isFixable": false,
+                                "fixedByVersion": "",
+                                "__typename": "NodeVulnerability",
+                                "vulnerabilityId": "CVE-2022-1996#rhcos:4.15",
+                                "cve": "CVE-2022-1996",
+                                "cvss": 9.100000381469727,
+                                "scoreVersion": "V3"
+                            }
+                        ],
+                        "__typename": "NodeComponent"
+                    }
+                ],
+                "__typename": "Node"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEMetadata.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEMetadata.json
@@ -1,0 +1,23 @@
+{
+    "data": {
+        "nodeCVE": {
+            "cve": "CVE-2022-1996",
+            "distroTuples": [
+                {
+                    "summary": "DOCUMENTATION: A flaw was found in CORS Filter feature from the go-restful package. When a user inputs a domain which is in AllowedDomains, all domains starting with the same pattern are accepted. This issue could allow an attacker to break the CORS policy by allowing any page to make requests and retrieve data on behalf of users. \n            STATEMENT: The go-restful package is a transitive dependency which is being pulled with k8s.io/api and not directly being used anywhere in OpenShift Container Platform (OCP), OpenShift Container Storage and OpenShift Data Foundation, hence these components are marked as 'Will not fix' or even \"Not affected\".",
+                    "link": "https://access.redhat.com/security/cve/CVE-2022-1996",
+                    "operatingSystem": "rhcos:4.14",
+                    "__typename": "NodeVulnerability"
+                },
+                {
+                    "summary": "DOCUMENTATION: A flaw was found in CORS Filter feature from the go-restful package. When a user inputs a domain which is in AllowedDomains, all domains starting with the same pattern are accepted. This issue could allow an attacker to break the CORS policy by allowing any page to make requests and retrieve data on behalf of users. \n            STATEMENT: The go-restful package is a transitive dependency which is being pulled with k8s.io/api and not directly being used anywhere in OpenShift Container Platform (OCP), OpenShift Container Storage and OpenShift Data Foundation, hence these components are marked as 'Will not fix' or even \"Not affected\".",
+                    "link": "https://access.redhat.com/security/cve/CVE-2022-1996",
+                    "operatingSystem": "rhcos:4.15",
+                    "__typename": "NodeVulnerability"
+                }
+            ],
+            "firstDiscoveredInSystem": "2024-03-14T22:48:43.642313Z",
+            "__typename": "NodeCVECore"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVESummaryData.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVESummaryData.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "totalNodeCount": 19,
+        "nodeCount": 19,
+        "nodeCVE": {
+            "distroTuples": [
+                {
+                    "operatingSystem": "rhcos:4.14",
+                    "__typename": "NodeVulnerability"
+                },
+                {
+                    "operatingSystem": "rhcos:4.15",
+                    "__typename": "NodeVulnerability"
+                }
+            ],
+            "affectedNodeCountBySeverity": {
+                "critical": {
+                    "total": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "important": {
+                    "total": 19,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "moderate": {
+                    "total": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "low": {
+                    "total": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "__typename": "ResourceCountByCVESeverity"
+            },
+            "__typename": "NodeCVECore"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeMetadata.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeMetadata.json
@@ -1,0 +1,13 @@
+{
+    "data": {
+        "node": {
+            "id": "1",
+            "name": "cypress-node-1",
+            "osImage": "Red Hat Enterprise Linux CoreOS 414.92.202402010350-0 (Plow)",
+            "kubeletVersion": "v1.27.10+28ed2d7",
+            "kernelVersion": "5.14.0-284.50.1.el9_2.x86_64",
+            "scanTime": "2024-07-09T13:42:01.32810868Z",
+            "__typename": "Node"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnSummary.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnSummary.json
@@ -1,0 +1,31 @@
+{
+    "data": {
+        "node": {
+            "id": "1",
+            "nodeCVECountBySeverity": {
+                "low": {
+                    "total": 15,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "moderate": {
+                    "total": 64,
+                    "fixable": 23,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "important": {
+                    "total": 23,
+                    "fixable": 16,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "critical": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "__typename": "ResourceCountByCVESeverity"
+            },
+            "__typename": "Node"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnerabilities.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnerabilities.json
@@ -1,0 +1,34 @@
+{
+    "data": {
+        "node": {
+            "id": "1",
+            "nodeVulnerabilityCount": 1,
+            "nodeVulnerabilities": [
+                {
+                    "cve": "CVE-2022-1996",
+                    "summary": "DOCUMENTATION: A flaw was found in CORS Filter feature from the go-restful package. When a user inputs a domain which is in AllowedDomains, all domains starting with the same pattern are accepted. This issue could allow an attacker to break the CORS policy by allowing any page to make requests and retrieve data on behalf of users. \n            STATEMENT: The go-restful package is a transitive dependency which is being pulled with k8s.io/api and not directly being used anywhere in OpenShift Container Platform (OCP), OpenShift Container Storage and OpenShift Data Foundation, hence these components are marked as 'Will not fix' or even \"Not affected\".",
+                    "cvss": 9.100000381469727,
+                    "scoreVersion": "V3",
+                    "nodeComponents": [
+                        {
+                            "name": "openshift-clients",
+                            "source": "INFRASTRUCTURE",
+                            "version": "4.14.0-202401111553.p0.g286cfa5.assembly.stream.el9.x86_64",
+                            "nodeVulnerabilities": [
+                                {
+                                    "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                    "isFixable": false,
+                                    "fixedByVersion": "",
+                                    "__typename": "NodeVulnerability"
+                                }
+                            ],
+                            "__typename": "NodeComponent"
+                        }
+                    ],
+                    "__typename": "NodeVulnerability"
+                }
+            ],
+            "__typename": "Node"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
@@ -1,0 +1,3 @@
+export function visitNodeCveOverviewPage() {
+    cy.visit('/main/vulnerabilities/node-cves');
+}

--- a/ui/apps/platform/cypress/selectors/navigation.js
+++ b/ui/apps/platform/cypress/selectors/navigation.js
@@ -1,6 +1,7 @@
 const navExpandable = 'ul.pf-v5-c-nav__list li.pf-v5-c-nav__item.pf-m-expandable button';
 
 const navigation = {
+    allNavLinks: '.pf-v5-c-nav a',
     navLinks: '.pf-v5-c-nav > ul.pf-v5-c-nav__list > li > a',
     navExpandable,
     navExpandablePlatformConfiguration: `${navExpandable}:contains("Platform Configuration")`,


### PR DESCRIPTION
### Description

Adds Cypress tests for the top level permissions requires across Node CVE pages.

Note: this includes fixtures for the core graphql requests needed on Node and Node CVE single pages. In the case of the Node CVE single page, we will need to mock requests for **every** test since it is likely that there will be zero Node CVEs in the CI environment.

In the case of the Node single page, there should be at least one node available on all systems so it is likely that we do not need to mock every request. In the initial permissions test, I did mock the response as an empty response to an arbitrary node id would display the "Not found" page in the UI. In this case we are not interested in the data being returned, only that the requests are made that would return _some_ data.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] added e2e tests

#### How I validated my change

CI