### PR TITLE
ROX-25302:  check for outdated proto.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,11 +12,7 @@ central/policy/**/*                 @stackrox/core-workflows
 central/reports/**/*                @stackrox/core-workflows
 central/reportconfiguration/**/*    @stackrox/core-workflows
 central/vulnmgmt/**/*               @stackrox/core-workflows
-proto/storage/policy.proto          @stackrox/core-workflows
-proto/storage/image.proto           @stackrox/core-workflows
-proto/storage/cve.proto             @stackrox/core-workflows
-proto/storage/alert.proto           @stackrox/core-workflows
-proto/storage/risk.proto            @stackrox/core-workflows
+proto/storage/*                     @stackrox/core-workflows
 migrator/**/*                       @stackrox/core-workflows
 pkg/postgres/**/*                   @stackrox/core-workflows
 tests/upgrade/*                     @stackrox/core-workflows

--- a/Makefile
+++ b/Makefile
@@ -271,10 +271,11 @@ check-service-protos:
 no-large-files:
 	$(BASE_DIR)/tools/detect-large-files.sh "$(BASE_DIR)/tools/allowed-large-files"
 
+# adding the uptodate flag will inform us if the protos and lock are out of date if they pass the compatibility check.
 .PHONY: storage-protos-compatible
 storage-protos-compatible: $(PROTOLOCK_BIN)
 	@echo "+ $@"
-	$(SILENT)$(PROTOLOCK_BIN) status -lockdir=$(BASE_DIR)/proto/storage -protoroot=$(BASE_DIR)/proto/storage
+	$(SILENT)$(PROTOLOCK_BIN) status -lockdir=$(BASE_DIR)/proto/storage -protoroot=$(BASE_DIR)/proto/storage --uptodate true
 
 .PHONY: blanks
 blanks:

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -281,5 +281,4 @@ message ComplianceOperatorRemediationV2 {
   string outdated_object = 6;
   string enforcement_type = 7;
   string cluster_id = 8; // @gotags: search:"Cluster ID,hidden"
-  string adding_test_field = 9;
 }

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -278,7 +278,7 @@ message ComplianceOperatorRemediationV2 {
   string current_object = 5;
   // outdated is an old remediation object when a new remediation was added to the "current" field in the compliance operator.
   // See: https://docs.openshift.com/container-platform/4.15/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-updating_compliance-remediation
-  bool outdated_object = 6;
+  string outdated_object = 6;
   string enforcement_type = 7;
   string cluster_id = 8; // @gotags: search:"Cluster ID,hidden"
   string adding_test_field = 9;

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -278,7 +278,8 @@ message ComplianceOperatorRemediationV2 {
   string current_object = 5;
   // outdated is an old remediation object when a new remediation was added to the "current" field in the compliance operator.
   // See: https://docs.openshift.com/container-platform/4.15/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-updating_compliance-remediation
-  string outdated_object = 6;
+  bool outdated_object = 6;
   string enforcement_type = 7;
   string cluster_id = 8; // @gotags: search:"Cluster ID,hidden"
+  string adding_test_field = 9;
 }

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -7152,6 +7152,24 @@
     {
       "protopath": "external_backup.proto",
       "def": {
+        "enums": [
+          {
+            "name": "S3URLStyle",
+            "enum_fields": [
+              {
+                "name": "S3_URL_STYLE_UNSPECIFIED"
+              },
+              {
+                "name": "S3_URL_STYLE_VIRTUAL_HOSTED",
+                "integer": 1
+              },
+              {
+                "name": "S3_URL_STYLE_PATH",
+                "integer": 2
+              }
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "ExternalBackup",
@@ -7191,6 +7209,12 @@
                 "id": 7,
                 "name": "gcs",
                 "type": "GCSConfig",
+                "oneof_parent": "Config"
+              },
+              {
+                "id": 9,
+                "name": "s3compatible",
+                "type": "S3Compatible",
                 "oneof_parent": "Config"
               },
               {
@@ -7244,6 +7268,46 @@
                 "id": 7,
                 "name": "endpoint",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "S3Compatible",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bucket",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "access_key_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "secret_access_key",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "region",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "object_prefix",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "endpoint",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "url_style",
+                "type": "S3URLStyle"
               }
             ]
           },


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->

To improve the liklihood of backwards compatibility we need to use the `proto.lock` to tell us when storage proto changes are not compatible with the previous version.  As part of that we also need to make sure we are updating the `proto.lock` file as we go.  So the `storage-protos-compatible` has been updated so that it will also flag if the `proto.lock` is out of date.  As you can see by the `proto.lock` file that is part of this PR, it was already out of date from a recent change.

Please look at #12045 to see the style job fail for an out of date `'proto.lock` https://github.com/stackrox/stackrox/actions/runs/9995368467/job/27627340681?pr=12045

and #12046 for an example of an incompatible storage proto update and the error that generates 
https://github.com/stackrox/stackrox/actions/runs/9997069132/job/27632771087?pr=12046

Additionally the codowners were update so that core workflows would get tagged anytime a storage proto is changed.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [ ] CHANGELOG update is not needed
- [ ] Documentation is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [ ] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

See #12045 and #12046 as where this was tested.
