### PR TITLE
chore(ui): Fix accessibility issue of color contrast in search label

### DIFF
--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -16,7 +16,7 @@ import { newWorkflowCases } from 'constants/useCaseTypes';
 const backgroundClass = 'bg-base-100';
 const borderClass = 'border border-base-300';
 const colorClass = 'pf-v5-u-color-100'; // override color from React select style rules
-const categoryOptionClass = `pf-v5-u-font-weight-bold ${backgroundClass} ${borderClass} ${colorClass}`;
+const categoryOptionClass = `pf-v5-u-font-weight-bold pf-v5-u-background-color-info ${borderClass} ${colorClass}`;
 const valueOptionClass = `${backgroundClass} ${borderClass} ${colorClass}`;
 
 // Render readonly input with placeholder instead of span to prevent insufficient color contrast.

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -13,9 +13,11 @@ import searchContext from 'Containers/searchContext';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { newWorkflowCases } from 'constants/useCaseTypes';
 
-const borderClass = 'border border-primary-300';
-const categoryOptionClass = `bg-primary-200 text-primary-700 ${borderClass}`;
-const valueOptionClass = `bg-base-200 text-base-600 ${borderClass}`;
+const backgroundClass = 'bg-base-100';
+const borderClass = 'border border-base-300';
+const colorClass = 'pf-v5-u-color-100'; // override color from React select style rules
+const categoryOptionClass = `pf-v5-u-font-weight-bold ${backgroundClass} ${borderClass} ${colorClass}`;
+const valueOptionClass = `${backgroundClass} ${borderClass} ${colorClass}`;
 
 // Render readonly input with placeholder instead of span to prevent insufficient color contrast.
 export const placeholderCreator = (placeholderText) =>
