### PR TITLE
ROX-25673: Remove SA token namespace usage in favor of POD_NAMESPACE

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -84,6 +84,10 @@ spec:
             valueFrom:
               resourceFieldRef:
                 resource: limits.cpu
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: ROX_SENSOR_ENDPOINT
             value: {{ ._rox.sensor.endpoint }}
           {{- include "srox.envVars" (list . "deployment" "admission-controller" "admission-controller") | nindent 10 }}

--- a/pkg/pods/namespace.go
+++ b/pkg/pods/namespace.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/namespaces"
-	"github.com/stackrox/rox/pkg/satoken"
 )
 
 var (
@@ -14,44 +13,14 @@ var (
 
 const (
 	// The corresponding environment variable is configured to contain pod namespace by sensor YAML/helm file using
-	// the Kubernetes Downward API.
+	// the Kubernetes Downward API, see
+	// https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/downward-api.md
 	nsEnvVar = "POD_NAMESPACE"
 )
 
-type HeuristicType int
-
-const (
-	// NoSATokenNamespace is the default option. It does *not* read the SAToken
-	// file. For more information on why this mechanism is the default, see
-	//     https://issues.redhat.com/browse/ROX-12349
-	NoSATokenNamespace HeuristicType = iota
-	// ConsiderSATokenNamespace switches the legacy mechanism which first reads the
-	// SAToken file namespace. While this mechanism works _most_ of the time, on
-	// our CI runners we saw the service account namespace set to `ci-op-<HASH`,
-	// see this for more information
-	//     https://github.com/openshift/ci-operator/blob/master/TEMPLATES.md
-	//
-	// This options is kept for now to avoid unexpected side effects but we aim
-	// to remove it in the future once we ensure that the POD_NAMESPACE env var
-	// is set correctly via the Kubernetes Downward API for all our pods, see
-	//     https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/downward-api.md
-	ConsiderSATokenNamespace
-)
-
-// GetPodNamespace is a heuristic to determine in which namespace a given Pod runs.
-func GetPodNamespace(heuristic HeuristicType) string {
-	var sensorNamespace string
-	if heuristic == ConsiderSATokenNamespace {
-		var err error
-		sensorNamespace, err = satoken.LoadNamespaceFromFile()
-		if err != nil {
-			log.Errorf("Failed to determine namespace from service account token file: %s", err)
-		}
-	}
-
-	if sensorNamespace == "" {
-		sensorNamespace = os.Getenv(nsEnvVar)
-	}
+// GetPodNamespace is a heuristic to determine in what namespace a given Pod runs.
+func GetPodNamespace() string {
+	sensorNamespace := os.Getenv(nsEnvVar)
 
 	if sensorNamespace == "" {
 		sensorNamespace = namespaces.StackRox

--- a/pkg/pods/namespace.go
+++ b/pkg/pods/namespace.go
@@ -18,7 +18,13 @@ const (
 	nsEnvVar = "POD_NAMESPACE"
 )
 
-// GetPodNamespace is a heuristic to determine in what namespace a given Pod runs.
+// GetPodNamespace is a heuristic to determine in what namespace a given pod
+// runs. It relies on the POD_NAMESPACE env var being correctly set. For more
+// information on why this mechanism is the default, see
+//     https://issues.redhat.com/browse/ROX-12349
+//
+// We don't read the SAToken file anymore because it sometimes lies, see
+//     https://github.com/openshift/ci-operator/blob/master/TEMPLATES.md
 func GetPodNamespace() string {
 	sensorNamespace := os.Getenv(nsEnvVar)
 

--- a/pkg/pods/namespace.go
+++ b/pkg/pods/namespace.go
@@ -21,10 +21,10 @@ const (
 // GetPodNamespace is a heuristic to determine in what namespace a given pod
 // runs. It relies on the POD_NAMESPACE env var being correctly set. For more
 // information on why this mechanism is the default, see
-//     https://issues.redhat.com/browse/ROX-12349
+// https://issues.redhat.com/browse/ROX-12349
 //
 // We don't read the SAToken file anymore because it sometimes lies, see
-//     https://github.com/openshift/ci-operator/blob/master/TEMPLATES.md
+// https://github.com/openshift/ci-operator/blob/master/TEMPLATES.md
 func GetPodNamespace() string {
 	sensorNamespace := os.Getenv(nsEnvVar)
 

--- a/pkg/satoken/load.go
+++ b/pkg/satoken/load.go
@@ -14,13 +14,3 @@ func LoadTokenFromFile() (string, error) {
 	}
 	return string(bytes.TrimSpace(contents)), nil
 }
-
-// LoadNamespaceFromFile loads the Kubernetes service account namespace (which is the same as the pod namespace)
-// from the canonical file location and returns the namespace or an error.
-func LoadNamespaceFromFile() (string, error) {
-	contents, err := os.ReadFile(ServiceAccountTokenNamespacePath)
-	if err != nil {
-		return "", err
-	}
-	return string(bytes.TrimSpace(contents)), nil
-}

--- a/pkg/satoken/paths.go
+++ b/pkg/satoken/paths.go
@@ -7,6 +7,4 @@ const (
 	ServiceAccountTokenDir = `/run/secrets/kubernetes.io/serviceaccount`
 	// ServiceAccountTokenJWTPath is the path of the file containing the Kubernetes service account JWT.
 	ServiceAccountTokenJWTPath = ServiceAccountTokenDir + `/token`
-	// ServiceAccountTokenNamespacePath is the path of the file containing the Kubernetes service account namespace.
-	ServiceAccountTokenNamespacePath = ServiceAccountTokenDir + `/namespace`
 )

--- a/sensor/admission-control/main.go
+++ b/sensor/admission-control/main.go
@@ -54,7 +54,7 @@ func mainCmd() error {
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, unix.SIGTERM, unix.SIGINT)
 
-	namespace := pods.GetPodNamespace(pods.ConsiderSATokenNamespace)
+	namespace := pods.GetPodNamespace()
 
 	if err := safe.RunE(func() error {
 		if err := configureCA(); err != nil {

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -271,7 +271,7 @@ func NewUpdater(client kubernetes.Interface, updateInterval time.Duration) commo
 		updates:        make(chan *message.ExpiringMessage),
 		stopSig:        concurrency.NewSignal(),
 		updateInterval: interval,
-		namespace:      pods.GetPodNamespace(pods.NoSATokenNamespace),
+		namespace:      pods.GetPodNamespace(),
 		updateTicker:   updateTicker,
 	}
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -185,7 +185,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		components = append(components, upgradeCmdHandler)
 	}
 
-	sensorNamespace := pods.GetPodNamespace(pods.ConsiderSATokenNamespace)
+	sensorNamespace := pods.GetPodNamespace()
 
 	if admCtrlSettingsMgr != nil {
 		components = append(components, k8sadmctrl.NewConfigMapSettingsPersister(cfg.k8sClient.Kubernetes(), admCtrlSettingsMgr, sensorNamespace))

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -160,7 +160,7 @@ func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
 func (h *commandHandler) deleteUpgraderDeployments() {
 	// Only try deleting once. There's no big issue if these linger around as the upgrader doesn't do anything without
 	// being told to by central, so we don't go out of our way to make sure they are gone.
-	err := h.k8sClient.AppsV1().Deployments(pods.GetPodNamespace(pods.NoSATokenNamespace)).DeleteCollection(
+	err := h.k8sClient.AppsV1().Deployments(pods.GetPodNamespace()).DeleteCollection(
 		h.ctx(), pkgKubernetes.DeleteBackgroundOption, v1.ListOptions{
 			LabelSelector: v1.FormatLabelSelector(&v1.LabelSelector{
 				MatchExpressions: []v1.LabelSelectorRequirement{

--- a/sensor/kubernetes/upgrade/deployment.go
+++ b/sensor/kubernetes/upgrade/deployment.go
@@ -46,7 +46,7 @@ func (p *process) determineImage() (string, error) {
 
 	// If the image is not specified, sensor uses the same image it's using to launch the upgrader.
 	// This code path will be hit during cert rotation.
-	sensorDeployment, err := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace(pods.NoSATokenNamespace)).Get(p.ctx(), sensorDeploymentName, metav1.GetOptions{})
+	sensorDeployment, err := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace()).Get(p.ctx(), sensorDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch sensor deployment from Kube")
 	}

--- a/sensor/kubernetes/upgrade/deployment.go
+++ b/sensor/kubernetes/upgrade/deployment.go
@@ -70,7 +70,7 @@ func (p *process) createDeployment(serviceAccountName string, sensorDeployment *
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgraderDeploymentName,
-			Namespace: pods.GetPodNamespace(pods.NoSATokenNamespace),
+			Namespace: pods.GetPodNamespace(),
 			Labels: map[string]string{
 				"app":             upgraderDeploymentName,
 				processIDLabelKey: p.trigger.GetUpgradeProcessId(),
@@ -86,7 +86,7 @@ func (p *process) createDeployment(serviceAccountName string, sensorDeployment *
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: pods.GetPodNamespace(pods.NoSATokenNamespace),
+					Namespace: pods.GetPodNamespace(),
 					Labels: map[string]string{
 						"app":             upgraderDeploymentName,
 						processIDLabelKey: p.trigger.GetUpgradeProcessId(),

--- a/sensor/kubernetes/upgrade/process.go
+++ b/sensor/kubernetes/upgrade/process.go
@@ -188,7 +188,7 @@ func (p *process) waitForDeploymentDeletion(name string, uid types.UID) error {
 }
 
 func (p *process) waitForDeploymentDeletionOnce(name string, uid types.UID) error {
-	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace(pods.NoSATokenNamespace))
+	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace())
 	listOpts := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
 	}
@@ -242,7 +242,7 @@ func (p *process) waitForDeploymentDeletionOnce(name string, uid types.UID) erro
 }
 
 func (p *process) createUpgraderDeploymentIfNecessary() error {
-	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace(pods.NoSATokenNamespace))
+	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace())
 
 	upgraderDeployment, err := deploymentsClient.Get(p.ctx(), upgraderDeploymentName, metav1.GetOptions{})
 	if err != nil {
@@ -341,7 +341,7 @@ func (p *process) watchUpgraderDeployment() {
 func (p *process) pollAndUpdateProgress() ([]*central.UpgradeCheckInFromSensorRequest_UpgraderPodState, bool, error) {
 	errs := errorhelpers.NewErrorList("polling")
 
-	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace(pods.NoSATokenNamespace))
+	deploymentsClient := p.k8sClient.AppsV1().Deployments(pods.GetPodNamespace())
 	foundDeployment, err := deploymentsClient.Get(p.ctx(), upgraderDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
@@ -419,7 +419,7 @@ func (p *process) GetID() string {
 }
 
 func (p *process) chooseServiceAccount() string {
-	saClient := p.k8sClient.CoreV1().ServiceAccounts(pods.GetPodNamespace(pods.NoSATokenNamespace))
+	saClient := p.k8sClient.CoreV1().ServiceAccounts(pods.GetPodNamespace())
 
 	sensorUpgraderSA, err := saClient.Get(p.ctx(), preferredServiceAccountName, metav1.GetOptions{})
 	if err != nil {

--- a/sensor/upgrader/bundle/dynamic_objects.go
+++ b/sensor/upgrader/bundle/dynamic_objects.go
@@ -88,7 +88,7 @@ func createDynamicObject(objDesc common.DynamicBundleObjectDesc, bundleContents 
 	}
 
 	obj.SetName(objDesc.Name)
-	obj.SetNamespace(pods.GetPodNamespace(pods.NoSATokenNamespace))
+	obj.SetNamespace(pods.GetPodNamespace())
 
 	lbls := obj.GetLabels()
 	if lbls == nil {

--- a/sensor/upgrader/common/namespaces.go
+++ b/sensor/upgrader/common/namespaces.go
@@ -11,7 +11,7 @@ import (
 // explanation. Then adapt the namespace validation in sensor/upgrader/preflight/namespace.go.
 var AllowedNamespaces = []string{
 	// Main StackRox namespace. The upgrader lives here.
-	pods.GetPodNamespace(pods.NoSATokenNamespace),
+	pods.GetPodNamespace(),
 	// Needed for OpenShift monitoring integration on OpenShift.
 	namespaces.KubeSystem,
 	// Needed for OpenShift monitoring integration on OpenShift.

--- a/sensor/upgrader/common/shared_objects.go
+++ b/sensor/upgrader/common/shared_objects.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	sensorNamespace = pods.GetPodNamespace(pods.NoSATokenNamespace)
+	sensorNamespace = pods.GetPodNamespace()
 	// SharedObjects are objects shared with other resource bundles (i.e., central). Not creating these objects is
 	// okay - Central takes precedence here.
 	SharedObjects = []k8sobjects.ObjectRef{

--- a/sensor/upgrader/config/config.go
+++ b/sensor/upgrader/config/config.go
@@ -46,7 +46,7 @@ func (c *UpgraderConfig) Validate() error {
 	if c.K8sRESTConfig == nil {
 		errs.AddString("kubernetes REST config not present")
 	}
-	if c.Owner != nil && c.Owner.Namespace != pods.GetPodNamespace(pods.NoSATokenNamespace) {
+	if c.Owner != nil && c.Owner.Namespace != pods.GetPodNamespace() {
 		errs.AddStringf("owner %v is in disallowed namespace", c.Owner)
 	}
 	return errs.ToError()

--- a/sensor/upgrader/preflight/namespace.go
+++ b/sensor/upgrader/preflight/namespace.go
@@ -35,7 +35,7 @@ func namespaceAllowed(resource *k8sobjects.ObjectRef) bool {
 	if matchesException(resource) {
 		return true
 	}
-	return (resource.Namespace == "") || (resource.Namespace == pods.GetPodNamespace(pods.NoSATokenNamespace))
+	return (resource.Namespace == "") || (resource.Namespace == pods.GetPodNamespace())
 }
 
 func (namespaceCheck) Check(_ *upgradectx.UpgradeContext, execPlan *plan.ExecutionPlan, reporter checkReporter) error {

--- a/sensor/upgrader/preflight/namespace.go
+++ b/sensor/upgrader/preflight/namespace.go
@@ -42,7 +42,7 @@ func (namespaceCheck) Check(_ *upgradectx.UpgradeContext, execPlan *plan.Executi
 	for _, act := range execPlan.Actions() {
 		act := act
 		if !namespaceAllowed(&act.ObjectRef) {
-			logging.Warnf("namespaceAllowed returned false for object \"%v\" in namespace %q and the pod is in namespace %q", act.ObjectRef, act.ObjectRef.Namespace, pods.GetPodNamespace(pods.NoSATokenNamespace))
+			logging.Warnf("namespaceAllowed returned false for object \"%v\" in namespace %q and the pod is in namespace %q", act.ObjectRef, act.ObjectRef.Namespace, pods.GetPodNamespace())
 			reporter.Errorf("To-be-%sd object %v is in disallowed namespace %s", act.ActionName, act.ObjectRef, act.ObjectRef.Namespace)
 		}
 	}

--- a/sensor/upgrader/snapshot/snapshot.go
+++ b/sensor/upgrader/snapshot/snapshot.go
@@ -15,6 +15,6 @@ type Options struct {
 // TakeOrReadSnapshot either reads a previously snapshotted pre-upgrade state from the secret, or creates a secret with this
 // state.
 func TakeOrReadSnapshot(ctx *upgradectx.UpgradeContext, opts Options) ([]*unstructured.Unstructured, error) {
-	s := &snapshotter{ctx: ctx, opts: opts, sensorNamespace: pods.GetPodNamespace(pods.NoSATokenNamespace)}
+	s := &snapshotter{ctx: ctx, opts: opts, sensorNamespace: pods.GetPodNamespace()}
 	return s.SnapshotState()
 }


### PR DESCRIPTION
### Description

An experiment in entirely discarding the usage of SAToken namespace in favor of using POD_NAMESPACE as a followup to https://github.com/stackrox/stackrox/pull/11852
This is a big change with potentially large side effects since the SAToken namespace has been the source of truth for the namespace of sensor and admission-control up until now.
Associated docs PR: https://github.com/openshift/openshift-docs/pull/80351

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Relying entirely on `POD_NAMESPACE` as our source of truth for the namespace that any given pod lives in could lead to unintended behavior since so far we've been using the SAToken namespace as our first option in both CreateSensor() as well as admissioncontrol mainCmd().
Our automated tests are not complaining now.
I've done the folllowing testing on GKE clusters as well as local colima with manifest based installs and helm based installs, and on an OCP cluster with helm based install:
- Checked that the cluster is healthy and there are no unusual warnings in the UI
- Checked that `POD_NAMESPACE` is set correctly in all `sensor` and `admission-control` pods
- Checked that `POD_NAMESPACE` is populated through the `.yaml` file of those deployments via the downward API