### PR TITLE
test(ui): node overview page tests

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEs.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEs.json
@@ -1,0 +1,111 @@
+{
+    "data": {
+        "nodeCVEs": [
+            {
+                "cve": "RHSA-2024:4533",
+                "affectedNodeCountBySeverity": {
+                    "critical": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 14,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "topCVSS": 7.099999904632568,
+                "affectedNodeCount": 14,
+                "firstDiscoveredInSystem": "2024-07-15T12:21:46.432487Z",
+                "distroTuples": [
+                    {
+                        "summary": "The kernel packages contain the Linux kernel, the core of any Linux operating system.\n\nSecurity Fix(es):\n\n* kernel: TIPC message reassembly use-after-free remote code execution vulnerability (CVE-2024-36886)\n\n* kernel: ethernet: hisilicon: hns: hns_dsaf_misc: fix a possible array overflow in hns_dsaf_ge_srst_by_port() (CVE-2021-47548)\n\n* kernel: net: hns3: fix use-after-free bug in hclgevf_send_mbx_msg (CVE-2021-47596)\n\n* kernel: vt: fix memory overlapping when deleting chars in the buffer (CVE-2022-48627)\n\n* kernel: can: j1939: prevent deadlock by changing j1939_socks_lock to rwlock (CVE-2023-52638)\n\n* kernel: tls: race between async notify and socket close (CVE-2024-26583)\n\n* kernel: tls: race between tx work scheduling and socket close (CVE-2024-26585)\n\n* kernel: mm/writeback: fix possible divide-by-zero in wb_dirty_limits(), again (CVE-2024-26720)\n\n* kernel: mm/vmscan: fix a bug calling wakeup_kswapd() with a wrong zone index (CVE-2024-26783)\n\n* kernel: Bluetooth: Avoid potential use-after-free in hci_error_reset (CVE-2024-26801)\n\n* kernel: net/ipv6: avoid possible UAF in ip6_route_mpath_notify() (CVE-2024-26852)\n\n* kernel: icmp: prevent possible NULL dereferences from icmp_build_probe() (CVE-2024-35857)\n\n* kernel: netfilter: nf_tables: Fix potential data-race in __nft_flowtable_type_get() (CVE-2024-35898)\n\n* kernel: ipv6: fix race condition between ipv6_get_ifaddr and ipv6_del_addr (CVE-2024-35969)\n\n* kernel: tty: n_gsm: fix possible out-of-bounds in gsm0_receive() (CVE-2024-36016)\n\n* kernel: netfilter: nf_tables: honor table dormant flag from netdev release event path (CVE-2024-36005)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "operatingSystem": "rhcos:4.14",
+                        "cvss": 7.099999904632568,
+                        "scoreVersion": "V3",
+                        "__typename": "NodeVulnerability"
+                    }
+                ],
+                "__typename": "NodeCVECore"
+            },
+            {
+                "cve": "RHSA-2024:4529",
+                "affectedNodeCountBySeverity": {
+                    "critical": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 14,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "topCVSS": 8.600000381469727,
+                "affectedNodeCount": 14,
+                "firstDiscoveredInSystem": "2024-07-15T04:45:15.639254Z",
+                "distroTuples": [
+                    {
+                        "summary": "The \"less\" utility is a text file browser that resembles \"more\", but allows users to move backwards in the file as well as forwards. Since \"less\" does not read the entire input file at startup, it also starts more quickly than ordinary text editors.\n\nSecurity Fix(es):\n\n* less: OS command injection (CVE-2024-32487)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "operatingSystem": "rhcos:4.14",
+                        "cvss": 8.600000381469727,
+                        "scoreVersion": "V3",
+                        "__typename": "NodeVulnerability"
+                    }
+                ],
+                "__typename": "NodeCVECore"
+            },
+            {
+                "cve": "RHSA-2024:4430",
+                "affectedNodeCountBySeverity": {
+                    "critical": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 14,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "topCVSS": 8.100000381469727,
+                "affectedNodeCount": 14,
+                "firstDiscoveredInSystem": "2024-07-15T01:18:15.765443Z",
+                "distroTuples": [
+                    {
+                        "summary": "HTTP::Tiny is a small and simple HTTP/1.1 client written in Perl.\n\nSecurity Fix(es):\n\n* http-tiny: insecure TLS cert default (CVE-2023-31486)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "operatingSystem": "rhcos:4.14",
+                        "cvss": 8.100000381469727,
+                        "scoreVersion": "V3",
+                        "__typename": "NodeVulnerability"
+                    }
+                ],
+                "__typename": "NodeCVECore"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodes.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodes.json
@@ -1,0 +1,66 @@
+{
+    "data": {
+        "nodes": [
+            {
+                "id": "1",
+                "name": "cypress-node-1",
+                "nodeCVECountBySeverity": {
+                    "critical": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 14,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 62,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 15,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "cluster": {
+                    "name": "staging-secured-cluster",
+                    "__typename": "Cluster"
+                },
+                "osImage": "Red Hat Enterprise Linux CoreOS 414.92.202401010110-0 (Plow)",
+                "scanTime": "2024-07-16T11:56:01.355441667Z",
+                "__typename": "Node"
+            },
+            {
+                "id": "2",
+                "name": "cypress-node-2",
+                "nodeCVECountBySeverity": {
+                    "critical": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 24,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 62,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 15,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "cluster": {
+                    "name": "staging-secured-cluster",
+                    "__typename": "Cluster"
+                },
+                "osImage": "Red Hat Enterprise Linux CoreOS 411.92.202101010110-0 (Plow)",
+                "scanTime": "2024-07-16T14:16:44.367903374Z",
+                "__typename": "Node"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -104,14 +104,13 @@ export function interactAndWaitForResponses(
  * @returns {Cypress.Chainable<Interception>}
  */
 export function interactAndInspectGraphQLVariables(interactionCallback, opname) {
-    const key = 'graphql';
     const url = `/api/graphql?opname=${opname}`;
 
-    cy.intercept({ method: 'POST', url, times: 1 }).as(key);
+    cy.intercept({ method: 'POST', url, times: 1 }).as(opname);
 
     interactionCallback();
 
-    return cy.wait(`@${key}`).then((interception) => {
+    return cy.wait(`@${opname}`).then((interception) => {
         return cy.wrap(interception.request.body.variables);
     });
 }

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -80,6 +80,7 @@ export function waitForResponses(routeMatcherMap, waitOptions = {}) {
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
+ * @returns {Cypress.Chainable<Interception[] | Interception>}
  */
 export function interactAndWaitForResponses(
     interactionCallback,
@@ -92,4 +93,25 @@ export function interactAndWaitForResponses(
     interactionCallback();
 
     return waitForResponses(routeMatcherMap, waitOptions);
+}
+
+/**
+ * Intercepts a GraphQL request during an interaction and yields the
+ * variables object passed to the request's query
+ *
+ * @param {() => void} interactionCallback The interaction performed to trigger the GraphQL request
+ * @param {string} opname The GraphQL operation name
+ * @returns {Cypress.Chainable<Interception>}
+ */
+export function interactAndInspectGraphQLVariables(interactionCallback, opname) {
+    const key = 'graphql';
+    const url = `/api/graphql?opname=${opname}`;
+
+    cy.intercept({ method: 'POST', url, times: 1 }).as(key);
+
+    interactionCallback();
+
+    return cy.wait(`@${key}`).then((interception) => {
+        return cy.wrap(interception.request.body.variables);
+    });
 }

--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -152,3 +152,13 @@ export const callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements 
         isValidVulnerabilitySeverityValue,
         isPairOfDescendingVulnerabilitySeverityValues
     );
+
+export function expectRequestedSort(expectedSort) {
+    return (variables) => {
+        const { sortOption } = variables.pagination;
+        expect(sortOption).to.deep.equal(
+            expectedSort,
+            `Expected sort option ${JSON.stringify(expectedSort)} but received ${JSON.stringify(sortOption)}`
+        );
+    };
+}

--- a/ui/apps/platform/cypress/helpers/tableHelpers.js
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.js
@@ -24,3 +24,17 @@ export function editIntegration(name) {
         `tr:contains('${name}') td.pf-v5-c-table__action button:contains("Edit Integration")`
     ).click();
 }
+
+export function queryTableHeader(headerName) {
+    return cy.get(`th`).contains(new RegExp(`^${headerName}$`, 'i'));
+}
+
+export function queryTableSortHeader(headerName) {
+    return cy
+        .get(`th button:has('.pf-v5-c-table__sort-indicator')`)
+        .contains(new RegExp(`^${headerName}$`, 'i'));
+}
+
+export function sortByTableHeader(headerName) {
+    return queryTableSortHeader(headerName).click();
+}

--- a/ui/apps/platform/cypress/helpers/tableHelpers.js
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.js
@@ -26,13 +26,13 @@ export function editIntegration(name) {
 }
 
 export function queryTableHeader(headerName) {
-    return cy.get(`th`).contains(new RegExp(`^${headerName}$`, 'i'));
+    return cy.get(`th`).contains(new RegExp(`^${headerName}$`));
 }
 
 export function queryTableSortHeader(headerName) {
     return cy
         .get(`th button:has('.pf-v5-c-table__sort-indicator')`)
-        .contains(new RegExp(`^${headerName}$`, 'i'));
+        .contains(new RegExp(`^${headerName}$`));
 }
 
 export function sortByTableHeader(headerName) {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
@@ -1,17 +1,39 @@
+import { graphql } from '../../../constants/apiEndpoints';
 import {
     getRouteMatcherMapForGraphQL,
     interactAndWaitForResponses,
 } from '../../../helpers/request';
 
+export function mockOverviewNodeCveListRequest() {
+    const opname = 'getNodeCVEs';
+    cy.intercept(
+        { method: 'POST', url: graphql(opname) },
+        { fixture: `vulnerabilities/nodeCves/${opname}.json` }
+    ).as(opname);
+}
+
+export function mockOverviewNodeListRequest() {
+    const opname = 'getNodes';
+    cy.intercept(
+        { method: 'POST', url: graphql(opname) },
+        { fixture: `vulnerabilities/nodeCves/${opname}.json` }
+    ).as(opname);
+}
+
 export function visitNodeCveOverviewPage() {
     cy.visit('/main/vulnerabilities/node-cves');
 }
 
-export function visitFirstNodeLinkFromTable() {
-    return interactAndWaitForResponses(
-        () => {
-            cy.get('tbody tr td[data-label="Node"] a').first().click();
-        },
-        getRouteMatcherMapForGraphQL(['getNodeMetadata'])
-    );
+export function visitFirstNodeLinkFromTable(): Cypress.Chainable<string> {
+    // Get the name of the first node in the table and pass it to the caller
+    return cy
+        .get('tbody tr td[data-label="Node"] a')
+        .first()
+        .then(($link) => {
+            interactAndWaitForResponses(
+                () => cy.wrap($link).click(),
+                getRouteMatcherMapForGraphQL(['getNodeMetadata'])
+            );
+            return cy.wrap($link.text());
+        });
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -6,8 +6,24 @@ import {
     visitWithStaticResponseForPermissions,
 } from '../../../helpers/visit';
 import navSelectors from '../../../selectors/navigation';
-import { visitNodeCveOverviewPage } from './NodeCve.helpers';
+import {
+    mockOverviewNodeCveListRequest,
+    visitFirstNodeLinkFromTable,
+    visitNodeCveOverviewPage,
+} from './NodeCve.helpers';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
+import {
+    queryTableHeader,
+    queryTableSortHeader,
+    sortByTableHeader,
+} from '../../../helpers/tableHelpers';
+import { expectRequestedSort } from '../../../helpers/sort';
+import { waitForTableLoadCompleteIndicator } from '../workloadCves/WorkloadCves.helpers';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndInspectGraphQLVariables,
+    interactAndWaitForResponses,
+} from '../../../helpers/request';
 
 describe('Node CVEs - Overview Page', () => {
     withAuth();
@@ -68,25 +84,135 @@ describe('Node CVEs - Overview Page', () => {
         assertAvailableFilters(expectedFilters);
     });
 
-    it('should link to the correct details pages', () => {
-        // clicking a CVE in the list should navigate to the correct CVE details page
-        // clicking a Node in the list should navigate to the correct Node details page
+    it('should link a CVE table row to the correct CVE detail page', () => {
+        // Having a CVE in CI is unreliable, so we mock the request and assert
+        // on the link construction instead of the content of the detail page.
+        mockOverviewNodeCveListRequest();
+        visitNodeCveOverviewPage();
+
+        cy.get('tbody tr td[data-label="CVE"] a')
+            .first()
+            .then(($link) => {
+                const linkHref = $link.attr('href');
+                const linkName = $link.text();
+                expect(linkHref).to.match(new RegExp(`.*/${linkName}$`));
+            });
+    });
+
+    it('should link a Node table row to the correct Node detail page', () => {
+        visitNodeCveOverviewPage();
+        cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
+
+        visitFirstNodeLinkFromTable().then((name) => {
+            cy.get('h1').contains(name);
+        });
     });
 
     it('should sort CVE table columns', () => {
+        visitNodeCveOverviewPage();
+        waitForTableLoadCompleteIndicator();
+
         // check sorting of CVE column
-        // check sorting of Nodes by Severity column
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('CVE'), 'getNodeCVEs').then(
+            expectRequestedSort({ field: 'CVE', reversed: true })
+        );
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('CVE'), 'getNodeCVEs').then(
+            expectRequestedSort({ field: 'CVE', reversed: false })
+        );
+
+        // check that the Nodes by severity column is not sortable
+        queryTableHeader('Nodes by severity');
+        queryTableSortHeader('Nodes by severity').should('not.exist');
+
         // check sorting of Top CVSS column
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Top CVSS'), 'getNodeCVEs').then(
+            expectRequestedSort({
+                field: 'CVSS',
+                reversed: true,
+                aggregateBy: { aggregateFunc: 'max', distinct: false },
+            })
+        );
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Top CVSS'), 'getNodeCVEs').then(
+            expectRequestedSort({
+                field: 'CVSS',
+                reversed: false,
+                aggregateBy: { aggregateFunc: 'max', distinct: false },
+            })
+        );
+
         // check sorting of Affected Nodes column
-        // check sorting of First discovered column
+        interactAndInspectGraphQLVariables(
+            () => sortByTableHeader('Affected Nodes'),
+            'getNodeCVEs'
+        ).then(
+            expectRequestedSort({
+                field: 'Node ID',
+                reversed: true,
+                aggregateBy: { aggregateFunc: 'count', distinct: true },
+            })
+        );
+        interactAndInspectGraphQLVariables(
+            () => sortByTableHeader('Affected Nodes'),
+            'getNodeCVEs'
+        ).then(
+            expectRequestedSort({
+                field: 'Node ID',
+                reversed: false,
+                aggregateBy: { aggregateFunc: 'count', distinct: true },
+            })
+        );
+
+        // check that the First Discovered column is not sortable
+        queryTableHeader('First Discovered');
+        queryTableSortHeader('First Discovered').should('not.exist');
     });
 
     it('should sort Node table columns', () => {
+        visitNodeCveOverviewPage();
+
+        // Visit Node tab and wait for initial load - sorting will be pre-applied to the Node column
+        interactAndWaitForResponses(
+            () => cy.get(vulnSelectors.entityTypeToggleItem('Node')).click(),
+            getRouteMatcherMapForGraphQL(['getNodes'])
+        );
+
         // check sorting of Node column
-        // check sorting of CVEs by Severity column
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Node'), 'getNodes').then(
+            expectRequestedSort({ field: 'Node', reversed: true })
+        );
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Node'), 'getNodes').then(
+            expectRequestedSort({ field: 'Node', reversed: false })
+        );
+
+        // check that CVEs by Severity is not sortable
+        queryTableHeader('CVEs by severity');
+        queryTableSortHeader('CVEs by severity').should('not.exist');
+
         // check sorting of Cluster column
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Cluster'), 'getNodes').then(
+            expectRequestedSort({ field: 'Cluster', reversed: true })
+        );
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Cluster'), 'getNodes').then(
+            expectRequestedSort({ field: 'Cluster', reversed: false })
+        );
+
         // check sorting of Operating System column
+        interactAndInspectGraphQLVariables(
+            () => sortByTableHeader('Operating System'),
+            'getNodes'
+        ).then(expectRequestedSort({ field: 'Operating System', reversed: true }));
+        interactAndInspectGraphQLVariables(
+            () => sortByTableHeader('Operating System'),
+            'getNodes'
+        ).then(expectRequestedSort({ field: 'Operating System', reversed: false }));
+
         // check sorting of Scan time column
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Scan time'), 'getNodes').then(
+            expectRequestedSort({ field: 'Node Scan Time', reversed: true })
+        );
+        interactAndInspectGraphQLVariables(() => sortByTableHeader('Scan time'), 'getNodes').then(
+            expectRequestedSort({ field: 'Node Scan Time', reversed: false })
+        );
     });
 
     it('should filter the CVE table', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -19,11 +19,7 @@ import {
 } from '../../../helpers/tableHelpers';
 import { expectRequestedSort } from '../../../helpers/sort';
 import { waitForTableLoadCompleteIndicator } from '../workloadCves/WorkloadCves.helpers';
-import {
-    getRouteMatcherMapForGraphQL,
-    interactAndInspectGraphQLVariables,
-    interactAndWaitForResponses,
-} from '../../../helpers/request';
+import { interactAndInspectGraphQLVariables } from '../../../helpers/request';
 
 describe('Node CVEs - Overview Page', () => {
     withAuth();
@@ -142,7 +138,7 @@ describe('Node CVEs - Overview Page', () => {
 
         // check sorting of Affected Nodes column
         interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Affected Nodes'),
+            () => sortByTableHeader('Affected nodes'),
             'getNodeCVEs'
         ).then(
             expectRequestedSort({
@@ -152,7 +148,7 @@ describe('Node CVEs - Overview Page', () => {
             })
         );
         interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Affected Nodes'),
+            () => sortByTableHeader('Affected nodes'),
             'getNodeCVEs'
         ).then(
             expectRequestedSort({
@@ -162,19 +158,17 @@ describe('Node CVEs - Overview Page', () => {
             })
         );
 
-        // check that the First Discovered column is not sortable
-        queryTableHeader('First Discovered');
-        queryTableSortHeader('First Discovered').should('not.exist');
+        // check that the First discovered column is not sortable
+        queryTableHeader('First discovered');
+        queryTableSortHeader('First discovered').should('not.exist');
     });
 
     it('should sort Node table columns', () => {
-        visitNodeCveOverviewPage();
-
         // Visit Node tab and wait for initial load - sorting will be pre-applied to the Node column
-        interactAndWaitForResponses(
-            () => cy.get(vulnSelectors.entityTypeToggleItem('Node')).click(),
-            getRouteMatcherMapForGraphQL(['getNodes'])
-        );
+        interactAndInspectGraphQLVariables(() => {
+            visitNodeCveOverviewPage();
+            cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
+        }, 'getNodes');
 
         // check sorting of Node column
         interactAndInspectGraphQLVariables(() => sortByTableHeader('Node'), 'getNodes').then(
@@ -198,11 +192,11 @@ describe('Node CVEs - Overview Page', () => {
 
         // check sorting of Operating System column
         interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Operating System'),
+            () => sortByTableHeader('Operating system'),
             'getNodes'
         ).then(expectRequestedSort({ field: 'Operating System', reversed: true }));
         interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Operating System'),
+            () => sortByTableHeader('Operating system'),
             'getNodes'
         ).then(expectRequestedSort({ field: 'Operating System', reversed: false }));
 


### PR DESCRIPTION
### Description

Adds Cypress tests for the Node CVE overview page.

- Tests that links in the table correctly point to the relevant detail pages
- Tests that sorting of the overview tables correctly sends the sort parameters to the queries

Note that due to the unpredictability of data in a CI environment, this doesn't e2e test that the data table is sorted correctly. Since the sorting is done server-side, we at most test that the UI interaction sends the correct sort parameters to the backend, and that sorting is only enabled on the correct columns.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] added e2e tests

#### How I validated my change

Local Cypress run + Inspected CI results