### PR TITLE
ROX-21117: Restrict Scanner V4 SCCs

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
@@ -24,6 +24,7 @@ rules:
   - securitycontextconstraints
   resourceNames:
   - nonroot-v2
+  - restricted-v2
   verbs:
   - use
 

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -26,9 +26,6 @@ spec:
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-indexer") | nindent 8 }}
       annotations:
         {{- $annotations := dict "traffic.sidecar.istio.io/excludeInboundPorts" "8443" -}}
-        {{- if eq ._rox.env.openshift 4 }}
-          {{- $_ := set $annotations "openshift.io/required-scc" "nonroot-v2" -}}
-        {{- end }}
         {{- include "srox.podAnnotations" (list . "deployment" "scanner-v4-indexer" $annotations) | nindent 8 }}
     spec:
       {{- if ._rox.scannerV4.indexer._nodeSelector }}
@@ -97,7 +94,6 @@ spec:
           capabilities:
             drop: ["NET_RAW"]
           runAsNonRoot: true
-          runAsUser: 65534
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -135,7 +131,6 @@ spec:
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
       serviceAccountName: scanner-v4
       volumes:
       - name: additional-ca-volume

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-indexer") | nindent 8 }}
       annotations:
         {{- $annotations := dict "traffic.sidecar.istio.io/excludeInboundPorts" "8443" -}}
+        {{- if eq ._rox.env.openshift 4 }}
+          {{- $_ := set $annotations "openshift.io/required-scc" "restricted-v2" -}}
+        {{- end }}
         {{- include "srox.podAnnotations" (list . "deployment" "scanner-v4-indexer" $annotations) | nindent 8 }}
     spec:
       {{- if ._rox.scannerV4.indexer._nodeSelector }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -26,9 +26,6 @@ spec:
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-matcher") | nindent 8 }}
       annotations:
         {{- $annotations := dict "traffic.sidecar.istio.io/excludeInboundPorts" "8443" -}}
-        {{- if eq ._rox.env.openshift 4 }}
-          {{- $_ := set $annotations "openshift.io/required-scc" "nonroot-v2" -}}
-        {{- end }}
         {{- include "srox.podAnnotations" (list . "deployment" "scanner-v4-matcher" $annotations) | nindent 8 }}
     spec:
       {{- if ._rox.scannerV4.matcher._nodeSelector }}
@@ -98,7 +95,6 @@ spec:
           capabilities:
             drop: ["NET_RAW"]
           runAsNonRoot: true
-          runAsUser: 65534
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -136,7 +132,6 @@ spec:
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
       serviceAccountName: scanner-v4
       volumes:
       - name: additional-ca-volume

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-matcher") | nindent 8 }}
       annotations:
         {{- $annotations := dict "traffic.sidecar.istio.io/excludeInboundPorts" "8443" -}}
+        {{- if eq ._rox.env.openshift 4 }}
+          {{- $_ := set $annotations "openshift.io/required-scc" "restricted-v2" -}}
+        {{- end }}
         {{- include "srox.podAnnotations" (list . "deployment" "scanner-v4-matcher" $annotations) | nindent 8 }}
     spec:
       {{- if ._rox.scannerV4.matcher._nodeSelector }}


### PR DESCRIPTION
### Description

Currently the three Scanner V4 pods (indexer, matcher and db) contain security context settings, which render them incompatible with the `restricted-v2` SecurityContextConstraint, instead they are running under the `nonroot-v2` SCC, which is less restrictive than `restricted-v2`.

With certain modifications to the way the containers are set up to run we can satisfy the hardened requirements of `restricted-v2` for `indexer` and `matcher`, but not for `db` (`db` will continue running as `nonroot-v2` for the time being).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

As far as I know we currently don't mention the details about the SCC configuration in our documentation. Hence nothing would need to be updated.

### Testing

- [x] inspected CI results (currently observed failures are due to problems with cluster allocation)

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)

- [x] contributed **no automated tests**

CI plus manual tests should be sufficient to test for regressions.

#### How I validated my change

I have deployed central w/ scanner V4 to OpenShift 4.16 clusters (infra) and verified that the assigned SCCs are `restricted-v2` for indexer and matcher pods:

```
for a in matcher indexer db; do
  kubectl get pod -l "app=scanner-v4-${a}" -o jsonpath="{range .items[*]}{.metadata.name}{\": \"}{.metadata.annotations.openshift\.io\/scc}{\"\n\"}{end}"
done
```

Furthermore I have verified that the logs of all scanner V4 pods do not contain errors.
