### PR TITLE
fix(ui): Replace some Button and LinkShim with React Router Link

### DIFF
--- a/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
+++ b/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
@@ -1,15 +1,13 @@
 import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import {
     Bullseye,
     Button,
-    ButtonVariant,
     EmptyState,
     EmptyStateBody,
     EmptyStateHeader,
     EmptyStateFooter,
 } from '@patternfly/react-core';
-
-import LinkShim from 'Components/PatternFly/LinkShim';
 
 export type NotFoundMessageProps = {
     title: string;
@@ -34,17 +32,12 @@ const NotFoundMessage = ({
                 <EmptyStateHeader titleText={title} headingLevel="h1" />
                 <EmptyStateFooter>
                     {message && <EmptyStateBody>{message}</EmptyStateBody>}
-                    {isButtonVisible && <Button variant="primary">{actionText}</Button>}
-                    {isLinkVisible && (
-                        <Button
-                            variant={ButtonVariant.link}
-                            isInline
-                            component={LinkShim}
-                            href={url}
-                        >
+                    {isButtonVisible && (
+                        <Button variant="primary" onClick={onClick}>
                             {actionText}
                         </Button>
                     )}
+                    {isLinkVisible && <Link to={url}>{actionText}</Link>}
                 </EmptyStateFooter>
             </EmptyState>
         </Bullseye>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlLinks.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlLinks.tsx
@@ -1,8 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { AccessControlEntityType } from 'constants/entityTypes';
 import { Role } from 'services/RolesService';
 
@@ -19,16 +18,7 @@ export function AccessControlEntityLink({
     entityId,
     entityName,
 }: AccessControlEntityLinkProps): ReactElement {
-    return (
-        <Button
-            variant={ButtonVariant.link}
-            isInline
-            component={LinkShim}
-            href={getEntityPath(entityType, entityId)}
-        >
-            {entityName}
-        </Button>
-    );
+    return <Link to={getEntityPath(entityType, entityId)}>{entityName}</Link>;
 }
 
 export type RolesLinkProps = {
@@ -51,9 +41,5 @@ export function RolesLink({ roles, entityType, entityId }: RolesLinkProps): Reac
     const count = roles.length;
     const url = getEntityPath('ROLE', '', { s: { [entityType]: entityId } });
     const text = `${count} ${pluralize('role', count)}`;
-    return (
-        <Button variant={ButtonVariant.link} isInline component={LinkShim} href={url}>
-            {text}
-        </Button>
-    );
+    return <Link to={url}>{text}</Link>;
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,9 +1,9 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Button, ButtonVariant, Card, Text } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Card, Text } from '@patternfly/react-core';
 import { Tbody, Tr, Td, Table, Th, Thead } from '@patternfly/react-table';
 
 import { riskBasePath } from 'routePaths';
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import { ListDeployment } from 'types/deployment.proto';
@@ -112,14 +112,7 @@ function ListeningEndpointsTable({
                                 }}
                             />
                             <Td dataLabel="Deployment">
-                                <Button
-                                    variant={ButtonVariant.link}
-                                    isInline
-                                    component={LinkShim}
-                                    href={`${riskBasePath}/${id}`}
-                                >
-                                    {name}
-                                </Button>
+                                <Link to={`${riskBasePath}/${id}`}>{name}</Link>
                             </Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import {
     Button,
     ButtonVariant,
@@ -199,14 +199,7 @@ function CollectionsTable({
                                 return (
                                     <Tr key={id}>
                                         <Td dataLabel="Collection">
-                                            <Button
-                                                variant={ButtonVariant.link}
-                                                isInline
-                                                component={LinkShim}
-                                                href={`${collectionsBasePath}/${id}`}
-                                            >
-                                                {name}
-                                            </Button>
+                                            <Link to={`${collectionsBasePath}/${id}`}>{name}</Link>
                                         </Td>
                                         <Td dataLabel="Description">
                                             <Truncate

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -213,11 +213,8 @@ function IntegrationsTable({
                                             ) {
                                                 return (
                                                     <Td key="name">
-                                                        <Button
-                                                            variant={ButtonVariant.link}
-                                                            isInline
-                                                            component={LinkShim}
-                                                            href={getPathToViewDetails(
+                                                        <Link
+                                                            to={getPathToViewDetails(
                                                                 source,
                                                                 type,
                                                                 id
@@ -227,7 +224,7 @@ function IntegrationsTable({
                                                                 row={integration}
                                                                 column={column}
                                                             />
-                                                        </Button>
+                                                        </Link>
                                                     </Td>
                                                 );
                                             }

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import {
     Button,
-    ButtonVariant,
     PageSection,
     Pagination,
     Toolbar,
@@ -25,7 +24,6 @@ import { ListPolicy } from 'types/policy.proto';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import PolicyDisabledIconText from 'Components/PatternFly/IconText/PolicyDisabledIconText';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
-import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterInput from 'Components/SearchFilterInput';
 import { ActionItem } from 'Containers/Violations/ViolationsTablePanel';
 import EnableDisableNotificationModal, {
@@ -413,14 +411,7 @@ function PoliciesTable({
                                         }}
                                     />
                                     <Td dataLabel="Policy">
-                                        <Button
-                                            variant={ButtonVariant.link}
-                                            isInline
-                                            component={LinkShim}
-                                            href={`${policiesBasePath}/${id}`}
-                                        >
-                                            {name}
-                                        </Button>
+                                        <Link to={`${policiesBasePath}/${id}`}>{name}</Link>
                                     </Td>
                                     <Td dataLabel="Status">
                                         <PolicyDisabledIconText isDisabled={disabled} />

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
     Button,
     ButtonVariant,
@@ -13,7 +14,6 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import isEqual from 'lodash/isEqual';
 import pluralize from 'pluralize';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import TableCellValue from 'Components/TableCellValue/TableCellValue';
 import { IntegrationTableColumnDescriptor } from 'Containers/Integrations/utils/tableColumnDescriptor';
 import useTableSelection from 'hooks/useTableSelection';
@@ -137,17 +137,12 @@ function TableModal({
                                                         if (column.Header === 'Name') {
                                                             return (
                                                                 <Td key="name">
-                                                                    <Button
-                                                                        variant={ButtonVariant.link}
-                                                                        isInline
-                                                                        component={LinkShim}
-                                                                        href={link}
-                                                                    >
+                                                                    <Link to={link}>
                                                                         <TableCellValue
                                                                             row={row}
                                                                             column={column}
                                                                         />
-                                                                    </Button>
+                                                                    </Link>
                                                                 </Td>
                                                             );
                                                         }

--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Flex, FlexItem } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { SearchResultCategory } from 'services/SearchService';
 import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
@@ -36,14 +36,7 @@ function FilterLinks({
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                 {filterLinks.map(({ basePath, linkText }) => (
                     <FlexItem key={linkText}>
-                        <Button
-                            variant="link"
-                            isInline
-                            component={LinkShim}
-                            href={`${basePath}?${queryString}`}
-                        >
-                            {linkText}
-                        </Button>
+                        <Link to={`${basePath}?${queryString}`}>{linkText}</Link>
                     </FlexItem>
                 ))}
             </Flex>

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Flex, FlexItem } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { SearchResult } from 'services/SearchService';
 import { safeGeneratePath } from 'utils/urlUtils';
 
@@ -23,15 +23,12 @@ function ViewLinks({ searchResult, searchResultCategoryMap }: ViewLinksProps): R
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                 {viewLinks.map(({ basePath, linkText }) => (
                     <FlexItem key={linkText}>
-                        <Button
-                            variant="link"
-                            isInline
-                            component={LinkShim}
-                            href={safeGeneratePath(basePath, searchResult, basePath)}
+                        <Link
+                            to={safeGeneratePath(basePath, searchResult, basePath)}
                             className="pf-v5-u-text-nowrap"
                         >
                             {linkText}
-                        </Button>
+                        </Link>
                     </FlexItem>
                 ))}
             </Flex>

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 import {
-    Button,
     Card,
     CardBody,
     CardTitle,
@@ -13,7 +13,6 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
 import { PrivateConfig } from 'types/config.proto';
 import { clustersBasePath } from 'routePaths';
@@ -286,14 +285,9 @@ const PrivateConfigDataRetentionDetails = ({
                     </CardBody>
                     {isClustersRoutePathRendered && (
                         <CardBody>
-                            <Button
-                                variant="link"
-                                isInline
-                                component={LinkShim}
-                                href={`${clustersBasePath}?s[Sensor Status]=UNHEALTHY`}
-                            >
+                            <Link to={`${clustersBasePath}?s[Sensor Status]=UNHEALTHY`}>
                                 Clusters which have Sensor Status: Unhealthy
-                            </Button>
+                            </Link>
                         </CardBody>
                     )}
                 </Card>

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Button, CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim/LinkShim';
 import { clustersBasePath } from 'routePaths';
 
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
@@ -42,9 +42,7 @@ function ClustersHealthCardHeader({
                 </FlexItem>
                 {phrase && <FlexItem>{phrase}</FlexItem>}
                 <FlexItem align={{ default: 'alignRight' }}>
-                    <Button variant="link" isInline component={LinkShim} href={clustersBasePath}>
-                        View clusters
-                    </Button>
+                    <Link to={clustersBasePath}>View clusters</Link>
                 </FlexItem>
             </Flex>
         </CardHeader>

--- a/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
+++ b/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonVariant, Flex, Icon } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Flex, Icon } from '@patternfly/react-core';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { userBasePath } from 'routePaths';
 
 const forbiddenIcon = (
@@ -36,15 +36,9 @@ function RolesForResourceAccess({ roleNames }: RolesForResourceAccessProps): Rea
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             {permittedIcon}
             {roleNames.map((roleName) => (
-                <Button
-                    key={roleName}
-                    variant={ButtonVariant.link}
-                    isInline
-                    component={LinkShim}
-                    href={getUserRolePath(roleName)}
-                >
+                <Link key={roleName} to={getUserRolePath(roleName)}>
                     {roleName}
-                </Button>
+                </Link>
             ))}
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 import dateFns from 'date-fns';
 import startCase from 'lodash/startCase';
-import { Button, ButtonVariant, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
-import LinkShim from 'Components/PatternFly/LinkShim';
 import dateTimeFormat from 'constants/dateTimeFormat';
 import { lifecycleStageLabels } from 'messages/common';
 import {
@@ -89,9 +89,7 @@ const tableColumnDescriptor = [
             const url = `${violationsBasePath}/${original.id as string}`;
             return (
                 <Tooltip content={original?.policy?.description || 'No description available'}>
-                    <Button variant={ButtonVariant.link} isInline component={LinkShim} href={url}>
-                        {original?.policy?.name}
-                    </Button>
+                    <Link to={url}>{original?.policy?.name}</Link>
                 </Tooltip>
             );
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import { Td } from '@patternfly/react-table';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { exceptionManagementPath } from 'routePaths';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
@@ -32,14 +31,7 @@ export type ExceptionDetailsCellProps = {
 function ExceptionDetailsCell({ cve, vulnerabilityState }: ExceptionDetailsCellProps) {
     return (
         <Td dataLabel="Request details">
-            <Button
-                variant="link"
-                isInline
-                component={LinkShim}
-                href={getExceptionManagementURL(cve, vulnerabilityState)}
-            >
-                View
-            </Button>
+            <Link to={getExceptionManagementURL(cve, vulnerabilityState)}>View</Link>
         </Td>
     );
 }


### PR DESCRIPTION
### Description

### Problem

Some links do not have **Copy** on right-click menu in browser:
* The following work correctly: **Copy Link Address** and so on, also keyboard access to link.
* But cannot copy link text for use elsewhere.

### Analysis

1. **David Vail** discovered that it is a limitation of PatternFly `Button` element:
    * with `variant="link"` which was our original idiom for link style
    * plus `component={LinkShim}` which solved **element is detached from the DOM** errors from cypress when pages re-render during integration tests
2. The current combination of PatternFly and classic style rules works for ordinary React Router `Link` element.

**But** for links that have button style, **Copy** command is not necessarily relevant, therefore leave them alone. Also leave edge cases:
* Links at upper edge do not have `isInline` prop because layout depends on padding from `Button` element.
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Dashboard/SummaryCount.tsx#L16
* Link in `Alert` of classic image overview has style with `Button` element but not with `Link` element.
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js#L209-L226

### Solution

Find in Files: 36 results in 29 files for `component={LinkShim}`

1. Replace `Button` with `Link` in only 14 files.
2. Add `onClick` prop (used only once in Risk timeline) that was missing from `Button` element in `NotFoundMessage` component.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
3. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -271 = 4615219 - 4615490
        total 149 = 11699401 - 11699252
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
4. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/listening-endpoints

    * Before changes, see absence of **Copy** command.
        ![listening-endpoints_without_Copy](https://github.com/user-attachments/assets/b6d769a4-39ec-479f-8932-0ed7faf2d01b)

    * After changes, see presence of **Copy** command.
        ![listening-endpoints_with_Copy](https://github.com/user-attachments/assets/bcc13c5b-cb51-49e1-b625-b787076a3c51)

2. Visit /main/bogus to see `NotFoundMessage` element:

    * Before changes, see absence of **Copy** command.
        ![bogus_without_Copy](https://github.com/user-attachments/assets/88da15a4-059e-4101-ad08-7b1515447717)

    * After changes, see presence of **Copy** command.
        ![bogus_with_Copy_and_onClick](https://github.com/user-attachments/assets/3e2ce20b-9d8f-4429-8829-bd3343ecadc0)
