### PR TITLE
fix(sensor): remove dead image cache

### DIFF
--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	grpcPkg "github.com/stackrox/rox/pkg/grpc"
@@ -16,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registrymirror"
 	"github.com/stackrox/rox/sensor/common"
-	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"google.golang.org/grpc"
@@ -43,9 +41,8 @@ type ServiceComponent interface {
 }
 
 // NewService returns the ImageService API for the Admission Controller to use.
-func NewService(imageCache imagecacheutils.ImageCache, registryStore registryStore, mirrorStore registrymirror.Store) ServiceComponent {
+func NewService(registryStore registryStore, mirrorStore registrymirror.Store) ServiceComponent {
 	return &serviceImpl{
-		imageCache:    imageCache,
 		registryStore: registryStore,
 		localScan:     scan.NewLocalScan(registryStore, mirrorStore),
 		centralReady:  concurrency.NewSignal(),
@@ -56,7 +53,6 @@ type serviceImpl struct {
 	sensor.UnimplementedImageServiceServer
 
 	centralClient centralClient
-	imageCache    imagecacheutils.ImageCache
 	registryStore registryStore
 	localScan     localScan
 	centralReady  concurrency.Signal
@@ -67,16 +63,6 @@ func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {
 }
 
 func (s *serviceImpl) GetImage(ctx context.Context, req *sensor.GetImageRequest) (*sensor.GetImageResponse, error) {
-	if id := req.GetImage().GetId(); id != "" {
-		v, _ := s.imageCache.Get(imagecacheutils.GetImageCacheKey(req.GetImage()))
-		img, _ := v.(*storage.Image)
-		if img != nil && (!req.GetScanInline() || img.GetScan() != nil) {
-			return &sensor.GetImageResponse{
-				Image: img,
-			}, nil
-		}
-	}
-
 	log.Debugf("scan request from admission control: %+v", req)
 
 	// Beyond this point we need to be able to reach central

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -129,7 +129,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, reprocessorHandler, k8sNodeName.Setting(), cfg.traceWriter, storeProvider, cfg.eventPipelineQueueSize, pubSub)
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
-	imageService := image.NewService(imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors())
+	imageService := image.NewService(storeProvider.Registries(), storeProvider.RegistryMirrors())
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
 
 	// Create Process Pipeline


### PR DESCRIPTION
### Description

This PR removes image cache usage from sensor as it always results with miss due to a bad expected type. Here we try to get `*storage.Image` while the only values are `cacheValue`. As type assertion fails, image is always `nil` which result in a miss.

There are only 2 places that adds to image cache:

https://github.com/stackrox/stackrox/blob/7d64f4eb4e1eecac3fcd8f09bbd31266d0b12910/sensor/common/detector/enricher.go#L292

https://github.com/stackrox/stackrox/blob/7d64f4eb4e1eecac3fcd8f09bbd31266d0b12910/sensor/common/detector/detector.go#L337

I discovered this issue while working on adding a generic types to a cache
- https://github.com/stackrox/stackrox/pull/11925#discussion_r1673965036
- https://github.com/stackrox/stackrox/pull/11924
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
