### PR TITLE
chore(ui): Fix key prop errors in violation details

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -80,7 +80,7 @@ function ContainerConfiguration({ container }: ContainerConfigurationProps): Rea
                 ) : (
                     secrets.map((secret, i) => (
                         <DescriptionListItem
-                            key={secret.name}
+                            key={`${secret.name}_${secret.path}`}
                             term={`secrets[${i}]`}
                             desc={<ContainerSecretDescriptionList secret={secret} />}
                         />

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
@@ -45,9 +45,8 @@ function NetworkPoliciesTab({ clusterId, namespaceName }: NetworkPoliciesTabProp
                             {namespacePolicies
                                 .sort(compareNetworkPolicies)
                                 .map((netpol: NetworkPolicy) => (
-                                    <ListItem>
+                                    <ListItem key={netpol.id}>
                                         <Button
-                                            key={netpol.id}
                                             variant="link"
                                             onClick={() => setSelectedNetworkPolicy(netpol)}
                                         >


### PR DESCRIPTION
### Description

Fix existing errors in browser console so it is easier to see recent regressions.

### 1

**Problem**

> Encountered two children with the same key, `central-tls`.

> Keys should be unique so that components maintain their identity across updates.

> Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

at dl
at DescriptionList
at ContainerConfiguration

**Analysis**: The `name` of `EmbeddedSecret` objects is not a unique key.

**Solution**: Concatenate `name` and `path` for a unique key.

### 2

**Problem**

> Each child in a list should have a unique "key" prop.

> Check the render method of `NetworkPoliciesTab`

**Analysis**: The `key` prop is on a child element for element rendered by `map` method.

**Solution**: Move `key` prop.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/violations, click a violation for a deployment that has secrets, and then click **Deployment** tab.

    * Before change, see presence of error in browser console.
        ![ContainerConfiguration_with_error](https://github.com/stackrox/stackrox/assets/11862657/c2df4451-3af6-4e35-8df3-5d3fe30d27b3)

    * After change, see absence of error in browser console.

2. Go back, click a violation for a deployment whose namespace has network policies, and then click **Network policies** tab.

    * Before change, see presence of error in browser console.
        ![NetworkPoliciesTab_with_error](https://github.com/stackrox/stackrox/assets/11862657/7905dd6c-7b04-4ace-9163-c93438eadc02)

    * After change, see absence of error in browser console.
