### PR TITLE
ROX-25290: Add test name to performance test meta data

### DIFF
--- a/tests/performance/scale/tests/kube-burner/cluster-density/run-workload.sh
+++ b/tests/performance/scale/tests/kube-burner/cluster-density/run-workload.sh
@@ -72,6 +72,7 @@ function run_workload() {
     template="${7}"
 
     local kube_burner_path="${8:-kube-burner}"
+    local test_name="${9:-}"
 
     local script_dir
     script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
@@ -83,6 +84,7 @@ function run_workload() {
     echo "Deployments per namespace: ${num_deployments}"
     echo "Pods per deployment: ${num_pods}"
     echo "Secrets and Configmaps per deployment: ${num_configs}"
+    echo "Test name: ${test_name}"
 
     local prometheus_url
     prometheus_url="https://$(oc get route --namespace openshift-monitoring prometheus-k8s --output jsonpath='{.spec.host}' | xargs)"
@@ -103,15 +105,22 @@ function run_workload() {
     local run_uuid
     run_uuid="node-${num_nodes}--${node_type}--run-$(date +%s)"
 
-    local metadata_path="user-metadata-${run_uuid}.yml"
+    local metadata_path="${script_dir}/user-metadata-${run_uuid}.yml"
 
-    go run ../../metadata-collector/main.go \
-        --namespaces-count "${num_namespaces}" \
-        --deployments-per-namespace-count "${num_deployments}" \
-        --pods-per-deployment-count "${num_pods}" \
-        --configs-per-deployment-count "${num_configs}" \
-        --test-workload-type "${template}" \
+    metadata=(
+        --namespaces-count "${num_namespaces}"
+        --deployments-per-namespace-count "${num_deployments}"
+        --pods-per-deployment-count "${num_pods}"
+        --configs-per-deployment-count "${num_configs}"
+        --test-workload-type "${template}"
         --output-file "${metadata_path}"
+    )
+
+    if [[ -n "${test_name:-}" ]]; then
+        metadata+=(--test-name "${test_name}")
+    fi
+
+    go run ../../metadata-collector/main.go "${metadata[@]}"
 
     echo "--- Starting kube-burner"
     "${kube_burner_path}" init \
@@ -175,6 +184,10 @@ function main() {
             ;;
         "--kube-burner-path")
             kube_burner_path="${2:-}"
+            shift
+            ;;
+	"--test-name")
+	    test_name="${2:-}"
             shift
             ;;
         "--help")

--- a/tests/performance/scale/tests/kube-burner/cluster-density/run-workload.sh
+++ b/tests/performance/scale/tests/kube-burner/cluster-density/run-workload.sh
@@ -29,6 +29,7 @@ OPTION:
   --num-patches        Number of times the deployments will be patched. (default 100)
                        This is only applied if the used template has a job type patch.
   --template           Indicates the template to the config to be used by kube-burner. (default cluster-density-template.yml)
+  --test-name          The test name
   --kube-burner-path   Path to kube-burner executable. (default: kube-burner)
   --help               Prints help information.
 
@@ -218,7 +219,8 @@ function main() {
       "${num_configs}" \
       "${num_patches}" \
       "${template}" \
-      "${kube_burner_path}"
+      "${kube_burner_path}" \
+      "${test_name:-}"
 }
 
 main "$@"

--- a/tests/performance/scale/tests/metadata-collector/main.go
+++ b/tests/performance/scale/tests/metadata-collector/main.go
@@ -64,6 +64,7 @@ var (
 	workerNodesCount             = newMetadataIntField("workerNodesCount", true, "number of worker nodes on the test cluster")
 	workerNodesKernelVersion     = newMetadataStringField("workerNodesKernelVersion", false, "kernel version used on the worker nodes on the test cluster")
 	workerNodesType              = newMetadataStringField("workerNodesType", true, "type of the worker nodes used on the test cluster")
+	testName                     = newMetadataStringField("testName", false, "The name of the test. Multiple tests that differ by the number namespaces, deployments, and pods can have the same name")
 
 	allMetadata = make(map[string]interface{}, len(metadataFields))
 )
@@ -276,6 +277,20 @@ func getGitRevision() (string, error) {
 	return hashString, nil
 }
 
+func truncateVersion(version string) string {
+    // Version should match x.y
+    re := regexp.MustCompile(`^\d+\.\d+`)
+
+    match := re.FindString(version)
+
+    // If the version is valid return it. Otherwise return 0.0
+    if match != "" {
+        return match
+    }
+    return "0.0"
+}
+
+
 func collectClusterInformation(kubeConfigurationPath string) error {
 	config, configErr := clientcmd.BuildConfigFromFlags("", kubeConfigurationPath)
 	if configErr != nil {
@@ -293,7 +308,7 @@ func collectClusterInformation(kubeConfigurationPath string) error {
 	allMetadata[clusterType.Name] = clusterMetadata.ClusterType
 	allMetadata[infraNodesCount.Name] = clusterMetadata.InfraNodesCount
 	allMetadata[infraNodesType.Name] = clusterMetadata.InfraNodesType
-	allMetadata[k8sVersion.Name] = clusterMetadata.K8SVersion
+	allMetadata[k8sVersion.Name] = truncateVersion(clusterMetadata.K8SVersion)
 	allMetadata[masterNodesCount.Name] = clusterMetadata.MasterNodesCount
 	allMetadata[masterNodesType.Name] = clusterMetadata.MasterNodesType
 	allMetadata[ocpMajorVersion.Name] = clusterMetadata.OCPMajorVersion

--- a/tests/performance/scale/tests/metadata-collector/main.go
+++ b/tests/performance/scale/tests/metadata-collector/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -279,13 +280,13 @@ func getGitRevision() (string, error) {
 
 func truncateVersion(version string) string {
     // Version should match x.y
-    re := regexp.MustCompile(`^\d+\.\d+`)
+    re := regexp.MustCompile(`^[vV]?(\d+\.\d+)`)
 
-    match := re.FindString(version)
+    match := re.FindStringSubmatch(version)
 
     // If the version is valid return it. Otherwise return 0.0
-    if match != "" {
-        return match
+    if len(match) > 1 {
+        return match[1]
     }
     return "0.0"
 }


### PR DESCRIPTION
### Description

Makes it possible to add a test name to performance test metadata. Many related tests can have the same name. This makes it possible to group tests and do analysis on groups of tests. For example tests with different numbers of namespaces, deployments per namespace, and pods per deployment, but everything else kept the same can have the same test name.

A couple of other minor changes are also made.

A full path is used for the metadata path in the `run-workload.sh` script.

Also if the k8s version does not match x.y it is truncated to x.y in the metadata.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

~~- [ ] CHANGELOG is updated~~
- [x] CHANGELOG update is not needed
~~- [ ] Documentation PR is created and linked above~~
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

~~- [ ] added unit tests~~
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~
- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

```
git checkout jv-ROX-25290-add-test-name-to-performance-test-meta-data

infractl create openshift-4-perf-scale jv-07-17-name --arg master-node-type=n2-standard-16 --arg worker-node-type=c2-standard-8 --description 'Perf testing cluster' --download-dir=/tmp/artifacts-jv-07-17-name

export KUBECONFIG=/tmp/artifacts-jv-07-17-name/kubeconfig

#### Running with a test name

./run-workload.sh --kube-burner-path "${KUBE_BURNER_PATH}" --num-namespaces 10 --num-deployments 20 --num-pods 1 --test-name fake-test
```

Check the metadata locally
```
$ cat user-metadata-node-9--c2-standard-8--run-1721324547.yml
clusterType: self-managed
configsPerDeploymentCount: 4
deploymentsPerNamespaceCount: 20
infraNodesCount: 0
infraNodesType: ""
k8sVersion: "1.29"
masterNodesCount: 3
masterNodesType: n2-standard-16
namespacesCount: 10
ocpMajorVersion: "4.16"
ocpVersion: 4.16.2
otherNodesCount: 0
platform: GCP
podsPerDeploymentCount: 1
sdnType: OVNKubernetes
testName: fake-test
testWorkloadType: cluster-density-template.yml
testWorkloadVersion: 79800eaecc15f9c95e7232bdca104e45d48d87d1-dirty
totalNodes: 12
workerNodesCount: 9
workerNodesType: c2-standard-8
```

Check the metadata in OpenSearch. Ran the following in a colab notebook

```
!python -m pip install 'awswrangler[opensearch]' --quiet --progress-bar off

import sys
import numpy as np
import pandas as pd
import awswrangler as wr
import plotly.express as px
import matplotlib.pyplot as plt


[redacted credentials]

  df = wr.opensearch.search_by_sql(
        aws_os_client,
        sql_query=f"""
          SELECT
            metadata.testName, metadata.k8sVersion
          FROM
            kube-burner
          WHERE
          uuid = 'node-9--c2-standard-8--run-1721324547'
            and metricName = 'jobSummary'
          ORDER BY timestamp DESC
        """
      )
  df.head()
```
The output was
```
_index	_id		                 metadata.k8sVersion	         metadata.testName
0	        kube-burner		1.29	                                 fake-test
```

#### Running without a test name

```
$ ./run-workload.sh --kube-burner-path "${KUBE_BURNER_PATH}" --num-namespaces 10 --num-deployments 20 --num-pods 1
```

Check the metadata locally

```
$ cat user-metadata-node-9--c2-standard-8--run-1721345892.yml
clusterType: self-managed
configsPerDeploymentCount: 4
deploymentsPerNamespaceCount: 20
infraNodesCount: 0
infraNodesType: ""
k8sVersion: "1.29"
masterNodesCount: 3
masterNodesType: n2-standard-16
namespacesCount: 10
ocpMajorVersion: "4.16"
ocpVersion: 4.16.2
otherNodesCount: 0
platform: GCP
podsPerDeploymentCount: 1
sdnType: OVNKubernetes
testWorkloadType: cluster-density-template.yml
testWorkloadVersion: 79800eaecc15f9c95e7232bdca104e45d48d87d1-dirty
totalNodes: 12
workerNodesCount: 9
workerNodesType: c2-standard-8
```

Checked the metadata in OpenSearch by running the same notebook, but with the new uuid
```
_index	_id		                 metadata.k8sVersion
0	        kube-burner		1.29	                       
```
