### PR TITLE
ROX-25129: Hide label expandable when there are no labels

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
@@ -25,6 +25,10 @@ function ExpandableLabelSection({ toggleText, labels }: ExpandableLabelSectionPr
         setIsExpanded(isExpanded);
     };
 
+    if (labels.length === 0) {
+        return null;
+    }
+
     return (
         <ExpandableSection
             toggleContent={


### PR DESCRIPTION
### Description

This PR does as the title mentions. We want to hide the labels expandable when there are no labels. It looks odd and isn't useful.

### Screenshots

Before
<img width="723" alt="Screenshot 2024-07-09 at 9 13 59 AM" src="https://github.com/stackrox/stackrox/assets/4805485/aad3d0e4-8c2a-4e21-948e-89ae014725a0">

After
<img width="1439" alt="Screenshot 2024-07-09 at 9 13 45 AM" src="https://github.com/stackrox/stackrox/assets/4805485/dddaa797-379b-4e11-8b28-a3610a225d3e">
