### PR TITLE
ROX-25331: Adding inactive deployment to the policy violations filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -1,0 +1,18 @@
+// If you're adding a new attribute, make sure to add it to "alertAttributes" as well
+
+import { CompoundSearchFilterAttribute } from '../types';
+
+export const InactiveDeployment: CompoundSearchFilterAttribute = {
+    displayName: 'Inactive deployment',
+    filterChipLabel: 'Inactive deployment',
+    searchTerm: 'Inactive Deployment',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { value: 'true', label: 'True' },
+            { value: 'false', label: 'False' },
+        ],
+    },
+};
+
+export const alertAttributes = [InactiveDeployment];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -3,14 +3,14 @@
 import { CompoundSearchFilterAttribute } from '../types';
 
 export const InactiveDeployment: CompoundSearchFilterAttribute = {
-    displayName: 'Inactive deployment',
-    filterChipLabel: 'Inactive deployment',
+    displayName: 'Deployment status',
+    filterChipLabel: 'Deployment status',
     searchTerm: 'Inactive Deployment',
     inputType: 'select',
     inputProps: {
         options: [
-            { value: 'true', label: 'True' },
-            { value: 'false', label: 'False' },
+            { value: 'false', label: 'Active' },
+            { value: 'true', label: 'Inactive' },
         ],
     },
 };

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -25,12 +25,18 @@ import {
     ID as DeploymentID,
     Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
+import { InactiveDeployment as AlertInactiveDeployment } from 'Components/CompoundSearchFilter/attributes/alert';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Policy',
         searchCategory: 'ALERTS',
         attributes: [PolicyName, PolicyCategory],
+    },
+    {
+        displayName: 'Policy violation',
+        searchCategory: 'ALERTS',
+        attributes: [AlertInactiveDeployment],
     },
     {
         displayName: 'Cluster',


### PR DESCRIPTION
### Description

This PR adds a multi-select dropdown for the Inactive deployment filter in Policy Violations.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="1440" alt="Screenshot 2024-08-06 at 2 39 21 PM" src="https://github.com/user-attachments/assets/8ebfb04c-950b-4e04-b8a4-23c34e133365">

