### PR TITLE
chore(ui): Declare scanInProgress as optional in compliance pages

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/ScanButton.js
+++ b/ui/apps/platform/src/Containers/Compliance/ScanButton.js
@@ -21,7 +21,7 @@ class ScanButton extends React.Component {
         addToast: PropTypes.func.isRequired,
         removeToast: PropTypes.func.isRequired,
         onScanTriggered: PropTypes.func,
-        scanInProgress: PropTypes.bool.isRequired,
+        scanInProgress: PropTypes.bool,
     };
 
     static defaultProps = {


### PR DESCRIPTION
### Description

Fix existing errors in browser console so it is easier to see recent regressions.

This is a more recent regression that most in the batch of chores.

### Problem

Error in browser console:

> Failed prop type: The prop `scanInProgress` is marked as required in `ScanButton`, but its value is `undefined`.

### Analysis

Added prop to 2 occurrences of `ScanButton` element in #8957

Which refetch queries:
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx#L42-L51
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx#L42-L51

But did not add prop to the other 2 occurrences:
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/Entity/Header.js#L43
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/List/Header.js#L46

During the initial scan, there are not links from compliance dashboard to these pages. During a re-scan, it is possible to visit these pages:
1. Click scan again, even though a scan is in progress.
2. Not see automatic update to results after a scan finishes.

### Solution

Weighing pro and con of possible changes:
1. Add `useComplianceRunStatuses` hook and `scanInProgress` prop to prevent item 1 above.
2. Provide `queriesToRefetchOnPollingComplete` prop for automatic update.

For now, declare `scanInProgress` prop as optional to describe current behavior.

Here are my thoughts about risk versus reward for additional changes:
1. Refrain from item 1 for now, because it changes adjacent lines of code to bug fix #11889
2. Refrain from item 2 for now, although it looks like main page query could become a prop of `Header` elements.
3. Investigate pro and con to deprecate, and then remove **Scan** buttons on entity and list pages to prevent possible confusion that they re-scan only the data for the page.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance and click **Scan environment** button.

    * See absence of error in browser console.

2. Click a link in **Passing standards across clusters** widget to visit controls page like:

    /main/compliance/controls?s[groupBy]=CLUSTER&s[standard]=CIS%20Kubernetes%20v1.5

    This is list header.

    * Before changes, see presence of error in browser console.
        ![List_Header_with_error](https://github.com/user-attachments/assets/db48057d-7a71-4e5d-b696-f1d617ab46c8)

    * After changes, see absence of error in browser console.

3. Click back, click **cluster** count button at upper edge, click a row to open side panel, and then click link to single page.

    This is entity header.

    Why do I need to refresh the page to see the error?

    * Before changes, see presence of error in browser console.
        ![Entity_Header_with_error](https://github.com/user-attachments/assets/8252c704-5f1d-445e-b868-f7883fbf997f)

    * After changes, see absence of error in browser console.

4. Visit /main/configmanagement

    * See absence of error in browser console.
