### PR TITLE
fix(ui): Specify accessible name of Network Graph side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -181,19 +181,16 @@ const TopologyComponent = ({
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
 
-    // id prop of headings in child components correspond to aria-labelledby prop of TopologySideBar
+    const labelledById = 'TopologySideBarLabelledBy';
     return (
         <TopologyView
             sideBar={
-                <TopologySideBar
-                    aria-labelledby="TopologySideBarLabelledBy"
-                    resizable
-                    onClose={closeSidebar}
-                >
+                <TopologySideBar aria-labelledby={labelledById} resizable onClose={closeSidebar}>
                     {hasReadAccessForNetworkPolicy &&
                         simulation.isOn &&
                         simulation.type === 'networkPolicy' && (
                             <NetworkPolicySimulatorSidePanel
+                                labelledById={labelledById}
                                 simulator={simulator}
                                 setNetworkPolicyModification={setNetworkPolicyModification}
                                 scopeHierarchy={scopeHierarchy}
@@ -202,6 +199,7 @@ const TopologyComponent = ({
                         )}
                     {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (
                         <NamespaceSideBar
+                            labelledById={labelledById}
                             namespaceId={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
@@ -210,6 +208,7 @@ const TopologyComponent = ({
                     )}
                     {selectedNode && selectedNode?.data?.type === 'DEPLOYMENT' && (
                         <DeploymentSideBar
+                            labelledById={labelledById}
                             deploymentId={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
@@ -220,6 +219,7 @@ const TopologyComponent = ({
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (
                         <ExternalGroupSideBar
+                            labelledById={labelledById}
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
@@ -228,6 +228,7 @@ const TopologyComponent = ({
                     )}
                     {selectedNode && isNodeOfType('CIDR_BLOCK', selectedNode) && (
                         <GenericEntitiesSideBar
+                            labelledById={labelledById}
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
@@ -239,6 +240,7 @@ const TopologyComponent = ({
                     )}
                     {selectedNode && isNodeOfType('EXTERNAL_ENTITIES', selectedNode) && (
                         <GenericEntitiesSideBar
+                            labelledById={labelledById}
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
@@ -250,6 +252,7 @@ const TopologyComponent = ({
                     )}
                     {selectedNode && isNodeOfType('INTERNAL_ENTITIES', selectedNode) && (
                         <GenericEntitiesSideBar
+                            labelledById={labelledById}
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -181,10 +181,15 @@ const TopologyComponent = ({
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
 
+    // id prop of headings in child components correspond to aria-labelledby prop of TopologySideBar
     return (
         <TopologyView
             sideBar={
-                <TopologySideBar resizable onClose={closeSidebar}>
+                <TopologySideBar
+                    aria-labelledby="TopologySideBarLabelledBy"
+                    resizable
+                    onClose={closeSidebar}
+                >
                     {hasReadAccessForNetworkPolicy &&
                         simulation.isOn &&
                         simulation.type === 'networkPolicy' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -42,6 +42,7 @@ const sidebarHeadingStyleConstant = {
 } as CSSProperties;
 
 type DeploymentSideBarProps = {
+    labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
     deploymentId: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
@@ -51,6 +52,7 @@ type DeploymentSideBarProps = {
 };
 
 function DeploymentSideBar({
+    labelledById,
     deploymentId,
     nodes,
     edges,
@@ -132,7 +134,6 @@ function DeploymentSideBar({
         );
     }
 
-    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -143,7 +144,7 @@ function DeploymentSideBar({
                     <FlexItem>
                         <Title
                             headingLevel="h2"
-                            id="TopologySideBarLabelledBy"
+                            id={labelledById}
                             className="pf-v5-u-max-width"
                             style={sidebarHeadingStyleConstant}
                             data-testid="drawer-title"

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -13,8 +13,7 @@ import {
     Tabs,
     TabTitleText,
     Text,
-    TextContent,
-    TextVariants,
+    Title,
 } from '@patternfly/react-core';
 
 import useTabs from 'hooks/patternfly/useTabs';
@@ -133,6 +132,7 @@ function DeploymentSideBar({
         );
     }
 
+    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -141,25 +141,21 @@ function DeploymentSideBar({
                         <DeploymentIcon />
                     </FlexItem>
                     <FlexItem>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h1}
-                                className="pf-v5-u-font-size-xl pf-v5-u-max-width"
-                                style={sidebarHeadingStyleConstant}
-                                data-testid="drawer-title"
-                            >
-                                {deployment?.name}
-                            </Text>
-                        </TextContent>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h2}
-                                className="pf-v5-u-font-size-sm pf-v5-u-color-200"
-                                data-testid="drawer-subtitle"
-                            >
-                                in &quot;{deployment?.clusterName} / {deployment?.namespace}&quot;
-                            </Text>
-                        </TextContent>
+                        <Title
+                            headingLevel="h2"
+                            id="TopologySideBarLabelledBy"
+                            className="pf-v5-u-max-width"
+                            style={sidebarHeadingStyleConstant}
+                            data-testid="drawer-title"
+                        >
+                            {deployment?.name}
+                        </Title>
+                        <Text
+                            className="pf-v5-u-font-size-sm pf-v5-u-color-200"
+                            data-testid="drawer-subtitle"
+                        >
+                            in &quot;{deployment?.clusterName} / {deployment?.namespace}&quot;
+                        </Text>
                     </FlexItem>
                 </Flex>
             </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -28,6 +28,7 @@ import { CidrBlockIcon, ExternalEntitiesIcon } from '../common/NetworkGraphIcons
 import EntityNameSearchInput from '../common/EntityNameSearchInput';
 
 type ExternalGroupSideBarProps = {
+    labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
     id: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
@@ -42,6 +43,7 @@ const columnNames = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ExternalGroupSideBar({
+    labelledById,
     id,
     nodes,
     edges,
@@ -70,13 +72,12 @@ function ExternalGroupSideBar({
           })
         : externalNodes;
 
-    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
                 <Flex direction={{ default: 'row' }} className="pf-v5-u-p-md pf-v5-u-mb-0">
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             {externalGroupNode?.label}
                         </Title>
                         <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -7,8 +7,7 @@ import {
     Stack,
     StackItem,
     Text,
-    TextContent,
-    TextVariants,
+    Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
@@ -71,24 +70,18 @@ function ExternalGroupSideBar({
           })
         : externalNodes;
 
+    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
                 <Flex direction={{ default: 'row' }} className="pf-v5-u-p-md pf-v5-u-mb-0">
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h2} className="pf-v5-u-font-size-xl">
-                                {externalGroupNode?.label}
-                            </Text>
-                        </TextContent>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h3}
-                                className="pf-v5-u-font-size-sm pf-v5-u-color-200"
-                            >
-                                Connected entities outside your cluster
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            {externalGroupNode?.label}
+                        </Title>
+                        <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">
+                            Connected entities outside your cluster
+                        </Text>
                     </FlexItem>
                 </Flex>
             </StackItem>
@@ -110,11 +103,9 @@ function ExternalGroupSideBar({
                         <Toolbar className="pf-v5-u-p-0">
                             <ToolbarContent className="pf-v5-u-px-0">
                                 <ToolbarItem>
-                                    <TextContent>
-                                        <Text component={TextVariants.h3}>
-                                            {filteredExternalNodes.length} results found
-                                        </Text>
-                                    </TextContent>
+                                    <Title headingLevel="h3">
+                                        {filteredExternalNodes.length} results found
+                                    </Title>
                                 </ToolbarItem>
                             </ToolbarContent>
                         </Toolbar>

--- a/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
@@ -30,6 +30,7 @@ import FlowsTable from '../common/FlowsTable';
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
 
 export type GenericEntitiesSideBarProps = {
+    labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
     id: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
@@ -40,6 +41,7 @@ export type GenericEntitiesSideBarProps = {
 };
 
 function GenericEntitiesSideBar({
+    labelledById,
     id,
     nodes,
     edges,
@@ -68,14 +70,13 @@ function GenericEntitiesSideBar({
         onNodeSelect(entityId);
     };
 
-    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
                 <Flex direction={{ default: 'row' }} className="pf-v5-u-p-md pf-v5-u-mb-0">
                     <FlexItem>{EntityHeaderIcon}</FlexItem>
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             {entityNode?.label}
                         </Title>
                         <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">

--- a/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
@@ -6,8 +6,7 @@ import {
     Stack,
     StackItem,
     Text,
-    TextContent,
-    TextVariants,
+    Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
@@ -69,25 +68,19 @@ function GenericEntitiesSideBar({
         onNodeSelect(entityId);
     };
 
+    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
                 <Flex direction={{ default: 'row' }} className="pf-v5-u-p-md pf-v5-u-mb-0">
                     <FlexItem>{EntityHeaderIcon}</FlexItem>
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h1} className="pf-v5-u-font-size-xl">
-                                {entityNode?.label}
-                            </Text>
-                        </TextContent>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h2}
-                                className="pf-v5-u-font-size-sm pf-v5-u-color-200"
-                            >
-                                {sidebarTitle}
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            {entityNode?.label}
+                        </Title>
+                        <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">
+                            {sidebarTitle}
+                        </Text>
                     </FlexItem>
                 </Flex>
             </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -9,8 +9,7 @@ import {
     Tabs,
     TabTitleText,
     Text,
-    TextContent,
-    TextVariants,
+    Title,
 } from '@patternfly/react-core';
 import uniq from 'lodash/uniq';
 
@@ -58,6 +57,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
     }, [] as string[]);
     const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);
 
+    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -66,21 +66,14 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                         <NamespaceIcon />
                     </FlexItem>
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h1} className="pf-v5-u-font-size-xl">
-                                {namespaceNode?.label}
-                            </Text>
-                        </TextContent>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h2}
-                                className="pf-v5-u-font-size-sm pf-v5-u-color-200"
-                            >
-                                in &quot;
-                                {cluster}
-                                &quot;
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            {namespaceNode?.label}
+                        </Title>
+                        <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">
+                            in &quot;
+                            {cluster}
+                            &quot;
+                        </Text>
                     </FlexItem>
                 </Flex>
             </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -26,13 +26,20 @@ import NamespaceDeployments from './NamespaceDeployments';
 import NetworkPolicies from '../common/NetworkPolicies';
 
 type NamespaceSideBarProps = {
+    labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
     namespaceId: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
     onNodeSelect: (id: string) => void;
 };
 
-function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: NamespaceSideBarProps) {
+function NamespaceSideBar({
+    labelledById,
+    namespaceId,
+    nodes,
+    edges,
+    onNodeSelect,
+}: NamespaceSideBarProps) {
     // component state
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: 'Deployments',
@@ -57,7 +64,6 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
     }, [] as string[]);
     const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);
 
-    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -66,7 +72,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                         <NamespaceIcon />
                     </FlexItem>
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             {namespaceNode?.label}
                         </Title>
                         <Text className="pf-v5-u-font-size-sm pf-v5-u-color-200">

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -17,8 +17,6 @@ import {
     Tabs,
     TabTitleText,
     Text,
-    TextContent,
-    TextVariants,
     Title,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
@@ -182,12 +180,14 @@ function NetworkPolicySimulatorSidePanel({
     }
 
     if (simulator.state === 'GENERATED') {
+        // Actioms: Rebuild rules from active traffic
         const currentPolicies = currentNetworkPolicies ?? [];
         const currentYaml =
             currentPolicies.length === 0
                 ? 'No network policies exist in the current scope'
                 : currentPolicies.map((policy) => policy.yaml).join('\n---\n');
         const generatedYaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
+        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -196,12 +196,10 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-md pf-v5-u-pb-sm pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h2}>Generated network policies</Text>
-                            <Text component={TextVariants.h3} className="pf-v5-u-m-0">
-                                Scope of baseline:
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            Generated network policies
+                        </Title>
+                        <Text className="pf-v5-u-font-weight-bold">Scope of baseline:</Text>
                     </FlexItem>
                     <NetworkPoliciesGenerationScope
                         scopeHierarchy={scopeHierarchy}
@@ -283,7 +281,9 @@ function NetworkPolicySimulatorSidePanel({
 
     // @TODO: Consider how to reuse parts of this that are similar between states
     if (simulator.state === 'UNDO') {
+        // Actions: Revert rules to previously applied YAML
         const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
+        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -292,11 +292,9 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-lg pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h2} className="pf-v5-u-font-size-xl">
-                                Network Policy Simulator
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            Network policy simulator
+                        </Title>
                     </FlexItem>
                 </Flex>
                 <Divider component="div" />
@@ -338,6 +336,7 @@ function NetworkPolicySimulatorSidePanel({
 
     if (simulator.state === 'UPLOAD') {
         const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
+        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -346,11 +345,9 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-lg pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <TextContent>
-                            <Text component={TextVariants.h2} className="pf-v5-u-font-size-xl">
-                                Network Policy Simulator
-                            </Text>
-                        </TextContent>
+                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                            Network policy simulator
+                        </Title>
                     </FlexItem>
                 </Flex>
                 <Divider component="div" />
@@ -388,6 +385,7 @@ function NetworkPolicySimulatorSidePanel({
         );
     }
 
+    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -396,12 +394,10 @@ function NetworkPolicySimulatorSidePanel({
                     spaceItems={{ default: 'spaceItemsSm' }}
                     className="pf-v5-u-p-md pf-v5-u-pb-sm pf-v5-u-mb-0"
                 >
-                    <TextContent>
-                        <Text component={TextVariants.h2}>Generate network policies</Text>
-                        <Text component={TextVariants.h3} className="pf-v5-u-m-0">
-                            Scope of baseline:
-                        </Text>
-                    </TextContent>
+                    <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        Generate network policies
+                    </Title>
+                    <Text className="pf-v5-u-font-weight-bold">Scope of baseline:</Text>
                     <NetworkPoliciesGenerationScope
                         scopeHierarchy={scopeHierarchy}
                         scopeDeploymentCount={scopeDeploymentCount}
@@ -433,24 +429,17 @@ function NetworkPolicySimulatorSidePanel({
                             <StackItem>
                                 <Stack hasGutter>
                                     <StackItem>
-                                        <TextContent>
-                                            <Text
-                                                component={TextVariants.h2}
-                                                className="pf-v5-u-font-size-lg"
-                                            >
-                                                Generate network policies from the traffic
-                                            </Text>
-                                        </TextContent>
+                                        <Title headingLevel="h3">
+                                            Generate network policies from the traffic
+                                        </Title>
                                     </StackItem>
                                     <StackItem>
-                                        <TextContent>
-                                            <Text component={TextVariants.p}>
-                                                Generate a set of recommended network policies based
-                                                on your cluster&apos;s traffic. Only deployments
-                                                that are part of the current scope will be included
-                                                in generated policies.
-                                            </Text>
-                                        </TextContent>
+                                        <Text>
+                                            Generate a set of recommended network policies based on
+                                            your cluster&apos;s traffic. Only deployments that are
+                                            part of the current scope will be included in generated
+                                            policies.
+                                        </Text>
                                     </StackItem>
                                     <StackItem>
                                         <Checkbox
@@ -479,24 +468,17 @@ function NetworkPolicySimulatorSidePanel({
                             <StackItem>
                                 <Stack hasGutter>
                                     <StackItem>
-                                        <TextContent>
-                                            <Text
-                                                component={TextVariants.h2}
-                                                className="pf-v5-u-font-size-lg"
-                                            >
-                                                Upload a network policy YAML
-                                            </Text>
-                                        </TextContent>
+                                        <Title headingLevel="h3">
+                                            Upload a network policy YAML
+                                        </Title>
                                     </StackItem>
                                     <StackItem>
-                                        <TextContent>
-                                            <Text component={TextVariants.p}>
-                                                Upload your network policies to quickly preview your
-                                                environment under different policy configurations
-                                                and time windows. When ready, apply the network
-                                                policies directly or share them with your team.
-                                            </Text>
-                                        </TextContent>
+                                        <Text>
+                                            Upload your network policies to quickly preview your
+                                            environment under different policy configurations and
+                                            time windows. When ready, apply the network policies
+                                            directly or share them with your team.
+                                        </Text>
                                     </StackItem>
                                     <StackItem>
                                         <UploadYAMLButton

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -180,7 +180,7 @@ function NetworkPolicySimulatorSidePanel({
     }
 
     if (simulator.state === 'GENERATED') {
-        // Actioms: Rebuild rules from active traffic
+        // Actions: Rebuild rules from active traffic
         const currentPolicies = currentNetworkPolicies ?? [];
         const currentYaml =
             currentPolicies.length === 0

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -58,6 +58,7 @@ export function clearSimulationQuery(search: string): string {
 }
 
 export type NetworkPolicySimulatorSidePanelProps = {
+    labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
     /** scopeHierarchy is the user's selected scope for the network graph */
@@ -71,6 +72,7 @@ const tabs = {
 }; // space in visible text, but id has underscore!
 
 function NetworkPolicySimulatorSidePanel({
+    labelledById,
     simulator,
     setNetworkPolicyModification,
     scopeHierarchy,
@@ -187,7 +189,6 @@ function NetworkPolicySimulatorSidePanel({
                 ? 'No network policies exist in the current scope'
                 : currentPolicies.map((policy) => policy.yaml).join('\n---\n');
         const generatedYaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
-        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -196,7 +197,7 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-md pf-v5-u-pb-sm pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             Generated network policies
                         </Title>
                         <Text className="pf-v5-u-font-weight-bold">Scope of baseline:</Text>
@@ -283,7 +284,6 @@ function NetworkPolicySimulatorSidePanel({
     if (simulator.state === 'UNDO') {
         // Actions: Revert rules to previously applied YAML
         const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
-        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -292,7 +292,7 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-lg pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             Network policy simulator
                         </Title>
                     </FlexItem>
@@ -336,7 +336,6 @@ function NetworkPolicySimulatorSidePanel({
 
     if (simulator.state === 'UPLOAD') {
         const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
-        // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
         return (
             <div>
                 <Flex
@@ -345,7 +344,7 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-v5-u-p-lg pf-v5-u-mb-0"
                 >
                     <FlexItem>
-                        <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                        <Title headingLevel="h2" id={labelledById}>
                             Network policy simulator
                         </Title>
                     </FlexItem>
@@ -385,7 +384,6 @@ function NetworkPolicySimulatorSidePanel({
         );
     }
 
-    // id prop of heading corresponds to aria-labelledby prop of TopologySideBar
     return (
         <Stack>
             <StackItem>
@@ -394,7 +392,7 @@ function NetworkPolicySimulatorSidePanel({
                     spaceItems={{ default: 'spaceItemsSm' }}
                     className="pf-v5-u-p-md pf-v5-u-pb-sm pf-v5-u-mb-0"
                 >
-                    <Title headingLevel="h2" id="TopologySideBarLabelledBy">
+                    <Title headingLevel="h2" id={labelledById}>
                         Generate network policies
                     </Title>
                     <Text className="pf-v5-u-font-weight-bold">Scope of baseline:</Text>


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> ARIA dialog and alertdialog nodes should have an accessible name

```html
<div role="dialog" class="pf-topology-resizable-side-bar">
```

To solve this problem, you need to fix at least (1) of the following:
* aria-label attribute does not exist or is empty
* aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
* Element has no title attribute

https://dequeuniversity.com/rules/axe/4.9/aria-dialog-name?application=AxeChrome

### Analysis

`TopologySideBar` element renders the HTML element above.
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx#L187-L257

It renders any of the following children which have headings for an accessible name.
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
* https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx

### Solution

1. Add `aria-labelledby="TopologySideBarLabelledBy"` prop to `TopologySideBar` element.
2. Add `id="TopologySideBarLabelledBy"` prop to heading in each of the children elements.
    * Also replace `Text` with `Title` element for headings because more mnemonic.
    * Also replace some occurrences of `h1` with `h2` element for consistency.
    * Also replace some occurrences of lower headings that do not represent page structure. That is, which might impede navigation by users of screen readers.
    * Also reduce `TextContent` and `TextVariants` to increase readability.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing

- [ ] inspected CI results

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4615317 - 4615317
        total -564 = 11700900 - 11701464
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui/apps/platform

### Manual testing

1. Visit /main/network-graph, select cluster and namespace, and then click **Network policy generator**

    * Before changes, see presence of accessibility issues.
        ![NetworkPolicySimulatorSidePanel_with_issue](https://github.com/user-attachments/assets/1848a737-07f5-4c99-ba2f-41df3ee5c73c)

    * After changes, see absence of accessibility issues.
        ![NetworkPolicySimulatorSidePanel_without_issue](https://github.com/user-attachments/assets/913fc43b-d808-4df2-abfb-84c18b09e534)

2. Click a namespace in the graph.

    * Before changes, see presence of accessibility issues.
        ![NamespaceSideBar_with_issue](https://github.com/user-attachments/assets/97f11495-5aeb-4b3d-98c0-12a5c166d617)

    * After changes, see absence of accessibility issues.
        ![NamespaceSideBar_without_issue](https://github.com/user-attachments/assets/f3933b79-91b3-457f-99f8-ab8a83811e9b)

3. Click a deployment in the graph.

    * Before changes, see presence of accessibility issues.
        ![DeploymentSideBar_with_issue](https://github.com/user-attachments/assets/30f4ee77-8ac1-4129-862a-47e9dcbe5555)

    * After changes, see absence of accessibility issues.
        ![DeploymentSideBar_without_issue](https://github.com/user-attachments/assets/4de909e5-077b-4353-ae7d-6d64cdc516e1)

4. Click an external entity group in the graph.

    * Before changes, see presence of accessibility issues.
        ![ExternalGroupSideBar_with_issue](https://github.com/user-attachments/assets/1d511c86-ed1e-4266-8c9f-ce275897a5b2)

    * After changes, see absence of accessibility issues.
        ![ExternalGroupSideBar_without_issue](https://github.com/user-attachments/assets/dbe4a46f-29c0-462d-b4c6-e97f6e548c74)

5. Click internal entities in the graph

    * Before changes, see presence of accessibility issues.
        ![GenericEntitiesSideBar_with_issue](https://github.com/user-attachments/assets/057effcd-908d-467d-ad04-4a28e20fe8e5)

    * After changes, see absence of accessibility issues.
        ![GenericEntitiesSideBar_without_issue](https://github.com/user-attachments/assets/e05f4de9-ba48-457d-bc3d-164bf9d7af30)

### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js
