### PR TITLE
fix: ensure config is only rewritten when changed

### DIFF
--- a/central/config/datastore/datastore_test.go
+++ b/central/config/datastore/datastore_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"testing"
 
+	datastoreMocks "github.com/stackrox/rox/central/config/datastore/mocks"
 	storeMocks "github.com/stackrox/rox/central/config/store/mocks"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/protomock"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stretchr/testify/suite"
@@ -55,31 +58,33 @@ func (s *configDataStoreTestSuite) TearDownTest() {
 }
 
 var (
-	sampleConfig = &storage.Config{
-		PublicConfig: &storage.PublicConfig{
-			LoginNotice: &storage.LoginNotice{
-				Enabled: false,
-				Text: "You step onto the road, and if you don't keep your feet, " +
-					"there's no knowing where you might be swept off to.",
-			},
-			Header: &storage.BannerConfig{
-				Enabled: false,
-				Text: "Home is behind, the world ahead, and there " +
-					"are many paths to tread through shadows to the edge of night, " +
-					"until the stars are all alight.",
-				Size:            10,
-				Color:           "0x88bbff",
-				BackgroundColor: "0x0000ff",
-			},
-			Footer: &storage.BannerConfig{
-				Enabled:         false,
-				Text:            "All's well that ends better.",
-				Size:            10,
-				Color:           "0x88bbff",
-				BackgroundColor: "0x0000ff",
-			},
-			Telemetry: nil,
+	samplePublicConfig = &storage.PublicConfig{
+		LoginNotice: &storage.LoginNotice{
+			Enabled: false,
+			Text: "You step onto the road, and if you don't keep your feet, " +
+				"there's no knowing where you might be swept off to.",
 		},
+		Header: &storage.BannerConfig{
+			Enabled: false,
+			Text: "Home is behind, the world ahead, and there " +
+				"are many paths to tread through shadows to the edge of night, " +
+				"until the stars are all alight.",
+			Size:            storage.BannerConfig_MEDIUM,
+			Color:           "0x88bbff",
+			BackgroundColor: "0x0000ff",
+		},
+		Footer: &storage.BannerConfig{
+			Enabled:         false,
+			Text:            "All's well that ends better.",
+			Size:            storage.BannerConfig_SMALL,
+			Color:           "0x88bbff",
+			BackgroundColor: "0x0000ff",
+		},
+		Telemetry: nil,
+	}
+
+	sampleConfig = &storage.Config{
+		PublicConfig: samplePublicConfig,
 		PrivateConfig: &storage.PrivateConfig{
 			AlertRetention:                      nil,
 			ImageRetentionDurationDays:          7,
@@ -202,4 +207,275 @@ func (s *configDataStoreTestSuite) TestAllowsUpdate() {
 	updatedPublicConfig, updatedFound := getPublicConfigCache().Get(publicConfigKey)
 	s.True(updatedFound)
 	s.NotNil(updatedPublicConfig)
+}
+
+var (
+	customAlertRetention = &storage.PrivateConfig_AlertConfig{
+		AlertConfig: &storage.AlertRetentionConfig{
+			ResolvedDeployRetentionDurationDays:   DefaultDeployAlertRetention + 1,
+			DeletedRuntimeRetentionDurationDays:   DefaultDeletedRuntimeAlertRetention + 1,
+			AllRuntimeRetentionDurationDays:       DefaultRuntimeAlertRetention + 1,
+			AttemptedDeployRetentionDurationDays:  DefaultAttemptedDeployAlertRetention + 1,
+			AttemptedRuntimeRetentionDurationDays: DefaultAttemptedRuntimeAlertRetention + 1,
+		},
+	}
+
+	customPrivateConfig = &storage.PrivateConfig{
+		AlertRetention:                      customAlertRetention,
+		ImageRetentionDurationDays:          DefaultImageRetention + 1,
+		ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+		DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+		ReportRetentionConfig:               customReportRetentionConfig,
+		VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+		AdministrationEventsConfig:          customAdministrationEventsConfig,
+	}
+
+	customVulnerabilityDeferralConfig = &storage.VulnerabilityExceptionConfig{
+		ExpiryOptions: &storage.VulnerabilityExceptionConfig_ExpiryOptions{
+			DayOptions: []*storage.DayOption{
+				{
+					NumDays: 15,
+					Enabled: true,
+				},
+				{
+					NumDays: 31,
+					Enabled: true,
+				},
+				{
+					NumDays: 61,
+					Enabled: true,
+				},
+				{
+					NumDays: 91,
+					Enabled: true,
+				},
+			},
+			FixableCveOptions: &storage.VulnerabilityExceptionConfig_FixableCVEOptions{
+				AllFixable: true,
+				AnyFixable: false,
+			},
+			CustomDate: false,
+			Indefinite: false,
+		},
+	}
+
+	customDecommissionedClusterRetention = &storage.DecommissionedClusterRetentionConfig{
+		RetentionDurationDays: DefaultDecommissionedClusterRetentionDays + 1,
+	}
+
+	customReportRetentionConfig = &storage.ReportRetentionConfig{
+		HistoryRetentionDurationDays:           DefaultReportHistoryRetentionWindow + 1,
+		DownloadableReportRetentionDays:        DefaultDownloadableReportRetentionDays + 1,
+		DownloadableReportGlobalRetentionBytes: DefaultDownloadableReportGlobalRetentionBytes + 1,
+	}
+
+	customAdministrationEventsConfig = &storage.AdministrationEventsConfig{
+		RetentionDurationDays: DefaultAdministrationEventsRetention + 1,
+	}
+)
+
+func TestValidateConfigAndPopulateMissingDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		enabledFlags   []string
+		disabledFlags  []string
+		initialConfig  *storage.Config
+		upsertedConfig *storage.Config
+	}{
+		"No Update for fully set config": {
+			initialConfig: &storage.Config{
+				PublicConfig:  samplePublicConfig,
+				PrivateConfig: customPrivateConfig,
+			},
+			upsertedConfig: nil,
+		},
+		"Missing private config gets fully configured when Features activated": {
+			enabledFlags: []string{features.UnifiedCVEDeferral.EnvVar()},
+			initialConfig: &storage.Config{
+				PublicConfig:  samplePublicConfig,
+				PrivateConfig: nil,
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      defaultAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention,
+					DecommissionedClusterRetention:      defaultDecommissionedClusterRetention,
+					ReportRetentionConfig:               defaultReportRetentionConfig,
+					VulnerabilityExceptionConfig:        defaultVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          defaultAdministrationEventsConfig,
+				},
+			},
+		},
+		"Missing private config gets partially configured when Features deactivated": {
+			disabledFlags: []string{features.UnifiedCVEDeferral.EnvVar()},
+			initialConfig: &storage.Config{
+				PublicConfig:  samplePublicConfig,
+				PrivateConfig: nil,
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      defaultAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention,
+					DecommissionedClusterRetention:      defaultDecommissionedClusterRetention,
+					ReportRetentionConfig:               defaultReportRetentionConfig,
+					VulnerabilityExceptionConfig:        nil,
+					AdministrationEventsConfig:          defaultAdministrationEventsConfig,
+				},
+			},
+		},
+		"Configure decommissioned cluster retention when missing": {
+			initialConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      nil,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      defaultDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+		},
+		"Configure report retention when missing": {
+			initialConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               nil,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               defaultReportRetentionConfig,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+		},
+		"Configure vulnerability exception management when missing and Feature activated": {
+			enabledFlags: []string{features.UnifiedCVEDeferral.EnvVar()},
+			initialConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        nil,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        defaultVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+		},
+		"No update when vulnerability exception management is missing and Feature deactivated": {
+			disabledFlags: []string{features.UnifiedCVEDeferral.EnvVar()},
+			initialConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        nil,
+					AdministrationEventsConfig:          customAdministrationEventsConfig,
+				},
+			},
+			upsertedConfig: nil,
+		},
+		"Configure administration event management when missing": {
+			enabledFlags: []string{features.UnifiedCVEDeferral.EnvVar()},
+			initialConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          nil,
+				},
+			},
+			upsertedConfig: &storage.Config{
+				PublicConfig: samplePublicConfig,
+				PrivateConfig: &storage.PrivateConfig{
+					AlertRetention:                      customAlertRetention,
+					ImageRetentionDurationDays:          DefaultImageRetention + 1,
+					ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention + 1,
+					DecommissionedClusterRetention:      customDecommissionedClusterRetention,
+					ReportRetentionConfig:               customReportRetentionConfig,
+					VulnerabilityExceptionConfig:        customVulnerabilityDeferralConfig,
+					AdministrationEventsConfig:          defaultAdministrationEventsConfig,
+				},
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(it *testing.T) {
+			mockCtrl := gomock.NewController(it)
+			defer mockCtrl.Finish()
+
+			datastore := datastoreMocks.NewMockDataStore(mockCtrl)
+			datastore.EXPECT().
+				GetConfig(gomock.Any()).
+				Times(1).
+				Return(testCase.initialConfig, nil)
+			if testCase.upsertedConfig != nil {
+				datastore.EXPECT().
+					UpsertConfig(
+						gomock.Any(),
+						protomock.GoMockMatcherEqualMessage(testCase.upsertedConfig),
+					).
+					Return(nil)
+			}
+			for _, featureFlag := range testCase.disabledFlags {
+				t.Setenv(featureFlag, "false")
+			}
+			for _, featureFlag := range testCase.enabledFlags {
+				t.Setenv(featureFlag, "true")
+			}
+
+			validateConfigAndPopulateMissingDefaults(datastore)
+		})
+	}
 }

