### PR TITLE
chore: extract ImageMetadata cache

### DIFF
--- a/central/image/service/service.go
+++ b/central/image/service/service.go
@@ -12,8 +12,8 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/waiter"
@@ -40,7 +40,7 @@ func New(
 	riskManager manager.Manager,
 	connManager connection.Manager,
 	enricher enricher.ImageEnricher,
-	metadataCache expiringcache.Cache,
+	metadataCache cache.ImageMetadata,
 	scanWaiterManager waiter.Manager[*storage.Image],
 	clusterSACHelper sachelper.ClusterSacHelper,
 ) Service {

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/images/utils"
@@ -98,7 +98,7 @@ type serviceImpl struct {
 	datastore   datastore.DataStore
 	riskManager manager.Manager
 
-	metadataCache expiringcache.Cache
+	metadataCache cache.ImageMetadata
 
 	connManager connection.Manager
 

--- a/central/image/service/singleton.go
+++ b/central/image/service/singleton.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	watchedImageDataStore "github.com/stackrox/rox/central/watchedimage/datastore"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -25,7 +26,7 @@ func initialize() {
 		manager.Singleton(),
 		connection.ManagerSingleton(),
 		enrichment.ImageEnricherSingleton(),
-		enrichment.ImageMetadataCacheSingleton(),
+		cache.ImageMetadataCacheSingleton(),
 		scanwaiter.Singleton(),
 		sachelper.NewClusterSacHelper(clusterDataStore.Singleton()),
 	)

--- a/central/policy/service/service.go
+++ b/central/policy/service/service.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/backgroundtasks"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/images/cache"
 	mitreDS "github.com/stackrox/rox/pkg/mitre/datastore"
 	"github.com/stackrox/rox/pkg/notifier"
 )
@@ -38,7 +38,7 @@ func New(policies datastore.DataStore,
 	reprocessor reprocessor.Loop,
 	manager lifecycle.Manager,
 	processor notifier.Processor,
-	metadataCache expiringcache.Cache,
+	metadataCache cache.ImageMetadata,
 	connectionManager connection.Manager) Service {
 	backgroundTaskManager := backgroundtasks.NewManager()
 	backgroundTaskManager.Start()

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -30,11 +30,11 @@ import (
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/logging"
 	mitreDS "github.com/stackrox/rox/pkg/mitre/datastore"
 	mitreUtils "github.com/stackrox/rox/pkg/mitre/utils"
@@ -110,7 +110,7 @@ type serviceImpl struct {
 	connectionManager connection.Manager
 	lifecycleManager  lifecycle.Manager
 	processor         notifier.Processor
-	metadataCache     expiringcache.Cache
+	metadataCache     cache.ImageMetadata
 
 	validator *policyValidator
 

--- a/central/policy/service/singleton.go
+++ b/central/policy/service/singleton.go
@@ -4,13 +4,13 @@ import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/detection/lifecycle"
-	"github.com/stackrox/rox/central/enrichment"
 	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
 	"github.com/stackrox/rox/central/sensor/service/connection"
+	"github.com/stackrox/rox/pkg/images/cache"
 	mitreDataStore "github.com/stackrox/rox/pkg/mitre/datastore"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -31,7 +31,7 @@ func initialize() {
 		reprocessor.Singleton(),
 		lifecycle.SingletonManager(),
 		notifierProcessor.Singleton(),
-		enrichment.ImageMetadataCacheSingleton(),
+		cache.ImageMetadataCacheSingleton(),
 		connection.ManagerSingleton())
 }
 

--- a/pkg/images/cache/imagemetadata.go
+++ b/pkg/images/cache/imagemetadata.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/expiringcache"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	metadataCacheOnce sync.Once
+	metadataCache     ImageMetadata
+)
+
+const imageCacheExpiryDuration = 4 * time.Hour
+
+type ImageMetadata expiringcache.Cache
+
+// ImageMetadataCacheSingleton returns the cache for image metadata
+func ImageMetadataCacheSingleton() ImageMetadata {
+	metadataCacheOnce.Do(func() {
+		metadataCache = expiringcache.NewExpiringCache(imageCacheExpiryDuration, expiringcache.UpdateExpirationOnGets)
+	})
+	return metadataCache
+}

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/delegatedregistry"
-	"github.com/stackrox/rox/pkg/expiringcache"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/images/integration"
 	"github.com/stackrox/rox/pkg/integrationhealth"
 	"github.com/stackrox/rox/pkg/logging"
@@ -143,7 +143,7 @@ type signatureVerifierForIntegrations func(ctx context.Context, integrations []*
 
 // New returns a new ImageEnricher instance for the given subsystem.
 // (The subsystem is just used for Prometheus metrics.)
-func New(cvesSuppressor CVESuppressor, cvesSuppressorV2 CVESuppressor, is integration.Set, subsystem pkgMetrics.Subsystem, metadataCache expiringcache.Cache,
+func New(cvesSuppressor CVESuppressor, cvesSuppressorV2 CVESuppressor, is integration.Set, subsystem pkgMetrics.Subsystem, metadataCache cache.ImageMetadata,
 	imageGetter ImageGetter, healthReporter integrationhealth.Reporter,
 	signatureIntegrationGetter SignatureIntegrationGetter, scanDelegator delegatedregistry.Delegator) ImageEnricher {
 	enricher := &enricherImpl{

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/images/integration"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/integrationhealth"
@@ -58,7 +58,7 @@ type enricherImpl struct {
 	integrationHealthReporter integrationhealth.Reporter
 
 	metadataLimiter *rate.Limiter
-	metadataCache   expiringcache.Cache
+	metadataCache   cache.ImageMetadata
 
 	signatureIntegrationGetter SignatureIntegrationGetter
 	signatureVerifier          signatureVerifierForIntegrations

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -13,6 +13,7 @@ import (
 	delegatorMocks "github.com/stackrox/rox/pkg/delegatedregistry/mocks"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/expiringcache"
+	"github.com/stackrox/rox/pkg/images/cache"
 	"github.com/stackrox/rox/pkg/images/integration"
 	"github.com/stackrox/rox/pkg/images/integration/mocks"
 	imgTypes "github.com/stackrox/rox/pkg/images/types"
@@ -1414,6 +1415,6 @@ func newEnricher(set *mocks.MockSet, mockReporter *reporterMocks.MockReporter) I
 		mockReporter, emptySignatureIntegrationGetter, nil)
 }
 
-func newCache() expiringcache.Cache {
-	return expiringcache.NewExpiringCache(1 * time.Minute)
+func newCache() cache.ImageMetadata {
+	return cache.ImageMetadata(expiringcache.NewExpiringCache(1 * time.Minute))
 }


### PR DESCRIPTION
### Description

Extract an ImageMetadata cache that is used in multiple places. It's a prefactor for https://github.com/stackrox/stackrox/pull/11924

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
