### PR TITLE
chore(ui): Alternative API for multi interact-and-wait scenarios

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -1,4 +1,10 @@
 /**
+ * @typedef {import("cypress/types/net-stubbing").RouteMatcherOptions} RouteMatcherOptions
+ * @typedef {import("cypress/types/net-stubbing").RouteHandler} RouteHandler
+ * @typedef {import("cypress/types/net-stubbing").WaitOptions} WaitOptions
+ */
+
+/**
  * For example, given ['searchOptions', 'getDeployments'] return:
  * {
  *     searchOptions: {
@@ -96,22 +102,56 @@ export function interactAndWaitForResponses(
 }
 
 /**
- * Intercepts a GraphQL request during an interaction and yields the
- * variables object passed to the request's query
+ * Intercept requests and monitor requests/responses across multiple interactions
  *
- * @param {() => void} interactionCallback The interaction performed to trigger the GraphQL request
- * @param {string} opname The GraphQL operation name
- * @returns {Cypress.Chainable<Interception>}
+ * @template {string} RouteKey
+ * @param {Record<RouteKey, RouteMatcherOptions>} routeMatcherMap
+ * @param {Partial<Record<RouteKey, RouteHandler>>} [staticResponseMap]
+ * @returns {Promise<{
+ *    waitForRequests: typeof waitForRequests,
+ *    waitAndYieldRequestBodyVariables: typeof waitAndYieldRequestBodyVariables,
+ * }>} Helper functions used to monitor requests
+ *          after an interaction that causes a request
  */
