### PR TITLE
fix(ui): Fix accessibility issues for Alert heading level plus lint

### DIFF
--- a/ui/apps/platform/eslint-plugins/accessibilityPlugin.js
+++ b/ui/apps/platform/eslint-plugins/accessibilityPlugin.js
@@ -1,0 +1,43 @@
+const accessibilityPlugin = {
+    meta: {
+        name: 'accessibilityPlugin',
+        version: '0.0.1',
+    },
+    rules: {
+        'require-Alert-component': {
+            // Require alternative markup to prevent axe DevTools issue:
+            // Heading levels should only increase by one
+            meta: {
+                type: 'problem',
+                docs: {
+                    description: 'Require that Alert element has component="p" prop',
+                },
+                fixable: 'code',
+                schema: [],
+            },
+            create(context) {
+                return {
+                    JSXOpeningElement(node) {
+                        if (node.name?.name === 'Alert') {
+                            if (
+                                !node.attributes.some((nodeAttribute) => {
+                                    return (
+                                        nodeAttribute.name?.name === 'component' &&
+                                        nodeAttribute.value?.value === 'p'
+                                    );
+                                })
+                            ) {
+                                context.report({
+                                    node,
+                                    message: 'Alert element requires component="p" prop',
+                                });
+                            }
+                        }
+                    },
+                };
+            },
+        },
+    },
+};
+
+module.exports = accessibilityPlugin;

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -19,6 +19,8 @@ const pluginTypeScriptESLint = require('@typescript-eslint/eslint-plugin');
 
 const { browser: browserGlobals, jest: jestGlobals, node: nodeGlobals } = require('globals');
 
