### PR TITLE
ROX-25336: Adding severity to the policy violations filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -1,5 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "policyAttributes" as well
 
+import { severityLabels } from 'messages/common';
 import { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
@@ -16,6 +17,21 @@ export const Category: CompoundSearchFilterAttribute = {
     inputType: 'autocomplete',
 };
 
+export const Severity: CompoundSearchFilterAttribute = {
+    displayName: 'Severity',
+    filterChipLabel: 'Policy severity',
+    searchTerm: 'Severity',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { label: severityLabels.CRITICAL_SEVERITY, value: 'CRITICAL_SEVERITY' },
+            { label: severityLabels.HIGH_SEVERITY, value: 'HIGH_SEVERITY' },
+            { label: severityLabels.MEDIUM_SEVERITY, value: 'MEDIUM_SEVERITY' },
+            { label: severityLabels.LOW_SEVERITY, value: 'LOW_SEVERITY' },
+        ],
+    },
+};
+
 export const LifecycleStage: CompoundSearchFilterAttribute = {
     displayName: 'Lifecycle stage',
     filterChipLabel: 'Lifecycle stage',
@@ -30,4 +46,4 @@ export const LifecycleStage: CompoundSearchFilterAttribute = {
     },
 };
 
-export const policyAttributes = [Name, Category, LifecycleStage];
+export const policyAttributes = [Name, Category, Severity, LifecycleStage];

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -13,6 +13,7 @@ import {
     Category as PolicyCategory,
     Name as PolicyName,
     LifecycleStage as PolicyLifecycleStage,
+    Severity as PolicySeverity,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import {
     ID as ClusterID,
@@ -31,7 +32,7 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Policy',
         searchCategory: 'ALERTS',
-        attributes: [PolicyName, PolicyCategory, PolicyLifecycleStage],
+        attributes: [PolicyName, PolicyCategory, PolicySeverity, PolicyLifecycleStage],
     },
     {
         displayName: 'Cluster',


### PR DESCRIPTION
### Description

This PR adds a multi-select dropdown for the Severity filter in Policy Violations.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="1440" alt="Screenshot 2024-08-06 at 2 25 57 PM" src="https://github.com/user-attachments/assets/bc94340a-2611-4c9c-8577-56149a87e772">

