### PR TITLE
chore(proto): switch from Size() to SizeVT()

### DIFF
--- a/central/blob/datastore/datastore.go
+++ b/central/blob/datastore/datastore.go
@@ -82,7 +82,7 @@ func (d *datastoreImpl) GetBlobWithDataInBuffer(ctx context.Context, name string
 
 	blob, exists, err := d.store.Get(ctx, name, buf)
 	if blob.GetLength() > int64(bufferedBlobDataLimitInBytes) {
-		utils.Should(fmt.Errorf("blob %s has %d in length which is beyond buffer limit %d", name, blob.Size(), bufferedBlobDataLimitInBytes))
+		utils.Should(fmt.Errorf("blob %s has %d in length which is beyond buffer limit %d", name, blob.SizeVT(), bufferedBlobDataLimitInBytes))
 	}
 	return buf, blob, exists, err
 }

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -204,7 +204,7 @@ func (c *sensorConnection) runRecv(ctx context.Context, grpcServer central.Senso
 			c.stopSig.SignalWithError(errors.Wrap(err, "recv error"))
 			return
 		}
-		metrics.SetGRPCLastMessageSizeReceived(getSensorMessageTypeString(msg), float64(msg.Size()))
+		metrics.SetGRPCLastMessageSizeReceived(getSensorMessageTypeString(msg), float64(msg.SizeVT()))
 		c.multiplexedPush(ctx, msg, queues)
 	}
 }
@@ -805,7 +805,7 @@ func (c *sensorConnection) sendDeduperState(server central.SensorService_Communi
 		},
 	}}
 
-	log.Infof("Sending %d hashes (Size=%d), current chunk: %d, total: %d", len(payload), deduperMessage.Size(), current, total)
+	log.Infof("Sending %d hashes (Size=%d), current chunk: %d, total: %d", len(payload), deduperMessage.SizeVT(), current, total)
 
 	err := server.Send(deduperMessage)
 	if err != nil {

--- a/central/sensor/service/connection/messagestream/sizing_events.go
+++ b/central/sensor/service/connection/messagestream/sizing_events.go
@@ -15,9 +15,9 @@ type sizingEventStream struct {
 
 func (s *sizingEventStream) Send(msg *central.MsgToSensor) error {
 	typ := reflectutils.Type(msg.GetMsg())
-	gaugeValue := math.Max(s.maxSeen[typ], float64(msg.Size()))
-	metrics.ObserveSentSize(typ, float64(msg.Size()))
-	metrics.SetGRPCLastMessageSizeGauge(typ, float64(msg.Size()))
+	gaugeValue := math.Max(s.maxSeen[typ], float64(msg.SizeVT()))
+	metrics.ObserveSentSize(typ, float64(msg.SizeVT()))
+	metrics.SetGRPCLastMessageSizeGauge(typ, float64(msg.SizeVT()))
 	metrics.SetGRPCMaxMessageSizeGauge(typ, gaugeValue)
 	s.maxSeen[typ] = gaugeValue
 	return s.stream.Send(msg)

--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -173,7 +173,7 @@ func ObserveScansTotal(nodeName string) {
 func ObserveInventoryProtobufMessage(cmsg *sensor.MsgFromCompliance) {
 	protobufMessageSize.With(prometheus.Labels{
 		"node_name": cmsg.GetNode(),
-	}).Observe(float64(cmsg.Size()))
+	}).Observe(float64(cmsg.SizeVT()))
 }
 
 // InventoryTransmission names the way in which a NodeInventory was obtained

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -103,7 +103,7 @@ type manager struct {
 // NewManager creates a new manager
 func NewManager(namespace string, maxImageCacheSize int64, imageServiceClient sensor.ImageServiceClient, deploymentServiceClient sensor.DeploymentServiceClient) *manager {
 	cache, err := sizeboundedcache.New(maxImageCacheSize, 2*size.MB, func(key string, value imageCacheEntry) int64 {
-		return int64(len(key) + value.Size())
+		return int64(len(key) + value.SizeVT())
 	})
 	utils.CrashOnError(err)
 

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -65,7 +65,7 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 		log.Infof("Adding %d events as unchanged to sync event", len(d.unchangedIDs))
 		resourcesSynced.UnchangedIds = d.unchangedIDs.AsSlice()
 		metrics.IncrementTotalResourcesSyncSent(len(d.unchangedIDs))
-		metrics.SetResourcesSyncedSize(msg.Size())
+		metrics.SetResourcesSyncedSize(msg.SizeVT())
 	}
 
 	// This filter works around race conditions in which image integrations may be initialized prior to CentralHello being received

--- a/sensor/common/metrics/sizing_events.go
+++ b/sensor/common/metrics/sizing_events.go
@@ -23,7 +23,7 @@ func (s *sizingEventStream) incrementMetric(msg *central.MsgFromSensor) {
 	}
 	messageType = s.metricKey(messageType, eventType)
 
-	messageSize := float64(msg.Size())
+	messageSize := float64(msg.SizeVT())
 	labels := prometheus.Labels{
 		"Type": messageType,
 	}

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -325,7 +325,7 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 			return errors.Wrapf(errIncorrectDeduperStateOrder, "expected message number %d but received %d", current, msg.GetDeduperState().GetCurrent())
 		}
 
-		log.Infof("Received %d hashes (size=%d), current chunk: %d, total: %d", len(msg.GetDeduperState().GetResourceHashes()), msg.Size(), msg.GetDeduperState().GetCurrent(), msg.GetDeduperState().GetTotal())
+		log.Infof("Received %d hashes (size=%d), current chunk: %d, total: %d", len(msg.GetDeduperState().GetResourceHashes()), msg.SizeVT(), msg.GetDeduperState().GetCurrent(), msg.GetDeduperState().GetTotal())
 		for k, v := range msg.GetDeduperState().GetResourceHashes() {
 			deduperState[k] = v
 		}

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -187,7 +187,7 @@ func (n *networkPolicyStoreImpl) Find(namespace string, podLabels map[string]str
 	// Apparently 'labels.MatchLabels' does not cover this corner case
 	if len(podLabels) == 0 {
 		for id, policy := range nsPolicies {
-			if policy.GetSpec().GetPodSelector().Size() == 0 {
+			if policy.GetSpec().GetPodSelector().SizeVT() == 0 {
 				results[id] = policy
 			}
 		}

--- a/sensor/tests/helper/trace.go
+++ b/sensor/tests/helper/trace.go
@@ -35,7 +35,7 @@ func (tr *NetworkFlowTraceWriter) Write(data []byte) (int, error) {
 	case <-tr.ctx.Done():
 		return 0, errors.New("Context done")
 	case tr.messageC <- message:
-		return message.Size(), nil
+		return message.SizeVT(), nil
 	}
 }
 
@@ -66,6 +66,6 @@ func (tr *ProcessIndicatorTraceWriter) Write(data []byte) (int, error) {
 	case <-tr.ctx.Done():
 		return 0, errors.New("Context done")
 	case tr.messageC <- message:
-		return message.Size(), nil
+		return message.SizeVT(), nil
 	}
 }


### PR DESCRIPTION
### Description

To remove proto compat generator we need to remove all wrapper methods references. This PR removes `Size` in favour to `SizeVT`

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
