### PR TITLE
chore(ui): Fix PropTypes error for clusterRetentionInfo

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
@@ -181,7 +181,7 @@ ClusterSummary.propTypes = {
     }).isRequired,
     centralVersion: PropTypes.string.isRequired,
     clusterId: PropTypes.string.isRequired,
-    clusterRetentionInfo: PropTypes.oneOf([PropTypes.shape({}), PropTypes.null]).isRequired,
+    clusterRetentionInfo: PropTypes.shape({}),
     isManagerTypeNonConfigurable: PropTypes.bool.isRequired,
 };
 


### PR DESCRIPTION
### Description

Fix existing errors in browser console so it is easier to see recent regressions.

### Problem

Error in browser console:

> Failed prop type: The prop `clusterRetentionInfo` is marked as required in `ClusterSummary`, but its value is `null`.

### Analysis

1. GET /v1/clusters response includes `clusterIdToRetentionInfo: {}` property for /main/clusters page
2. GET /v1/clusters/id response includes `clusterRetentionInfo: null` property for /main/clusters/id page

My bad, multiple mistakes in `PropTypes.oneOf([PropTypes.shape({}), PropTypes.null]).isRequired`
* `PropTypes` does not have `null` property.
* `oneOf` tests values, not types as intended.
* `PropTypes.object` is more or less `typeof clusterRetendionInfo === 'object'` which includes `null` in JavaScript.

### Solution

If this `ClusterSummary` component had a future, I would rewrite PropTypes as TypeScript types.

Because redesign of clusters page might provde a component to replace it on cluster page, rewrite to work around limitations.
* `isRequired` excludes `null` as a value.
* TypeScript interprets either `PropTypes.object` or `isRequired` or both to exclude `null` as a value.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters and then click a row to visit cluster page.

    * Before changes, see presence of error in browser console.
        ![ClusterSummary_with_error](https://github.com/user-attachments/assets/8120991d-59d6-4755-bee3-83d2b0e7d2f9)

    * After changes, see absence of error in browser console.
