### PR TITLE
test(roxctl): cleanup cluster entries when done

### DIFF
--- a/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
@@ -15,17 +15,18 @@ setup_file() {
 
 setup() {
     out_dir="$(mktemp -d -u)"
+    sensor_name="sensor-test-${RANDOM}-${RANDOM}-${RANDOM}"
+    bundle_dir="${out_dir}/bundle-${sensor_name}"
 }
 
 teardown() {
     rm -rf "$out_dir"
+    roxctl-release -e "$API_ENDPOINT" -p "$ROX_PASSWORD" cluster delete --name="${sensor_name}"
 }
 
 sensor_bundle_psp_enabled() {
     local cluster_type="$1"
     shift
-    local sensor_name="sensor-test-${RANDOM}-${RANDOM}-${RANDOM}"
-    local bundle_dir="${out_dir}/bundle-${sensor_name}"
     roxctl-release -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate "${cluster_type}" --name="${sensor_name}" "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
     assert_success
@@ -34,8 +35,6 @@ sensor_bundle_psp_enabled() {
 sensor_bundle_psp_disabled() {
     local cluster_type="$1"
     shift
-    local sensor_name="sensor-test-${RANDOM}-${RANDOM}-${RANDOM}"
-    local bundle_dir="${out_dir}/bundle-${sensor_name}"
     roxctl-release -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate "${cluster_type}" --name="${sensor_name}" "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
     assert_failure

--- a/tests/roxctl/istio-support.sh
+++ b/tests/roxctl/istio-support.sh
@@ -59,10 +59,13 @@ test_roxctl_cmd() {
 test_roxctl_cmd central generate k8s none --output-format kubectl
 test_roxctl_cmd central generate openshift none
 
-test_roxctl_cmd sensor generate k8s --name k8s-istio-test-cluster  --continue-if-exists
+test_roxctl_cmd sensor generate k8s --name k8s-istio-test-cluster --continue-if-exists
 test_roxctl_cmd sensor get-bundle k8s-istio-test-cluster
 test_roxctl_cmd sensor generate openshift --name os-istio-test-cluster --continue-if-exists
 test_roxctl_cmd sensor get-bundle os-istio-test-cluster
+
+roxctl --insecure-skip-tls-verify -e "$API_ENDPOINT" -p "$ROX_PASSWORD" cluster delete --name k8s-istio-test-cluster
+roxctl --insecure-skip-tls-verify -e "$API_ENDPOINT" -p "$ROX_PASSWORD" cluster delete --name os-istio-test-cluster
 
 if [ $FAILURES -eq 0 ]; then
   echo "Passed"


### PR DESCRIPTION
### Description

<!-- A detailed explanation of the changes in your PR. Feel free to remove this section if the title of your PR is sufficiently descriptive. -->
It's easier to write other tests if they can assume that there is only one connected cluster.
Stumbled upon this when [rewriting](https://github.com/stackrox/stackrox/pull/11986) TLSChallengeTest in go.

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.
-->

I verified that a test that runs later only sees one cluster.