### PR TITLE
chore(ui): Add links to risk for keyboard accessibility

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import find from 'lodash/find';
@@ -7,6 +8,7 @@ import { Tooltip } from '@patternfly/react-core';
 
 import dateTimeFormat from 'constants/dateTimeFormat';
 import { sortValue, sortDate } from 'sorters/sorters';
+import { riskBasePath } from 'routePaths';
 
 function DeploymentNameColumn({ original }) {
     const isSuspicious = find(original.baselineStatuses, {
@@ -22,7 +24,7 @@ function DeploymentNameColumn({ original }) {
                 )}
                 {!isSuspicious && <Icon.Circle className="h-2 w-2" />}
             </span>
-            {original.deployment.name}
+            <Link to={`${riskBasePath}/${original.deployment.id}`}>{original.deployment.name}</Link>
         </div>
     );
 }
@@ -30,6 +32,7 @@ function DeploymentNameColumn({ original }) {
 DeploymentNameColumn.propTypes = {
     original: PropTypes.shape({
         deployment: PropTypes.shape({
+            id: PropTypes.string.isRequired,
             name: PropTypes.string.isRequired,
         }).isRequired,
         baselineStatuses: PropTypes.arrayOf(PropTypes.object).isRequired,


### PR DESCRIPTION
### Description

### Problem from axe DevTools

> Scrollable region must have keyboard access `<div class="rt-table" role="grid">`

### Analysis

https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable?application=AxeChrome

Classic routes that render tables have `onRowClick` event handler:
* which does not have associated keyboard action
* which is probably invisible to screen readers

### Solution

Add in name column a link to open the side panel.

### Residue

1. After we finish this batch of accessiblity issues, adjust style rules to render links with PatternFly style in classic tables.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

### Manual testing

1. Visit /main/risk.

    * Before changes, see presence of accessibility issue.
        If the number of deployments is low enough that there is no scrollbar, reduce the height of the page until scrollbar appears.
        See tab key navigation skips the table.
        ![risk_with_issue](https://github.com/user-attachments/assets/e2f9437e-334b-4c1e-bba0-cd441166bc5c)

    * After changes, see absence of accessibility issue.
        See tab key navigation visits name link in each row of the table.
        Press enter key to open the side panel.
        ![risk_with_link](https://github.com/user-attachments/assets/3546a25b-3d42-4c7f-b486-cbbb78b93f36)

### Integration testing

* risk/risk.test.js
