### PR TITLE
chore(ui): Add links to vulnmanagement for keyboard accessibility

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.js
@@ -8,6 +8,7 @@ import {
     defaultColumnClassName,
 } from 'Components/Table';
 import DateTimeField from 'Components/DateTimeField';
+import TableCellLink from 'Components/TableCellLink';
 import ClusterTableCountLinks from 'Components/workflow/ClusterTableCountLinks';
 import entityTypes from 'constants/entityTypes';
 import CVEStackedPill from 'Components/CVEStackedPill';
@@ -18,6 +19,7 @@ import { clusterSortFields } from 'constants/sortFields';
 import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
 import removeEntityContextColumns from 'utils/tableUtils';
 import { vulMgmtPolicyQuery } from '../../Entity/VulnMgmtPolicyQueryUtil';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 import WorkflowListPage from '../WorkflowListPage';
 
 export const defaultClusterSort = [
@@ -66,6 +68,14 @@ const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data, totalResult
                 Header: `Cluster`,
                 headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                 className: `w-1/8 ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('CLUSTER', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {original.name}
+                        </TableCellLink>
+                    );
+                },
                 id: clusterSortFields.CLUSTER,
                 accessor: 'name',
                 sortField: clusterSortFields.CLUSTER,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -16,6 +16,7 @@ import DateTimeField from 'Components/DateTimeField';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import Menu from 'Components/Menu';
+import TableCellLink from 'Components/TableCellLink';
 import TableCountLinks from 'Components/workflow/TableCountLinks';
 import TopCvssLabel from 'Components/TopCvssLabel';
 import PanelButton from 'Components/PanelButton';
@@ -45,6 +46,7 @@ import CveType from 'Components/CveType';
 import CveBulkActionDialogue from './CveBulkActionDialogue';
 
 import { entityCountNounOrdinaryCase } from '../../entitiesForVulnerabilityManagement';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 import WorkflowListPage from '../WorkflowListPage';
 import { getFilteredCVEColumns, parseCveNamesFromIds } from './ListCVEs.utils';
 
@@ -81,6 +83,14 @@ export function getCveTableColumns(workflowState, isFeatureFlagEnabled) {
             Header: `CVE`,
             headerClassName: `w-1/10 ${defaultHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
+            Cell: ({ original, pdf }) => {
+                const url = getVulnMgmtPathForEntitiesAndId(currentEntityType, original.id);
+                return (
+                    <TableCellLink pdf={pdf} url={url}>
+                        {original.cve}
+                    </TableCellLink>
+                );
+            },
             id: cveSortFields.CVE,
             accessor: 'cve',
             sortField: cveSortFields.CVE,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.js
@@ -20,6 +20,7 @@ import { deploymentSortFields } from 'constants/sortFields';
 import { getRatioOfScannedImages } from './deployments.utils';
 import WorkflowListPage from '../WorkflowListPage';
 import { vulMgmtPolicyQuery } from '../../Entity/VulnMgmtPolicyQueryUtil';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 
 export const defaultDeploymentSort = [
     {
@@ -45,6 +46,14 @@ export function getCurriedDeploymentTableColumns() {
                 Header: `Deployment`,
                 headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                 className: `w-1/8 ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('DEPLOYMENT', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {original.name}
+                        </TableCellLink>
+                    );
+                },
                 id: deploymentSortFields.DEPLOYMENT,
                 accessor: 'name',
                 sortField: deploymentSortFields.DEPLOYMENT,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.js
@@ -17,9 +17,11 @@ import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entit
 import removeEntityContextColumns from 'utils/tableUtils';
 import { componentSortFields } from 'constants/sortFields';
 
+import TableCellLink from 'Components/TableCellLink';
 import TableCountLink from 'Components/workflow/TableCountLink';
 import { getFilteredComponentColumns } from './ListImageComponents.utils';
 import WorkflowListPage from '../WorkflowListPage';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 
 export const defaultComponentSort = [
     {
@@ -41,9 +43,13 @@ export function getComponentTableColumns() {
                 Header: `Component`,
                 headerClassName: `w-1/4 ${defaultHeaderClassName}`,
                 className: `w-1/4 ${defaultColumnClassName}`,
-                Cell: ({ original }) => {
-                    const { version, name } = original;
-                    return `${name} ${version}`;
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('IMAGE_COMPONENT', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {`${original.name} ${original.version}`}
+                        </TableCellLink>
+                    );
                 },
                 id: componentSortFields.COMPONENT,
                 accessor: 'name',

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -4,6 +4,7 @@ import { gql } from '@apollo/client';
 import { Button } from '@patternfly/react-core';
 
 import ImageActiveIconText from 'Components/PatternFly/IconText/ImageActiveIconText';
+import TableCellLink from 'Components/TableCellLink';
 import TopCvssLabel from 'Components/TopCvssLabel';
 import ImageTableCountLinks from 'Components/workflow/ImageTableCountLinks';
 import CVEStackedPill from 'Components/CVEStackedPill';
@@ -27,6 +28,7 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import queryService from 'utils/queryService';
 import WatchedImagesDialog from './WatchedImagesDialog';
 import WorkflowListPage from '../WorkflowListPage';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 
 export const defaultImageSort = [
     {
@@ -48,6 +50,14 @@ export function getCurriedImageTableColumns(watchedImagesTrigger, isFeatureFlagE
                 Header: `Image`,
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('IMAGE', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {original.name.fullName}
+                        </TableCellLink>
+                    );
+                },
                 id: imageSortFields.NAME,
                 accessor: 'name.fullName',
                 sortField: imageSortFields.NAME,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.js
@@ -18,6 +18,7 @@ import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entit
 import removeEntityContextColumns from 'utils/tableUtils';
 import { namespaceSortFields } from 'constants/sortFields';
 import { vulMgmtPolicyQuery } from '../../Entity/VulnMgmtPolicyQueryUtil';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 import WorkflowListPage from '../WorkflowListPage';
 
 export const defaultNamespaceSort = [
@@ -40,6 +41,14 @@ const VulnMgmtNamespaces = ({ selectedRowId, search, sort, page, data, totalResu
                 Header: `Namespace`,
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('NAMESPACE', original.metadata.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {original.metadata.name}
+                        </TableCellLink>
+                    );
+                },
                 id: namespaceSortFields.NAMESPACE,
                 accessor: 'metadata.name',
                 sortField: namespaceSortFields.NAMESPACE,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.js
@@ -6,6 +6,7 @@ import {
     defaultColumnClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
+import TableCellLink from 'Components/TableCellLink';
 import TopCvssLabel from 'Components/TopCvssLabel';
 import entityTypes from 'constants/entityTypes';
 import { LIST_PAGE_SIZE } from 'constants/workflowPages.constants';
@@ -20,6 +21,7 @@ import { componentSortFields } from 'constants/sortFields';
 
 import { getFilteredComponentColumns } from './ListNodeComponents.utils';
 import WorkflowListPage from '../WorkflowListPage';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 
 export const defaultComponentSort = [
     {
@@ -41,9 +43,13 @@ export function getComponentTableColumns() {
                 Header: `Component`,
                 headerClassName: `w-1/4 ${defaultHeaderClassName}`,
                 className: `w-1/4 ${defaultColumnClassName}`,
-                Cell: ({ original }) => {
-                    const { version, name } = original;
-                    return `${name} ${version}`;
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('NODE_COMPONENT', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {`${original.name} ${original.version}`}
+                        </TableCellLink>
+                    );
                 },
                 id: componentSortFields.COMPONENT,
                 accessor: 'name',

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.js
@@ -16,6 +16,7 @@ import removeEntityContextColumns from 'utils/tableUtils';
 import { nodeSortFields } from 'constants/sortFields';
 
 import WorkflowListPage from '../WorkflowListPage';
+import { getVulnMgmtPathForEntitiesAndId } from '../../VulnMgmt.utils/entities';
 
 const nodeListUpdatedQuery = gql`
     query getNodes($query: String, $pagination: Pagination) {
@@ -50,6 +51,14 @@ export function getNodeTableColumns() {
                 Header: `Node`,
                 headerClassName: `w-1/6 ${defaultHeaderClassName}`,
                 className: `w-1/6 word-break-all ${defaultColumnClassName}`,
+                Cell: ({ original, pdf }) => {
+                    const url = getVulnMgmtPathForEntitiesAndId('NODE', original.id);
+                    return (
+                        <TableCellLink pdf={pdf} url={url}>
+                            {original.name}
+                        </TableCellLink>
+                    );
+                },
                 id: nodeSortFields.NODE,
                 accessor: 'name',
                 sortField: nodeSortFields.NODE,

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/entities.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/entities.ts
@@ -1,0 +1,12 @@
+import useCaseTypes from 'constants/useCaseTypes';
+import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
+import { WorkflowState } from 'utils/WorkflowState';
+
+const useCase = useCaseTypes.VULN_MANAGEMENT;
+
+export function getVulnMgmtPathForEntitiesAndId(
+    entityListType: VulnerabilityManagementEntityType,
+    id: string
+) {
+    return new WorkflowState(useCase).pushList(entityListType).pushListItem(id).toUrl();
+}


### PR DESCRIPTION
### Description

### Problem

Unlike some other classic tables, for which axe DevTools reports an issue:

> Scrollable region must have keyboard access `<div class="rt-table" role="grid">`

These tables have links in various columns to open the side panel for secondary entities, but **not** a link to open the side panel for the primary entity.

### Analysis

https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable?application=AxeChrome

Classic routes that render tables have `onRowClick` event handler:
* which does not have associated keyboard action
* which is probably invisible to screen readers

### Solution

Thank you Brad for discovery that Vulnerability Management renders hidden table for PDF export, therefore page crash:

> Invariant failed: You should not use `Link` outside of a `Router`

Even though **Export** button is available only for the 3 CVEs pages :(

1. Add in name column a link to open the side panel. Because of the discovery, instead of React Router `Link` element, `TableCellLink` element which encapsulates conditional rendering to omit links in hidden table.

    * Adapt `getVulnMgmtPathForEntitiesAndId` from row click handler:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.js#L60-L65

    * Construct `WorkflowState` because table column configuration does not have `location` or `match` from page address.

### Residue

1. After we finish this batch of accessiblity issues, adjust style rules to render links with PatternFly style in classic tables.
2. Delete obsolete code like `VulnMgmtListComponents` for generic components.
3. Ditto for conditions which include generic `'CVE'` entity type.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -4 = 4615480 - 4615484
        total 896 = 11699385 - 11698489
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui

### Manual testing

After changes, see tab key navigation.

1. Visit /main/vulnerability-management/image-cves
    ![image-cves_with_link](https://github.com/user-attachments/assets/f43b4e67-1183-4a4d-9974-e4797b0cc062)

2. Visit /main/vulnerability-management/node-cves
    ![node-cves_with_link](https://github.com/user-attachments/assets/addc2959-4e7d-4c05-8319-34e563f7dff0)

3. Visit /main/vulnerability-management/cluster-cves
    ![cluster-cves_with_link](https://github.com/user-attachments/assets/b5681829-8433-48f1-af5d-5cf6f28ddb4c)

4. Visit /main/vulnerability-management/nodes
    ![nodes_with_link](https://github.com/user-attachments/assets/c954c8ff-1307-4868-b760-79adf5d6f5e0)

5. Visit /main/vulnerability-management/images
    ![images_with_link](https://github.com/user-attachments/assets/02fddf85-f5fe-4e67-b032-2f14baa1aec3)

6. Visit /main/vulnerability-management/clusters
    ![clusters_with_link](https://github.com/user-attachments/assets/8ad10661-3276-473f-b4a2-e3d77e54e1ad)

7. Visit /main/vulnerability-management/namespaces
    ![namespaces_with_link](https://github.com/user-attachments/assets/c14cbfb6-f8ba-4c1c-bff5-a7511739f36d)

8. Visit /main/vulnerability-management/deployments
    ![deployments_with_link](https://github.com/user-attachments/assets/60edb5ca-a4f6-4b41-8a42-dff9ddf0ece6)

9. Visit /main/vulnerability-management/node-components
    ![node-components_with_link](https://github.com/user-attachments/assets/6bc77f3d-4384-42dd-8ccf-daf3c73d90c4)

10. Visit /main/vulnerability-management/image-components
    ![image-components_with_link](https://github.com/user-attachments/assets/74c5ca66-655b-4b42-9d37-e6d46c5f910b)

### Integration testing

* vulnmanagement/clusterCves.test.js
* vulnmanagement/clusters.test.js
* vulnmanagement/deployments.test.js
* vulnmanagement/imageComponents.test.js
* vulnmanagement/imageCves.test.js
* vulnmanagement/images.test.js
* vulnmanagement/namespaces.test.js
* vulnmanagement/nodeComponents.test.js
* vulnmanagement/nodeCves.test.js
* vulnmanagement/nodes.test.js

### Unit testing

* src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
