### PR TITLE
Added deprecation message for gRPC error fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Entries in this file should be limited to:
 - Obscure side-effects that are not obviously apparent based on the JIRA associated with the changes.
 Please avoid adding duplicate information across this changelog and JIRA/doc input pages.
 
+## [NEXT RELEASE]
+
+### Added Features
+
+- ROX-25066: Add new external backup integration for non-AWS S3 compatible providers.
+
+### Removed Features
+
+### Deprecated Features
+
+### Technical Changes
+
+
 ## [4.5.0]
 
 ### Added Features
@@ -42,6 +55,29 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - The `/v1/summary/counts` API has been deprecated in 4.5 and will be removed in the future.
 - 'Dashboard' view under 'Vulnerability Management' is deprecated and will be removed in a future release. Use 'Workload CVEs', 'Exception Management', 'Platform CVEs', and 'Node CVEs' views instead.
 - ROX-25067: The Amazon S3 external backup integration interoperability with Google Cloud Storage has been deprecated. Backups to Google Cloud Storage should be done by using the dedicated Google Cloud Storage external backup integration.
+- The fields `grpcCode`, `httpCode`, and `httpStatus` in returned error for gRPC stream APIs will be removed in the next release. A new field `code` will be added, which should be used instead of `grpcCode`. This change will unify returned API calls for streams and unary requests and it will simplify error handling.
+  Here is an example of the current error payload:
+  ```
+  {
+     "error": {
+       "grpcCode": 16,
+       "httpCode": 401,
+       "message": "credentials not found",
+       "httpStatus": "Unauthorized",
+       "details": []
+     }
+  }
+  ```
+  That example error will be returned in the following format with the next release:
+  ```
+  {
+     "error": {
+       "code": 16,
+       "message": "credentials not found",
+       "details": []
+     }
+  }
+  ```
 
 ### Technical Changes
 


### PR DESCRIPTION
Cherry-picked: #11948
### Description

With the migration to protobuf V2, we also have to migrate to `grpc-gateway` V2. Migration to `grpc-gateway` brings some changes related to error messages. They have unified error messages and simplified handling for them.

We do not have the possibility of replacing the error message format for stream APIs, so we will announce the deprecation of this message and replace it with the next release.

Endpoints are are impacted with this change are:
```
  - get /v1/debug/authz/trace
  - get /v1/export/deployments
  - get /v1/export/images
  - get /v1/export/nodes
  - get /v1/export/pods
  - get /v1/export/vuln-mgmt/workloads
```

### User-facing documentation

(*must be* 2 items and both *must be* checked)
<!-- Remove conflicting items that won't be checked. -->

- [x] CHANGELOG is updated

Changes in this PR should be part of: This https://github.com/openshift/openshift-docs/pull/78414
If we manage to get changes into 4.5 RC2.

### Testing

- [x] inspected CI results

#### Automated testing

(*must be* at least 1 item and all items *must be* checked)
<!-- Remove item(s) that don't apply and won't be checked. -->

- [x] contributed **no automated tests**
  <!-- Please explain why unless it's obvious, e.g., the PR is a one-line comment change. -->

#### How I validated my change

I have tested if the markdown will be properly formatted on GitHub - by checking it in the comment preview.
