### PR TITLE
ROX-25332: Adding Lifecycle stage to the policy violations filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -16,4 +16,18 @@ export const Category: CompoundSearchFilterAttribute = {
     inputType: 'autocomplete',
 };
 
-export const policyAttributes = [Name, Category];
+export const LifecycleStage: CompoundSearchFilterAttribute = {
+    displayName: 'Lifecycle stage',
+    filterChipLabel: 'Lifecycle stage',
+    searchTerm: 'Lifecycle Stage',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { value: 'DEPLOY', label: 'Deploy' },
+            { value: 'BUILD', label: 'Build' },
+            { value: 'RUNTIME', label: 'Runtime' },
+        ],
+    },
+};
+
+export const policyAttributes = [Name, Category, LifecycleStage];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -3,21 +3,25 @@ import { SearchCategory } from 'services/SearchService';
 
 // Compound search filter types
 
-export type InputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number' | 'select';
+export type BaseInputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number';
+export type InputType = BaseInputType | 'select';
 
 type BaseSearchFilterAttribute = {
     displayName: string;
     filterChipLabel: string;
     searchTerm: string;
-    inputType: InputType;
+    inputType: BaseInputType;
 };
 
-export interface SelectSearchFilterAttribute extends BaseSearchFilterAttribute {
+export type SelectSearchFilterAttribute = {
+    displayName: string;
+    filterChipLabel: string;
+    searchTerm: string;
     inputType: 'select';
     inputProps: {
         options: { label: string; value: string }[];
     };
-}
+};
 
 export type CompoundSearchFilterAttribute = BaseSearchFilterAttribute | SelectSearchFilterAttribute;
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -12,6 +12,7 @@ import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/Com
 import {
     Category as PolicyCategory,
     Name as PolicyName,
+    LifecycleStage as PolicyLifecycleStage,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import {
     ID as ClusterID,
@@ -30,7 +31,7 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Policy',
         searchCategory: 'ALERTS',
-        attributes: [PolicyName, PolicyCategory],
+        attributes: [PolicyName, PolicyCategory, PolicyLifecycleStage],
     },
     {
         displayName: 'Cluster',


### PR DESCRIPTION
### Description

This PR adds a multi-select dropdown for the Lifecycle stage filter in Policy Violations.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="1440" alt="Screenshot 2024-08-06 at 2 23 02 PM" src="https://github.com/user-attachments/assets/6b43b038-fe54-4ddd-9547-6252d564eede">


