### PR TITLE
tests(CI): do not build all arch for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,17 @@ jobs:
 
           # The base matrix
           matrix="$(jq '.pre_build_go_binaries.name += ["default"]' <<< "$matrix")"
-          matrix="$(jq '.pre_build_go_binaries.arch += ["amd64", "arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+          matrix="$(jq '.pre_build_go_binaries.arch += ["amd64"]' <<< "$matrix")"
 
-          matrix="$(jq '.build_and_push_main.name += ["STACKROX_BRANDING", "RHACS_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.build_and_push_main.arch += ["amd64", "arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_main.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_main.arch += ["amd64"]' <<< "$matrix")"
 
-          matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING", "RHACS_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+
+          if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+            matrix="$(jq '.pre_build_go_binaries.arch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.arch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+          fi;
 
           # Conditionally add a prerelease build (binaries built with GOTAGS=release)
           if ! is_tagged; then
@@ -508,7 +513,10 @@ jobs:
         if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
           push_context="merge-to-master"
         fi
-        architectures="amd64,arm64,ppc64le,s390x"
+        architectures="amd64"
+        if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+          architectures="amd64,arm64,ppc64le,s390x"
+        fi
         if [[ "${{ matrix.name }}" == "race-condition-debug" ]]; then
           architectures="amd64"
         fi

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -30,7 +30,11 @@ jobs:
         source './scripts/ci/lib.sh'
 
         # If goarch is updated, be sure to update architectures in push-manifests below.
-        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le", "s390x"] }, "push_manifests": { "name":["default"] } }'
+        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64"] }, "push_manifests": { "name":["default"] } }'
+
+        if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+          matrix="$(jq '.build_and_push.arch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+        fi;
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
         if ! is_tagged; then
@@ -275,7 +279,10 @@ jobs:
         source ./scripts/ci/lib.sh
 
         # If this is updated, be sure to update goarch in define-scanner-job-matrix above.
-        architectures="amd64,arm64,ppc64le,s390x"
+        architectures="amd64"
+        if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+          architectures="amd64,arm64,ppc64le,s390x"
+        fi
         if [[ "${{ matrix.name }}" == "race-condition-debug" ]]; then
           architectures="amd64"
         fi


### PR DESCRIPTION
### Description

This PR changes the job matrix to build only amd64/stackrox images for PRs unless [ci-build-all-arch](https://github.com/stackrox/stackrox/labels/ci-build-all-arch) label is specified.
The reason to do this is that we do not have a CI for other architectures on PR unless asked so in most cases we waste time and resources building other architectures. Building more than we need causes docker.io to throtled our calls made by qemu install action that is necessary to build other architectures.

- https://github.com/stackrox/stackrox/pull/7657
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
