### PR TITLE
ROX-22359: Make renovate active only outside of working hours

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,8 +15,11 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
-    // TODO(ROX-22359): switch to non-working hours like in https://github.com/stackrox/stackrox/pull/9787/files#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790R17
-    "at any time"
+    // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
+    // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
+    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
+    // that.
+    "after 3am and before 7am"
   ],
   "dockerfile": {
     "fileMatch": [


### PR DESCRIPTION
### Description

Per title and see related ticket.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

No contribution to it.

#### How I validated my change

Only ran config validation cli. Will have to observe renovate behavior after merging this.