### PR TITLE
fix(CI): Remove pause-reconcile annotation before cleanup

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -889,7 +889,7 @@ remove_existing_stackrox_resources() {
                 centrals.platform.stackrox.io \
                 stackrox-central-services \
                 stackrox.io/pause-reconcile-
-            
+
             kubectl get centrals -o name | while read -r central; do
                 kubectl -n "${namespace}" delete --ignore-not-found --wait "${central}"
                 kubectl wait -n "${namespace}"  --for=delete deployment/central --timeout=60s

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -883,6 +883,13 @@ remove_existing_stackrox_resources() {
             done
         fi
         if [[ "${centrals_supported}" == "true" ]]; then
+            # Remove stackrox.io/pause-reconcile annotation since it prevents
+            # deletion of central in static clusters
+               kubectl annotate -n "${namespace}" \
+                centrals.platform.stackrox.io \
+                stackrox-central-services \
+                stackrox.io/pause-reconcile-
+            
             kubectl get centrals -o name | while read -r central; do
                 kubectl -n "${namespace}" delete --ignore-not-found --wait "${central}"
                 kubectl wait -n "${namespace}"  --for=delete deployment/central --timeout=60s

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -876,6 +876,13 @@ remove_existing_stackrox_resources() {
     (
         # Delete StackRox CRs first to give the operator a chance to properly finish the resource cleanup.
         if [[ "${securedclusters_supported}" == "true" ]]; then
+            # Remove stackrox.io/pause-reconcile annotation since it prevents
+            # deletion of secured cluster in static clusters
+            kubectl annotate -n stackrox \
+            securedclusters.platform.stackrox.io \
+            stackrox-secured-cluster-services \
+            stackrox.io/pause-reconcile=true
+
             kubectl get securedclusters -o name | while read -r securedcluster; do
                 kubectl -n "${namespace}" delete --ignore-not-found --wait "${securedcluster}"
                 # Wait until resources are actually deleted.

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -881,7 +881,7 @@ remove_existing_stackrox_resources() {
             kubectl annotate -n stackrox \
             securedclusters.platform.stackrox.io \
             stackrox-secured-cluster-services \
-            stackrox.io/pause-reconcile=true
+            stackrox.io/pause-reconcile-
 
             kubectl get securedclusters -o name | while read -r securedcluster; do
                 kubectl -n "${namespace}" delete --ignore-not-found --wait "${securedcluster}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -885,7 +885,7 @@ remove_existing_stackrox_resources() {
         if [[ "${centrals_supported}" == "true" ]]; then
             # Remove stackrox.io/pause-reconcile annotation since it prevents
             # deletion of central in static clusters
-               kubectl annotate -n "${namespace}" \
+               kubectl annotate -n stackrox \
                 centrals.platform.stackrox.io \
                 stackrox-central-services \
                 stackrox.io/pause-reconcile-


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

Setting pause-reconcile annotation to `true` causes problem when deleting central and secured-cluster services in static clusters(ppc64le) before deploying and running tests.
This PR removes the annotation before cleanup of central and secured-cluster is performed. 

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG is updated
- [ ] CHANGELOG update is not needed
- [ ] Documentation PR is created and linked above
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

Change validated by running the change against an ocp 4.16 ppc64le cluster.