@@ -23,7 +25,7 @@ export const placeholderCreator = (placeholderText) =>
         return (
             <span className="flex h-full items-center pointer-events-none">
                 <input
-                    className="bg-base-100 text-base-600 absolute pf-v5-u-w-100"
+                    className={`${backgroundClass} ${colorClass} absolute pf-v5-u-w-100`}
                     placeholder={placeholderText}
                     readOnly
                 />
@@ -34,17 +36,11 @@ export const placeholderCreator = (placeholderText) =>
 const isCategoryChip = (value) => value.endsWith(':');
 
 export const Option = ({ children, ...rest }) => {
-    let className;
-    if (isCategoryChip(children)) {
-        className = 'bg-primary-200 text-primary-700';
-    } else {
-        className = 'bg-base-200 text-base-600';
-    }
     return (
         <components.Option {...rest}>
             <div className="flex">
                 <span
-                    className={`${className} border-2 border-primary-300 rounded-sm p-1 px-2 text-sm`}
+                    className={`${isCategoryChip(children) ? categoryOptionClass : valueOptionClass} rounded-sm p-1 px-2 text-sm`}
                 >
                     {children}
                 </span>


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Ensures must meet minimum color contrast ratio thresholds

> Element has insufficient color contrast of 3.33 (foreground color: #468bc3, background color: `#ebf6ff`, font size: 8.9pt (11.9px), font weight: normal). Expected contrast ratio of 4.5:1

```html
<div class="css-12jo7m5 bg-primary-200 text-primary-700 border border-primary-300 react-select__multi-value__label">Cluster:</div>
```

### Analysis

Find in Files: `bg-primary-200 text-primary-700` from Inspector panel of browser
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js#L16-L18
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js#L26
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js#L36-L54

### Solution

Replace Tailwind classes with PatternFly utility classes:
* Replace StackRox primary blue with base blackish for background and border.
    UPDATE: As recommended by David Value, `pf-v5-u-background-color-info` blue for category
* Replace StackRox primary blue with ordinary PatternFly black for text.
* Replace StackRox primary blue versus base blackish with PatternFly bold versus normal font weight for category versus option.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] contributed **no automated tests**

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4615484 - 4615484
        total -152 = 11697773 - 11697925
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/violations, and then enter **Deployment: stackrox-monitoring-alertmanager** in search filter.

    * Before changes, see presence of accessibility issue.
        ![violations_with_issue](https://github.com/user-attachments/assets/410fa886-84a4-4e21-9075-9d395563955c)

    * After changes, see absence of accessibility issue. Inspect `color` to see PatternFly instead of from React Select.
        ![violations_without_issue](https://github.com/user-attachments/assets/4abf2d93-7172-493d-b49b-10846408aae5)

    * Requested change with `violations_without_issue_background-color` class for category in search bar:
        ![violations_without_issue_background-color](https://github.com/user-attachments/assets/189903e6-637c-406d-8d10-2b1345eb4d67)

    * Requested change with `violations_without_issue_background-color` class for category in search menu:
        ![violations_without_issue_background-color_menu](https://github.com/user-attachments/assets/855477df-c8c9-4642-b990-ed4423dc56b3)

2. Visit /main/compliance, click **Scan environment**, click namespaces count link, and then enter **Namespace: stackrox** in search filter.

    * Before changes, see presence of accessibility issue.
        ![compliance_namespaces_with_issue](https://github.com/user-attachments/assets/6c73c90f-023b-4082-a642-86c59d6f9479)

    * After changes, see absence of accessibility issue.
        Inspect `font-weight` of category to see PatternFly instead of Tailwind class.
        ![compliance_namespaces_without_issue](https://github.com/user-attachments/assets/087d4ace-2643-43a4-9324-5865241a7836)

3. Visit /main/vulnerability-management/images, and then enter **Namespace: stackrox** in search filter

    * Before changes, see presence of accessibility issue.
        ![vulnerability-management_images_with_issue_1](https://github.com/user-attachments/assets/818cdabe-7e12-4e2a-b7d0-943d73abd745)

        See similar style for options in drop-down list.
![vulnerability-management_images_with_issue_2](https://github.com/user-attachments/assets/59051546-2b13-4283-b713-788ac0fd98b5)

    * After changes, see absence of accessibility issue.
        Inspect `font-weight` of value to see PatternFly instead of Tailwind class.
        ![vulnerability-management_images_without_issue_1](https://github.com/user-attachments/assets/0623cf7b-a3f1-4c91-8fe9-1fefe2a0ce55)

        See similar style for options in drop-down list.
        ![vulnerability-management_images_without_issue_2](https://github.com/user-attachments/assets/d68881f8-bacf-4ba1-9c41-70a670e1b755)

4. Visit /main/configmanagement/policies, and then enter **Severity: CRITICAL_SEVERITY** in search filter

    * Before changes, see presence of accessibility issue.
        ![configmanagement_policies_with_issue](https://github.com/user-attachments/assets/e051d1ff-62ed-4589-be7e-0ebc207356c9)

    * After changes, see absence of accessibility issue.
        ![configmanagement_policies_without_issue](https://github.com/user-attachments/assets/c05a577d-d7b4-4cef-b7a3-de4e0d9f7201)

5. Visit /main/risk, and then enter **Namespace: stackrox** in search filter

    * Before changes, see presence of accessibility issue.
        ![risk_with_issue](https://github.com/user-attachments/assets/e14ce17d-8bf1-496e-bd19-7d440f36b05f)

    * After changes, see absence of accessibility issue.
        ![risk_without_issue](https://github.com/user-attachments/assets/bcf4a1f9-f0f2-483d-b9df-09e8fb5d6bff)

6. Visit /main/clusters, and then enter **Cluster: remote** in search filter

    * Before changes, see presence of accessibility issue.
        ![clusters_with_issue](https://github.com/user-attachments/assets/ba3b49d3-3b2b-4933-a4ce-d55bc990af68)

    * After changes, see absence of accessibility issue. This is example of PatternFly style for links in classic tables.
        ![clusters_without_issue](https://github.com/user-attachments/assets/9822e554-1066-4d7c-ac5f-92417a8ad73d)
