### PR TITLE
tests: do not print file content in test

### DIFF
--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -3,7 +3,6 @@ package renderer
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"slices"
 	"strconv"
@@ -152,7 +151,6 @@ func TestRenderSensorHelm(t *testing.T) {
 
 			for _, file := range files {
 				if file.Name == "admission-controller.yaml" {
-					fmt.Println(string(file.Content))
 					admissionControllerRendered = true
 				}
 				if file.Name == "admission-controller-secret.yaml" {

--- a/roxctl/helm/output/output_lint_test.go
+++ b/roxctl/helm/output/output_lint_test.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -160,11 +159,14 @@ func executeHelpOutputCommand(chartName, outputDir string, removeOutputDir bool,
 }
 
 func testChartInNamespaceLint(t *testing.T, chartDir string, namespace string) {
-	linter := lint.All(chartDir, nil, namespace, false)
+	// The 'ca.cert' config option MUST be set to StackRox's Service CA certificate
+	// in order for the admission controller to be usable
+	// To not produce warning let's provide it
+	values := map[string]any{"ca": map[string]any{"cert": "fake"}}
+	linter := lint.All(chartDir, values, namespace, false)
 
 	assert.LessOrEqualf(t, linter.HighestSeverity, maxTolerableSev, "linting chart produced warnings with severity %v", linter.HighestSeverity)
 	for _, msg := range linter.Messages {
-		fmt.Fprintln(os.Stderr, msg.Error())
 		assert.LessOrEqual(t, msg.Severity, maxTolerableSev, msg.Error())
 	}
 }


### PR DESCRIPTION
### Description

Printing yamls make a lot of noise in CI output. Let's remove it.
Also warnings from helm prints the whole chart ([example](https://github.com/stackrox/stackrox/actions/runs/9872012673/job/27261202032?pr=11925#step:6:25520)) Let's pass required values so output will be clean.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] modified existing tests
- [x] contributed **no automated tests**

#### How I validated my change

CI