### PR TITLE
chore: Print return code from curl in scanner download nvd workflow

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -25,7 +25,7 @@ jobs:
             -H "If-Modified-Since: $since_time" \
             https://definitions.stackrox.io/v4/nvd/nvd.zip \
         > $outfile
-        
+
         echo "code: $(cat $outfile)"
         grep 200 code.txt
 

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -18,12 +18,16 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
+        outfile=./code.txt
         curl \
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
             https://definitions.stackrox.io/v4/nvd/nvd.zip \
-        | grep 200
+        > $outfile
+        
+        echo "code: $(cat $outfile)"
+        grep 200 code.txt
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -18,16 +18,14 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
-        outfile=./code.txt
-        curl \
+        code=$(curl \
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
-            https://definitions.stackrox.io/v4/nvd/nvd.zip \
-        > $outfile
+            https://definitions.stackrox.io/v4/nvd/nvd.zip)
 
-        echo "code: $(cat $outfile)"
-        grep 200 $outfile
+        echo "code: $code"
+        echo $code | grep -q 200
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -25,7 +25,7 @@ jobs:
             https://definitions.stackrox.io/v4/nvd/nvd.zip)
 
         echo "code: $code"
-        echo $code | grep -q 200
+        echo "$code" | grep -q 200
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -27,7 +27,7 @@ jobs:
         > $outfile
 
         echo "code: $(cat $outfile)"
-        grep 200 code.txt
+        grep 200 $outfile
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:


### PR DESCRIPTION
### Description

When current workflow fails its not obvious why:

![image](https://github.com/user-attachments/assets/1bd17469-cdd5-485d-8d90-9e9290f36afb)

This PR prints the output from `curl`

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

Dispatched workflow from branch:

<img width="673" alt="image" src="https://github.com/user-attachments/assets/75a43818-af6e-450c-ae1d-733dfaa3dc6a">
