### PR TITLE
ROX-25218, ROX-23907: Consider 34.118.224.0/20 as a private network

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -823,6 +823,10 @@ function launch_sensor {
        kubectl -n "${sensor_namespace}" set env ds/collector ROX_AFTERGLOW_PERIOD="${ROX_AFTERGLOW_PERIOD}"
     fi
 
+    if [[ -n "${ROX_NON_AGGREGATED_NETWORKS}" ]]; then
+      kubectl -n "${sensor_namespace}" set env ds/collector ROX_NON_AGGREGATED_NETWORKS="${ROX_NON_AGGREGATED_NETWORKS}"
+    fi
+
     # For local installations (e.g. on Colima): hotload binary and update resource requests
     if [[ "$(local_dev)" == "true" ]]; then
         if [[ "${ROX_HOTRELOAD}" == "true" ]]; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -165,6 +165,11 @@ export_test_environment() {
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
     fi
+
+    if [[ "${CI_JOB_NAME}" =~ gke ]]; then
+        # GKE uses this network for services. Consider it as a private subnet.
+        ci_export ROX_NON_AGGREGATED_NETWORKS "${ROX_NON_AGGREGATED_NETWORKS:-34.118.224.0/20}"
+    fi
 }
 
 deploy_stackrox_operator() {


### PR DESCRIPTION
### Description

ROX-25218, ROX-23907: Consider 34.118.224.0/20 as a private network in GKE tests

See https://github.com/stackrox/stackrox/pull/11934.

### User-facing documentation

- [x] update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~- [ ] added unit tests~
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
~- [ ] modified existing tests~

#### How I validated my change

Passing CI is sufficient.
