### PR TITLE
build(Makefile): more docker env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ sensor-kubernetes-build:
 .PHONY: main-build-dockerized
 main-build-dockerized: build-volumes
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
+	docker run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
 
 .PHONY: main-build-nodeps
 main-build-nodeps: central-build-nodeps migrator-build-nodeps

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 	  echo "development_build"; \
 	fi)
 
-DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
+DEFAULT_IMAGE_REGISTRY ?= quay.io/stackrox-io
 ifeq ($(ROX_PRODUCT_BRANDING),RHACS_BRANDING)
 	DEFAULT_IMAGE_REGISTRY := quay.io/rhacs-eng
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ROX_IMAGE_FLAVOR ?= $(shell \
 	  echo "development_build"; \
 	fi)
 
-DEFAULT_IMAGE_REGISTRY ?= quay.io/stackrox-io
+DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 ifeq ($(ROX_PRODUCT_BRANDING),RHACS_BRANDING)
 	DEFAULT_IMAGE_REGISTRY := quay.io/rhacs-eng
 endif


### PR DESCRIPTION
### Description

This is a small change to the main Makefile that forwards `SHORTCOMMIT` inside the context of dockerized build. This simplifies building in git worktrees, where git is not available from within the container.

### Testing

I expect those changes to be no-op in the usual build environment.