### PR TITLE
chore(ui): node cypress test refactors v1

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -114,3 +114,13 @@ export function interactAndInspectGraphQLVariables(interactionCallback, opname) 
         return cy.wrap(interception.request.body.variables);
     });
 }
+
+export function expectRequestedSort(expectedSort) {
+    return (variables) => {
+        const { sortOption } = variables.pagination;
+        expect(sortOption).to.deep.equal(
+            expectedSort,
+            `Expected sort option ${JSON.stringify(expectedSort)} but received ${JSON.stringify(sortOption)}`
+        );
+    };
+}

--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -152,13 +152,3 @@ export const callbackForPairOfDescendingVulnerabilitySeverityValuesFromElements 
         isValidVulnerabilitySeverityValue,
         isPairOfDescendingVulnerabilitySeverityValues
     );
-
-export function expectRequestedSort(expectedSort) {
-    return (variables) => {
-        const { sortOption } = variables.pagination;
-        expect(sortOption).to.deep.equal(
-            expectedSort,
-            `Expected sort option ${JSON.stringify(expectedSort)} but received ${JSON.stringify(sortOption)}`
-        );
-    };
-}

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import("cypress/types/net-stubbing").RouteMatcherOptions} RouteMatcherOptions
+ * @typedef {import("cypress/types/net-stubbing").RouteHandler} RouteHandler
+ * @typedef {import("cypress/types/net-stubbing").WaitOptions} WaitOptions
+ */
 import { interceptRequests, waitForResponses } from './request';
 
 // Single source of truth for keys in staticResponseMapForAuthenticatedRoutes object.
