### PR TITLE
chore: Limit Renovate focus to Konflux things

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,5 +27,12 @@
       // See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721809083784519
       "(^|\\/)konflux\\.([Dd]ocker|[Cc]ontainer)file$"
     ]
-  }
+  },
+  "enabledManagers": [
+    // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
+    "tekton",
+    "dockerfile",
+    // It's unclear what does rpm manager provide but let's have it enabled and see what PRs we get.
+    "rpm",
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,5 @@
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
     "dockerfile",
-    // It's unclear what does rpm manager provide but let's have it enabled and see what PRs we get.
-    "rpm",
   ],
 }


### PR DESCRIPTION
### Description

This is to have less noise from Konflux.

See https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1722013572686099 related.

The default active list of managers from our config was
```yaml
    "enabledManagers": [
      "tekton",
      "dockerfile",
      "rpm",
      "git-submodules",
      "custom.regex",
      "argocd",
      "crossplane",
      "fleet",
      "flux",
      "helm-requirements",
      "helm-values",
      "helmfile",
      "helmsman",
      "helmv3",
      "jsonnet-bundler",
      "kubernetes",
      "kustomize"
    ],
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No auto-tests.

#### How I validated my change

Ran validator.