### PR TITLE
feat(local-sensor): Only create real k8s client when needed

### DIFF
--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -256,7 +256,6 @@ func main() {
 		metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 	}
 	var k8sClient client.Interface
-	k8sClient, err := k8s.MakeOutOfClusterClient()
 	// when replying a trace, there is no need to connect to K8s cluster
 	if localConfig.ReplayK8sEnabled {
 		k8sClient = k8s.MakeFakeClient()
@@ -268,7 +267,11 @@ func main() {
 			WithWorkloadFile(localConfig.FakeWorkloadFile))
 		k8sClient = workloadManager.Client()
 	}
-	utils.CrashOnError(err)
+	if k8sClient == nil {
+		var err error
+		k8sClient, err = k8s.MakeOutOfClusterClient()
+		utils.CrashOnError(err)
+	}
 	if !localConfig.NoCPUProfile {
 		f, err := os.Create(fmt.Sprintf("local-sensor-cpu-%s.prof", time.Now().UTC().Format(time.RFC3339)))
 		if err != nil {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Right now `local-sensor` always tries to create a real k8s client even if a fake client is configured. This is a problem because forces the user to have a cluster even if they don't intent to use it. This PR fixes this issue by only creating the real k8s client if the fake client was not configured previously.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~[ ] added unit tests~
- ~[ ] added e2e tests~
- ~[ ] added regression tests~
- ~[ ] added compatibility tests~
- ~[ ] modified existing tests~

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Run `local-sensor` without a real cluster configured.
