### PR TITLE
tests: grab openshift-ingress logs too

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -176,6 +176,7 @@ class PostClusterTest(StoreArtifacts):
             "openshift-etcd",
             "openshift-controller-manager",
             "openshift-compliance",
+            "openshift-ingress",
             "openshift-marketplace",
         ]
         self.collect_central_artifacts = collect_central_artifacts


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

From time to time we're getting unexplained connection refused errors to central which seems to be fine otherwise:

```
ERROR:	Analyst: rpc error: code = Unavailable desc = transport: dial tcp 35.193.54.114:443: connect: connection refused 
```

```
curl: (7) Failed to connect to 35.193.54.114
```

According to a [random troubleshooting doc](https://www.freekb.net/Article?id=3689) that Google spit up `openshift-ingress` ns is where the reverse-proxy pods live. Let's grab their logs so we can investigate closer the next time it happens.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results
- [x] verified the logs land on GCS as expected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

See above.