### PR TITLE
chore(ui): Fix key prop errors in notifier integrations

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/NotifierIntegrationsSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/NotifierIntegrationsSection.tsx
@@ -31,7 +31,7 @@ function NotifierIntegrationsSection(): ReactElement {
             {descriptors.filter(featureFlagDependencyFilter).map((descriptor) => {
                 const { image, label, type } = descriptor;
                 if (!canUseAcscsEmailIntegration && type === 'acscsEmail') {
-                    return <></>;
+                    return <React.Fragment key={type} />;
                 }
                 return (
                     <IntegrationTile

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/NotifierIntegrationsSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/NotifierIntegrationsSection.tsx
@@ -31,7 +31,7 @@ function NotifierIntegrationsSection(): ReactElement {
             {descriptors.filter(featureFlagDependencyFilter).map((descriptor) => {
                 const { image, label, type } = descriptor;
                 if (!canUseAcscsEmailIntegration && type === 'acscsEmail') {
-                    return <React.Fragment key={type} />;
+                    return null;
                 }
                 return (
                     <IntegrationTile


### PR DESCRIPTION
### Description

Fix existing errors in browser console so it is easier to see recent regressions.

**Problem**

Error in browser console:

> Each child in a list should have a unique "key" prop.

> heck the render method of `NotifierIntegrationsSection`.

**Analysis**: `<></>` in `map` method does not have `key` prop.

**Solution**

https://react.dev/reference/react/Fragment#rendering-a-list-of-fragments

> Here’s a situation where you need to write Fragment explicitly instead of using the `<></>` syntax. When you render multiple elements in a loop, you need to assign a key to each element. If the elements within the loop are Fragments, you need to use the normal JSX element syntax in order to provide the key attribute.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change


1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/integrations

    * Before changes, see presence of error in browser console.
        ![NotifierIntegrationsSection_with_error](https://github.com/user-attachments/assets/8f0e7eb8-026b-4d9b-8eca-bd82c1759bdb)

    * After changes, see absence of error in browser console.
