### PR TITLE
chore(deadcode): Remove known secret IDs from Sensor

### DIFF
--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -35,10 +35,6 @@ type Store struct {
 	// store maps a namespace to the names of registries accessible from within the namespace.
 	store map[string]registries.Set
 
-	// knownSecretIDs keeps track of all secret IDs in the cluster. This is used to reconcile with
-	// central in case secrets were deleted while the connection was broken.
-	knownSecretIDs set.StringSet
-
 	// clusterLocalRegistryHosts contains hosts (names and/or IPs) for registries that are local
 	// to this cluster (ie: the OCP internal registry).
 	clusterLocalRegistryHosts      set.StringSet
@@ -97,7 +93,6 @@ func NewRegistryStore(checkTLSFunc CheckTLS) *Store {
 			types.WithGCPTokenManager(gcp.Singleton()),
 		),
 		clusterLocalRegistryHosts: set.NewStringSet(),
-		knownSecretIDs:            set.NewStringSet(),
 		tlsCheckCache:             tlsCheckCache,
 	}
 
@@ -186,16 +181,6 @@ func genIntegrationName(prefix string, namespace string, registry string) string
 	}
 
 	return fmt.Sprintf("%v%v%v", prefix, namespace, registry)
-}
-
-// AddSecretID appends a kubernetes secret ID into a set to keep track of its existence in the cluster.
-func (rs *Store) AddSecretID(id string) {
-	rs.knownSecretIDs.Add(id)
-}
-
-// RemoveSecretID removes a kubernetes secret ID from tracking set.
-func (rs *Store) RemoveSecretID(id string) bool {
-	return rs.knownSecretIDs.Remove(id)
 }
 
 // UpsertRegistry upserts the given registry with the given credentials in the given namespace into the store.

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -42,13 +42,13 @@ var dataTypeMap = map[string]storage.SecretType{
 	"-----BEGIN CERTIFICATE-----":              storage.SecretType_PUBLIC_CERTIFICATE,
 	"-----BEGIN NEW CERTIFICATE REQUEST-----":  storage.SecretType_CERTIFICATE_REQUEST,
 	"-----BEGIN PRIVACY-ENHANCED MESSAGE-----": storage.SecretType_PRIVACY_ENHANCED_MESSAGE,
-	"-----BEGIN OPENSSH PRIVATE KEY-----":      storage.SecretType_OPENSSH_PRIVATE_KEY,
-	"-----BEGIN PGP PRIVATE KEY BLOCK-----":    storage.SecretType_PGP_PRIVATE_KEY,
-	"-----BEGIN EC PRIVATE KEY-----":           storage.SecretType_EC_PRIVATE_KEY,
-	"-----BEGIN RSA PRIVATE KEY-----":          storage.SecretType_RSA_PRIVATE_KEY,
-	"-----BEGIN DSA PRIVATE KEY-----":          storage.SecretType_DSA_PRIVATE_KEY,
-	"-----BEGIN PRIVATE KEY-----":              storage.SecretType_CERT_PRIVATE_KEY,
-	"-----BEGIN ENCRYPTED PRIVATE KEY-----":    storage.SecretType_ENCRYPTED_PRIVATE_KEY,
+	"-----BEGIN OPENSSH PRIVATE KEY-----":      storage.SecretType_OPENSSH_PRIVATE_KEY,   // notsecret
+	"-----BEGIN PGP PRIVATE KEY BLOCK-----":    storage.SecretType_PGP_PRIVATE_KEY,       // notsecret
+	"-----BEGIN EC PRIVATE KEY-----":           storage.SecretType_EC_PRIVATE_KEY,        // notsecret
+	"-----BEGIN RSA PRIVATE KEY-----":          storage.SecretType_RSA_PRIVATE_KEY,       // notsecret
+	"-----BEGIN DSA PRIVATE KEY-----":          storage.SecretType_DSA_PRIVATE_KEY,       // notsecret
+	"-----BEGIN PRIVATE KEY-----":              storage.SecretType_CERT_PRIVATE_KEY,      // notsecret
+	"-----BEGIN ENCRYPTED PRIVATE KEY-----":    storage.SecretType_ENCRYPTED_PRIVATE_KEY, // notsecret
 }
 
 func getSecretType(data string) storage.SecretType {
@@ -398,16 +398,6 @@ func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 	oldSecret, ok := oldObj.(*v1.Secret)
 	if !ok {
 		oldSecret = nil
-	}
-
-	parsedID := string(secret.GetUID())
-	switch action {
-	case central.ResourceAction_SYNC_RESOURCE, central.ResourceAction_CREATE_RESOURCE:
-		s.regStore.AddSecretID(parsedID)
-	case central.ResourceAction_REMOVE_RESOURCE:
-		if !s.regStore.RemoveSecretID(parsedID) {
-			log.Warnf("Should have secret (%s:%s) in registryStore known IDs but ID wasn't found", secret.GetName(), parsedID)
-		}
 	}
 
 	switch secret.Type {


### PR DESCRIPTION
### Description

Code was added in https://github.com/stackrox/stackrox/pull/8210 and assuming was meant to be removed in https://github.com/stackrox/stackrox/pull/8732 but was missed ([was partially removed](https://github.com/stackrox/stackrox/pull/8732/files#diff-facd557d8edc441d1d39f8de8ff4ccebe7f19fdd6bce46fa6c7b5de377a39b0cL74-L83))

This PR removes the dead code

The `// notsecret` comments were added to suppress false positive alerts from the internal gitleaks `pre-commit` hook that was blocking the updates to `sensor/kubernetes/listener/resources/secrets.go`

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

CI

#### How I validated my change

None, relying on CI / compilation.
