### PR TITLE
ROX-25333: Add autocomplete inputs to policy violations filters

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -1,0 +1,19 @@
+// If you're adding a new attribute, make sure to add it to "policyAttributes" as well
+
+import { CompoundSearchFilterAttribute } from '../types';
+
+export const Name: CompoundSearchFilterAttribute = {
+    displayName: 'Name',
+    filterChipLabel: 'Policy name',
+    searchTerm: 'Policy',
+    inputType: 'autocomplete',
+};
+
+export const Category: CompoundSearchFilterAttribute = {
+    displayName: 'Category',
+    filterChipLabel: 'Policy category',
+    searchTerm: 'Category',
+    inputType: 'autocomplete',
+};
+
+export const policyAttributes = [Name, Category];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -31,6 +31,8 @@ export type CompoundSearchFilterConfig = CompoundSearchFilterEntity[];
 
 // Misc
 
+export type OnSearchCallback = (payload: OnSearchPayload) => void;
+
 export type OnSearchPayload = {
     action: 'ADD' | 'REMOVE';
     category: string;

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -200,6 +200,8 @@ function ViolationsTablePage(): ReactElement {
                             getSortParams={getSortParams}
                             columns={columns}
                             isAdvancedFiltersEnabled={isAdvancedFiltersEnabled}
+                            searchFilter={searchFilter}
+                            setSearchFilter={setSearchFilter}
                         />
                     </PageSection>
                 )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -9,6 +9,8 @@ import useEntitiesByIdsCache from 'hooks/useEntitiesByIdsCache';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import VIOLATION_STATES from 'constants/violationStates';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
+import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useEffectAfterFirstRender from 'hooks/useEffectAfterFirstRender';
@@ -66,6 +68,10 @@ function ViolationsTablePage(): ReactElement {
         sortFields,
         defaultSortOption,
     });
