### PR TITLE
chore: return error if batch loading fails

### DIFF
--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -272,6 +272,9 @@ batch_load_test_metrics() {
         info "one image prefetches batch processed"
     done
     info "done loading"
+    if [ -f error ]; then
+       die "ERROR during loading one or more batch has failed"
+    fi
 }
 
 _load_one_batch() {
@@ -310,6 +313,7 @@ _load_one_batch() {
         gsutil -m mv "${process_location}" "${storage_done}/"
     else
         info "ERROR processing the batch, leaving in ${process_location}"
+        touch error
     fi
 
     return 0


### PR DESCRIPTION
### Description

We do not mark batch load job a failed even when there are failures. This PR fixes that.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
