### PR TITLE
ROX-25335: Adding resource type to the policy violations filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -1,0 +1,24 @@
+// If you're adding a new attribute, make sure to add it to "alertAttributes" as well
+
+import { CompoundSearchFilterAttribute } from '../types';
+
+export const ResourceType: CompoundSearchFilterAttribute = {
+    displayName: 'Resource type',
+    filterChipLabel: 'Resource type',
+    searchTerm: 'Resource Type',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { value: 'UNKNOWN', label: 'Unknown' },
+            { value: 'SECRETS', label: 'Secrets' },
+            { value: 'CONFIGMAPS', label: 'Configmaps' },
+            { value: 'CLUSTER_ROLES', label: 'Cluster roles' },
+            { value: 'CLUSTER_ROLE_BINDINGS', label: 'Cluster role bindings' },
+            { value: 'NETWORK_POLICIES', label: 'Network policies' },
+            { value: 'SECURITY_CONTEXT_CONSTRAINTS', label: 'Security context constraints' },
+            { value: 'EGRESS_FIREWALLS', label: 'Egress firewalls' },
+        ],
+    },
+};
+
+export const alertAttributes = [ResourceType];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -3,21 +3,25 @@ import { SearchCategory } from 'services/SearchService';
 
 // Compound search filter types
 
-export type InputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number' | 'select';
+export type BaseInputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number';
+export type InputType = BaseInputType | 'select';
 
 type BaseSearchFilterAttribute = {
     displayName: string;
     filterChipLabel: string;
     searchTerm: string;
-    inputType: InputType;
+    inputType: BaseInputType;
 };
 
-export interface SelectSearchFilterAttribute extends BaseSearchFilterAttribute {
+export type SelectSearchFilterAttribute = {
+    displayName: string;
+    filterChipLabel: string;
+    searchTerm: string;
     inputType: 'select';
     inputProps: {
         options: { label: string; value: string }[];
     };
-}
+};
 
 export type CompoundSearchFilterAttribute = BaseSearchFilterAttribute | SelectSearchFilterAttribute;
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -25,6 +25,7 @@ import {
     ID as DeploymentID,
     Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
+import { ResourceType as AlertResourceType } from 'Components/CompoundSearchFilter/attributes/alert';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
     {
@@ -46,6 +47,11 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
         displayName: 'Deployment',
         searchCategory: 'ALERTS',
         attributes: [DeploymentID, DeploymentName],
+    },
+    {
+        displayName: 'Alert',
+        searchCategory: 'ALERTS',
+        attributes: [AlertResourceType],
     },
 ];
 


### PR DESCRIPTION
### Description

This PR adds a multi-select dropdown for the Resource type filter in Policy Violations.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="1440" alt="Screenshot 2024-08-06 at 2 24 21 PM" src="https://github.com/user-attachments/assets/c3e6f42c-132c-4c4f-a497-7ee655a70372">


