### PR TITLE
fix: make expiring cache type aware

### DIFF
--- a/central/compliance/datastore/internal/store/postgres/store.go
+++ b/central/compliance/datastore/internal/store/postgres/store.go
@@ -48,7 +48,7 @@ var (
 
 	domainCacheExpiry = 30 * time.Second
 	cacheLock         = concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize)
-	domainCache       = expiringcache.NewExpiringCache(domainCacheExpiry, expiringcache.UpdateExpirationOnGets)
+	domainCache       = expiringcache.NewExpiringCache(domainCacheExpiry, expiringcache.UpdateExpirationOnGets[string, *storage.ComplianceDomain])
 	targetResource    = resources.Compliance
 
 	runResultsCache   *expirable.LRU[string, *storage.ComplianceRunResults]
@@ -93,7 +93,7 @@ func (s *storeImpl) getDomain(ctx context.Context, domainID string) (*storage.Co
 	defer cacheLock.Unlock(domainID)
 
 	if cachedDomain, ok := domainCache.Get(domainID); ok {
-		return cachedDomain.(*storage.ComplianceDomain), nil
+		return cachedDomain, nil
 	}
 
 	domain, exists, err := s.domain.Get(ctx, domainID)

--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -12,7 +12,7 @@ const (
 
 var (
 	cache = &deploymentCache{
-		cache: expiringcache.NewExpiringCache(deletedDeploymentsRetentionPeriod),
+		cache: expiringcache.NewExpiringCache[string, struct{}](deletedDeploymentsRetentionPeriod),
 	}
 )
 
@@ -22,7 +22,7 @@ type DeletedDeployments interface {
 }
 
 type deploymentCache struct {
-	cache expiringcache.Cache
+	cache expiringcache.Cache[string, struct{}]
 }
 
 func (c *deploymentCache) Add(id string) {

--- a/central/user/datastore/internal/store/store.go
+++ b/central/user/datastore/internal/store/store.go
@@ -21,6 +21,6 @@ type Store interface {
 // The information is stored for 1 day.
 func New() Store {
 	return &storeImpl{
-		ec: expiringcache.NewExpiringCache(24 * time.Hour),
+		ec: expiringcache.NewExpiringCache[string, *storage.User](24 * time.Hour),
 	}
 }

--- a/central/user/datastore/internal/store/store_impl.go
+++ b/central/user/datastore/internal/store/store_impl.go
@@ -6,30 +6,17 @@ import (
 )
 
 type storeImpl struct {
-	ec expiringcache.Cache
+	ec expiringcache.Cache[string, *storage.User]
 }
 
 // GetAllUsers retrieves all users from the store.
 func (s *storeImpl) GetAllUsers() ([]*storage.User, error) {
-	msgs := s.ec.GetAll()
-	if len(msgs) == 0 {
-		return nil, nil
-	}
-	// Cast as list of users.
-	users := make([]*storage.User, 0, len(msgs))
-	for _, msg := range msgs {
-		users = append(users, msg.(*storage.User))
-	}
-	return users, nil
+	return s.ec.GetAll(), nil
 }
 
 // GetUser retrieves a user from the store by id.
 func (s *storeImpl) GetUser(id string) (*storage.User, error) {
-	v, ok := s.ec.Get(id)
-	if !ok {
-		return nil, nil
-	}
-	user, _ := v.(*storage.User)
+	user, _ := s.ec.Get(id)
 	return user, nil
 }
 

--- a/pkg/expiringcache/cache.go
+++ b/pkg/expiringcache/cache.go
@@ -106,6 +106,7 @@ func (e *expiringCacheImpl[K, V]) Get(key K) (V, bool) {
 	e.cleanNoLock(e.clock.Now())
 	value := e.getValue(key)
 	if value == nil {
+		var empty V
 		return empty, false
 	}
 

--- a/pkg/expiringcache/cache.go
+++ b/pkg/expiringcache/cache.go
@@ -10,30 +10,30 @@ import (
 // Cache implements a cache where the elements expire after a specific time
 //
 //go:generate mockgen-wrapper
-type Cache interface {
-	Add(key, value interface{})
-	Get(key interface{}) (interface{}, bool)
-	GetAll() []interface{}
-	GetOrSet(key interface{}, value interface{}) interface{}
-	Remove(key ...interface{})
+type Cache[K comparable, V any] interface {
+	Add(key K, value V)
+	Get(key K) (V, bool)
+	GetAll() []V
+	GetOrSet(key K, value V) V
+	Remove(key ...K)
 	RemoveAll()
 }
 
-type opts func(*expiringCacheImpl)
+type opts[K comparable, V any] func(*expiringCacheImpl[K, V])
 
 // UpdateExpirationOnGets resets the clock for a specific object when it is retrieved
-func UpdateExpirationOnGets(e *expiringCacheImpl) {
+func UpdateExpirationOnGets[K comparable, V any](e *expiringCacheImpl[K, V]) {
 	e.updateOnGets = true
 }
 
 // NewExpiringCache returns a new lru Cache with time based expiration on values.
-func NewExpiringCache(expiry time.Duration, options ...opts) Cache {
-	return NewExpiringCacheWithClock(realClock{}, expiry, options...)
+func NewExpiringCache[K comparable, V any](expiry time.Duration, options ...opts[K, V]) Cache[K, V] {
+	return NewExpiringCacheWithClock[K, V](realClock{}, expiry, options...)
 }
 
 // NewExpiringCacheWithClock returns a new lru Cache with time based expiration on values, using the input clock.
-func NewExpiringCacheWithClock(clock Clock, expiry time.Duration, options ...opts) Cache {
-	e := &expiringCacheImpl{
+func NewExpiringCacheWithClock[K comparable, V any](clock Clock, expiry time.Duration, options ...opts[K, V]) Cache[K, V] {
+	e := &expiringCacheImpl[K, V]{
 		mq: newMappedQueue(),
 
 		clock:  clock,
@@ -45,7 +45,7 @@ func NewExpiringCacheWithClock(clock Clock, expiry time.Duration, options ...opt
 	return e
 }
 
-type expiringCacheImpl struct {
+type expiringCacheImpl[K comparable, V any] struct {
 	lock sync.Mutex
 
 	mq mappedQueue
@@ -58,14 +58,14 @@ type expiringCacheImpl struct {
 }
 
 // Add adds a new key/value pair to the cache.
-func (e *expiringCacheImpl) Add(key, value interface{}) {
+func (e *expiringCacheImpl[K, V]) Add(key K, value V) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
 	e.addNoLock(key, value)
 }
 
-func (e *expiringCacheImpl) addNoLock(key, value interface{}) {
+func (e *expiringCacheImpl[K, V]) addNoLock(key K, value interface{}) {
 	now := e.clock.Now()
 	e.cleanNoLock(now)
 
@@ -98,47 +98,48 @@ func (e *expiringCacheImpl) addNoLock(key, value interface{}) {
 }
 
 // Get takes in a key and returns nil if the item doesn't exist or if the item has expired
-func (e *expiringCacheImpl) Get(key interface{}) (interface{}, bool) {
+func (e *expiringCacheImpl[K, V]) Get(key K) (V, bool) {
+	var empty V
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
 	e.cleanNoLock(e.clock.Now())
 	value := e.getValue(key)
 	if value == nil {
-		return nil, false
+		return empty, false
 	}
 
 	if e.updateOnGets {
 		e.removeNoLock(key)
 		e.addNoLock(key, value)
 	}
-	return value, true
+	return value.(V), true
 }
 
 // GetAll returns all non-expired values in the cache.
-func (e *expiringCacheImpl) GetAll() []interface{} {
+func (e *expiringCacheImpl[K, V]) GetAll() []V {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
 	e.cleanNoLock(e.clock.Now())
 
 	cachedValues := e.mq.getAllValues()
-	actualValues := make([]interface{}, 0, len(cachedValues))
+	actualValues := make([]V, 0, len(cachedValues))
 	for _, cv := range cachedValues {
-		v, _ := unwrap(cv)
+		v, _ := unwrap[V](cv)
 		actualValues = append(actualValues, v)
 	}
 	return actualValues
 }
 
-func (e *expiringCacheImpl) removeNoLock(keys ...interface{}) {
+func (e *expiringCacheImpl[K, V]) removeNoLock(keys ...K) {
 	for _, key := range keys {
 		e.mq.remove(key)
 	}
 }
 
 // Remove removes a key in the cache if present. Returns if it was present.
-func (e *expiringCacheImpl) Remove(keys ...interface{}) {
+func (e *expiringCacheImpl[K, V]) Remove(keys ...K) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -147,7 +148,7 @@ func (e *expiringCacheImpl) Remove(keys ...interface{}) {
 }
 
 // RemoveAll removes all values from the cache.
-func (e *expiringCacheImpl) RemoveAll() {
+func (e *expiringCacheImpl[K, V]) RemoveAll() {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -156,7 +157,7 @@ func (e *expiringCacheImpl) RemoveAll() {
 
 // GetOrSet returns the value for the key if it exists or sets the value if it does not
 // In the case of setting the value, it will return the passed value
-func (e *expiringCacheImpl) GetOrSet(key, value interface{}) interface{} {
+func (e *expiringCacheImpl[K, V]) GetOrSet(key K, value V) V {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -166,14 +167,14 @@ func (e *expiringCacheImpl) GetOrSet(key, value interface{}) interface{} {
 			e.removeNoLock(key)
 			e.addNoLock(key, currValue)
 		}
-		return currValue
+		return currValue.(V)
 	}
 
 	e.addNoLock(key, value)
 	return value
 }
 
-func (e *expiringCacheImpl) getValue(key interface{}) interface{} {
+func (e *expiringCacheImpl[K, V]) getValue(key interface{}) interface{} {
 	value := e.mq.get(key)
 	if value == nil {
 		return nil
@@ -195,16 +196,16 @@ func wrap(value interface{}, at time.Time) *cacheValue {
 	}
 }
 
-func unwrap(value interface{}) (interface{}, time.Time) {
+func unwrap[V any](value interface{}) (V, time.Time) {
 	cv := value.(*cacheValue)
-	return cv.value, cv.at
+	return cv.value.(V), cv.at
 }
 
 // Intermittent clean up of expired values.
 // Called during Add or Get when needed.
 ////////////////////////////////////////
 
-func (e *expiringCacheImpl) cleanNoLock(at time.Time) {
+func (e *expiringCacheImpl[K, V]) cleanNoLock(at time.Time) {
 	for {
 		key, value := e.mq.front()
 		if key == nil {

--- a/pkg/expiringcache/cache.go
+++ b/pkg/expiringcache/cache.go
@@ -99,7 +99,6 @@ func (e *expiringCacheImpl[K, V]) addNoLock(key K, value interface{}) {
 
 // Get takes in a key and returns nil if the item doesn't exist or if the item has expired
 func (e *expiringCacheImpl[K, V]) Get(key K) (V, bool) {
-	var empty V
 	e.lock.Lock()
 	defer e.lock.Unlock()
 

--- a/pkg/expiringcache/cache_test.go
+++ b/pkg/expiringcache/cache_test.go
@@ -35,7 +35,7 @@ func TestExpiringCache(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clock := mocks.NewMockClock(mockCtrl)
 
-	ec := NewExpiringCacheWithClock(clock, 10*time.Second)
+	ec := NewExpiringCacheWithClock[string, string](clock, 10*time.Second)
 
 	// Insert all values one second apart.
 	addTime := time.Time{}
@@ -52,7 +52,7 @@ func TestExpiringCache(t *testing.T) {
 		clock.EXPECT().Now().Return(getTime)
 		v, ok := ec.Get(p.key)
 		assert.True(t, ok)
-		assert.Equal(t, p.value, v.(string))
+		assert.Equal(t, p.value, v)
 	}
 
 	// Move forward 11 seconds, and the first element should get pruned but the rest should be available.
@@ -61,7 +61,7 @@ func TestExpiringCache(t *testing.T) {
 	// First is gone.
 	clock.EXPECT().Now().Return(getTime)
 	v, ok := ec.Get(pairs[0].key)
-	assert.Nil(t, v)
+	assert.Empty(t, v)
 	assert.False(t, ok)
 
 	// Other two are still available.
@@ -69,7 +69,7 @@ func TestExpiringCache(t *testing.T) {
 	currentValues := ec.GetAll()
 	assert.Equal(t, 2, len(currentValues))
 	for i, value := range currentValues {
-		assert.Equal(t, pairs[i+1].value, value.(string))
+		assert.Equal(t, pairs[i+1].value, value)
 	}
 
 	// Move forward another second, and the second element should drop off.
@@ -78,12 +78,12 @@ func TestExpiringCache(t *testing.T) {
 	// First and second elements are gone.
 	clock.EXPECT().Now().Return(getTime)
 	v, ok = ec.Get(pairs[0].key)
-	assert.Nil(t, v)
+	assert.Empty(t, v)
 	assert.False(t, ok)
 
 	clock.EXPECT().Now().Return(getTime)
 	v, ok = ec.Get(pairs[1].key)
-	assert.Nil(t, v)
+	assert.Empty(t, v)
 	assert.False(t, ok)
 
 	// Third element is still there.
@@ -91,7 +91,7 @@ func TestExpiringCache(t *testing.T) {
 	currentValues = ec.GetAll()
 	assert.Equal(t, 1, len(currentValues))
 	for i, value := range currentValues {
-		assert.Equal(t, pairs[i+2].value, value.(string))
+		assert.Equal(t, pairs[i+2].value, value)
 	}
 
 	mockCtrl.Finish()

--- a/pkg/expiringcache/mocks/cache.go
+++ b/pkg/expiringcache/mocks/cache.go
@@ -16,85 +16,85 @@ import (
 )
 
 // MockCache is a mock of Cache interface.
-type MockCache struct {
+type MockCache[K comparable, V any] struct {
 	ctrl     *gomock.Controller
-	recorder *MockCacheMockRecorder
+	recorder *MockCacheMockRecorder[K, V]
 }
 
 // MockCacheMockRecorder is the mock recorder for MockCache.
-type MockCacheMockRecorder struct {
-	mock *MockCache
+type MockCacheMockRecorder[K comparable, V any] struct {
+	mock *MockCache[K, V]
 }
 
 // NewMockCache creates a new mock instance.
-func NewMockCache(ctrl *gomock.Controller) *MockCache {
-	mock := &MockCache{ctrl: ctrl}
-	mock.recorder = &MockCacheMockRecorder{mock}
+func NewMockCache[K comparable, V any](ctrl *gomock.Controller) *MockCache[K, V] {
+	mock := &MockCache[K, V]{ctrl: ctrl}
+	mock.recorder = &MockCacheMockRecorder[K, V]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockCache) EXPECT() *MockCacheMockRecorder {
+func (m *MockCache[K, V]) EXPECT() *MockCacheMockRecorder[K, V] {
 	return m.recorder
 }
 
 // Add mocks base method.
-func (m *MockCache) Add(key, value any) {
+func (m *MockCache[K, V]) Add(key K, value V) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Add", key, value)
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockCacheMockRecorder) Add(key, value any) *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) Add(key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockCache)(nil).Add), key, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockCache[K, V])(nil).Add), key, value)
 }
 
 // Get mocks base method.
-func (m *MockCache) Get(key any) (any, bool) {
+func (m *MockCache[K, V]) Get(key K) (V, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
-	ret0, _ := ret[0].(any)
+	ret0, _ := ret[0].(V)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockCacheMockRecorder) Get(key any) *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) Get(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache)(nil).Get), key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache[K, V])(nil).Get), key)
 }
 
 // GetAll mocks base method.
-func (m *MockCache) GetAll() []any {
+func (m *MockCache[K, V]) GetAll() []V {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAll")
-	ret0, _ := ret[0].([]any)
+	ret0, _ := ret[0].([]V)
 	return ret0
 }
 
 // GetAll indicates an expected call of GetAll.
-func (mr *MockCacheMockRecorder) GetAll() *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) GetAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockCache)(nil).GetAll))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockCache[K, V])(nil).GetAll))
 }
 
 // GetOrSet mocks base method.
-func (m *MockCache) GetOrSet(key, value any) any {
+func (m *MockCache[K, V]) GetOrSet(key K, value V) V {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrSet", key, value)
-	ret0, _ := ret[0].(any)
+	ret0, _ := ret[0].(V)
 	return ret0
 }
 
 // GetOrSet indicates an expected call of GetOrSet.
-func (mr *MockCacheMockRecorder) GetOrSet(key, value any) *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) GetOrSet(key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrSet", reflect.TypeOf((*MockCache)(nil).GetOrSet), key, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrSet", reflect.TypeOf((*MockCache[K, V])(nil).GetOrSet), key, value)
 }
 
 // Remove mocks base method.
-func (m *MockCache) Remove(key ...any) {
+func (m *MockCache[K, V]) Remove(key ...K) {
 	m.ctrl.T.Helper()
 	varargs := []any{}
 	for _, a := range key {
@@ -104,19 +104,19 @@ func (m *MockCache) Remove(key ...any) {
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockCacheMockRecorder) Remove(key ...any) *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) Remove(key ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockCache)(nil).Remove), key...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockCache[K, V])(nil).Remove), key...)
 }
 
 // RemoveAll mocks base method.
-func (m *MockCache) RemoveAll() {
+func (m *MockCache[K, V]) RemoveAll() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveAll")
 }
 
 // RemoveAll indicates an expected call of RemoveAll.
-func (mr *MockCacheMockRecorder) RemoveAll() *gomock.Call {
+func (mr *MockCacheMockRecorder[K, V]) RemoveAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockCache)(nil).RemoveAll))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockCache[K, V])(nil).RemoveAll))
 }

--- a/pkg/images/cache/imagemetadata.go
+++ b/pkg/images/cache/imagemetadata.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"time"
 
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -14,12 +15,12 @@ var (
 
 const imageCacheExpiryDuration = 4 * time.Hour
 
-type ImageMetadata expiringcache.Cache
+type ImageMetadata expiringcache.Cache[string, *storage.ImageMetadata]
 
 // ImageMetadataCacheSingleton returns the cache for image metadata
 func ImageMetadataCacheSingleton() ImageMetadata {
 	metadataCacheOnce.Do(func() {
-		metadataCache = expiringcache.NewExpiringCache(imageCacheExpiryDuration, expiringcache.UpdateExpirationOnGets)
+		metadataCache = expiringcache.NewExpiringCache(imageCacheExpiryDuration, expiringcache.UpdateExpirationOnGets[string, *storage.ImageMetadata])
 	})
 	return metadataCache
 }

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -347,7 +347,7 @@ func (e *enricherImpl) enrichWithMetadata(ctx context.Context, enrichmentContext
 		// The metadata in the cache is always up-to-date with respect to the current metadataVersion
 		if metadataValue, ok := e.metadataCache.Get(getRef(image)); ok {
 			e.metrics.IncrementMetadataCacheHit()
-			image.Metadata = metadataValue.(*storage.ImageMetadata).Clone()
+			image.Metadata = metadataValue.Clone()
 			return true, nil
 		}
 		e.metrics.IncrementMetadataCacheMiss()

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -1416,5 +1416,5 @@ func newEnricher(set *mocks.MockSet, mockReporter *reporterMocks.MockReporter) I
 }
 
 func newCache() cache.ImageMetadata {
-	return cache.ImageMetadata(expiringcache.NewExpiringCache(1 * time.Minute))
+	return cache.ImageMetadata(expiringcache.NewExpiringCache[string, *storage.ImageMetadata](1 * time.Minute))
 }

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -17,7 +17,7 @@ var (
 	_   telemeter.Telemeter = (*segmentTelemeter)(nil)
 	// expiringIDCache stores the computed message IDs to drop duplicates if
 	// requested.
-	expiringIDCache = expiringcache.NewExpiringCache(24*time.Hour, expiringcache.UpdateExpirationOnGets)
+	expiringIDCache = expiringcache.NewExpiringCache[string, bool](24*time.Hour, expiringcache.UpdateExpirationOnGets[string, bool])
 )
 
 type segmentTelemeter struct {

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -217,7 +217,7 @@ func (tc *testClock) add(d time.Duration) {
 func initTestCache() *testClock {
 	var tc testClock = testClock{time.Now()}
 	// Override the global cache with custom clock for testing purposes:
-	expiringIDCache = expiringcache.NewExpiringCacheWithClock(&tc, 1*time.Hour, expiringcache.UpdateExpirationOnGets)
+	expiringIDCache = expiringcache.NewExpiringCacheWithClock(&tc, 1*time.Hour, expiringcache.UpdateExpirationOnGets[string, bool])
 	return &tc
 }
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -35,7 +35,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/unified"
 	"github.com/stackrox/rox/sensor/common/enforcer"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/registry"
@@ -72,7 +72,7 @@ type Detector interface {
 
 // New returns a new detector
 func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.SettingsManager,
-	deploymentStore store.DeploymentStore, serviceAccountStore store.ServiceAccountStore, cache imagecacheutils.ImageCache, auditLogEvents chan *sensor.AuditEvents,
+	deploymentStore store.DeploymentStore, serviceAccountStore store.ServiceAccountStore, cache cache.Image, auditLogEvents chan *sensor.AuditEvents,
 	auditLogUpdater updater.Component, networkPolicyStore store.NetworkPolicyStore, registryStore *registry.Store, localScan *scan.LocalScan) Detector {
 	detectorStopper := concurrency.NewStopper()
 	netFlowQueueSize := 0
@@ -327,7 +327,7 @@ func (d *detectorImpl) processNetworkBaselineSync(sync *central.NetworkBaselineS
 
 // ProcessUpdatedImage updates the imageCache with a new value
 func (d *detectorImpl) ProcessUpdatedImage(image *storage.Image) error {
-	key := imagecacheutils.GetImageCacheKey(image)
+	key := cache.GetKey(image)
 	log.Debugf("Receiving update for image: %s from central. Updating cache", image.GetName().GetFullName())
 	newValue := &cacheValue{
 		image:     image,

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/registry"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ type enricherSuite struct {
 	suite.Suite
 	mockCtrl                *gomock.Controller
 	enricher                *enricher
-	mockCache               expiringcache.Cache
+	mockCache               expiringcache.Cache[imagecacheutils.Key, imagecacheutils.Value]
 	mockServiceAccountStore *mockStore.MockServiceAccountStore
 	mockRegistryStore       *registry.Store
 }
@@ -43,7 +44,7 @@ var _ suite.TearDownTestSuite = &enricherSuite{}
 
 func (s *enricherSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.mockCache = expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
+	s.mockCache = expiringcache.NewExpiringCache[imagecacheutils.Key, imagecacheutils.Value](env.ReprocessInterval.DurationSetting())
 	s.mockServiceAccountStore = mockStore.NewMockServiceAccountStore(s.mockCtrl)
 	s.mockRegistryStore = registry.NewRegistryStore(nil)
 	s.enricher = newEnricher(s.mockCache,

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/registry"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +34,7 @@ type enricherSuite struct {
 	suite.Suite
 	mockCtrl                *gomock.Controller
 	enricher                *enricher
-	mockCache               expiringcache.Cache[imagecacheutils.Key, imagecacheutils.Value]
+	mockCache               expiringcache.Cache[cache.Key, cache.Value]
 	mockServiceAccountStore *mockStore.MockServiceAccountStore
 	mockRegistryStore       *registry.Store
 }
@@ -44,7 +44,7 @@ var _ suite.TearDownTestSuite = &enricherSuite{}
 
 func (s *enricherSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.mockCache = expiringcache.NewExpiringCache[imagecacheutils.Key, imagecacheutils.Value](env.ReprocessInterval.DurationSetting())
+	s.mockCache = expiringcache.NewExpiringCache[cache.Key, cache.Value](env.ReprocessInterval.DurationSetting())
 	s.mockServiceAccountStore = mockStore.NewMockServiceAccountStore(s.mockCtrl)
 	s.mockRegistryStore = registry.NewRegistryStore(nil)
 	s.enricher = newEnricher(s.mockCache,

--- a/sensor/common/image/cache/cache.go
+++ b/sensor/common/image/cache/cache.go
@@ -1,11 +1,12 @@
-package imagecacheutils
+package cache
 
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/expiringcache"
 )
 
-type ImageCache expiringcache.Cache[Key, Value]
+// Image is a cache for scanned images
+type Image expiringcache.Cache[Key, Value]
 
 // Value represents the value stored in image cache
 type Value interface {
@@ -16,25 +17,25 @@ type Value interface {
 }
 
 // Key is the type for keys in image cache to prevent accidental use,
-// it should be obtained from image with GetImageCacheKey
+// it should be obtained from image with GetKey
 type Key string
 
-// CacheKeyProvider represents an interface from which image cache can be generated.
-type CacheKeyProvider interface {
+// KeyProvider represents an interface from which image cache can be generated.
+type KeyProvider interface {
 	GetId() string
 	GetName() *storage.ImageName
 }
 
-// GetImageCacheKey generates image cache key from a cache key provider.
-func GetImageCacheKey(provider CacheKeyProvider) Key {
+// GetKey generates image cache key from a cache key provider.
+func GetKey(provider KeyProvider) Key {
 	if id := provider.GetId(); id != "" {
 		return Key(id)
 	}
 	return Key(provider.GetName().GetFullName())
 }
 
-// CompareImageCacheKey given two CacheKeyProvider, compares if they're equal
-func CompareImageCacheKey(a, b CacheKeyProvider) bool {
+// CompareKeys given two KeyProvider, compares if they're equal
+func CompareKeys(a, b KeyProvider) bool {
 	if a.GetId() != "" && b.GetId() != "" {
 		return a.GetId() == b.GetId()
 	}

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	grpcPkg "github.com/stackrox/rox/pkg/grpc"
@@ -67,9 +66,10 @@ func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {
 }
 
 func (s *serviceImpl) GetImage(ctx context.Context, req *sensor.GetImageRequest) (*sensor.GetImageResponse, error) {
-	if id := req.GetImage().GetId(); id != "" {
-		v, _ := s.imageCache.Get(imagecacheutils.GetImageCacheKey(req.GetImage()))
-		img, _ := v.(*storage.Image)
+	id := req.GetImage().GetId()
+	v, ok := s.imageCache.Get(imagecacheutils.GetImageCacheKey(req.GetImage()))
+	if id != "" && ok {
+		img := v.GetIfDone()
 		if img != nil && (!req.GetScanInline() || img.GetScan() != nil) {
 			return &sensor.GetImageResponse{
 				Image: img,

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registrymirror"
 	"github.com/stackrox/rox/sensor/common"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"google.golang.org/grpc"
@@ -42,7 +42,7 @@ type ServiceComponent interface {
 }
 
 // NewService returns the ImageService API for the Admission Controller to use.
-func NewService(imageCache imagecacheutils.ImageCache, registryStore registryStore, mirrorStore registrymirror.Store) ServiceComponent {
+func NewService(imageCache cache.Image, registryStore registryStore, mirrorStore registrymirror.Store) ServiceComponent {
 	return &serviceImpl{
 		imageCache:    imageCache,
 		registryStore: registryStore,
@@ -55,7 +55,7 @@ type serviceImpl struct {
 	sensor.UnimplementedImageServiceServer
 
 	centralClient centralClient
-	imageCache    imagecacheutils.ImageCache
+	imageCache    cache.Image
 	registryStore registryStore
 	localScan     localScan
 	centralReady  concurrency.Signal
@@ -67,7 +67,7 @@ func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {
 
 func (s *serviceImpl) GetImage(ctx context.Context, req *sensor.GetImageRequest) (*sensor.GetImageResponse, error) {
 	id := req.GetImage().GetId()
-	v, ok := s.imageCache.Get(imagecacheutils.GetImageCacheKey(req.GetImage()))
+	v, ok := s.imageCache.Get(cache.GetKey(req.GetImage()))
 	if id != "" && ok {
 		img := v.GetIfDone()
 		if img != nil && (!req.GetScanInline() || img.GetScan() != nil) {

--- a/sensor/common/image/service_impl_test.go
+++ b/sensor/common/image/service_impl_test.go
@@ -12,8 +12,8 @@ import (
 	cacheMocks "github.com/stackrox/rox/pkg/expiringcache/mocks"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	imageMocks "github.com/stackrox/rox/sensor/common/image/mocks"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -25,7 +25,7 @@ func TestImageService(t *testing.T) {
 type imageServiceSuite struct {
 	suite.Suite
 	mockCtrl          *gomock.Controller
-	mockCache         *cacheMocks.MockCache[imagecacheutils.Key, imagecacheutils.Value]
+	mockCache         *cacheMocks.MockCache[cache.Key, cache.Value]
 	mockRegistryStore *imageMocks.MockregistryStore
 	mockCentral       *imageMocks.MockcentralClient
 	mockLocalScan     *imageMocks.MocklocalScan
@@ -36,7 +36,7 @@ var _ suite.SetupTestSuite = (*imageServiceSuite)(nil)
 
 func (s *imageServiceSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.mockCache = cacheMocks.NewMockCache[imagecacheutils.Key, imagecacheutils.Value](s.mockCtrl)
+	s.mockCache = cacheMocks.NewMockCache[cache.Key, cache.Value](s.mockCtrl)
 	s.mockRegistryStore = imageMocks.NewMockregistryStore(s.mockCtrl)
 	s.mockCentral = imageMocks.NewMockcentralClient(s.mockCtrl)
 	s.mockLocalScan = imageMocks.NewMocklocalScan(s.mockCtrl)
@@ -154,7 +154,7 @@ func (s *imageServiceSuite) TestGetImage() {
 	}
 }
 
-func expectCacheHelper(mockCache *cacheMocks.MockCache[imagecacheutils.Key, imagecacheutils.Value], times int, retValue imagecacheutils.Value) expectFn {
+func expectCacheHelper(mockCache *cacheMocks.MockCache[cache.Key, cache.Value], times int, retValue cache.Value) expectFn {
 	return func() {
 		mockCache.EXPECT().Get(gomock.Any()).Times(times).
 			Return(retValue, retValue != nil)
@@ -201,7 +201,7 @@ func (d *dummyValue) GetIfDone() *storage.Image {
 	return d.image
 }
 
-func createScannedImage(name, id string) imagecacheutils.Value {
+func createScannedImage(name, id string) cache.Value {
 	return &dummyValue{image: &storage.Image{
 		Id: id,
 		Name: &storage.ImageName{

--- a/sensor/common/imagecacheutils/common.go
+++ b/sensor/common/imagecacheutils/common.go
@@ -9,7 +9,9 @@ type ImageCache expiringcache.Cache[Key, Value]
 
 // Value represents the value stored in image cache
 type Value interface {
+	// WaitAndGet wait for image scan before returning the image
 	WaitAndGet() *storage.Image
+	// GetIfDone returns image if scan was done, otherwise it returns nil
 	GetIfDone() *storage.Image
 }
 

--- a/sensor/common/imagecacheutils/common.go
+++ b/sensor/common/imagecacheutils/common.go
@@ -5,7 +5,17 @@ import (
 	"github.com/stackrox/rox/pkg/expiringcache"
 )
 
-type ImageCache expiringcache.Cache
+type ImageCache expiringcache.Cache[Key, Value]
+
+// Value represents the value stored in image cache
+type Value interface {
+	WaitAndGet() *storage.Image
+	GetIfDone() *storage.Image
+}
+
+// Key is the type for keys in image cache to prevent accidental use,
+// it should be obtained from image with GetImageCacheKey
+type Key string
 
 // CacheKeyProvider represents an interface from which image cache can be generated.
 type CacheKeyProvider interface {
@@ -14,11 +24,11 @@ type CacheKeyProvider interface {
 }
 
 // GetImageCacheKey generates image cache key from a cache key provider.
-func GetImageCacheKey(provider CacheKeyProvider) string {
+func GetImageCacheKey(provider CacheKeyProvider) Key {
 	if id := provider.GetId(); id != "" {
-		return id
+		return Key(id)
 	}
-	return provider.GetName().GetFullName()
+	return Key(provider.GetName().GetFullName())
 }
 
 // CompareImageCacheKey given two CacheKeyProvider, compares if they're equal

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -67,7 +67,7 @@ type Store struct {
 	// the number of connections can be reduced to one.
 	//
 	// An expiring cache is used because the TLS state of a registry may change.
-	tlsCheckResults expiringcache.Cache
+	tlsCheckResults expiringcache.Cache[string, tlsCheckResult]
 }
 
 // CheckTLS defines a function which checks if the given address is using TLS.
@@ -97,7 +97,7 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 			types.WithGCPTokenManager(gcp.Singleton()),
 		),
 		clusterLocalRegistryHosts: set.NewStringSet(),
-		tlsCheckResults:           expiringcache.NewExpiringCache(tlsCheckTTL),
+		tlsCheckResults:           expiringcache.NewExpiringCache[string, tlsCheckResult](tlsCheckTTL),
 		knownSecretIDs:            set.NewStringSet(),
 	}
 

--- a/sensor/common/registry/tlscheck.go
+++ b/sensor/common/registry/tlscheck.go
@@ -49,7 +49,7 @@ func (rs *Store) getCachedTLSCheckResult(registry string) tlsCheckResult {
 		return tlsCheckResultUnknown
 	}
 
-	return resultI.(tlsCheckResult)
+	return resultI
 }
 
 func (rs *Store) doAndCacheTLSCheck(ctx context.Context, registry string) (bool, error) {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
 	"github.com/stackrox/rox/sensor/common/detector"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/message"
 )
 
@@ -27,7 +27,7 @@ type Handler interface {
 }
 
 // NewHandler returns a new instance of a deployment reprocessor.
-func NewHandler(admCtrlSettingsMgr admissioncontroller.SettingsManager, detector detector.Detector, imageCache imagecacheutils.ImageCache) Handler {
+func NewHandler(admCtrlSettingsMgr admissioncontroller.SettingsManager, detector detector.Detector, imageCache cache.Image) Handler {
 	return &handlerImpl{
 		admCtrlSettingsMgr: admCtrlSettingsMgr,
 		detector:           detector,
@@ -39,7 +39,7 @@ func NewHandler(admCtrlSettingsMgr admissioncontroller.SettingsManager, detector
 type handlerImpl struct {
 	admCtrlSettingsMgr admissioncontroller.SettingsManager
 	detector           detector.Detector
-	imageCache         imagecacheutils.ImageCache
+	imageCache         cache.Image
 	stopSig            concurrency.ErrorSignal
 }
 
@@ -84,13 +84,13 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 	default:
 		h.admCtrlSettingsMgr.FlushCache()
 
-		keysToDelete := make([]imagecacheutils.Key, 0, len(req.GetImageKeys()))
+		keysToDelete := make([]cache.Key, 0, len(req.GetImageKeys()))
 		for _, image := range req.GetImageKeys() {
 			key := image.GetImageId()
 			if key == "" {
 				key = image.GetImageFullName()
 			}
-			keysToDelete = append(keysToDelete, imagecacheutils.Key(key))
+			keysToDelete = append(keysToDelete, cache.Key(key))
 		}
 		h.imageCache.Remove(keysToDelete...)
 	}

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -84,13 +84,13 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 	default:
 		h.admCtrlSettingsMgr.FlushCache()
 
-		keysToDelete := make([]interface{}, 0, len(req.GetImageKeys()))
+		keysToDelete := make([]imagecacheutils.Key, 0, len(req.GetImageKeys()))
 		for _, image := range req.GetImageKeys() {
 			key := image.GetImageId()
 			if key == "" {
 				key = image.GetImageFullName()
 			}
-			keysToDelete = append(keysToDelete, key)
+			keysToDelete = append(keysToDelete, imagecacheutils.Key(key))
 		}
 		h.imageCache.Remove(keysToDelete...)
 	}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/store"
 )
@@ -201,7 +201,7 @@ func (ds *DeploymentStore) findDeploymentIDsByImageNoLock(image *storage.Image) 
 	ids := set.NewStringSet()
 	for _, d := range ds.deployments {
 		for _, c := range d.GetContainers() {
-			if imagecacheutils.CompareImageCacheKey(c.GetImage(), image) {
+			if cache.CompareKeys(c.GetImage(), image) {
 				ids.Add(d.GetId())
 				// The deployment id is already the set, we can break here
 				break

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/image"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/installmethod"
 	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -118,7 +118,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		return nil, errors.Wrap(err, "creating enforcer")
 	}
 
-	imageCache := expiringcache.NewExpiringCache[imagecacheutils.Key, imagecacheutils.Value](env.ReprocessInterval.DurationSetting())
+	imageCache := expiringcache.NewExpiringCache[cache.Key, cache.Value](env.ReprocessInterval.DurationSetting())
 
 	localScan := scan.NewLocalScan(storeProvider.Registries(), storeProvider.RegistryMirrors())
 	delegatedRegistryHandler := delegatedregistry.NewHandler(storeProvider.Registries(), localScan)

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/image"
+	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/installmethod"
 	"github.com/stackrox/rox/sensor/common/internalmessage"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -117,7 +118,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		return nil, errors.Wrap(err, "creating enforcer")
 	}
 
-	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
+	imageCache := expiringcache.NewExpiringCache[imagecacheutils.Key, imagecacheutils.Value](env.ReprocessInterval.DurationSetting())
 
 	localScan := scan.NewLocalScan(storeProvider.Registries(), storeProvider.RegistryMirrors())
 	delegatedRegistryHandler := delegatedregistry.NewHandler(storeProvider.Registries(), localScan)


### PR DESCRIPTION
### Description

This PR adds types to expirable cache so instead of using `interface{}` as key and value we have a types that help controlling what is stored inside. Also it fixes image cache that used to store different values under the same key. As image cache uses specific version of key (it's not always image id) I created a type to prevent accidental string passing and force usage of cache key provider. It also changes Get method to return two values as we cannot explicitly return `nil` (only `var empty V`) with generic solution. 

- https://github.com/stackrox/stackrox/pull/11925#discussion_r1673965036

Prefactor:

- https://github.com/stackrox/stackrox/pull/12022
- https://github.com/stackrox/stackrox/pull/11961
- https://github.com/stackrox/stackrox/pull/11968
- https://github.com/stackrox/stackrox/pull/11966
- https://github.com/stackrox/stackrox/pull/11960

Refs:
- https://github.com/stackrox/stackrox/pull/11987

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] modified existing tests
- [x] contributed **no automated tests**

#### How I validated my change

CI
