### PR TITLE
chore(ui): Add links to clusters for keyboard accessibility

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Trash2 } from 'react-feather';
+import { Link } from 'react-router-dom';
 
 import RowActionButton from 'Components/RowActionButton';
 import {
@@ -8,6 +9,7 @@ import {
     wrapClassName,
     rtTrActionsClassName,
 } from 'Components/Table';
+import { clustersBasePath } from 'routePaths';
 
 import { formatCloudProvider } from './cluster.helpers';
 import ClusterDeletion from './Components/ClusterDeletion';
@@ -46,7 +48,7 @@ export function getColumnsForClusters({
             className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
             Cell: ({ original }) => (
                 <span className="flex items-center" data-testid="cluster-name">
-                    {original.name}
+                    <Link to={`${clustersBasePath}/${original.id}`}>{original.name}</Link>
                     {(original.managedBy === 'MANAGER_TYPE_HELM_CHART' ||
                         (original.managedBy === 'MANAGER_TYPE_UNKNOWN' &&
                             !!original.helmConfig)) && (


### PR DESCRIPTION
### Description

### Problem

Unlike some other classic tables, for which axe DevTools reports an issue:

> Scrollable region must have keyboard access `<div class="rt-table" role="grid">`

This table has an `input` element for bulk actions, but **not** a link to open the side panel for the primary entity.

### Analysis

https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable?application=AxeChrome

Classic routes that render tables have `onRowClick` event handler:
* which does not have associated keyboard action
* which is probably invisible to screen readers

### Solution

In theory, this classic table has a very short shelf life, but fix it just in case of change in plans or priorities.

1. Add in name column a link to open the side panel.

### Residue

1. Find in Files `data-testid="cluster-name"` reminds me that rewrite of clusters table in PatternFly implies rewrite of integration tests.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui

#### Manual testing

1. Visit /main/clusters and see tab key navigation after changes.
    ![clusters_with_link](https://github.com/user-attachments/assets/c670b2ed-45fe-48b5-9cfb-89828a524802)

#### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * clusters/clusterDeletion.test.js
    * clusters/clusters.test.js
    * clusters/clustersCertificateExpiration.test.js
    * clusters/clustersHealthStatus.test.js
    * clusters/clustersManager.test.js

Pictures without and with link to verify no side effect on alignment of icons.
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js#L8-L23

* Without link before changes:
    ![cypress_without_link](https://github.com/user-attachments/assets/edb159c3-fb2c-4c19-9b71-5085ed47d309)

* With link after changes:
    ![cypress_with_link](https://github.com/user-attachments/assets/61c9772d-12f5-470e-8ca6-9da629b3aaea)
