### PR TITLE
chore: switch to UnmarshalVT

### DIFF
--- a/central/globaldb/v2backuprestore/service/http_handlers.go
+++ b/central/globaldb/v2backuprestore/service/http_handlers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/ioutils"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -52,7 +51,7 @@ func (s *service) handleRestore(req *http.Request) error {
 	}
 
 	var header v1.DBRestoreRequestHeader
-	if err := protocompat.Unmarshal(headerBytes, &header); err != nil {
+	if err := (&header).UnmarshalVT(headerBytes); err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "could not parse restore request header: %v", err)
 	}
 

--- a/central/globaldb/v2backuprestore/service/http_handlers.go
+++ b/central/globaldb/v2backuprestore/service/http_handlers.go
@@ -51,7 +51,7 @@ func (s *service) handleRestore(req *http.Request) error {
 	}
 
 	var header v1.DBRestoreRequestHeader
-	if err := (&header).UnmarshalVT(headerBytes); err != nil {
+	if err := header.UnmarshalVT(headerBytes); err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "could not parse restore request header: %v", err)
 	}
 

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -893,7 +893,7 @@ func (s *storeImpl) getFullImage(ctx context.Context, tx *postgres.Tx, imageID s
 	}
 
 	var image storage.Image
-	if err := image.Unmarshal(data); err != nil {
+	if err := image.UnmarshalVT(data); err != nil {
 		return nil, false, err
 	}
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -71,7 +71,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge() {
 	s.Require().NoError(err)
 
 	trustInfo := &v1.TrustInfo{}
-	err = protocompat.Unmarshal(resp.GetTrustInfoSerialized(), trustInfo)
+	err = trustInfo.UnmarshalVT(resp.GetTrustInfoSerialized())
 	s.Require().NoError(err)
 
 	// Verify that additional CAs were received
@@ -101,7 +101,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_VerifySignatureWithCACert_Should
 	s.Require().NoError(err)
 
 	trustInfo := &v1.TrustInfo{}
-	err = protocompat.Unmarshal(resp.GetTrustInfoSerialized(), trustInfo)
+	err = trustInfo.UnmarshalVT(resp.GetTrustInfoSerialized())
 	s.Require().NoError(err)
 
 	// Read root CA from response

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -169,7 +169,7 @@ func (c *configuration) getCredentials() (string, string, error) {
 		return "", "", errors.Errorf("Error decrypting notifier secret for notifier '%s'", c.descriptor.GetName())
 	}
 	creds := &storage.AWSSecurityHub_Credentials{}
-	err = creds.Unmarshal([]byte(decCredsStr))
+	err = creds.UnmarshalVT([]byte(decCredsStr))
 	if err != nil {
 		return "", "", errors.Errorf("Error unmarshalling notifier credentials for notifier '%s'", c.descriptor.GetName())
 	}

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/probeupload"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/utils"
 	"google.golang.org/grpc"
@@ -119,7 +118,7 @@ func (s *service) doHandleProbeUpload(req *http.Request) error {
 	}
 
 	var manifest v1.ProbeUploadManifest
-	if err := protocompat.Unmarshal(manifestBytes, &manifest); err != nil {
+	if err := (&manifest).UnmarshalVT(manifestBytes); err != nil {
 		return errors.Wrap(err, "failed to unmarshal manifest")
 	}
 

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -118,7 +118,7 @@ func (s *service) doHandleProbeUpload(req *http.Request) error {
 	}
 
 	var manifest v1.ProbeUploadManifest
-	if err := (&manifest).UnmarshalVT(manifestBytes); err != nil {
+	if err := manifest.UnmarshalVT(manifestBytes); err != nil {
 		return errors.Wrap(err, "failed to unmarshal manifest")
 	}
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -602,7 +602,7 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := protocompat.Unmarshal(serialized, &msg); err != nil {
+		if err := (&msg).UnmarshalVT(serialized); err != nil {
 			return nil, err
 		}
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -602,7 +602,7 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := (&msg).UnmarshalVT(serialized); err != nil {
+		if err := msg.UnmarshalVT(serialized); err != nil {
 			return nil, err
 		}
 

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -11,7 +11,6 @@ import (
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -183,13 +182,13 @@ func (s *fullStoreImpl) readRows(
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := protocompat.Unmarshal(serialized, &msg); err != nil {
+		if err := (&msg).UnmarshalVT(serialized); err != nil {
 			return nil, err
 		}
 
 		var procMsg storage.ProcessIndicator
 		if procSerialized != nil {
-			if err := protocompat.Unmarshal(procSerialized, &procMsg); err != nil {
+			if err := (&procMsg).UnmarshalVT(procSerialized); err != nil {
 				return nil, err
 			}
 		}

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -182,13 +182,13 @@ func (s *fullStoreImpl) readRows(
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := (&msg).UnmarshalVT(serialized); err != nil {
+		if err := msg.UnmarshalVT(serialized); err != nil {
 			return nil, err
 		}
 
 		var procMsg storage.ProcessIndicator
 		if procSerialized != nil {
-			if err := (&procMsg).UnmarshalVT(procSerialized); err != nil {
+			if err := procMsg.UnmarshalVT(procSerialized); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/cryptoutils/cryptocodec/crypto_codec_test.go
+++ b/pkg/cryptoutils/cryptocodec/crypto_codec_test.go
@@ -38,7 +38,7 @@ func TestGCMEncryptionDecryption(t *testing.T) {
 	assert.NoError(t, err)
 	decryptedBytes := []byte(decryptedText)
 	decryptedCreds := &storage.AWSSecurityHub_Credentials{}
-	err = decryptedCreds.Unmarshal(decryptedBytes)
+	err = decryptedCreds.UnmarshalVT(decryptedBytes)
 	assert.NoError(t, err)
 	protoassert.Equal(t, originalCreds, decryptedCreds)
 }

--- a/pkg/grpc/common/authn/servicecerttoken/token.go
+++ b/pkg/grpc/common/authn/servicecerttoken/token.go
@@ -32,7 +32,7 @@ func ParseToken(token string, maxLeeway time.Duration) (*x509.Certificate, error
 	}
 
 	var auth central.ServiceCertAuth
-	if err := protocompat.Unmarshal(authBytes, &auth); err != nil {
+	if err := (&auth).UnmarshalVT(authBytes); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal service cert auth structure")
 	}
 

--- a/pkg/grpc/common/authn/servicecerttoken/token.go
+++ b/pkg/grpc/common/authn/servicecerttoken/token.go
@@ -32,7 +32,7 @@ func ParseToken(token string, maxLeeway time.Duration) (*x509.Certificate, error
 	}
 
 	var auth central.ServiceCertAuth
-	if err := (&auth).UnmarshalVT(authBytes); err != nil {
+	if err := auth.UnmarshalVT(authBytes); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal service cert auth structure")
 	}
 

--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -24,7 +24,7 @@ func unmarshal[T any, PT protocompat.Unmarshaler[T]](row pgx.Row) (*T, error) {
 		return nil, err
 	}
 	msg := new(T)
-	if err := PT(msg).Unmarshal(data); err != nil {
+	if err := PT(msg).UnmarshalVT(data); err != nil {
 		return nil, err
 	}
 	return msg, nil

--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -54,21 +54,20 @@ func Unmarshal[T any, PT Unmarshaler[T]](dAtA []byte, msg PT) error {
 		return ErrNil
 	}
 
-	return msg.Unmarshal(dAtA)
+	return msg.UnmarshalVT(dAtA)
 }
 
 // Unmarshaler is a generic interface type wrapping around types that implement protobuf Unmarshaler.
 type Unmarshaler[T any] interface {
-	Unmarshal(dAtA []byte) error
+	UnmarshalVT(dAtA []byte) error
 	*T
 }
 
 // ClonedUnmarshaler is a generic interface type wrapping around types that implement protobuf Unmarshaler
 // and that have a Clone deep-copy method.
 type ClonedUnmarshaler[T any] interface {
+	Unmarshaler[T]
 	Clone() *T
-	Unmarshal(dAtA []byte) error
-	*T
 }
 
 // Merge merges src into dst.

--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -43,20 +43,6 @@ func MarshalTextString(m proto.Message) string {
 	return prototext.MarshalOptions{Multiline: true}.Format(m)
 }
 
-// Unmarshal parses the protocol buffer representation in buf and places
-// the decoded result in pb. If the struct underlying pb does not match
-// the data in buf, the results can be unpredictable.
-//
-// Unmarshal resets pb before starting to unmarshal, so any existing data
-// in pb is always removed.
-func Unmarshal[T any, PT Unmarshaler[T]](dAtA []byte, msg PT) error {
-	if dAtA == nil {
-		return ErrNil
-	}
-
-	return msg.UnmarshalVT(dAtA)
-}
-
 // Unmarshaler is a generic interface type wrapping around types that implement protobuf Unmarshaler.
 type Unmarshaler[T any] interface {
 	UnmarshalVT(dAtA []byte) error

--- a/pkg/protocompat/message_test.go
+++ b/pkg/protocompat/message_test.go
@@ -3,7 +3,6 @@ package protocompat
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac/testconsts"
 	"github.com/stretchr/testify/assert"
@@ -73,22 +72,6 @@ func TestMarshalTextString(t *testing.T) {
 ` + `cluster_name: +"Cluster 1"
 `
 	assert.Regexp(t, expectedRegex, asString)
-}
-
-func TestUnmarshal(t *testing.T) {
-	msg := &storage.NamespaceMetadata{
-		Id:          testconsts.NamespaceA,
-		Name:        "Namespace A",
-		ClusterId:   testconsts.Cluster1,
-		ClusterName: "Cluster 1",
-	}
-	data, err := proto.Marshal(msg)
-	assert.NoError(t, err)
-
-	decoded := &storage.NamespaceMetadata{}
-	err = Unmarshal(data, decoded)
-	assert.NoError(t, err)
-	assert.True(t, msg.EqualVT(decoded))
 }
 
 func TestMerge(t *testing.T) {

--- a/pkg/protocompat/nil_test.go
+++ b/pkg/protocompat/nil_test.go
@@ -21,18 +21,3 @@ func TestErrorOnNilMarshal(t *testing.T) {
 	_, err = Marshal(&storage.Image{})
 	assert.NoError(t, err)
 }
-
-func TestErrorOnNilUnmarshal(t *testing.T) {
-	err := Unmarshal([]byte{}, null)
-	assert.NoError(t, err)
-
-	err = Unmarshal(nil, null)
-	assert.Equal(t, proto.ErrNil, err)
-
-	err = Unmarshal(nil, null)
-	assert.Equal(t, proto.ErrNil, err)
-
-	img := &storage.Image{}
-	err = Unmarshal([]byte{}, img)
-	assert.NoError(t, err)
-}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1105,7 +1105,7 @@ func unmarshal[T any, PT protocompat.Unmarshaler[T]](row pgx.Row) (*T, error) {
 		return nil, err
 	}
 	msg := new(T)
-	if err := PT(msg).Unmarshal(data); err != nil {
+	if err := PT(msg).UnmarshalVT(data); err != nil {
 		return nil, err
 	}
 	return msg, nil

--- a/sensor/admission-control/settingswatch/common.go
+++ b/sensor/admission-control/settingswatch/common.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/gziputil"
-	"github.com/stackrox/rox/pkg/protocompat"
 )
 
 func getPoliciesFromFile(file string) (*storage.PolicyList, error) {
@@ -25,7 +24,7 @@ func decompressAndUnmarshalPolicies(data []byte) (*storage.PolicyList, error) {
 	}
 
 	var policyList storage.PolicyList
-	if err := protocompat.Unmarshal(runTimePoliciesData, &policyList); err != nil {
+	if err := (&policyList).UnmarshalVT(runTimePoliciesData); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling decompressed policies data")
 	}
 	return &policyList, nil

--- a/sensor/admission-control/settingswatch/common.go
+++ b/sensor/admission-control/settingswatch/common.go
@@ -24,7 +24,7 @@ func decompressAndUnmarshalPolicies(data []byte) (*storage.PolicyList, error) {
 	}
 
 	var policyList storage.PolicyList
-	if err := (&policyList).UnmarshalVT(runTimePoliciesData); err != nil {
+	if err := policyList.UnmarshalVT(runTimePoliciesData); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling decompressed policies data")
 	}
 	return &policyList, nil

--- a/sensor/admission-control/settingswatch/k8s.go
+++ b/sensor/admission-control/settingswatch/k8s.go
@@ -103,7 +103,7 @@ func parseSettings(cm *v1.ConfigMap) (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var config storage.DynamicClusterConfig
-	if err := (&config).UnmarshalVT(configData); err != nil {
+	if err := config.UnmarshalVT(configData); err != nil {
 		return nil, errors.Wrap(err, "could not parse protobuf-encoded config data from configmap")
 	}
 

--- a/sensor/admission-control/settingswatch/k8s.go
+++ b/sensor/admission-control/settingswatch/k8s.go
@@ -103,7 +103,7 @@ func parseSettings(cm *v1.ConfigMap) (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var config storage.DynamicClusterConfig
-	if err := protocompat.Unmarshal(configData, &config); err != nil {
+	if err := (&config).UnmarshalVT(configData); err != nil {
 		return nil, errors.Wrap(err, "could not parse protobuf-encoded config data from configmap")
 	}
 

--- a/sensor/admission-control/settingswatch/mount.go
+++ b/sensor/admission-control/settingswatch/mount.go
@@ -61,7 +61,7 @@ func (m *mountSettingsWatch) OnChange(dir string) (interface{}, error) {
 	}
 
 	var clusterConfig storage.DynamicClusterConfig
-	if err := protocompat.Unmarshal(configData, &clusterConfig); err != nil {
+	if err := (&clusterConfig).UnmarshalVT(configData); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling decompressed cluster config data from file %s", configPath)
 	}
 

--- a/sensor/admission-control/settingswatch/mount.go
+++ b/sensor/admission-control/settingswatch/mount.go
@@ -61,7 +61,7 @@ func (m *mountSettingsWatch) OnChange(dir string) (interface{}, error) {
 	}
 
 	var clusterConfig storage.DynamicClusterConfig
-	if err := (&clusterConfig).UnmarshalVT(configData); err != nil {
+	if err := clusterConfig.UnmarshalVT(configData); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling decompressed cluster config data from file %s", configPath)
 	}
 

--- a/sensor/admission-control/settingswatch/persist.go
+++ b/sensor/admission-control/settingswatch/persist.go
@@ -81,7 +81,7 @@ func (p *persister) loadExisting() (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var settings sensor.AdmissionControlSettings
-	if err := (&settings).UnmarshalVT(bytes); err != nil {
+	if err := settings.UnmarshalVT(bytes); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling initial admission control settings from %s", settingsPath)
 	}
 

--- a/sensor/admission-control/settingswatch/persist.go
+++ b/sensor/admission-control/settingswatch/persist.go
@@ -81,7 +81,7 @@ func (p *persister) loadExisting() (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var settings sensor.AdmissionControlSettings
-	if err := protocompat.Unmarshal(bytes, &settings); err != nil {
+	if err := (&settings).UnmarshalVT(bytes); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling initial admission control settings from %s", settingsPath)
 	}
 

--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -44,10 +44,10 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 	require.NoError(t, err, "missing or corrupted config data in config map")
 
 	var policyList storage.PolicyList
-	require.NoError(t, (&policyList).UnmarshalVT(policiesData), "could not unmarshal policies list")
+	require.NoError(t, policyList.UnmarshalVT(policiesData), "could not unmarshal policies list")
 
 	var config storage.DynamicClusterConfig
-	require.NoError(t, (&config).UnmarshalVT(configData), "could not unmarshal config")
+	require.NoError(t, config.UnmarshalVT(configData), "could not unmarshal config")
 
 	cc := centralgrpc.GRPCConnectionToCentral(t)
 
@@ -111,7 +111,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		require.NoError(t, err, "missing or corrupted config data in config map")
 
 		var newPolicyList storage.PolicyList
-		require.NoError(t, (&newPolicyList).UnmarshalVT(newPoliciesData), "could not unmarshal policies list")
+		require.NoError(t, newPolicyList.UnmarshalVT(newPoliciesData), "could not unmarshal policies list")
 		assert.Len(t, newPolicyList.GetPolicies(), len(policyList.GetPolicies())+1, "expected one additional policy")
 		numMatches := 0
 		for _, policy := range newPolicyList.GetPolicies() {
@@ -122,7 +122,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		assert.Equal(t, 1, numMatches, "expected new policy list to contain new policy exactly once")
 
 		var newConfig storage.DynamicClusterConfig
-		require.NoError(t, (&newConfig).UnmarshalVT(newConfigData), "could not unmarshal config")
+		require.NoError(t, newConfig.UnmarshalVT(newConfigData), "could not unmarshal config")
 		assert.True(t, (&newConfig).EqualVT(&config), "new and old config should be equal")
 	})
 }

--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/gziputil"
 	"github.com/stackrox/rox/pkg/namespaces"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -45,10 +44,10 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 	require.NoError(t, err, "missing or corrupted config data in config map")
 
 	var policyList storage.PolicyList
-	require.NoError(t, protocompat.Unmarshal(policiesData, &policyList), "could not unmarshal policies list")
+	require.NoError(t, (&policyList).UnmarshalVT(policiesData), "could not unmarshal policies list")
 
 	var config storage.DynamicClusterConfig
-	require.NoError(t, protocompat.Unmarshal(configData, &config), "could not unmarshal config")
+	require.NoError(t, (&config).UnmarshalVT(configData), "could not unmarshal config")
 
 	cc := centralgrpc.GRPCConnectionToCentral(t)
 
@@ -112,7 +111,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		require.NoError(t, err, "missing or corrupted config data in config map")
 
 		var newPolicyList storage.PolicyList
-		require.NoError(t, protocompat.Unmarshal(newPoliciesData, &newPolicyList), "could not unmarshal policies list")
+		require.NoError(t, (&newPolicyList).UnmarshalVT(newPoliciesData), "could not unmarshal policies list")
 		assert.Len(t, newPolicyList.GetPolicies(), len(policyList.GetPolicies())+1, "expected one additional policy")
 		numMatches := 0
 		for _, policy := range newPolicyList.GetPolicies() {
@@ -123,7 +122,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		assert.Equal(t, 1, numMatches, "expected new policy list to contain new policy exactly once")
 
 		var newConfig storage.DynamicClusterConfig
-		require.NoError(t, protocompat.Unmarshal(newConfigData, &newConfig), "could not unmarshal config")
+		require.NoError(t, (&newConfig).UnmarshalVT(newConfigData), "could not unmarshal config")
 		assert.True(t, (&newConfig).EqualVT(&config), "new and old config should be equal")
 	})
 }


### PR DESCRIPTION
### Description

We don't need another layer of compatibility so we can switch to `UnmarshalVT`

```yaml
rules:
- id: a
  languages:
  - go
  message: WIP
  pattern: protocompat.Unmarshal($A, $X)
  fix: $X.UnmarshalVT($A)
  severity: WARNING
- id: b
  languages:
  - go
  message: WIP
  patterns:
    - pattern: $A.Unmarshal($X)
    - metavariable-regex:
        metavariable: $A
        regex: ([^json|yaml])
  fix: $A.UnmarshalVT($X)
  severity: WARNING
```

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
