### PR TITLE
ROX-25299:  add metrics to see dead tuple growth

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -99,4 +99,18 @@ var (
 		Name:      "postgres_maximum_db_connections",
 		Help:      "number of total connections allowed to the Postgres database server",
 	})
+
+	PostgresTableLiveTuples = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_live_tuples",
+		Help:      "live tuples for the table",
+	}, []string{"table"})
+
+	PostgresTableDeadTuples = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_dead_tuples",
+		Help:      "dead tuples for the table",
+	}, []string{"table"})
 )

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -18,6 +18,8 @@ func init() {
 		PostgresConnected,
 		PostgresTotalConnections,
 		PostgresMaximumConnections,
+		PostgresTableLiveTuples,
+		PostgresTableDeadTuples,
 	)
 }
 


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

Adds metrics to report on the number of live and dead tuples.  Being able to view this growth will provide us additionally intelligence on how to tune vacuum jobs as well as when we may need to recommend a manual vacuum.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

pulled the artifacts from one of the tests and verified the metrics files that are in the debug/diagnostic bundles.

```
# HELP rox_central_postgres_dead_tuples dead tuples for the table
# TYPE rox_central_postgres_dead_tuples gauge
rox_central_postgres_dead_tuples{table="active_components"} 0
rox_central_postgres_dead_tuples{table="active_components_active_contexts_slices"} 0
rox_central_postgres_dead_tuples{table="administration_events"} 1
rox_central_postgres_dead_tuples{table="alerts"} 302
rox_central_postgres_dead_tuples{table="api_tokens"} 3
rox_central_postgres_dead_tuples{table="auth_machine_to_machine_configs"} 0
rox_central_postgres_dead_tuples{table="auth_machine_to_machine_configs_mappings"} 0
rox_central_postgres_dead_tuples{table="auth_providers"} 25
...
```

```
# HELP rox_central_postgres_live_tuples live tuples for the table
# TYPE rox_central_postgres_live_tuples gauge
rox_central_postgres_live_tuples{table="active_components"} 108
rox_central_postgres_live_tuples{table="active_components_active_contexts_slices"} 108
rox_central_postgres_live_tuples{table="administration_events"} 6
rox_central_postgres_live_tuples{table="alerts"} 2256
rox_central_postgres_live_tuples{table="api_tokens"} 68
rox_central_postgres_live_tuples{table="auth_machine_to_machine_configs"} 0
rox_central_postgres_live_tuples{table="auth_machine_to_machine_configs_mappings"} 0
rox_central_postgres_live_tuples{table="auth_providers"} 1
rox_central_postgres_live_tuples{table="blobs"} 1
rox_central_postgres_live_tuples{table="cloud_sources"} 0
rox_central_postgres_live_tuples{table="cluster_cve_edges"} 4
rox_central_postgres_live_tuples{table="cluster_cves"} 4
rox_central_postgres_live_tuples{table="cluster_health_statuses"} 1
rox_central_postgres_live_tuples{table="cluster_init_bundles"} 1
```

