### PR TITLE
ROX-21485: Disable repo list for quay scanner's registry

### DIFF
--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -167,7 +167,7 @@ func (r *Registry) Match(image *storage.ImageName) bool {
 	return r.repositoryList.Contains(image.GetRemote())
 }
 
-// lazyLoadRepoList will perform the initial repo list load if neccessary.
+// lazyLoadRepoList will perform the initial repo list load if necessary.
 // This is safe to call multiple times.
 func (r *Registry) lazyLoadRepoList() {
 	r.repoListOnce.Do(func() {

--- a/pkg/scanners/quay/quay.go
+++ b/pkg/scanners/quay/quay.go
@@ -51,7 +51,7 @@ func newScanner(protoImageIntegration *storage.ImageIntegration) (*quay, error) 
 	}
 	config := quayConfig.Quay
 
-	registry, err := quayRegistry.NewRegistryFromConfig(quayConfig.Quay, protoImageIntegration, false, nil)
+	registry, err := quayRegistry.NewRegistryFromConfig(quayConfig.Quay, protoImageIntegration, true, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

The ACS Quay Image Integration can be set as a 'scanner' - upon doing so the quay scanner logic [creates an underlying registry](https://github.com/stackrox/stackrox/blob/b01b02b2efff186817db44577db8b8537b3f6688/pkg/scanners/quay/quay.go#L54) used when 'matching' the scanner integration to an image during scanning.  This PR disables the usage of the 'repo list' for that registry to improve matching and align with the default behavior of other non-autogenerated registries.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

None

#### How I validated my change

Deployed changes to an infra cluster, changed the default quay integration to and from scanner type, and observed debug logs indicating whether repo list was disabled as desired.

Before fix:
```sh
## Changing integration to be a 'scanner' only
pkg/registries/docker: 2024/07/25 22:26:56.409193 docker.go:98: Debug: created integration "Public Quay.io" with repo list enabled
pkg/registries/docker: 2024/07/25 22:26:56.467053 docker.go:98: Debug: created integration "Public Quay.io" with repo list enabled

## Changing integration to back to a 'registry' only
pkg/registries/docker: 2024/07/25 22:27:28.167875 docker.go:98: Debug: created integration "Public Quay.io" with repo list disabled
pkg/registries/docker: 2024/07/25 22:27:28.210377 docker.go:98: Debug: created integration "Public Quay.io" with repo list disabled
```

After fix:
```sh
## Changing integration to be a 'scanner' only
pkg/registries/docker: 2024/07/25 22:43:57.777313 docker.go:92: Debug: created integration "Public Quay.io" with repo list disabled
pkg/registries/docker: 2024/07/25 22:43:57.923338 docker.go:92: Debug: created integration "Public Quay.io" with repo list disabled

## Changing integration to back to a 'registry' only
pkg/registries/docker: 2024/07/25 22:44:20.025618 docker.go:92: Debug: created integration "Public Quay.io" with repo list disabled
pkg/registries/docker: 2024/07/25 22:44:20.076436 docker.go:92: Debug: created integration "Public Quay.io" with repo list disabled
```
