### PR TITLE
ROX-25440: Add stackrox CRs to diagnostic bundle

### DIFF
--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -416,7 +416,7 @@ func (c *collector) Run() error {
 		for _, objCfg := range c.cfg.Objects {
 			objClient := clientMap[objCfg.GVK]
 			if objClient == nil {
-				log.Warningf("Error generating diagnostic bundle. No client found for %s", objCfg.GVK.String())
+				log.Infof("Missing CRD to collect for generating a diagnostic bundle. No client found for %s.", objCfg.GVK.String())
 				continue
 			}
 			if err := c.collectObjectsData(ns, objCfg, objClient); err != nil {

--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -416,7 +416,7 @@ func (c *collector) Run() error {
 		for _, objCfg := range c.cfg.Objects {
 			objClient := clientMap[objCfg.GVK]
 			if objClient == nil {
-				log.Warningf("Missing CRD to collect for generating a diagnostic bundle. No client found for %s.", objCfg.GVK.String())
+				log.Warningf("Missing type information for %q when generating diagnostic bundle. (CRD not present in cluster?)", objCfg.GVK.String())
 				continue
 			}
 			if err := c.collectObjectsData(ns, objCfg, objClient); err != nil {

--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -416,7 +416,7 @@ func (c *collector) Run() error {
 		for _, objCfg := range c.cfg.Objects {
 			objClient := clientMap[objCfg.GVK]
 			if objClient == nil {
-				log.Infof("Missing CRD to collect for generating a diagnostic bundle. No client found for %s.", objCfg.GVK.String())
+				log.Warningf("Missing CRD to collect for generating a diagnostic bundle. No client found for %s.", objCfg.GVK.String())
 				continue
 			}
 			if err := c.collectObjectsData(ns, objCfg, objClient); err != nil {

--- a/pkg/k8sintrospect/default_config.go
+++ b/pkg/k8sintrospect/default_config.go
@@ -1,6 +1,7 @@
 package k8sintrospect
 
 import (
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/pkg/env"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -24,6 +25,12 @@ func DefaultConfig() Config {
 			},
 			{
 				GVK: schema.GroupVersionKind{Version: "v1", Kind: "Service"},
+			},
+			{
+				GVK: v1alpha1.SecuredClusterGVK,
+			},
+			{
+				GVK: v1alpha1.CentralGVK,
 			},
 		},
 	}

--- a/pkg/k8sintrospect/default_config.go
+++ b/pkg/k8sintrospect/default_config.go
@@ -1,7 +1,7 @@
 package k8sintrospect
 
 import (
-	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/env"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -368,6 +368,10 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 		allowedPackages = appendPackageWithChildren(allowedPackages, "tests/bad-ca")
 	}
 
+	if validImportRoot == "pkg" {
+		allowedPackages = appendPackageWithChildren(allowedPackages, "operator/apis")
+	}
+
 	for _, imp := range imports {
 		err := verifySingleImportFromAllowedPackagesOnly(imp, packageName, validImportRoot, allowedPackages...)
 		if err != nil {

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -369,7 +369,7 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 	}
 
 	if validImportRoot == "pkg" {
-		allowedPackages = appendPackageWithChildren(allowedPackages, "operator/apis")
+		allowedPackages = appendPackageWithChildren(allowedPackages, "operator/api")
 	}
 
 	for _, imp := range imports {


### PR DESCRIPTION
### Description

Add CRs to `_ungrouped` directory in the diagnostic bundle.

```
stackrox
├── admission-control
│  ....
├── sensor
│   ...
├── stackrox
│   ├── ...
└── _ungrouped
    ├── central-stackrox-central-services.yaml
    ├── configmap-admission-control.yaml
    ├── configmap-kube-root-ca.crt.yaml
    ├── secret-sh.helm.release.v1.stackrox-central-services.v1.yaml
    ├── secret-sh.helm.release.v1.stackrox-secured-cluster-services.v1.yaml
    └── securedcluster-stackrox-secured-cluster-services.yaml

```

#### How I validated my change

 - Create a Kubernetes cluster and install the RHACS operator into it
 - Install StackRox using the Central and SecuredCluster custom resources
 - Fetch a diagnostic bundle from Central, run `ls -la ./_ungrouped`