### PR TITLE
ROX-25512:  walk upgrade

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -176,7 +176,6 @@ test_upgrade_paths() {
 
       wait_for_api
       wait_for_central_db
-      info "4.5.0 should fail"
     done
 
     ########################################################################################

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -201,7 +201,7 @@ test_upgrade_paths() {
     ########################################################################################
     # Upgrade back to latest to run the smoke tests by first walking previous releases     #
     ########################################################################################
-    for str in ${myArray[@]}; do
+    for str in ${PREVIOUS_RELEASES[@]}; do
       info "Walking upgrades -- release => $str"
       kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$str"
       kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$str"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.1.3"
 EARLIER_SHA="8a4677e3d45ebc4f065ec052d1d66d6ead2084bb"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.1.3" "4.2.5" "4.3.8" "4.4.4" "4.5.0")
+PREVIOUS_RELEASES=("4.1.3" "4.2.5" "4.3.8" "4.4.4" "4.5.1")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -10,6 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.1.3"
 EARLIER_SHA="8a4677e3d45ebc4f065ec052d1d66d6ead2084bb"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
+PREVIOUS_RELEASES=("4.1.3" "4.2.5" "4.3.8" "4.4.4" "4.5.0")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"
@@ -198,8 +199,18 @@ test_upgrade_paths() {
     touch "${UPGRADE_PROGRESS_POSTGRES_ROLLBACK}"
 
     ########################################################################################
-    # Upgrade back to latest to run the smoke tests                                        #
+    # Upgrade back to latest to run the smoke tests by first walking previous releases     #
     ########################################################################################
+    for str in ${myArray[@]}; do
+      info "Walking upgrades -- release => $str"
+      kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$str"
+      kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$str"
+
+      wait_for_api
+      info "4.5.0 should fail"
+    done
+
+    # Now go back to the current release
     kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
     kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

ROX-25435 was missed by the upgrade test because the upgrade test goes from 4.1.3 to current.  The issue in that ticket was introduced by a bug in a dependency in 4.3.1 and exacerbated by a worse bug in the same dependency in 4.5.0.   To find such we need to test both going from 4.1.3 to current AND walking each release between 4.1.3 and current.  This update simply adds a list of releases and walks through them.  We will update the release process to update the list each time a new patch is added.

To prove it works here is the failure when it hits 4.5.0.  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/12203/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1818334937766432768
We cannot check in the test until we have 4.5.1 but I thought it helpful to show that this update would have caught the 4.5.0 issue.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

As mentioned above, ran it against 4.5.0 and proved that we would have caught that issue.  Otherwise, it is simply an update to a CI test thus CI is sufficient.
