### PR TITLE
fix(ui): microtask useURLParameter fix

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -70,7 +70,7 @@ function CheckDetails() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields: [CLUSTER_QUERY],
         defaultSortOption: { field: CLUSTER_QUERY, direction: 'asc' },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
     const [activeTabKey, setActiveTabKey] = useURLStringUnion(TAB_NAV_QUERY, TAB_NAV_VALUES);
@@ -138,7 +138,7 @@ function CheckDetails() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     const onCheckStatusSelect = (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -56,7 +56,7 @@ function ClusterDetailsPage() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields: [CHECK_NAME_QUERY],
         defaultSortOption: { field: CHECK_NAME_QUERY, direction: 'asc' },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -123,7 +123,7 @@ function ClusterDetailsPage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     if (scanConfigProfilesError) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -24,7 +24,7 @@ function ProfileChecksPage() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields: [CHECK_NAME_QUERY],
         defaultSortOption: { field: CHECK_NAME_QUERY, direction: 'asc' },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -55,7 +55,7 @@ function ProfileChecksPage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -25,7 +25,7 @@ function ProfileClustersPage() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields: [CLUSTER_QUERY],
         defaultSortOption: { field: CLUSTER_QUERY, direction: 'asc' },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -62,7 +62,7 @@ function ProfileClustersPage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -99,7 +99,7 @@ function ApprovedDeferrals() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     if (tableState.type === 'ERROR') {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -92,7 +92,7 @@ function ApprovedFalsePositives() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     if (tableState.type === 'ERROR') {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -96,7 +96,7 @@ function DeniedRequests() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     if (tableState.type === 'ERROR') {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -97,7 +97,7 @@ function PendingApprovals() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     if (tableState.type === 'ERROR') {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -155,7 +155,7 @@ function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
                         getSortParams={getSortParams}
                         onClearFilters={() => {
                             setSearchFilter({});
-                            setPage(1, 'replace');
+                            setPage(1);
                         }}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -88,7 +88,7 @@ function NodeCvePage() {
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
     const isFiltered = getHasSearchApplied(querySearchFilter);
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
@@ -200,7 +200,7 @@ function NodeCvePage() {
                         getSortParams={getSortParams}
                         onClearFilters={() => {
                             setSearchFilter({});
-                            setPage(1, 'replace');
+                            setPage(1);
                         }}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -74,7 +74,7 @@ function NodeCvesOverviewPage() {
         sortFields: activeEntityTabKey === 'CVE' ? cveSortFields : nodeSortFields,
         defaultSortOption:
             activeEntityTabKey === 'CVE' ? cveDefaultSortOption : nodeDefaultSortOption,
-        onSort: () => pagination.setPage(1, 'replace'),
+        onSort: () => pagination.setPage(1),
     });
 
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -88,10 +88,7 @@ function NodeCvesOverviewPage() {
 
     function onEntityTabChange(entityTab: 'CVE' | 'Node') {
         pagination.setPage(1);
-        setSortOption(
-            entityTab === 'CVE' ? cveDefaultSortOption : nodeDefaultSortOption,
-            'replace'
-        );
+        setSortOption(entityTab === 'CVE' ? cveDefaultSortOption : nodeDefaultSortOption);
 
         analyticsTrack({
             event: NODE_CVE_ENTITY_CONTEXT_VIEWED,
@@ -109,7 +106,7 @@ function NodeCvesOverviewPage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        pagination.setPage(1, 'replace');
+        pagination.setPage(1);
     }
 
     const { data } = useNodeCveEntityCounts(querySearchFilter);
@@ -125,7 +122,7 @@ function NodeCvesOverviewPage() {
             searchFilterConfig={searchFilterConfig}
             onFilterChange={(newFilter, searchPayload) => {
                 setSearchFilter(newFilter);
-                pagination.setPage(1, 'replace');
+                pagination.setPage(1);
                 trackAppliedFilter(NODE_CVE_FILTER_APPLIED, searchPayload);
             }}
         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -51,7 +51,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
 
     const { data, loading, error } = useClusterVulnerabilities({
@@ -144,7 +144,7 @@ function ClusterPageVulnerabilities({ clusterId }: ClusterPageVulnerabilitiesPro
                         getSortParams={getSortParams}
                         onClearFilters={() => {
                             setSearchFilter({});
-                            setPage(1, 'replace');
+                            setPage(1);
                         }}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -68,7 +68,7 @@ function PlatformCvesOverviewPage() {
         sortFields: activeEntityTabKey === 'CVE' ? cveSortFields : clusterSortFields,
         defaultSortOption:
             activeEntityTabKey === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
-        onSort: () => pagination.setPage(1, 'replace'),
+        onSort: () => pagination.setPage(1),
     });
 
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -82,10 +82,7 @@ function PlatformCvesOverviewPage() {
 
     function onEntityTabChange(entityTab: 'CVE' | 'Cluster') {
         pagination.setPage(1);
-        setSortOption(
-            entityTab === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption,
-            'replace'
-        );
+        setSortOption(entityTab === 'CVE' ? cveDefaultSortOption : clusterDefaultSortOption);
 
         analyticsTrack({
             event: PLATFORM_CVE_ENTITY_CONTEXT_VIEWED,
@@ -110,7 +107,7 @@ function PlatformCvesOverviewPage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        pagination.setPage(1, 'replace');
+        pagination.setPage(1);
     }
 
     const filterToolbar = (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -211,7 +211,7 @@ function PlatformCvePage() {
                         getSortParams={getSortParams}
                         onClearFilters={() => {
                             setSearchFilter({});
-                            setPage(1, 'replace');
+                            setPage(1);
                         }}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -135,7 +135,7 @@ function DeploymentPageVulnerabilities({
             field: 'Severity',
             direction: 'desc',
         },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
 
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -234,7 +234,7 @@ function DeploymentPageVulnerabilities({
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1, 'replace');
+                        setPage(1);
                     }}
                 />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">
@@ -245,7 +245,7 @@ function DeploymentPageVulnerabilities({
                             searchFilter={searchFilter}
                             onFilterChange={(newFilter, searchPayload) => {
                                 setSearchFilter(newFilter);
-                                setPage(1, 'replace');
+                                setPage(1);
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                         />
@@ -316,7 +316,7 @@ function DeploymentPageVulnerabilities({
                                 vulnerabilityState={currentVulnerabilityState}
                                 onClearFilters={() => {
                                     setSearchFilter({});
-                                    setPage(1, 'replace');
+                                    setPage(1);
                                 }}
                             />
                         </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -136,7 +136,7 @@ function ImagePageVulnerabilities({
             field: 'Severity',
             direction: 'desc',
         },
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
 
     // TODO Split metadata, counts, and vulnerabilities into separate queries
@@ -232,7 +232,7 @@ function ImagePageVulnerabilities({
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1, 'replace');
+                        setPage(1);
                     }}
                 />
                 <div className="pf-v5-u-px-sm pf-v5-u-background-color-100">
@@ -243,7 +243,7 @@ function ImagePageVulnerabilities({
                             searchFilter={searchFilter}
                             onFilterChange={(newFilter, searchPayload) => {
                                 setSearchFilter(newFilter);
-                                setPage(1, 'replace');
+                                setPage(1);
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                         />
@@ -359,7 +359,7 @@ function ImagePageVulnerabilities({
                                 createTableActions={createTableActions}
                                 onClearFilters={() => {
                                     setSearchFilter({});
-                                    setPage(1, 'replace');
+                                    setPage(1);
                                 }}
                             />
                         </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -222,7 +222,7 @@ function ImageCvePage() {
     const { sortOption, setSortOption, getSortParams } = useURLSort({
         sortFields: getSortFields(entityTab),
         defaultSortOption: getDefaultSortOption(entityTab),
-        onSort: () => setPage(1, 'replace'),
+        onSort: () => setPage(1),
     });
 
     const metadataRequest = useQuery<{ imageCVE: CveMetadata | null }, { cve: string }>(
@@ -318,7 +318,7 @@ function ImageCvePage() {
     function onEntityTypeChange(entityTab: WorkloadEntityTab) {
         setPage(1);
         if (entityTab !== 'CVE') {
-            setSortOption(getDefaultSortOption(entityTab), 'replace');
+            setSortOption(getDefaultSortOption(entityTab));
         }
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
@@ -331,7 +331,7 @@ function ImageCvePage() {
 
     function onClearFilters() {
         setSearchFilter({});
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     // Track the initial entity tab view
@@ -407,7 +407,7 @@ function ImageCvePage() {
                     isBox
                     onChange={() => {
                         setSearchFilter({});
-                        setPage(1, 'replace');
+                        setPage(1);
                     }}
                 />
                 <div className="pf-v5-u-background-color-100">
@@ -419,7 +419,7 @@ function ImageCvePage() {
                                 searchFilter={searchFilter}
                                 onFilterChange={(newFilter, searchPayload) => {
                                     setSearchFilter(newFilter);
-                                    setPage(1, 'replace');
+                                    setPage(1);
                                     trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -155,7 +155,7 @@ function NamespaceViewPage() {
     }
 
     function onFilterChange() {
-        setPage(1, 'replace');
+        setPage(1);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -169,7 +169,7 @@ function CVEsTableContainer({
                     createTableActions={createTableActions}
                     onClearFilters={() => {
                         setSearchFilter({});
-                        pagination.setPage(1, 'replace');
+                        pagination.setPage(1);
                     }}
                 />
             </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -80,7 +80,7 @@ function DeploymentsTableContainer({
                     showCveDetailFields={showCveDetailFields}
                     onClearFilters={() => {
                         setSearchFilter({});
-                        pagination.setPage(1, 'replace');
+                        pagination.setPage(1);
                     }}
                 />
             </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -237,7 +237,7 @@ function WorkloadCvesOverviewPage() {
     const sort = useURLSort({
         sortFields: getWorkloadSortFields(activeEntityTabKey),
         defaultSortOption: getDefaultSortOption(activeEntityTabKey),
-        onSort: () => pagination.setPage(1, 'replace'),
+        onSort: () => pagination.setPage(1),
     });
 
     function updateDefaultFilters(values: DefaultFilters) {
@@ -248,14 +248,13 @@ function WorkloadCvesOverviewPage() {
                 localStorageValue.preferences.defaultFilters,
                 values,
                 searchFilter
-            ),
-            'replace'
+            )
         );
     }
 
     function onEntityTabChange(entityTab: WorkloadEntityTab) {
         pagination.setPage(1);
-        sort.setSortOption(getDefaultSortOption(entityTab), 'replace');
+        sort.setSortOption(getDefaultSortOption(entityTab));
 
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
@@ -270,11 +269,11 @@ function WorkloadCvesOverviewPage() {
         // Set the observed CVE mode, pushing a new history entry to the stack
         setObservedCveMode(mode);
         // Reset all filters, sorting, and pagination and apply to the current history entry
-        pagination.setPage(1, 'replace');
-        setSearchFilter({}, 'replace');
+        pagination.setPage(1);
+        setSearchFilter({});
         if (activeEntityTabKey === 'CVE') {
-            setActiveEntityTabKey('Image', 'replace');
-            sort.setSortOption(getDefaultSortOption('Image'), 'replace');
+            setActiveEntityTabKey('Image');
+            sort.setSortOption(getDefaultSortOption('Image'));
         }
 
         // Re-apply the default filters when changing modes to the "WITH_CVES" mode
@@ -286,10 +285,10 @@ function WorkloadCvesOverviewPage() {
     function onVulnerabilityStateChange(vulnerabilityState: VulnerabilityState) {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
-        setSearchFilter({}, 'replace');
-        sort.setSortOption(getDefaultWorkloadSortOption('CVE'), 'replace');
-        pagination.setPage(1, 'replace');
-        setObservedCveMode('WITH_CVES', 'replace');
+        setSearchFilter({});
+        sort.setSortOption(getDefaultWorkloadSortOption('CVE'));
+        pagination.setPage(1);
+        setObservedCveMode('WITH_CVES');
 
         // Re-apply the default filters when changing to the "OBSERVED" state
         if (vulnerabilityState === 'OBSERVED') {
@@ -299,7 +298,7 @@ function WorkloadCvesOverviewPage() {
 
     function applyDefaultFilters() {
         if (isFixabilityFiltersEnabled) {
-            setSearchFilter(localStorageValue.preferences.defaultFilters, 'replace');
+            setSearchFilter(localStorageValue.preferences.defaultFilters);
         }
     }
 
@@ -338,7 +337,7 @@ function WorkloadCvesOverviewPage() {
             defaultFilters={localStorageValue.preferences.defaultFilters}
             onFilterChange={(newFilter, searchPayload) => {
                 setSearchFilter(newFilter);
-                pagination.setPage(1, 'replace');
+                pagination.setPage(1);
                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
             }}
             includeCveSeverityFilters={isViewingWithCves}
@@ -348,7 +347,7 @@ function WorkloadCvesOverviewPage() {
     ) : (
         <WorkloadCveFilterToolbar
             defaultFilters={localStorageValue.preferences.defaultFilters}
-            onFilterChange={() => pagination.setPage(1, 'replace')}
+            onFilterChange={() => pagination.setPage(1)}
             searchOptions={
                 isViewingWithCves
                     ? searchOptions

--- a/ui/apps/platform/src/hooks/useURLPagination.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLPagination.test.tsx
@@ -29,6 +29,17 @@ const createWrapper = (props) => {
     };
 };
 
+beforeAll(() => {
+    jest.useFakeTimers();
+});
+
+function actAndRunTicks(callback) {
+    return act(() => {
+        callback();
+        jest.runAllTicks();
+    });
+}
+
 test('should update pagination parameters in the URL', async () => {
     let params;
     let testLocation;
@@ -52,7 +63,7 @@ test('should update pagination parameters in the URL', async () => {
     expect(params.get('perPage')).toBe(null);
 
     // Check new and existing values when URL parameter is set
-    act(() => {
+    actAndRunTicks(() => {
         const { setPage } = result.current;
         setPage(2);
     });
@@ -63,7 +74,7 @@ test('should update pagination parameters in the URL', async () => {
     expect(params.get('perPage')).toBe(null);
 
     // Check that updating the perPage parameter also resets the page parameter to 1
-    act(() => {
+    actAndRunTicks(() => {
         const { setPerPage } = result.current;
         setPerPage(20);
     });
@@ -97,7 +108,7 @@ test('should not add history states when setting values with a "replace" action'
     expect(params.get('perPage')).toBe(null);
 
     // Update the page parameter with a 'replace' action
-    act(() => {
+    actAndRunTicks(() => {
         const { setPage } = result.current;
         setPage(2, 'replace');
     });
@@ -109,7 +120,7 @@ test('should not add history states when setting values with a "replace" action'
     expect(params.get('perPage')).toBe(null);
 
     // Update the perPage parameter with a 'replace' action
-    act(() => {
+    actAndRunTicks(() => {
         const { setPerPage } = result.current;
         setPerPage(20, 'replace');
     });
@@ -144,7 +155,7 @@ test('should only add a single history state when setting perPage without an act
     expect(params.get('perPage')).toBe(null);
 
     // Update the page parameter
-    act(() => {
+    actAndRunTicks(() => {
         const { setPage } = result.current;
         setPage(2);
     });
@@ -156,7 +167,7 @@ test('should only add a single history state when setting perPage without an act
     expect(params.get('perPage')).toBe(null);
 
     // Update the perPage parameter and check the length of the history stack
-    act(() => {
+    actAndRunTicks(() => {
         const { setPerPage } = result.current;
         setPerPage(20);
     });

--- a/ui/apps/platform/src/hooks/useURLParameter.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLParameter.test.tsx
@@ -31,6 +31,17 @@ const createWrapper = (props) => {
     };
 };
 
+beforeAll(() => {
+    jest.useFakeTimers();
+});
+
+function actAndRunTicks(callback) {
+    return act(() => {
+        callback();
+        jest.runAllTicks();
+    });
+}
+
 test('should read/write scoped string value in URL parameter without changing existing URL parameters', async () => {
     let params;
     let testLocation;
@@ -53,7 +64,7 @@ test('should read/write scoped string value in URL parameter without changing ex
     expect(params.get('bogusKey')).toBeNull();
 
     // Check new and existing values when URL parameter is set
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam('testValue');
     });
@@ -64,7 +75,7 @@ test('should read/write scoped string value in URL parameter without changing ex
     expect(params.get('bogusKey')).toBeNull();
 
     // Check new and existing values when URL parameter is cleared
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam(undefined);
     });
@@ -76,6 +87,7 @@ test('should read/write scoped string value in URL parameter without changing ex
 });
 
 test('should allow multiple sequential parameter updates without data loss', async () => {
+    jest.useFakeTimers();
     let params;
     let testLocation;
 
@@ -96,7 +108,7 @@ test('should allow multiple sequential parameter updates without data loss', asy
     expect(params.get('key1')).toBe('oldValue1');
     expect(params.get('key2')).toBe(null);
 
-    act(() => {
+    actAndRunTicks(() => {
         const [[, setParam1], [, setParam2]] = result.current;
         setParam1('newValue1');
         setParam2('newValue2');
@@ -109,6 +121,7 @@ test('should allow multiple sequential parameter updates without data loss', asy
 });
 
 test('should read/write scoped complex object in URL parameter without changing existing URL parameters', async () => {
+    jest.useFakeTimers();
     let params: URLSearchParams;
     let testLocation;
 
@@ -148,7 +161,7 @@ test('should read/write scoped complex object in URL parameter without changing 
     expect(params.get('oldKey')).toBe('test');
     expect(Array.from(params.entries())).toHaveLength(1);
 
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam({
             clusters: [
@@ -180,7 +193,7 @@ test('should read/write scoped complex object in URL parameter without changing 
     expect(params.get('testKey[clusters][0][namespaces][1][name]')).toBe('payments');
 
     // Clear value and ensure URL search is removed
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam(emptyState);
     });
@@ -191,6 +204,7 @@ test('should read/write scoped complex object in URL parameter without changing 
 });
 
 test('should implement push and replace state for history', async () => {
+    jest.useFakeTimers();
     let testHistory;
     let testLocation;
 
@@ -207,26 +221,26 @@ test('should implement push and replace state for history', async () => {
     });
 
     // Test the the default behavior is to push URL parameter changes to the history stack
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam('testValue');
     });
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test&testKey=testValue');
-    act(() => {
+    actAndRunTicks(() => {
         testHistory.goBack();
     });
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test');
 
     // Test that specifying a history action of 'replace' changes the history entry in-place
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam('newTestValue', 'replace');
     });
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test&testKey=newTestValue');
-    act(() => {
+    actAndRunTicks(() => {
         testHistory.goBack();
     });
     expect(testLocation.pathname).toBe('/main/dashboard');

--- a/ui/apps/platform/src/hooks/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/useURLSort.test.js
@@ -19,6 +19,17 @@ const wrapper = ({ children }) => {
     return <Router history={history}>{children}</Router>;
 };
 
+beforeAll(() => {
+    jest.useFakeTimers();
+});
+
+function actAndRunTicks(callback) {
+    return act(() => {
+        callback();
+        jest.runAllTicks();
+    });
+}
+
 describe('useURLSort', () => {
     it('should get the sort options from URL by default', () => {
         const { result } = renderHook(
@@ -44,7 +55,7 @@ describe('useURLSort', () => {
             }
         );
 
-        act(() => {
+        actAndRunTicks(() => {
             result.current.getSortParams('Name').onSort(null, null, 'asc');
         });
 
@@ -62,7 +73,7 @@ describe('useURLSort', () => {
             }
         );
 
-        act(() => {
+        actAndRunTicks(() => {
             result.current.getSortParams('Status').onSort(null, null, 'desc');
         });
 

--- a/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
@@ -31,6 +31,17 @@ const createWrapper = (props) => {
     };
 };
 
+beforeAll(() => {
+    jest.useFakeTimers();
+});
+
+function actAndRunTicks(callback) {
+    return act(() => {
+        callback();
+        jest.runAllTicks();
+    });
+}
+
 test('should read/write only the specified set of strings to the URL parameter', async () => {
     let params;
     let testLocation;
@@ -46,6 +57,7 @@ test('should read/write only the specified set of strings to the URL parameter',
             initialEntries: [''],
         }),
     });
+    actAndRunTicks(() => {});
 
     // Check that default value is applied correctly
     params = new URLSearchParams(testLocation.search);
@@ -53,7 +65,7 @@ test('should read/write only the specified set of strings to the URL parameter',
     expect(params.get('urlKey')).toBe('Alpha');
 
     // Check that setting the value changes the parameter
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam('Delta');
     });
@@ -75,7 +87,7 @@ test('should read/write only the specified set of strings to the URL parameter',
     ];
 
     invalidValues.forEach((invalid) => {
-        act(() => {
+        actAndRunTicks(() => {
             const [, setParam] = result.current;
             setParam(invalid);
         });
@@ -85,7 +97,7 @@ test('should read/write only the specified set of strings to the URL parameter',
     });
 
     // Check setting a valid value after invalid attempts correctly sets the new value
-    act(() => {
+    actAndRunTicks(() => {
         const [, setParam] = result.current;
         setParam('Beta');
     });
@@ -111,6 +123,7 @@ test('should default to the current URL parameter value on initialization, if it
             }),
         }
     );
+    actAndRunTicks(() => {});
 
     // Check that default value is not applied if the URL param already contains a valid value
     const params = new URLSearchParams(testLocation.search);
@@ -134,6 +147,7 @@ test('should use the default value when an invalid value is entered directly int
             }),
         }
     );
+    actAndRunTicks(() => {});
 
     // Check that default value is applied correctly when the URL param is invalid
     const params = new URLSearchParams(testLocation.search);


### PR DESCRIPTION
### Description

Fixes the issue with URL state functions requiring an explicit `'replace'` parameter to be passed when making multiple state changes in order to avoid multiple pushes to the browser's history stack.

This PR contains 3 main commits that might be easier to review in sequence to get a better sense of the change:
1. Proof of concept to automatically batch URL parameter updates into a single atomic update
2. Refactor to remove global module state in favor of React context
3. Refactor of existing code to remove the unnecessary `'replace'` parameter at each call site

Of the 20+ files touched in this PR, [ui/apps/platform/src/hooks/useURLParameter.ts](https://github.com/stackrox/stackrox/pull/12282/files#diff-4fcf6e26eda811c7c48207521e83c20ec3e1546ead71898df7b7b84c554a29f7) is the only functional change. There are 4 test files that are updated as they now require `jest.useFakeTimers()` to function correctly. All other files are a refactor to remove the now unneeded `'replace'` parameter.

### Overview

This problem occurs because the `useURLParameter()` hook and descendants track state and state changes isolated from one-another. Two calls to `setUrlParameter()` from two separate hooks have no way to coordinate, and by default will `push` history state, leading to two separate history entries as well as buggy behavior when the user navigates back and forth. An in place fix was added here https://github.com/stackrox/stackrox/pull/11135 with a recommendation to always use `'replace'` on subsequent hook calls when updating multiple state variables.

```ts
        // example where -5- different pieces of URL state are changed at once
        setActiveEntityTabKey('CVE');
        setSearchFilter({}, 'replace');
        sort.setSortOption(getDefaultWorkloadSortOption('CVE'), 'replace');
        pagination.setPage(1, 'replace');
        setObservedCveMode('WITH_CVES', 'replace');
```

This _works_, but is verbose and also error prone. We do not have any automated checks in place that can prevent these types of bugs from being reintroduced and it is easy to forget to add the second parameter.

An alternative solution as implemented in this PR is as follows:

1. Instead of immediately updating the URL parameter synchronously whenever a state setter is called, instead push an update event to some globally shared array.
2. When the first event is pushed, queue a `microtask` that will apply all URL state updates in a batch once the current function stack finishes executing, before the next tick of the event loop, react render, etc.
3. When this microtask executes, if *any* update even is of type `'push'`, it will push a single new entry to the history stack. Otherwise if *every* update is of type `'replace'`, it will update the history in place.

This allows the above code example to be written as follows, which will only push a single entry to the browser's history:

```ts
        setActiveEntityTabKey('CVE');
        setSearchFilter({});
        sort.setSortOption(getDefaultWorkloadSortOption('CVE'));
        pagination.setPage(1);
        setObservedCveMode('WITH_CVES');
```

#### State considerations

Since the `useURLParameter()` hook now needs to track state updates across multiple instances of the hook and coordinate applying these updates at once, there needs to be a globally accessible, *single* location to store this state.

1. Globally, in a mutable state local to the `useURLParameter.ts` file. This is what was done in the first commit for a proof of concept. Although the URL is global, and it seems unlikely we would ever need to track multiple batches of state at the same time, this isn't a great practice and is bound to cause problems eventually.
2. In `React.Context`, which is the implementation in the second commit for this PR. Very similar to the option above as all code exists local to the `useURLParameter` module and is effectively a singleton state due to the default React context. However, this does allow us to easily move the state elsewhere by implementing a context provider higher up in the tree with an alternative state storage.
3. In Redux. I tested this but decided against it. I didn't see much value over option 2, and it added quite a bit of complexity with changes to multiple other files, and would require the use of thunks. I did not finish implementation, but it is possible that the async thunks would have even made the overall approach not possible, depending on how they are scheduled by the library.

### Downsides

To me, the only known downside is that this approach blocks us from easily pushing multiple history states as a result of a single user action. To my knowledge, we do not do this anywhere in the app, which makes sense as this work is explicitly trying to avoid that behavior. This can be worked around by calling separate batches in a `setTimeout(() => {}, 0)`, but I doubt we will ever need to use it.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Updates to unit tests, run CI e2e tests.

Manual verification of behavior on different pages when applying url state changes and using the back button.