### PR TITLE
fix(tests): Fix GKE version compatibility tests

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -2,6 +2,7 @@
 PreTests - something to run before test but after resource provisioning.
 """
 
+import os
 import subprocess
 
 

--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -59,13 +59,13 @@ class PreSystemTests:
         )
 
 
-class CollectionPreTest:
+class CollectionMethodOverridePreTest:
     """
     CollectionPreTest - allows finer control over collection method
-    for individual tests
+    for individual test jobs
     """
     def __init__(self, method):
-        self._collection_method = method or "NO_COLLECTION"
+        self._collection_method = method
 
     def run(self):
         os.environ['COLLECTION_METHOD'] = self._collection_method

--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -65,7 +65,7 @@ class CollectionPreTest:
     for individual tests
     """
     def __init__(self, method):
-        self._collection_method = method
+        self._collection_method = method or "NO_COLLECTION"
 
     def run(self):
         os.environ['COLLECTION_METHOD'] = self._collection_method

--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -56,3 +56,15 @@ class PreSystemTests:
             check=True,
             timeout=PreSystemTests.START_PREFETCH_TIMEOUT,
         )
+
+
+class CollectionPreTest:
+    """
+    CollectionPreTest - allows finer control over collection method
+    for individual tests
+    """
+    def __init__(self, method):
+        self._collection_method = method
+
+    def run(self):
+        os.environ['COLLECTION_METHOD'] = self._collection_method

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -21,9 +21,11 @@ import services.ProcessBaselineService
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
+import spock.lang.IgnoreIf
 
 @Tag("Parallel")
 @Tag("PZ")
+@IgnoreIf({ Env.COLLECTION_METHOD == "NO_COLLECTION"  })
 class ProcessBaselinesTest extends BaseSpecification {
     @Shared
     private String clusterId

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -15,8 +15,10 @@ import services.AlertService
 import util.Timer
 
 import spock.lang.Tag
+import spock.lang.IgnoreIf
 
 @Tag("PZ")
+@IgnoreIf({ Env.COLLECTION_METHOD == "NO_COLLECTION" })
 class RuntimeViolationLifecycleTest extends BaseSpecification  {
     static final private String APTGETPOLICY = "Ubuntu Package Manager Execution"
 

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -11,7 +11,10 @@ import sys
 from collections import namedtuple
 from pathlib import Path
 
-from pre_tests import PreSystemTests
+from pre_tests import (
+    PreSystemTests,
+    CollectionPreTest
+)
 from ci_tests import QaE2eTestCompatibility
 from post_tests import PostClusterTest, FinalPost
 from runners import ClusterTestSetsRunner
@@ -81,13 +84,6 @@ test_tuples.extend(
     if support_exception not in test_tuples
 )
 
-class PreTestCollection:
-    def __init__(self, method):
-        self._collection_method = method
-
-    def run(self):
-        os.environ['COLLECTION_METHOD'] = self._collection_method
-
 sets = []
 for test_tuple in test_tuples:
     os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
@@ -104,7 +100,7 @@ for test_tuple in test_tuples:
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
-            "pre_test": PreTestCollection(collection_method)
+            "pre_test": CollectionPreTest(collection_method)
         },
     )
 ClusterTestSetsRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -18,7 +18,6 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_latest_helm_chart_versions,
-    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -28,6 +28,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["COLLECTION_METHOD"] = "core-bpf"
 
 central_chart_versions = get_latest_helm_chart_versions(
     "stackrox-central-services", 2)
@@ -62,23 +63,6 @@ test_tuples.extend(
                       sensor_version=latest_tag)
         for central_chart_version in central_chart_versions
     ]
-)
-
-# Support exception for latest central and sensor 3.74 as per
-# https://issues.redhat.com/browse/ROX-18223
-support_exceptions = [
-    ChartVersions(
-        central_version=latest_tag,
-        sensor_version=get_latest_helm_chart_version_for_specific_release(
-            "stackrox-secured-cluster-services", Release(major=3, minor=74)
-        ),
-    )
-]
-
-test_tuples.extend(
-    support_exception
-    for support_exception in support_exceptions
-    if support_exception not in test_tuples
 )
 
 sets = []

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -82,11 +82,11 @@ test_tuples.extend(
 )
 
 class PreTestCollection:
-    def __init__(self, collection):
-        self._collection = collection
+    def __init__(self, method):
+        self._collection_method = method
 
     def run(self):
-        os.environ['COLLECTION_METHOD'] = self._collection
+        os.environ['COLLECTION_METHOD'] = self._collection_method
 
 sets = []
 for test_tuple in test_tuples:
