### PR TITLE
ROX-25476: fix race condition QA tests

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -155,7 +155,7 @@ function get_cluster_zip {
     fi
 
     echo "Creating a new cluster"
-    export CLUSTER_JSON="{\"name\": \"$CLUSTER_NAME\", \"type\": \"$CLUSTER_TYPE\", \"main_image\": \"$CLUSTER_IMAGE\", \"central_api_endpoint\": \"$CLUSTER_API_ENDPOINT\", \"collection_method\": \"$COLLECTION_METHOD_ENUM\", \"admission_controller\": $ADMISSION_CONTROLLER $EXTRA_JSON}"
+    export CLUSTER_JSON="{\"name\": \"$CLUSTER_NAME\", \"type\": \"$CLUSTER_TYPE\", \"main_image\": \"$CLUSTER_IMAGE\", \"central_api_endpoint\": \"$CLUSTER_API_ENDPOINT\", \"collection_method\": \"$COLLECTION_METHOD_ENUM\" $EXTRA_JSON}"
     echo "Using cluster config: ${CLUSTER_JSON}"
 
     TMP=$(mktemp)


### PR DESCRIPTION
### Description

#### Summary
This PR addresses the issue of a failing race condition QA test due to invalid JSON payloads. The root cause was identified as a duplicated field in the JSON payload, disguised by the use of both snake case and camel case for the same field.

#### Problem Details
- **Error Encountered**: POST cluster requests were returning a 400 error with no accompanying message.
- **Initial Hypotheses**:
  - Suspected camel case vs. snake case issue (hypothesis disproved as both formats are supported).
  - Investigated content type, noting curl sends www-encoded content (hypothesis disproved).

#### Solution
- **Unit Test Creation**: Developed a unit test replicating the failing payload.
- **Findings**: Identified that the JSON payload contained duplicated fields due to mixed casing (snake and camel case).
- **Fix**: Corrected the JSON payload to eliminate the duplicated field.

#### Open Questions
- **Curl vs. Roxctl**: Why is curl preferred over roxctl in certain conditions (main tag mismatch)?
- **Error Messaging**: Why does the HTTP response provide only a 400 error code without an accompanying message, while the unit test offers a clear explanation?

#### Notes
This fix should address the immediate issue, but further investigation into the open questions is recommended to ensure robust error handling and consistency in our tool usage.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
