### PR TITLE
ROX-22019: Ensure random space is removed from compact proto to json

### DIFF
--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -2,6 +2,7 @@ package jsonutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"strings"
 
@@ -65,6 +66,15 @@ func ProtoToJSON(m protocompat.Message, options ...ConversionOption) (string, er
 	x, err := marshaller.Marshal(m)
 	if err != nil {
 		return "", err
+	}
+
+	if contains(options, OptCompact) {
+		compactBuf := &bytes.Buffer{}
+		if err := json.Compact(compactBuf, x); err != nil {
+			return string(x), nil
+		}
+
+		return compactBuf.String(), nil
 	}
 
 	return string(x), nil


### PR DESCRIPTION
### Description

The new protojson library has randomization for spaces to ensure lib users are not relying on stable string output.

This PR fixes usage in our wrapper that outputs compact JSON.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

Problem is found by Unit Test - no changes on unit test is important.

#### How I validated my change

Executed unit test locally (several times).
