### PR TITLE
ci(scanner): remove vcs information from binary

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -2,11 +2,6 @@ name: Scanner release vulnerability update
 on:
   schedule:
   - cron: "0 */3 * * *"
-  pull_request: # TODO: DELETE THIS PRIOR TO MERGE
-    types:
-    - opened
-    - reopened
-    - synchronize
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -2,6 +2,11 @@ name: Scanner release vulnerability update
 on:
   schedule:
   - cron: "0 */3 * * *"
+  pull_request: # TODO: DELETE THIS PRIOR TO MERGE
+    types:
+    - opened
+    - reopened
+    - synchronize
   workflow_dispatch:
 
 jobs:
@@ -130,7 +135,7 @@ jobs:
         # Just run go mod tidy and hope for the best.
         go mod tidy
         cd scanner
-        go build -trimpath -o bin/updater ./cmd/updater
+        go build -trimpath -buildvcs=false -o bin/updater ./cmd/updater
         go clean -cache -modcache
 
         mkdir ${{ env.ROX_PRODUCT_VERSION }}


### PR DESCRIPTION
### Description

Release vulns again continue to fail. This time it's because of some invalid VCS information in the Go binary. This PR just leaves that out.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

Made this run on my PR prior to merge. Now that NVD API is giving 200s again, looks like it's finally running successfully. https://github.com/stackrox/stackrox/actions/runs/9878607837