### PR TITLE
chore: custom struct for deleted deployment

### DIFF
--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -16,7 +16,7 @@ var (
 	}
 )
 
-type DeletedDeploymentCache interface {
+type DeletedDeployments interface {
 	Add(id string)
 	Contains(id string) bool
 }
@@ -34,7 +34,7 @@ func (c *deploymentCache) Contains(id string) bool {
 	return ok
 }
 
-// DeletedDeploymentCacheSingleton returns a global expiringcache for deployments that have been recently deleted
-func DeletedDeploymentCacheSingleton() DeletedDeploymentCache {
+// DeletedDeploymentsSingleton returns a global expiringcache for deployments that have been recently deleted
+func DeletedDeploymentsSingleton() DeletedDeployments {
 	return cache
 }

--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -34,7 +34,7 @@ func (c *deploymentCache) Contains(id string) bool {
 	return ok
 }
 
-// DeletedDeploymentsSingleton returns a global expiringcache for deployments that have been recently deleted
+// DeletedDeploymentsSingleton returns a global expiringcache for deployments that have been recently deleted.
 func DeletedDeploymentsSingleton() DeletedDeployments {
 	return cache
 }

--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -11,10 +11,30 @@ const (
 )
 
 var (
-	cache = expiringcache.NewExpiringCache(deletedDeploymentsRetentionPeriod)
+	cache = &deploymentCache{
+		cache: expiringcache.NewExpiringCache(deletedDeploymentsRetentionPeriod),
+	}
 )
 
+type DeletedDeploymentCache interface {
+	Add(id string)
+	Contains(id string) bool
+}
+
+type deploymentCache struct {
+	cache expiringcache.Cache
+}
+
+func (c *deploymentCache) Add(id string) {
+	cache.cache.Add(id, struct{}{})
+}
+
+func (c *deploymentCache) Contains(id string) bool {
+	_, ok := cache.cache.Get(id)
+	return ok
+}
+
 // DeletedDeploymentCacheSingleton returns a global expiringcache for deployments that have been recently deleted
-func DeletedDeploymentCacheSingleton() expiringcache.Cache {
+func DeletedDeploymentCacheSingleton() DeletedDeploymentCache {
 	return cache
 }

--- a/central/deployment/datastore/datastore.go
+++ b/central/deployment/datastore/datastore.go
@@ -46,7 +46,7 @@ type DataStore interface {
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(deployment *storage.Deployment) error) error
 }
 
-func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
+func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeployments, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
 	searcher := search.NewV2(storage)
 	ds := newDatastoreImpl(storage, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 
@@ -55,6 +55,6 @@ func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.
 }
 
 // New creates a deployment datastore using postgres.
-func New(pool postgres.DB, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
+func New(pool postgres.DB, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeployments, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
 	return newDataStore(pgStore.NewFullStore(pool), images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 }

--- a/central/deployment/datastore/datastore.go
+++ b/central/deployment/datastore/datastore.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/deployment/cache"
 	"github.com/stackrox/rox/central/deployment/datastore/internal/search"
 	"github.com/stackrox/rox/central/deployment/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/deployment/datastore/internal/store/postgres"
@@ -13,7 +14,6 @@ import (
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/process/filter"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
@@ -46,7 +46,7 @@ type DataStore interface {
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(deployment *storage.Deployment) error) error
 }
 
-func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache expiringcache.Cache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
+func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
 	searcher := search.NewV2(storage)
 	ds := newDatastoreImpl(storage, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 
@@ -55,6 +55,6 @@ func newDataStore(storage store.Store, images imageDS.DataStore, baselines pbDS.
 }
 
 // New creates a deployment datastore using postgres.
-func New(pool postgres.DB, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache expiringcache.Cache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
+func New(pool postgres.DB, images imageDS.DataStore, baselines pbDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) (DataStore, error) {
 	return newDataStore(pgStore.NewFullStore(pool), images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 }

--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/deployment/cache"
 	deploymentSearch "github.com/stackrox/rox/central/deployment/datastore/internal/search"
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore/internal/store"
 	"github.com/stackrox/rox/central/globaldb"
@@ -18,7 +19,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/process/filter"
@@ -39,7 +39,7 @@ type datastoreImpl struct {
 	networkFlows           nfDS.ClusterDataStore
 	baselines              pwDS.DataStore
 	risks                  riskDS.DataStore
-	deletedDeploymentCache expiringcache.Cache
+	deletedDeploymentCache cache.DeletedDeploymentCache
 	processFilter          filter.Filter
 
 	keyedMutex *concurrency.KeyedMutex
@@ -49,7 +49,7 @@ type datastoreImpl struct {
 	deploymentRanker *ranking.Ranker
 }
 
-func newDatastoreImpl(storage deploymentStore.Store, searcher deploymentSearch.Searcher, images imageDS.DataStore, baselines pwDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache expiringcache.Cache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) *datastoreImpl {
+func newDatastoreImpl(storage deploymentStore.Store, searcher deploymentSearch.Searcher, images imageDS.DataStore, baselines pwDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) *datastoreImpl {
 	return &datastoreImpl{
 		deploymentStore:        storage,
 		deploymentSearcher:     searcher,
@@ -295,10 +295,10 @@ func (ds *datastoreImpl) RemoveDeployment(ctx context.Context, clusterID, id str
 	// Dedupe the removed deployments. This can happen because Pods have many completion states
 	// and we may receive multiple Remove calls
 	if ds.deletedDeploymentCache != nil {
-		if _, ok := ds.deletedDeploymentCache.Get(id); ok {
+		if ds.deletedDeploymentCache.Contains(id) {
 			return nil
 		}
-		ds.deletedDeploymentCache.Add(id, true)
+		ds.deletedDeploymentCache.Add(id)
 	}
 	// Though the filter is updated upon pod update,
 	// We still want to ensure it is properly cleared when the deployment is deleted.

--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -39,7 +39,7 @@ type datastoreImpl struct {
 	networkFlows           nfDS.ClusterDataStore
 	baselines              pwDS.DataStore
 	risks                  riskDS.DataStore
-	deletedDeploymentCache cache.DeletedDeploymentCache
+	deletedDeploymentCache cache.DeletedDeployments
 	processFilter          filter.Filter
 
 	keyedMutex *concurrency.KeyedMutex
@@ -49,7 +49,7 @@ type datastoreImpl struct {
 	deploymentRanker *ranking.Ranker
 }
 
-func newDatastoreImpl(storage deploymentStore.Store, searcher deploymentSearch.Searcher, images imageDS.DataStore, baselines pwDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeploymentCache, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) *datastoreImpl {
+func newDatastoreImpl(storage deploymentStore.Store, searcher deploymentSearch.Searcher, images imageDS.DataStore, baselines pwDS.DataStore, networkFlows nfDS.ClusterDataStore, risks riskDS.DataStore, deletedDeploymentCache cache.DeletedDeployments, processFilter filter.Filter, clusterRanker *ranking.Ranker, nsRanker *ranking.Ranker, deploymentRanker *ranking.Ranker) *datastoreImpl {
 	return &datastoreImpl{
 		deploymentStore:        storage,
 		deploymentSearcher:     searcher,

--- a/central/deployment/datastore/datastore_test_constructors.go
+++ b/central/deployment/datastore/datastore_test_constructors.go
@@ -26,7 +26,7 @@ type DeploymentTestStoreParams struct {
 	ProcessBaselinesDataStore         pbDS.DataStore
 	NetworkGraphFlowClustersDataStore nfDS.ClusterDataStore
 	RisksDataStore                    riskDS.DataStore
-	DeletedDeploymentCache            cache.DeletedDeploymentCache
+	DeletedDeploymentCache            cache.DeletedDeployments
 	ProcessIndicatorFilter            filter.Filter
 	ClusterRanker                     *ranking.Ranker
 	NamespaceRanker                   *ranking.Ranker

--- a/central/deployment/datastore/datastore_test_constructors.go
+++ b/central/deployment/datastore/datastore_test_constructors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stackrox/rox/central/deployment/cache"
 	"github.com/stackrox/rox/central/deployment/datastore/internal/search"
 	pgStore "github.com/stackrox/rox/central/deployment/datastore/internal/store/postgres"
 	imageDS "github.com/stackrox/rox/central/image/datastore"
@@ -13,7 +14,6 @@ import (
 	processIndicatorFilter "github.com/stackrox/rox/central/processindicator/filter"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/process/filter"
@@ -26,7 +26,7 @@ type DeploymentTestStoreParams struct {
 	ProcessBaselinesDataStore         pbDS.DataStore
 	NetworkGraphFlowClustersDataStore nfDS.ClusterDataStore
 	RisksDataStore                    riskDS.DataStore
-	DeletedDeploymentCache            expiringcache.Cache
+	DeletedDeploymentCache            cache.DeletedDeploymentCache
 	ProcessIndicatorFilter            filter.Filter
 	ClusterRanker                     *ranking.Ranker
 	NamespaceRanker                   *ranking.Ranker

--- a/central/deployment/datastore/singleton.go
+++ b/central/deployment/datastore/singleton.go
@@ -23,7 +23,7 @@ var (
 
 func initialize() {
 	var err error
-	ad, err = New(globaldb.GetPostgres(), imageDatastore.Singleton(), pbDS.Singleton(), nfDS.Singleton(), riskDS.Singleton(), cache.DeletedDeploymentCacheSingleton(), filter.Singleton(), ranking.ClusterRanker(), ranking.NamespaceRanker(), ranking.DeploymentRanker())
+	ad, err = New(globaldb.GetPostgres(), imageDatastore.Singleton(), pbDS.Singleton(), nfDS.Singleton(), riskDS.Singleton(), cache.DeletedDeploymentsSingleton(), filter.Singleton(), ranking.ClusterRanker(), ranking.NamespaceRanker(), ranking.DeploymentRanker())
 	if err != nil {
 		log.Fatalf("could not initialize deployment datastore: %v", err)
 	}

--- a/central/detection/lifecycle/manager.go
+++ b/central/detection/lifecycle/manager.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/activecomponent/updater/aggregator"
+	"github.com/stackrox/rox/central/deployment/cache"
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/deployment/queue"
 	"github.com/stackrox/rox/central/detection/alertmanager"
@@ -14,7 +15,6 @@ import (
 	processDatastore "github.com/stackrox/rox/central/processindicator/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/set"
@@ -47,7 +47,7 @@ type Manager interface {
 // newManager returns a new manager with the injected dependencies.
 func newManager(buildTimeDetector buildtime.Detector, deployTimeDetector deploytime.Detector, runtimeDetector runtime.Detector,
 	deploymentDatastore deploymentDatastore.DataStore, processesDataStore processDatastore.DataStore, baselines baselineDataStore.DataStore,
-	alertManager alertmanager.AlertManager, reprocessor reprocessor.Loop, deletedDeploymentsCache expiringcache.Cache, filter filter.Filter,
+	alertManager alertmanager.AlertManager, reprocessor reprocessor.Loop, deletedDeploymentsCache cache.DeletedDeploymentCache, filter filter.Filter,
 	processAggregator aggregator.ProcessAggregator) *managerImpl {
 	m := &managerImpl{
 		buildTimeDetector:       buildTimeDetector,

--- a/central/detection/lifecycle/manager.go
+++ b/central/detection/lifecycle/manager.go
@@ -47,7 +47,7 @@ type Manager interface {
 // newManager returns a new manager with the injected dependencies.
 func newManager(buildTimeDetector buildtime.Detector, deployTimeDetector deploytime.Detector, runtimeDetector runtime.Detector,
 	deploymentDatastore deploymentDatastore.DataStore, processesDataStore processDatastore.DataStore, baselines baselineDataStore.DataStore,
-	alertManager alertmanager.AlertManager, reprocessor reprocessor.Loop, deletedDeploymentsCache cache.DeletedDeploymentCache, filter filter.Filter,
+	alertManager alertmanager.AlertManager, reprocessor reprocessor.Loop, deletedDeploymentsCache cache.DeletedDeployments, filter filter.Filter,
 	processAggregator aggregator.ProcessAggregator) *managerImpl {
 	m := &managerImpl{
 		buildTimeDetector:       buildTimeDetector,

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -65,7 +65,7 @@ type managerImpl struct {
 	deploymentDataStore     deploymentDatastore.DataStore
 	processesDataStore      processIndicatorDatastore.DataStore
 	baselines               baselineDataStore.DataStore
-	deletedDeploymentsCache cache.DeletedDeploymentCache
+	deletedDeploymentsCache cache.DeletedDeployments
 	processFilter           filter.Filter
 
 	queuedIndicators           map[string]*storage.ProcessIndicator

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/activecomponent/updater/aggregator"
+	"github.com/stackrox/rox/central/deployment/cache"
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/deployment/queue"
 	"github.com/stackrox/rox/central/detection/alertmanager"
@@ -22,7 +23,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/policies"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/process/filter"
@@ -65,7 +65,7 @@ type managerImpl struct {
 	deploymentDataStore     deploymentDatastore.DataStore
 	processesDataStore      processIndicatorDatastore.DataStore
 	baselines               baselineDataStore.DataStore
-	deletedDeploymentsCache expiringcache.Cache
+	deletedDeploymentsCache cache.DeletedDeploymentCache
 	processFilter           filter.Filter
 
 	queuedIndicators           map[string]*storage.ProcessIndicator
@@ -188,8 +188,7 @@ func (m *managerImpl) flushIndicatorQueue() {
 	// Map copiedQueue to slice
 	indicatorSlice := make([]*storage.ProcessIndicator, 0, len(copiedQueue))
 	for _, indicator := range copiedQueue {
-		_, deleted := m.deletedDeploymentsCache.Get(indicator.GetDeploymentId())
-		if deleted {
+		if m.deletedDeploymentsCache.Contains(indicator.GetDeploymentId()) {
 			continue
 		}
 		indicatorSlice = append(indicatorSlice, indicator)

--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -33,7 +33,7 @@ func initialize() {
 		baselineDataStore.Singleton(),
 		alertmanager.Singleton(),
 		reprocessor.Singleton(),
-		cache.DeletedDeploymentCacheSingleton(),
+		cache.DeletedDeploymentsSingleton(),
 		filter.Singleton(),
 		aggregator.Singleton(),
 	)

--- a/central/networkgraph/flow/datastore/cluster.go
+++ b/central/networkgraph/flow/datastore/cluster.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stackrox/rox/central/deployment/cache"
 	graphConfigDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
 	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
@@ -22,7 +22,7 @@ type ClusterDataStore interface {
 }
 
 // NewClusterDataStore returns a new instance of ClusterDataStore using the input storage underneath.
-func NewClusterDataStore(storage store.ClusterStore, graphConfig graphConfigDS.DataStore, networkTreeMgr networktree.Manager, deletedDeploymentsCache expiringcache.Cache) ClusterDataStore {
+func NewClusterDataStore(storage store.ClusterStore, graphConfig graphConfigDS.DataStore, networkTreeMgr networktree.Manager, deletedDeploymentsCache cache.DeletedDeploymentCache) ClusterDataStore {
 	return &clusterDataStoreImpl{
 		storage:                 storage,
 		graphConfig:             graphConfig,

--- a/central/networkgraph/flow/datastore/cluster.go
+++ b/central/networkgraph/flow/datastore/cluster.go
@@ -22,7 +22,7 @@ type ClusterDataStore interface {
 }
 
 // NewClusterDataStore returns a new instance of ClusterDataStore using the input storage underneath.
-func NewClusterDataStore(storage store.ClusterStore, graphConfig graphConfigDS.DataStore, networkTreeMgr networktree.Manager, deletedDeploymentsCache cache.DeletedDeploymentCache) ClusterDataStore {
+func NewClusterDataStore(storage store.ClusterStore, graphConfig graphConfigDS.DataStore, networkTreeMgr networktree.Manager, deletedDeploymentsCache cache.DeletedDeployments) ClusterDataStore {
 	return &clusterDataStoreImpl{
 		storage:                 storage,
 		graphConfig:             graphConfig,

--- a/central/networkgraph/flow/datastore/cluster_impl.go
+++ b/central/networkgraph/flow/datastore/cluster_impl.go
@@ -16,7 +16,7 @@ type clusterDataStoreImpl struct {
 	storage                 store.ClusterStore
 	networkTreeMgr          networktree.Manager
 	graphConfig             graphConfigDS.DataStore
-	deletedDeploymentsCache cache.DeletedDeploymentCache
+	deletedDeploymentsCache cache.DeletedDeployments
 }
 
 func (cds *clusterDataStoreImpl) GetFlowStore(ctx context.Context, clusterID string) (FlowDataStore, error) {

--- a/central/networkgraph/flow/datastore/cluster_impl.go
+++ b/central/networkgraph/flow/datastore/cluster_impl.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/deployment/cache"
 	"github.com/stackrox/rox/central/networkgraph/aggregator"
 	graphConfigDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
 	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/sac"
 )
 
@@ -16,7 +16,7 @@ type clusterDataStoreImpl struct {
 	storage                 store.ClusterStore
 	networkTreeMgr          networktree.Manager
 	graphConfig             graphConfigDS.DataStore
-	deletedDeploymentsCache expiringcache.Cache
+	deletedDeploymentsCache cache.DeletedDeploymentCache
 }
 
 func (cds *clusterDataStoreImpl) GetFlowStore(ctx context.Context, clusterID string) (FlowDataStore, error) {

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -23,7 +23,7 @@ type flowDataStoreImpl struct {
 	storage                   store.FlowStore
 	graphConfig               graphConfigDS.DataStore
 	hideDefaultExtSrcsManager aggregator.NetworkConnsAggregator
-	deletedDeploymentsCache   cache.DeletedDeploymentCache
+	deletedDeploymentsCache   cache.DeletedDeployments
 }
 
 func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/deployment/cache"
 	"github.com/stackrox/rox/central/networkgraph/aggregator"
 	graphConfigDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -23,7 +23,7 @@ type flowDataStoreImpl struct {
 	storage                   store.FlowStore
 	graphConfig               graphConfigDS.DataStore
 	hideDefaultExtSrcsManager aggregator.NetworkConnsAggregator
-	deletedDeploymentsCache   expiringcache.Cache
+	deletedDeploymentsCache   cache.DeletedDeploymentCache
 }
 
 func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *time.Time) ([]*storage.NetworkFlow, *time.Time, error) {
@@ -84,12 +84,7 @@ func (fds *flowDataStoreImpl) adjustFlowsForGraphConfig(_ context.Context, flows
 }
 
 func (fds *flowDataStoreImpl) isDeletedDeployment(id string) bool {
-	if v, ok := fds.deletedDeploymentsCache.Get(id); ok {
-		deleted, _ := v.(bool)
-		return deleted
-	}
-	return false
-	return deleted
+	return fds.deletedDeploymentsCache.Contains(id)
 }
 
 func (fds *flowDataStoreImpl) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -84,11 +84,11 @@ func (fds *flowDataStoreImpl) adjustFlowsForGraphConfig(_ context.Context, flows
 }
 
 func (fds *flowDataStoreImpl) isDeletedDeployment(id string) bool {
-	v, ok := fds.deletedDeploymentsCache.Get(id)
-	if !ok {
-		return false
+	if v, ok := fds.deletedDeploymentsCache.Get(id); ok {
+		deleted, _ := v.(bool)
+		return deleted
 	}
-	deleted, _ := v.(bool)
+	return false
 	return deleted
 }
 

--- a/central/networkgraph/flow/datastore/singleton.go
+++ b/central/networkgraph/flow/datastore/singleton.go
@@ -16,7 +16,7 @@ var (
 // Singleton provides the instance of ClusterDataStore to use.
 func Singleton() ClusterDataStore {
 	once.Do(func() {
-		instance = NewClusterDataStore(singleton.Singleton(), graphConfigDS.Singleton(), networktree.Singleton(), cache.DeletedDeploymentCacheSingleton())
+		instance = NewClusterDataStore(singleton.Singleton(), graphConfigDS.Singleton(), networktree.Singleton(), cache.DeletedDeploymentsSingleton())
 	})
 	return instance
 }


### PR DESCRIPTION
### Description

DeletedDeployments is used as a naked type of expiring cache. It alsos stores boolean (always true). In this PR I've changed it store an empty struct to reduce used memory and exposed a smaller interface.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
