### PR TITLE
ROX-24500: Certificate validation error in `roxctl` is an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 
 - ROX-28263: New `roxctl` help formatting.
+- ROX-24500: Certificate validation error in `roxctl` is an error.
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 
 - ROX-28263: New `roxctl` help formatting.
-- ROX-24500: Certificate validation error in `roxctl` is an error.
+- ROX-24500: Certificate validation failure in `roxctl` is now an error.
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - `roxctl central generate k8s hostpath` and `roxctl central generate openshift hostpath` no longer have the flags `--hostpath`, `--node-selector-key`, and `--node-selector-value`.
 
 ### Deprecated Features
+
 - ROX-25677: The format for specifying durations in JSON requests to
   `v1/nodecves/suppress`, `v1/clustercves/suppress` and `v1/imagecves/suppress`
   will be restricted to a [proto JSON format](https://protobuf.dev/programming-guides/proto3/#json:~:text=are%20also%20accepted.-,Duration,-string).
@@ -94,6 +95,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-26670: Google Container Registry integration is now deprecated. Users should use Artifact Registry as a registry replacement and Scanner V4 as a scanner replacement.
 
 ### Technical Changes
+
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.
 - ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
 - ROX-22701: Prevent deleting default policies through the API
@@ -130,8 +132,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Alpine vulnerabilities will now have a link to https://security.alpinelinux.org instead of https://www.cve.org.
 
 ## [4.5.0]
-
-
 
 ### Added Features
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -898,7 +898,6 @@ function launch_sensor {
              --collection-method="$COLLECTION_METHOD" \
              "${ORCH}" \
              "${extra_config[@]+"${extra_config[@]}"}"
-        echo "continue..."
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
         if [[ "${GENERATE_SCANNER_DEPLOYMENT_BUNDLE:-}" == "true" ]]; then
             roxctl --endpoint "${API_ENDPOINT}" scanner generate \

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -539,6 +539,7 @@ function launch_central {
 
     if [[ -n "${ROX_DEV_INTERNAL_SSO_CLIENT_SECRET}" ]]; then
         ${KUBE_COMMAND:-kubectl} create secret generic sensitive-declarative-configurations -n "${central_namespace}" &>/dev/null
+        export_central_cert
         setup_internal_sso "${API_ENDPOINT}" "${ROX_DEV_INTERNAL_SSO_CLIENT_SECRET}"
     fi
 
@@ -613,6 +614,25 @@ preemptionPolicy: PreemptLowerPriority
 globalDefault: false
 description: "This priority class shall be used for collector pods, which must be able to preempt other pods to fit exactly one collector on each node."
 EOT
+}
+
+function export_central_cert {
+    # Export the internal central TLS certificate for roxctl to access central
+    # through TLS-passthrough router by specifying the TLS server name.
+    ROX_SERVER_NAME="central.${CENTRAL_NAMESPACE:-stackrox}"
+    export ROX_SERVER_NAME
+
+    local central_cert
+    central_cert="$(mktemp -d)/central_cert.pem"
+    echo "Storing central certificate in ${central_cert}"
+
+    export LOGLEVEL=debug
+    roxctl -e "$API_ENDPOINT" \
+        central cert --insecure-skip-tls-verify 1>"$central_cert"
+
+    ROX_CA_CERT_FILE="$central_cert"
+    export ROX_CA_CERT_FILE
+    openssl x509 -in "${ROX_CA_CERT_FILE}" -subject -issuer -noout
 }
 
 function launch_sensor {
@@ -873,10 +893,12 @@ function launch_sensor {
     else
       if [[ -x "$(command -v roxctl)" && "$(roxctl version)" == "$MAIN_IMAGE_TAG" ]]; then
         [[ -n "${ROX_ADMIN_PASSWORD}" ]] || { echo >&2 "ROX_ADMIN_PASSWORD not found! Cannot launch sensor."; return 1; }
+        export_central_cert
         roxctl --endpoint "${API_ENDPOINT}" sensor generate --main-image-repository="${MAIN_IMAGE_REPO}" --central="$CLUSTER_API_ENDPOINT" --name="$CLUSTER" \
              --collection-method="$COLLECTION_METHOD" \
              "${ORCH}" \
              "${extra_config[@]+"${extra_config[@]}"}"
+        echo "continue..."
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
         if [[ "${GENERATE_SCANNER_DEPLOYMENT_BUNDLE:-}" == "true" ]]; then
             roxctl --endpoint "${API_ENDPOINT}" scanner generate \

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/ioutils"
-	"github.com/stackrox/rox/pkg/logging"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/tlsutils"
 	"github.com/stackrox/rox/pkg/utils"
@@ -63,7 +62,6 @@ func (cmd *centralCertCommand) certs() error {
 	if err != nil {
 		return err
 	}
-	logging.Debugf("timeout: %v", cmd.timeout)
 	// Connect to the given server. We're not expecting the endpoint be
 	// trusted, but force the user to use insecure mode if needed.
 	config := tls.Config{
@@ -72,7 +70,6 @@ func (cmd *centralCertCommand) certs() error {
 	}
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)
 	defer cancel()
-	logging.LoggerForModule().Debugf("connecting to tcp %s, server name: %s", endpoint, config.ServerName)
 	conn, err := tlsutils.DialContext(ctx, "tcp", endpoint, &config)
 	if err != nil {
 		return err

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -62,6 +62,7 @@ func (cmd *centralCertCommand) certs() error {
 	if err != nil {
 		return err
 	}
+
 	// Connect to the given server. We're not expecting the endpoint be
 	// trusted, but force the user to use insecure mode if needed.
 	config := tls.Config{

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/ioutils"
+	"github.com/stackrox/rox/pkg/logging"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/tlsutils"
 	"github.com/stackrox/rox/pkg/utils"
@@ -62,7 +63,7 @@ func (cmd *centralCertCommand) certs() error {
 	if err != nil {
 		return err
 	}
-
+	logging.Debugf("timeout: %v", cmd.timeout)
 	// Connect to the given server. We're not expecting the endpoint be
 	// trusted, but force the user to use insecure mode if needed.
 	config := tls.Config{
@@ -71,6 +72,7 @@ func (cmd *centralCertCommand) certs() error {
 	}
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)
 	defer cancel()
+	logging.LoggerForModule().Debugf("connecting to tcp %s, server name: %s", endpoint, config.ServerName)
 	conn, err := tlsutils.DialContext(ctx, "tcp", endpoint, &config)
 	if err != nil {
 		return err

--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -19,7 +19,7 @@ import (
 )
 
 const errorMsg = `The remote endpoint failed TLS validation.
-  Please do one of the following:
+  Do one of the following:
   1. Obtain a valid certificate for your Central instance/Load Balancer.
   2. Use the --ca option to specify a custom CA certificate (PEM format).
      This certificate can be obtained by running "roxctl central cert".

--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -11,41 +11,45 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/netutil"
-	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/tlscheck"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/logger"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-const warningMsg = `The remote endpoint failed TLS validation. This will be a fatal error in future releases.
-Please do one of the following at your earliest convenience:
+const errorMsg = `The remote endpoint failed TLS validation.
+  Please do one of the following:
   1. Obtain a valid certificate for your Central instance/Load Balancer.
-  2. Use the --ca option to specify a custom CA certificate (PEM format). This Certificate can be obtained by
-     running "roxctl central cert".
-  3. Update all your roxctl usages to pass the --insecure-skip-tls-verify option, in order to
-     suppress this warning and retain the old behavior of not validating TLS certificates in
-     the future (NOT RECOMMENDED).
-
+  2. Use the --ca option to specify a custom CA certificate (PEM format).
+     This certificate can be obtained by running "roxctl central cert".
+  3. Use the --insecure-skip-tls-verify option to suppress this error
+     and not validate TLS certificates (NOT RECOMMENDED).
 `
 
-type insecureVerifierWithWarning struct {
-	printWarningOnce sync.Once
-	logger           logger.Logger
+type grpcPermissionDenied struct{ error }
+
+func (p *grpcPermissionDenied) GRPCStatus() *status.Status {
+	return status.New(codes.PermissionDenied, p.Error())
 }
 
-func (v *insecureVerifierWithWarning) VerifyPeerCertificate(leaf *x509.Certificate, chainRest []*x509.Certificate, conf *tls.Config) error {
+type insecureVerifierWithError struct {
+	logger logger.Logger
+}
+
+func (v *insecureVerifierWithError) VerifyPeerCertificate(leaf *x509.Certificate, chainRest []*x509.Certificate, conf *tls.Config) error {
 	verifyOpts := x509.VerifyOptions{
 		DNSName:       conf.ServerName,
 		Intermediates: tlscheck.NewCertPool(chainRest...),
 		Roots:         conf.RootCAs,
 	}
-
-	_, err := leaf.Verify(verifyOpts)
-	if err != nil {
-		v.printWarningOnce.Do(func() {
-			v.logger.WarnfLn(warningMsg)
-			v.logger.WarnfLn("Certificate validation error: %v", err)
-		})
+	v.logger.InfofLn("trying to verify cert for %s, signed by %s (CA %v)", leaf.Subject, leaf.Issuer, leaf.IsCA)
+	for i, c := range chainRest {
+		v.logger.InfofLn("%d cert in chain %s, signed by %s (CA %v)", i, c.Subject, c.Issuer, c.IsCA)
+	}
+	if _, err := leaf.Verify(verifyOpts); err != nil {
+		v.logger.ErrfLn(errorMsg)
+		return &grpcPermissionDenied{err}
 	}
 	return nil
 }
@@ -100,15 +104,15 @@ func tlsConfigOptsForCentral(logger logger.Logger) (*clientconn.TLSConfigOptions
 			logger.WarnfLn("--insecure-skip-tls-verify has no effect when --ca is set")
 		}
 	} else {
+		customVerifier = &insecureVerifierWithError{
+			logger: logger,
+		}
 		if flags.CAFile() != "" {
 			var err error
 			if ca, err = os.ReadFile(flags.CAFile()); err != nil {
 				return nil, errors.Wrap(err, "failed to parse CA certificates from file")
 			}
 		} else {
-			customVerifier = &insecureVerifierWithWarning{
-				logger: logger,
-			}
 			// Read the CA from the central secret.
 			if flags.UseKubeContext() {
 				_, core, namespace, err := getConfigs()

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1274,6 +1274,7 @@ restore_4_1_postgres_backup() {
     require_environment "ROX_ADMIN_PASSWORD"
 
     gsutil cp gs://stackrox-ci-upgrade-test-fixtures/upgrade-test-dbs/postgres_db_4_1.sql.zip .
+    export_central_cert
     roxctl -e "$API_ENDPOINT" \
         central db restore --timeout 5m postgres_db_4_1.sql.zip
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -502,14 +502,14 @@ export_central_cert() {
     ci_export ROX_SERVER_NAME "central.${CENTRAL_NAMESPACE:-stackrox}"
 
     require_environment "API_ENDPOINT"
-    require_environment "ROX_PASSWORD"
+    require_environment "ROX_ADMIN_PASSWORD"
 
     local central_cert
     central_cert="$(mktemp -d)/central_cert.pem"
     info "Storing central certificate in ${central_cert} for ${API_ENDPOINT}"
     stacktrace
 
-    roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" \
+    roxctl -e "$API_ENDPOINT" \
         central cert --insecure-skip-tls-verify 1>"$central_cert"
 
     ci_export ROX_CA_CERT_FILE "$central_cert"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -41,14 +41,6 @@ POD_CONTAINERS_MAP["pod: collector - container: collector"]="collector-[A-Za-z0-
 POD_CONTAINERS_MAP["pod: collector - container: compliance"]="collector-[A-Za-z0-9]+-compliance-previous.log"
 POD_CONTAINERS_MAP["pod: collector - container: node-inventory"]="collector-[A-Za-z0-9]+-node-inventory-previous.log"
 
-stacktrace() {
-   local i=1 line file func
-   while read -r line func file < <(caller $i); do
-      echo >&2 "[$i] $file:$line $func(): $(sed -n "${line}p" "$file")"
-      ((i++))
-   done
-}
-
 # shellcheck disable=SC2120
 deploy_stackrox() {
     local tls_client_certs=${1:-}
@@ -507,7 +499,6 @@ export_central_cert() {
     local central_cert
     central_cert="$(mktemp -d)/central_cert.pem"
     info "Storing central certificate in ${central_cert} for ${API_ENDPOINT}"
-    stacktrace
 
     roxctl -e "$API_ENDPOINT" \
         central cert --insecure-skip-tls-verify 1>"$central_cert"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -981,6 +981,7 @@ _deploy_stackrox() {
       DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}" export_central_basic_auth_creds
     fi
     wait_for_api "${central_namespace}"
+    export_central_cert "${central_namespace}"
     setup_client_TLS_certs "${tls_client_certs}"
     record_build_info "${central_namespace}"
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -273,7 +273,7 @@ run_proxy_tests() {
             local central_cert
             central_cert="$(mktemp -d)/central_cert.pem"
             info "Fetching central certificate for ${name}..."
-            roxctl "${extra_args[@]}" -e "$endpoint" -p "$ROX_PASSWORD" \
+            roxctl "${extra_args[@]}" -e "$endpoint" \
                 central cert --insecure-skip-tls-verify 1>"$central_cert" || \
                 failures+=("$p,fetch-CA")
             extra_args+=(--ca "$central_cert")

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -274,7 +274,8 @@ run_proxy_tests() {
             central_cert="$(mktemp -d)/central_cert.pem"
             info "Fetching central certificate for ${name}..."
             roxctl "${extra_args[@]}" -e "$endpoint" -p "$ROX_PASSWORD" \
-                central cert --insecure-skip-tls-verify 1>"$central_cert"
+                central cert --insecure-skip-tls-verify 1>"$central_cert" || \
+                failures+=("$p,fetch-CA")
             extra_args+=(--ca "$central_cert")
         fi
 
@@ -283,7 +284,7 @@ run_proxy_tests() {
             failures+=("$p")
         if (( direct )); then
             info "Direct gRPC to ${endpoint_tgt} with ${extra_args[*]}"
-            roxctl "${extra_args[@]}" -e "${endpoint_tgt}" central debug log >/dev/null && \
+            roxctl "${extra_args[@]}" -e "${endpoint_tgt}" central debug log >/dev/null || \
             failures+=("${p},direct-grpc")
         else
             info "Force HTTP1 to ${endpoint_tgt} with ${extra_args[*]} and --plaintext=${plaintext}"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -235,7 +235,9 @@ run_proxy_tests() {
         "HTTP/2 proxy with TLS backends:14443"
         "HTTP/2 proxy with plain backends:15443"
     )
-
+    
+    export ROX_CA_CERT_FILE=""
+    export ROX_SERVER_NAME=""
     local failures=()
     for p in "${proxies[@]}"; do
         local name
@@ -266,13 +268,22 @@ run_proxy_tests() {
 
         info "Testing roxctl access through ${name}..."
         local endpoint="${server_name}:${port}"
+
+        if [[ "$plaintext" = "false" ]]; then
+            local central_cert
+            central_cert="$(mktemp -d)/central_cert.pem"
+            info "Fetching central certificate for ${name}..."
+            roxctl "${extra_args[@]}" -e "$endpoint" -p "$ROX_PASSWORD" \
+                central cert --insecure-skip-tls-verify 1>"$central_cert"
+            extra_args+=(--ca "$central_cert")
+        fi
+
         for endpoint_tgt in "${scheme}://${endpoint}" "${scheme}://${endpoint}/" "$endpoint"; do
         roxctl "${extra_args[@]}" --plaintext="$plaintext" -e "${endpoint_tgt}" central debug log >/dev/null || \
             failures+=("$p")
-
         if (( direct )); then
-            roxctl "${extra_args[@]}" --plaintext="$plaintext" --force-http1 -e "${endpoint_tgt}" central debug log &>/dev/null && \
-            failures+=("${p},force-http1")
+            roxctl "${extra_args[@]}" -e "${endpoint_tgt}" central debug log >/dev/null && \
+            failures+=("${p},direct-grpc")
         else
             roxctl "${extra_args[@]}" --plaintext="$plaintext" --force-http1 -e "${endpoint_tgt}" central debug log >/dev/null || \
             failures+=("${p},force-http1")

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -235,7 +235,7 @@ run_proxy_tests() {
         "HTTP/2 proxy with TLS backends:14443"
         "HTTP/2 proxy with plain backends:15443"
     )
-    
+
     export ROX_CA_CERT_FILE=""
     export ROX_SERVER_NAME=""
     local failures=()

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -174,7 +174,7 @@ validate_sensor_bundle_via_upgrader() {
 
 test_sensor_bundle() {
     info "Testing the sensor bundle"
-
+    export_central_cert
     rm -rf sensor-remote
     "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl" -e "$API_ENDPOINT" sensor get-bundle remote
     [[ -d sensor-remote ]]
@@ -191,7 +191,7 @@ test_sensor_bundle() {
 
 test_upgrader() {
     info "Starting bin/upgrader tests"
-
+    export_central_cert
     deactivate_metrics_server
 
     info "Creating a 'sensor-remote-new' cluster"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -93,6 +93,7 @@ test_upgrade_paths() {
     deploy_earlier_postgres_central
     wait_for_api
     setup_client_TLS_certs
+    export_central_cert
 
     restore_4_1_backup
     wait_for_api


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

1. Convert warning to error, as promised a long time ago.
2. Prevent retries on such an error.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```console
me@work$ bin/linux_amd64/roxctl -e localhost:8443 -p admin central whoami
ERROR:	The remote endpoint failed TLS validation. Please do one of the following:
  1. Obtain a valid certificate for your Central instance/Load Balancer.
  3. Use the --ca option to specify a custom CA certificate (PEM format). This Certificate can be obtained by
     running "roxctl central cert".
  4. Update all your roxctl usages to pass the --insecure-skip-tls-verify option, in order to
     suppress this warning and retain the old behavior of not validating TLS certificates in
     the future (NOT RECOMMENDED).


ERROR:	connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for central.stackrox, central.stackrox.svc, not localhost"

me@work$ echo $?
1
```