### PR TITLE
ROX-22359: Stop renovating Dockerfiles other than Konflux ones

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,11 +24,11 @@
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
   "dockerfile": {
-    "fileMatch": [
+    "includePaths": [
       // Instruct Renovate not try to update Dockerfiles other than */konflux.Dockerfile to have less PR noise.
       // See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721809083784519
-      "(^|\\/)konflux\\.([Dd]ocker|[Cc]ontainer)file$"
-    ]
+      "**/konflux.*Dockerfile",
+    ],
   },
   "enabledManagers": [
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,8 +25,8 @@
   "updateNotScheduled": false,
   "dockerfile": {
     "includePaths": [
-      // Instruct Renovate not try to update Dockerfiles other than */konflux.Dockerfile to have less PR noise.
-      // See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721809083784519
+      // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)
+      // to have less PR noise.
       "**/konflux.*Dockerfile",
     ],
   },


### PR DESCRIPTION
### Description

I.e. these ones must not be created https://github.com/stackrox/stackrox/pull/12271, https://github.com/stackrox/stackrox/pull/12272.

Use [includePaths](https://docs.renovatebot.com/configuration-options/#includepaths) instead of [fileMatch](https://docs.renovatebot.com/configuration-options/#filematch) since the former one is not set in parent configs.

Context: https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1722842262116049?thread_ts=1722013572.686099&cid=C05TS9N0S7L

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No automated tests.

#### How I validated my change

Ran validator.