-export function interactAndInspectGraphQLVariables(interactionCallback, opname) {
-    const url = `/api/graphql?opname=${opname}`;
+export function interceptAndWatchRequests(routeMatcherMap, staticResponseMap) {
+    interceptRequests(routeMatcherMap, staticResponseMap);
 
-    cy.intercept({ method: 'POST', url, times: 1 }).as(opname);
+    /**
+     * Wait for requests to complete after an interaction
+     *
+     * @param {RouteKey[]=} keys The keys of the routeMatcherMap to wait for, if not provided, wait for all keys in routeMatcherMap
+     * @param {WaitOptions=} waitOptions Wait options for cy.wait
+     * @returns {Cypress.Chainable<Interception> | Cypress.Chainable<Interception[]>} The interception object or array of interception objects
+     */
+    function waitForRequests(keys, waitOptions) {
+        const aliases =
+            keys && keys.length > 0
+                ? keys.map((key) => `@${key}`)
+                : Object.keys(routeMatcherMap).map((key) => `@${key}`);
 
-    interactionCallback();
+        return cy.wait(aliases, waitOptions);
+    }
 
-    return cy.wait(`@${opname}`).then((interception) => {
-        return cy.wrap(interception.request.body.variables);
+    /**
+     * Wait for requests to complete after an interaction and yield the variables object passed in the request body
+     *
+     * @param {RouteKey[]=} keys The keys of the routeMatcherMap to wait for, if not provided, wait for all keys in routeMatcherMap
+     * @param {WaitOptions=} waitOptions Wait options for cy.wait
+     * @returns {Cypress.Chainable<any> | Cypress.Chainable<any[]>} The request variables object or array of request variables objects that were passed in the
+     *          request body of the intercepted request, if available
+     */
+    function waitAndYieldRequestBodyVariables(keys, waitOptions) {
+        return waitForRequests(keys, waitOptions).then((interception) => {
+            if (Array.isArray(interception)) {
+                return cy.wrap(interception.map(({ request }) => request.body.variables));
+            }
+            return cy.wrap(interception.request.body.variables);
+        });
+    }
+
+    return Promise.resolve({
+        waitForRequests,
+        waitAndYieldRequestBodyVariables,
     });
 }
 

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -149,7 +149,7 @@ export function interceptAndWatchRequests(routeMatcherMap, staticResponseMap) {
         });
     }
 
-    return Promise.resolve({
+    return cy.wrap({
         waitForRequests,
         waitAndYieldRequestBodyVariables,
     });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -90,7 +90,11 @@ describe('Node CVEs - Overview Page', () => {
     it('should link a CVE table row to the correct CVE detail page', () => {
         // Having a CVE in CI is unreliable, so we mock the request and assert
         // on the link construction instead of the content of the detail page.
-        visitNodeCveOverviewPage(routeMatcherMapForNodeCves, staticResponseMapForNodeCVES);
+        visitNodeCveOverviewPage(routeMatcherMapForNodeCves, {
+            [getNodeCvesOpname]: {
+                fixture: `vulnerabilities/nodeCves/${getNodeCvesOpname}`,
+            },
+        });
 
         cy.get('tbody tr td[data-label="CVE"] a')
             .first()

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -9,6 +9,7 @@ import navSelectors from '../../../selectors/navigation';
 import {
     getNodeCvesOpname,
     routeMatcherMapForNodeCves,
+    routeMatcherMapForNodes,
     visitFirstNodeLinkFromTable,
     visitNodeCveOverviewPage,
 } from './NodeCve.helpers';
@@ -18,14 +19,7 @@ import {
     queryTableSortHeader,
     sortByTableHeader,
 } from '../../../helpers/tableHelpers';
-import { waitForTableLoadCompleteIndicator } from '../workloadCves/WorkloadCves.helpers';
-import { expectRequestedSort, interactAndInspectGraphQLVariables } from '../../../helpers/request';
-
-const staticResponseMapForNodeCVES = {
-    [getNodeCvesOpname]: {
-        fixture: `vulnerabilities/nodeCves/${getNodeCvesOpname}`,
-    },
-};
+import { expectRequestedSort, interceptAndWatchRequests } from '../../../helpers/request';
 
 describe('Node CVEs - Overview Page', () => {
     withAuth();
@@ -117,107 +111,131 @@ describe('Node CVEs - Overview Page', () => {
     });
 
     it('should sort CVE table columns', () => {
-        visitNodeCveOverviewPage();
-        waitForTableLoadCompleteIndicator();
-
         // check sorting of CVE column
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('CVE'), 'getNodeCVEs').then(
-            expectRequestedSort({ field: 'CVE', reversed: true })
-        );
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('CVE'), 'getNodeCVEs').then(
-            expectRequestedSort({ field: 'CVE', reversed: false })
-        );
+        interceptAndWatchRequests(routeMatcherMapForNodeCves).then(
+            ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
+                visitNodeCveOverviewPage();
+                waitForRequests();
 
-        // check that the Nodes by severity column is not sortable
-        queryTableHeader('Nodes by severity');
-        queryTableSortHeader('Nodes by severity').should('not.exist');
+                // check sorting of CVE column
+                sortByTableHeader('CVE');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({ field: 'CVE', reversed: true })
+                );
 
-        // check sorting of Top CVSS column
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Top CVSS'), 'getNodeCVEs').then(
-            expectRequestedSort({
-                field: 'CVSS',
-                reversed: true,
-                aggregateBy: { aggregateFunc: 'max', distinct: false },
-            })
-        );
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Top CVSS'), 'getNodeCVEs').then(
-            expectRequestedSort({
-                field: 'CVSS',
-                reversed: false,
-                aggregateBy: { aggregateFunc: 'max', distinct: false },
-            })
-        );
+                sortByTableHeader('CVE');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({ field: 'CVE', reversed: false })
+                );
 
-        // check sorting of Affected Nodes column
-        interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Affected nodes'),
-            'getNodeCVEs'
-        ).then(
-            expectRequestedSort({
-                field: 'Node ID',
-                reversed: true,
-                aggregateBy: { aggregateFunc: 'count', distinct: true },
-            })
-        );
-        interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Affected nodes'),
-            'getNodeCVEs'
-        ).then(
-            expectRequestedSort({
-                field: 'Node ID',
-                reversed: false,
-                aggregateBy: { aggregateFunc: 'count', distinct: true },
-            })
-        );
+                // check that the Nodes by severity column is not sortable
+                queryTableHeader('Nodes by severity');
+                queryTableSortHeader('Nodes by severity').should('not.exist');
 
-        // check that the First discovered column is not sortable
-        queryTableHeader('First discovered');
-        queryTableSortHeader('First discovered').should('not.exist');
+                // check sorting of Top CVSS column
+                sortByTableHeader('Top CVSS');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({
+                        field: 'CVSS',
+                        reversed: true,
+                        aggregateBy: { aggregateFunc: 'max', distinct: false },
+                    })
+                );
+
+                sortByTableHeader('Top CVSS');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({
+                        field: 'CVSS',
+                        reversed: false,
+                        aggregateBy: { aggregateFunc: 'max', distinct: false },
+                    })
+                );
+
+                // check sorting of Affected nodes column
+                sortByTableHeader('Affected nodes');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({
+                        field: 'Node ID',
+                        reversed: true,
+                        aggregateBy: { aggregateFunc: 'count', distinct: true },
+                    })
+                );
+
+                sortByTableHeader('Affected nodes');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({
+                        field: 'Node ID',
+                        reversed: false,
+                        aggregateBy: { aggregateFunc: 'count', distinct: true },
+                    })
+                );
+
+                // check that the First discovered column is not sortable
+                queryTableHeader('First discovered');
+                queryTableSortHeader('First discovered').should('not.exist');
+            }
+        );
     });
 
     it('should sort Node table columns', () => {
-        // Visit Node tab and wait for initial load - sorting will be pre-applied to the Node column
-        interactAndInspectGraphQLVariables(() => {
-            visitNodeCveOverviewPage();
-            cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
-        }, 'getNodes');
+        interceptAndWatchRequests(routeMatcherMapForNodes).then(
+            ({
+                waitForRequests,
+                waitAndYieldRequestBodyVariables: waitAndInspectRequestVariables,
+            }) => {
+                // Visit Node tab and wait for initial load - sorting will be pre-applied to the Node column
+                visitNodeCveOverviewPage();
+                cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
+                waitForRequests();
 
-        // check sorting of Node column
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Node'), 'getNodes').then(
-            expectRequestedSort({ field: 'Node', reversed: true })
-        );
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Node'), 'getNodes').then(
-            expectRequestedSort({ field: 'Node', reversed: false })
-        );
+                // check sorting of Node column
+                sortByTableHeader('Node');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Node', reversed: true })
+                );
 
-        // check that CVEs by Severity is not sortable
-        queryTableHeader('CVEs by severity');
-        queryTableSortHeader('CVEs by severity').should('not.exist');
+                sortByTableHeader('Node');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Node', reversed: false })
+                );
 
