### PR TITLE
chore(ui): Prepare for react router v6 upgrade

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -70,7 +70,6 @@
                 "react-responsive": "^9.0.2",
                 "react-router-dom": "^5.3.4",
                 "react-router-hash-link": "^2.4.3",
-                "react-router-prop-types": "^1.0.5",
                 "react-select": "^2.0.0",
                 "react-spinners": "^0.10.4",
                 "react-table-6": "^6.11.0",
@@ -18995,15 +18994,6 @@
                 "react-router-dom": ">=4"
             }
         },
-        "node_modules/react-router-prop-types": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/react-router-prop-types/-/react-router-prop-types-1.0.5.tgz",
-            "integrity": "sha1-LmcdhBKnkxBr9w3BXJ7Mg+pLwVs= sha512-q1xlFU2ol2U5zeVbA5hyBuxD3scHenqgMgCTuJQUanA2SyG8A3Fb1S6DleOo1cnGJB5Q05hnLge64kRj+xsuPA==",
-            "dependencies": {
-                "@types/prop-types": "^15.7.3",
-                "prop-types": "^15.7.2"
-            }
-        },
         "node_modules/react-scripts": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -19880,18 +19870,6 @@
                 "htmlparser2": "^6.1.0",
                 "lodash": "^4.17.21",
                 "strip-ansi": "^6.0.1"
-            }
-        },
-        "node_modules/renderkid/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk= sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/request-progress": {
@@ -21061,17 +21039,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc= sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk= sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.11",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -74,6 +74,7 @@
         "react-responsive": "^9.0.2",
         "react-router-dom": "^5.3.4",
         "react-router-hash-link": "^2.4.3",
+        "react-router-prop-types": "^1.0.5",
         "react-select": "^2.0.0",
         "react-spinners": "^0.10.4",
         "react-table-6": "^6.11.0",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -74,7 +74,6 @@
         "react-responsive": "^9.0.2",
         "react-router-dom": "^5.3.4",
         "react-router-hash-link": "^2.4.3",
-        "react-router-prop-types": "^1.0.5",
         "react-select": "^2.0.0",
         "react-spinners": "^0.10.4",
         "react-table-6": "^6.11.0",

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import Raven from 'raven-js';
 
 import ErrorBoundaryPage from './ErrorBoundaryPage';
@@ -58,4 +58,9 @@ class ErrorBoundary extends Component<Props, State> {
     }
 }
 
-export default withRouter(ErrorBoundary);
+function ErrorBoundaryWrapper({ children }: { children: ReactNode }) {
+    const location = useLocation();
+    return <ErrorBoundary location={location.pathname}>{children}</ErrorBoundary>;
+}
+
+export default ErrorBoundaryWrapper;

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ type State =
           errorInfo: ErrorInfo;
       };
 
-class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundaryClass extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
@@ -58,9 +58,9 @@ class ErrorBoundary extends Component<Props, State> {
     }
 }
 
-function ErrorBoundaryWrapper({ children }: { children: ReactNode }) {
+function ErrorBoundary({ children }: { children: ReactNode }) {
     const location = useLocation();
-    return <ErrorBoundary location={location.pathname}>{children}</ErrorBoundary>;
+    return <ErrorBoundaryClass location={location.pathname}>{children}</ErrorBoundaryClass>;
 }
 
-export default ErrorBoundaryWrapper;
+export default ErrorBoundary;

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ type State =
           errorInfo: ErrorInfo;
       };
 
-class ErrorBoundaryClass extends Component<Props, State> {
+class ErrorBoundary extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
@@ -58,9 +58,9 @@ class ErrorBoundaryClass extends Component<Props, State> {
     }
 }
 