+const accessibilityPlugin = require('./eslint-plugins/accessibilityPlugin');
+
 const parserAndOptions = {
     parser: parserTypeScriptESLint,
     parserOptions: {
@@ -36,6 +38,7 @@ module.exports = [
             'coverage/**',
             'react-app-rewired/**',
             'scripts/**',
+            'eslint-plugins/**',
             'src/setupProxy.js',
             'src/setupTests.js',
             'cypress.d.ts',
@@ -533,8 +536,11 @@ module.exports = [
             'jsx-a11y': pluginAccessibility,
             react: pluginReact,
             'react-hooks': pluginReactHooks,
+            accessibilityPlugin,
         },
         rules: {
+            'accessibilityPlugin/require-Alert-component': 'error',
+
             'no-restricted-imports': [
                 'error',
                 {
@@ -695,7 +701,7 @@ module.exports = [
         },
     },
     {
-        files: ['*.js', 'tailwind-plugins/*.js'], // non-product files
+        files: ['*.js', 'eslint-plugins/*.js', 'tailwind-plugins/*.js'], // non-product files
 
         languageOptions: {
             ...parserAndOptions,

--- a/ui/apps/platform/src/Components/ComplianceUsageDisclaimer.tsx
+++ b/ui/apps/platform/src/Components/ComplianceUsageDisclaimer.tsx
@@ -19,7 +19,7 @@ function ComplianceUsageDisclaimer({ className, onAccept }: ComplianceUsageDiscl
                 variant="info"
                 isInline
                 title="Usage disclaimer"
-                component="div"
+                component="p"
                 actionLinks={
                     <>
                         <AlertActionLink onClick={onAccept}>

--- a/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierForm.tsx
+++ b/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierForm.tsx
@@ -136,6 +136,7 @@ function EmailNotifierForm({
                                 <Alert
                                     className="pf-v5-u-mt-md"
                                     title="Security Warning"
+                                    component="p"
                                     variant="warning"
                                     isInline
                                 >

--- a/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
@@ -19,6 +19,7 @@ function FormMessage({ message }: FormMessageProps): ReactElement {
                 <Alert
                     className="pf-v5-u-mt-md pf-v5-u-mb-md"
                     title={title}
+                    component="p"
                     variant={variant}
                     isInline
                 >

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlRouteNotFound.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlRouteNotFound.tsx
@@ -15,6 +15,7 @@ function AccessControlRouteNotFound(): ReactElement {
             <PageSection variant="light">
                 <Alert
                     title="Access Control route not found"
+                    component="p"
                     variant={AlertVariant.warning}
                     isInline
                 >

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
@@ -103,6 +103,7 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
                 setAlertCompute(
                     <Alert
                         title="Compute effective access scope failed"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -98,6 +98,7 @@ function AccessScopeFormWrapper({
                 setAlertSubmit(
                     <Alert
                         title="Failed to save access scope"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -67,6 +67,7 @@ function AccessScopes(): ReactElement {
                 setAlertAccessScopes(
                     <Alert
                         title="Fetch access scopes failed"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >
@@ -91,6 +92,7 @@ function AccessScopes(): ReactElement {
                 setAlertRoles(
                     <Alert
                         title="Fetch roles failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -52,6 +52,7 @@ function AccessScopesList({
                 setAlertDelete(
                     <Alert
                         title="Delete access scope failed"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -372,7 +372,7 @@ function AuthProviderForm({
                 </ToolbarContent>
             </Toolbar>
             {saveAuthProviderStatus?.status === 'error' && (
-                <Alert isInline variant="danger" title="Problem saving auth provider">
+                <Alert isInline variant="danger" title="Problem saving auth provider" component="p">
                     <p>{saveAuthProviderStatus?.message}</p>
                 </Alert>
             )}
@@ -388,6 +388,7 @@ function AuthProviderForm({
                                 is working properly.
                             </span>
                         }
+                        component="p"
                     />
                 )}
             {selectedAuthProvider.active && (
@@ -401,6 +402,7 @@ function AuthProviderForm({
                             delete and recreate.
                         </span>
                     }
+                    component="p"
                 />
             )}
             {getIsAuthProviderImmutable(selectedAuthProvider) && (
@@ -413,6 +415,7 @@ function AuthProviderForm({
                             rules.
                         </span>
                     }
+                    component="p"
                 />
             )}
             <FormikProvider value={formik}>
@@ -500,6 +503,7 @@ function AuthProviderForm({
                             variant="info"
                             title="Note: the minimum access role is granted to all users who sign in with
                                 this authentication provider."
+                            component="p"
                         >
                             <p>
                                 To give users different roles, add rules. Users are granted all
@@ -521,6 +525,7 @@ function AuthProviderForm({
                                 variant="info"
                                 title="Note: the required attributes are used to require attributes being
                                     returned from the authentication provider."
+                                component="p"
                             >
                                 <p>
                                     In case a required attribute is not returned from the
@@ -637,6 +642,7 @@ function AuthProviderForm({
                                 isInline
                                 variant="info"
                                 title="Note: the claim mappings are used to map claims returned in underlying identity provider's token to ACS token."
+                                component="p"
                             >
                                 <p>
                                     In case claim mapping is not configured for a certain claim,

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -209,6 +209,7 @@ function AuthProviders(): ReactElement {
                             variant="info"
                             title="Consider using short-lived tokens for machine-to-machine communications
                             such as CI/CD pipelines, scripts, and other automation."
+                            component="p"
                         >
                             <Flex
                                 direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
@@ -171,6 +171,7 @@ function ConfigurationFormFields({
                                     Note: if required by your IdP, use the following callback URL:
                                 </span>
                             }
+                            component="p"
                         >
                             <p>{oidcFragmentCallbackURL}</p>
                         </Alert>
@@ -354,6 +355,7 @@ function ConfigurationFormFields({
                             isInline
                             variant="info"
                             title={<span>Note: allow the following callback URLs:</span>}
+                            component="p"
                         >
                             <p>
                                 {oidcFragmentCallbackURL}
@@ -643,6 +645,7 @@ function ConfigurationFormFields({
                                     Consumer Service (ACS) URL:
                                 </span>
                             }
+                            component="p"
                         >
                             <p>{samlACSURL}</p>
                         </Alert>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -96,6 +96,7 @@ function PermissionSetForm({
                 setAlertSubmit(
                     <Alert
                         title="Failed to save permission set"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >
@@ -183,7 +184,12 @@ function PermissionSetForm({
                 />
             </FormGroup>
             {action === 'create' && (
-                <Alert title="Recommended minimum set of read permissions" variant="info" isInline>
+                <Alert
+                    title="Recommended minimum set of read permissions"
+                    component="p"
+                    variant="info"
+                    isInline
+                >
                     <p>
                         Users might not be able to load certain pages if they do not have a minimum
                         set of read permissions.

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -71,6 +71,7 @@ function PermissionSets(): ReactElement {
                 setAlertPermissionSets(
                     <Alert
                         title="Fetch permission sets failed"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >
@@ -95,6 +96,7 @@ function PermissionSets(): ReactElement {
                 setAlertRoles(
                     <Alert
                         title="Fetch resources failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}
@@ -118,6 +120,7 @@ function PermissionSets(): ReactElement {
                 setAlertRoles(
                     <Alert
                         title="Fetch roles failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -51,6 +51,7 @@ function PermissionSetsList({
                 setAlertDelete(
                     <Alert
                         title="Delete permission set failed"
+                        component="p"
                         variant={AlertVariant.danger}
                         isInline
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -92,7 +92,12 @@ function RoleForm({
         handleSubmit(values)
             .catch((error) => {
                 setAlertSubmit(
-                    <Alert title="Failed to save role" variant={AlertVariant.danger} isInline>
+                    <Alert
+                        title="Failed to save role"
+                        component="p"
+                        variant={AlertVariant.danger}
+                        isInline
+                    >
                         {error.message}
                     </Alert>
                 );

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -89,7 +89,12 @@ function Roles(): ReactElement {
             })
             .catch((error) => {
                 setAlertRoles(
-                    <Alert title="Fetch roles failed" variant={AlertVariant.danger} isInline>
+                    <Alert
+                        title="Fetch roles failed"
+                        component="p"
+                        variant={AlertVariant.danger}
+                        isInline
+                    >
                         {error.message}
                     </Alert>
                 );
@@ -126,6 +131,7 @@ function Roles(): ReactElement {
                 setAlertGroups(
                     <Alert
                         title="Fetch auth providers or groups failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}
@@ -149,6 +155,7 @@ function Roles(): ReactElement {
                 setAlertPermissionSets(
                     <Alert
                         title="Fetch permission sets failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}
@@ -172,6 +179,7 @@ function Roles(): ReactElement {
                 setAlertAccessScopes(
                     <Alert
                         title="Fetch access scopes failed"
+                        component="p"
                         variant={AlertVariant.warning}
                         isInline
                         actionClose={actionClose}

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -62,7 +62,12 @@ function RolesList({
         handleDelete(nameDeleting)
             .catch((error) => {
                 setAlertDelete(
-                    <Alert title="Delete role failed" variant={AlertVariant.danger} isInline>
+                    <Alert
+                        title="Delete role failed"
+                        component="p"
+                        variant={AlertVariant.danger}
+                        isInline
+                    >
                         {error.message}
                     </Alert>
                 );

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
@@ -70,7 +70,7 @@ function AdministrationEventPage({ id }: AdministrationEventPageProps): ReactEle
                         <Alert
                             variant="warning"
                             title="Unable to fetch administration event"
-                            component="div"
+                            component="p"
                             isInline
                         >
                             {errorMessage}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -109,7 +109,7 @@ function AdministrationEventsPage(): ReactElement {
                     <Alert
                         variant="warning"
                         title="Unable to fetch administration events"
-                        component="div"
+                        component="p"
                         isInline
                     >
                         {errorMessage}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -43,7 +43,7 @@ function ClusterDeployment({
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
             {editing && clusterCheckedIn && (
-                <Alert variant="info" isInline title={managerTypeTitle} component="div">
+                <Alert variant="info" isInline title={managerTypeTitle} component="p">
                     {managerTypeText}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -312,6 +312,7 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                                 variant={messageState.variant}
                                 isInline
                                 title={messageState.title}
+                                component="p"
                             >
                                 {messageState.text}
                             </Alert>
@@ -320,7 +321,12 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                     {submissionError && (
                         <div className="w-full">
                             <div className="mb-4 mx-4">
-                                <Alert type="danger" isInline title={submissionError.title}>
+                                <Alert
+                                    type="danger"
+                                    isInline
+                                    title={submissionError.title}
+                                    component="p"
+                                >
                                     {submissionError.text}
                                 </Alert>
                             </div>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -273,10 +273,10 @@ function DelegateScanningPage() {
                 {!!alertObj && (
                     <Alert
                         title={alertObj.title}
+                        component="p"
                         variant={alertObj.type}
                         isInline
                         className="pf-v5-u-mb-lg"
-                        component="h2"
                     >
                         {alertObj.body}
                     </Alert>

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -114,7 +114,7 @@ function DiscoveredClustersPage(): ReactElement {
                     <Alert
                         variant="warning"
                         title="Unable to fetch discovered clusters"
-                        component="div"
+                        component="p"
                         isInline
                     >
                         {errorMessage}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -65,7 +65,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
                     <Alert
                         variant="warning"
                         title="Unable to fetch cluster init bundles"
-                        component="div"
+                        component="p"
                         isInline
                     >
                         {getAxiosErrorMessage(errorForFetch)}
@@ -84,7 +84,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
                     <Alert
                         variant="warning"
                         title="Unable to find cluster init bundle"
-                        component="div"
+                        component="p"
                         isInline
                     />
                 )}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -62,7 +62,7 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
                     <Alert
                         variant="warning"
                         title="Unable to fetch cluster init bundles"
-                        component="div"
+                        component="p"
                         isInline
                     >
                         {getAxiosErrorMessage(errorForFetch)}

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -93,7 +93,7 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
             <Alert
                 variant="info"
                 title="Upon successful installation, the secured clusters might take a few moments to show up."
-                component="div"
+                component="p"
                 isInline
             />
             <PageSection variant="light">
@@ -105,7 +105,7 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                     <Alert
                         variant="warning"
                         title="Unable to fetch cluster init bundles"
-                        component="div"
+                        component="p"
                         isInline
                     >
                         {errorMessage}

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
@@ -340,10 +340,16 @@ const StaticConfigurationSection = ({
                             variant="warning"
                             isInline
                             title="Failed to check if Central has kernel support packages available"
+                            component="p"
                         />
                     )}
                     {showSlimCollectorWarning && (
-                        <Alert variant="warning" isInline title="Kernel support package">
+                        <Alert
+                            variant="warning"
+                            isInline
+                            title="Kernel support package"
+                            component="p"
+                        >
                             <span>
                                 Central doesn’t have the required Kernel support package. Retrieve
                                 it from{' '}

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -76,6 +76,7 @@ function CollectionAttacher({
                     variant="danger"
                     isInline
                     title="There was an error loading more collections"
+                    component="p"
                 >
                     {getAxiosErrorMessage(fetchMoreError)}
                 </Alert>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -411,12 +411,18 @@ function CollectionForm({
                             {configError?.type === 'EmptyCollection' && (
                                 <Alert
                                     title="At least one rule must be configured or one collection must be attached from the section below"
+                                    component="p"
                                     variant="danger"
                                     isInline
                                 />
                             )}
                             {configError?.type === 'InvalidRule' && (
-                                <Alert title={configError.message} variant="danger" isInline>
+                                <Alert
+                                    title={configError.message}
+                                    component="p"
+                                    variant="danger"
+                                    isInline
+                                >
                                     {configError.details}
                                 </Alert>
                             )}
@@ -481,12 +487,18 @@ function CollectionForm({
                             {configError?.type === 'EmptyCollection' && (
                                 <Alert
                                     title="At least one collection must be attached or one rule must be configured from the section above"
+                                    component="p"
                                     variant="danger"
                                     isInline
                                 />
                             )}
                             {configError?.type === 'CollectionLoop' && (
-                                <Alert title={configError.message} variant="danger" isInline>
+                                <Alert
+                                    title={configError.message}
+                                    component="p"
+                                    variant="danger"
+                                    isInline
+                                >
                                     {configError.details}
                                 </Alert>
                             )}

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -174,6 +174,7 @@ function CollectionsFormModal({
                 <Alert
                     className="pf-v5-u-mx-lg pf-v5-u-mb-md"
                     title={configError.message}
+                    component="p"
                     variant="danger"
                     isInline
                 >

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -315,6 +315,7 @@ function CollectionsFormPage({
                                 <Alert
                                     className="pf-v5-u-m-md"
                                     title={configError.message}
+                                    component="p"
                                     variant="danger"
                                     isInline
                                 >
@@ -351,6 +352,7 @@ function CollectionsFormPage({
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -131,6 +131,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
@@ -9,7 +9,7 @@ export type ManageStandardsErrorProp = {
 function ManageStandardsError({ onClose, errorMessage }: ManageStandardsErrorProp): ReactElement {
     return (
         <Modal title="Manage standards" variant="small" isOpen onClose={onClose} showClose>
-            <Alert title="Unable to fetch standards" variant="warning" isInline>
+            <Alert title="Unable to fetch standards" component="p" variant="warning" isInline>
                 {errorMessage}
             </Alert>
         </Modal>

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -126,6 +126,7 @@ function ManageStandardsModal({
             {errorMessage && (
                 <Alert
                     title="Unable to save changes"
+                    component="p"
                     variant="danger"
                     isInline
                     className="pf-v5-u-mt-lg"

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -346,7 +346,12 @@ const ListTable = ({
                         contents = (
                             <>
                                 {data.results.errorMessage && (
-                                    <Alert variant="danger" isInline title="Unable to get data">
+                                    <Alert
+                                        variant="danger"
+                                        isInline
+                                        title="Unable to get data"
+                                        component="p"
+                                    >
                                         {data.results.errorMessage}
                                     </Alert>
                                 )}

--- a/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.js
@@ -58,7 +58,12 @@ const LinkListWidget = ({
                 contents = <Loader />;
             } else if (error) {
                 contents = (
-                    <Alert variant="warning" isInline title="Unable to get aggregated results">
+                    <Alert
+                        variant="warning"
+                        isInline
+                        title="Unable to get aggregated results"
+                        component="p"
+                    >
                         {error}
                     </Alert>
                 );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsHeader.tsx
@@ -27,12 +27,7 @@ function CheckDetailsHeader({
 
         if (error) {
             return (
-                <Alert
-                    variant="danger"
-                    title="Unable to fetch check stats"
-                    component="div"
-                    isInline
-                >
+                <Alert variant="danger" title="Unable to fetch check stats" component="p" isInline>
                     {getAxiosErrorMessage(error)}
                 </Alert>
             );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -136,7 +136,7 @@ function ClusterDetailsPage() {
             <Alert
                 variant="warning"
                 title="Unable to fetch cluster profiles"
-                component="div"
+                component="p"
                 isInline
             >
                 {getAxiosErrorMessage(scanConfigProfilesError)}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -35,7 +35,7 @@ function CoverageContent() {
 
     if (error) {
         return (
-            <Alert variant="warning" title="Unable to fetch profiles" component="div" isInline>
+            <Alert variant="warning" title="Unable to fetch profiles" component="p" isInline>
                 {getAxiosErrorMessage(error)}
             </Alert>
         );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CheckDetailsInfo.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/CheckDetailsInfo.tsx
@@ -28,7 +28,7 @@ type CheckDetailsInfoProps = {
 function CheckDetailsInfo({ checkDetails, isLoading, error }: CheckDetailsInfoProps) {
     if (error) {
         return (
-            <Alert title="Unable to fetch check details" isInline variant="danger">
+            <Alert title="Unable to fetch check details" component="p" isInline variant="danger">
                 {getAxiosErrorMessage(error)}
             </Alert>
         );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/EditScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/EditScanConfigDetail.tsx
@@ -73,7 +73,7 @@ function EditScanConfigDetail({
                         <Alert
                             variant="warning"
                             title="Unable to fetch scan schedule"
-                            component="div"
+                            component="p"
                             isInline
                         >
                             {getAxiosErrorMessage(error)}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -285,7 +285,7 @@ function ScanConfigsTablePage({
             {error ? (
                 <PageSection variant="light" isFilled id="policies-table-error">
                     <Bullseye>
-                        <Alert variant="danger" title={getAxiosErrorMessage(error)} />
+                        <Alert variant="danger" title={getAxiosErrorMessage(error)} component="p" />
                     </Bullseye>
                 </PageSection>
             ) : (
@@ -293,10 +293,10 @@ function ScanConfigsTablePage({
                     {alertObj !== null && (
                         <Alert
                             title={alertObj.title}
+                            component="p"
                             variant={alertObj.type}
                             isInline
                             className="pf-v5-u-mb-lg"
-                            component="h2"
                             actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
                         >
                             {alertObj.children}
@@ -348,6 +348,7 @@ function ScanConfigsTablePage({
                                             isInline
                                             variant="danger"
                                             title="Failed to delete"
+                                            component="p"
                                             className="pf-v5-u-mb-sm"
                                         >
                                             {deleteError.toString()}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -147,9 +147,9 @@ function ViewScanConfigDetail({
                         {alertObj !== null && (
                             <Alert
                                 title={alertObj.title}
+                                component="p"
                                 variant={alertObj.type}
                                 className="pf-v5-u-mb-lg pf-v5-u-mx-lg"
-                                component="h2"
                                 actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
                             >
                                 {alertObj.children}
@@ -169,7 +169,7 @@ function ViewScanConfigDetail({
                         <Alert
                             variant="warning"
                             title="Unable to fetch scan schedule"
-                            component="div"
+                            component="p"
                             isInline
                         >
                             {getAxiosErrorMessage(error)}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ClusterSelection.tsx
@@ -165,6 +165,7 @@ function ClusterSelection({
                 {formikTouched.clusters && formikValues.clusters.length === 0 && (
                     <Alert
                         title="At least one cluster is required to proceed"
+                        component="p"
                         variant="danger"
                         isInline
                     />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ProfileSelection.tsx
@@ -177,6 +177,7 @@ function ProfileSelection({
                 {formikTouched.profiles && formikValues.profiles.length === 0 && (
                     <Alert
                         title="At least one profile is required to proceed"
+                        component="p"
                         variant="danger"
                         isInline
                     />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -58,6 +58,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                     {errorMessage && (
                         <Alert
                             title={'Scan configuration request failure'}
+                            component="p"
                             variant="danger"
                             isInline
                         >
@@ -106,7 +107,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                 <Alert
                     variant="info"
                     title="Save for new versus existing scan schedule"
-                    component="div"
+                    component="p"
                     isInline
                 >
                     Compliance Operator runs a new scan schedule immediately upon creation, but does

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -108,6 +108,7 @@ function SummaryCounts({ hasReadAccessForResource }: SummaryCountsProps): ReactE
                 isInline
                 variant="warning"
                 title="There was an error loading system summary counts"
+                component="p"
             />
         );
     }

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
@@ -327,6 +327,7 @@ function VulnerabilitiesConfiguration({
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout={variant === 'success'}
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ApiTokenIntegrationForm/ApiTokenFormMessageAlert.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ApiTokenIntegrationForm/ApiTokenFormMessageAlert.tsx
@@ -63,7 +63,12 @@ function ApiTokenResponseDetails({ message }) {
 
 function ApiTokenFormMessageAlert({ message }: ApiTokenFormMessageAlertProps): ReactElement {
     return (
-        <Alert isInline variant={message.isError ? 'danger' : 'success'} title={message.message}>
+        <Alert
+            isInline
+            variant={message.isError ? 'danger' : 'success'}
+            title={message.message}
+            component="p"
+        >
             {message.responseData && <ApiTokenResponseDetails message={message} />}
         </Alert>
     );

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -95,6 +95,7 @@ function ClairIntegrationForm({
             <PageSection variant="light" isFilled hasOverflowScroll>
                 <Alert
                     title="Deprecation notice"
+                    component="p"
                     variant={AlertVariant.warning}
                     isInline
                     className="pf-v5-u-mb-lg"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
@@ -279,6 +279,7 @@ function EmailIntegrationForm({
                                 <Alert
                                     className="pf-v5-u-mt-md"
                                     title="Security Warning"
+                                    component="p"
                                     variant={AlertVariant.warning}
                                     isInline
                                 >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -112,7 +112,12 @@ function MachineAccessIntegrationForm({
     return (
         <>
             {alertRoles && (
-                <Alert title="Fetch roles failed" variant={AlertVariant.warning} isInline>
+                <Alert
+                    title="Fetch roles failed"
+                    component="p"
+                    variant={AlertVariant.warning}
+                    isInline
+                >
                     {alertRoles}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
@@ -255,7 +255,7 @@ function QuayIntegrationForm({
                         />
                     </FormLabelGroup>
                     {isEditable && (
-                        <Alert variant="info" isInline title="Authentication">
+                        <Alert variant="info" isInline title="Authentication" component="p">
                             <List>
                                 {values.config.categories.includes('SCANNER') ? (
                                     <ListItem>
@@ -334,6 +334,7 @@ function QuayIntegrationForm({
                                     variant="info"
                                     isInline
                                     title="Use your Quay.io or Quay robot account username and password"
+                                    component="p"
                                 />
                             </GridItem>
                             <GridItem span={12} lg={6}>

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -150,7 +150,13 @@ class LoginPage extends Component {
                     []
                 ))(authProviderResponse.error_uri);
             return (
-                <Alert variant="danger" isInline title={errorKey} className="pf-v5-u-mb-md">
+                <Alert
+                    variant="danger"
+                    isInline
+                    title={errorKey}
+                    component="p"
+                    className="pf-v5-u-mb-md"
+                >
                     {errorMsg} {errorLink}
                 </Alert>
             );
@@ -180,6 +186,7 @@ class LoginPage extends Component {
                         variant="danger"
                         isInline
                         title="roxct-authorize-error"
+                        component="p"
                         className="pf-v5-u-mb-md"
                     >
                         Only basic auth provider given. Authorizing roxctl only works with non-basic

--- a/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
+++ b/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
@@ -99,7 +99,7 @@ function TestLoginResultsPage({ authProviderTestResults }) {
             <div className="flex flex-col items-center justify-center h-full theme-light">
                 <div className="flex flex-col items-center pf-v5-u-background-color-100 w-4/5 relative">
                     <div className="p-4 w-full">
-                        <Alert variant={variant} isInline title={title}>
+                        <Alert variant={variant} isInline title={title} component="p">
                             {messageBody}
                         </Alert>
                     </div>

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
@@ -21,6 +21,7 @@ function InviteUsersConfirmationNoEmail({
             {emailBuckets.newEmails.length === 0 ? (
                 <Alert
                     title="All entered emails already have auth provider rules"
+                    component="p"
                     variant="warning"
                     isInline
                     className="pf-v5-u-mb-lg"
@@ -42,6 +43,7 @@ function InviteUsersConfirmationNoEmail({
                     {emailBuckets.existingEmails.length > 0 && (
                         <Alert
                             title="Some emails already have auth provider rules."
+                            component="p"
                             variant="warning"
                             isInline
                             className="pf-v5-u-mb-lg"

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
@@ -220,6 +220,7 @@ function InviteUsersModal(): ReactElement | null {
                 {authProviders.length === 0 && (
                     <Alert
                         title="No auth providers are available."
+                        component="p"
                         variant="warning"
                         isInline
                         className="pf-v5-u-mb-lg"
@@ -240,6 +241,7 @@ function InviteUsersModal(): ReactElement | null {
                         {apiError && (
                             <Alert
                                 title="Problem inviting the specified users"
+                                component="p"
                                 variant="danger"
                                 isInline
                                 className="pf-v5-u-mb-lg"

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
@@ -29,7 +29,13 @@ function MitreAttackVectorsView({
 
     if (errorMessage) {
         return (
-            <Alert className="pf-v5-u-my-md" title="Request failed" variant="warning" isInline>
+            <Alert
+                className="pf-v5-u-my-md"
+                title="Request failed"
+                component="p"
+                variant="warning"
+                isInline
+            >
                 {errorMessage}
             </Alert>
         );

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -97,6 +97,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                 isInline
                 variant={AlertVariant.danger}
                 title={getAxiosErrorMessage(error)}
+                component="p"
                 className="pf-v5-u-mb-lg"
             />
         );
@@ -112,6 +113,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                         isInline
                         variant={AlertVariant.warning}
                         title="There was an error loading network policy data"
+                        component="p"
                     >
                         {getAxiosErrorMessage(networkPolicyError)}
                     </Alert>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
@@ -223,6 +223,7 @@ function CIDRFormModal({ selectedClusterId, isOpen, onClose }: CIDRFormModalProp
                         <Alert
                             variant={formCallout.type}
                             title={formCallout.message}
+                            component="p"
                             className="pf-v5-u-mb-md"
                         />
                     )}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
@@ -42,7 +42,7 @@ function DefaultCIDRToggle({ updateNetworkNodes = () => {} }): ReactElement {
                 onChange={toggleHandler}
                 label="Auto-discovered CIDR blocks"
             />
-            {errorMessage && <Alert variant="danger" title={errorMessage} />}
+            {errorMessage && <Alert variant="danger" title={errorMessage} component="p" />}
         </Flex>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -153,6 +153,7 @@ function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: Deploym
                     isInline
                     variant={AlertVariant.danger}
                     title={errorMessage}
+                    component="p"
                     className="pf-v5-u-mb-sm"
                 />
             )}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -149,6 +149,7 @@ function DeploymentFlows({
                     isInline
                     variant={AlertVariant.danger}
                     title={networkFlowsError || modifyError}
+                    component="p"
                     className="pf-v5-u-mb-sm"
                 />
             )}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -125,6 +125,7 @@ function DeploymentSideBar({
                     <Alert
                         variant={AlertVariant.danger}
                         title={error.toString()}
+                        component="p"
                         className="pf-v5-u-my-lg pf-v5-u-mx-lg"
                     />
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -311,6 +311,7 @@ function NetworkPolicySimulatorSidePanel({
                                     ? simulator.error
                                     : 'Viewing modification that will undo last applied change'
                             }
+                            component="p"
                         />
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
@@ -362,6 +363,7 @@ function NetworkPolicySimulatorSidePanel({
                             title={
                                 simulator.error ? simulator.error : 'Uploaded policies processed'
                             }
+                            component="p"
                         />
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -124,6 +124,7 @@ function NotifyYAMLModal({
                     isInline
                     variant={AlertVariant.danger}
                     title={errorMessage}
+                    component="p"
                     className="pf-v5-u-mb-lg"
                 />
             )}

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -104,6 +104,7 @@ function PolicyDetail({
                 setRequestError(
                     <Alert
                         title={`Request failed: ${formatUpdateDisabledStateAction(disabled)}`}
+                        component="p"
                         variant="danger"
                         isInline
                         actionClose={
@@ -131,6 +132,7 @@ function PolicyDetail({
                 setRequestError(
                     <Alert
                         title="Request failed: Delete policy"
+                        component="p"
                         variant="danger"
                         isInline
                         actionClose={
@@ -255,6 +257,7 @@ function PolicyDetail({
                         <Alert
                             variant={variant}
                             title={title}
+                            component="p"
                             timeout={4000}
                             onTimeout={() => removeToast(key)}
                             actionClose={

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -77,6 +77,7 @@ function ImportPolicyJSONError({
                                 ? 'Policy already exists'
                                 : 'Policy errors causing import failure'
                         }
+                        component="p"
                         variant="danger"
                         className="pf-v5-u-mt-md"
                         isInline

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -207,7 +207,7 @@ function PoliciesTablePage({
         pageContent = (
             <PageSection variant="light" isFilled id="policies-table-error">
                 <Bullseye>
-                    <Alert variant="danger" title={errorMessage} />
+                    <Alert variant="danger" title={errorMessage} component="p" />
                 </Bullseye>
             </PageSection>
         );
@@ -269,6 +269,7 @@ function PoliciesTablePage({
                     <Alert
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout={4000}
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
@@ -107,7 +107,13 @@ function MitreAttackVectorsFormSection(): ReactElement {
             className="pf-v5-c-tree-view pf-m-compact pf-m-no-background"
         >
             {mitreAttackVectorsError && (
-                <Alert className="pf-v5-u-my-md" title="Request failed" variant="warning" isInline>
+                <Alert
+                    className="pf-v5-u-my-md"
+                    title="Request failed"
+                    component="p"
+                    variant="warning"
+                    isInline
+                >
                     {mitreAttackVectorsError}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
@@ -68,7 +68,7 @@ function PolicyDetailsForm({ id, mitreVectorsLocked }: PolicyDetailsFormProps): 
                                 variant="info"
                                 isInline
                                 title="Editing MITRE ATT&CK is disabled for system default policies"
-                                component="h3"
+                                component="p"
                                 className="pf-v5-u-mt-sm"
                             >
                                 If you need to edit MITRE ATT&CK, clone this policy or create a new

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -187,7 +187,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                     variant="info"
                     isInline
                     title="Lifecycle stages"
-                    component="h3"
+                    component="p"
                     className="pf-v5-u-my-md"
                 >
                     <Flex
@@ -258,7 +258,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                             isInline
                             variant="warning"
                             title="Policy has active violations, and the lifecycle stage cannot be changed. To update the lifecycle, clone and create a new policy."
-                            component="div"
+                            component="p"
                         />
                     )}
                     <FormGroup

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -66,7 +66,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         variant="info"
                         isInline
                         title="Editing policy criteria is disabled for system default policies"
-                        component="h3"
+                        component="p"
                         className="pf-v5-u-mt-sm pf-v5-u-mb-md"
                         data-testid="default-policy-alert"
                     >
@@ -78,7 +78,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         variant="warning"
                         isInline
                         title="This policy has active violations, and the policy criteria cannot be changed. To update criteria, disable the policy first."
-                        component="div"
+                        component="p"
                         className="pf-v5-u-mt-sm pf-v5-u-mb-md"
                         data-testid="active-violations-policy-alert"
                     />

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/ReviewPolicyForm.tsx
@@ -128,6 +128,7 @@ function ReviewPolicyForm({
                     {policyErrorMessage && (
                         <Alert
                             title={isBadRequest ? 'Policy is invalid' : 'Policy request failure'}
+                            component="p"
                             variant="danger"
                             isInline
                         >
@@ -163,6 +164,7 @@ function ReviewPolicyForm({
                                 isInline
                                 variant="info"
                                 title="Policy disabled"
+                                component="p"
                             >
                                 <p>Violations will not be generated unless the policy is enabled</p>
                             </Alert>
@@ -175,7 +177,12 @@ function ReviewPolicyForm({
                                 </FlexItem>
                             </Flex>
                         ) : checkDryRunErrorMessage ? (
-                            <Alert title="Violations request failure" variant="warning" isInline>
+                            <Alert
+                                title="Violations request failure"
+                                component="p"
+                                variant="warning"
+                                isInline
+                            >
                                 {checkDryRunErrorMessage}
                             </Alert>
                         ) : (

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -46,7 +46,7 @@ function PolicyCategoriesPage(): React.ReactElement {
         listContent = (
             <PageSection variant="light" isFilled id="policies-table-error">
                 <Bullseye>
-                    <Alert variant="danger" title={errorMessage} component="div" />
+                    <Alert variant="danger" title={errorMessage} component="p" />
                 </Bullseye>
             </PageSection>
         );
@@ -117,7 +117,7 @@ function PolicyCategoriesPage(): React.ReactElement {
                     <Alert
                         variant={variant}
                         title={title}
-                        component="div"
+                        component="p"
                         timeout={4000}
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/Risk/DeploymentDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentDetails.js
@@ -65,6 +65,7 @@ const DeploymentDetails = ({ deployment }) => {
                     variant="warning"
                     isInline
                     title="This data is a snapshot of a deployment that no longer exists"
+                    component="p"
                 />
             )}
             <div className="px-3 pt-5">

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
@@ -27,7 +27,7 @@ function RiskSidePanelContent({ isFetching, selectedDeployment, deploymentRisk, 
     if (!selectedDeployment) {
         return (
             <div className="h-full flex-1 bg-base-200 border-r border-l border-b border-base-400 p-3">
-                <Alert variant="warning" isInline title="Deployment not found">
+                <Alert variant="warning" isInline title="Deployment not found" component="p">
                     The selected deployment may have been removed.
                 </Alert>
             </div>
@@ -59,7 +59,7 @@ function RiskSidePanelContent({ isFetching, selectedDeployment, deploymentRisk, 
                         </Link>
                     )}
                     {!deploymentRisk ? (
-                        <Alert variant="warning" isInline title="Risk not found">
+                        <Alert variant="warning" isInline title="Risk not found" component="p">
                             Risk for selected deployment may not have been processed.
                         </Alert>
                     ) : (
@@ -80,7 +80,12 @@ function RiskSidePanelContent({ isFetching, selectedDeployment, deploymentRisk, 
                         {!processGroup ||
                         !processGroup.groups ||
                         processGroup.groups.length === 0 ? (
-                            <Alert variant="warning" isInline title="No processes discovered">
+                            <Alert
+                                variant="warning"
+                                isInline
+                                title="No processes discovered"
+                                component="p"
+                            >
                                 <p>
                                     The selected deployment may not have running pods, or Collector
                                     may not be running in your cluster.

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -133,7 +133,7 @@ function SearchPage(): ReactElement {
         );
     } else if (searchOptions.length !== 0 && stringifiedSearchFilter.length === 0) {
         content = (
-            <Alert variant="info" isInline title="Enter a new search filter">
+            <Alert variant="info" isInline title="Enter a new search filter" component="p">
                 <p>
                     Instead of a new search, you can go back in browser history to see previous
                     search results.
@@ -146,7 +146,14 @@ function SearchPage(): ReactElement {
         );
     } else if (searchResponse) {
         if (searchResponse.results.length === 0) {
-            content = <Alert variant="info" isInline title="No results match the search filter" />;
+            content = (
+                <Alert
+                    variant="info"
+                    isInline
+                    title="No results match the search filter"
+                    component="p"
+                />
+            );
         } else {
             content = (
                 <SearchNavAndTable
@@ -158,7 +165,12 @@ function SearchPage(): ReactElement {
         }
     } else if (typeof searchResponseErrorMessage === 'string') {
         content = (
-            <Alert variant="danger" isInline title="Request failed for search results">
+            <Alert
+                variant="danger"
+                isInline
+                title="Request failed for search results"
+                component="p"
+            >
                 {searchResponseErrorMessage}
             </Alert>
         );
@@ -178,7 +190,12 @@ function SearchPage(): ReactElement {
                         Search
                     </Title>
                     {typeof searchOptionsErrorMessage === 'string' ? (
-                        <Alert variant="danger" isInline title="Request failed for search options">
+                        <Alert
+                            variant="danger"
+                            isInline
+                            title="Request failed for search options"
+                            component="p"
+                        >
                             {searchOptionsErrorMessage}
                         </Alert>
                     ) : (

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -745,7 +745,12 @@ const SystemConfigForm = ({
                 )}
             </Grid>
             {typeof errorMessage === 'string' && (
-                <Alert variant="danger" isInline title="Failed to save system configuration">
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Failed to save system configuration"
+                    component="p"
+                >
                     {errorMessage}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
@@ -90,7 +90,12 @@ const SystemConfigPage = (): ReactElement => {
         );
     } else {
         content = (
-            <Alert variant="warning" isInline title="Failed to get system configuration">
+            <Alert
+                variant="warning"
+                isInline
+                title="Failed to get system configuration"
+                component="p"
+            >
                 {errorMessage}
             </Alert>
         );

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -159,6 +159,7 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                         isInline
                         variant="warning"
                         title={errorMessageFetching}
+                        component="p"
                         className="pf-v5-u-mt-md"
                     />
                 )}
@@ -167,6 +168,7 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                         isInline
                         variant="danger"
                         title={errorMessageDownloading}
+                        component="p"
                         className="pf-v5-u-mt-md"
                     />
                 )}

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -64,7 +64,7 @@ function ClusterStatusTable({
             />
             {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={errorMessageFetching} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} component="p" />
                 </CardBody>
             ) : countsOverall !== null &&
               countsSensor !== null &&

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -57,7 +57,7 @@ function CredentialExpirationCard({
             />
             {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={errorMessageFetching} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} component="p" />
                 </CardBody>
             ) : counts !== null &&
               (counts.HEALTHY === 0 || counts.UNHEALTHY !== 0 || counts.DEGRADED !== 0) ? (

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -56,7 +56,7 @@ function SensorUpgradeCard({
             />
             {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={errorMessageFetching} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} component="p" />
                 </CardBody>
             ) : counts !== null &&
               (counts.HEALTHY === 0 || counts.UNHEALTHY !== 0 || counts.DEGRADED !== 0) ? (

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -66,7 +66,12 @@ const IntegrationHealthWidget = ({
             {(errorMessageFetching || integrations.length !== 0) && (
                 <CardBody>
                     {errorMessageFetching ? (
-                        <Alert isInline variant="warning" title={errorMessageFetching} />
+                        <Alert
+                            isInline
+                            variant="warning"
+                            title={errorMessageFetching}
+                            component="p"
+                        />
                     ) : (
                         <IntegrationsHealth integrations={integrations} />
                     )}

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -86,7 +86,12 @@ function DeclarativeConfigurationHealthCard({
             {(errorMessageFetching || unhealthyCount !== 0) && (
                 <CardBody>
                     {errorMessageFetching ? (
-                        <Alert isInline variant="warning" title={errorMessageFetching} />
+                        <Alert
+                            isInline
+                            variant="warning"
+                            title={errorMessageFetching}
+                            component="p"
+                        />
                     ) : (
                         <Table variant="compact">
                             <Thead>

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
@@ -67,9 +67,11 @@ function AdministrationUsageForm(): ReactElement {
     return (
         <>
             {errorFetchingCurrent && (
-                <Alert isInline title={errorFetchingCurrent} variant="danger" />
+                <Alert isInline title={errorFetchingCurrent} component="p" variant="danger" />
             )}
-            {errorFetchingMax && <Alert isInline title={errorFetchingMax} variant="danger" />}
+            {errorFetchingMax && (
+                <Alert isInline title={errorFetchingMax} component="p" variant="danger" />
+            )}
             <Title headingLevel="h2">Currently secured</Title>
             <Divider className="pf-v5-u-pt-xs pf-v5-u-pb-sm" />
             <DescriptionList

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -98,7 +98,7 @@ const VulnerabilityDefinitionsHealthCard = ({
             </CardHeader>
             {errorMessageFetching && (
                 <CardBody>
-                    <Alert isInline variant="warning" title={errorMessageFetching} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} component="p" />
                 </CardBody>
             )}
         </Card>

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -35,6 +35,7 @@ function DeploymentTabWithReadAccessForDeployment({
                     variant="warning"
                     isInline
                     title="There was an error fetching the deployment details. This deployment may no longer exist."
+                    component="p"
                 >
                     {getAxiosErrorMessage(relatedDeploymentFetchError)}
                 </Alert>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -172,7 +172,11 @@ function ViolationsTablePage(): ReactElement {
             <PageSection variant="default">
                 {currentPageAlertsErrorMessage ? (
                     <Bullseye>
-                        <Alert variant="danger" title={currentPageAlertsErrorMessage} />
+                        <Alert
+                            variant="danger"
+                            title={currentPageAlertsErrorMessage}
+                            component="p"
+                        />
                     </Bullseye>
                 ) : (
                     <PageSection variant="light">

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -171,6 +171,7 @@ function ViolationsTablePanel({
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout={variant === 'success'}
                         onTimeout={() => removeToast(key)}
                         actionClose={

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
@@ -6,7 +6,7 @@ import { ScanMessage } from 'messages/vulnMgmt.messages';
 function ScanDataMessage({ header = '', body = '' }: ScanMessage): ReactElement | null {
     return header?.length > 0 || body?.length > 0 ? (
         <div className="px-4 pt-4">
-            <Alert variant="warning" isInline title="CVE data may be inaccurate" component="h3">
+            <Alert variant="warning" isInline title="CVE data may be inaccurate" component="p">
                 {header && <p>{header}</p>}
                 {body && <p>{body}</p>}
             </Alert>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -223,6 +223,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                                         for a detailed breakdown of detected vulnerabilities
                                     </>
                                 }
+                                component="p"
                             />
                         ) : (
                             <div className="w-full">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -145,7 +145,12 @@ const TableWidgetFixableCves = ({
                 </div>
             )}
             {cvesError && (
-                <Alert variant="warning" isInline title="Error retrieving fixable CVEs">
+                <Alert
+                    variant="warning"
+                    isInline
+                    title="Error retrieving fixable CVEs"
+                    component="p"
+                >
                     {cvesError.message}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -276,7 +276,12 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
                 ) : (
                     <>
                         {messageObj && (
-                            <Alert variant={messageObj.variant} isInline title={messageObj.title}>
+                            <Alert
+                                variant={messageObj.variant}
+                                isInline
+                                title={messageObj.title}
+                                component="p"
+                            >
                                 {messageObj.text}
                             </Alert>
                         )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx
@@ -174,14 +174,14 @@ const WatchedImagesDialog = ({ closeDialog }: WatchedImagesDialogProps): ReactEl
                 </Formik>
                 {!!successMessage && (
                     <div className="pb-4">
-                        <Alert isInline variant="success" component="h3" title={successTitle}>
+                        <Alert isInline variant="success" title={successTitle} component="p">
                             {successMessage}
                         </Alert>
                     </div>
                 )}
                 {!!errorMessage && (
                     <div className="pb-4">
-                        <Alert isInline variant="danger" component="h3" title={errorTitle}>
+                        <Alert isInline variant="danger" title={errorTitle} component="p">
                             {errorMessage}
                         </Alert>
                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -176,11 +176,17 @@ function ExceptionRequestDetailsPage() {
                     variant={AlertVariant.success}
                     isInline
                     title={successMessage}
+                    component="p"
                     actionClose={<AlertActionCloseButton onClose={() => setSuccessMessage(null)} />}
                 />
             )}
             {expired && (
-                <Alert variant={AlertVariant.warning} isInline title="Request Canceled.">
+                <Alert
+                    variant={AlertVariant.warning}
+                    isInline
+                    title="Request Canceled."
+                    component="p"
+                >
                     You are viewing a canceled request. If this cancelation was not intended, please
                     submit a new request
                 </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -101,7 +101,12 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
                 showClose={false}
             >
                 {errorMessage && (
-                    <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
+                    <Alert
+                        isInline
+                        variant={AlertVariant.danger}
+                        title={errorMessage}
+                        component="p"
+                    />
                 )}
                 <Form>
                     <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -63,12 +63,18 @@ function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonM
             >
                 <Flex className="pf-v5-u-py-md">
                     {errorMessage && (
-                        <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
+                        <Alert
+                            isInline
+                            variant={AlertVariant.danger}
+                            title={errorMessage}
+                            component="p"
+                        />
                     )}
                     <Alert
                         variant="warning"
                         isInline
                         title="Cancelling the request will return the CVEs to the 'Observed' status."
+                        component="p"
                     >
                         <Text>CVE count: {exception.cves.length}</Text>
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -100,12 +100,18 @@ function RequestDenialButtonModal({ exception, onSuccess }: RequestDenialButtonM
             >
                 <Flex direction={{ default: 'column' }}>
                     {errorMessage && (
-                        <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
+                        <Alert
+                            isInline
+                            variant={AlertVariant.danger}
+                            title={errorMessage}
+                            component="p"
+                        />
                     )}
                     <Alert
                         variant="warning"
                         isInline
                         title="Denying the request will return the CVEs to the 'Observed' status."
+                        component="p"
                     >
                         <Text>CVE count: {exception.cves.length}</Text>
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormErrorAlert.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormErrorAlert.tsx
@@ -20,6 +20,7 @@ function ReportFormErrorAlert({ error }) {
                     isInline
                     variant={AlertVariant.danger}
                     title={error}
+                    component="p"
                     className="pf-v5-u-mb-sm"
                 />
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -399,6 +399,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                             isInline
                             variant={AlertVariant.danger}
                             title={deleteDownloadError}
+                            component="p"
                             className="pf-v5-u-mb-sm"
                         />
                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -162,6 +162,7 @@ function ViewVulnReportPage() {
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout
                         onTimeout={() => removeToast(key)}
                         actionClose={
@@ -176,7 +177,9 @@ function ViewVulnReportPage() {
                     </Alert>
                 ))}
             </AlertGroup>
-            {runError && <Alert variant={AlertVariant.danger} isInline title={runError} />}
+            {runError && (
+                <Alert variant={AlertVariant.danger} isInline title={runError} component="p" />
+            )}
             <PageTitle title="View vulnerability report" />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
@@ -371,6 +374,7 @@ function ViewVulnReportPage() {
                                 isInline
                                 variant={AlertVariant.danger}
                                 title={`Failed to delete "${reportConfiguration.name}"`}
+                                component="p"
                                 className="pf-v5-u-mb-sm"
                             >
                                 {deleteResult.error}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -164,6 +164,7 @@ function VulnReportsPage() {
                         key={key}
                         variant={variant}
                         title={title}
+                        component="p"
                         timeout
                         onTimeout={() => removeToast(key)}
                         actionClose={
@@ -179,7 +180,9 @@ function VulnReportsPage() {
                 ))}
             </AlertGroup>
             <PageTitle title="Vulnerability reporting" />
-            {runError && <Alert variant={AlertVariant.danger} isInline title={runError} />}
+            {runError && (
+                <Alert variant={AlertVariant.danger} isInline title={runError} component="p" />
+            )}
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex
                     direction={{ default: 'row' }}
@@ -597,6 +600,7 @@ function VulnReportsPage() {
                                 'report',
                                 numSuccessfulDeletions
                             )}`}
+                            component="p"
                             className="pf-v5-u-mb-sm"
                         />
                     )}
@@ -612,6 +616,7 @@ function VulnReportsPage() {
                                 isInline
                                 variant={AlertVariant.danger}
                                 title={`Failed to delete "${report.name}"`}
+                                component="p"
                                 className="pf-v5-u-mb-sm"
                             >
                                 {deleteResult.error}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -95,6 +95,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPar
                     isInline
                     variant={AlertVariant.danger}
                     title="Delivery destination & schedule are both required to be configured since the 'Last scheduled report that was successfully sent' option has been selected in Step 1."
+                    component="p"
                 />
             )}
             <PageSection variant="light" padding={{ default: 'noPadding' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -139,6 +139,7 @@ function ImagePage() {
                                     variant="warning"
                                     isInline
                                     title="CVE data may be inaccurate"
+                                    component="p"
                                 >
                                     <Flex
                                         direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/UnwatchImageModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/UnwatchImageModal.tsx
@@ -55,6 +55,7 @@ function UnwatchImageModal({
                         variant="success"
                         isInline
                         title="The image was successfully removed from the watch list"
+                        component="p"
                     />
                 )}
                 {unwatchImageMutation.isError && (
@@ -62,6 +63,7 @@ function UnwatchImageModal({
                         variant="danger"
                         isInline
                         title="There was an error removing the image from the watch list"
+                        component="p"
                     >
                         {getAxiosErrorMessage(unwatchImageMutation.error)}
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -91,6 +91,7 @@ function WatchedImagesModal({
                         variant="success"
                         isInline
                         title="The image was successfully added to the watch list"
+                        component="p"
                     >
                         {watchImageMutation.data ?? ''}
                     </Alert>
@@ -100,6 +101,7 @@ function WatchedImagesModal({
                         variant="danger"
                         isInline
                         title="There was an error adding the image to the watch list"
+                        component="p"
                     >
                         {getAxiosErrorMessage(watchImageMutation.error)}
                     </Alert>
@@ -109,6 +111,7 @@ function WatchedImagesModal({
                         variant="success"
                         isInline
                         title="The image was successfully removed from the watch list"
+                        component="p"
                     />
                 )}
                 {unwatchImageMutation.isError && (
@@ -116,6 +119,7 @@ function WatchedImagesModal({
                         variant="danger"
                         isInline
                         title="There was an error removing the image from the watch list"
+                        component="p"
                     >
                         {getAxiosErrorMessage(unwatchImageMutation.error)}
                     </Alert>
@@ -125,6 +129,7 @@ function WatchedImagesModal({
                         variant="danger"
                         isInline
                         title="There was an error loading the current list of watched images"
+                        component="p"
                     >
                         {getAxiosErrorMessage(currentWatchedImagesRequest.error)}
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
@@ -27,7 +27,12 @@ function CveSelections({ cves, selectedCVEIds, onAdd, onRemove }: CveSelectionsP
     return (
         <>
             <div className="pf-v5-u-mb-md">
-                <Alert title="Include or exclude selected CVEs" variant="info" isInline>
+                <Alert
+                    title="Include or exclude selected CVEs"
+                    component="p"
+                    variant="info"
+                    isInline
+                >
                     You currently have ({selectedCVEIds.length}) selected. Review your selection
                     below.
                 </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -181,6 +181,7 @@ function ExceptionRequestModal({
                         variant="danger"
                         isInline
                         title="There was an error submitting the exception request"
+                        component="p"
                     >
                         {getAxiosErrorMessage(submissionError)}
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
@@ -84,13 +84,19 @@ function SnoozeCvesModal({ action, cveType, cves, onSuccess, onClose }: SnoozeCv
         >
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
                 {isSuccess && (
-                    <Alert variant="success" isInline title="Request submitted successfully" />
+                    <Alert
+                        variant="success"
+                        isInline
+                        title="Request submitted successfully"
+                        component="p"
+                    />
                 )}
                 {isError && (
                     <Alert
                         variant="danger"
                         isInline
                         title="There was an error submitting the request"
+                        component="p"
                     >
                         {getAxiosErrorMessage(error)}
                     </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
@@ -56,7 +56,7 @@ export function SummaryCardLayout({
         <LoadingContext.Provider value={{ isLoading }}>
             <div className="pf-v5-u-background-color-100 pf-v5-u-p-lg">
                 {error ? (
-                    <Alert title={errorAlertTitle} isInline variant="danger">
+                    <Alert title={errorAlertTitle} component="p" isInline variant="danger">
                         {getAxiosErrorMessage(error)}
                     </Alert>
                 ) : (


### PR DESCRIPTION
### Description

Apply 80/20 principle to fix generic issues so team members can divide and conquer pages that have specific issues.

More like 100/1 principle: 114 changed files!

### Problem

> Heading levels should only increase by one

```html
<h4 class="pf-v5-c-alert__title">
```

### Analysis

PatternFly `Alert` element renders `h4` element by default.
* The content seems separate from heading hierarchy.
* To add insult to injury, `title` prop is sometimes the body, not a heading.

### Specific solution

It is often not obvious from component that renders `Alert` element what is the heading hierarchy on the page.

Because it is unlikely that screen reader users will consider it intuitive for heading levels to vary from page to page, specify `component="p"` prop to remove alert from heading hierarchy. I started with `component="div"` recently, but decided after reflection and research that this is content.

PatternFly renders `title` content with bold font weight and text size that is intuitive for visual users.

Given so much inconsistency in order of props, append `component="p"` prop immediately following `title` prop:
* For reviewability now.
* For pattern later.

### Generic solution

Prevent future problems via project-specific lint rules.

Adapt excellent exploration by **David Vail** in #10839

I used astexplorer dot net with typescript-eslint parser to find relevant properties for the rule.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing

- [x] inspected CI results

#### Automated testing

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 98 = 4615582 - 4615484
        total 2035 = 11700801 - 11698766
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/access-control/auth-providers

    * Before changes, see presence of accessibility issues.
        ![access-control_auth-providers_with_issue](https://github.com/user-attachments/assets/06f37f99-c3e2-4653-adb9-0bc6c05e13c6)

    * After changes, see absence of accessibility issues.
        ![access-control_auth-providers_without_issue](https://github.com/user-attachments/assets/a14f5cb1-bdd1-4941-bc17-a661e30cf69f)
