### PR TITLE
ROX-22865: Change loading to isLoading for useRestQuery

### DIFF
--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -10,11 +10,11 @@ import { scannerV4ImageIntegrationType } from 'types/imageIntegration.proto';
 
 function ScannerV4IntegrationBanner() {
     const { version } = useMetadata();
-    const { data, loading, error } = useRestQuery(fetchImageIntegrations);
+    const { data, isLoading, error } = useRestQuery(fetchImageIntegrations);
     const branding = getProductBranding();
 
     // Don't show the banner if we don't have successful responses
-    if (!data || loading || error || !version) {
+    if (!data || isLoading || error || !version) {
         return null;
     }
 

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -93,7 +93,7 @@ function ListeningEndpointsPage() {
 
     const countQuery = useRestQuery(deploymentCountFetcher);
 
-    const { data, error, loading } = useDeploymentListeningEndpoints(
+    const { data, error, isLoading } = useDeploymentListeningEndpoints(
         searchFilter,
         sortOption,
         page,
@@ -238,12 +238,12 @@ function ListeningEndpointsPage() {
                             </EmptyStateTemplate>
                         </Bullseye>
                     )}
-                    {loading && (
+                    {isLoading && (
                         <Bullseye>
                             <Spinner aria-label="Loading listening endpoints for deployments" />
                         </Bullseye>
                     )}
-                    {!error && !loading && data && (
+                    {!error && !isLoading && data && (
                         <>
                             {data.length === 0 ? (
                                 <Bullseye>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -21,7 +21,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
 
     const {
         data: dataForFetch,
-        loading: isFetching,
+        isLoading: isFetching,
         error: errorForFetch,
     } = useRestQuery(fetchClusterInitBundles);
 

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -38,7 +38,7 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
     const {
         data: dataForFetch,
         error: errorForFetch,
-        loading: isFetching,
+        isLoading: isFetching,
         refetch,
     } = useRestQuery(fetchClusterInitBundles);
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -81,7 +81,7 @@ function CollectionsFormModal({
         openSelect: openDrawer,
     } = useSelectToggle(isXLargeScreen);
 
-    const { data, loading, error } = useCollection(
+    const { data, isLoading, error } = useCollection(
         modalAction.type === 'view' ? modalAction.collectionId : undefined
     );
 
@@ -99,7 +99,7 @@ function CollectionsFormModal({
             </Bullseye>
         );
         modalTitle = 'Collection error';
-    } else if (loading) {
+    } else if (isLoading) {
         content = (
             <Bullseye className="pf-v5-u-p-2xl">
                 <Spinner />
@@ -126,7 +126,7 @@ function CollectionsFormModal({
     }
 
     const modalHeaderButtons =
-        error || loading ? (
+        error || isLoading ? (
             ''
         ) : (
             <>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -71,7 +71,7 @@ function CollectionsFormPage({
 
     const { analyticsTrack } = useAnalytics();
 
-    const { data, loading, error } = useCollection(collectionId);
+    const { data, isLoading, error } = useCollection(collectionId);
 
     const { toasts, addToast, removeToast } = useToasts();
 
@@ -191,7 +191,7 @@ function CollectionsFormPage({
                 />
             </>
         );
-    } else if (loading) {
+    } else if (isLoading) {
         content = (
             <Bullseye>
                 <Spinner />

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -52,7 +52,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
     );
     const {
         data: listData,
-        loading: listLoading,
+        isLoading: listLoading,
         error: listError,
         refetch: listRefetch,
     } = useRestQuery(listQuery);
@@ -60,7 +60,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
     const countQuery = useCallback(() => getCollectionCount(searchFilter), [searchFilter]);
     const {
         data: countData,
-        loading: countLoading,
+        isLoading: countLoading,
         error: countError,
         refetch: countRefetch,
     } = useRestQuery(countQuery);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -78,7 +78,7 @@ function CheckDetails() {
     );
     const {
         data: checkStatsResponse,
-        loading: isLoadingCheckStats,
+        isLoading: isLoadingCheckStats,
         error: checkStatsError,
     } = useRestQuery(fetchCheckStats);
 
@@ -88,7 +88,7 @@ function CheckDetails() {
     );
     const {
         data: checkDetailsResponse,
-        loading: isLoadingCheckDetails,
+        isLoading: isLoadingCheckDetails,
         error: CheckDetailsError,
     } = useRestQuery(fetchCheckDetails);
 
@@ -107,7 +107,7 @@ function CheckDetails() {
     }, [page, perPage, checkName, profileName, sortOption, searchFilter, selectedScanConfigName]);
     const {
         data: checkResultsResponse,
-        loading: isLoadingCheckResults,
+        isLoading: isLoadingCheckResults,
         error: checkResultsError,
     } = useRestQuery(fetchCheckResults);
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -71,7 +71,7 @@ function ClusterDetailsPage() {
     );
     const {
         data: scanConfigProfilesResponse,
-        loading: isLoadingScanConfigProfiles,
+        isLoading: isLoadingScanConfigProfiles,
         error: scanConfigProfilesError,
     } = useRestQuery(fetchProfilesStats);
 
@@ -89,7 +89,7 @@ function ClusterDetailsPage() {
     }, [clusterId, page, perPage, profileName, sortOption, searchFilter]);
     const {
         data: checkResultsResponse,
-        loading: isLoadingCheckResults,
+        isLoading: isLoadingCheckResults,
         error: checkResultsError,
     } = useRestQuery(fetchCheckResults);
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ComplianceProfilesProvider.tsx
@@ -36,11 +36,7 @@ function ComplianceProfilesProvider({ children }: { children: React.ReactNode })
         () => listComplianceScanConfigProfiles(createScanConfigFilter(selectedScanConfigName)),
         [selectedScanConfigName]
     );
-    const {
-        data: scanConfigProfilesResponse,
-        loading: isLoading,
-        error,
-    } = useRestQuery(fetchProfiles);
+    const { data: scanConfigProfilesResponse, isLoading, error } = useRestQuery(fetchProfiles);
 
     const contextValue: ComplianceProfilesContextValue = {
         scanConfigProfilesResponse: scanConfigProfilesResponse ?? defaultProfilesResponse,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -85,7 +85,7 @@ function CoveragesPage() {
         return response;
     }, [profileName]);
 
-    const { loading: isLoadingProfilesStats, error: profilesStatsError } =
+    const { isLoading: isLoadingProfilesStats, error: profilesStatsError } =
         useRestQuery(fetchProfilesStats);
 
     function handleProfilesToggleChange(selectedProfile: string) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -44,7 +44,7 @@ function ProfileChecksPage() {
             searchFilter: combinedFilter,
         });
     }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
-    const { data: profileChecks, loading: isLoading, error } = useRestQuery(fetchProfileChecks);
+    const { data: profileChecks, isLoading, error } = useRestQuery(fetchProfileChecks);
 
     const tableState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -45,7 +45,7 @@ function ProfileClustersPage() {
             searchFilter: combinedFilter,
         });
     }, [page, perPage, profileName, sortOption, searchFilter, selectedScanConfigName]);
-    const { data: profileClusters, loading: isLoading, error } = useRestQuery(fetchProfileClusters);
+    const { data: profileClusters, isLoading, error } = useRestQuery(fetchProfileClusters);
 
     const tableState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ScanConfigurationsProvider.tsx
@@ -47,7 +47,7 @@ function ScanConfigurationsProvider({ children }: { children: React.ReactNode })
     const fetchScanConfigurations = useCallback(() => listComplianceScanConfigurations(), []);
     const {
         data: scanConfigurationsResponse,
-        loading: isLoading,
+        isLoading,
         error,
     } = useRestQuery(fetchScanConfigurations);
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigDetailPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigDetailPage.tsx
@@ -24,17 +24,17 @@ function ScanConfigDetailPage({
         return { request, cancel };
     }, [scanConfigId]);
 
-    const { data, loading, error } = useRestQuery(scanConfigFetcher);
+    const { data, isLoading, error } = useRestQuery(scanConfigFetcher);
 
     if (pageAction === 'edit' && hasWriteAccessForCompliance) {
-        return <EditScanConfigDetail scanConfig={data} isLoading={loading} error={error} />;
+        return <EditScanConfigDetail scanConfig={data} isLoading={isLoading} error={error} />;
     }
 
     return (
         <ViewScanConfigDetail
             hasWriteAccessForCompliance={hasWriteAccessForCompliance}
             scanConfig={data}
-            isLoading={loading}
+            isLoading={isLoading}
             error={error}
         />
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -93,7 +93,7 @@ function ScanConfigsTablePage({
         () => listComplianceScanConfigurations(sortOption, page - 1, perPage),
         [sortOption, page, perPage]
     );
-    const { data: listData, loading: isLoading, error, refetch } = useRestQuery(listQuery);
+    const { data: listData, isLoading, error, refetch } = useRestQuery(listQuery);
 
     const { alertObj, setAlertObj, clearAlertObj } = useAlert();
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -47,7 +47,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
     const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
 
     const listClustersQuery = useCallback(() => listComplianceIntegrations(), []);
-    const { data: clusters, loading: isFetchingClusters } = useRestQuery(listClustersQuery);
+    const { data: clusters, isLoading: isFetchingClusters } = useRestQuery(listClustersQuery);
 
     const listProfilesQuery = useCallback(() => {
         if (clustersUsedForProfileData.length > 0) {
@@ -55,7 +55,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
         }
         return Promise.resolve([]);
     }, [clustersUsedForProfileData]);
-    const { data: profiles, loading: isFetchingProfiles } = useRestQuery(listProfilesQuery);
+    const { data: profiles, isLoading: isFetchingProfiles } = useRestQuery(listProfilesQuery);
 
     async function onSave() {
         setIsCreating(true);

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRisk.tsx
@@ -12,11 +12,11 @@ import NoDataEmptyState from './NoDataEmptyState';
 
 function DeploymentsAtMostRisk() {
     const { searchFilter } = useURLSearch();
-    const { data: deployments, loading, error } = useDeploymentsAtRisk(searchFilter);
+    const { data: deployments, isLoading, error } = useDeploymentsAtRisk(searchFilter);
     const urlQueryString = getUrlQueryStringForSearchFilter(searchFilter);
     return (
         <WidgetCard
-            isLoading={loading}
+            isLoading={isLoading}
             error={error}
             header={
                 <Flex direction={{ default: 'row' }}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.tsx
@@ -59,7 +59,7 @@ function ViolationsByPolicyCategory() {
         queryFilter['Lifecycle Stage'] = LIFECYCLE_STAGES.RUNTIME;
     }
     const query = getRequestQueryStringForSearchFilter(queryFilter);
-    const { data: alertGroups, loading, error } = useAlertGroups(query, 'CATEGORY');
+    const { data: alertGroups, isLoading, error } = useAlertGroups(query, 'CATEGORY');
 
     const isOptionsChanged =
         lifecycle !== defaultConfig.lifecycle ||
@@ -69,7 +69,7 @@ function ViolationsByPolicyCategory() {
 
     return (
         <WidgetCard
-            isLoading={loading}
+            isLoading={isLoading}
             error={error}
             header={
                 <Flex direction={{ default: 'row' }}>

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/useVulnerabilitiesExceptionConfig.ts
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/useVulnerabilitiesExceptionConfig.ts
@@ -25,7 +25,7 @@ export function useVulnerabilitiesExceptionConfig(): UseVulnerabilitiesException
 
     return {
         config: getConfigRequest.data ?? undefined,
-        isConfigLoading: getConfigRequest.loading,
+        isConfigLoading: getConfigRequest.isLoading,
         configLoadError: getConfigRequest.error,
         isUpdateInProgress: updateConfigMutation.isLoading,
         updateConfig: updateConfigMutation.mutate,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -89,7 +89,7 @@ function ApprovedDeferrals() {
         [searchFilter, sortOption, page, perPage]
     );
     // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
-    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -82,7 +82,7 @@ function ApprovedFalsePositives() {
         [searchFilter, sortOption, page, perPage]
     );
     // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
-    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -86,7 +86,7 @@ function DeniedRequests() {
         [searchFilter, sortOption, page, perPage]
     );
     // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
-    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -92,7 +92,7 @@ function ExceptionRequestDetailsPage() {
     );
     const {
         data: vulnerabilityException,
-        loading,
+        isLoading,
         error,
         refetch,
     } = useRestQuery(vulnerabilityExceptionByIdFn);
@@ -121,7 +121,7 @@ function ExceptionRequestDetailsPage() {
         setSuccessMessage(`The vulnerability request was successfully updated.`);
     }
 
-    if (loading && !vulnerabilityException) {
+    if (isLoading && !vulnerabilityException) {
         return (
             <Bullseye>
                 <Spinner />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -87,7 +87,7 @@ function PendingApprovals() {
         [searchFilter, sortOption, page, perPage]
     );
     // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
-    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -135,7 +135,7 @@ function WatchedImagesModal({
                     watchedImagesRequest={currentWatchedImagesRequest}
                 />
                 <Divider component="div" />
-                {currentWatchedImagesRequest.loading && !currentWatchedImagesRequest.data && (
+                {currentWatchedImagesRequest.isLoading && !currentWatchedImagesRequest.data && (
                     <Bullseye>
                         <Spinner aria-label="Loading current watched images" />
                     </Bullseye>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExpiryField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExpiryField.tsx
@@ -34,14 +34,14 @@ export type ExpiryFieldProps = {
 };
 
 function ExpiryField({ formik }: ExpiryFieldProps) {
-    const { data: config, loading, error } = useRestQuery(fetchVulnerabilitiesExceptionConfig);
+    const { data: config, isLoading, error } = useRestQuery(fetchVulnerabilitiesExceptionConfig);
     const { values, errors, setValues } = formik;
 
     function setExpiry(expiry: DeferralValues['expiry']) {
         return setValues((prev) => ({ ...prev, expiry }));
     }
 
-    if (loading || !config) {
+    if (isLoading || !config) {
         return (
             <Bullseye>
                 <Spinner />

--- a/ui/apps/platform/src/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/hooks/useRestQuery.ts
@@ -4,7 +4,7 @@ import { CancellableRequest, isCancellableRequest } from 'services/cancellationU
 
 export type UseRestQueryReturn<ReturnType> = {
     data: ReturnType | undefined;
-    loading: boolean;
+    isLoading: boolean;
     error?: Error;
     refetch: () => void;
 };
@@ -13,7 +13,7 @@ export default function useRestQuery<ReturnType>(
     requestFn: () => CancellableRequest<ReturnType> | Promise<ReturnType>
 ): UseRestQueryReturn<ReturnType> {
     const [data, setData] = useState<ReturnType>();
-    const [loading, setLoading] = useState<boolean>(true);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<Error | undefined>();
 
     const execFetch = useCallback(() => {
@@ -23,19 +23,19 @@ export default function useRestQuery<ReturnType>(
         const cancel = isCancellableRequest(requestResult) ? requestResult.cancel : noop;
 
         setError(undefined);
-        setLoading(true);
+        setIsLoading(true);
 
         request
             .then((result) => {
                 if (isMounted) {
                     setData(result);
-                    setLoading(false);
+                    setIsLoading(false);
                     setError(undefined);
                 }
             })
             .catch((err) => {
                 if (isMounted) {
-                    setLoading(false);
+                    setIsLoading(false);
                     setError(err);
                 }
             });
@@ -48,5 +48,5 @@ export default function useRestQuery<ReturnType>(
 
     useEffect(execFetch, [execFetch]);
 
-    return { data, loading, error, refetch: execFetch };
+    return { data, isLoading, error, refetch: execFetch };
 }


### PR DESCRIPTION
### Description

Finally have time to take care of a few tech debt items. This PR involves rewording `loading` to `isLoading` to adhere more to the naming conventions we see in libraries like Apollo GraphQL.

### User-facing documentation

- [ ] CHANGELOG is updated
- [X] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [X] Documentation is not needed

### Testing

- [X] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [X] contributed **no automated tests**

It's just a wording change. We will just double-check that all tests pass as usual.

#### How I validated my change

1. Checking that there are no apparent issues in the UI
2. No linting errors
