### PR TITLE
ROX-25526: Fix OCP Internal Registry Scan Regressions

### DIFF
--- a/sensor/kubernetes/listener/resources/secrets_test.go
+++ b/sensor/kubernetes/listener/resources/secrets_test.go
@@ -246,29 +246,26 @@ func TestSAAnnotationImageIntegrationEvents(t *testing.T) {
 	assert.Len(t, iiEvents, 0)
 
 	// a secret w/ the `default` OCP sa annotation should trigger no imageintegration events
-	secret = openshift4xDockerConfigSecret.DeepCopy()
 	delete(secret.Annotations, saAnnotations[0])
 	secret.Annotations[saAnnotations[1]] = defaultSA
 	events = d.ProcessEvent(secret, nil, central.ResourceAction_SYNC_RESOURCE)
 	iiEvents = getImageIntegrationEvents(events)
 	assert.Len(t, iiEvents, 0)
+	delete(secret.Annotations, saAnnotations[1])
 
-	// // a secret w/ any sa annotation should trigger no imageintegration events
-	secret = openshift4xDockerConfigSecret.DeepCopy()
+	// a secret w/ any sa annotation should trigger no imageintegration events
 	secret.Annotations[saAnnotations[0]] = "blah"
 	events = d.ProcessEvent(secret, nil, central.ResourceAction_SYNC_RESOURCE)
 	iiEvents = getImageIntegrationEvents(events)
 	assert.Len(t, iiEvents, 0)
 
-	// // a secret w/ an empty sa annotation should trigger an imageintegration event
-	secret = openshift4xDockerConfigSecret.DeepCopy()
+	// a secret w/ an empty sa annotation should trigger an imageintegration event
 	secret.Annotations[saAnnotations[0]] = ""
 	events = d.ProcessEvent(secret, nil, central.ResourceAction_SYNC_RESOURCE)
 	iiEvents = getImageIntegrationEvents(events)
 	assert.Len(t, iiEvents, 1)
 
-	// // a secret w/ no sa annotation should trigger an imageintegration event
-	secret = openshift4xDockerConfigSecret.DeepCopy()
+	// a secret w/ no sa annotation should trigger an imageintegration event
 	delete(secret.Annotations, saAnnotations[0])
 	events = d.ProcessEvent(secret, nil, central.ResourceAction_SYNC_RESOURCE)
 	iiEvents = getImageIntegrationEvents(events)


### PR DESCRIPTION
### Description

The annotation used to associate a pull secret with a service account has changed in OCP 4.16 from:

```yaml
kubernetes.io/service-account.name: default
```

to 
```yaml
openshift.io/internal-registry-auth-token.service-account: default
```

OCP 4.15
```yaml
$ oc version
Server Version: 4.15.22
Kubernetes Version: v1.28.11+add48d0
...

$ oc get secret default-dockercfg-k4wgc -o yaml | yq '.metadata.annotations'
kubernetes.io/service-account.name: default
...

$ oc get secret deployer-dockercfg-pb5r9 -o yaml | yq '.metadata.annotations'
kubernetes.io/service-account.name: deployer
...
```

OCP 4.16
```yaml
$ oc version
Server Version: 4.16.3
Kubernetes Version: v1.29.6+aba1e8d
...

$ oc get secret default-dockercfg-f99p5 -o yaml | yq '.metadata.annotations'
openshift.io/internal-registry-auth-token.service-account: default
...

$ oc get secret builder-dockercfg-hq4dl -o yaml | yq '.metadata.annotations'
openshift.io/internal-registry-auth-token.service-account: builder
...
```

**Impact:**
In environments w/ multiple clusters, this may break scanning of images from the OCP internal registry.  This also results in auto-generated image integrations being created in Central for the internal registries (previously suppressed).  

As a workaround before this fix is in place, adding the OCP internal registry hosts to the delegated scanning config will allow for images to be scanned.  CLI/API scan requests delegated to a secured cluster are NOT impacted. 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Spun up OCP 4.16 and 4.15 secured clusters, and verified that image scans are working on both for images from the OCP internal registry, also verified that the auto-generated integrations are no longer created for internal registry.