+
+    const onSearch = (payload: OnSearchPayload) => {
+        onURLSearch(searchFilter, setSearchFilter, payload);
+    };
 
     useEffectAfterFirstRender(() => {
         if (hasExecutableFilter && !isViewFiltered) {
@@ -201,7 +207,7 @@ function ViolationsTablePage(): ReactElement {
                             columns={columns}
                             isAdvancedFiltersEnabled={isAdvancedFiltersEnabled}
                             searchFilter={searchFilter}
-                            setSearchFilter={setSearchFilter}
+                            onSearch={onSearch}
                         />
                     </PageSection>
                 )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -10,6 +10,7 @@ import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import VIOLATION_STATES from 'constants/violationStates';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useEffectAfterFirstRender from 'hooks/useEffectAfterFirstRender';
 import useURLSort from 'hooks/useURLSort';
 import { SortOption } from 'types/table';
@@ -26,6 +27,9 @@ import './ViolationsTablePage.css';
 const searchCategory = 'ALERTS';
 
 function ViolationsTablePage(): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_POLICY_VIOLATIONS_ADVANCED_FILTERS');
+
     // Handle changes to applied search options.
     const [searchOptions, setSearchOptions] = useState<string[]>([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -159,15 +163,19 @@ function ViolationsTablePage(): ReactElement {
         <>
             <PageSection variant="light" id="violations-table">
                 <Title headingLevel="h1">Violations</Title>
-                <Divider className="pf-v5-u-py-md" />
-                <SearchFilterInput
-                    className="theme-light pf-search-shim"
-                    handleChangeSearchFilter={setSearchFilter}
-                    placeholder="Filter violations"
-                    searchCategory={searchCategory}
-                    searchFilter={searchFilter}
-                    searchOptions={searchOptions}
-                />
+                {!isAdvancedFiltersEnabled && (
+                    <>
+                        <Divider className="pf-v5-u-py-md" />
+                        <SearchFilterInput
+                            className="theme-light pf-search-shim"
+                            handleChangeSearchFilter={setSearchFilter}
+                            placeholder="Filter violations"
+                            searchCategory={searchCategory}
+                            searchFilter={searchFilter}
+                            searchOptions={searchOptions}
+                        />
+                    </>
+                )}
             </PageSection>
             <PageSection variant="default">
                 {currentPageAlertsErrorMessage ? (
@@ -191,6 +199,7 @@ function ViolationsTablePage(): ReactElement {
                             setPerPage={setPerPage}
                             getSortParams={getSortParams}
                             columns={columns}
+                            isAdvancedFiltersEnabled={isAdvancedFiltersEnabled}
                         />
                     </PageSection>
                 )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -4,12 +4,13 @@ import {
     AlertActionCloseButton,
     AlertGroup,
     Divider,
-    Flex,
-    FlexItem,
     Title,
     PageSection,
     Pagination,
     pluralize,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
 } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { ActionsColumn, Table, Tbody, Thead, Td, Th, Tr } from '@patternfly/react-table';
@@ -32,6 +33,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';
+import ViolationsTableSearchFilter from './ViolationsTableSearchFilter';
 
 export type ActionItem = {
     title: string | ReactElement;
@@ -51,6 +53,7 @@ type ViolationsTablePanelProps = {
     setPerPage: (perPage) => void;
     getSortParams: GetSortParams;
     columns: TableColumn[];
+    isAdvancedFiltersEnabled?: boolean;
 };
 
 function ViolationsTablePanel({
@@ -64,6 +67,7 @@ function ViolationsTablePanel({
     excludableAlerts,
     getSortParams,
     columns,
+    isAdvancedFiltersEnabled = false,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
@@ -186,53 +190,57 @@ function ViolationsTablePanel({
                     </Alert>
                 ))}
             </AlertGroup>
-            <Flex
-                className="pf-v5-u-pb-md"
-                alignSelf={{ default: 'alignSelfCenter' }}
-                fullWidth={{ default: 'fullWidth' }}
-            >
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                    <Title headingLevel="h2" className="pf-v5-u-color-100">
-                        {pluralize(violationsCount, 'result')} found
-                    </Title>
-                </FlexItem>
-                {hasActions && (
-                    <FlexItem>
-                        <Select
-                            onToggle={(_event, toggleOpen) => onToggleSelect(toggleOpen)}
-                            isOpen={isSelectOpen}
-                            placeholderText="Row actions"
-                            onSelect={closeSelect}
-                            isDisabled={!hasSelections}
-                        >
-                            <SelectOption
-                                key="1"
-                                value={`Mark as resolved (${numResolveable})`}
-                                isDisabled={!hasWriteAccessForAlert || numResolveable === 0}
-                                onClick={showResolveConfirmationDialog}
-                            />
-                            <SelectOption
-                                key="2"
-                                value={`Exclude deployments from policy (${numScopesToExclude})`}
-                                isDisabled={
-                                    !hasWriteAccessForExcludeDeploymentsFromPolicy ||
-                                    numScopesToExclude === 0
-                                }
-                                onClick={showExcludeConfirmationDialog}
-                            />
-                        </Select>
-                    </FlexItem>
-                )}
-                <FlexItem align={{ default: 'alignRight' }}>
-                    <Pagination
-                        itemCount={violationsCount}
-                        page={currentPage}
-                        onSetPage={changePage}
-                        perPage={perPage}
-                        onPerPageSelect={changePerPage}
-                    />
-                </FlexItem>
-            </Flex>
+            {isAdvancedFiltersEnabled && (
+                <>
+                    <ViolationsTableSearchFilter />
+                    <Divider component="div" />
+                </>
+            )}
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <Title headingLevel="h2" className="pf-v5-u-color-100">
+                            {pluralize(violationsCount, 'result')} found
+                        </Title>
+                    </ToolbarItem>
+                    {hasActions && (
+                        <ToolbarItem align={{ default: 'alignRight' }}>
+                            <Select
+                                onToggle={(_event, toggleOpen) => onToggleSelect(toggleOpen)}
+                                isOpen={isSelectOpen}
+                                placeholderText="Row actions"
+                                onSelect={closeSelect}
+                                isDisabled={!hasSelections}
+                            >
+                                <SelectOption
+                                    key="1"
+                                    value={`Mark as resolved (${numResolveable})`}
+                                    isDisabled={!hasWriteAccessForAlert || numResolveable === 0}
+                                    onClick={showResolveConfirmationDialog}
+                                />
+                                <SelectOption
+                                    key="2"
+                                    value={`Exclude deployments from policy (${numScopesToExclude})`}
+                                    isDisabled={
+                                        !hasWriteAccessForExcludeDeploymentsFromPolicy ||
+                                        numScopesToExclude === 0
+                                    }
+                                    onClick={showExcludeConfirmationDialog}
+                                />
+                            </Select>
+                        </ToolbarItem>
+                    )}
+                    <ToolbarItem align={{ default: 'alignRight' }} variant="pagination">
+                        <Pagination
+                            itemCount={violationsCount}
+                            page={currentPage}
+                            onSetPage={changePage}
+                            perPage={perPage}
+                            onPerPageSelect={changePerPage}
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
             <Divider component="div" />
             <PageSection isFilled padding={{ default: 'noPadding' }} hasOverflowScroll>
                 <Table variant="compact" isStickyHeader>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -30,6 +30,8 @@ import { excludeDeployments } from 'services/PoliciesService';
 import { ListAlert } from 'types/alert.proto';
 import { TableColumn } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { SearchFilter } from 'types/search';
+import { SetSearchFilter } from 'hooks/useURLSearch';
 
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';
@@ -54,6 +56,8 @@ type ViolationsTablePanelProps = {
     getSortParams: GetSortParams;
     columns: TableColumn[];
     isAdvancedFiltersEnabled?: boolean;
+    searchFilter: SearchFilter;
+    setSearchFilter: SetSearchFilter;
 };
 
 function ViolationsTablePanel({
@@ -68,6 +72,8 @@ function ViolationsTablePanel({
     getSortParams,
     columns,
     isAdvancedFiltersEnabled = false,
+    searchFilter,
+    setSearchFilter,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
@@ -192,7 +198,10 @@ function ViolationsTablePanel({
             </AlertGroup>
             {isAdvancedFiltersEnabled && (
                 <>
-                    <ViolationsTableSearchFilter />
+                    <ViolationsTableSearchFilter
+                        searchFilter={searchFilter}
+                        setSearchFilter={setSearchFilter}
+                    />
                     <Divider component="div" />
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -31,8 +31,8 @@ import { ListAlert } from 'types/alert.proto';
 import { TableColumn } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { SearchFilter } from 'types/search';
-import { SetSearchFilter } from 'hooks/useURLSearch';
 
+import { OnSearchCallback } from 'Components/CompoundSearchFilter/types';
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';
 import ViolationsTableSearchFilter from './ViolationsTableSearchFilter';
@@ -57,7 +57,7 @@ type ViolationsTablePanelProps = {
     columns: TableColumn[];
     isAdvancedFiltersEnabled?: boolean;
     searchFilter: SearchFilter;
-    setSearchFilter: SetSearchFilter;
+    onSearch: OnSearchCallback;
 };
 
 function ViolationsTablePanel({
@@ -73,7 +73,7 @@ function ViolationsTablePanel({
     columns,
     isAdvancedFiltersEnabled = false,
     searchFilter,
-    setSearchFilter,
+    onSearch,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
@@ -198,10 +198,7 @@ function ViolationsTablePanel({
             </AlertGroup>
             {isAdvancedFiltersEnabled && (
                 <>
-                    <ViolationsTableSearchFilter
-                        searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
-                    />
+                    <ViolationsTableSearchFilter searchFilter={searchFilter} onSearch={onSearch} />
                     <Divider component="div" />
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+
+import useURLSearch from 'hooks/useURLSearch';
+import {
+    makeFilterChipDescriptors,
+    onURLSearch,
+} from 'Components/CompoundSearchFilter/utils/utils';
+import { CompoundSearchFilterConfig, OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import {
+    Category as PolicyCategory,
+    Name as PolicyName,
+} from 'Components/CompoundSearchFilter/attributes/policy';
+import {
+    ID as ClusterID,
+    Name as ClusterName,
+} from 'Components/CompoundSearchFilter/attributes/cluster';
+import {
+    ID as NamespaceID,
+    Name as NamespaceName,
+} from 'Components/CompoundSearchFilter/attributes/namespace';
+import {
+    ID as DeploymentID,
+    Name as DeploymentName,
+} from 'Components/CompoundSearchFilter/attributes/deployment';
+
+const searchFilterConfig: CompoundSearchFilterConfig = [
+    {
+        displayName: 'Policy',
+        searchCategory: 'ALERTS',
+        attributes: [PolicyName, PolicyCategory],
+    },
+    {
+        displayName: 'Cluster',
+        searchCategory: 'ALERTS',
+        attributes: [ClusterID, ClusterName],
+    },
+    {
+        displayName: 'Namespace',
+        searchCategory: 'ALERTS',
+        attributes: [NamespaceID, NamespaceName],
+    },
+    {
+        displayName: 'Deployment',
+        searchCategory: 'ALERTS',
+        attributes: [DeploymentID, DeploymentName],
+    },
+];
+
+function ViolationsTableSearchFilter() {
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
+
+    const onSearch = (payload: OnSearchPayload) => {
+        onURLSearch(searchFilter, setSearchFilter, payload);
+    };
+
+    return (
+        <Toolbar>
+            <ToolbarContent>
+                <ToolbarGroup className="pf-v5-u-w-100">
+                    <ToolbarItem className="pf-v5-u-flex-1">
+                        <CompoundSearchFilter
+                            config={searchFilterConfig}
+                            searchFilter={searchFilter}
+                            onSearch={onSearch}
+                        />
+                    </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup className="pf-v5-u-w-100">
+                    <SearchFilterChips filterChipGroupDescriptors={filterChipGroupDescriptors} />
+                </ToolbarGroup>
+            </ToolbarContent>
+        </Toolbar>
+    );
+}
+
+export default ViolationsTableSearchFilter;

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
-import useURLSearch from 'hooks/useURLSearch';
+import { SearchFilter } from 'types/search';
 import {
     makeFilterChipDescriptors,
     onURLSearch,
@@ -25,6 +25,7 @@ import {
     ID as DeploymentID,
     Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
+import { SetSearchFilter } from 'hooks/useURLSearch';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
     {
@@ -49,9 +50,15 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     },
 ];
 
-function ViolationsTableSearchFilter() {
-    const { searchFilter, setSearchFilter } = useURLSearch();
+export type ViolationsTableSearchFilterProps = {
+    searchFilter: SearchFilter;
+    setSearchFilter: SetSearchFilter;
+};
 
+function ViolationsTableSearchFilter({
+    searchFilter,
+    setSearchFilter,
+}: ViolationsTableSearchFilterProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
     const onSearch = (payload: OnSearchPayload) => {

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
+import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 import {
-    makeFilterChipDescriptors,
-    onURLSearch,
-} from 'Components/CompoundSearchFilter/utils/utils';
-import { CompoundSearchFilterConfig, OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+    CompoundSearchFilterConfig,
+    OnSearchCallback,
+} from 'Components/CompoundSearchFilter/types';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import {
@@ -25,7 +25,6 @@ import {
     ID as DeploymentID,
     Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
-import { SetSearchFilter } from 'hooks/useURLSearch';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
     {
@@ -52,18 +51,11 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
 
 export type ViolationsTableSearchFilterProps = {
     searchFilter: SearchFilter;
-    setSearchFilter: SetSearchFilter;
+    onSearch: OnSearchCallback;
 };
 
-function ViolationsTableSearchFilter({
-    searchFilter,
-    setSearchFilter,
-}: ViolationsTableSearchFilterProps) {
+function ViolationsTableSearchFilter({ searchFilter, onSearch }: ViolationsTableSearchFilterProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
-
-    const onSearch = (payload: OnSearchPayload) => {
-        onURLSearch(searchFilter, setSearchFilter, payload);
-    };
 
     return (
         <Toolbar>


### PR DESCRIPTION
### Description

This PR makes a few changes to the Policy Violations page to accommodate the implementation of advanced filters:

1. Adding feature flag logic 
2. Changing the placement of the search filter and the bulk actions dropdown
3. Creating a component for the policy violations search filter

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change


https://github.com/user-attachments/assets/0e6e4021-d5c9-4b72-98dc-3f288ba7927d



