### PR TITLE
ROX-16461: Fix kube-proxy assertion

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -1,6 +1,7 @@
 package orchestratormanager
 
 import io.fabric8.kubernetes.api.model.EnvVar
+import io.fabric8.kubernetes.api.model.ObjectMeta
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration
 import objects.ConfigMap
@@ -119,6 +120,7 @@ interface OrchestratorMain {
     def removeNamespaceAnnotation(String ns, String key)
     def getAllNetworkPoliciesNamesByNamespace(Boolean ignoreUndoneStackroxGenerated)
     Namespace getNamespaceDetailsByName(String name)
+    boolean ownerIsTracked(ObjectMeta obj)
     List<String> getNamespaces()
 
     //NetworkPolicies

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -94,9 +94,12 @@ class ProcessVisualizationTest extends BaseSpecification {
 
         then:
         "Ensure it has processes"
+        def query = "Namespace:kube-system+Deployment:static-kube-proxy-pods"
         // if the kube-proxy pod owner is tracked (e.g. DaemonSet), then sensor does not track the individual pods as
         // `static-kube-proxy-pods` so we must assert against the DaemonSet `kube-proxy`
-        def query = podOwnerIsTracked ? "Namespace:kube-system+Deployment:kube-proxy" : "Namespace:kube-system+Deployment:static-kube-proxy-pods"
+        if (podOwnerIsTracked) {
+            query = "Namespace:kube-system+Deployment:kube-proxy"
+        }
         def kubeProxyDeploymentsInRox = DeploymentService.listDeploymentsSearch(
                 SearchServiceOuterClass.RawQuery.newBuilder().
                         setQuery(query).

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -110,7 +110,7 @@ class ProcessVisualizationTest extends BaseSpecification {
         def receivedProcessPaths = ProcessService.getUniqueProcessPaths(kubeProxyDeploymentID)
         log.info "Received processes: ${receivedProcessPaths}"
         // Avoid asserting on the specific process names since that might change across versions/distributions.
-        // The goal is to make sure we pick up processes from static pods.
+        // The goal is to make sure we pick up processes running in pods.
         assert receivedProcessPaths.size() > 0
     }
 

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -94,12 +94,9 @@ class ProcessVisualizationTest extends BaseSpecification {
 
         then:
         "Ensure it has processes"
-        def query = "Namespace:kube-system+Deployment:static-kube-proxy-pods"
         // if the kube-proxy pod owner is tracked (e.g. DaemonSet), then sensor does not track the individual pods as
         // `static-kube-proxy-pods` so we must assert against the DaemonSet `kube-proxy`
-        if (podOwnerIsTracked) {
-            query = "Namespace:kube-system+Deployment:kube-proxy"
-        }
+        def query = podOwnerIsTracked ? "Namespace:kube-system+Deployment:kube-proxy" : "Namespace:kube-system+Deployment:static-kube-proxy-pods"
         def kubeProxyDeploymentsInRox = DeploymentService.listDeploymentsSearch(
                 SearchServiceOuterClass.RawQuery.newBuilder().
                         setQuery(query).

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -4,10 +4,8 @@ import objects.Deployment
 import services.DeploymentService
 import services.ProcessService
 import util.Timer
-import util.Env
 
 import org.junit.Assume
-import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll
 
@@ -93,7 +91,8 @@ class ProcessVisualizationTest extends BaseSpecification {
         def kubeProxyPods = orchestrator.getPodsByLabel("kube-system", ["component": "kube-proxy"])
         def podOwnerIsTracked = false
         for (pod in kubeProxyPods) {
-            if (podOwnerIsTracked = orchestrator.ownerIsTracked(pod.getMetadata())) {
+            if (orchestrator.ownerIsTracked(pod.getMetadata())) {
+                podOwnerIsTracked = true
                 break
             }
         }

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -17,7 +17,6 @@ class ProcessVisualizationTest extends BaseSpecification {
     static final private String CENTOSDEPLOYMENT = "centosdeployment"
     static final private String FEDORADEPLOYMENT = "fedoradeployment"
     static final private String ELASTICDEPLOYMENT = "elasticdeployment"
-    //static final private String REDISDEPLOYMENT = "redisdeployment"
     static final private String MONGODEPLOYMENT = "mongodeployment"
     static final private String ROX4751DEPLOYMENT = "rox4751deployment"
     static final private String ROX4979DEPLOYMENT = "rox4979deployment"
@@ -47,12 +46,6 @@ class ProcessVisualizationTest extends BaseSpecification {
                 .setImage ("quay.io/rhacs-eng/qa-multi-arch:elasticsearch-"+
                            "cdeb134689bb0318a773e03741f4414b3d1d0ee443b827d5954f957775db57eb")
                 .addLabel ("app", "test" ),
-            /* deployment is flaky on few arches, disabling has no impact as other deployments have sufficient coverage
-            new Deployment()
-                .setName (REDISDEPLOYMENT)
-                .setImage ("quay.io/rhacs-eng/qa-multi-arch:redis-4.0.11")
-                .addLabel ("app", "test" ),
-            */
             new Deployment()
                 .setName (MONGODEPLOYMENT)
                 .setImage ("quay.io/rhacs-eng/qa-multi-arch:mongodb")


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

AKS kube-proxy pods are not tracked as static pods because the owner reference is the kube-proxy DaemonSet and in those cases we only track the DaemonSet. The test needs to assert with the kube-proxy DaemonSet.

### User-facing documentation

<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!-- Remove item(s) that don't apply and won't be checked. -->


- [x] modified existing tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

- [x] AKS test should pass
