### PR TITLE
fix(ui): Fix accessibility issue in legend of sunburst graphs

### DIFF
--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -809,6 +809,14 @@ h6 {
 /* React-vis */
 @import '~react-vis/dist/style.css';
 
+/*
+ * Override overflow-y: auto which causes axe DevTools to report:
+ * Scrollable region must have keyboard access
+ */
+.rv-discrete-color-legend {
+    overflow-y: hidden;
+}
+
 /* Legend */
 .horizontal-bar-legend .rv-discrete-color-legend-item {
     padding: 3px 4px;


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Scrollable region must have keyboard access

### Analysis

src/app.tw.css imports react-vis/dist/style.css from from node_modules folder:

```css
.rv-discrete-color-legend{box-sizing:border-box;overflow-y:auto;font-size:12px}
```

Unlike table rows, there is no interaction in the legend of sunburst graphs.

### Solution

Add rule to override property in app.tw.css file.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

Automated testing is independent of presentation style.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/compliance, click **Scan environment**, click namespaces count link, click a namespace link to open the side panel, and then scroll down to see sunburst graphs.

    * Before changes, see presence of accessibility issue.
        ![compliance_namespaces_with_issue](https://github.com/user-attachments/assets/0fe3950e-f09e-418b-a025-c5506d51d546)

    * After changes, see absence of accessibility issue.
        Inspect `overflow-y` property to see override value.
        ![compliance_namespaces_without_issue](https://github.com/user-attachments/assets/2839cea8-431f-464a-bbbf-b4e93199c469)

1. Visit /main/configmanagement.

    * Before changes, see presence of accessibility issue.
        ![configmanagement_with_issue](https://github.com/user-attachments/assets/1c444400-df5e-454e-a95b-94c510deae0b)

    * After changes, see absence of accessibility issue.
        Inspect `overflow-y` property to see override value.
        ![configmanagement_without_issue](https://github.com/user-attachments/assets/1305b013-c4ad-433a-9917-f150bf657c10)
