### PR TITLE
ROX-25421: Compact error msg through removing duplicates 

### DIFF
--- a/sensor/upgrader/preflight/access.go
+++ b/sensor/upgrader/preflight/access.go
@@ -100,7 +100,7 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 			reporter.Warnf("Evaluation error performing access review check for action %s on resource %s: %s", ra.Verb, ra.Resource, sarResult.Status.EvaluationError)
 		}
 		if !sarResult.Status.Allowed && !sarResult.Status.Denied {
-			errEntry := fmt.Sprintf("%s:%s (sarResult=%q)", ra.Verb, ra.Resource, sarResult.Status.String())
+			errEntry := fmt.Sprintf("%s:%s", ra.Verb, ra.Resource)
 			actionResourceErr[errEntry] = struct{}{}
 		} else if !sarResult.Status.Allowed {
 			reporter.Errorf("Action %s on resource %s is not allowed", ra.Verb, ra.Resource)

--- a/sensor/upgrader/preflight/access.go
+++ b/sensor/upgrader/preflight/access.go
@@ -2,12 +2,14 @@ package preflight
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/sensor/upgrader/plan"
 	"github.com/stackrox/rox/sensor/upgrader/resources"
 	"github.com/stackrox/rox/sensor/upgrader/upgradectx"
+	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -82,7 +84,7 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 		return err
 	}
 
-	actionResourceErr := make([]string, 0)
+	actionResourceErr := make(map[string]struct{})
 	for i := range resourceAttribs {
 		ra := resourceAttribs[i]
 		sar := &v1.SelfSubjectAccessReview{
@@ -98,15 +100,18 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 			reporter.Warnf("Evaluation error performing access review check for action %s on resource %s: %s", ra.Verb, ra.Resource, sarResult.Status.EvaluationError)
 		}
 		if !sarResult.Status.Allowed && !sarResult.Status.Denied {
-			actionResourceErr = append(actionResourceErr, fmt.Sprintf("%s:%s", ra.Verb, ra.Resource))
+			errEntry := fmt.Sprintf("%s:%s (sarResult=%q)", ra.Verb, ra.Resource, sarResult.Status.String())
+			actionResourceErr[errEntry] = struct{}{}
 		} else if !sarResult.Status.Allowed {
 			reporter.Errorf("Action %s on resource %s is not allowed", ra.Verb, ra.Resource)
 		}
 	}
 	if len(actionResourceErr) > 0 {
+		affected := maps.Keys(actionResourceErr)
+		slices.Sort(affected)
 		reporter.Errorf("K8s authorizer did not explicitly allow or deny access to perform "+
 			"the following actions on following resources: %s. This usually means access is denied.",
-			strings.Join(actionResourceErr, ", "))
+			strings.Join(affected, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
### Description

The error message produced by the preflight check "Kubernetes authorization" contains many duplicated names of k8s resources. This makes it unnecessary long and unreadable - see screenshot.

In this PR, I remove the duplicates and sort the names of resources in the error message.

![Screenshot 2024-07-30 at 17 26 59](https://github.com/user-attachments/assets/db38fabf-291a-4ed7-aeb3-e0314e3ec137)

⚠️ This PR does not fix the cause of the missing authorization - for that a follow-up may appear soon.  

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [x] Manually by triggering it on the cluster and comparing visually

![Screenshot 2024-07-31 at 12 58 35](https://github.com/user-attachments/assets/98b60763-a39b-4ca4-9a35-fcd588d5ed32)

![Screenshot 2024-07-31 at 12 59 35](https://github.com/user-attachments/assets/8d850e98-4922-4c04-aa27-d84dc0b97648)

