### PR TITLE
use centos:stream9

### DIFF
--- a/qa-tests-backend/test-images/trigger-policy-violations/most/Dockerfile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/most/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM quay.io/centos/centos:stream9
 
 WORKDIR /
 
@@ -8,8 +8,13 @@ WORKDIR /
 # RUN echo "a secret" > /run/secrets/asecret
 # VOLUME /run/secrets
 
+RUN yum update -y
+
 # For: "Shell Spawned by Java Application"
 RUN yum -y install csh
+
+# For: trigger-violations.sh to trigger systemctl violation
+RUN yum update -y && yum install systemd -y
 
 # Using ADD also triggers: "ADD Command used instead of COPY"
 ADD trigger-violations.sh /trigger-violations-insecure.sh

--- a/qa-tests-backend/test-images/trigger-policy-violations/most/Makefile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/most/Makefile
@@ -4,6 +4,6 @@ VERSION=0.20
 
 .PHONY: image
 image:
-	docker build -t trigger-policy-violations/most:${VERSION} .
+	docker build --platform linux/amd64 -t trigger-policy-violations/most:${VERSION} .
 	docker tag trigger-policy-violations/most:${VERSION} us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:${VERSION}
 	docker push us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:${VERSION}


### PR DESCRIPTION
### Description

Changes the base image to `quay.io/centos/centos:stream9` and installs systemd. Also adds the platform flag to the docker build command so we ensure the amd64 version is built for CI.