-        // check sorting of Cluster column
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Cluster'), 'getNodes').then(
-            expectRequestedSort({ field: 'Cluster', reversed: true })
-        );
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Cluster'), 'getNodes').then(
-            expectRequestedSort({ field: 'Cluster', reversed: false })
-        );
+                // check that CVEs by Severity is not sortable
+                queryTableHeader('CVEs by severity');
+                queryTableSortHeader('CVEs by severity').should('not.exist');
 
-        // check sorting of Operating System column
-        interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Operating system'),
-            'getNodes'
-        ).then(expectRequestedSort({ field: 'Operating System', reversed: true }));
-        interactAndInspectGraphQLVariables(
-            () => sortByTableHeader('Operating system'),
-            'getNodes'
-        ).then(expectRequestedSort({ field: 'Operating System', reversed: false }));
+                // check sorting of Cluster column
+                sortByTableHeader('Cluster');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Cluster', reversed: true })
+                );
 
-        // check sorting of Scan time column
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Scan time'), 'getNodes').then(
-            expectRequestedSort({ field: 'Node Scan Time', reversed: true })
-        );
-        interactAndInspectGraphQLVariables(() => sortByTableHeader('Scan time'), 'getNodes').then(
-            expectRequestedSort({ field: 'Node Scan Time', reversed: false })
+                sortByTableHeader('Cluster');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Cluster', reversed: false })
+                );
+
+                // check sorting of Operating System column
+                sortByTableHeader('Operating system');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Operating System', reversed: true })
+                );
+
+                sortByTableHeader('Operating system');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Operating System', reversed: false })
+                );
+
+                // check sorting of Scan time column
+                sortByTableHeader('Scan time');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Node Scan Time', reversed: true })
+                );
+
+                sortByTableHeader('Scan time');
+                waitAndInspectRequestVariables().then(
+                    expectRequestedSort({ field: 'Node Scan Time', reversed: false })
+                );
+            }
         );
     });
 


### PR DESCRIPTION
### Description

Adds a new helper for a cleaner pattern in the Node Overview page tests. The pattern here is a multi-step cousin of the widely used `interactAndWaitForResponses()` function. Instead of passing a callback for the interaction, this helper inverts control and returns functions that allow the caller to specify when to wait for the request, and to do so multiple times.

This results in a more readable pattern of "act -> wait -> assert" than the callback driven approach used in the previous Node CVE sorting tests.

Inspiration from comment thread here https://github.com/stackrox/stackrox/pull/12018#discussion_r1686972491

_May be easier to review in "Split" view - or compared side-by-side to the previous code in a non-diff view._

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [ ] modified existing tests

#### How I validated my change

CI