### PR TITLE
ROX-22359: Try tame Renovate bot's schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+  ],
+  "timezone": "Etc/UTC",
+  "schedule": [
+    "after 3am and before 7am"
+  ],
+  "dockerfile": {
+    "fileMatch": [
+      "(^|\\/)konflux\\.([Dd]ocker|[Cc]ontainer)file$"
+    ]
+  }
+}


### PR DESCRIPTION
### Description

I was hoping to reduce the updates frequency by the renovate bot with <https://github.com/stackrox/stackrox/pull/12160> but this apparently did not have an effect as proved by updates arriving at <https://github.com/stackrox/stackrox/pull/12191> during EU working hours.

Remembering [this message](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721811188524519?thread_ts=1721809083.784519&cid=C04PZ7H0VA8), I'm trying to move config to `renovate.json` in the root of the repo.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [ ] inspected CI results

#### Automated testing

No.

#### How I validated my change

Ran config validator:
```
$ docker run --rm -it --entrypoint=/usr/local/bin/renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
 INFO: Validating renovate.json
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```

Can only observe any behavior changes after it's merged. Plan doing so.