### PR TITLE
chore(ui): Add Node CVE tests for available filters

### DIFF
--- a/ui/apps/platform/cypress/helpers/compoundFilters.ts
+++ b/ui/apps/platform/cypress/helpers/compoundFilters.ts
@@ -1,0 +1,67 @@
+/*
+ * Helper functions to interact with the compound search filters component
+ */
+
+const entityMenuToggle = '[aria-label="compound search filter entity selector toggle"]';
+const entityMenu = '[aria-label="compound search filter entity selector menu"]';
+const entityMenuItem = `${entityMenu} li`;
+const attributeMenuToggle = '[aria-label="compound search filter attribute selector toggle"]';
+const attributeMenu = '[aria-label="compound search filter attribute selector menu"]';
+const attributeMenuItem = `${attributeMenu} li`;
+
+export const compoundFiltersSelectors = {
+    entityMenuToggle,
+    entityMenu,
+    entityMenuItem,
+    attributeMenuToggle,
+    attributeMenu,
+    attributeMenuItem,
+};
+
+export function toggleEntitySelectorMenu() {
+    cy.get(entityMenuToggle).click();
+}
+export function selectEntity(entity: string) {
+    toggleEntitySelectorMenu();
+    cy.get(entityMenu)
+        .contains(new RegExp(`^${entity}$`, 'i'))
+        .click();
+}
+
+export function toggleAttributeSelectorMenu() {
+    cy.get(attributeMenuToggle).click();
+}
+
+export function selectAttribute(attribute: string) {
+    toggleAttributeSelectorMenu();
+    cy.get(attributeMenuItem)
+        .contains(new RegExp(`^${attribute}$`, 'i'))
+        .click();
+}
+
+/**
+ * Checks that the available filters in the UI match the expected filters
+ * @param expectedFilters - A record of entity names and their corresponding attributes
+ */
+export function assertAvailableFilters(expectedFilters: Record<string, string[]>) {
+    const filterKeys = Object.keys(expectedFilters);
+
+    toggleEntitySelectorMenu();
+    cy.get(compoundFiltersSelectors.entityMenuItem).should('have.length', filterKeys.length);
+    filterKeys.forEach((entity) => {
+        cy.get(compoundFiltersSelectors.entityMenuItem).contains(new RegExp(`^${entity}$`, 'i'));
+    });
+    toggleEntitySelectorMenu();
+
+    Object.entries(expectedFilters).forEach(([entity, attributes]) => {
+        selectEntity(entity);
+        toggleAttributeSelectorMenu();
+        cy.get(compoundFiltersSelectors.attributeMenuItem).should('have.length', attributes.length);
+        attributes.forEach((attribute) => {
+            cy.get(compoundFiltersSelectors.attributeMenuItem).contains(
+                new RegExp(`^${attribute}$`, 'i')
+            );
+        });
+        toggleAttributeSelectorMenu();
+    });
+}

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -19,6 +19,7 @@
  * @returns Record<string, { method: string, url: string }>
  */
 export function getRouteMatcherMapForGraphQL(opnames) {
+    /** @type Record<string, { method: string, url: string }> */
     const routeMatcherMap = {};
 
     opnames.forEach((opname) => {

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -60,6 +60,7 @@ const routeMatcherMapForAuthenticatedRoutes = {
  * @param {string} pageUrl
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function visit(pageUrl, routeMatcherMap, staticResponseMap, waitOptions) {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
@@ -1,3 +1,17 @@
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+} from '../../../helpers/request';
+
 export function visitNodeCveOverviewPage() {
     cy.visit('/main/vulnerabilities/node-cves');
+}
+
+export function visitFirstNodeLinkFromTable() {
+    return interactAndWaitForResponses(
+        () => {
+            cy.get('tbody tr td[data-label="Node"] a').first().click();
+        },
+        getRouteMatcherMapForGraphQL(['getNodeMetadata'])
+    );
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
@@ -1,8 +1,11 @@
 import { graphql } from '../../../constants/apiEndpoints';
 import withAuth from '../../../helpers/basicAuth';
+import { assertAvailableFilters } from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
+import { getRouteMatcherMapForGraphQL } from '../../../helpers/request';
 import {
     assertCannotFindThePage,
+    visit,
     visitWithStaticResponseForPermissions,
 } from '../../../helpers/visit';
 
@@ -55,7 +58,13 @@ describe('Node CVEs - CVE Detail Page', () => {
     });
 
     it('should only show relevant filters for the page', () => {
-        // check the advanced filters and ensure only the relevant filters are displayed
+        const url = `${nodeCveBaseUrl}/${mockCveName}`;
+        visit(url, getRouteMatcherMapForGraphQL(['getNodeCVEMetadata']), {});
+        assertAvailableFilters({
+            Cluster: ['Name', 'Label', 'Type', 'Platform type'],
+            Node: ['Name', 'Operating System', 'Label', 'Annotation', 'Scan Time'],
+            'Node Component': ['Name', 'Version'],
+        });
     });
 
     it('should link to the overview page from the breadcrumbs', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -1,4 +1,11 @@
 import withAuth from '../../../helpers/basicAuth';
+import {
+    assertAvailableFilters,
+    compoundFiltersSelectors,
+    selectEntity,
+    toggleAttributeSelectorMenu,
+    toggleEntitySelectorMenu,
+} from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     assertCannotFindThePage,
@@ -6,6 +13,7 @@ import {
 } from '../../../helpers/visit';
 import navSelectors from '../../../selectors/navigation';
 import { visitNodeCveOverviewPage } from './NodeCve.helpers';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 describe('Node CVEs - Overview Page', () => {
     withAuth();
@@ -50,8 +58,20 @@ describe('Node CVEs - Overview Page', () => {
     });
 
     it('should only show relevant filters for the Node CVEs page', () => {
+        visitNodeCveOverviewPage();
+        const expectedFilters = {
+            CVE: ['Name', 'CVSS', 'Discovered Time'],
+            Node: ['Name', 'Operating System', 'Label', 'Annotation', 'Scan Time'],
+            'Node Component': ['Name', 'Version'],
+            Cluster: ['Name', 'Label', 'Type', 'Platform type'],
+        };
+
         // check the advanced filters and ensure only the relevant filters are displayed for CVEs
+        assertAvailableFilters(expectedFilters);
+
         // check the advanced filters and ensure only the relevant filters are displayed for Nodes
+        cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
+        assertAvailableFilters(expectedFilters);
     });
 
     it('should link to the correct details pages', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -1,11 +1,5 @@
 import withAuth from '../../../helpers/basicAuth';
-import {
-    assertAvailableFilters,
-    compoundFiltersSelectors,
-    selectEntity,
-    toggleAttributeSelectorMenu,
-    toggleEntitySelectorMenu,
-} from '../../../helpers/compoundFilters';
+import { assertAvailableFilters } from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     assertCannotFindThePage,

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -1,10 +1,13 @@
 import { graphql } from '../../../constants/apiEndpoints';
 import withAuth from '../../../helpers/basicAuth';
+import { assertAvailableFilters } from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     assertCannotFindThePage,
     visitWithStaticResponseForPermissions,
 } from '../../../helpers/visit';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
+import { visitFirstNodeLinkFromTable, visitNodeCveOverviewPage } from './NodeCve.helpers';
 
 const nodeBaseUrl = '/main/vulnerabilities/node-cves/nodes';
 const mockNodeId = '1';
@@ -51,7 +54,15 @@ describe('Node CVEs - Node Detail Page', () => {
     });
 
     it('should only show relevant filters for the Node Detail page', () => {
-        // check the advanced filters and ensure only the relevant filters are displayed
+        visitNodeCveOverviewPage();
+        cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
+
+        visitFirstNodeLinkFromTable();
+
+        assertAvailableFilters({
+            CVE: ['Name', 'CVSS', 'Discovered Time'],
+            'Node Component': ['Name', 'Version'],
+        });
     });
 
     it('should link to the correct pages', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/vulnerabilities.selectors.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/vulnerabilities.selectors.ts
@@ -3,4 +3,6 @@ const filterChipSection =
 
 export const selectors = {
     clearFiltersButton: `${filterChipSection} button:contains("Clear filters")`,
+    entityTypeToggleItem: (entityType: string) =>
+        `.pf-v5-c-toggle-group[aria-label="Entity type toggle items"] button:contains("${entityType}")`,
 } as const;

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -159,7 +159,7 @@ export function typeAndEnterCustomSearchFilterValue(entity, searchTerm, value) {
  * @param {('CVE' | 'Image' | 'Deployment')} entityType
  */
 export function selectEntityTab(entityType) {
-    cy.get(selectors.entityTypeToggleItem(entityType)).click();
+    cy.get(vulnSelectors.entityTypeToggleItem(entityType)).click();
 }
 
 const allSeverities = ['Critical', 'Important', 'Moderate', 'Low'];

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -45,8 +45,6 @@ export const selectors = {
 
     // General selectors
     filteredViewLabel: '.pf-v5-c-label:contains("Filtered view")',
-    entityTypeToggleItem: (entityType) =>
-        `.pf-v5-c-toggle-group[aria-label="Entity type toggle items"] button:contains("${entityType}")`,
     summaryCard: (cardTitle) => `.pf-v5-c-card:contains("${cardTitle}")`,
     iconText: (textContent) => `svg ~ *:contains("${textContent}")`,
     bulkActionMenuToggle: 'button:contains("Bulk actions")',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -97,7 +97,7 @@ describe('Workload CVE Image CVE Single page', () => {
 
     it('should correctly handle local filters on the deployments tab', () => {
         visitFirstCve();
-        cy.get(selectors.entityTypeToggleItem('Deployment')).click();
+        cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).click();
 
         // Wait for the loading spinner to disappear
         cy.get('.pf-v5-c-spinner').should('not.exist');
@@ -160,7 +160,7 @@ describe('Workload CVE Image CVE Single page', () => {
         cy.go('back');
 
         // Go to the deployment toggle tab
-        cy.get(selectors.entityTypeToggleItem('Deployment')).click();
+        cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).click();
 
         // Test the the deployment links navigate to the correct page
         cy.get(`${selectors.firstTableRow} td[data-label="Deployment"] a`).then(

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -13,6 +13,7 @@ import {
     typeAndEnterCustomSearchFilterValue,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 describe('Workload CVE overview page tests', () => {
     const isAdvancedFiltersEnabled = hasFeatureFlag('ROX_VULN_MGMT_ADVANCED_FILTERS');
@@ -31,13 +32,17 @@ describe('Workload CVE overview page tests', () => {
         // TODO Test that the default tab is set to "Observed"
 
         // Check that the CVE entity toggle is selected and Image/Deployment are disabled
-        cy.get(selectors.entityTypeToggleItem('CVE')).should('have.attr', 'aria-pressed', 'true');
-        cy.get(selectors.entityTypeToggleItem('Image')).should(
+        cy.get(vulnSelectors.entityTypeToggleItem('CVE')).should(
+            'have.attr',
+            'aria-pressed',
+            'true'
+        );
+        cy.get(vulnSelectors.entityTypeToggleItem('Image')).should(
             'not.have.attr',
             'aria-pressed',
             'true'
         );
-        cy.get(selectors.entityTypeToggleItem('Deployment')).should(
+        cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).should(
             'not.have.attr',
             'aria-pressed',
             'true'

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Truncate } from '@patternfly/react-core';
-import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import DateDistance from 'Components/DateDistance';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
@@ -96,40 +96,42 @@ function NodesTable({
                 colSpan={5}
                 emptyProps={{ message: 'No CVEs have been reported for your scanned nodes' }}
                 filteredEmptyProps={{ onClearFilters }}
-                renderer={({ data }) =>
-                    data.map((node) => {
-                        const { id, name, nodeCVECountBySeverity, cluster, osImage, scanTime } =
-                            node;
-                        const { critical, important, moderate, low } = nodeCVECountBySeverity;
-                        return (
-                            <Tr key={id}>
-                                <Td dataLabel="Node" modifier="nowrap">
-                                    <Link to={getNodeEntityPagePath('Node', id)}>
-                                        <Truncate position="middle" content={name} />
-                                    </Link>
-                                </Td>
-                                <Td dataLabel="CVEs by severity">
-                                    <SeverityCountLabels
-                                        criticalCount={critical.total}
-                                        importantCount={important.total}
-                                        moderateCount={moderate.total}
-                                        lowCount={low.total}
-                                        filteredSeverities={filteredSeverities}
-                                    />
-                                </Td>
-                                <Td dataLabel="Cluster" modifier="nowrap">
-                                    <Truncate position="middle" content={cluster.name} />
-                                </Td>
-                                <Td dataLabel="Operating system" modifier="nowrap">
-                                    <Truncate position="middle" content={osImage} />
-                                </Td>
-                                <Td dataLabel="Scan time">
-                                    <DateDistance date={scanTime} />
-                                </Td>
-                            </Tr>
-                        );
-                    })
-                }
+                renderer={({ data }) => (
+                    <Tbody>
+                        {data.map((node) => {
+                            const { id, name, nodeCVECountBySeverity, cluster, osImage, scanTime } =
+                                node;
+                            const { critical, important, moderate, low } = nodeCVECountBySeverity;
+                            return (
+                                <Tr key={id}>
+                                    <Td dataLabel="Node" modifier="nowrap">
+                                        <Link to={getNodeEntityPagePath('Node', id)}>
+                                            <Truncate position="middle" content={name} />
+                                        </Link>
+                                    </Td>
+                                    <Td dataLabel="CVEs by severity">
+                                        <SeverityCountLabels
+                                            criticalCount={critical.total}
+                                            importantCount={important.total}
+                                            moderateCount={moderate.total}
+                                            lowCount={low.total}
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Cluster" modifier="nowrap">
+                                        <Truncate position="middle" content={cluster.name} />
+                                    </Td>
+                                    <Td dataLabel="Operating system" modifier="nowrap">
+                                        <Truncate position="middle" content={osImage} />
+                                    </Td>
+                                    <Td dataLabel="Scan time">
+                                        <DateDistance date={scanTime} />
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
+                    </Tbody>
+                )}
             />
         </Table>
     );


### PR DESCRIPTION
### Description

Adds tests asserting the correct filters are present across Node CVE pages.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] added e2e tests

#### How I validated my change

CI