### PR TITLE
ROX-25197: Fix kube proxy pod retrieval

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -890,7 +890,8 @@ class Kubernetes implements OrchestratorMain {
     Set<String> getStaticPodCount(String ns = null) {
         return evaluateWithRetry(2, 3) {
             // This method assumes that a static pod will either have no OwnerReferences,
-            // it will have a owner not tracked by ACS, or it will be a kube-proxy pod
+            // it will have a owner not tracked by ACS, or
+            // it will be a kube-proxy pod with a non-tracked owner
             Set<String> staticPods = [] as Set
             PodList podList = ns == null ? client.pods().list() : client.pods().inNamespace(ns).list()
             podList.items.each {
@@ -898,11 +899,11 @@ class Kubernetes implements OrchestratorMain {
                     return
                 }
                 if (it.getMetadata().getOwnerReferences().size() > 0) {
-                        if (!isKubeProxyPod(it) && ownerIsTracked(it.getMetadata())) {
-                            return
-                        }
+                    if (ownerIsTracked(it.getMetadata()) || !isKubeProxyPod(it)) {
+                        return
+                    }
                 }
-                // Sensor tracks all kube-proxy pods as one with name `static-kube-proxy-pods`
+                // Sensor tracks all kube-proxy static-pods as one with name `static-kube-proxy-pods`
                 isKubeProxyPod(it) ? staticPods.add("static-kube-proxy-pods") : staticPods.add(it.metadata.name)
             }
             return staticPods

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -890,8 +890,8 @@ class Kubernetes implements OrchestratorMain {
     Set<String> getStaticPodCount(String ns = null) {
         return evaluateWithRetry(2, 3) {
             // This method assumes that a static pod will either have no OwnerReferences,
-            // it will have a owner not tracked by ACS, or
-            // it will be a kube-proxy pod with a non-tracked owner
+            // it has an owner not tracked by ACS, or
+            // it is a kube-proxy pod with a non-tracked owner.
             Set<String> staticPods = [] as Set
             PodList podList = ns == null ? client.pods().list() : client.pods().inNamespace(ns).list()
             podList.items.each {

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -11,7 +11,6 @@ import services.ClusterService
 import services.NamespaceService
 import services.NodeService
 import services.SummaryService
-import util.Env
 import util.Helpers
 
 import org.junit.Assume
@@ -109,9 +108,6 @@ class SummaryTest extends BaseSpecification {
     }
 
     @Tag("BAT")
-    // TODO(ROX-25197): Fails under AKS
-    @IgnoreIf({ Env.CI_JOB_NAME.contains("aks-qa-e2e") })
-    @IgnoreIf({ Env.CI_JOB_NAME.contains("aks-ebpf-qa-e2e") })
     @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify namespace details"() {
         // https://issues.redhat.com/browse/ROX-6844


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

kube-proxy pods are only tracked in sensor as static pods if the owner reference is not from a tracked owner (e.g. a Node). When the test retrieves the static pods from the orchestrator, it should check first if the owner is tracked and, if the owner is not tracked, it should check if the pod is a kube-proxy pod.

### User-facing documentation

<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

- [x] Test pass in aks
- [x] Test pass in gke
- [x] Test pass in eks <- the runs failed but the `Verify namespace details` passed.
