### PR TITLE
chore: add comment on cloudflare r2 subscription

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -536,7 +536,7 @@ class IntegrationsTest extends BaseSpecification {
         "configurations are:"
 
         // Cloudflare R2 requires an active credit card subscription to access the buckets.
-        // See BitWarden item `180af798-5f0e-486c-a595-b1a901445715` for the account details.
+        // See BitWarden item `06917dbc-17be-40f9-b8e1-b1a1015ce473` for the account details.
         integrationName                          | endpoint
         | urlStyle
         "Cloudflare R2/path-based/no-prefix"     | Env.mustGetCloudflareR2Endpoint()

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -535,6 +535,8 @@ class IntegrationsTest extends BaseSpecification {
         where:
         "configurations are:"
 
+        // Cloudflare R2 requires an active credit card subscription to access the buckets.
+        // See BitWarden item `180af798-5f0e-486c-a595-b1a901445715` for the account details.
         integrationName                          | endpoint
         | urlStyle
         "Cloudflare R2/path-based/no-prefix"     | Env.mustGetCloudflareR2Endpoint()


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

add a comment to explain the cloudflare r2 resources.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