@@ -58,9 +63,9 @@ const routeMatcherMapForAuthenticatedRoutes = {
  * staticResponseMap: { alias: { fixture }, … }
  *
  * @param {string} pageUrl
- * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
- * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
- * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
+ * @param {Record<string, RouteMatcherOptions>} [routeMatcherMap]
+ * @param {Record<string, RouteHandler>} [staticResponseMap]
+ * @param {WaitOptions} [waitOptions]
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function visit(pageUrl, routeMatcherMap, staticResponseMap, waitOptions) {
@@ -113,8 +118,8 @@ export function visitWithStaticResponseForAuthStatus(
  *
  * @param {string} pageUrl
  * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} staticResponseForPermissions
- * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
- * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @param {Record<string, RouteMatcherOptions>} [routeMatcherMap]
+ * @param {Record<string, RouteHandler>} [staticResponseMap]
  */
 export function visitWithStaticResponseForPermissions(
     pageUrl,

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
@@ -1,27 +1,87 @@
+import type { RouteHandler, RouteMatcherOptions } from 'cypress/types/net-stubbing';
+
 import { graphql } from '../../../constants/apiEndpoints';
 import {
     getRouteMatcherMapForGraphQL,
     interactAndWaitForResponses,
 } from '../../../helpers/request';
+import { visit, visitWithStaticResponseForPermissions } from '../../../helpers/visit';
 
-export function mockOverviewNodeCveListRequest() {
-    const opname = 'getNodeCVEs';
-    cy.intercept(
-        { method: 'POST', url: graphql(opname) },
-        { fixture: `vulnerabilities/nodeCves/${opname}.json` }
-    ).as(opname);
+export const nodeCveBaseUrl = '/main/vulnerabilities/node-cves/cves';
+
+// Source of truth for keys in routeMatcherMap and staticResponseMap objects.
+// Overview page
+export const getNodesOpname = 'getNodes';
+export const getNodeCvesOpname = 'getNodeCVEs';
+
+// Node CVE page
+export const getNodeCveMetadataOpname = 'getNodeCVEMetadata';
+
+// Node page
+export const getNodeMetadataOpname = 'getNodeMetadata';
+export const getNodeVulnSummaryOpname = 'getNodeVulnSummary';
+export const getNodeVulnerabilitiesOpname = 'getNodeVulnerabilities';
+
+export const routeMatcherMapForNodes = {
+    [getNodesOpname]: {
+        method: 'POST',
+        url: graphql(getNodesOpname),
+    },
+};
+
+export const routeMatcherMapForNodeCves = {
+    [getNodeCvesOpname]: {
+        method: 'POST',
+        url: graphql(getNodeCvesOpname),
+    },
+};
+
+export const routeMatcherMapForNodeCveMetadata = {
+    [getNodeCveMetadataOpname]: {
+        method: 'POST',
+        url: graphql(getNodeCveMetadataOpname),
+    },
+};
+
+export const routeMatcherMapForNodePage = {
+    [getNodeMetadataOpname]: {
+        method: 'POST',
+        url: graphql(getNodeMetadataOpname),
+    },
+    [getNodeVulnSummaryOpname]: {
+        method: 'POST',
+        url: graphql(getNodeVulnSummaryOpname),
+    },
+    [getNodeVulnerabilitiesOpname]: {
+        method: 'POST',
+        url: graphql(getNodeVulnerabilitiesOpname),
+    },
+};
+
+// visit
+export function visitNodeCveOverviewPage(
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    visit('/main/vulnerabilities/node-cves', routeMatcherMap, staticResponseMap);
 }
 
-export function mockOverviewNodeListRequest() {
-    const opname = 'getNodes';
-    cy.intercept(
-        { method: 'POST', url: graphql(opname) },
-        { fixture: `vulnerabilities/nodeCves/${opname}.json` }
-    ).as(opname);
-}
+export function visitNodeCvePageWithStaticPermissions(
+    mockCveName: string,
+    resourceToAccess: Record<string, string>,
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    const mockNodeCvePageUrl = `${nodeCveBaseUrl}/${mockCveName}`;
 
-export function visitNodeCveOverviewPage() {
-    cy.visit('/main/vulnerabilities/node-cves');
+    return visitWithStaticResponseForPermissions(
+        mockNodeCvePageUrl,
+        {
+            body: { resourceToAccess },
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
 }
 
 export function visitFirstNodeLinkFromTable(): Cypress.Chainable<string> {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
@@ -23,6 +23,8 @@ function mockNodeCvePageRequests() {
     });
 }
 
+const mockNodeCvePageUrl = `${nodeCveBaseUrl}/${mockCveName}`;
+
 describe('Node CVEs - CVE Detail Page', () => {
     withAuth();
 
@@ -38,28 +40,29 @@ describe('Node CVEs - CVE Detail Page', () => {
         mockNodeCvePageRequests();
     });
 
-    it('should restrict access to users with insufficient permissions', () => {
-        const url = `${nodeCveBaseUrl}/${mockCveName}`;
-
-        visitWithStaticResponseForPermissions(url, {
+    it('should restrict access to users with insufficient "Node" permission', () => {
+        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
             body: { resourceToAccess: { Node: 'READ_ACCESS' } },
         });
         assertCannotFindThePage();
+    });
 
-        visitWithStaticResponseForPermissions(url, {
+    it('should restrict access to users with insufficient "Cluster" permission', () => {
+        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
             body: { resourceToAccess: { Cluster: 'READ_ACCESS' } },
         });
         assertCannotFindThePage();
+    });
 
-        visitWithStaticResponseForPermissions(url, {
+    it('should allow access to users with sufficient permissions', () => {
+        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
             body: { resourceToAccess: { Node: 'READ_ACCESS', Cluster: 'READ_ACCESS' } },
         });
         cy.get('h1').contains(mockCveName);
     });
 
     it('should only show relevant filters for the page', () => {
-        const url = `${nodeCveBaseUrl}/${mockCveName}`;
-        visit(url, getRouteMatcherMapForGraphQL(['getNodeCVEMetadata']), {});
+        visit(mockNodeCvePageUrl, getRouteMatcherMapForGraphQL(['getNodeCVEMetadata']), {});
         assertAvailableFilters({
             Cluster: ['Name', 'Label', 'Type', 'Platform type'],
             Node: ['Name', 'Operating System', 'Label', 'Annotation', 'Scan Time'],

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
@@ -1,29 +1,22 @@
-import { graphql } from '../../../constants/apiEndpoints';
 import withAuth from '../../../helpers/basicAuth';
 import { assertAvailableFilters } from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
 import { getRouteMatcherMapForGraphQL } from '../../../helpers/request';
+import { assertCannotFindThePage, visit } from '../../../helpers/visit';
 import {
-    assertCannotFindThePage,
-    visit,
-    visitWithStaticResponseForPermissions,
-} from '../../../helpers/visit';
-
-const nodeCveBaseUrl = '/main/vulnerabilities/node-cves/cves';
+    getNodeCveMetadataOpname,
+    nodeCveBaseUrl,
+    routeMatcherMapForNodeCveMetadata,
+    visitNodeCvePageWithStaticPermissions,
+} from './NodeCve.helpers';
 
 const mockCveName = 'CVE-2022-1996';
 
-function mockNodeCvePageRequests() {
-    const opnames = ['getNodeCVEMetadata', 'getNodeCVESummaryData', 'getAffectedNodes'];
-    opnames.forEach((opname) => {
-        cy.intercept(
-            { method: 'POST', url: graphql(opname) },
-            { fixture: `vulnerabilities/nodeCves/${opname}.json` }
-        ).as(opname);
-    });
-}
-
-const mockNodeCvePageUrl = `${nodeCveBaseUrl}/${mockCveName}`;
+const staticResponseMapForNodeCveMetadata = {
+    [getNodeCveMetadataOpname]: {
+        fixture: `vulnerabilities/nodeCves/${getNodeCveMetadataOpname}`,
+    },
+};
 
 describe('Node CVEs - CVE Detail Page', () => {
     withAuth();
@@ -34,35 +27,35 @@ describe('Node CVEs - CVE Detail Page', () => {
         }
     });
 
-    beforeEach(() => {
-        // We cannot rely on any Node CVE data being available in CI so we need to mock the data
-        // and test page behavior independent of any expected server response.
-        mockNodeCvePageRequests();
-    });
-
     it('should restrict access to users with insufficient "Node" permission', () => {
-        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
-            body: { resourceToAccess: { Node: 'READ_ACCESS' } },
-        });
+        visitNodeCvePageWithStaticPermissions(mockCveName, { Node: 'READ_ACCESS' });
         assertCannotFindThePage();
     });
 
     it('should restrict access to users with insufficient "Cluster" permission', () => {
-        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
-            body: { resourceToAccess: { Cluster: 'READ_ACCESS' } },
-        });
+        visitNodeCvePageWithStaticPermissions(mockCveName, { Cluster: 'READ_ACCESS' });
         assertCannotFindThePage();
     });
 
     it('should allow access to users with sufficient permissions', () => {
-        visitWithStaticResponseForPermissions(mockNodeCvePageUrl, {
-            body: { resourceToAccess: { Node: 'READ_ACCESS', Cluster: 'READ_ACCESS' } },
-        });
+        visitNodeCvePageWithStaticPermissions(
+            mockCveName,
+            {
+                Node: 'READ_ACCESS',
+                Cluster: 'READ_ACCESS',
+            },
+            routeMatcherMapForNodeCveMetadata,
+            staticResponseMapForNodeCveMetadata
+        );
         cy.get('h1').contains(mockCveName);
     });
 
     it('should only show relevant filters for the page', () => {
-        visit(mockNodeCvePageUrl, getRouteMatcherMapForGraphQL(['getNodeCVEMetadata']), {});
+        visit(
+            `${nodeCveBaseUrl}/${mockCveName}`,
+            getRouteMatcherMapForGraphQL(['getNodeCVEMetadata']),
+            {}
+        );
         assertAvailableFilters({
             Cluster: ['Name', 'Label', 'Type', 'Platform type'],
             Node: ['Name', 'Operating System', 'Label', 'Annotation', 'Scan Time'],

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -30,7 +30,7 @@ describe('Node CVEs - Overview Page', () => {
         }
     });
 
-    it('should restrict access to users with insufficient permissions', () => {
+    it('should restrict access to users with insufficient "Cluster" permission', () => {
         // When lacking the minimum permissions:
         // - Check that the Node CVEs link is not visible in the left navigation
         // - Check that direct navigation fails
@@ -42,7 +42,12 @@ describe('Node CVEs - Overview Page', () => {
         cy.get(navSelectors.allNavLinks).contains('Node CVEs').should('not.exist');
         visitNodeCveOverviewPage();
         assertCannotFindThePage();
+    });
 
+    it('should restrict access to users with insufficient "Node" permission', () => {
+        // When lacking the minimum permissions:
+        // - Check that the Node CVEs link is not visible in the left navigation
+        // - Check that direct navigation fails
         // Missing 'Node' permission
         visitWithStaticResponseForPermissions('/main', {
             body: { resourceToAccess: { Cluster: 'READ_ACCESS' } },
@@ -50,7 +55,9 @@ describe('Node CVEs - Overview Page', () => {
         cy.get(navSelectors.allNavLinks).contains('Node CVEs').should('not.exist');
         visitNodeCveOverviewPage();
         assertCannotFindThePage();
+    });
 
+    it('should allow access to users with sufficient "Node" and "Cluster" permissions', () => {
         // Has both 'Node' and 'Cluster' permissions
         visitWithStaticResponseForPermissions('/main', {
             body: { resourceToAccess: { Node: 'READ_ACCESS', Cluster: 'READ_ACCESS' } },

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -7,7 +7,8 @@ import {
 } from '../../../helpers/visit';
 import navSelectors from '../../../selectors/navigation';
 import {
-    mockOverviewNodeCveListRequest,
+    getNodeCvesOpname,
+    routeMatcherMapForNodeCves,
     visitFirstNodeLinkFromTable,
     visitNodeCveOverviewPage,
 } from './NodeCve.helpers';
@@ -17,9 +18,14 @@ import {
     queryTableSortHeader,
     sortByTableHeader,
 } from '../../../helpers/tableHelpers';
-import { expectRequestedSort } from '../../../helpers/sort';
 import { waitForTableLoadCompleteIndicator } from '../workloadCves/WorkloadCves.helpers';
-import { interactAndInspectGraphQLVariables } from '../../../helpers/request';
+import { expectRequestedSort, interactAndInspectGraphQLVariables } from '../../../helpers/request';
+
+const staticResponseMapForNodeCVES = {
+    [getNodeCvesOpname]: {
+        fixture: `vulnerabilities/nodeCves/${getNodeCvesOpname}`,
+    },
+};
 
 describe('Node CVEs - Overview Page', () => {
     withAuth();
@@ -90,8 +96,7 @@ describe('Node CVEs - Overview Page', () => {
     it('should link a CVE table row to the correct CVE detail page', () => {
         // Having a CVE in CI is unreliable, so we mock the request and assert
         // on the link construction instead of the content of the detail page.
-        mockOverviewNodeCveListRequest();
-        visitNodeCveOverviewPage();
+        visitNodeCveOverviewPage(routeMatcherMapForNodeCves, staticResponseMapForNodeCVES);
 
         cy.get('tbody tr td[data-label="CVE"] a')
             .first()

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -23,6 +23,8 @@ function mockNodePageRequests() {
     });
 }
 
+const mockNodePageUrl = `${nodeBaseUrl}/${mockNodeId}`;
+
 describe('Node CVEs - Node Detail Page', () => {
     withAuth();
 
@@ -32,22 +34,26 @@ describe('Node CVEs - Node Detail Page', () => {
         }
     });
 
-    it('should restrict access to users with insufficient permissions', () => {
+    it('should restrict access to users with insufficient "Node" permission', () => {
         mockNodePageRequests();
 
-        const url = `${nodeBaseUrl}/${mockNodeId}`;
-
-        visitWithStaticResponseForPermissions(url, {
+        visitWithStaticResponseForPermissions(mockNodePageUrl, {
             body: { resourceToAccess: { Node: 'READ_ACCESS' } },
         });
         assertCannotFindThePage();
+    });
 
-        visitWithStaticResponseForPermissions(url, {
+    it('should restrict access to users with insufficient "Cluster" permission', () => {
+        mockNodePageRequests();
+        visitWithStaticResponseForPermissions(mockNodePageUrl, {
             body: { resourceToAccess: { Cluster: 'READ_ACCESS' } },
         });
         assertCannotFindThePage();
+    });
 
-        visitWithStaticResponseForPermissions(url, {
+    it('should allow access to users with sufficient permissions', () => {
+        mockNodePageRequests();
+        visitWithStaticResponseForPermissions(mockNodePageUrl, {
             body: { resourceToAccess: { Node: 'READ_ACCESS', Cluster: 'READ_ACCESS' } },
         });
         cy.get('h1').contains(mockNodeName);


### PR DESCRIPTION
### Description

Small refactors of existing integration tests:
1. Break up permission tests into a single assertion per test
2. Do away with "mock" functions and use staticResponseMaps instead

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] modified existing tests

#### How I validated my change

Local `yarn cypress`, CI