### PR TITLE
ROX-24364: Reenable Summary test for counting objects

### DIFF
--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -24,7 +24,8 @@ class SummaryTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("COMPATIBILITY")
-    @Ignore("ROX-24528: This API is deprecated in 4.5. Remove this test once the API is removed")
+    // Temporarily enable this test to gather debug data and fix the flaky behavior
+    // @Ignore("ROX-24528: This API is deprecated in 4.5. Remove this test once the API is removed")
     @IgnoreIf({ System.getenv("OPENSHIFT_CI_CLUSTER_CLAIM") == "openshift-4" })
     def "Verify TopNav counts for Nodes, Deployments, and Secrets"() {
         // https://issues.redhat.com/browse/ROX-6844


### PR DESCRIPTION
### Description

We want to gather more data on the failures for this test. Reenabling it after the release was cut, so that we do not add more flakes to handle in the release process.
  
### User-facing documentation

(*must be* 2 items and both *must be* checked)

- [ ] CHANGELOG is updated
- [x] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] contributed **no automated tests**

#### How I validated my change

I have not.

change me!
