### PR TITLE
fix: call EqualVT in Equal

### DIFF
--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -18,6 +18,11 @@ func Clone(msg proto.Message) proto.Message {
 	return proto.Clone(msg)
 }
 
+// Equalable is an interface for proto objects that have generated Equal method.
+type Equalable[T any] interface {
+	EqualVT(t T) bool
+}
+
 // Equal returns true iff protocol buffers a and b are equal. The arguments must both be pointers to protocol buffer structs.
 //
 // Equality is defined in this way:
@@ -32,8 +37,8 @@ func Clone(msg proto.Message) proto.Message {
 // * Every other combination of things are not equal.
 //
 // The return value is undefined if a and b are not protocol buffers.
-func Equal(a proto.Message, b proto.Message) bool {
-	return proto.Equal(a, b)
+func Equal[T Equalable[T]](a T, b T) bool {
+	return a.EqualVT(b)
 }
 
 // ErrNil is the error returned if Marshal is called with nil.

--- a/pkg/protocompat/message_test.go
+++ b/pkg/protocompat/message_test.go
@@ -19,14 +19,14 @@ func TestClone(t *testing.T) {
 
 	cloned := Clone(m1)
 
-	assert.True(t, Equal(m1, cloned))
+	assert.True(t, Equal(m1, cloned.(*storage.NamespaceMetadata)))
 
 	// Change a field value to ensure the clone does not point
 	// to the original struct.
 	clonedNamespace, casted := cloned.(*storage.NamespaceMetadata)
 	assert.True(t, casted)
 	clonedNamespace.Name = "Namespace AA"
-	assert.False(t, Equal(m1, cloned))
+	assert.False(t, Equal(m1, cloned.(*storage.NamespaceMetadata)))
 }
 
 func TestEqual(t *testing.T) {

--- a/pkg/protocompat/time.go
+++ b/pkg/protocompat/time.go
@@ -211,9 +211,7 @@ var (
 
 // IsZeroTimestamp returns whether a Timestamp pointer is either nil, or pointing to the zero of the type.
 func IsZeroTimestamp(ts *timestamppb.Timestamp) bool {
-	return ts == nil || equal(ts, GetProtoTimestampZero()) || equal(ts, zeroProtoTimestampFromTime)
-}
-
-func equal(a, b *timestamppb.Timestamp) bool {
-	return a.Nanos == b.Nanos && a.Seconds == b.Seconds
+	return ts == nil ||
+		CompareTimestamps(ts, GetProtoTimestampZero()) == 0 ||
+		CompareTimestamps(ts, zeroProtoTimestampFromTime) == 0
 }

--- a/pkg/protocompat/time.go
+++ b/pkg/protocompat/time.go
@@ -211,5 +211,9 @@ var (
 
 // IsZeroTimestamp returns whether a Timestamp pointer is either nil, or pointing to the zero of the type.
 func IsZeroTimestamp(ts *timestamppb.Timestamp) bool {
-	return ts == nil || Equal(ts, GetProtoTimestampZero()) || Equal(ts, zeroProtoTimestampFromTime)
+	return ts == nil || equal(ts, GetProtoTimestampZero()) || equal(ts, zeroProtoTimestampFromTime)
+}
+
+func equal(a, b *timestamppb.Timestamp) bool {
+	return a.Nanos == b.Nanos && a.Seconds == b.Seconds
 }

--- a/pkg/protomock/mock_matcher.go
+++ b/pkg/protomock/mock_matcher.go
@@ -5,8 +5,12 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func GoMockMatcherEqualMessage(expectedMsg protocompat.Message) gomock.Matcher {
+func GoMockMatcherEqualMessage[T protocompat.Equalable[T]](expectedMsg T) gomock.Matcher {
 	return gomock.Cond(func(msg any) bool {
-		return protocompat.Equal(expectedMsg, msg.(protocompat.Message))
+		return protocompat.Equal(expectedMsg, toT(expectedMsg, msg))
 	})
+}
+
+func toT[T any](_ T, a any) T {
+	return a.(T)
 }

--- a/pkg/protomock/mock_matcher.go
+++ b/pkg/protomock/mock_matcher.go
@@ -7,10 +7,6 @@ import (
 
 func GoMockMatcherEqualMessage[T protocompat.Equalable[T]](expectedMsg T) gomock.Matcher {
 	return gomock.Cond(func(msg any) bool {
-		return protocompat.Equal(expectedMsg, toT(expectedMsg, msg))
+		return protocompat.Equal(expectedMsg, msg.(T))
 	})
-}
-
-func toT[T any](_ T, a any) T {
-	return a.(T)
 }

--- a/pkg/protoutils/slices.go
+++ b/pkg/protoutils/slices.go
@@ -5,7 +5,7 @@ import (
 )
 
 // SliceContains returns whether the given slice of proto objects contains the given proto object.
-func SliceContains[T protocompat.Message](msg T, slice []T) bool {
+func SliceContains[T protocompat.Equalable[T]](msg T, slice []T) bool {
 	for _, elem := range slice {
 		if protocompat.Equal(elem, msg) {
 			return true
@@ -15,7 +15,7 @@ func SliceContains[T protocompat.Message](msg T, slice []T) bool {
 }
 
 // SlicesEqual returns whether the given two slices of proto objects have equal values.
-func SlicesEqual[T protocompat.Message](first, second []T) bool {
+func SlicesEqual[T protocompat.Equalable[T]](first, second []T) bool {
 	if len(first) != len(second) {
 		return false
 	}
@@ -29,7 +29,7 @@ func SlicesEqual[T protocompat.Message](first, second []T) bool {
 }
 
 // SliceUnique returns a slice returning unique values from the given slice.
-func SliceUnique[T protocompat.Message](slice []T) []T {
+func SliceUnique[T protocompat.Equalable[T]](slice []T) []T {
 	var uniqueSlice []T
 	for _, elem := range slice {
 		if !SliceContains(elem, uniqueSlice) {


### PR DESCRIPTION
### Description

This PR introduces Equalable interface and use it in `protocompat.Equal` so instead of relaying on `proto.Equal` implementation we can use generated `EqualVT` method that does not rely on reflection.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
