### PR TITLE
fix: filename used by scanner release vuln update job

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -57,12 +57,14 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
-        curl \
+        code=$(curl \
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
-            https://definitions.stackrox.io/v4/nvd/nvd.zip \
-        | grep 200
+            https://definitions.stackrox.io/v4/nvd/nvd-feeds.zip)
+
+        echo "code: $code"
+        echo "$code" | grep -q 200
 
     - uses: ./.github/actions/upload-artifact-with-retry
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -22,7 +22,7 @@ jobs:
             -o nvd.zip \
             -w "%{http_code}" \
             -H "If-Modified-Since: $since_time" \
-            https://definitions.stackrox.io/v4/nvd/nvd.zip)
+            https://definitions.stackrox.io/v4/nvd/nvd-feeds.zip)
 
         echo "code: $code"
         echo "$code" | grep -q 200


### PR DESCRIPTION
### Description

This [PR changed the name of the NVD files](https://github.com/stackrox/stackrox/pull/11950), however the name was not propagated to the vuln update jobs.

This sets the filename to be `nvd-feeds.zip` for both the `release` and `dev` jobs and also updates the `dev` job to print the status code to mirror the `release` job.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

[Manually triggered workflow](https://github.com/stackrox/stackrox/actions/runs/9966580606)