### PR TITLE
chore(fix): Fix build for compliance e2e tests

### DIFF
--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	coNamespace       = "openshift-compliance"
+	coNamespaceV2     = "openshift-compliance"
 	stackroxNamespace = "stackrox"
 )
 
@@ -256,7 +256,7 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 			Id: res.GetId(),
 		}
 		_, _ = scanConfigService.DeleteComplianceScanConfiguration(ctx, reqDelete)
-		cleanUpResources(ctx, t, scanName, coNamespace)
+		cleanUpResources(ctx, t, scanName, coNamespaceV2)
 	})
 
 	// Scale up Sensor
@@ -266,8 +266,8 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	// Assert the ScanSetting and the ScanSettingBinding are created
 	scanSetting := &complianceoperatorv1.ScanSetting{}
 	scanSettingBinding := &complianceoperatorv1.ScanSettingBinding{}
-	assertResourceDoesExist(ctx, t, scanName, coNamespace, scanSetting)
-	assertResourceDoesExist(ctx, t, scanName, coNamespace, scanSettingBinding)
+	assertResourceDoesExist(ctx, t, scanName, coNamespaceV2, scanSetting)
+	assertResourceDoesExist(ctx, t, scanName, coNamespaceV2, scanSettingBinding)
 	assertScanSetting(t, scanConfig, scanSetting)
 	assertScanSettingBinding(t, scanConfig, scanSettingBinding)
 
@@ -287,8 +287,8 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	waitForDeploymentReady(ctx, t, "sensor", stackroxNamespace, 1)
 
 	// Assert the ScanSetting and the ScanSettingBinding are updated
-	assertResourceWasUpdated(ctx, t, scanName, coNamespace, scanSetting)
-	assertResourceWasUpdated(ctx, t, scanName, coNamespace, scanSettingBinding)
+	assertResourceWasUpdated(ctx, t, scanName, coNamespaceV2, scanSetting)
+	assertResourceWasUpdated(ctx, t, scanName, coNamespaceV2, scanSettingBinding)
 	assertScanSetting(t, scanConfig, scanSetting)
 	assertScanSettingBinding(t, scanConfig, scanSettingBinding)
 
@@ -307,8 +307,8 @@ func TestComplianceV2CentralSendsScanConfiguration(t *testing.T) {
 	waitForDeploymentReady(ctx, t, "sensor", stackroxNamespace, 1)
 
 	// Assert the ScanSetting and the ScanSettingBinding are deleted
-	assertResourceDoesNotExist(ctx, t, scanName, coNamespace, scanSetting)
-	assertResourceDoesNotExist(ctx, t, scanName, coNamespace, scanSettingBinding)
+	assertResourceDoesNotExist(ctx, t, scanName, coNamespaceV2, scanSetting)
+	assertResourceDoesNotExist(ctx, t, scanName, coNamespaceV2, scanSettingBinding)
 }
 
 // ACS API test suite for integration testing for the Compliance Operator.
@@ -543,7 +543,7 @@ func TestComplianceV2UpdateScanConfigurations(t *testing.T) {
 	assert.Equal(t, req.GetScanName(), resp.GetScanName())
 	t.Cleanup(func() {
 		_ = deleteScanConfig(ctx, resp.GetId(), scanConfigService)
-		cleanUpResources(ctx, t, req.GetScanName(), coNamespace)
+		cleanUpResources(ctx, t, req.GetScanName(), coNamespaceV2)
 	})
 
 	query := &v2.RawQuery{Query: ""}
@@ -555,8 +555,8 @@ func TestComplianceV2UpdateScanConfigurations(t *testing.T) {
 	// Assert the ScanSetting and the ScanSettingBinding are created
 	scanSetting := &complianceoperatorv1.ScanSetting{}
 	scanSettingBinding := &complianceoperatorv1.ScanSettingBinding{}
-	assertResourceDoesExist(ctx, t, scanName, coNamespace, scanSetting)
-	assertResourceDoesExist(ctx, t, scanName, coNamespace, scanSettingBinding)
+	assertResourceDoesExist(ctx, t, scanName, coNamespaceV2, scanSetting)
+	assertResourceDoesExist(ctx, t, scanName, coNamespaceV2, scanSettingBinding)
 	assertScanSetting(t, *req, scanSetting)
 	assertScanSettingBinding(t, *req, scanSettingBinding)
 
@@ -584,8 +584,8 @@ func TestComplianceV2UpdateScanConfigurations(t *testing.T) {
 	assert.GreaterOrEqual(t, scanConfigs.TotalCount, int32(1))
 
 	// Assert the ScanSetting and the ScanSettingBinding are updated
-	assertResourceWasUpdated(ctx, t, scanName, coNamespace, scanSetting)
-	assertResourceWasUpdated(ctx, t, scanName, coNamespace, scanSettingBinding)
+	assertResourceWasUpdated(ctx, t, scanName, coNamespaceV2, scanSetting)
+	assertResourceWasUpdated(ctx, t, scanName, coNamespaceV2, scanSettingBinding)
 	assertScanSetting(t, *updateReq, scanSetting)
 	assertScanSettingBinding(t, *updateReq, scanSettingBinding)
 }


### PR DESCRIPTION
### Description

We are getting build fails in the CI pipeline for `e2e` tests, but only compliance `e2e` tests.

The error is:
```
# github.com/stackrox/rox/tests [github.com/stackrox/rox/tests.test]
./compliance_operator_v2_test.go:38:2: coNamespace redeclared in this block
	./compliance_operator_test.go:26:2: other declaration of coNamespace
FAIL	github.com/stackrox/rox/tests [build failed]
```

We have a collision of constant names in this package.
```
coNamespace
```

This is not visible in IDE (at least for me), because IDE is handling files with defined `//go:build` tags. In this case we have one constant behind `test_e2e` build tag and another behind `compliance` tag. It looks like that problem happens only when both tags are enabled in the build.

An example: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-15-compliance-e2e-tests/1816267638465105920

**NOTE:** This PR only renames one constant to remove name collision. I thought to pull constant into `common.go`, but I prefer to keep tests isolated from each other and avoid future problems if tags are changed for some reason.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

I'll let the CI pipeline run.