-function ErrorBoundary({ children }: { children: ReactNode }) {
+function ErrorBoundaryWrapper({ children }: { children: ReactNode }) {
     const location = useLocation();
-    return <ErrorBoundaryClass location={location.pathname}>{children}</ErrorBoundaryClass>;
+    return <ErrorBoundary location={location.pathname}>{children}</ErrorBoundary>;
 }
 
-export default ErrorBoundary;
+export default ErrorBoundaryWrapper;

--- a/ui/apps/platform/src/Components/RelatedEntity.js
+++ b/ui/apps/platform/src/Components/RelatedEntity.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
 import Widget from 'Components/Widget';
 import EntityIcon from 'Components/EntityIcon';
@@ -11,16 +10,10 @@ import hexagonal from 'images/side-panel-icons/hexagonal.svg';
 import URLService from 'utils/URLService';
 
 // @TODO We should try to use this component for Compliance as well
-const RelatedEntity = ({
-    match,
-    location,
-    history,
-    name,
-    entityType,
-    entityId,
-    value,
-    ...rest
-}) => {
+const RelatedEntity = ({ name, entityType, entityId, value, ...rest }) => {
+    const history = useHistory();
+    const location = useLocation();
+    const match = useRouteMatch();
     const workflowState = useContext(workflowStateContext);
 
     function onClick() {
@@ -78,9 +71,6 @@ RelatedEntity.propTypes = {
     entityId: PropTypes.string,
     value: PropTypes.string,
     link: PropTypes.string,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
 RelatedEntity.defaultProps = {
@@ -90,4 +80,4 @@ RelatedEntity.defaultProps = {
     name: null,
 };
 
-export default withRouter(RelatedEntity);
+export default RelatedEntity;

--- a/ui/apps/platform/src/Components/RelatedEntityListCount.js
+++ b/ui/apps/platform/src/Components/RelatedEntityListCount.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Widget from 'Components/Widget';
 import { newWorkflowCases } from 'constants/useCaseTypes';
@@ -9,7 +8,10 @@ import workflowStateContext from 'Containers/workflowStateContext';
 import URLService from 'utils/URLService';
 
 // @TODO We should try to use this component for Compliance as well
-const RelatedEntityListCount = ({ match, location, history, name, value, entityType, ...rest }) => {
+const RelatedEntityListCount = ({ name, value, entityType, ...rest }) => {
+    const history = useHistory();
+    const location = useLocation();
+    const match = useRouteMatch();
     const workflowState = useContext(workflowStateContext);
 
     function onClick() {
@@ -53,9 +55,6 @@ const RelatedEntityListCount = ({ match, location, history, name, value, entityT
 RelatedEntityListCount.propTypes = {
     name: PropTypes.string.isRequired,
     value: PropTypes.number,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     entityType: PropTypes.string.isRequired,
 };
 
@@ -63,4 +62,4 @@ RelatedEntityListCount.defaultProps = {
     value: 0,
 };
 
-export default withRouter(RelatedEntityListCount);
+export default RelatedEntityListCount;

--- a/ui/apps/platform/src/Components/TablePagination.js
+++ b/ui/apps/platform/src/Components/TablePagination.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
-import { withRouter } from 'react-router-dom';
 import debounce from 'lodash/debounce';
 import clamp from 'lodash/clamp';
 
@@ -120,4 +119,4 @@ TablePagination.defaultProps = {
     dataLength: 0,
 };
 
-export default withRouter(TablePagination);
+export default TablePagination;

--- a/ui/apps/platform/src/Components/URLSearchInput.js
+++ b/ui/apps/platform/src/Components/URLSearchInput.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 
 import Query from 'Components/ThrowingQuery';
 import URLSearchInputWithAutocomplete from 'Components/URLSearchInputWithAutocomplete';
@@ -52,4 +51,4 @@ URLSearchInput.defaultProps = {
     categories: [],
 };
 
-export default withRouter(URLSearchInput);
+export default URLSearchInput;

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import { components } from 'react-select';
 import queryString from 'qs';
 import { connect } from 'react-redux';
@@ -100,8 +100,6 @@ export const removeValuesForKey = (oldOptions, newOptions) => {
 };
 
 const URLSearchInputWithAutocomplete = ({
-    location,
-    history,
     autoCompleteResults,
     categoryOptions,
     setAllSearchOptions,
@@ -112,6 +110,8 @@ const URLSearchInputWithAutocomplete = ({
     prependAutocompleteQuery,
     ...rest
 }) => {
+    const location = useLocation();
+    const history = useHistory();
     const searchParam = useContext(searchContext);
     const workflowState = useContext(workflowStateContext);
 
@@ -309,8 +309,6 @@ URLSearchInputWithAutocomplete.propTypes = {
     placeholder: PropTypes.string.isRequired,
     categoryOptions: PropTypes.arrayOf(PropTypes.string),
     autoCompleteResults: PropTypes.arrayOf(PropTypes.string),
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     fetchAutocomplete: PropTypes.func,
     clearAutocomplete: PropTypes.func,
     setAllSearchOptions: PropTypes.func.isRequired,

--- a/ui/apps/platform/src/Components/visuals/Sunburst.js
+++ b/ui/apps/platform/src/Components/visuals/Sunburst.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Sunburst, DiscreteColorLegend, LabelSeries } from 'react-vis';
 import PropTypes from 'prop-types';
 import merge from 'deepmerge';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
 
 import SunburstDetailSection from 'Components/visuals/SunburstDetailSection';
 
@@ -70,7 +68,6 @@ class BasicSunburst extends React.Component {
         onValueSelect: PropTypes.func,
         onValueDeselect: PropTypes.func,
         staticDetails: PropTypes.bool,
-        history: ReactRouterPropTypes.history.isRequired,
         units: PropTypes.string,
         small: PropTypes.bool,
     };
@@ -234,4 +231,4 @@ class BasicSunburst extends React.Component {
     }
 }
 
-export default withRouter(BasicSunburst);
+export default BasicSunburst;

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -17,9 +17,11 @@ function AccessControl(): ReactElement {
     return (
         <>
             <Switch>
-                <Route exact path={accessControlBasePath}>
-                    <Redirect to={getEntityPath('AUTH_PROVIDER')} />
-                </Route>
+                <Route
+                    exact
+                    path={accessControlBasePath}
+                    render={() => <Redirect to={getEntityPath('AUTH_PROVIDER')} />}
+                />
                 <Route path={accessControlPath}>
                     <Switch>
                         <Route path={getEntityPath('AUTH_PROVIDER', paramId)}>

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -20,14 +20,21 @@ function AppPage(): ReactElement {
             <AppPageTitle />
             <AppPageFavicon />
             <Switch>
-                <Route path={loginPath} component={LoginPage} />
-                <Route
-                    path={authorizeRoxctlPath}
-                    render={(props) => <LoginPage {...props} authorizeRoxctlMode />}
-                />
-                <Route path={testLoginResultsPath} component={TestLoginResultsPage} />
-                <Route path={authResponsePrefix} component={LoadingSection} />
-                <Route component={AuthenticatedRoutes} />
+                <Route path={loginPath}>
+                    <LoginPage authProviders={undefined} />
+                </Route>
+                <Route path={authorizeRoxctlPath}>
+                    <LoginPage authorizeRoxctlMode authProviders={undefined} />
+                </Route>
+                <Route path={testLoginResultsPath}>
+                    <TestLoginResultsPage />
+                </Route>
+                <Route path={authResponsePrefix}>
+                    <LoadingSection />
+                </Route>
+                <Route>
+                    <AuthenticatedRoutes />
+                </Route>
             </Switch>
         </>
     );

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -21,10 +21,10 @@ function AppPage(): ReactElement {
             <AppPageFavicon />
             <Switch>
                 <Route path={loginPath}>
-                    <LoginPage authProviders={undefined} />
+                    <LoginPage />
                 </Route>
                 <Route path={authorizeRoxctlPath}>
-                    <LoginPage authorizeRoxctlMode authProviders={undefined} />
+                    <LoginPage authorizeRoxctlMode />
                 </Route>
                 <Route path={testLoginResultsPath}>
                     <TestLoginResultsPage />

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Page.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Page.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
 
@@ -12,7 +11,10 @@ import ControlPage from './Control';
 import DeploymentPage from './Deployment';
 import StandardPage from './Standard';
 
-const ComplianceEntityPage = ({ match, location }) => {
+const ComplianceEntityPage = () => {
+    const location = useLocation();
+    const match = useRouteMatch();
+
     const params = URLService.getParams(match, location);
 
     const pageProps = {
@@ -39,8 +41,6 @@ const ComplianceEntityPage = ({ match, location }) => {
 };
 
 ComplianceEntityPage.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     params: PropTypes.shape({
         entityId: PropTypes.string,
         entityType: PropTypes.string,
@@ -53,4 +53,4 @@ ComplianceEntityPage.defaultProps = {
     sidePanelMode: false,
 };
 
-export default withRouter(ComplianceEntityPage);
+export default ComplianceEntityPage;

--- a/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { Link, useLocation, useRouteMatch } from 'react-router-dom';
 import { resourceLabels } from 'messages/common';
 import URLService from 'utils/URLService';
 import pluralize from 'pluralize';
@@ -10,7 +9,10 @@ import { SEARCH_WITH_CONTROLS as QUERY } from 'queries/search';
 import queryService from 'utils/queryService';
 import { getResourceCountFromAggregatedResults } from 'utils/complianceUtils';
 
-const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType, match, location }) => {
+const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+
     function getLinkToListType(listEntityType) {
         return URLService.getURL(match, location)
             .base(entityType, entityId)
@@ -87,8 +89,6 @@ const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType, match,
 };
 
 ResourceTabs.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType: PropTypes.string.isRequired,
     entityId: PropTypes.string.isRequired,
     selectedType: PropTypes.string,
@@ -100,4 +100,4 @@ ResourceTabs.defaultProps = {
     selectedType: null,
 };
 
-export default withRouter(ResourceTabs);
+export default ResourceTabs;

--- a/ui/apps/platform/src/Containers/Compliance/List/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 import lowerCase from 'lodash/lowerCase';
 import startCase from 'lodash/startCase';
 
@@ -72,4 +71,4 @@ ListHeader.defaultProps = {
     standard: null,
 };
 
-export default withRouter(ListHeader);
+export default ListHeader;

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.js
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import lowerCase from 'lodash/lowerCase';
 import pluralize from 'pluralize';
 
@@ -12,8 +11,10 @@ import searchContext from 'Containers/searchContext';
 import ComplianceSearchInput from '../ComplianceSearchInput';
 import Header from './Header';
 
-const ComplianceListPage = ({ match, location }) => {
+const ComplianceListPage = () => {
     const [isExporting, setIsExporting] = useState(false);
+    const location = useLocation();
+    const match = useRouteMatch();
     const params = URLService.getParams(match, location);
     const searchParam = useContext(searchContext);
     const query = { ...params.query[searchParam] };
@@ -51,8 +52,6 @@ const ComplianceListPage = ({ match, location }) => {
 };
 
 ComplianceListPage.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     params: PropTypes.shape({
         entityType: PropTypes.string.isRequired,
     }),
@@ -62,4 +61,4 @@ ComplianceListPage.defaultProps = {
     params: null,
 };
 
-export default withRouter(ComplianceListPage);
+export default ComplianceListPage;

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { Link, withRouter } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Link, useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
 import Query from 'Components/CacheFirstQuery';
 import CloseButton from 'Components/CloseButton';
@@ -22,7 +21,11 @@ import DeploymentPage from '../Entity/Deployment';
 
 const MAX_CONTROL_TITLE = 120;
 
-const ComplianceListSidePanel = ({ entityType, entityId, match, location, history }) => {
+const ComplianceListSidePanel = ({ entityType, entityId }) => {
+    const history = useHistory();
+    const location = useLocation();
+    const match = useRouteMatch();
+
     function getEntityPage() {
         switch (entityType) {
             case resourceTypes.NODE:
@@ -94,11 +97,8 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
 };
 
 ComplianceListSidePanel.propTypes = {
-    history: ReactRouterPropTypes.history.isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType: PropTypes.string.isRequired,
     entityId: PropTypes.string.isRequired,
 };
 
-export default withRouter(ComplianceListSidePanel);
+export default ComplianceListSidePanel;

--- a/ui/apps/platform/src/Containers/Compliance/Page.js
+++ b/ui/apps/platform/src/Containers/Compliance/Page.js
@@ -21,9 +21,15 @@ const complianceEntityPath = `${mainPath}/:context/:pageEntityType(${pageEntityT
 const Page = () => (
     <searchContext.Provider value="s">
         <Switch>
-            <Route exact path={complianceDashboardPath} component={Dashboard} />
-            <Route path={complianceListPath} component={List} />
-            <Route path={complianceEntityPath} component={Entity} />
+            <Route exact path={complianceDashboardPath}>
+                <Dashboard />
+            </Route>
+            <Route path={complianceListPath}>
+                <List />
+            </Route>
+            <Route path={complianceEntityPath}>
+                <Entity />
+            </Route>
             <Route>
                 <PageNotFound useCase="compliance" />
             </Route>

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.js
@@ -5,16 +5,13 @@ import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
 import { AGGREGATED_RESULTS as QUERY } from 'queries/controls';
 import queryService from 'utils/queryService';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { useLocation, useRouteMatch, Link } from 'react-router-dom';
 import searchContext from 'Containers/searchContext';
 
 import { entityNounOrdinaryCase } from '../entitiesForCompliance';
 import LinkListWidget from './LinkListWidget';
 
 const ControlRelatedEntitiesList = ({
-    match,
-    location,
     listEntityType,
     pageEntityType,
     pageEntity,
@@ -24,6 +21,8 @@ const ControlRelatedEntitiesList = ({
 }) => {
     const linkContext = useCases.COMPLIANCE;
     const searchParam = useContext(searchContext);
+    const location = useLocation();
+    const match = useRouteMatch();
 
     function processData(data) {
         if (!data || !data.results) {
@@ -128,8 +127,6 @@ const ControlRelatedEntitiesList = ({
 };
 
 ControlRelatedEntitiesList.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     listEntityType: PropTypes.string.isRequired,
     pageEntityType: PropTypes.string.isRequired,
     pageEntity: PropTypes.shape({
@@ -147,4 +144,4 @@ ControlRelatedEntitiesList.defaultProps = {
     className: '',
 };
 
-export default withRouter(ControlRelatedEntitiesList);
+export default ControlRelatedEntitiesList;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.js
@@ -7,9 +7,8 @@ import {
     HorizontalBarSeries,
     LabelSeries,
 } from 'react-vis';
-import { withRouter, Link } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import merge from 'deepmerge';
 
 import { getColor } from './colorsForCompliance';
@@ -37,7 +36,7 @@ class HorizontalBarChart extends Component {
         valueGradientColorStart: PropTypes.string,
         valueGradientColorEnd: PropTypes.string,
         minimal: PropTypes.bool,
-        history: ReactRouterPropTypes.history.isRequired,
+        history: PropTypes.object.isRequired,
     };
 
     static defaultProps = {
@@ -214,4 +213,9 @@ class HorizontalBarChart extends Component {
     }
 }
 
-export default withRouter(HorizontalBarChart);
+function HorizontalBarChartWrapper(props) {
+    const history = useHistory();
+    return <HorizontalBarChart {...props} history={history} />;
+}
+
+export default HorizontalBarChartWrapper;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.js
@@ -11,22 +11,17 @@ import CountWidget from 'Components/CountWidget';
 import { SEARCH_WITH_CONTROLS as QUERY } from 'queries/search';
 import queryService from 'utils/queryService';
 import { getResourceCountFromAggregatedResults } from 'utils/complianceUtils';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import useCases from 'constants/useCaseTypes';
 import searchContext from 'Containers/searchContext';
 
 import { entityNounSentenceCaseSingular } from '../entitiesForCompliance';
 
-const ResourceCount = ({
-    match,
-    location,
-    entityType,
-    relatedToResourceType,
-    relatedToResource,
-    count,
-}) => {
+const ResourceCount = ({ entityType, relatedToResourceType, relatedToResource, count }) => {
     const searchParam = useContext(searchContext);
+    const match = useRouteMatch();
+    const location = useLocation();
+
     function getUrl() {
         if (entityType === entityTypes.SECRET) {
             return URLService.getURL(match, location)
@@ -95,8 +90,6 @@ const ResourceCount = ({
 };
 
 ResourceCount.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType: PropTypes.string,
     relatedToResourceType: PropTypes.string.isRequired,
     relatedToResource: PropTypes.shape({
@@ -113,4 +106,4 @@ ResourceCount.defaultProps = {
     count: null,
 };
 
-export default withRouter(ResourceCount);
+export default ResourceCount;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import merge from 'lodash/merge';
 
@@ -50,8 +49,10 @@ function setStandardsMapping(data, key, type) {
     return mapping;
 }
 
-const StandardsAcrossEntity = ({ match, location, entityType, bodyClassName, className }) => {
+const StandardsAcrossEntity = ({ entityType, bodyClassName, className }) => {
     const searchParam = useContext(searchContext);
+    const match = useRouteMatch();
+    const location = useLocation();
     const headerText = `Passing standards across ${entityNounOrdinaryCasePlural[entityType]}`;
 
     function processData(data, type) {
@@ -133,8 +134,6 @@ const StandardsAcrossEntity = ({ match, location, entityType, bodyClassName, cla
 };
 
 StandardsAcrossEntity.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType: PropTypes.string.isRequired,
     bodyClassName: PropTypes.string,
     className: PropTypes.string,
@@ -145,4 +144,4 @@ StandardsAcrossEntity.defaultProps = {
     className: '',
 };
 
-export default withRouter(StandardsAcrossEntity);
+export default StandardsAcrossEntity;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import capitalize from 'lodash/capitalize';
 import sortBy from 'lodash/sortBy';
@@ -91,8 +90,10 @@ function getLabelLinks(match, location, data, entityType) {
     return labelLinks;
 }
 
-const StandardsByEntity = ({ match, location, entityType, bodyClassName, className }) => {
+const StandardsByEntity = ({ entityType, bodyClassName, className }) => {
     const searchParam = useContext(searchContext);
+    const match = useRouteMatch();
+    const location = useLocation();
     const headerText = `Passing standards by ${entityNounOrdinaryCaseSingular[entityType]}`;
 
     const variables = {
@@ -164,8 +165,6 @@ const StandardsByEntity = ({ match, location, entityType, bodyClassName, classNa
     );
 };
 StandardsByEntity.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType: PropTypes.string.isRequired,
     bodyClassName: PropTypes.string,
     className: PropTypes.string,
@@ -176,4 +175,4 @@ StandardsByEntity.defaultProps = {
     className: '',
 };
 
-export default withRouter(StandardsByEntity);
+export default StandardsByEntity;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.js
@@ -8,8 +8,7 @@ import {
     VerticalBarSeries,
 } from 'react-vis';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 import merge from 'deepmerge';
 
@@ -20,7 +19,7 @@ import { verticalBarColors } from './colorsForCompliance';
 class VerticalClusterBar extends Component {
     static propTypes = {
         id: PropTypes.string,
-        history: ReactRouterPropTypes.history.isRequired,
+        history: PropTypes.object.isRequired,
         data: PropTypes.shape({}).isRequired,
         containerProps: PropTypes.shape({}),
         plotProps: PropTypes.shape({}),
@@ -156,4 +155,9 @@ class VerticalClusterBar extends Component {
     }
 }
 
-export default withRouter(VerticalClusterBar);
+function VerticalClusterBarWrapper(props) {
+    const history = useHistory();
+    return <VerticalClusterBar {...props} history={history} />;
+}
+
+export default VerticalClusterBarWrapper;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ComplianceEnhancedPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ComplianceEnhancedPage.tsx
@@ -16,9 +16,11 @@ import ScanConfigsPage from './Schedules/ScanConfigsPage';
 function ComplianceEnhancedPage() {
     return (
         <Switch>
-            <Route exact path={complianceEnhancedBasePath}>
-                <Redirect to={complianceEnhancedCoveragePath} />
-            </Route>
+            <Route
+                exact
+                path={complianceEnhancedBasePath}
+                render={() => <Redirect to={complianceEnhancedCoveragePath} />}
+            />
             <Route path={complianceEnhancedCoveragePath}>
                 <CoveragePage />
             </Route>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -47,21 +47,24 @@ function CoverageContent() {
 
     return (
         <Switch>
-            <Route
-                exact
-                path={[coverageProfileChecksPath, coverageProfileClustersPath]}
-                component={CoveragesPage}
-            />
-            <Route exact path={coverageCheckDetailsPath} component={CheckDetailsPage} />
-            <Route exact path={coverageClusterDetailsPath} component={ClusterDetailsPage} />
+            <Route exact path={[coverageProfileChecksPath, coverageProfileClustersPath]}>
+                <CoveragesPage />
+            </Route>
+            <Route exact path={coverageCheckDetailsPath}>
+                <CheckDetailsPage />
+            </Route>
+            <Route exact path={coverageClusterDetailsPath}>
+                <ClusterDetailsPage />
+            </Route>
             <Route
                 exact
                 path={[
                     `${complianceEnhancedCoveragePath}`,
                     `${complianceEnhancedCoveragePath}/profiles`,
                 ]}
-                component={ProfilesRedirectHandler}
-            />
+            >
+                <ProfilesRedirectHandler />
+            </Route>
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -191,16 +191,12 @@ function CoveragesPage() {
                             </Toolbar>
                             <Divider />
                             <Switch>
-                                <Route
-                                    exact
-                                    path={coverageProfileChecksPath}
-                                    render={() => <ProfileChecksPage />}
-                                />
-                                <Route
-                                    exact
-                                    path={coverageProfileClustersPath}
-                                    render={() => <ProfileClustersPage />}
-                                />
+                                <Route exact path={coverageProfileChecksPath}>
+                                    <ProfileChecksPage />
+                                </Route>
+                                <Route exact path={coverageProfileClustersPath}>
+                                    <ProfileClustersPage />
+                                </Route>
                             </Switch>
                         </PageSection>
                     </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -25,10 +25,8 @@ function ScanConfigsPage() {
 
     return (
         <Switch>
-            <Route
-                exact
-                path={complianceEnhancedSchedulesPath}
-                render={() => {
+            <Route exact path={complianceEnhancedSchedulesPath}>
+                {() => {
                     if (pageAction === 'create' && hasWriteAccessForCompliance) {
                         return <CreateScanConfigPage />;
                     }
@@ -41,18 +39,14 @@ function ScanConfigsPage() {
                     }
                     return <Redirect to={complianceEnhancedSchedulesPath} />;
                 }}
-            />
-            <Route
-                exact
-                path={scanConfigDetailsPath}
-                render={() => {
-                    return (
-                        <ScanConfigDetailPage
-                            hasWriteAccessForCompliance={hasWriteAccessForCompliance}
-                        />
-                    );
-                }}
-            />
+            </Route>
+            <Route exact path={scanConfigDetailsPath}>
+                {() => (
+                    <ScanConfigDetailPage
+                        hasWriteAccessForCompliance={hasWriteAccessForCompliance}
+                    />
+                )}
+            </Route>
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -26,19 +26,22 @@ function ScanConfigsPage() {
     return (
         <Switch>
             <Route exact path={complianceEnhancedSchedulesPath}>
-                {() => {
-                    if (pageAction === 'create' && hasWriteAccessForCompliance) {
-                        return <CreateScanConfigPage />;
-                    }
-                    if (pageAction === undefined) {
-                        return (
-                            <ScanConfigsTablePage
-                                hasWriteAccessForCompliance={hasWriteAccessForCompliance}
-                            />
-                        );
-                    }
-                    return <Redirect to={complianceEnhancedSchedulesPath} />;
-                }}
+                <Route
+                    // eslint-disable-next-line react/no-children-prop
+                    children={() => {
+                        if (pageAction === 'create' && hasWriteAccessForCompliance) {
+                            return <CreateScanConfigPage />;
+                        }
+                        if (pageAction === undefined) {
+                            return (
+                                <ScanConfigsTablePage
+                                    hasWriteAccessForCompliance={hasWriteAccessForCompliance}
+                                />
+                            );
+                        }
+                        return <Redirect to={complianceEnhancedSchedulesPath} />;
+                    }}
+                />
             </Route>
             <Route exact path={scanConfigDetailsPath}>
                 {() => (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -25,30 +25,25 @@ function ScanConfigsPage() {
 
     return (
         <Switch>
-            <Route exact path={complianceEnhancedSchedulesPath}>
-                <Route
-                    // eslint-disable-next-line react/no-children-prop
-                    children={() => {
-                        if (pageAction === 'create' && hasWriteAccessForCompliance) {
-                            return <CreateScanConfigPage />;
-                        }
-                        if (pageAction === undefined) {
-                            return (
-                                <ScanConfigsTablePage
-                                    hasWriteAccessForCompliance={hasWriteAccessForCompliance}
-                                />
-                            );
-                        }
-                        return <Redirect to={complianceEnhancedSchedulesPath} />;
-                    }}
-                />
-            </Route>
+            <Route
+                exact
+                path={complianceEnhancedSchedulesPath}
+                render={() => {
+                    if (pageAction === 'create' && hasWriteAccessForCompliance) {
+                        return <CreateScanConfigPage />;
+                    }
+                    if (!pageAction) {
+                        return (
+                            <ScanConfigsTablePage
+                                hasWriteAccessForCompliance={hasWriteAccessForCompliance}
+                            />
+                        );
+                    }
+                    return <Redirect to={complianceEnhancedSchedulesPath} />;
+                }}
+            />
             <Route exact path={scanConfigDetailsPath}>
-                {() => (
-                    <ScanConfigDetailPage
-                        hasWriteAccessForCompliance={hasWriteAccessForCompliance}
-                    />
-                )}
+                <ScanConfigDetailPage hasWriteAccessForCompliance={hasWriteAccessForCompliance} />
             </Route>
         </Switch>
     );

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.js
@@ -3,7 +3,7 @@ import entityTypes from 'constants/entityTypes';
 import pluralize from 'pluralize';
 import entityLabels from 'messages/entity';
 import URLService from 'utils/URLService';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 
 import DashboardMenu from 'Components/DashboardMenu';
 
@@ -18,7 +18,7 @@ const createOptions = (urlBuilder, types) => {
     });
 };
 
-const AppMenu = ({ match, location }) => {
+const AppMenu = () => {
     const types = [
         entityTypes.CLUSTER,
         entityTypes.NAMESPACE,
@@ -28,10 +28,12 @@ const AppMenu = ({ match, location }) => {
         entityTypes.SECRET,
     ];
 
+    const match = useRouteMatch();
+    const location = useLocation();
     const urlBuilder = URLService.getURL(match, location);
     const options = createOptions(urlBuilder, types);
 
     return <DashboardMenu text="Application & Infrastructure" options={options} />;
 };
 
-export default withRouter(AppMenu);
+export default AppMenu;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import URLService from 'utils/URLService';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import entityTypes from 'constants/entityTypes';
 import { gql, useQuery } from '@apollo/client';
 import logError from 'utils/logError';
@@ -14,12 +13,14 @@ const NUM_CIS_CONTROLS = gql`
     }
 `;
 
-const CISControlsTile = ({ match, location }) => {
+const CISControlsTile = () => {
     const { loading, error, data } = useQuery(NUM_CIS_CONTROLS);
     if (error) {
         logError(error);
     }
 
+    const match = useRouteMatch();
+    const location = useLocation();
     const controlsURL = URLService.getURL(match, location).base(entityTypes.CONTROL).url();
 
     const numCISControls = data?.executedControlCount || 0;
@@ -35,9 +36,4 @@ const CISControlsTile = ({ match, location }) => {
     );
 };
 
-CISControlsTile.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(CISControlsTile);
+export default CISControlsTile;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import URLService from 'utils/URLService';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import entityTypes from 'constants/entityTypes';
 import Query from 'Components/ThrowingQuery';
 import EntityTileLink from 'Components/EntityTileLink';
 import queryService from 'utils/queryService';
+import URLService from 'utils/URLService';
 
 const policiesQuery = gql`
     query numPolicies($query: String) {
@@ -14,8 +13,11 @@ const policiesQuery = gql`
     }
 `;
 
-const PoliciesTile = ({ match, location }) => {
+const PoliciesTile = () => {
+    const match = useRouteMatch();
+    const location = useLocation();
     const policiesURL = URLService.getURL(match, location).base(entityTypes.POLICY).url();
+
     return (
         <Query
             query={policiesQuery}
@@ -40,9 +42,4 @@ const PoliciesTile = ({ match, location }) => {
     );
 };
 
-PoliciesTile.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(PoliciesTile);
+export default PoliciesTile;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.js
@@ -3,7 +3,7 @@ import entityTypes from 'constants/entityTypes';
 import pluralize from 'pluralize';
 import entityLabels from 'messages/entity';
 import URLService from 'utils/URLService';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 
 import DashboardMenu from 'Components/DashboardMenu';
 
@@ -18,13 +18,15 @@ const createOptions = (urlBuilder, types) => {
     });
 };
 
-const RBACMenu = ({ match, location }) => {
+const RBACMenu = () => {
     const types = [entityTypes.SUBJECT, entityTypes.SERVICE_ACCOUNT, entityTypes.ROLE];
 
+    const match = useRouteMatch();
+    const location = useLocation();
     const urlBuilder = URLService.getURL(match, location);
     const options = createOptions(urlBuilder, types);
 
     return <DashboardMenu text="Role-Based Access Control" options={options} />;
 };
 
-export default withRouter(RBACMenu);
+export default RBACMenu;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
@@ -1,13 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { Alert } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import { gql } from '@apollo/client';
+import { Link, useLocation, useRouteMatch } from 'react-router-dom';
 import queryService from 'utils/queryService';
 import entityTypes, { standardEntityTypes, standardBaseTypes } from 'constants/entityTypes';
 import { COMPLIANCE_FAIL_COLOR, COMPLIANCE_PASS_COLOR } from 'constants/severityColors';
 import { standardLabels } from 'messages/standards';
-import { Link, withRouter } from 'react-router-dom';
 import URLService from 'utils/URLService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import searchContext from 'Containers/searchContext';
@@ -259,7 +258,7 @@ const ViewStandardButton = ({ standardType, searchParam, urlBuilder }) => {
 
 const queriesToRefetchOnPollingComplete = [QUERY];
 
-const ComplianceByControls = ({ match, location, className, standardOptions }) => {
+const ComplianceByControls = ({ className, standardOptions }) => {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
 
@@ -274,6 +273,9 @@ const ComplianceByControls = ({ match, location, className, standardOptions }) =
         standard,
     }));
     const [selectedStandard, selectStandard] = useState(options[0]);
+
+    const location = useLocation();
+    const match = useRouteMatch();
 
     function onChange(datum) {
         const standard = options.find((option) => option.value === datum);
@@ -381,8 +383,6 @@ const ComplianceByControls = ({ match, location, className, standardOptions }) =
 };
 
 ComplianceByControls.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     className: PropTypes.string,
     standardOptions: PropTypes.arrayOf(PropTypes.shape).isRequired,
 };
@@ -391,4 +391,4 @@ ComplianceByControls.defaultProps = {
     className: '',
 };
 
-export default withRouter(ComplianceByControls);
+export default ComplianceByControls;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.js
@@ -10,12 +10,13 @@ import {
     GradientDefs,
 } from 'react-vis';
 import max from 'lodash/max';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import BarGradient from 'Components/visuals/BarGradient';
 
-const Lollipop = ({ data, history }) => {
+const Lollipop = ({ data }) => {
+    const history = useHistory();
+
     function getGridLineValues() {
         const interval = data.length < 5 ? 1 : 5;
         const values = data.map((datum) => datum.x);
@@ -114,7 +115,6 @@ const Lollipop = ({ data, history }) => {
 
 Lollipop.propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
-export default withRouter(Lollipop);
+export default Lollipop;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
 import URLService from 'utils/URLService';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import Widget from 'Components/Widget';
 import Sunburst from 'Components/visuals/Sunburst';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import networkStatuses from 'constants/networkStatuses';
-import { Link, withRouter } from 'react-router-dom';
+import { Link, useRouteMatch, useLocation } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import max from 'lodash/max';
 import { severityValues, severities } from 'constants/severities';
@@ -59,7 +58,9 @@ function getCategorySeverity(category, violationsByCategory) {
     return policySeverityColorMap[severityEntry[0]];
 }
 
-const PolicyViolationsBySeverity = ({ match, location }) => {
+const PolicyViolationsBySeverity = () => {
+    const match = useRouteMatch();
+    const location = useLocation();
     const searchParam = useContext(searchContext);
     const processData = (data) => {
         if (!data || !data.policies || !data.policies.length) {
@@ -289,9 +290,4 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
     );
 };
 
-PolicyViolationsBySeverity.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(PolicyViolationsBySeverity);
+export default PolicyViolationsBySeverity;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link, withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { Link, useRouteMatch, useLocation } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import dateFns from 'date-fns';
@@ -66,7 +65,10 @@ const getCertificateStatus = (files) => {
     return `has ${status} certs`;
 };
 
-const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
+const SecretsMostUsedAcrossDeployments = () => {
+    const match = useRouteMatch();
+    const location = useLocation();
+
     function processData(data) {
         if (!data || !data.secrets) {
             return [];
@@ -77,6 +79,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
             .sort((a, b) => b.deploymentCount - a.deploymentCount)
             .slice(0, 10);
     }
+
     return (
         <Query query={QUERY}>
             {({ loading, data }) => {
@@ -149,9 +152,4 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
     );
 };
 
-SecretsMostUsedAcrossDeployments.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(SecretsMostUsedAcrossDeployments);
+export default SecretsMostUsedAcrossDeployments;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { gql } from '@apollo/client';
 import Loader from 'Components/Loader';
-import { Link, withRouter } from 'react-router-dom';
+import { Link, useLocation, useRouteMatch } from 'react-router-dom';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
 import networkStatuses from 'constants/networkStatuses';
 import Query from 'Components/ThrowingQuery';
 import Widget from 'Components/Widget';
-import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Lollipop from './Lollipop';
 
@@ -24,7 +23,10 @@ const QUERY = gql`
     }
 `;
 
-const UsersWithMostClusterAdminRoles = ({ match, location }) => {
+const UsersWithMostClusterAdminRoles = () => {
+    const match = useRouteMatch();
+    const location = useLocation();
+
     function processData(data) {
         if (!data || !data.clusters) {
             return [];
@@ -115,9 +117,4 @@ const UsersWithMostClusterAdminRoles = ({ match, location }) => {
     );
 };
 
-UsersWithMostClusterAdminRoles.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(UsersWithMostClusterAdminRoles);
+export default UsersWithMostClusterAdminRoles;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Control.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Control.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
@@ -42,7 +43,9 @@ const QUERY = gql`
     }
 `;
 
-const Control = ({ id, entityListType, query, match, location, entityContext }) => {
+const Control = ({ id, entityListType, query, entityContext }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const searchParam = useContext(searchContext);
 
     const variables = {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.js
@@ -4,8 +4,7 @@ import entityTypes from 'constants/entityTypes';
 import entityLabels from 'messages/entity';
 import pluralize from 'pluralize';
 import URLService from 'utils/URLService';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useRouteMatch, useLocation } from 'react-router-dom';
 import GroupedTabs from 'Components/GroupedTabs';
 import entityTabsMap from '../entityTabRelationships';
 
@@ -39,7 +38,10 @@ const ENTITY_TO_TAB = {
     [entityTypes.CONTROL]: TAB_GROUPS.POLICIES,
 };
 
-const EntityTabs = ({ match, location, entityType, entityListType, pageEntityId }) => {
+const EntityTabs = ({ entityType, entityListType, pageEntityId }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+
     function getTab(relationship) {
         const failingText =
             entityType === entityTypes.DEPLOYMENT && relationship === entityTypes.POLICY
@@ -76,12 +78,10 @@ EntityTabs.propTypes = {
     entityType: PropTypes.string.isRequired,
     entityListType: PropTypes.string,
     pageEntityId: PropTypes.string.isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
 };
 
 EntityTabs.defaultProps = {
     entityListType: null,
 };
 
-export default withRouter(EntityTabs);
+export default EntityTabs;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useRouteMatch, useLocation } from 'react-router-dom';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
@@ -20,9 +19,11 @@ import Tabs from './EntityTabs';
 import SidePanel from '../SidePanel/SidePanel';
 import Entity from '../Entity';
 
-const EntityPage = ({ match, location }) => {
+const EntityPage = () => {
     const [isExporting, setIsExporting] = useState(false);
     const { isDarkMode } = useTheme();
+    const location = useLocation();
+    const match = useRouteMatch();
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;
     const pageState = new WorkflowState(
@@ -116,9 +117,4 @@ const EntityPage = ({ match, location }) => {
     );
 };
 
-EntityPage.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-};
-
-export default withRouter(EntityPage);
+export default EntityPage;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { useRouteMatch, useLocation } from 'react-router-dom';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
@@ -11,6 +11,7 @@ import configMgmtPaginationContext, {
 import searchContext from 'Containers/searchContext';
 import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
+import useClickOutside from 'hooks/useClickOutside';
 import parseURL from 'utils/URLParser';
 import URLService from 'utils/URLService';
 import { WorkflowState } from 'utils/WorkflowState';
@@ -20,9 +21,11 @@ import SidePanel from '../SidePanel/SidePanel';
 import Entity from '../Entity';
 
 const EntityPage = () => {
+    const sidePanelRef = useRef(null);
     const [isExporting, setIsExporting] = useState(false);
     const { isDarkMode } = useTheme();
     const location = useLocation();
+    const history = useHistory();
     const match = useRouteMatch();
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;
@@ -50,6 +53,12 @@ const EntityPage = () => {
     const [fadeIn, setFadeIn] = useState(false);
 
     useEffect(() => setFadeIn(false), [pageEntityId]);
+
+    const closeSidePanel = useCallback(() => {
+        history.push(URLService.getURL(match, location).clearSidePanelParams().url());
+    }, [history, match, location]);
+
+    useClickOutside(sidePanelRef, closeSidePanel, !!entityId1);
 
     // manually adding the styles to fade back in
     if (!fadeIn) {
@@ -96,17 +105,19 @@ const EntityPage = () => {
                     <searchContext.Provider value={searchParams.sidePanel}>
                         <configMgmtPaginationContext.Provider value={SIDEPANEL_PAGINATION_PARAMS}>
                             <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!entityId1}>
-                                <SidePanel
-                                    contextEntityId={pageEntityId}
-                                    contextEntityType={pageEntityType}
-                                    entityListType1={entityListType1}
-                                    entityType1={entityType1}
-                                    entityId1={entityId1}
-                                    entityType2={entityType2}
-                                    entityListType2={entityListType2}
-                                    entityId2={entityId2}
-                                    query={query}
-                                />
+                                <div ref={sidePanelRef}>
+                                    <SidePanel
+                                        contextEntityId={pageEntityId}
+                                        contextEntityType={pageEntityType}
+                                        entityListType1={entityListType1}
+                                        entityType1={entityType1}
+                                        entityId1={entityId1}
+                                        entityType2={entityType2}
+                                        entityListType2={entityListType2}
+                                        entityId2={entityId2}
+                                        query={query}
+                                    />
+                                </div>
                             </SidePanelAnimatedArea>
                         </configMgmtPaginationContext.Provider>
                     </searchContext.Provider>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 
 import VIOLATIONS from 'queries/violation';
 import resolvePath from 'object-resolve-path';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
-import { withRouter } from 'react-router-dom';
 import uniq from 'lodash/uniq';
 import CollapsibleRow from 'Components/CollapsibleRow';
 import NoResultsMessage from 'Components/NoResultsMessage';
@@ -17,6 +15,7 @@ import { entityViolationsColumns } from 'constants/listColumns';
 
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import Table, { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import TableWidget from './TableWidget';
 
 const getDeploymentsGroupedByPolicies = (data) => {
@@ -36,9 +35,13 @@ const getDeploymentsGroupedByPolicies = (data) => {
     return Object.values(groups);
 };
 
-const Deployments = ({ original: policy, match, location, history, entityContext }) => {
+const Deployments = ({ original: policy, entityContext }) => {
     const { deployments } = policy;
     const columns = entityViolationsColumns[entityTypes.DEPLOYMENT](entityContext);
+    const history = useHistory();
+    const location = useLocation();
+    const match = useRouteMatch();
+
     function onRowClick(row) {
         const id = resolvePath(row, 'id');
         const url = URLService.getURL(match, location).push(entityTypes.DEPLOYMENT, id).url();
@@ -57,17 +60,12 @@ const Deployments = ({ original: policy, match, location, history, entityContext
 
 Deployments.propTypes = {
     original: PropTypes.shape({ deployments: PropTypes.arrayOf(PropTypes.shape({})) }).isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     entityContext: PropTypes.shape({}),
 };
 
 Deployments.defaultProps = {
     entityContext: {},
 };
-
-const DeploymentsWithRouter = withRouter(Deployments);
 
 const DeploymentsWithFailedPolicies = ({ query, message, entityContext }) => (
     <Query query={VIOLATIONS} variables={{ query }}>
@@ -119,10 +117,7 @@ const DeploymentsWithFailedPolicies = ({ query, message, entityContext }) => (
                                 className="z-20"
                                 hasTitleBorder={false}
                             >
-                                <DeploymentsWithRouter
-                                    original={original}
-                                    entityContext={entityContext}
-                                />
+                                <Deployments original={original} entityContext={entityContext} />
                             </CollapsibleRow>
                         );
                         return group;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import entityTypes from 'constants/entityTypes';
-import { withRouter } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
@@ -44,7 +43,9 @@ const createTableRows = (data) => {
     return failedPolicies;
 };
 
-const FailedPoliciesAcrossDeployment = ({ deploymentID }) => {
+const FailedPoliciesAcrossDeployment = () => {
+    const { deploymentID } = useParams();
+
     return (
         <Query
             query={QUERY}
@@ -151,8 +152,4 @@ const FailedPoliciesAcrossDeployment = ({ deploymentID }) => {
     );
 };
 
-FailedPoliciesAcrossDeployment.propTypes = {
-    deploymentID: PropTypes.string.isRequired,
-};
-
-export default withRouter(FailedPoliciesAcrossDeployment);
+export default FailedPoliciesAcrossDeployment;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import resolvePath from 'object-resolve-path';
 
 import Widget from 'Components/Widget';
@@ -9,7 +8,7 @@ import TablePagination from 'Components/TablePagination';
 import Table from 'Components/Table';
 import URLService from 'utils/URLService';
 
-const TableWidget = ({ match, location, history, header, entityType, ...rest }) => {
+const TableWidget = ({ header, entityType, ...rest }) => {
     const [page, setPage] = useState(0);
     const {
         columns,
@@ -25,6 +24,11 @@ const TableWidget = ({ match, location, history, header, entityType, ...rest }) 
         defaultSorted,
         ...widgetProps
     } = { ...rest };
+
+    const history = useHistory();
+    const location = useLocation();
+    const match = useRouteMatch();
+
     const headerComponents = (
         <TablePagination page={page} dataLength={rows.length} setPage={setPage} />
     );
@@ -61,13 +65,10 @@ const TableWidget = ({ match, location, history, header, entityType, ...rest }) 
 
 TableWidget.propTypes = {
     header: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     entityType: PropTypes.string,
 };
 
 TableWidget.defaultProps = {
     entityType: '',
 };
-export default withRouter(TableWidget);
+export default TableWidget;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Clusters.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Clusters.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 
@@ -208,7 +209,9 @@ const buildTableColumns = (match, location) => {
 
 const createTableRows = (data) => data.results;
 
-const Clusters = ({ match, location, className, selectedRowId, onRowClick, query, data }) => {
+const Clusters = ({ className, selectedRowId, onRowClick, query, data }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location);
     const { [SEARCH_OPTIONS.POLICY_STATUS.CATEGORY]: policyStatus, ...restQuery } = query || {};

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Deployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Deployments.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
@@ -182,8 +183,6 @@ const buildTableColumns = (match, location, entityContext) => {
 const createTableRows = (data) => data.results;
 
 const Deployments = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -192,6 +191,8 @@ const Deployments = ({
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const searchParam = useContext(searchContext);
 
     const autoFocusSearchInput = !selectedRowId;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/EntityList.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/EntityList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
@@ -49,4 +48,4 @@ EntityList.defaultProps = {
     entityId: null,
 };
 
-export default withRouter(EntityList);
+export default EntityList;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Images.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Images.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 import { format } from 'date-fns';
 
@@ -101,12 +102,12 @@ const Images = ({
     selectedRowId,
     onRowClick,
     query,
-    match,
-    location,
     data,
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const queryText = queryService.objectToWhereClause(query);
     const variables = queryText ? { query: queryText } : null;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useRouteMatch, useLocation, useHistory } from 'react-router-dom'; // Updated imports
 import pluralize from 'pluralize';
 import resolvePath from 'object-resolve-path';
 
@@ -41,10 +40,10 @@ const List = ({
     totalResults,
     autoFocusSearchInput,
     noDataText,
-    match,
-    location,
-    history,
 }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+    const history = useHistory();
     const workflowState = useContext(workflowStateContext);
     const configMgmtPagination = useContext(configMgmtPaginationContext);
     const page = workflowState.paging[configMgmtPagination.pageParam];
@@ -201,9 +200,6 @@ List.propTypes = {
     totalResults: PropTypes.number,
     autoFocusSearchInput: PropTypes.bool,
     noDataText: PropTypes.string,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
 List.defaultProps = {
@@ -218,4 +214,4 @@ List.defaultProps = {
     noDataText: 'No results found. Please refine your search.',
 };
 
-export default withRouter(List);
+export default List;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useRouteMatch, useLocation, useHistory } from 'react-router-dom';
 import pluralize from 'pluralize';
 import resolvePath from 'object-resolve-path';
 
@@ -34,10 +33,10 @@ const ListFrontendPaginated = ({
     data,
     autoFocusSearchInput,
     noDataText,
-    match,
-    location,
-    history,
 }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+    const history = useHistory();
     const [page, setPage] = useState(0);
 
     function onRowClickHandler(row) {
@@ -160,9 +159,6 @@ ListFrontendPaginated.propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape({})),
     autoFocusSearchInput: PropTypes.bool,
     noDataText: PropTypes.string,
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
 ListFrontendPaginated.defaultProps = {
@@ -176,4 +172,4 @@ ListFrontendPaginated.defaultProps = {
     noDataText: 'No results found. Please refine your search.',
 };
 
-export default withRouter(ListFrontendPaginated);
+export default ListFrontendPaginated;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Namespaces.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Namespaces.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
@@ -199,8 +200,6 @@ const buildTableColumns = (match, location, entityContext) => {
 const createTableRows = (data) => data.results;
 
 const Namespaces = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -209,6 +208,8 @@ const Namespaces = ({
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const searchParam = useContext(searchContext);
 
     const autoFocusSearchInput = !selectedRowId;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Nodes.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Nodes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import { format } from 'date-fns';
 import pluralize from 'pluralize';
@@ -159,8 +159,6 @@ const buildTableColumns = (match, location, entityContext) => {
 const createTableRows = (data) => data.results;
 
 const Nodes = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -169,6 +167,8 @@ const Nodes = ({
     totalResults,
     entityContext,
 }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location, entityContext);
     const queryText = queryService.objectToWhereClause(query);
@@ -194,4 +194,4 @@ const Nodes = ({
 Nodes.propTypes = entityListPropTypes;
 Nodes.defaultProps = entityListDefaultprops;
 
-export default withRouter(Nodes);
+export default Nodes;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';
@@ -26,7 +26,10 @@ import { WorkflowState } from 'utils/WorkflowState';
 import EntityList from './EntityList';
 import SidePanel from '../SidePanel/SidePanel';
 
-const ListPage = ({ match, location, history }) => {
+const ListPage = () => {
+    const location = useLocation();
+    const history = useHistory();
+    const match = useRouteMatch();
     const [isExporting, setIsExporting] = useState(false);
     const { isDarkMode } = useTheme();
 
@@ -105,12 +108,6 @@ const ListPage = ({ match, location, history }) => {
             {isExporting && <BackdropExporting />}
         </workflowStateContext.Provider>
     );
-};
-
-ListPage.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
 export default ListPage;

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useRef, useState } from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
@@ -18,6 +18,7 @@ import searchContext from 'Containers/searchContext';
 import { searchParams } from 'constants/searchParams';
 import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
+import useClickOutside from 'hooks/useClickOutside';
 import entityLabels from 'messages/entity';
 import parseURL from 'utils/URLParser';
 import URLService from 'utils/URLService';
@@ -27,6 +28,7 @@ import EntityList from './EntityList';
 import SidePanel from '../SidePanel/SidePanel';
 
 const ListPage = () => {
+    const sidePanelRef = useRef(null);
     const location = useLocation();
     const history = useHistory();
     const match = useRouteMatch();
@@ -47,6 +49,12 @@ const ListPage = () => {
     const { pageEntityListType, entityId1, entityType2, entityListType2, entityId2, query } =
         params;
     const searchParam = useContext(searchContext);
+
+    const closeSidePanel = useCallback(() => {
+        history.push(URLService.getURL(match, location).clearSidePanelParams().url());
+    }, [history, match, location]);
+
+    useClickOutside(sidePanelRef, closeSidePanel, !!entityId1);
 
     function onRowClick(entityId) {
         const urlBuilder = URLService.getURL(match, location).push(entityId);
@@ -93,14 +101,16 @@ const ListPage = () => {
                 <searchContext.Provider value={searchParams.sidePanel}>
                     <configMgmtPaginationContext.Provider value={SIDEPANEL_PAGINATION_PARAMS}>
                         <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!entityId1}>
-                            <SidePanel
-                                entityType1={pageEntityListType}
-                                entityId1={entityId1}
-                                entityType2={entityType2}
-                                entityListType2={entityListType2}
-                                entityId2={entityId2}
-                                query={query}
-                            />
+                            <div ref={sidePanelRef}>
+                                <SidePanel
+                                    entityType1={pageEntityListType}
+                                    entityId1={entityId1}
+                                    entityType2={entityType2}
+                                    entityListType2={entityListType2}
+                                    entityId2={entityId2}
+                                    query={query}
+                                />
+                            </div>
                         </SidePanelAnimatedArea>
                     </configMgmtPaginationContext.Provider>
                 </searchContext.Provider>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Roles.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Roles.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 import { format } from 'date-fns';
 
@@ -218,8 +219,6 @@ const buildTableColumns = (match, location, entityContext) => {
 const createTableRows = (data) => data.results;
 
 const Roles = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -228,6 +227,8 @@ const Roles = ({
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location, entityContext);
     const queryText = queryService.objectToWhereClause(query);

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Secrets.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Secrets.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import uniq from 'lodash/uniq';
 import { format } from 'date-fns';
 import pluralize from 'pluralize';
@@ -149,8 +150,6 @@ const createTableRows = (data) => {
 };
 
 const Secrets = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -159,6 +158,8 @@ const Secrets = ({
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location, entityContext);
     const queryText = queryService.objectToWhereClause(query);

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ServiceAccounts.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ServiceAccounts.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 
 import {
@@ -167,8 +168,6 @@ const buildTableColumns = (match, location, entityContext) => {
 const createTableRows = (data) => data.results;
 
 const ServiceAccounts = ({
-    match,
-    location,
     className,
     selectedRowId,
     onRowClick,
@@ -177,6 +176,8 @@ const ServiceAccounts = ({
     totalResults,
     entityContext,
 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location, entityContext);
     const queryText = queryService.objectToWhereClause(query);

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Subjects.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Subjects.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import pluralize from 'pluralize';
 
 import {
@@ -103,16 +104,9 @@ const buildTableColumns = (match, location) => {
 
 const createTableRows = (data) => data?.results || [];
 
-const Subjects = ({
-    match,
-    location,
-    selectedRowId,
-    onRowClick,
-    query,
-    className,
-    data,
-    totalResults,
-}) => {
+const Subjects = ({ selectedRowId, onRowClick, query, className, data, totalResults }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
     const autoFocusSearchInput = !selectedRowId;
     const tableColumns = buildTableColumns(match, location);
     const queryText = queryService.objectToWhereClause(query);

--- a/ui/apps/platform/src/Containers/ConfigManagement/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Page.js
@@ -13,9 +13,15 @@ import EntityPage from './Entity/Page';
 const Page = () => (
     <searchContext.Provider value={searchParams.page}>
         <Switch>
-            <Route exact path={workflowPaths.DASHBOARD} component={DashboardPage} />
-            <Route path={workflowPaths.ENTITY} component={EntityPage} />
-            <Route path={workflowPaths.LIST} component={ListPage} />
+            <Route exact path={workflowPaths.DASHBOARD}>
+                <DashboardPage />
+            </Route>
+            <Route path={workflowPaths.ENTITY}>
+                <EntityPage />
+            </Route>
+            <Route path={workflowPaths.LIST}>
+                <ListPage />
+            </Route>
             <Route>
                 <PageNotFound useCase={useCases.CONFIG_MANAGEMENT} />
             </Route>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.js
@@ -1,13 +1,15 @@
 import React from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { Link, useLocation, useRouteMatch } from 'react-router-dom';
 import URLService from 'utils/URLService';
 
 import { ArrowLeft } from 'react-feather';
 import EntityIcon from 'Components/EntityIcon';
 
-const BackButton = ({ match, location, entityType1, entityListType2, entityId2 }) => {
+const BackButton = ({ entityType1, entityListType2, entityId2 }) => {
+    const location = useLocation();
+    const match = useRouteMatch();
+
     if (entityListType2 || entityId2) {
         const link = URLService.getURL(match, location).pop().url();
         return (
@@ -29,8 +31,6 @@ const BackButton = ({ match, location, entityType1, entityListType2, entityId2 }
 };
 
 BackButton.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     entityType1: PropTypes.string,
     entityListType2: PropTypes.string,
     entityId2: PropTypes.string,
@@ -42,4 +42,4 @@ BackButton.defaultProps = {
     entityId2: null,
 };
 
-export default withRouter(BackButton);
+export default BackButton;

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
 import { ChevronRight } from 'react-feather';
-import { Link, withRouter } from 'react-router-dom';
+import { Link, useLocation, useRouteMatch } from 'react-router-dom';
 
 import useEntityName from 'hooks/useEntityName';
 import entityLabels from 'messages/entity';
@@ -85,9 +84,12 @@ const getMaxWidthClass = (length) => {
 };
 
 const BreadCrumbLinks = (props) => {
+    const location = useLocation();
+    const match = useRouteMatch();
+
     // disable because unused history might be specified for rest spread idiom.
     /* eslint-disable no-unused-vars */
-    const { className, match, location, history, ...params } = props;
+    const { className, ...params } = props;
     /* eslint-enable no-unused-vars */
     const { entityType1, entityId1, entityListType2, entityId2 } = params;
     if (!entityId1) {
@@ -139,9 +141,6 @@ const BreadCrumbLinks = (props) => {
 };
 
 BreadCrumbLinks.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     className: PropTypes.string,
 };
 
@@ -150,9 +149,9 @@ BreadCrumbLinks.defaultProps = {
 };
 
 const BreadCrumbs = (props) => {
-    // disable because unused className, match, location might be specified for rest spread idiom.
+    // disable because unused className might be specified for rest spread idiom.
     /* eslint-disable no-unused-vars */
-    const { className, match, location, ...params } = props;
+    const { className, ...params } = props;
     /* eslint-enable no-unused-vars */
     const { entityType1, entityId1, entityType2, entityListType2, entityId2 } = params;
 
@@ -187,8 +186,6 @@ const BreadCrumbs = (props) => {
 };
 
 BreadCrumbs.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     className: PropTypes.string,
     entityType1: PropTypes.string,
     entityId1: PropTypes.string,
@@ -206,4 +203,4 @@ BreadCrumbs.defaultProps = {
     entityId2: null,
 };
 
-export default withRouter(BreadCrumbs);
+export default BreadCrumbs;

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -88,9 +88,7 @@ const BreadCrumbLinks = (props) => {
     const match = useRouteMatch();
 
     // disable because unused history might be specified for rest spread idiom.
-    /* eslint-disable no-unused-vars */
     const { className, ...params } = props;
-    /* eslint-enable no-unused-vars */
     const { entityType1, entityId1, entityListType2, entityId2 } = params;
     if (!entityId1) {
         return null;

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useHistory, useRouteMatch, Link } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
@@ -30,27 +30,6 @@ const SidePanel = ({
     const searchParam = useContext(searchContext);
     const isList = !entityId1 || (entityListType2 && !entityId2);
 
-    const panelRef = useRef(null);
-
-    const handleClickOutside = useCallback(
-        (event) => {
-            if (panelRef.current && !panelRef.current.contains(event.target)) {
-                history.push(URLService.getURL(match, location).clearSidePanelParams().url());
-            }
-        },
-        [history, match, location]
-    );
-
-    useEffect(() => {
-        document.addEventListener('click', handleClickOutside);
-        document.addEventListener('touchstart', handleClickOutside);
-
-        return () => {
-            document.removeEventListener('click', handleClickOutside);
-            document.removeEventListener('touchstart', handleClickOutside);
-        };
-    }, [handleClickOutside]);
-
     function getCurrentEntityId() {
         return entityId2 || entityId1;
     }
@@ -79,10 +58,6 @@ const SidePanel = ({
     function onClose() {
         history.push(URLService.getURL(match, location).clearSidePanelParams().url());
     }
-
-    SidePanel.handleClickOutside = () => {
-        onClose();
-    };
 
     const entityId = getCurrentEntityId();
     const entityType = getCurrentEntityType();
@@ -114,33 +89,31 @@ const SidePanel = ({
     }
     return (
         <workflowStateContext.Provider value={workflowState}>
-            <div ref={panelRef}>
-                <PanelNew testid="side-panel">
-                    <PanelHead>
-                        <BreadCrumbs
-                            className="leading-normal text-base-600 truncate"
-                            entityType1={entityType1 || entityListType1}
-                            entityId1={entityId1}
-                            entityType2={entityType2}
-                            entityListType2={entityListType2}
-                            entityId2={entityId2}
-                        />
-                        <PanelHeadEnd>
-                            {externalLink}
-                            <CloseButton onClose={onClose} className="border-base-400 border-l" />
-                        </PanelHeadEnd>
-                    </PanelHead>
-                    <PanelBody>
-                        <Entity
-                            entityContext={entityContext}
-                            entityType={entityType}
-                            entityId={entityId}
-                            entityListType={listType}
-                            query={query}
-                        />
-                    </PanelBody>
-                </PanelNew>
-            </div>
+            <PanelNew testid="side-panel">
+                <PanelHead>
+                    <BreadCrumbs
+                        className="leading-normal text-base-600 truncate"
+                        entityType1={entityType1 || entityListType1}
+                        entityId1={entityId1}
+                        entityType2={entityType2}
+                        entityListType2={entityListType2}
+                        entityId2={entityId2}
+                    />
+                    <PanelHeadEnd>
+                        {externalLink}
+                        <CloseButton onClose={onClose} className="border-base-400 border-l" />
+                    </PanelHeadEnd>
+                </PanelHead>
+                <PanelBody>
+                    <Entity
+                        entityContext={entityContext}
+                        entityType={entityType}
+                        entityId={entityId}
+                        entityListType={listType}
+                        query={query}
+                    />
+                </PanelBody>
+            </PanelNew>
         </workflowStateContext.Provider>
     );
 };

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { useLocation, useHistory, useRouteMatch, Link } from 'react-router-dom';
 import onClickOutside from 'react-onclickoutside';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
@@ -15,9 +14,6 @@ import URLService from 'utils/URLService';
 import BreadCrumbs from './BreadCrumbs';
 
 const SidePanel = ({
-    match,
-    location,
-    history,
     contextEntityType,
     contextEntityId,
     entityListType1,
@@ -28,6 +24,9 @@ const SidePanel = ({
     entityId2,
     query,
 }) => {
+    const match = useRouteMatch();
+    const location = useLocation();
+    const history = useHistory();
     const workflowState = parseURL(location);
     const searchParam = useContext(searchContext);
     const isList = !entityId1 || (entityListType2 && !entityId2);
@@ -125,9 +124,6 @@ const SidePanel = ({
 };
 
 SidePanel.propTypes = {
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     contextEntityType: PropTypes.string,
     contextEntityId: PropTypes.string,
     entityType1: PropTypes.string,
@@ -158,4 +154,4 @@ const clickOutsideConfig = {
  * If more than one SidePanel is rendered, this Pure Functional Component will need to be converted to
  * a Class Component in order to work correctly. See https://github.com/stackrox/rox/pull/3090#pullrequestreview-274948849
  */
-export default onClickOutside(withRouter(SidePanel), clickOutsideConfig);
+export default onClickOutside(SidePanel, clickOutsideConfig);

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -21,19 +21,32 @@ const Page = (): ReactElement => {
     // Redirect from list or view page to cluster init bundles list.
     return (
         <Switch>
-            <Route exact path={integrationsPath} component={IntegrationTilesPage} />
+            <Route exact path={integrationsPath}>
+                <IntegrationTilesPage />
+            </Route>
             <Route
                 path={[
                     `${integrationsPath}/authProviders/clusterInitBundle`,
                     `${integrationsPath}/authProviders/clusterInitBundle/:action/:id`,
                 ]}
-                render={() => <Redirect to={clustersInitBundlesPath} />}
-            />
-            <Route exact path={integrationsListPath} component={IntegrationsListPage} />
-            <Route path={integrationCreatePath} component={CreateIntegrationPage} />
-            <Route path={integrationEditPath} component={EditIntegrationPage} />
-            <Route path={integrationDetailsPath} component={IntegrationDetailsPage} />
-            <Route component={IntegrationsNotFoundPage} />
+            >
+                <Redirect to={clustersInitBundlesPath} />
+            </Route>
+            <Route exact path={integrationsListPath}>
+                <IntegrationsListPage />
+            </Route>
+            <Route path={integrationCreatePath}>
+                <CreateIntegrationPage />
+            </Route>
+            <Route path={integrationEditPath}>
+                <EditIntegrationPage />
+            </Route>
+            <Route path={integrationDetailsPath}>
+                <IntegrationDetailsPage />
+            </Route>
+            <Route>
+                <IntegrationsNotFoundPage />
+            </Route>
         </Switch>
     );
 };

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -29,9 +29,8 @@ const Page = (): ReactElement => {
                     `${integrationsPath}/authProviders/clusterInitBundle`,
                     `${integrationsPath}/authProviders/clusterInitBundle/:action/:id`,
                 ]}
-            >
-                <Redirect to={clustersInitBundlesPath} />
-            </Route>
+                render={() => <Redirect to={clustersInitBundlesPath} />}
+            />
             <Route exact path={integrationsListPath}>
                 <IntegrationsListPage />
             </Route>

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -39,7 +39,7 @@ class LoginPage extends Component {
     static propTypes = {
         authStatus: PropTypes.oneOf(Object.keys(AUTH_STATUS).map((key) => AUTH_STATUS[key]))
             .isRequired,
-        authProviders: PropTypes.arrayOf(PropTypes.object).isRequired,
+        authProviders: PropTypes.arrayOf(PropTypes.object),
         authProviderResponse: PropTypes.shape({
             error: PropTypes.string,
             error_description: PropTypes.string,
@@ -58,6 +58,7 @@ class LoginPage extends Component {
 
     static defaultProps = {
         authorizeRoxctlMode: false,
+        authProviders: [],
     };
 
     constructor(props) {
@@ -320,7 +321,7 @@ const Form = reduxForm({
 // which are based on the Redux state. Yet because initialValues matter only when
 // component is mounted, we cannot mount a component until we have everything to populate
 // initial values (in this case the list of auth providers)
-const LoadingOrForm = ({ authProviders, authorizeRoxctlMode = false }) => {
+const LoadingOrForm = ({ authProviders = [], authorizeRoxctlMode = false }) => {
     if (!authProviders.length) {
         return <LoadingSection message="Loading..." />;
     }

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -28,7 +28,6 @@ import {
     listeningEndpointsBasePath,
     mainPath,
     networkPath,
-    policiesPath,
     policyManagementBasePath,
     riskPath,
     searchPath,
@@ -43,6 +42,8 @@ import {
     exceptionManagementPath,
     vulnerabilitiesNodeCvesPath,
     vulnerabilitiesPlatformCvesPath,
+    deprecatedPoliciesBasePath,
+    policiesBasePath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -265,9 +266,16 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Route
-                        path={deprecatedPoliciesPath}
+                        path={deprecatedPoliciesBasePath}
                         exact
-                        render={() => <Redirect to={policiesPath} />}
+                        render={() => <Redirect to={policiesBasePath} />}
+                    />
+                    <Route
+                        exact
+                        path={deprecatedPoliciesPath}
+                        render={({ match }) => (
+                            <Redirect to={`${policiesBasePath}/${match.params.policyId}`} />
+                        )}
                     />
                     {Object.keys(routeComponentMap)
                         .filter((routeKey) => isRouteEnabled(routePredicates, routeKey as RouteKey))

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -271,7 +271,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                             const { component, path } = routeComponentMap[routeKey];
                             return <Route key={routeKey} path={path} component={component} />;
                         })}
-                    <Route component={NotFoundPage} />
+                    <Route>
+                        <NotFoundPage />
+                    </Route>
                 </Switch>
                 {hasWriteAccessForInviting && showInviteModal && <InviteUsersModal />}
             </ErrorBoundary>

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -264,7 +264,11 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
-                    <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
+                    <Route
+                        path={deprecatedPoliciesPath}
+                        exact
+                        render={() => <Redirect to={policiesPath} />}
+                    />
                     {Object.keys(routeComponentMap)
                         .filter((routeKey) => isRouteEnabled(routePredicates, routeKey as RouteKey))
                         .map((routeKey) => {

--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -1,5 +1,4 @@
 import React, { useState, ReactElement } from 'react';
-import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { DownloadIcon } from '@patternfly/react-icons';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -114,4 +113,4 @@ const mapDispatchToProps = {
     removeToast: actions.removeOldestNotification,
 };
 
-export default withRouter(connect(null, mapDispatchToProps)(CLIDownloadMenu));
+export default connect(null, mapDispatchToProps)(CLIDownloadMenu);

--- a/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
@@ -1,6 +1,5 @@
 import React, { useState, CSSProperties } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import initials from 'initials';
@@ -139,4 +138,4 @@ const mapDispatchToProps = (dispatch) => ({
     logout: () => dispatch(authActions.logout()),
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(UserMenu));
+export default connect(mapStateToProps, mapDispatchToProps)(UserMenu);

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -8,7 +8,11 @@ import PolicyCategoriesPage from 'Containers/PolicyCategories/PolicyCategoriesPa
 function PolicyManagementPage() {
     return (
         <Switch>
-            <Redirect exact from={policyManagementBasePath} to={policiesPath} />
+            <Route
+                exact
+                path={policyManagementBasePath}
+                render={() => <Redirect to={policiesPath} />}
+            />
             <Route path={policiesPath}>
                 <PoliciesPage />
             </Route>

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { policiesPath, policyManagementBasePath, policyCategoriesPath } from 'routePaths';
+import {
+    policiesBasePath,
+    policiesPath,
+    policyManagementBasePath,
+    policyCategoriesPath,
+} from 'routePaths';
 import PoliciesPage from 'Containers/Policies/PoliciesPage';
 import PolicyCategoriesPage from 'Containers/PolicyCategories/PolicyCategoriesPage';
 
@@ -11,7 +16,7 @@ function PolicyManagementPage() {
             <Route
                 exact
                 path={policyManagementBasePath}
-                render={() => <Redirect to={policiesPath} />}
+                render={() => <Redirect to={policiesBasePath} />}
             />
             <Route path={policiesPath}>
                 <PoliciesPage />

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 
 import { PageBody } from 'Components/Panel';
@@ -12,13 +12,12 @@ import RiskPageHeader from './RiskPageHeader';
 import RiskSidePanel from './RiskSidePanel';
 import RiskTablePanel from './RiskTablePanel';
 
-const RiskPage = ({
-    history,
-    location: { pathname, search },
-    match: {
-        params: { deploymentId },
-    },
-}) => {
+const RiskPage = () => {
+    const history = useHistory();
+    const location = useLocation();
+    const params = useParams();
+    const { deploymentId } = params;
+    const { pathname, search } = location;
     const workflowState = parseURL({ pathname, search });
 
     // Handle changes to applied search options.
@@ -72,12 +71,6 @@ const RiskPage = ({
             </PageBody>
         </workflowStateContext.Provider>
     );
-};
-
-RiskPage.propTypes = {
-    history: ReactRouterPropTypes.history.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
 };
 
 export default RiskPage;

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
@@ -1,7 +1,6 @@
 import React, { useContext, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Bullseye } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -28,13 +27,13 @@ import RiskTable from './RiskTable';
 
 const DEFAULT_RISK_SORT = [{ id: 'Deployment Risk Priority', desc: false }];
 function RiskTablePanel({
-    history,
     selectedDeploymentId,
     setSelectedDeploymentId,
     isViewFiltered,
     setIsViewFiltered,
     searchOptions,
 }) {
+    const history = useHistory();
     const workflowState = useContext(workflowStateContext);
     const pageSearch = workflowState.search[searchParams.page];
     const sortOption = workflowState.sort[sortParams.page] || DEFAULT_RISK_SORT;
@@ -134,7 +133,6 @@ function RiskTablePanel({
 }
 
 RiskTablePanel.propTypes = {
-    history: ReactRouterPropTypes.history.isRequired,
     selectedDeploymentId: PropTypes.string,
     setSelectedDeploymentId: PropTypes.func.isRequired,
     isViewFiltered: PropTypes.bool.isRequired,
@@ -147,4 +145,4 @@ RiskTablePanel.defaultProps = {
     searchOptions: [],
 };
 
-export default withRouter(RiskTablePanel);
+export default RiskTablePanel;

--- a/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
@@ -9,9 +9,15 @@ import ViolationNotFoundPage from './ViolationNotFoundPage';
 function ViolationsPage(): ReactElement {
     return (
         <Switch>
-            <Route exact path={violationsBasePath} component={ViolationsTablePage} />
-            <Route path={violationsPath} component={ViolationDetailsPage} />
-            <Route component={ViolationNotFoundPage} />
+            <Route exact path={violationsBasePath}>
+                <ViolationsTablePage />
+            </Route>
+            <Route path={violationsPath}>
+                <ViolationDetailsPage />
+            </Route>
+            <Route>
+                <ViolationNotFoundPage />
+            </Route>
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory } from 'react-router-dom';
 
 import usePermissions from 'hooks/usePermissions';
 import entityTypes from 'constants/entityTypes';
@@ -29,7 +28,8 @@ const entityMenuTypes = [
     entityTypes.IMAGE_COMPONENT,
 ];
 
-const VulnDashboardPage = ({ history }) => {
+const VulnDashboardPage = () => {
+    const history = useHistory();
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
     const workflowState = useContext(workflowStateContext);
@@ -126,8 +126,4 @@ const VulnDashboardPage = ({ history }) => {
     );
 };
 
-VulnDashboardPage.propTypes = {
-    history: ReactRouterPropTypes.history.isRequired,
-};
-
-export default withRouter(VulnDashboardPage);
+export default VulnDashboardPage;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import URLService from 'utils/URLService';
 import useCaseTypes from 'constants/useCaseTypes';
-import { withRouter } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import parseURL from 'utils/URLParser';
 import workflowStateContext from 'Containers/workflowStateContext';
 
@@ -11,7 +11,10 @@ const DashboardMap = {
     [useCaseTypes.VULN_MANAGEMENT]: VulnMgmtDashboardPage,
 };
 
-const WorkflowDashboardLayout = ({ match, location }) => {
+const WorkflowDashboardLayout = () => {
+    const location = useLocation();
+    const match = useRouteMatch();
+
     const params = URLService.getParams(match, location);
     const workflowState = parseURL(location);
     const { context: useCase } = params;
@@ -23,4 +26,4 @@ const WorkflowDashboardLayout = ({ match, location }) => {
     );
 };
 
-export default withRouter(WorkflowDashboardLayout);
+export default WorkflowDashboardLayout;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import resolvePath from 'object-resolve-path';
 
 import workflowStateContext from 'Containers/workflowStateContext';
@@ -11,7 +10,6 @@ import TablePagination from 'Components/TablePagination';
 import Table, { DEFAULT_PAGE_SIZE } from 'Components/Table';
 
 const TableWidget = ({
-    history,
     header,
     entityType,
     pageSize,
@@ -21,6 +19,7 @@ const TableWidget = ({
     ...rest
 }) => {
     const workflowState = useContext(workflowStateContext);
+    const history = useHistory();
     const [localPage, setLocalPage] = useState(0);
     const {
         columns,
@@ -98,7 +97,6 @@ const TableWidget = ({
 
 TableWidget.propTypes = {
     header: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     idAttribute: PropTypes.string,
     pageSize: PropTypes.number,
     parentPageState: PropTypes.shape({
@@ -118,4 +116,5 @@ TableWidget.defaultProps = {
     currentSort: null,
     sortHandler: null,
 };
-export default withRouter(TableWidget);
+
+export default TableWidget;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
@@ -24,9 +24,10 @@ import WorkflowSidePanel from '../WorkflowSidePanel';
 import EntityComponent from './VulnMgmtEntity';
 import EntityTabs from './EntityTabs';
 
-const WorkflowEntityPageLayout = ({ location }) => {
+const WorkflowEntityPageLayout = () => {
     const [isExporting, setIsExporting] = useState(false);
     const { isDarkMode } = useTheme();
+    const location = useLocation();
 
     const workflowState = parseURL(location);
     const { stateStack, useCase, search } = workflowState;
@@ -155,4 +156,4 @@ const WorkflowEntityPageLayout = ({ location }) => {
     );
 };
 
-export default withRouter(WorkflowEntityPageLayout);
+export default WorkflowEntityPageLayout;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import * as Icon from 'react-feather';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import {
     defaultHeaderClassName,
@@ -280,7 +280,6 @@ export function renderCveDescription(row) {
 }
 
 const VulnMgmtCves = ({
-    history,
     selectedRowId,
     search,
     sort,
@@ -292,6 +291,7 @@ const VulnMgmtCves = ({
     refreshTrigger,
     setRefreshTrigger,
 }) => {
+    const history = useHistory();
     const { analyticsTrack } = useAnalytics();
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
@@ -654,4 +654,4 @@ const mapDispatchToProps = {
     removeToast: notificationActions.removeOldestNotification,
 };
 
-export default withRouter(connect(null, mapDispatchToProps)(VulnMgmtCves));
+export default connect(null, mapDispatchToProps)(VulnMgmtCves);

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.js
@@ -1,13 +1,12 @@
 import React, { useContext, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory } from 'react-router-dom';
 import resolvePath from 'object-resolve-path';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
 import Table from 'Components/Table';
 import TablePagination from 'Components/TablePagination';
 import URLSearchInput from 'Components/URLSearchInput';
-import { withRouter } from 'react-router-dom';
 import { searchCategories } from 'constants/entityTypes';
 import createPDFTable from 'utils/pdfUtils';
 import CheckboxTable from 'Components/CheckboxTable';
@@ -21,7 +20,6 @@ import {
 const EntityList = ({
     autoFocusSearchInput,
     entityType,
-    history,
     idAttribute,
     rowData,
     searchOptions,
@@ -44,6 +42,7 @@ const EntityList = ({
 }) => {
     const tableRef = useRef(null);
     const workflowState = useContext(workflowStateContext);
+    const history = useHistory();
 
     function toggleTableRow(id) {
         const newSelection = toggleRow(id, selection);
@@ -173,7 +172,6 @@ EntityList.propTypes = {
     autoFocusSearchInput: PropTypes.bool,
     entityType: PropTypes.string.isRequired,
     idAttribute: PropTypes.string.isRequired,
-    history: ReactRouterPropTypes.history.isRequired,
     rowData: PropTypes.arrayOf(PropTypes.shape({})),
     searchOptions: PropTypes.arrayOf(PropTypes.string),
     sort: PropTypes.arrayOf(PropTypes.shape({})),
@@ -215,4 +213,4 @@ EntityList.defaultProps = {
     pageSize: null,
 };
 
-export default withRouter(EntityList);
+export default EntityList;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.js
@@ -1,8 +1,7 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import { useHistory } from 'react-router-dom';
 
 import PageNotFound from 'Components/PageNotFound';
 import Loader from 'Components/Loader';
@@ -39,8 +38,8 @@ const WorkflowListPage = ({
     selection,
     setSelection,
     renderRowActionButtons,
-    history,
 }) => {
+    const history = useHistory();
     const workflowState = useContext(workflowStateContext);
     const [sortFields, setSortFields] = useState({});
     const { isFeatureFlagEnabled } = useFeatureFlags();
@@ -149,7 +148,6 @@ WorkflowListPage.propTypes = {
     selection: PropTypes.arrayOf(PropTypes.string),
     setSelection: PropTypes.func,
     renderRowActionButtons: PropTypes.func,
-    history: ReactRouterPropTypes.history.isRequired,
     totalResults: PropTypes.number,
 };
 
@@ -172,4 +170,4 @@ WorkflowListPage.defaultProps = {
     totalResults: 0,
 };
 
-export default withRouter(WorkflowListPage);
+export default WorkflowListPage;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import startCase from 'lodash/startCase';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
@@ -22,7 +23,8 @@ import WorkflowSidePanel from '../WorkflowSidePanel';
 import EntityComponent from '../Entity/VulnMgmtEntity';
 import ListComponent from './VulnMgmtList';
 
-const WorkflowListPageLayout = ({ location }) => {
+const WorkflowListPageLayout = () => {
+    const location = useLocation();
     const [isExporting, setIsExporting] = useState(false);
 
     const { isDarkMode } = useTheme();

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
@@ -144,36 +144,24 @@ function RiskAcceptancePage(): ReactElement {
                     </Tabs>
                 </div>
                 <Switch>
-                    <Route
-                        exact
-                        path={vulnManagementPendingApprovalsPath}
-                        render={() => (
-                            <>
-                                <PageTitle title="Pending Approvals" />
-                                <TabContentList activeKeyTab={activeKeyTab} />
-                            </>
-                        )}
-                    />
-                    <Route
-                        exact
-                        path={vulnManagementApprovedDeferralsPath}
-                        render={() => (
-                            <>
-                                <PageTitle title="Approved Deferrals" />
-                                <TabContentList activeKeyTab={activeKeyTab} />
-                            </>
-                        )}
-                    />
-                    <Route
-                        exact
-                        path={vulnManagementApprovedFalsePositivesPath}
-                        render={() => (
-                            <>
-                                <PageTitle title="Approved False Positives" />
-                                <TabContentList activeKeyTab={activeKeyTab} />
-                            </>
-                        )}
-                    />
+                    <Route exact path={vulnManagementPendingApprovalsPath}>
+                        <>
+                            <PageTitle title="Pending Approvals" />
+                            <TabContentList activeKeyTab={activeKeyTab} />
+                        </>
+                    </Route>
+                    <Route exact path={vulnManagementApprovedDeferralsPath}>
+                        <>
+                            <PageTitle title="Approved Deferrals" />
+                            <TabContentList activeKeyTab={activeKeyTab} />
+                        </>
+                    </Route>
+                    <Route exact path={vulnManagementApprovedFalsePositivesPath}>
+                        <>
+                            <PageTitle title="Approved False Positives" />
+                            <TabContentList activeKeyTab={activeKeyTab} />
+                        </>
+                    </Route>
                 </Switch>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.js
@@ -10,10 +10,18 @@ import EntityPage from './Entity/WorkflowEntityPageLayout';
 
 const Page = () => (
     <Switch>
-        <Route exact path={workflowPaths.DASHBOARD} component={DashboardPage} />
-        <Route path={workflowPaths.ENTITY} component={EntityPage} />
-        <Route path={workflowPaths.LIST} component={ListPage} />
-        <Route render={PageNotFound} />
+        <Route exact path={workflowPaths.DASHBOARD}>
+            <DashboardPage />
+        </Route>
+        <Route path={workflowPaths.ENTITY}>
+            <EntityPage />
+        </Route>
+        <Route path={workflowPaths.LIST}>
+            <ListPage />
+        </Route>
+        <Route>
+            <PageNotFound />
+        </Route>
     </Switch>
 );
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { withRouter, Link } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
@@ -9,7 +9,9 @@ import parseURL from 'utils/URLParser';
 
 import EntityBreadCrumbs from './EntityBreadCrumbs';
 
-const WorkflowSidePanel = ({ history, location, children }) => {
+const WorkflowSidePanel = ({ children }) => {
+    const history = useHistory();
+    const location = useLocation();
     const workflowState = parseURL(location);
     const pageStack = workflowState.getPageStack();
     const breadCrumbEntities = workflowState.stateStack.slice(pageStack.length);
@@ -48,4 +50,4 @@ const WorkflowSidePanel = ({ history, location, children }) => {
  * If more than one SidePanel is rendered, this Pure Functional Component will need to be converted to
  * a Class Component in order to work correctly. See https://github.com/stackrox/rox/pull/3090#pullrequestreview-274948849
  */
-export default withRouter(WorkflowSidePanel);
+export default WorkflowSidePanel;

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import max from 'lodash/max';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import {
     FlexibleXYPlot,
@@ -37,7 +37,8 @@ function getLabelData(data) {
     }));
 }
 
-const LabeledBarGraph = ({ data, title, history }) => {
+const LabeledBarGraph = ({ data, title }) => {
+    const history = useHistory();
     const { onValueMouseOver, onValueMouseOut } = useGraphHoverHint();
 
     const upperBoundX = max([...data.map((datum) => datum.x)]);
@@ -93,9 +94,7 @@ const LabeledBarGraph = ({ data, title, history }) => {
     );
 };
 
-const HOCLabeledBarGraph = withRouter(LabeledBarGraph);
-
-HOCLabeledBarGraph.propTypes = {
+LabeledBarGraph.propTypes = {
     data: PropTypes.arrayOf(
         PropTypes.shape({
             color: PropTypes.string,
@@ -107,9 +106,9 @@ HOCLabeledBarGraph.propTypes = {
     title: PropTypes.string,
 };
 
-HOCLabeledBarGraph.defaultProps = {
+LabeledBarGraph.defaultProps = {
     data: [],
     title: null,
 };
 
-export default HOCLabeledBarGraph;
+export default LabeledBarGraph;

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
-import ReactRouterPropTypes from 'react-router-prop-types';
-
+import { useHistory } from 'react-router-dom';
 import {
     FlexibleXYPlot,
     XAxis,
@@ -31,9 +29,9 @@ const Scatterplot = ({
     yAxisTitle,
     xAxisTitle,
     legendData,
-    history,
 }) => {
     const { onValueMouseOver, onValueMouseOut } = useGraphHoverHint();
+    const history = useHistory();
 
     const lowX = lowerX !== null ? lowerX : getLowValue(data, 'x', xMultiple);
     const highX = upperX !== null ? upperX : getHighValue(data, 'x', xMultiple, shouldPadX);
@@ -116,7 +114,6 @@ Scatterplot.propTypes = {
     legendData: PropTypes.arrayOf(
         PropTypes.shape({ title: PropTypes.string, color: PropTypes.string })
     ),
-    history: ReactRouterPropTypes.history.isRequired,
 };
 
 Scatterplot.defaultProps = {
@@ -135,4 +132,4 @@ Scatterplot.defaultProps = {
     legendData: null,
 };
 
-export default withRouter(Scatterplot);
+export default Scatterplot;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
@@ -12,11 +12,12 @@ import ExceptionRequestDetailsPage from './ExceptionRequestDetailsPage';
 function ExceptionManagementPage() {
     return (
         <Switch>
-            <Route
-                path={`${exceptionManagementPath}/requests/:requestId`}
-                component={ExceptionRequestDetailsPage}
-            />
-            <Route path={exceptionManagementPath} component={ExceptionRequestsPage} />
+            <Route path={`${exceptionManagementPath}/requests/:requestId`}>
+                <ExceptionRequestDetailsPage />
+            </Route>
+            <Route path={exceptionManagementPath}>
+                <ExceptionRequestsPage />
+            </Route>
             <Route>
                 <PageSection variant="light">
                     <PageTitle title="Exception requests - Not Found" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -102,14 +102,18 @@ function ExceptionRequestsPage() {
                     />
                 </Tabs>
                 <Switch>
-                    <Route exact path={pendingRequestsURL} component={PendingRequests} />
-                    <Route exact path={approvedDeferralsURL} component={ApprovedDeferrals} />
-                    <Route
-                        exact
-                        path={approvedFalsePositivesURL}
-                        component={ApprovedFalsePositives}
-                    />
-                    <Route exact path={deniedRequestsURL} component={DeniedRequests} />
+                    <Route exact path={pendingRequestsURL}>
+                        <PendingRequests />
+                    </Route>
+                    <Route exact path={approvedDeferralsURL}>
+                        <ApprovedDeferrals />
+                    </Route>
+                    <Route exact path={approvedFalsePositivesURL}>
+                        <ApprovedFalsePositives />
+                    </Route>
+                    <Route exact path={deniedRequestsURL}>
+                        <DeniedRequests />
+                    </Route>
                     <Redirect to={pendingRequestsURL} />
                 </Switch>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -114,7 +114,7 @@ function ExceptionRequestsPage() {
                     <Route exact path={deniedRequestsURL}>
                         <DeniedRequests />
                     </Route>
-                    <Redirect to={pendingRequestsURL} />
+                    <Route render={() => <Redirect to={pendingRequestsURL} />} />
                 </Switch>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
@@ -22,9 +22,15 @@ function NodeCvesPage() {
         <>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
-                <Route path={vulnerabilitiesNodeCveSinglePath} component={NodeCvePage} />
-                <Route path={vulnerabilitiesNodeSinglePath} component={NodePage} />
-                <Route exact path={vulnerabilitiesNodeCvesPath} component={NodeCvesOverviewPage} />
+                <Route path={vulnerabilitiesNodeCveSinglePath}>
+                    <NodeCvePage />
+                </Route>
+                <Route path={vulnerabilitiesNodeSinglePath}>
+                    <NodePage />
+                </Route>
+                <Route exact path={vulnerabilitiesNodeCvesPath}>
+                    <NodeCvesOverviewPage />
+                </Route>
                 <Route>
                     <PageSection variant="light">
                         <PageTitle title="Node CVEs - Not Found" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -23,13 +23,15 @@ function PlatformCvesPage() {
         <>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
-                <Route path={vulnerabilitiesPlatformCveSinglePath} component={PlatformCvePage} />
-                <Route path={vulnerabilitiesPlatformClusterSinglePath} component={ClusterPage} />
-                <Route
-                    exact
-                    path={vulnerabilitiesPlatformCvesPath}
-                    component={PlatformCvesOverviewPage}
-                />
+                <Route path={vulnerabilitiesPlatformCveSinglePath}>
+                    <PlatformCvePage />
+                </Route>
+                <Route path={vulnerabilitiesPlatformClusterSinglePath}>
+                    <ClusterPage />
+                </Route>
+                <Route exact path={vulnerabilitiesPlatformCvesPath}>
+                    <PlatformCvesOverviewPage />
+                </Route>
                 <Route>
                     <PageSection variant="light">
                         <PageTitle title="Platform CVEs - Not Found" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -28,8 +28,11 @@ function VulnReportingPage() {
 
     return (
         <Switch>
-            <Route exact path={vulnerabilityReportsPath}>
-                {() => {
+            <Route
+                exact
+                path={vulnerabilityReportsPath}
+                // eslint-disable-next-line react/no-children-prop
+                children={() => {
                     if (pageAction === 'create' && hasWriteAccessForReport) {
                         return <CreateVulnReportPage />;
                     }
@@ -38,9 +41,12 @@ function VulnReportingPage() {
                     }
                     return <Redirect to={vulnerabilityReportsPath} />;
                 }}
-            </Route>
-            <Route exact path={vulnerabilityReportPath}>
-                {() => {
+            />
+            <Route
+                exact
+                path={vulnerabilityReportPath}
+                // eslint-disable-next-line react/no-children-prop
+                children={() => {
                     if (pageAction === 'edit' && hasWriteAccessForReport) {
                         return <EditVulnReportPage />;
                     }
@@ -49,7 +55,7 @@ function VulnReportingPage() {
                     }
                     return <ViewVulnReportPage />;
                 }}
-            </Route>
+            />
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -28,32 +28,28 @@ function VulnReportingPage() {
 
     return (
         <Switch>
-            <Route
-                exact
-                path={vulnerabilityReportsPath}
-                render={(props) => {
+            <Route exact path={vulnerabilityReportsPath}>
+                {() => {
                     if (pageAction === 'create' && hasWriteAccessForReport) {
-                        return <CreateVulnReportPage {...props} />;
+                        return <CreateVulnReportPage />;
                     }
                     if (pageAction === undefined) {
-                        return <VulnReportsPage {...props} />;
+                        return <VulnReportsPage />;
                     }
                     return <Redirect to={vulnerabilityReportsPath} />;
                 }}
-            />
-            <Route
-                exact
-                path={vulnerabilityReportPath}
-                render={(props) => {
+            </Route>
+            <Route exact path={vulnerabilityReportPath}>
+                {() => {
                     if (pageAction === 'edit' && hasWriteAccessForReport) {
-                        return <EditVulnReportPage {...props} />;
+                        return <EditVulnReportPage />;
                     }
                     if (pageAction === 'clone' && hasWriteAccessForReport) {
-                        return <CloneVulnReportPage {...props} />;
+                        return <CloneVulnReportPage />;
                     }
-                    return <ViewVulnReportPage {...props} />;
+                    return <ViewVulnReportPage />;
                 }}
-            />
+            </Route>
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -31,8 +31,7 @@ function VulnReportingPage() {
             <Route
                 exact
                 path={vulnerabilityReportsPath}
-                // eslint-disable-next-line react/no-children-prop
-                children={() => {
+                render={() => {
                     if (pageAction === 'create' && hasWriteAccessForReport) {
                         return <CreateVulnReportPage />;
                     }
@@ -45,8 +44,7 @@ function VulnReportingPage() {
             <Route
                 exact
                 path={vulnerabilityReportPath}
-                // eslint-disable-next-line react/no-children-prop
-                children={() => {
+                render={() => {
                     if (pageAction === 'edit' && hasWriteAccessForReport) {
                         return <EditVulnReportPage />;
                     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -44,19 +44,22 @@ function WorkloadCvesPage() {
             )}
             <Switch>
                 {hasReadAccessForNamespaces && (
-                    <Route path={vulnerabilityNamespaceViewPath} component={NamespaceViewPage} />
+                    <Route path={vulnerabilityNamespaceViewPath}>
+                        <NamespaceViewPage />
+                    </Route>
                 )}
-                <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />
-                <Route path={vulnerabilitiesWorkloadCveImageSinglePath} component={ImagePage} />
-                <Route
-                    path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
-                    component={DeploymentPage}
-                />
-                <Route
-                    exact
-                    path={vulnerabilitiesWorkloadCvesPath}
-                    component={WorkloadCvesOverviewPage}
-                />
+                <Route path={vulnerabilitiesWorkloadCveSinglePath}>
+                    <ImageCvePage />
+                </Route>
+                <Route path={vulnerabilitiesWorkloadCveImageSinglePath}>
+                    <ImagePage />
+                </Route>
+                <Route path={vulnerabilitiesWorkloadCveDeploymentSinglePath}>
+                    <DeploymentPage />
+                </Route>
+                <Route exact path={vulnerabilitiesWorkloadCvesPath}>
+                    <WorkloadCvesOverviewPage />
+                </Route>
                 <Route>
                     <PageSection variant="light">
                         <PageTitle title="Workload CVEs - Not Found" />

--- a/ui/apps/platform/src/constants/entityPageProps.js
+++ b/ui/apps/platform/src/constants/entityPageProps.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
 
 export const entityPagePropTypes = {
     entityId: PropTypes.string.isRequired,
@@ -32,8 +31,6 @@ export const entityListPropTypes = {
     className: PropTypes.string,
     selectedRowId: PropTypes.string,
     query: PropTypes.shape({}),
-    match: ReactRouterPropTypes.match.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
     data: PropTypes.arrayOf(PropTypes.shape({})),
 };
 

--- a/ui/apps/platform/src/hooks/useClickOutside.ts
+++ b/ui/apps/platform/src/hooks/useClickOutside.ts
@@ -1,0 +1,31 @@
+import { useEffect, useCallback } from 'react';
+
+const useClickOutside = (
+    ref: React.RefObject<HTMLElement>,
+    callback: () => void,
+    isOpen: boolean
+) => {
+    const handleClickOutside = useCallback(
+        (event: MouseEvent) => {
+            const { target } = event;
+            if (ref.current && target instanceof HTMLElement && !ref.current.contains(target)) {
+                callback();
+            }
+        },
+        [callback, ref]
+    );
+
+    useEffect(() => {
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            if (isOpen) {
+                document.removeEventListener('mousedown', handleClickOutside);
+            }
+        };
+    }, [isOpen, handleClickOutside]);
+};
+
+export default useClickOutside;


### PR DESCRIPTION
### Description

Satisfies step 2 in the [official react router v6 upgrade documentation](https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v51)

1. ~~Upgrade to React v16.8 or greater~~
2. **Upgrade to React Router v5.1**
    * **Remove `<Redirect>`s inside `<Switch>`**
    * **Refactor custom `<Route>`s**
3. Upgrade to React Router v6

More specifically it satisfies the following steps:

- Use `<Route children>` instead of `<Route render>` and/or `<Route component>` props
- Use hooks API to access router state like the current location and params
- Replace all uses of `withRouter` with hooks
- Remove `<Redirect>`s inside of `<Switch>`

### User-facing documentation

- [ ] CHANGELOG update is not needed
- [ ] documentation PR is not needed


#### How I validated my change

Verify links and routes still work as intended