### PR TITLE
ROX-23594: improve wait_for_api output and wait longer

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -18,7 +18,7 @@ info() {
 }
 
 die() {
-    echo >&2 "$@"
+    echo >&2 "ERROR:" "$@"
     exit 1
 }
 


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

If we went already as far as a stackrox deployment, then let's wait some more to give central a chance to initialize.

Also, current output is not super intuitive to someone who does not already know this function by heart:
```
INFO: Wed Jul 10 15:31:39 UTC 2024: Waiting for Central to be ready in namespace stackrox
waiting (0/600)
waiting (6/600)
waiting (11/600)
INFO: Wed Jul 10 15:32:25 UTC 2024: Central deployment is ready in namespace stackrox.
INFO: Wed Jul 10 15:32:25 UTC 2024: Waiting for Central API endpoint
INFO: Wed Jul 10 15:32:25 UTC 2024: Found ingress endpoint: 34.66.167.49
INFO: Wed Jul 10 15:32:25 UTC 2024: PING_URL is set to https://34.66.167.49:443/v1/ping
INFO: Wed Jul 10 15:32:28 UTC 2024: Status is now: ok
INFO: Wed Jul 10 15:32:31 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:32:43 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:32:55 UTC 2024: Status is now: ok
.INFO: Wed Jul 10 15:33:02 UTC 2024: Status is now: ok
....INFO: Wed Jul 10 15:33:24 UTC 2024: Status is now: ok
.INFO: Wed Jul 10 15:33:32 UTC 2024: Status is now: ok
...INFO: Wed Jul 10 15:33:49 UTC 2024: Status is now: ok
.INFO: Wed Jul 10 15:33:56 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:34:08 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:34:20 UTC 2024: Status is now: ok
........INFO: Wed Jul 10 15:35:03 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:35:15 UTC 2024: Status is now: ok
.INFO: Wed Jul 10 15:35:22 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:35:34 UTC 2024: Status is now: ok
....INFO: Wed Jul 10 15:35:57 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:36:09 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:36:21 UTC 2024: Status is now: ok
..INFO: Wed Jul 10 15:36:33 UTC 2024: Status is now: ok
INFO: Wed Jul 10 15:36:35 UTC 2024: Failed to connect to Central in namespace stackrox. Failed with 1 successes in a row
INFO: Wed Jul 10 15:36:35 UTC 2024: port-forwards:
INFO: Wed Jul 10 15:36:35 UTC 2024: pods:
NAME                          READY   STATUS    RESTARTS   AGE
central-cbdd54ff9-4fbsr       1/1     Running   0          5m15s
central-db-f476f6cd5-gh652    1/1     Running   0          5m15s
scanner-5db787ccbb-jff9z      1/1     Running   0          5m15s
scanner-db-74777d57bf-rb4h9   1/1     Running   0          5m15s
```

This improves it a bit.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

- [x] inspect and paste output from CI run after these changes

```
INFO: Thu Jul 11 07:23:30 UTC 2024: Waiting for Central to be ready in namespace stackrox
INFO: Thu Jul 11 07:23:30 UTC 2024: Still waiting (0s/600s)...
INFO: Thu Jul 11 07:23:36 UTC 2024: Still waiting (6s/600s)...
INFO: Thu Jul 11 07:23:41 UTC 2024: Still waiting (11s/600s)...
INFO: Thu Jul 11 07:23:47 UTC 2024: Still waiting (17s/600s)...
INFO: Thu Jul 11 07:24:22 UTC 2024: Central deployment is ready in namespace stackrox.
INFO: Thu Jul 11 07:24:22 UTC 2024: Waiting for Central API endpoint
INFO: Thu Jul 11 07:24:23 UTC 2024: Found ingress endpoint: 34.41.2.49
INFO: Thu Jul 11 07:24:23 UTC 2024: Attempting to get 3 'ok' responses in a row from https://34.41.2.49:443/v1/ping
INFO: Thu Jul 11 07:24:23 UTC 2024: Curl exited with status 7 and returned ''.
INFO: Thu Jul 11 07:24:28 UTC 2024: Status is now: ok
INFO: Thu Jul 11 07:24:30 UTC 2024: Status is now: ok
```
