### PR TITLE
tests: do not install Qemu on amd64 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -326,6 +326,7 @@ jobs:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Set up QEMU
+        if: matrix.arch != 'amd64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -197,6 +197,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Set up QEMU
+      if: matrix.goarch != 'amd64'
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx


### PR DESCRIPTION
### Description

Qemu install action downloads image from docker.io that from time to time throttles us causing build failures. This PR do not install qemu when it's not needed to reduce dependency on docker.io.

- https://github.com/stackrox/stackrox/pull/12041

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
