### PR TITLE
fix(scanner): upload correct offline vulns for 4.5+

### DIFF
--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -2,6 +2,11 @@ name: Scanner release offline vulnerability bundle update
 on:
   schedule:
     - cron: '0 */3 * * *'
+  pull_request: # TODO: remove prior to merge
+    types:
+    - opened
+    - reopened
+    - synchronize
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -54,7 +54,15 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Generate offline vulnerability bundle
-      run: .github/workflows/scripts/scanner-update-offline-bundle.sh "$ROX_PRODUCT_VERSION"
+      run: |
+        case "${{ env.ROX_PRODUCT_VERSION }}" in
+        4.4)
+            .github/workflows/scripts/scanner-update-offline-bundle.sh "${{ env.ROX_PRODUCT_VERSION }}" "vulns.json.zst"
+            ;;
+        *)
+            .github/workflows/scripts/scanner-update-offline-bundle.sh "${{ env.ROX_PRODUCT_VERSION }}" "vulnerabilities.zip"
+            ;;
+        esac
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -2,11 +2,6 @@ name: Scanner release offline vulnerability bundle update
 on:
   schedule:
     - cron: '0 */3 * * *'
-  pull_request: # TODO: remove prior to merge
-    types:
-    - opened
-    - reopened
-    - synchronize
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scripts/scanner-update-offline-bundle.sh
+++ b/.github/workflows/scripts/scanner-update-offline-bundle.sh
@@ -5,10 +5,15 @@ set -eu
 SCANNER_V4_DEFS_BUCKET="https://storage.googleapis.com/definitions.stackrox.io"
 ROX_PRODUCT_VERSION="$1"
 PRODUCT_VERSION="${ROX_PRODUCT_VERSION}.0"
+
 declare -A files_to_download=(
-    ["v4/vulns.json.zst"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulns.json.zst"
     ["v4/mapping.zip"]="https://definitions.stackrox.io/v4/redhat-repository-mappings/mapping.zip"
 )
+if [[ "$ROX_PRODUCT_VERSION" == "4.4" ]]; then
+    files_to_download["v4/vulns.json.zst"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulns.json.zst"
+else
+    files_to_download["v4/vulnerabilities.zip"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulnerabilities.zip"
+fi
 
 # Download the files
 for f in "${!files_to_download[@]}"; do

--- a/.github/workflows/scripts/scanner-update-offline-bundle.sh
+++ b/.github/workflows/scripts/scanner-update-offline-bundle.sh
@@ -5,15 +5,12 @@ set -eu
 SCANNER_V4_DEFS_BUCKET="https://storage.googleapis.com/definitions.stackrox.io"
 ROX_PRODUCT_VERSION="$1"
 PRODUCT_VERSION="${ROX_PRODUCT_VERSION}.0"
+VULNS_FILE_NAME="$2"
 
 declare -A files_to_download=(
+    ["v4/$VULNS_FILE_NAME"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/$VULNS_FILE_NAME"
     ["v4/mapping.zip"]="https://definitions.stackrox.io/v4/redhat-repository-mappings/mapping.zip"
 )
-if [[ "$ROX_PRODUCT_VERSION" == "4.4" ]]; then
-    files_to_download["v4/vulns.json.zst"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulns.json.zst"
-else
-    files_to_download["v4/vulnerabilities.zip"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulnerabilities.zip"
-fi
 
 # Download the files
 for f in "${!files_to_download[@]}"; do


### PR DESCRIPTION
### Description

`Scanner release offline vulnerability bundle update` was failing because in 4.5 we switched over from a `vulns.json.zst` file to a `vulnerabilities.zip` file. This was not accounted for in the offline vuln updater CI job. See https://github.com/stackrox/stackrox/actions/runs/9893807082/job/27329862714 for an example.

This PR checks for `vulns.json.zst` in 4.4, otherwise `vulnerabilities.zip`.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

Made this run on the PR prior to merge. You can see https://definitions.stackrox.io/v4/offline-bundles/scanner-v4-defs-4.5.zip is there, and it did not exist prior to this PR.