### PR TITLE
fix(qa): Fix operator deployment on OCP 4.16 ppc64le clusters

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -54,7 +54,7 @@ function apply_operator_manifests() {
     operator_channel=$(< midstream/iib.json jq -r '.operator.channel')
   env -i PATH="${PATH}" \
     INDEX_VERSION="${index_version}" OPERATOR_VERSION="${operator_version}" NAMESPACE="${operator_ns}" OPERATOR_CHANNEL="${operator_channel}" \
-    IMAGE_TAG_BASE="${image_tag_base}" \
+    IMAGE_TAG_BASE="${image_tag_base}" DISABLE_SECURITY_CONTEXT_CONFIG="${disable_security_context_config}" \
     envsubst < "${ROOT_DIR}/operator/hack/operator-midstream.envsubst.yaml" \
     | "${ROOT_DIR}/operator/hack/retry-kubectl.sh" -n "${operator_ns}" apply -f -
   else

--- a/operator/hack/operator-midstream.envsubst.yaml
+++ b/operator/hack/operator-midstream.envsubst.yaml
@@ -6,6 +6,8 @@ spec:
   sourceType: grpc
   image: ${IMAGE_TAG_BASE}:${INDEX_VERSION}
   displayName: StackRox Operator Test index
+  grpcPodConfig:
+    ${DISABLE_SECURITY_CONTEXT_CONFIG}securityContextConfig: restricted
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup


### PR DESCRIPTION
### Description
ACS Operator catalog source remains unhealthy when deployed on ocp 4.16 cluster due to podsecurity policy violation.
This PR adds `spec.grpcPodConfig.securityContextConfig` to the operator midstream CR.

## Checklist
- [x] Investigated and inspected CI test results

Not doing these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
Performed locally on the cluster 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
