### PR TITLE
ROX-25451: Re-enable Sensor upgrader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - `roxctl central generate k8s pvc` and `roxctl central generate openshift pvc` no longer have the flags `--name`, `--size`, and `--storage-class`.
   - `roxctl central generate k8s hostpath` and `roxctl central generate openshift hostpath` no longer have the flags `--hostpath`, `--node-selector-key`, and `--node-selector-value`.
 
-### Deprecated Fatures
+### Deprecated Features
 - ROX-25677: The format for specifying durations in JSON requests to
   `v1/nodecves/suppress`, `v1/clustercves/suppress` and `v1/imagecves/suppress`
   will be restricted to a [proto JSON format](https://protobuf.dev/programming-guides/proto3/#json:~:text=are%20also%20accepted.-,Duration,-string).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 - ROX-25066: Add new external backup integration for non-AWS S3 compatible providers.
+- ROX-25376: Add the release stage property to the `/v1/featureflags` response.
+- ROX-25451: Secured Cluster Auto-Upgrader is now enabled for all kind of clusters.
 
 ### Removed Features
 

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -125,7 +125,7 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 	}
 
 	if req.GetConfig().GetEnableAutoUpgrade() && getAutoUpgradeFeatureStatus() == v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED {
-		return nil, errors.Wrap(errox.InvalidArgs, "auto-upgrade not supported on managed ACS")
+		return nil, errors.Wrap(errox.InvalidArgs, "sensor auto-upgrade is not supported")
 	}
 
 	if err := s.configDataStore.UpsertSensorUpgradeConfig(ctx, req.GetConfig()); err != nil {

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -125,7 +125,7 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 	if req.GetConfig() == nil {
 		return nil, errors.Wrap(errox.InvalidArgs, "need to specify a config")
 	}
-	log.Infof("UI triggered auto-upgrader change: %+v", req.GetConfig().String())
+	log.Infof("Auto-upgrader toggled in the UI: %+v", req.GetConfig().String())
 
 	if req.GetConfig().GetEnableAutoUpgrade() && getAutoUpgradeFeatureStatus() == v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED {
 		return nil, errors.Wrap(errox.InvalidArgs, "sensor auto-upgrade is not supported")
@@ -135,7 +135,6 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 		return nil, err
 	}
 	s.autoTriggerFlag.Set(req.GetConfig().EnableAutoUpgrade)
-	log.Infof("autoTriggerFlag is set to: %t", req.GetConfig().EnableAutoUpgrade)
 
 	return &v1.Empty{}, nil
 }

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -113,10 +113,10 @@ func (s *service) AutoUpgradeSetting() *concurrency.Flag {
 }
 
 func getAutoUpgradeFeatureStatus() v1.GetSensorUpgradeConfigResponse_SensorAutoUpgradeFeatureStatus {
-	if env.ManagedCentral.BooleanSetting() {
-		return v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED
+	if env.SensorUpgraderEnabled.BooleanSetting() {
+		return v1.GetSensorUpgradeConfigResponse_SUPPORTED
 	}
-	return v1.GetSensorUpgradeConfigResponse_SUPPORTED
+	return v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED
 }
 
 func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateSensorUpgradeConfigRequest) (*v1.Empty, error) {

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"google.golang.org/grpc"
@@ -34,6 +35,7 @@ var (
 			"/v1.SensorUpgradeService/TriggerSensorCertRotation",
 		},
 	})
