### PR TITLE
chore: mark protocompat.Clone as deprecated

### DIFF
--- a/pkg/protocompat/message.go
+++ b/pkg/protocompat/message.go
@@ -11,16 +11,12 @@ import (
 type Message = proto.Message
 
 // Clone returns a deep copy of a protocol buffer.
+// Deprecated: Use CloneVT or CloneMessageVT instead.
 func Clone(msg proto.Message) proto.Message {
 	if vtMsg, ok := msg.(interface{ CloneMessageVT() proto.Message }); ok {
 		return vtMsg.CloneMessageVT()
 	}
 	return proto.Clone(msg)
-}
-
-// Equalable is an interface for proto objects that have generated Equal method.
-type Equalable[T any] interface {
-	EqualVT(t T) bool
 }
 
 // ErrNil is the error returned if Marshal is called with nil.

--- a/pkg/protomock/mock_matcher.go
+++ b/pkg/protomock/mock_matcher.go
@@ -1,11 +1,11 @@
 package protomock
 
 import (
-	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"go.uber.org/mock/gomock"
 )
 
-func GoMockMatcherEqualMessage[T protocompat.Equalable[T]](expectedMsg T) gomock.Matcher {
+func GoMockMatcherEqualMessage[T protoutils.Equalable[T]](expectedMsg T) gomock.Matcher {
 	return gomock.Cond(func(msg any) bool {
 		return expectedMsg.EqualVT(msg.(T))
 	})

--- a/pkg/protoutils/slices.go
+++ b/pkg/protoutils/slices.go
@@ -1,11 +1,12 @@
 package protoutils
 
-import (
-	"github.com/stackrox/rox/pkg/protocompat"
-)
+// Equalable is an interface for proto objects that have generated Equal method.
+type Equalable[T any] interface {
+	EqualVT(t T) bool
+}
 
 // SliceContains returns whether the given slice of proto objects contains the given proto object.
-func SliceContains[T protocompat.Equalable[T]](msg T, slice []T) bool {
+func SliceContains[T Equalable[T]](msg T, slice []T) bool {
 	for _, elem := range slice {
 		if elem.EqualVT(msg) {
 			return true
@@ -15,7 +16,7 @@ func SliceContains[T protocompat.Equalable[T]](msg T, slice []T) bool {
 }
 
 // SlicesEqual returns whether the given two slices of proto objects have equal values.
-func SlicesEqual[T protocompat.Equalable[T]](first, second []T) bool {
+func SlicesEqual[T Equalable[T]](first, second []T) bool {
 	if len(first) != len(second) {
 		return false
 	}
@@ -29,7 +30,7 @@ func SlicesEqual[T protocompat.Equalable[T]](first, second []T) bool {
 }
 
 // SliceUnique returns a slice returning unique values from the given slice.
-func SliceUnique[T protocompat.Equalable[T]](slice []T) []T {
+func SliceUnique[T Equalable[T]](slice []T) []T {
 	var uniqueSlice []T
 	for _, elem := range slice {
 		if !SliceContains(elem, uniqueSlice) {


### PR DESCRIPTION
### Description

Prevent accidental usage by marking as deprecated. This function is used only in one place:

https://github.com/stackrox/stackrox/blob/cdfb007fd7e9dc81715f6324a38994541096f0ba/pkg/protoutils/any.go#L34

Also move Equalable interface to the place where it's used the most.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
