### PR TITLE
ROX-24871: Remove flaky scan time assertion

### DIFF
--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -1,24 +1,21 @@
 import static util.Helpers.waitForTrue
 import static util.Helpers.withRetry
 
-import com.google.protobuf.Timestamp
-
 import io.stackrox.proto.storage.NodeOuterClass.Node
 
 import common.Constants
 import services.BaseService
 import services.ClusterService
 import services.NodeService
+import util.Env
+
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
-import util.Env
 
 // skip if executed in a test environment with just secured-cluster deployed in the test cluster
 // i.e. central is deployed elsewhere
 @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
-@Ignore("ROX-24871") // After merging PR #11865, the test now fails more often and needs attention
 @Tag("PZ")
 class NodeInventoryTest extends BaseSpecification {
     @Shared

--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -39,7 +39,6 @@ class NodeInventoryTest extends BaseSpecification {
         "given a non-empty list of nodes"
         List<Node> nodes = NodeService.getNodes()
         assert nodes.size() > 0
-        def previousScanTime = [:]
 
         when:
         boolean nodeInventoryContainerAvailable =
@@ -69,12 +68,6 @@ class NodeInventoryTest extends BaseSpecification {
                 }
                 return true
             }
-            // Finally, before starting the test, make note of the current scan time, which should be updated
-            nodes.each { node ->
-                previousScanTime[node.getId()] = node.hasScan() ?
-                        node.getScan().getScanTime() : Timestamp.getDefaultInstance()
-                log.info("Previous scan time of node ${node.getId()}: ${previousScanTime[node.getId()]}")
-            }
         }
         log.info("Waiting for scanner deployment to be ready")
         waitForTrue(20, 6) {
@@ -103,9 +96,6 @@ class NodeInventoryTest extends BaseSpecification {
             }
             assert node.getScan().getComponentsList().size() > 4,
                 "Expected to find more than 4 components on RHCOS node"
-
-            assert previousScanTime[node.getId()] != node.getScan().getScanTime(),
-                "Expected the scan time of the node to have changed"
         }
     }
 }


### PR DESCRIPTION
### Description

In ROX-24871, we discovered that the original test code to verify the correct functionality of the Node Inventory is flaky.
This was due to the test expecting that each and every scanned node will have an active vulnerability.
Depending on the age of the base image and Scanners CVE  sources, this is not always the case.

In #11865, I removed that assertion and replaced it with an assertion to `getScanTime()`, the idea being that a newly arrived node inventory will result in an updated scan time.
This assertion also was flaky, as our E2E test suite relies on an existing StackRox deployment, which means that a Node Inventory will very likely already exist by the time this test is run. Given that we keep the default rescan interval of 4 hours for a scan, we cannot expect a new scan to arrive in the runtime of this test.
Therefore, the assertion on the scan time is removed.

What we want to check with this E2E test is: 
- All nodes are successfully inventorized
- All node inventories were seen/scanned by Scanner
- All results are persisted in the respective `storage.Node` objects

I followed the inventory from the node_inventory container all the way to central to understand where and when it is persisted.
I have found that the only place in our code that writes to `node.Scan` is the [result of Scanner](https://github.com/stackrox/stackrox/blob/bfa2b597b01a131676ba087600d0e93957001fe9/pkg/nodes/enricher/enricher_impl.go#L123).
This means that if `node.getScan()` contains a scan, we can be reasonably sure that Scanner has scanned the node inventory for the node in question.


### User-facing documentation
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing
- [x] modified existing tests
 
#### How I validated my change

- CI
- Repeated manual runs of the groovy test against a GKE and an OpenShift infra clusters
