### PR TITLE
ROX-22019: Add test coverage for protoconv time functions

### DIFF
--- a/pkg/protoconv/time_test.go
+++ b/pkg/protoconv/time_test.go
@@ -2,6 +2,7 @@ package protoconv
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -76,4 +77,63 @@ func TestConvertMicroTSToProtobufTS(t *testing.T) {
 	assert.NotNil(t, convertedTimestamp1)
 	assert.Equal(t, timestamp1.Seconds, convertedTimestamp1.Seconds)
 	assert.Equal(t, int32(123456000), convertedTimestamp1.Nanos)
+}
+
+func TestConvertTimestampToTimeOrDefault(t *testing.T) {
+	defaultGoTime := time.Unix(0x7E57ED, 0xAC5)
+	protoTime := &types.Timestamp{
+		Seconds: 1518046140,
+		Nanos:   123456789,
+	}
+	goTime := ConvertTimestampToTimeOrDefault(protoTime, defaultGoTime)
+	assert.Equal(t, goTime.Unix(), protoTime.GetSeconds())
+	assert.Equal(t, goTime.Nanosecond(), int(protoTime.GetNanos()))
+
+	goTime = ConvertTimestampToTimeOrDefault(nil, defaultGoTime)
+	assert.Equal(t, goTime.UTC(), defaultGoTime.UTC())
+
+	// Negative Nanos is not valid for Timestamp.
+	invalidProtoTime := &types.Timestamp{
+		Nanos: -1,
+	}
+	goTime = ConvertTimestampToTimeOrDefault(invalidProtoTime, defaultGoTime)
+	assert.Equal(t, goTime.UTC(), defaultGoTime.UTC())
+}
+
+func TestConvertTimeToTimestamp(t *testing.T) {
+	goTime := time.Unix(0x7E57ED, 0xAC5)
+	protoTime := ConvertTimeToTimestamp(goTime)
+	assert.Equal(t, goTime.Unix(), protoTime.GetSeconds())
+	assert.Equal(t, goTime.Nanosecond(), int(protoTime.GetNanos()))
+
+	goTimeBeforeCall := time.Now()
+	invalidGoTime := goTime.AddDate(-10000, 0, 0)
+	protoTime = ConvertTimeToTimestamp(invalidGoTime)
+
+	// When conversion fails, `ConvertTimeToTimestamp` will return the current time.
+	// We are checking that the returned time is after the time fetched before the call.
+	assert.GreaterOrEqual(t, protoTime.GetSeconds()*time.Second.Nanoseconds()+int64(protoTime.GetNanos())*time.Nanosecond.Nanoseconds(), goTimeBeforeCall.UnixNano())
+}
+
+func TestConvertTimeToTimestampOrNil(t *testing.T) {
+	goTime := time.Unix(0x7E57ED, 0xAC5)
+	protoTime := ConvertTimeToTimestampOrNil(goTime)
+	assert.Equal(t, goTime.Unix(), protoTime.GetSeconds())
+	assert.Equal(t, goTime.Nanosecond(), int(protoTime.GetNanos()))
+
+	invalidGoTime := goTime.AddDate(-10000, 0, 0)
+	invalidProtoTime := ConvertTimeToTimestampOrNil(invalidGoTime)
+	assert.Nil(t, invalidProtoTime)
+}
+
+func TestMustConvertTimeToTimestamp(t *testing.T) {
+	goTime := time.Unix(0x7E57ED, 0xAC5)
+	protoTime := MustConvertTimeToTimestamp(goTime)
+	assert.Equal(t, goTime.Unix(), protoTime.GetSeconds())
+	assert.Equal(t, goTime.Nanosecond(), int(protoTime.GetNanos()))
+
+	invalidGoTime := goTime.AddDate(-10000, 0, 0)
+	assert.Panics(t, func() {
+		MustConvertTimeToTimestamp(invalidGoTime)
+	})
 }


### PR DESCRIPTION
### Description

This PR adds test coverage for specific `protoconv` time functions. This is important to protbuf V2 migration because protobuf V2 framework does not include validation, and it has to be done explicitly.

This will allow us to confirm that the protobuf V2 switch is correct and that the behavior has not changed.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] added unit tests
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

Run tests locally.
