### PR TITLE
fix: filename used by scanner release vuln update job

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -22,7 +22,7 @@ jobs:
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
-            https://definitions.stackrox.io/v4/nvd/nvd.zip)
+            https://definitions.stackrox.io/v4/nvd/nvd-feeds.zip)
 
         echo "code: $code"
         echo "$code" | grep -q 200

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -25,7 +25,7 @@ jobs:
             -H "If-Modified-Since: $since_time" \
             https://definitions.stackrox.io/v4/nvd/nvd.zip \
         > $outfile
-        
+
         echo "code: $(cat $outfile)"
         grep 200 code.txt
 

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -18,12 +18,16 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
+        outfile=./code.txt
         curl \
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
             https://definitions.stackrox.io/v4/nvd/nvd.zip \
-        | grep 200
+        > $outfile
+        
+        echo "code: $(cat $outfile)"
+        grep 200 code.txt
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -18,16 +18,14 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
-        outfile=./code.txt
-        curl \
+        code=$(curl \
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
-            https://definitions.stackrox.io/v4/nvd/nvd.zip \
-        > $outfile
+            https://definitions.stackrox.io/v4/nvd/nvd.zip)
 
-        echo "code: $(cat $outfile)"
-        grep 200 $outfile
+        echo "code: $code"
+        echo $code | grep -q 200
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -25,7 +25,7 @@ jobs:
             https://definitions.stackrox.io/v4/nvd/nvd.zip)
 
         echo "code: $code"
-        echo $code | grep -q 200
+        echo "$code" | grep -q 200
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -27,7 +27,7 @@ jobs:
         > $outfile
 
         echo "code: $(cat $outfile)"
-        grep 200 code.txt
+        grep 200 $outfile
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:


### PR DESCRIPTION
### Description

This [PR changed the name of the files](https://github.com/stackrox/stackrox/pull/11950), however the name was not propagated to the vuln update job.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

Manually triggered workflow