### PR TITLE
ROX-22359: Disable Renovate's `updateNotScheduled`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,8 @@
     // that.
     "after 3am and before 7am"
   ],
+  // Tell Renovate not to update PRs when outside of schedule.
+  "updateNotScheduled": false,
   "dockerfile": {
     "fileMatch": [
       // Instruct Renovate not try to update Dockerfiles other than */konflux.Dockerfile to have less PR noise.


### PR DESCRIPTION
### Description

I hope this will finally help.

https://docs.renovatebot.com/configuration-options/#updatenotscheduled

Context: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1722589342564299?thread_ts=1721809083.784519&cid=C04PZ7H0VA8

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No automated testing. I start thinking we may include Renovate config validation to CI but the problem is that the container is pulled from DockerHub which may start throttling us.

#### How I validated my change

Only validated.