### PR TITLE
tests: improve and give collect-service-logs.sh more time

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -15,7 +15,7 @@ from common import log_print
 
 class PostTestsConstants:
     API_TIMEOUT = 5 * 60
-    COLLECT_TIMEOUT = 10 * 60
+    COLLECT_TIMEOUT = 15 * 60
     COLLECT_INFRA_TIMEOUT = 12 * 60
     CHECK_TIMEOUT = 5 * 60
     STORE_TIMEOUT = 5 * 60

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -29,10 +29,12 @@ usage() {
 dump_logs() {
     local json_path="$1"
     for ctr in $(kubectl -n "${namespace}" get "${object}" "${item}" -o jsonpath="{${json_path}[*].name}"); do
+        info "Dumping log of ${object}/${item} current container ${ctr} in ${namespace}..."
         kubectl -n "${namespace}" logs "${object}/${item}" -c "${ctr}" > "${log_dir}/${object}/${item}-${ctr}.log"
         exit_code="$(kubectl -n "${namespace}" get "${object}/${item}" -o jsonpath="{${json_path}}" | jq --arg ctr "$ctr" '.[] | select(.name == $ctr) | .lastState.terminated.exitCode')"
         if [ "${exit_code}" != "null" ]; then
             prev_log_file="${log_dir}/${object}/${item}-${ctr}-previous.log"
+            info "Dumping log of ${object}/${item} previous container ${ctr} in ${namespace}..."
             if kubectl -n "${namespace}" logs "${object}/${item}" -p -c "${ctr}" > "${prev_log_file}"; then
                 if [ "$exit_code" -eq "0" ]; then
                     mv "${prev_log_file}" "${log_dir}/${object}/${item}-${ctr}-prev-success.log"


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

This timed out on [two](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-release-4.5-merge-eks-ebpf-qa-e2e-tests/1811048962430341120) [separate](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-release-4.5-merge-eks-qa-e2e-tests/1811048962468089856) EKS cluster jobs when releasing 4.5.
- give it more time in an attempt to succeed
- log actions with timestamps to allow us to find out what takes so long

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

- [x] inspect and paste here output from CI jobs

Example output before this change:

```
16:51:37: Running post command: ['scripts/ci/collect-service-logs.sh', 'stackrox', '/tmp/k8s-service-logs/part-1/k8s-logs']
NAME       STATUS   AGE
stackrox   Active   90m

>>> Collecting from namespace stackrox <<<

>>> daemonsets <<<
NAME        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE   CONTAINERS             IMAGES                                                                          SELECTOR
collector   3         3         3       3            3           <none>          85m   collector,compliance   quay.io/rhacs-eng/collector-slim:4.5.0-rc.1,quay.io/rhacs-eng/main:4.5.0-rc.1   service=collector
>>> deployments <<<
NAME                READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS          IMAGES                                              SELECTOR
admission-control   3/3     3            3           86m   admission-control   quay.io/rhacs-eng/main:4.5.0-rc.1                   app=admission-control
central             1/1     1            1           90m   central             quay.io/rhacs-eng/main:4.5.0-rc.1                   app=central
central-db          1/1     1            1           90m   central-db          quay.io/rhacs-eng/central-db:4.5.0-rc.1             app=central-db
scanner             2/2     2            2           90m   scanner             quay.io/rhacs-eng/scanner:4.5.0-rc.1                app=scanner
scanner-db          1/1     1            1           90m   db                  quay.io/rhacs-eng/scanner-db:4.5.0-rc.1             app=scanner-db
sensor              1/1     1            1           86m   sensor              quay.io/rhacs-eng/main:4.5.0-rc.1                   app=sensor
webhookserver       1/1     1            1           84m   webhookserver       quay.io/rhacs-eng/qa-multi-arch:webhookserver-1.2   app=webhookserver
>>> services <<<
NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP                                                               PORT(S)             AGE   SELECTOR
admission-control      ClusterIP      10.100.75.243    <none>                                                                    443/TCP             87m   app=admission-control
central                ClusterIP      10.100.40.176    <none>                                                                    443/TCP             91m   app=central
central-db             ClusterIP      10.100.252.148   <none>                                                                    5432/TCP            91m   app=central-db
central-loadbalancer   LoadBalancer   10.100.62.102    ac8803c57c8e74ef1bc77f40801bd187-2053692655.us-west-2.elb.amazonaws.com   443:31382/TCP       91m   app=central
scanner                ClusterIP      10.100.201.144   <none>                                                                    8080/TCP,8443/TCP   91m   app=scanner
scanner-db             ClusterIP      10.100.138.51    <none>                                                                    5432/TCP            91m   app=scanner-db
sensor                 ClusterIP      10.100.196.156   <none>                                                                    443/TCP             87m   app=sensor
sensor-webhook         ClusterIP      10.100.4.143     <none>                                                                    443/TCP             87m   app=sensor
webhookserver          ClusterIP      10.100.89.93     <none>                                                                    8080/TCP,8443/TCP   85m   app=webhookserver
>>> pods <<<
NAME                                 READY   STATUS    RESTARTS   AGE   IP               NODE                                           NOMINATED NODE   READINESS GATES
admission-control-5475bb86bf-8xvfd   1/1     Running   0          79m   192.168.92.23    ip-192-168-90-137.us-west-2.compute.internal   <none>           <none>
admission-control-5475bb86bf-nljlw   1/1     Running   0          79m   192.168.16.241   ip-192-168-8-243.us-west-2.compute.internal    <none>           <none>
admission-control-5475bb86bf-rwzjp   1/1     Running   0          79m   192.168.56.134   ip-192-168-58-173.us-west-2.compute.internal   <none>           <none>
central-7dfbfbcd75-nkpgh             1/1     Running   0          92m   192.168.86.248   ip-192-168-90-137.us-west-2.compute.internal   <none>           <none>
central-db-5c4f94cdfd-pqj4n          1/1     Running   0          92m   192.168.55.6     ip-192-168-58-173.us-west-2.compute.internal   <none>           <none>
collector-6stv4                      2/2     Running   0          87m   192.168.23.45    ip-192-168-8-243.us-west-2.compute.internal    <none>           <none>
collector-8fqls                      2/2     Running   0          87m   192.168.84.42    ip-192-168-90-137.us-west-2.compute.internal   <none>           <none>
collector-dqjpq                      2/2     Running   0          87m   192.168.43.75    ip-192-168-58-173.us-west-2.compute.internal   <none>           <none>
scanner-b7bdf79fb-kh9g4              1/1     Running   0          92m   192.168.94.73    ip-192-168-90-137.us-west-2.compute.internal   <none>           <none>
scanner-b7bdf79fb-p49cd              1/1     Running   0          92m   192.168.40.200   ip-192-168-58-173.us-west-2.compute.internal   <none>           <none>
scanner-db-77c5dc5bd5-8j9r6          1/1     Running   0          92m   192.168.0.233    ip-192-168-8-243.us-west-2.compute.internal    <none>           <none>
sensor-78d495b799-nc4sj              1/1     Running   0          87m   192.168.15.20    ip-192-168-8-243.us-west-2.compute.internal    <none>           <none>
webhookserver-6cf4d7f9db-nd2l7       1/1     Running   0          87m   192.168.7.202    ip-192-168-8-243.us-west-2.compute.internal    <none>           <none>
>>> secrets <<<
NAME                                  TYPE                             DATA   AGE
additional-ca-sensor                  Opaque                           1      91m
admission-control-tls                 Opaque                           3      91m
central-db-password                   Opaque                           1      95m
central-db-tls                        Opaque                           3      95m
central-default-tls-cert              kubernetes.io/tls                2      95m
central-htpasswd                      Opaque                           1      95m
central-tls                           Opaque                           5      95m
collector-stackrox                    kubernetes.io/dockerconfigjson   1      92m
collector-tls                         Opaque                           3      91m
helm-effective-cluster-name           Opaque                           1      91m
proxy-config                          Opaque                           1      95m
scanner-db-password                   Opaque                           1      95m
scanner-db-tls                        Opaque                           3      95m
scanner-tls                           Opaque                           3      95m
sensor-tls                            Opaque                           3      91m
sh.helm.release.v1.webhookserver.v1   helm.sh/release.v1               1      90m
stackrox                              kubernetes.io/dockerconfigjson   1      95m
stackrox-generated-0fvgjf             Opaque                           1      95m
webhook-server-certs                  Opaque                           2      90m
>>> serviceaccounts <<<
NAME                SECRETS   AGE
admission-control   0         94m
central             0         98m
central-db          0         98m
collector           0         94m
default             0         98m
scanner             0         98m
sensor              0         94m
sensor-upgrader     0         94m
>>> validatingwebhookconfigurations <<<
NAME                                        WEBHOOKS   AGE
eks-aws-auth-configmap-validation-webhook   1          119m
stackrox                                    2          95m
vpc-resource-validating-webhook             2          119m
>>> catalogsources <<<
Cannot get catalogsources in stackrox: error: the server doesn't have a resource type "catalogsources"
>>> subscriptions <<<
Cannot get subscriptions in stackrox: error: the server doesn't have a resource type "subscriptions"
>>> clusterserviceversions <<<
Cannot get clusterserviceversions in stackrox: error: the server doesn't have a resource type "clusterserviceversions"
>>> central <<<
Cannot get central in stackrox: error: the server doesn't have a resource type "central"
>>> securedclusters <<<
Cannot get securedclusters in stackrox: error: the server doesn't have a resource type "securedclusters"
>>> nodes <<<
17:01:37: Exception raised in ['scripts/ci/collect-service-logs.sh', 'stackrox', '/tmp/k8s-service-logs/part-1/k8s-logs'], Command '['scripts/ci/collect-service-logs.sh', 'stackrox', '/tmp/k8s-service-logs/part-1/k8s-logs']' timed out after 600 seconds
```

Snippet of example output after this change:
```
08:01:16: Running post command: ['scripts/ci/collect-service-logs.sh', 'stackrox-operator', '/tmp/k8s-service-logs']
NAME                STATUS   AGE
stackrox-operator   Active   34m
INFO: Thu Jul 11 08:01:16 UTC 2024: >>> Collecting from namespace stackrox-operator <<<
INFO: Thu Jul 11 08:01:16 UTC 2024: >>> Collecting daemonsets from namespace stackrox-operator <<<
No resources found in stackrox-operator namespace.
INFO: Thu Jul 11 08:01:17 UTC 2024: >>> Collecting deployments from namespace stackrox-operator <<<
NAME                                READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                                                     SELECTOR
rhacs-operator-controller-manager   1/1     1            1           34m   manager      quay.io/rhacs-eng/stackrox-operator:4.6.0-16-g0bfcd1234b   app=rhacs-operator,control-plane=controller-manager
INFO: Thu Jul 11 08:01:20 UTC 2024: >>> Collecting services from namespace stackrox-operator <<<
NAME                                                TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)     AGE   SELECTOR
rhacs-operator-controller-manager-metrics-service   ClusterIP   10.94.7.61    <none>        8443/TCP    34m   app=rhacs-operator,control-plane=controller-manager
rhacs-operator-controller-manager-service           ClusterIP   10.94.7.69    <none>        443/TCP     24m   app=rhacs-operator,control-plane=controller-manager
rhacs-operator-webhook-service                      ClusterIP   10.94.7.24    <none>        443/TCP     34m   app=rhacs-operator,control-plane=controller-manager
stackrox-operator-test-index                        ClusterIP   10.94.7.180   <none>        50051/TCP   35m   olm.catalogSource=stackrox-operator-test-index,olm.managed=true
INFO: Thu Jul 11 08:01:28 UTC 2024: >>> Collecting pods from namespace stackrox-operator <<<
NAME                                                              READY   STATUS      RESTARTS   AGE   IP              NODE                                                  NOMINATED NODE   READINESS GATES
033f995354f491e524a25db9c41bdbca6c940598f196e47d03f832bd0477xws   0/1     Completed   0          34m   10.118.112.14   gke-rox-ci-operator-e2e--default-pool-c756d537-wbsl   <none>           <none>
6899a2abbd0c4cf6bc112c8b35dc7ff3997b4cc8f5d41202ee7fee4c4d26vnk   0/1     Completed   0          34m   10.118.112.13   gke-rox-ci-operator-e2e--default-pool-c756d537-wbsl   <none>           <none>
rhacs-operator-controller-manager-55449cc7dd-sphkn                1/1     Running     0          24m   10.118.115.21   gke-rox-ci-operator-e2e--default-pool-c756d537-6f1z   <none>           <none>
stackrox-operator-test-index-p77h2                                1/1     Running     0          35m   10.118.112.12   gke-rox-ci-operator-e2e--default-pool-c756d537-wbsl   <none>           <none>
INFO: Thu Jul 11 08:01:31 UTC 2024: Dumping log of pods/033f995354f491e524a25db9c41bdbca6c940598f196e47d03f832bd0477xws current container extract in stackrox-operator...
INFO: Thu Jul 11 08:01:32 UTC 2024: Dumping log of pods/033f995354f491e524a25db9c41bdbca6c940598f196e47d03f832bd0477xws current container util in stackrox-operator...
INFO: Thu Jul 11 08:01:33 UTC 2024: Dumping log of pods/033f995354f491e524a25db9c41bdbca6c940598f196e47d03f832bd0477xws current container pull in stackrox-operator...
INFO: Thu Jul 11 08:01:35 UTC 2024: Dumping log of pods/6899a2abbd0c4cf6bc112c8b35dc7ff3997b4cc8f5d41202ee7fee4c4d26vnk current container extract in stackrox-operator...
INFO: Thu Jul 11 08:01:36 UTC 2024: Dumping log of pods/6899a2abbd0c4cf6bc112c8b35dc7ff3997b4cc8f5d41202ee7fee4c4d26vnk current container util in stackrox-operator...
INFO: Thu Jul 11 08:01:37 UTC 2024: Dumping log of pods/6899a2abbd0c4cf6bc112c8b35dc7ff3997b4cc8f5d41202ee7fee4c4d26vnk current container pull in stackrox-operator...
INFO: Thu Jul 11 08:01:40 UTC 2024: Dumping log of pods/rhacs-operator-controller-manager-55449cc7dd-sphkn current container manager in stackrox-operator...
INFO: Thu Jul 11 08:01:43 UTC 2024: Dumping log of pods/stackrox-operator-test-index-p77h2 current container registry-server in stackrox-operator...
INFO: Thu Jul 11 08:01:44 UTC 2024: >>> Collecting secrets from namespace stackrox-operator <<<
NAME                                             TYPE                             DATA   AGE
operator-pull-secret                             kubernetes.io/dockerconfigjson   1      35m
rhacs-operator-controller-manager-service-cert   kubernetes.io/tls                3      24m
INFO: Thu Jul 11 08:01:48 UTC 2024: >>> Collecting serviceaccounts from namespace stackrox-operator <<<
NAME                                SECRETS   AGE
default                             0         35m
rhacs-operator-controller-manager   0         34m
stackrox-operator-test-index        0         35m
INFO: Thu Jul 11 08:01:54 UTC 2024: >>> Collecting validatingwebhookconfigurations from namespace stackrox-operator <<<
NAME                                                              WEBHOOKS   AGE
flowcontrol-guardrails.config.common-webhooks.networking.gke.io   1          45m
gmp-operator.gmp-system.monitoring.googleapis.com                 6          45m
nodelimit.config.common-webhooks.networking.gke.io                1          45m
validation-webhook.snapshot.storage.k8s.io                        1          44m
vcentral.kb.io-9l6f9                                              1          25m
warden-validating.config.common-webhooks.networking.gke.io        1          45m
```