### PR TITLE
chore(CI): use pull policy Never to bar prefetch misses

### DIFF
--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -72,4 +72,4 @@ quay.io/rhacs-eng/qa-signatures:centos9-multiarch@sha256:743cf31b5c29c227aa1371e
 quay.io/rhacs-eng/qa-multi-arch@sha256:b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e
 quay.io/rhacs-eng/qa-multi-arch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:nginx-multiarch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
-quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
+# quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -72,11 +72,11 @@ quay.io/rhacs-eng/qa-signatures:centos9-multiarch@sha256:743cf31b5c29c227aa1371e
 quay.io/rhacs-eng/qa-multi-arch@sha256:b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e
 quay.io/rhacs-eng/qa-multi-arch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:nginx-multiarch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
+quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
 
+# Non quay
 us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12
 us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3
 us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:0.3
 us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.19
-# The ECR tests have elements of the image path in secrets but should they?
-# XXXXXXXXXXXX.dkr.ecr.XXXXXXXXX.amazonaws.com/stackrox-qa-ecr-test:registry-image-no-secrets
-quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
+051999192406.dkr.ecr.us-east-2.amazonaws.com/stackrox-qa-ecr-test:registry-image-no-secrets

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -72,3 +72,11 @@ quay.io/rhacs-eng/qa-signatures:centos9-multiarch@sha256:743cf31b5c29c227aa1371e
 quay.io/rhacs-eng/qa-multi-arch@sha256:b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e
 quay.io/rhacs-eng/qa-multi-arch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:nginx-multiarch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
+
+us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12
+us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3
+us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:0.3
+us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.19
+# The ECR tests have elements of the image path in secrets but should they?
+# XXXXXXXXXXXX.dkr.ecr.XXXXXXXXX.amazonaws.com/stackrox-qa-ecr-test:registry-image-no-secrets
+quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -1,6 +1,8 @@
 # Images used by QA e2e tests that will be prefetched
 
-# This list was largely derived manually
+# If renaming/moving this file, update the reference in
+# qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+
 quay.io/centos/centos:stream9
 quay.io/rhacs-eng/qa-multi-arch-busybox:1.30
 quay.io/rhacs-eng/qa-multi-arch-busybox:latest

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -73,10 +73,3 @@ quay.io/rhacs-eng/qa-multi-arch@sha256:b73f527d86e3461fd652f62cf47e7b375196063bb
 quay.io/rhacs-eng/qa-multi-arch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:nginx-multiarch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
-
-# Non quay
-us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12
-us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3
-us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/more:0.3
-us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.19
-051999192406.dkr.ecr.us-east-2.amazonaws.com/stackrox-qa-ecr-test:registry-image-no-secrets

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -72,4 +72,4 @@ quay.io/rhacs-eng/qa-signatures:centos9-multiarch@sha256:743cf31b5c29c227aa1371e
 quay.io/rhacs-eng/qa-multi-arch@sha256:b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e
 quay.io/rhacs-eng/qa-multi-arch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
 quay.io/rhacs-eng/qa-signatures:nginx-multiarch@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
-# quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
+quay.io/rhacs-eng/qa-signatures:byopki@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2109,7 +2109,7 @@ class Kubernetes implements OrchestratorMain {
         }
         if (!deployment.skipReplicaWait && !deployment.deploymentUid) {
             String exceptionMsg = "The deployment did not start or reach replica ready state"
-            if (deployment.imagePullPolicy == "Never") {
+            if (Env.IMAGE_PULL_POLICY_FOR_QUAY_IO == "Never") {
                 exceptionMsg += " - if this job uses image prefetch check that this image is in the jobs prefetch list"+
                                 " - " + deployment.image
             }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2326,7 +2326,6 @@ class Kubernetes implements OrchestratorMain {
         Container container = new Container(
                 name: deployment.containerName ? deployment.containerName : deployment.name,
                 image: deployment.image,
-                imagePullPolicy: "Never",
                 command: deployment.command,
                 args: deployment.args,
                 ports: depPorts,
@@ -2339,6 +2338,12 @@ class Kubernetes implements OrchestratorMain {
                                                      capabilities: new Capabilities(add: deployment.addCapabilities,
                                                                                     drop: deployment.dropCapabilities)),
         )
+        // Allow override of imagePullPolicy for quay.io images. Typically used
+        // to set to Never to help keep the list of quay.io prebuilt images up
+        // to date for image-prefetcher. Why not all images? ROX-xxx.
+        if (Env.IMAGE_PULL_POLICY_FOR_QUAY_IO && deployment.image =~ /^quay.io/) {
+            container.setImagePullPolicy(Env.IMAGE_PULL_POLICY_FOR_QUAY_IO)
+        }
         if (deployment.livenessProbeDefined) {
             Probe livenessProbe = new Probe(
                 exec: new ExecAction(command: ["touch", "/tmp/healthy"]),

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2110,7 +2110,8 @@ class Kubernetes implements OrchestratorMain {
         if (!deployment.skipReplicaWait && !deployment.deploymentUid) {
             String exceptionMsg = "The deployment did not start or reach replica ready state"
             if (Env.IMAGE_PULL_POLICY_FOR_QUAY_IO == "Never") {
-                exceptionMsg += " - if this job uses image prefetch check that this image is in the jobs prefetch list"+
+                exceptionMsg += " - if this job uses image prefetch check that this image "+
+                                "is in the jobs prefetch list e.g. qa-tests-backend/scripts/images-to-prefetch.txt"+
                                 " - " + deployment.image
             }
             throw new OrchestratorManagerException(exceptionMsg)

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2108,7 +2108,12 @@ class Kubernetes implements OrchestratorMain {
             log.warn("Error while waiting for deployment/populating deployment info: ", e)
         }
         if (!deployment.skipReplicaWait && !deployment.deploymentUid) {
-            throw new OrchestratorManagerException("The deployment did not start or reach replica ready state")
+            String exceptionMsg = "The deployment did not start or reach replica ready state"
+            if (deployment.imagePullPolicy == "Never") {
+                exceptionMsg += " - if this job uses image prefetch check that this image is in the jobs prefetch list"+
+                                " - " + deployment.image
+            }
+            throw new OrchestratorManagerException(exceptionMsg)
         }
     }
 

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2340,7 +2340,7 @@ class Kubernetes implements OrchestratorMain {
         )
         // Allow override of imagePullPolicy for quay.io images. Typically used
         // to set to Never to help keep the list of quay.io prebuilt images up
-        // to date for image-prefetcher. Why not all images? ROX-xxx.
+        // to date for image-prefetcher. Why not all images? See ROX-25258.
         if (Env.IMAGE_PULL_POLICY_FOR_QUAY_IO && deployment.image =~ /^quay.io/) {
             container.setImagePullPolicy(Env.IMAGE_PULL_POLICY_FOR_QUAY_IO)
         }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2326,7 +2326,7 @@ class Kubernetes implements OrchestratorMain {
         Container container = new Container(
                 name: deployment.containerName ? deployment.containerName : deployment.name,
                 image: deployment.image,
-                imagePullPolicy: "IfNotPresent",
+                imagePullPolicy: "Never",
                 command: deployment.command,
                 args: deployment.args,
                 ports: depPorts,

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -552,6 +552,10 @@ _image_prefetcher_prebuilt_start() {
     case "$CI_JOB_NAME" in
     *qa-e2e-tests)
         image_prefetcher_start_set qa-e2e
+        # Override the default image pull policy for containers with quay.io
+        # images to rely on prefetched images. This helps ensure that the static
+        # prefect list stays up to date with additions.
+        ci_export "IMAGE_PULL_POLICY_FOR_QUAY_IO" "Never"
         ;;
     # TODO(ROX-20508): for operaror-e2e jobs, pre-fetch images of the release from which operator upgrade test starts.
     *)


### PR DESCRIPTION
### Description

This PR allows image-prefetch to override the default imagePullPolicy when it is in use. And sets it to `Never` in that case to help keep the image list in sync with additional images. The quay.io limitation is tracked with ROX-25258.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

- [x] force a failure due to an added image that is not prefetched
  - fails the test that relies on it [1](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11915/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1811077422594920448), [2](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11915/pull-ci-stackrox-stackrox-master-ocp-4-15-qa-e2e-tests/1811077448385695744), with a better failure message [3](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/11915/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1811428721240838144)
- [x] happy path - all images prefetched
- [x] all-qa-e2e

