### PR TITLE
chore(fix): Fix scanner multi arch build

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -29,11 +29,11 @@ jobs:
       run: |
         source './scripts/ci/lib.sh'
 
-        # If goarch is updated, be sure to update architectures in push-manifests below.
+        # If goarch is updated, be sure to update architectures in "push-scanner-manifests" below.
         matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64"] }, "push_manifests": { "name":["default"] } }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
-          matrix="$(jq '.build_and_push.arch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push.goarch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"
         fi;
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)


### PR DESCRIPTION
### Description

We have failures like this: https://github.com/stackrox/stackrox/actions/runs/10096815144/job/27920233643

The assumption is that typo in line `36` (`s/arch/goarch`) is causing the issue:
https://github.com/stackrox/stackrox/blob/f405221b4639dd639cd2950c24a2763fdbc44576/.github/workflows/scanner-build.yaml#L33-L37

**EDIT:** I was able to reproduce it with this PR by using label [ci-build-all-arch](https://github.com/stackrox/stackrox/labels/ci-build-all-arch).

This run: https://github.com/stackrox/stackrox/actions/runs/10097827676/job/27923556491?pr=12151

A comment is also tweaked to point to the exact build step.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [x] no changes on tests, just CI pipeline

#### How I validated my change

CI pipeline runs with labels and without them

Only local testing done was:
```
❯ matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64"] }, "push_manifests": { "name":["default"] } }'
❯ matrix="$(jq '.build_and_push.arch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"

❯ echo $matrix
{
  "build_and_push": {
    "name": [
      "default"
    ],
    "goos": [
      "linux"
    ],
    "goarch": [
      "amd64"
    ],
    "arch": [
      "arm64",
      "ppc64le",
      "s390x"
    ]
  },
  "push_manifests": {
    "name": [
      "default"
    ]
  }
}

###

❯ matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64"] }, "push_manifests": { "name":["default"] } }'
❯ matrix="$(jq '.build_and_push.goarch += ["arm64", "ppc64le", "s390x"]' <<< "$matrix")"

❯ echo $matrix
{
  "build_and_push": {
    "name": [
      "default"
    ],
    "goos": [
      "linux"
    ],
    "goarch": [
      "amd64",
      "arm64",
      "ppc64le",
      "s390x"
    ]
  },
  "push_manifests": {
    "name": [
      "default"
    ]
  }
}
```
