### PR TITLE
chore(ui): Add links to compliance tables for keyboard accessibility

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.selectors.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.selectors.js
@@ -4,8 +4,8 @@ export const selectors = {
             firstGroup: '.table-group-active:first',
             firstTableGroup: '.rt-table:first',
             firstRow: 'div.rt-tr-group > .rt-tr.-odd:first',
-            firstRowName: 'div.rt-tr-group > .rt-tr.-odd:first [data-testid="table-row-name"]',
-            secondRowName: 'div.rt-tr-group > .rt-tr.-even:first [data-testid="table-row-name"]',
+            firstRowName: 'div.rt-tr-group > .rt-tr.-odd:first .rt-td a',
+            secondRowName: 'div.rt-tr-group > .rt-tr.-even:first .rt-td a',
         },
     },
 };

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -12,7 +12,6 @@ import Table from 'Components/Table';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
 import Loader from 'Components/Loader';
 import TablePagination from 'Components/TablePagination';
-import { getColumnsByEntity, getColumnsByStandard } from 'constants/tableColumns';
 import Query from 'Components/CacheFirstQuery';
 import NoResultsMessage from 'Components/NoResultsMessage';
 
@@ -23,6 +22,7 @@ import queryService from 'utils/queryService';
 
 import { complianceEntityTypes, entityCountNounOrdinaryCase } from '../entitiesForCompliance';
 import TableGroup from './TableGroup';
+import { getColumnsByEntity, getColumnsByStandard, getColumnsForControl } from './tableColumns';
 
 function getQuery(entityType) {
     switch (entityType) {
@@ -272,6 +272,8 @@ const ListTable = ({
     let tableColumns;
     if (standardId) {
         tableColumns = getColumnsByStandard(standardId);
+    } else if (isControlList) {
+        tableColumns = getColumnsForControl(query);
     } else {
         tableColumns = getColumnsByEntity(entityType, standardsData.results);
     }

--- a/ui/apps/platform/src/Containers/Compliance/List/tableColumns.test.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/tableColumns.test.js
@@ -1,7 +1,7 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectColumnsToContain", "expectColumnsNotToContain"] }] */
 
+import { resourceTypes, standardTypes } from 'constants/entityTypes';
 import { getColumnsByEntity, getColumnsByStandard } from './tableColumns';
-import { resourceTypes, standardTypes } from './entityTypes';
 
 function expectColumnsToContain(columns, shouldContain) {
     const accessors = columns.map((c) => c.accessor);


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Scrollable region must have keyboard access `<div class="rt-table" role="grid">`

### Analysis

https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable?application=AxeChrome

Classic routes that render tables have `onRowClick` event handler:
* which does not have associated keyboard action
* which is probably invisible to screen readers

### Solution

1. Move tableColumns.js file into Compliance/List folder.
    * Replace `getNameCell` function with `TableCellLink` element.
    * Replace `controlColumns` object with `getColumnsForControl` function which has `query` argument because control links need same search as controls table.
        For example, `?Cluster=%2A&standard=CIS%20Kubernetes%20v1.5`
    * Replace redundant `Cell` properties to use ordinary `accessor` property for cluster and namespace in `getDeploymentColumns` function.
2. Adjust selectors for integration tests not to require `data-testid="table-row-name"` attribute.

### Residue

1. Fix color contrast of key label in classic search filter.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -6 = 4615478 - 4615484
        total 545 = 11698442 - 11697897
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui/apps/platform

#### Manual testing

Verify that page address for links is same as page address for rows!

1. Visit /main/compliance, click **Scan environment**, and then click a standard link in **Passing standards across clusters** widget.

    * Before changes, see presence of accessibility issue.
        ![compliance_controls_with_issue](https://github.com/user-attachments/assets/178b7d5b-7e29-4b0a-86eb-c5094b58c05f)

    * After changes, see absence of accessibility issue.
        See `a` element in Inspector.
        Tab key moves from search filter to buttons, and then to table rows. Press enter to open side panel.
        ![compliance_controls_with_link](https://github.com/user-attachments/assets/0c889208-a4a3-49d4-b1c9-9a74c3c6eeb3)

2. Go back, and then click clusters count link.
    ![compliance_clusters_with_link](https://github.com/user-attachments/assets/20e2fd4b-d714-40c0-9a38-9913120b60d3)

3. Go back, and then click namespaces count link.
    ![compliance_namespaces_with_link](https://github.com/user-attachments/assets/8ed1dd18-82dc-47b7-a1b7-e1863939544d)

4. Go back, and then click nodes count link.
    ![compliance_nodes_with_link](https://github.com/user-attachments/assets/c271b440-9dbb-4b5f-9bbd-0924795a2c87)

5. Go back, and then click deployments count link.

    * Before changes, see presence of accessibility issue.
        ![compliance_deployments_with_issue](https://github.com/user-attachments/assets/ff1bd731-2b64-47ff-82a9-7f414e4003a4)

    * After changes, see absence of accessibility issue.
        ![compliance_deployments_with_link](https://github.com/user-attachments/assets/a78c4cdc-fec1-479c-a919-f20048ccd442)

6. Visit /main/dashboard scroll down to **Compliance by standard** at lower right, and then click a link.
    ![dashboard_controls_with_link](https://github.com/user-attachments/assets/75d69145-261c-4d64-9be1-027f8d459819)

#### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js

#### Unit testing

* src/constants/tableColumns.test.js
