### PR TITLE
tests: auto \retest all PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,6 +56,10 @@ area/postgres:
     - pkg/search/postgres/**/*
     - tools/generate-helpers/pg-table-bindings/**/*
     - tools/generate-helpers/pg-table-bindings-wrapper
+
+auto-retest:
+- base-branch: 'master'
+
 ci-all-qa-tests:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
### Description

This PR introduces auto-retesting for all PRs targeting master. Previously, this was an opt-in feature, but it will now be automatically enabled for everyone. To opt out of auto-retesting, simply remove the auto-retest label. This change aims to help identify flaky tests and ensure tests pass eventually.

Refs:
- https://github.com/stackrox/stackrox/pull/12074
- https://github.com/stackrox/stackrox/pull/10635
- https://github.com/stackrox/stackrox/pull/10438

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
