### PR TITLE
fix(e2e-tests): Nongroovy e2e tests not running

### DIFF
--- a/make/stackrox.mk
+++ b/make/stackrox.mk
@@ -37,7 +37,7 @@ posttest:
 .PHONY: test-common
 test-common:
 	@echo "+ $@"
-	$(SILENT)$(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v $(shell go list -e ./... | grep -v generated | grep -v vendor) 2>&1 | tee test.log
+	@GOTAGS=$(GOTAGS),test,test_e2e $(SILENT)$(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v $(shell go list -e ./... | grep -v generated | grep -v vendor) 2>&1 | tee test.log
 
 .PHONY: test-integration
 test-integration:

--- a/make/stackrox.mk
+++ b/make/stackrox.mk
@@ -37,7 +37,7 @@ posttest:
 .PHONY: test-common
 test-common:
 	@echo "+ $@"
-	@GOTAGS=$(GOTAGS),test,test_e2e $(SILENT)$(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v $(shell go list -e ./... | grep -v generated | grep -v vendor) 2>&1 | tee test.log
+	$(SILENT)GOTAGS=$(GOTAGS),test,test_e2e $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v $(shell go list -e ./... | grep -v generated | grep -v vendor) 2>&1 | tee test.log
 
 .PHONY: test-integration
 test-integration:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,9 +6,8 @@ TESTFLAGS=-race -p 1 -timeout 30m
 TOPLEVEL=$(CURDIR)/..
 
 .PHONY: all
-all: test
+all: tests
 	@echo "+ $@"
-	@GOTAGS=$(GOTAGS),test,test_e2e ../scripts/go-test.sh -cover -v -run Test 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=all-tests-results
 
 .PHONY: destructive-tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ TESTFLAGS=-race -p 1 -timeout 30m
 TOPLEVEL=$(CURDIR)/..
 
 .PHONY: all
-all: tests
+all: test
 	@echo "+ $@"
 	@$(MAKE) report JUNIT_OUT=all-tests-results
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,23 +8,24 @@ TOPLEVEL=$(CURDIR)/..
 .PHONY: all
 all: test
 	@echo "+ $@"
+	@GOTAGS=$(GOTAGS),test,test_e2e ../scripts/go-test.sh -cover -v -run Test 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=all-tests-results
 
 .PHONY: destructive-tests
 destructive-tests:
 	@echo "+ $@"
-	@GOTAGS=$(GOTAGS),test,test_e2e,destructive ../scripts/go-test.sh -cover -v -run TestClusterDeletion 2>&1 | tee test.log
+	@GOTAGS=$(GOTAGS),test,destructive ../scripts/go-test.sh -cover -v -run TestClusterDeletion 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=destructive-tests-results
 
 .PHONY: external-backup-tests
 external-backup-tests:
 	@echo "+ $@"
-	@GOTAGS=$(GOTAGS),test,test_e2e,externalbackups ../scripts/go-test.sh -cover -v -run TestGCSExternalBackup 2>&1 | tee test.log
+	@GOTAGS=$(GOTAGS),test,externalbackups ../scripts/go-test.sh -cover -v -run TestGCSExternalBackup 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=external-backup-tests-results
 
 .PHONY: compliance-v2-tests
 compliance-v2-tests:
-	@GOTAGS=$(GOTAGS),test,test_e2e,compliance ../scripts/go-test.sh -cover -v -run TestComplianceV2 2>&1 | tee test.log
+	@GOTAGS=$(GOTAGS),test,compliance ../scripts/go-test.sh -cover -v -run TestComplianceV2 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=compliance-v2-tests-results
 
 include ../make/stackrox.mk

--- a/tests/cluster_delete_test.go
+++ b/tests/cluster_delete_test.go
@@ -19,10 +19,6 @@ type allCounts struct {
 	PodCount int
 }
 
-const (
-	timeout = 30 * time.Second
-)
-
 func allIntsZero(ints ...int) bool {
 	for _, i := range ints {
 		if i != 0 {

--- a/tests/cluster_delete_test.go
+++ b/tests/cluster_delete_test.go
@@ -19,6 +19,10 @@ type allCounts struct {
 	PodCount int
 }
 
+const (
+	timeout = 30 * time.Second
+)
+
 func allIntsZero(ints ...int) bool {
 	for _, i := range ints {
 		if i != 0 {

--- a/tests/common.go
+++ b/tests/common.go
@@ -36,6 +36,7 @@ const (
 	expectedLatestTagPolicy = `Latest tag`
 
 	waitTimeout = 5 * time.Minute
+	timeout     = 30 * time.Second
 )
 
 var (

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || sql_integration || compliance
+//go:build test_e2e || sql_integration || compliance || destructive || externalbackups
 
 package tests
 

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -33,7 +33,6 @@ type authMode int
 
 const (
 	dialRetries = 3
-	timeout     = 30 * time.Second
 
 	userPKIProviderName = "test-userpki"
 )


### PR DESCRIPTION
### Description

After introducing //go:build directives in https://github.com/stackrox/stackrox/pull/11933 our e2e tests were not being executed since I had set the go build targets incorrectly. This PR fixes the build targets and go tags for files used by multiple different test targets such as `tests/common.go`

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Looked through CI to confirm that all tests run again