+	log = logging.LoggerForModule()
 )
 
 type service struct {
@@ -123,6 +125,7 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 	if req.GetConfig() == nil {
 		return nil, errors.Wrap(errox.InvalidArgs, "need to specify a config")
 	}
+	log.Infof("UI triggered auto-upgrader change: %+v", req.GetConfig().String())
 
 	if req.GetConfig().GetEnableAutoUpgrade() && getAutoUpgradeFeatureStatus() == v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED {
 		return nil, errors.Wrap(errox.InvalidArgs, "sensor auto-upgrade is not supported")
@@ -132,6 +135,8 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 		return nil, err
 	}
 	s.autoTriggerFlag.Set(req.GetConfig().EnableAutoUpgrade)
+	log.Infof("autoTriggerFlag is set to: %t", req.GetConfig().EnableAutoUpgrade)
+
 	return &v1.Empty{}, nil
 }
 

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -128,7 +128,7 @@ func (s *service) UpdateSensorUpgradeConfig(ctx context.Context, req *v1.UpdateS
 	log.Infof("Auto-upgrader toggled in the UI: %+v", req.GetConfig().String())
 
 	if req.GetConfig().GetEnableAutoUpgrade() && getAutoUpgradeFeatureStatus() == v1.GetSensorUpgradeConfigResponse_NOT_SUPPORTED {
-		return nil, errors.Wrap(errox.InvalidArgs, "sensor auto-upgrade is not supported")
+		return nil, errors.Wrap(errox.InvalidArgs, "secured cluster auto-upgrade is not supported")
 	}
 
 	if err := s.configDataStore.UpsertSensorUpgradeConfig(ctx, req.GetConfig()); err != nil {

--- a/central/sensorupgrade/service/service_impl_test.go
+++ b/central/sensorupgrade/service/service_impl_test.go
@@ -175,7 +175,7 @@ func (s *SensorUpgradeServiceTestSuite) Test_GetSensorUpgradeConfig_WithValueNot
 	}
 
 	for envValue, expectations := range testCases {
-		s.Run(fmt.Sprintf("ROX_SENSOR_UPGRADER_ENABLED=%v", envValue), func() {
+		s.Run(fmt.Sprintf("%s=%v", env.SensorUpgraderEnabled.EnvVar(), envValue), func() {
 			s.dataStore.EXPECT().GetSensorUpgradeConfig(gomock.Any()).Times(1).Return(nil, nil)
 			s.dataStore.EXPECT().UpsertSensorUpgradeConfig(gomock.Any(), &UpgradeConfigMatcher{expectations.expectedAutoUpdate})
 			s.T().Setenv(env.SensorUpgraderEnabled.EnvVar(), envValue)

--- a/central/sensorupgrade/service/service_impl_test.go
+++ b/central/sensorupgrade/service/service_impl_test.go
@@ -96,7 +96,7 @@ func (s *SensorUpgradeServiceTestSuite) Test_UpdateSensorUpgradeConfig() {
 	for caseName, testCase := range testCases {
 		s.Run(caseName, func() {
 			s.T().Setenv(env.ManagedCentral.EnvVar(), strconv.FormatBool(testCase.managedCentral))
-			s.T().Setenv(env.UpgraderEnabled.EnvVar(), strconv.FormatBool(!testCase.upgraderDisabled))
+			s.T().Setenv(env.SensorUpgraderEnabled.EnvVar(), strconv.FormatBool(!testCase.upgraderDisabled))
 			s.dataStore.EXPECT().GetSensorUpgradeConfig(gomock.Any()).Times(1).Return(nil, nil)
 			s.dataStore.EXPECT().UpsertSensorUpgradeConfig(gomock.Any(), gomock.Any()).Times(1)
 			serviceInstance, err := New(s.dataStore, s.manager)
@@ -155,10 +155,10 @@ func (s *SensorUpgradeServiceTestSuite) Test_GetSensorUpgradeConfig_WithValueNot
 	}
 
 	for envValue, expectations := range testCases {
-		s.Run(fmt.Sprintf("ROX_UPGRADER_ENABLED=%v", envValue), func() {
+		s.Run(fmt.Sprintf("ROX_SENSOR_UPGRADER_ENABLED=%v", envValue), func() {
 			s.dataStore.EXPECT().GetSensorUpgradeConfig(gomock.Any()).Times(1).Return(nil, nil)
 			s.dataStore.EXPECT().UpsertSensorUpgradeConfig(gomock.Any(), &UpgradeConfigMatcher{expectations.expectedAutoUpdate})
-			s.T().Setenv(env.UpgraderEnabled.EnvVar(), envValue)
+			s.T().Setenv(env.SensorUpgraderEnabled.EnvVar(), envValue)
 
 			instance, err := New(s.dataStore, s.manager)
 			s.NoError(err)

--- a/pkg/env/managed.go
+++ b/pkg/env/managed.go
@@ -4,6 +4,9 @@ var (
 	// ManagedCentral is set to true to signal that the central is running as a managed instance.
 	ManagedCentral = RegisterBooleanSetting("ROX_MANAGED_CENTRAL", false)
 
+	// SensorUpgraderEnabled controls whether the secured cluster auto-upgrader is enabled
+	SensorUpgraderEnabled = RegisterBooleanSetting("ROX_SENSOR_UPGRADER_ENABLED", true)
+
 	ACSCSEmailURL = RegisterSetting("ROX_ACSCS_EMAIL_URL", WithDefault("https://emailsender.rhacs.svc"))
 
 	// TenantID is set from the according central pod label with the Downward API.

--- a/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
@@ -30,7 +30,7 @@ function AutoUpgradeToggle(): ReactElement {
     }
 
     if (!isAutoUpgradeSupported(autoUpgradeConfig)) {
-        return <>Automatic upgrades are disabled for Cloud Service</>;
+        return <>Automatic upgrades are disabled</>;
     }
 
     const toggleAutoUpgrade = () => {


### PR DESCRIPTION
### Description

This PR decouples the sensor upgrader from the `ROX_MANAGED_CENTRAL` env var and introduces new variable `ROX_SENSOR_UPGRADER_ENABLED` (default: true) that controls whether the upgrader is enabled.

I additionally fix here the potential issue where the test suite can be incorrectly stopped by a subtest.


⚠️ It is okay to review but don't merge yet - we want to wait with the enabling until we investigate all potential blockers for the upgrader.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [x] Ran unit-tests
- [x] Deployed the image to OCP/GKE and toggled the variable `ROX_SENSOR_UPGRADER_ENABLED`
- [ ] Deployed to CS
