### PR TITLE
ROX-24951: Update images without vulnerabilities description

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
@@ -28,7 +28,7 @@ export function getViewStateDescription(
         case 'OBSERVED':
             return cveViewingMode === 'WITH_CVES'
                 ? 'Images and deployments observed with CVEs'
-                : 'Images and deployments observed without CVEs (results may be inaccurate due to scanner errors)';
+                : 'Images and deployments without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)';
         case 'DEFERRED':
             return 'Observed vulnerabilities that are approved by administrators to be deferred for a period of time or until fixable';
         case 'FALSE_POSITIVE':

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
@@ -27,7 +27,7 @@ export function getViewStateDescription(
     switch (vulnerabilityState) {
         case 'OBSERVED':
             return cveViewingMode === 'WITH_CVES'
-                ? 'Images and deployments observed with CVEs'
+                ? 'Images and deployments with observed CVEs'
                 : 'Images and deployments without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)';
         case 'DEFERRED':
             return 'Observed vulnerabilities that are approved by administrators to be deferred for a period of time or until fixable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -15,7 +15,7 @@ import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
 import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../../types';
-import ImageScanningErrorLabel from '../components/ImageScanningErrorLabelLayout';
+import ImageScanningIncompleteLabel from '../components/ImageScanningIncompleteLabelLayout';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -179,7 +179,7 @@ function ImagesTable({
                                                     </Label>
                                                 )}
                                                 {(notes.length !== 0 || scanNotes.length !== 0) && (
-                                                    <ImageScanningErrorLabel
+                                                    <ImageScanningIncompleteLabel
                                                         imageNotes={notes}
                                                         scanNotes={scanNotes}
                                                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabelLayout.tsx
@@ -5,12 +5,15 @@ import isEmpty from 'lodash/isEmpty';
 
 import getImageScanMessage from '../utils/getImageScanMessage';
 
-export type ImageScanningErrorLabelProps = {
+export type ImageScanningIncompleteLabelProps = {
     imageNotes: string[];
     scanNotes: string[];
 };
 
-function ImageScanningErrorLabel({ imageNotes, scanNotes }: ImageScanningErrorLabelProps) {
+function ImageScanningIncompleteLabel({
+    imageNotes,
+    scanNotes,
+}: ImageScanningIncompleteLabelProps) {
     const scanMessage = getImageScanMessage(imageNotes, scanNotes);
 
     if (isEmpty(scanMessage)) {
@@ -20,7 +23,7 @@ function ImageScanningErrorLabel({ imageNotes, scanNotes }: ImageScanningErrorLa
     return (
         <>
             <Popover
-                aria-label="Image scanning error label"
+                aria-label="Image scanning incomplete label"
                 headerContent={<div>CVE data may be inaccurate</div>}
                 bodyContent={
                     <Flex
@@ -41,7 +44,7 @@ function ImageScanningErrorLabel({ imageNotes, scanNotes }: ImageScanningErrorLa
                         icon={<ExclamationTriangleIcon />}
                         variant="outline"
                     >
-                        Image scanning error
+                        Image scanning incomplete
                     </Label>
                 </Button>
             </Popover>
@@ -49,4 +52,4 @@ function ImageScanningErrorLabel({ imageNotes, scanNotes }: ImageScanningErrorLa
     );
 }
 
-export default ImageScanningErrorLabel;
+export default ImageScanningIncompleteLabel;

--- a/ui/apps/platform/src/messages/vulnMgmt.messages.ts
+++ b/ui/apps/platform/src/messages/vulnMgmt.messages.ts
@@ -6,23 +6,23 @@ export type ScanMessage = {
 export const imageScanMessages = {
     missingMetadata: {
         header: 'Failed to retrieve metadata from the registry.',
-        body: 'Couldn’t retrieve metadata from the registry, check registry connection.',
+        body: 'Check the registry connection.',
     },
     missingScanData: {
         header: 'Failed to get the base OS information.',
-        body: 'Failed to get the base OS information. Either the integrated scanner can’t find the OS or the base OS is unidentifiable.',
+        body: "The integrated scanner can't find the OS, or the base OS is unidentifiable.",
     },
     osUnavailable: {
         header: 'The scanner doesn’t provide OS information.',
-        body: 'Failed to get the base OS information. Either the integrated scanner can’t find the OS or the base OS is unidentifiable.',
+        body: "The integrated scanner can't find the OS, or the base OS is unidentifiable.",
     },
     languageCvesUnavailable: {
-        header: 'Unable to retrieve the Language CVE data, only OS CVE data is available.',
-        body: 'Only showing information about the OS CVEs. Turn on the Language CVE feature in a scanner to view additional details.',
+        header: 'Unable to retrieve Language CVE data; only OS CVE data available',
+        body: 'Turn on the Language CVE feature in the scanner to view additional details.',
     },
     osCvesUnavailable: {
-        header: 'Unable to retrieve the OS CVE data, only Language CVE data is available.',
-        body: 'Only showing information about the Language CVEs.',
+        header: 'Unable to retrieve OS CVE data; only Language CVE data available.',
+        body: 'Only Language CVE information is shown.',
     },
     osCvesStale: {
         header: 'Stale OS CVE data.',
@@ -31,14 +31,14 @@ export const imageScanMessages = {
     },
     certifiedRHELUnavailable: {
         header: 'Image out of scope for Red Hat Vulnerability Scanner Certification.',
-        body: 'The scan results are not certified, as the base RHEL image is out of scope for certification. Please consider updating the base image.',
+        body: 'The scan results are not certified because the base RHEL image is out of scope for certification. Please consider updating the base image.',
     },
 };
 
 export const nodeScanMessages = {
     missingScanData: {
         header: 'Failed to get scan data.',
-        body: 'Failed to get scan data. There may have been an error communicating with the integrated node scanner.',
+        body: 'There may have been an error communicating with the integrated node scanner.',
     },
     unsupported: {
         header: 'Node unsupported.',


### PR DESCRIPTION
### Description

For context about the changes here, check out [this thread](https://redhat-internal.slack.com/archives/C03JMGWJYMD/p1719328756778209).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

One line change

#### How I validated my change

Before
<img width="329" alt="Screenshot 2024-07-09 at 9 18 40 AM" src="https://github.com/stackrox/stackrox/assets/4805485/0412acd5-e786-4135-b1f8-c2d06da0ee95">

After
<img width="329" alt="Screenshot 2024-07-09 at 11 28 48 AM" src="https://github.com/stackrox/stackrox/assets/4805485/dda861d0-9f55-4461-9fc3-db91ba2ac416">


Before
<img width="1169" alt="Screenshot 2024-07-09 at 10 59 37 AM" src="https://github.com/stackrox/stackrox/assets/4805485/59fa5f01-1b6a-4851-a1a1-48fc77639a94">

After
<img width="1163" alt="Screenshot 2024-07-09 at 10 58 52 AM" src="https://github.com/stackrox/stackrox/assets/4805485/f0e869cf-c2df-4545-a086-336222fd1549">