--- a/central/config/datastore/singleton.go
+++ b/central/config/datastore/singleton.go
@@ -45,17 +45,19 @@ var (
 
 	d DataStore
 
-	defaultPrivateConfig = storage.PrivateConfig{
-		ImageRetentionDurationDays: DefaultImageRetention,
-		AlertRetention: &storage.PrivateConfig_AlertConfig{
-			AlertConfig: &storage.AlertRetentionConfig{
-				ResolvedDeployRetentionDurationDays:   DefaultDeployAlertRetention,
-				DeletedRuntimeRetentionDurationDays:   DefaultDeletedRuntimeAlertRetention,
-				AllRuntimeRetentionDurationDays:       DefaultRuntimeAlertRetention,
-				AttemptedDeployRetentionDurationDays:  DefaultAttemptedDeployAlertRetention,
-				AttemptedRuntimeRetentionDurationDays: DefaultAttemptedRuntimeAlertRetention,
-			},
+	defaultAlertRetention = &storage.PrivateConfig_AlertConfig{
+		AlertConfig: &storage.AlertRetentionConfig{
+			ResolvedDeployRetentionDurationDays:   DefaultDeployAlertRetention,
+			DeletedRuntimeRetentionDurationDays:   DefaultDeletedRuntimeAlertRetention,
+			AllRuntimeRetentionDurationDays:       DefaultRuntimeAlertRetention,
+			AttemptedDeployRetentionDurationDays:  DefaultAttemptedDeployAlertRetention,
+			AttemptedRuntimeRetentionDurationDays: DefaultAttemptedRuntimeAlertRetention,
 		},
+	}
+
+	defaultPrivateConfig = storage.PrivateConfig{
+		ImageRetentionDurationDays:          DefaultImageRetention,
+		AlertRetention:                      defaultAlertRetention,
 		ExpiredVulnReqRetentionDurationDays: DefaultExpiredVulnReqRetention,
 	}
 
@@ -87,19 +89,29 @@ var (
 			Indefinite: false,
 		},
 	}
+
+	defaultDecommissionedClusterRetention = &storage.DecommissionedClusterRetentionConfig{
+		RetentionDurationDays: DefaultDecommissionedClusterRetentionDays,
+	}
+
+	defaultReportRetentionConfig = &storage.ReportRetentionConfig{
+		HistoryRetentionDurationDays:           DefaultReportHistoryRetentionWindow,
+		DownloadableReportRetentionDays:        DefaultDownloadableReportRetentionDays,
+		DownloadableReportGlobalRetentionBytes: DefaultDownloadableReportGlobalRetentionBytes,
+	}
+
+	defaultAdministrationEventsConfig = &storage.AdministrationEventsConfig{
+		RetentionDurationDays: DefaultAdministrationEventsRetention,
+	}
 )
 
-func initialize() {
-	store := pgStore.New(globaldb.GetPostgres())
-
-	d = New(store)
-
+func validateConfigAndPopulateMissingDefaults(datastore DataStore) {
 	ctx := sac.WithGlobalAccessScopeChecker(
 		context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Administration)))
-	config, err := d.GetConfig(ctx)
+	config, err := datastore.GetConfig(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -111,23 +123,17 @@ func initialize() {
 	needsUpsert := false
 	privateConfig := config.GetPrivateConfig()
 	if privateConfig == nil {
-		privateConfig = &defaultPrivateConfig
+		privateConfig = defaultPrivateConfig.Clone()
 		needsUpsert = true
 	}
 
 	if privateConfig.GetDecommissionedClusterRetention() == nil {
-		privateConfig.DecommissionedClusterRetention = &storage.DecommissionedClusterRetentionConfig{
-			RetentionDurationDays: DefaultDecommissionedClusterRetentionDays,
-		}
+		privateConfig.DecommissionedClusterRetention = defaultDecommissionedClusterRetention
 		needsUpsert = true
 	}
 
 	if privateConfig.GetReportRetentionConfig() == nil {
-		privateConfig.ReportRetentionConfig = &storage.ReportRetentionConfig{
-			HistoryRetentionDurationDays:           DefaultReportHistoryRetentionWindow,
-			DownloadableReportRetentionDays:        DefaultDownloadableReportRetentionDays,
-			DownloadableReportGlobalRetentionBytes: DefaultDownloadableReportGlobalRetentionBytes,
-		}
+		privateConfig.ReportRetentionConfig = defaultReportRetentionConfig
 		needsUpsert = true
 	}
 
@@ -139,18 +145,24 @@ func initialize() {
 	}
 
 	if privateConfig.GetAdministrationEventsConfig() == nil {
-		privateConfig.AdministrationEventsConfig = &storage.AdministrationEventsConfig{
-			RetentionDurationDays: DefaultAdministrationEventsRetention,
-		}
+		privateConfig.AdministrationEventsConfig = defaultAdministrationEventsConfig
 		needsUpsert = true
 	}
 
 	if needsUpsert {
-		utils.Must(d.UpsertConfig(ctx, &storage.Config{
+		utils.Must(datastore.UpsertConfig(ctx, &storage.Config{
 			PublicConfig:  config.GetPublicConfig(),
 			PrivateConfig: privateConfig,
 		}))
 	}
+}
+
+func initialize() {
+	store := pgStore.New(globaldb.GetPostgres())
+
+	d = New(store)
+
+	validateConfigAndPopulateMissingDefaults(d)
 }
 
 // Singleton provides the interface for non-service external interaction.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

After some feature flag cleanup, it was noticed that the configuration was systematically rewritten on instance start, and the logic to conditionally rewrite on change was dropped.
This probably came from a mistaken pattern application in the default initialization logic, which this PR aims at restoring.

### User-facing documentation

- [x] CHANGELOG is updated **OR** _update is not needed_
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** _is not needed_

### Testing

- [ ] inspected CI results

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Instrumented the development code with a log in the database singleton configuration upsert at initialization codeblock.
Checked the log did appear on first central instance start.
Restart central
Checked the log did **NOT** appear on second central instance start