@@ -94,7 +94,7 @@ for test_tuple in test_tuples:
     test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
 
     # Collection not supported on 3.74
-    collection = 'none' if test_tuple.sensor_version.startswith('74') else 'core-bpf'
+    collection_method = 'none' if test_tuple.sensor_version.startswith('74') else 'core-bpf'
 
     sets.append(
         {
@@ -104,7 +104,7 @@ for test_tuple in test_tuples:
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
-            "pre_test": PreTestCollection(collection)
+            "pre_test": PreTestCollection(collection_method)
         },
     )
 ClusterTestSetsRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -89,9 +89,6 @@ for test_tuple in test_tuples:
     os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
     test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
 
-    # Collection not supported on 3.74
-    collection_method = 'none' if test_tuple.sensor_version.startswith('74') else 'core-bpf'
-
     sets.append(
         {
             "name": f'version compatibility tests: {test_versions}',
@@ -100,7 +97,8 @@ for test_tuple in test_tuples:
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
-            "pre_test": CollectionPreTest(collection_method)
+            # Collection not supported on 3.74
+            "pre_test": CollectionPreTest("none" if test_tuple.sensor_version.startswith('74') else "core-bpf")
         },
     )
 ClusterTestSetsRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -89,16 +89,19 @@ for test_tuple in test_tuples:
     os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
     test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
 
+    is_374_sensor = test_tuple.sensor_version.startswith('74')
+
     sets.append(
         {
             "name": f'version compatibility tests: {test_versions}',
             "test": QaE2eTestCompatibility(test_tuple.central_version, test_tuple.sensor_version),
             "post_test": PostClusterTest(
+                    collect_collector_metrics=not is_374_sensor,
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
             # Collection not supported on 3.74
-            "pre_test": CollectionPreTest(None if test_tuple.sensor_version.startswith('74') else "core_bpf")
+            "pre_test": CollectionPreTest(None if is_374_sensor else "core_bpf")
         },
     )
 ClusterTestSetsRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -98,7 +98,7 @@ for test_tuple in test_tuples:
                     artifact_destination_prefix=test_versions,
             ),
             # Collection not supported on 3.74
-            "pre_test": CollectionPreTest("none" if test_tuple.sensor_version.startswith('74') else "core-bpf")
+            "pre_test": CollectionPreTest(None if test_tuple.sensor_version.startswith('74') else "core_bpf")
         },
     )
 ClusterTestSetsRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from pre_tests import (
     PreSystemTests,
-    CollectionPreTest
+    CollectionMethodOverridePreTest
 )
 from ci_tests import QaE2eTestCompatibility
 from post_tests import PostClusterTest, FinalPost
@@ -89,19 +89,20 @@ for test_tuple in test_tuples:
     os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
     test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
 
-    is_374_sensor = test_tuple.sensor_version.startswith('74')
+    # expected version string is like 74.x.x for ACS 3.74 versions
+    is_3_74_sensor = test_tuple.sensor_version.startswith('74')
 
     sets.append(
         {
             "name": f'version compatibility tests: {test_versions}',
             "test": QaE2eTestCompatibility(test_tuple.central_version, test_tuple.sensor_version),
             "post_test": PostClusterTest(
-                    collect_collector_metrics=not is_374_sensor,
+                    collect_collector_metrics=not is_3_74_sensor,
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
             # Collection not supported on 3.74
-            "pre_test": CollectionPreTest(None if is_374_sensor else "core_bpf")
+            "pre_test": CollectionMethodOverridePreTest("NO_COLLECTION" if is_3_74_sensor else "core_bpf")
         },
     )
 ClusterTestSetsRunner(

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -532,6 +532,12 @@ wait_for_collectors_to_be_operational() {
     local timeout=300
     local retry_interval=10
 
+    if [[ "$COLLECTION_METHOD" == "NO_COLLECTION" ]]; then
+        # With NO_COLLECTION, no collector containers are deployed
+        # so no need to check for readiness
+        return
+    fi
+
     local start_time
     start_time="$(date '+%s')"
     local all_ready="false"


### PR DESCRIPTION
### Description

3.74 test removed (not supported on GKE)
https://issues.redhat.com/browse/ROX-18223

CORE_BPF collection used, to avoid eBPF download flakes on older versions

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests


#### How I validated my change

Based on failures: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-release-4.5-merge-gke-version-compatibility-tests/1811048972521836544

And ticket posted above (3.74 only supported on OCP 3.11)
