### PR TITLE
chore: login to docker.io to fix builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -325,6 +325,12 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - name: Login to docker.io to mitigate rate limiting on downloading images
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_CI_ACCOUNT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
+
       - name: Set up QEMU
         if: matrix.arch != 'amd64'
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -196,6 +196,13 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+
+    - name: Login to docker.io to mitigate rate limiting on downloading images
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_CI_ACCOUNT_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
+
     - name: Set up QEMU
       if: matrix.goarch != 'amd64'
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
### Description

To mitigate rate limiting by docker.io we should login to have our own pool of request to use.

Refs:
- https://github.com/stackrox/stackrox/pull/12041
- https://github.com/stackrox/stackrox/pull/12205

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
