### PR TITLE
fix(ui): Move banner elements into landmarks for accessibility

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
@@ -1,0 +1,49 @@
+import React, { ReactElement } from 'react';
+
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+
+import AnnouncementBanner from './AnnouncementBanner';
+import CredentialExpiryBanner from './CredentialExpiryBanner';
+import DatabaseStatusBanner from './DatabaseStatusBanner';
+import OutdatedVersionBanner from './OutdatedVersionBanner';
+import ServerStatusBanner from './ServerStatusBanner';
+
+function Banners(): ReactElement {
+    // Assume MainPage renders this element only after feature flags and permissions are available.
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadWriteAccess } = usePermissions();
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const centralCanUpdateCert = isCentralCapabilityAvailable('centralCanUpdateCert');
+    const hasAdministrationWritePermission = hasReadWriteAccess('Administration');
+    const showCertGenerateAction = centralCanUpdateCert && hasAdministrationWritePermission;
+
+    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+
+    return (
+        <>
+            <AnnouncementBanner />
+            <CredentialExpiryBanner
+                component="CENTRAL"
+                showCertGenerateAction={showCertGenerateAction}
+            />
+            <CredentialExpiryBanner
+                component="SCANNER"
+                showCertGenerateAction={showCertGenerateAction}
+            />
+            {isScannerV4Enabled && (
+                <CredentialExpiryBanner
+                    component="SCANNER_V4"
+                    showCertGenerateAction={showCertGenerateAction}
+                />
+            )}
+            <OutdatedVersionBanner />
+            <DatabaseStatusBanner />
+            <ServerStatusBanner />
+        </>
+    );
+}
+
+export default Banners;

--- a/ui/apps/platform/src/Containers/MainPage/Header/Header.css
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Header.css
@@ -1,0 +1,6 @@
+/* Render as grid row in Masthead element above toggle, main, and content elements. */
+.pf-v5-c-masthead .Toastify,
+.pf-v5-c-masthead .pf-v5-c-banner {
+    grid-column-start: 1;
+    grid-column-end: -1; /* from end, independent of number of columns */
+}

--- a/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
@@ -23,7 +23,6 @@ function Header(): ReactElement {
     // aria-label="primary" prop makes header element a unique landmark.
     return (
         <Masthead
-            aria-label="primary"
             className="ignore-react-onclickoutside theme-dark"
             inset={{ default: 'insetNone' }}
         >

--- a/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
@@ -10,14 +10,27 @@ import {
 import { BarsIcon } from '@patternfly/react-icons';
 
 import BrandLogo from 'Components/PatternFly/BrandLogo';
+import Banners from '../Banners/Banners';
+import PublicConfigHeader from '../PublicConfig/PublicConfigHeader';
 import MastheadToolbar from './MastheadToolbar';
+import Notifications from './Notifications';
+
+// Style rule for Notifications, PublicConfigHeader, and Banners elements.
+import './Header.css';
 
 function Header(): ReactElement {
     // PageToggleButton assumes isManagedSidebar prop of Page element.
     // aria-label="primary" prop makes header element a unique landmark.
     return (
-        <Masthead className="ignore-react-onclickoutside theme-dark">
-            <MastheadToggle>
+        <Masthead
+            aria-label="primary"
+            className="ignore-react-onclickoutside theme-dark"
+            inset={{ default: 'insetNone' }}
+        >
+            <Notifications />
+            <PublicConfigHeader />
+            <Banners />
+            <MastheadToggle className="pf-v5-u-pl-lg">
                 <PageToggleButton variant="plain">
                     <BarsIcon />
                 </PageToggleButton>
@@ -27,7 +40,7 @@ function Header(): ReactElement {
                     <BrandLogo />
                 </MastheadBrand>
             </MastheadMain>
-            <MastheadContent className="pf-v5-u-flex-grow-1 pf-v5-u-justify-content-flex-end">
+            <MastheadContent className="pf-v5-u-flex-grow-1 pf-v5-u-justify-content-flex-end pf-v5-u-pr-lg">
                 <MastheadToolbar />
             </MastheadContent>
         </Masthead>

--- a/ui/apps/platform/src/Containers/MainPage/Header/Notifications.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Notifications.tsx
@@ -13,11 +13,7 @@ function Notifications(): ReactElement {
         Upgrading to React types 18 causes a type error below due to the `children` prop being removed from the `React.FC` type
 
         @ts-expect-error ToastContainer does not expect children as a prop */
-        <ToastContainer
-            toastClassName="toast-selector bg-base-100"
-            hideProgressBar
-            autoClose={8000}
-        >
+        <ToastContainer toastClassName="toast-selector" hideProgressBar autoClose={8000}>
             {notifications.length !== 0 && toast(notifications[0])}
         </ToastContainer>
     );

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -5,7 +5,6 @@ import { Page, Button } from '@patternfly/react-core';
 import { OutlinedCommentsIcon } from '@patternfly/react-icons';
 
 import LoadingSection from 'Components/PatternFly/LoadingSection';
-import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import { selectors } from 'reducers';
@@ -13,21 +12,11 @@ import { actions } from 'reducers/feedback';
 import { getClustersForPermissions } from 'services/RolesService';
 import { clustersBasePath } from 'routePaths';
 
-import AnnouncementBanner from './Banners/AnnouncementBanner';
-import CredentialExpiryBanner from './Banners/CredentialExpiryBanner';
-import DatabaseStatusBanner from './Banners/DatabaseStatusBanner';
-import OutdatedVersionBanner from './Banners/OutdatedVersionBanner';
-import ServerStatusBanner from './Banners/ServerStatusBanner';
-
 import Header from './Header/Header';
-
 import PublicConfigFooter from './PublicConfig/PublicConfigFooter';
-import PublicConfigHeader from './PublicConfig/PublicConfigHeader';
-
 import NavigationSidebar from './Sidebar/NavigationSidebar';
 
 import Body from './Body';
-import Notifications from './Notifications';
 import AcsFeedbackModal from './AcsFeedbackModal';
 
 function MainPage(): ReactElement {
@@ -40,14 +29,7 @@ function MainPage(): ReactElement {
     const isLoadingCentralCapabilities = useSelector(selectors.getIsLoadingCentralCapabilities);
     const [isLoadingClustersCount, setIsLoadingClustersCount] = useState(false);
 
-    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
-
-    const hasAdministrationWritePermission = hasReadWriteAccess('Administration');
-    const { isCentralCapabilityAvailable } = useCentralCapabilities();
-    const centralCanUpdateCert = isCentralCapabilityAvailable('centralCanUpdateCert');
-    const currentUserCanGenerateCert = centralCanUpdateCert && hasAdministrationWritePermission;
 
     useEffect(() => {
         if (hasWriteAccessForCluster) {
@@ -84,9 +66,7 @@ function MainPage(): ReactElement {
         return <LoadingSection message="Loading..." />;
     }
 
-    return (
-        <>
-            <Notifications />
+    /*
             <PublicConfigHeader />
             <AnnouncementBanner />
             <CredentialExpiryBanner
@@ -106,6 +86,10 @@ function MainPage(): ReactElement {
             <OutdatedVersionBanner />
             <DatabaseStatusBanner />
             <ServerStatusBanner />
+    */
+
+    return (
+        <>
             <div id="PageParent">
                 <Button
                     style={{
@@ -144,7 +128,9 @@ function MainPage(): ReactElement {
                     />
                 </Page>
             </div>
-            <PublicConfigFooter />
+            <footer>
+                <PublicConfigFooter />
+            </footer>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -66,28 +66,6 @@ function MainPage(): ReactElement {
         return <LoadingSection message="Loading..." />;
     }
 
-    /*
-            <PublicConfigHeader />
-            <AnnouncementBanner />
-            <CredentialExpiryBanner
-                component="CENTRAL"
-                showCertGenerateAction={currentUserCanGenerateCert}
-            />
-            <CredentialExpiryBanner
-                component="SCANNER"
-                showCertGenerateAction={currentUserCanGenerateCert}
-            />
-            {isScannerV4Enabled && (
-                <CredentialExpiryBanner
-                    component="SCANNER_V4"
-                    showCertGenerateAction={currentUserCanGenerateCert}
-                />
-            )}
-            <OutdatedVersionBanner />
-            <DatabaseStatusBanner />
-            <ServerStatusBanner />
-    */
-
     return (
         <>
             <div id="PageParent">

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -114,9 +114,22 @@ h6 {
     z-index: 9000;
 }
 
+/* Specify PatternFly light-on-dark colors explicitly for toast because variables have light-on-dark colors in Masthead. */
+
 .toast-selector {
-    @apply text-base !important;
+    background-color: #ffffff;
+    color: #151515;
     font-family: var(--pf-v5-global--FontFamily--sans-serif);
+    font-size: var(--pf-v5-global--FontSize--sm);
+}
+
+.Toastify__close-button--default {
+    color: #151515;
+    opacity: 1;
+}
+
+.Toastify__progress-bar {
+    display: none; /* Prevent axe DevTools issue: ARIA progressbar node must have an accessible name */
 }
 
 .pill {


### PR DESCRIPTION
### Description

### Problems reported by axe DevTools

> All page content should be contained by landmarks

https://dequeuniversity.com/rules/axe/4.9/region?application=AxeChrome

```html
<div class="pf-v5-c-banner pf-m-red pf-v5-u-text-align-center"><span class="pf-v5-u-text-align-center">The database is currently not available. If this problem persists, please contact support.</span></div>
```

> ARIA progressbar node must have an accessible name

https://dequeuniversity.com/rules/axe/4.9/aria-progressbar-name?application=AxeChrome

```html
<div role="progressbar" class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default" style="animation-duration: 800000ms; animation-play-state: paused; opacity: 0;"></div>
```

### Analysis

Indeed, MainPage.tsx file renders banner elements outside of landmark elements.

### Solution

1. Move (conditional) rendering of banners from MainPage.tsx to Banners.tsx file.
2. Render `Notifications`, `PublicConfigHeader`, and `Banners` elements in Header.tsx file, therefore in `header` landmark element.
3. Add Header.css file for grid layout of banners preceding the grid row of ordinary children in `Masthead` element.
4. Move and edit Notifications.tsx file.
    * Replace `bg-base-100` class with style rules in app.tw.css file for better PatternFly compatibility.
    * Add style rule with `display: none` for progress bar to prevent the second accessibility issue.
5. Enclose `PublicConfigFooter` element in `footer` landmark element.

### Residue

1. Investigate need for `div` elements:
    * MainPage.tsx file: `<div id="PageParent">` or redundant with `<div id="root">` from index.html file?
    * Body.tsx file: `<div className="flex flex-col h-full w-full relative overflow-auto">` or redundant with `main` element?
2. Replace notifications via react-toastify with PatternFly `Alert` elements?

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 283 = 4617983 - 4617700
        total 283 = 11703449 - 11703166
    * `ls -al build/static/js/*.js | wc`
        files 0 = 173 - 173
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Temporarily edit Notifications.tsx file to increase value of `autoClose` prop.

2. Visit /main/compliance, click **Scan environment**, click a built-in standard, and then click **Scan**.
    There is a current convenient error that displays a toast notification.

    * Before changes, see presence of accessibility issue.
        ![notifications_with_issues](https://github.com/user-attachments/assets/a0d32baf-cdef-4c21-bc63-e5292a8e9b41)

    * After changes, see absence of accessibility issue **but** inconsistent style.
        ![notifications_without_issues_dark](https://github.com/user-attachments/assets/b219f9df-fd22-4b26-989f-9b46986fb243)

    * After changes, see absence of accessibility issue **and** consistent style.
        ![notifications_without_issues_light](https://github.com/user-attachments/assets/57e09296-63f4-4a64-8650-b68776c3d633)

3. Temporarily edit DatabaseStatusBanner.tsx files to render one banner.

    * Before changes, see presence of accessibility issue.
        ![banners_1_0_with_issues_axe_DevTools](https://github.com/user-attachments/assets/4b2bdfd0-ffae-4710-85cf-375a7142e754)

    * After changes, see absence of accessibility issue.
        ![banners_1_0_without_issues](https://github.com/user-attachments/assets/2dd30f67-dea1-4b83-babc-205e6ec1bda4)

4. Temporarily edit AnnouncementBanner.tsx file to render another banner,

    * Before changes, see presence of accessibility issues.
        ![banners_2_0_with_issues_axe_DevTools](https://github.com/user-attachments/assets/1e9e1687-c859-471c-be27-6832ef0c56bb)

    * After changes, see absence of accessibility issues.
        ![banners_2_0_without_issues](https://github.com/user-attachments/assets/af59fcdf-da9f-408f-846d-8c265d9466da)

5. Visit /main/systemconfig and enable header and footer for 3 at upper edge and 1 at lower edge.

    * Before changes, see presence of accessibility issues.
        ![banners_3_1_with_issues_axe_DevTools](https://github.com/user-attachments/assets/71d1da6b-d078-40a3-ae14-fde5a48ceaf9)
        ![banners_3_1_with_issues_Elements](https://github.com/user-attachments/assets/2eab8eb4-8789-46fa-ab91-1470017f6230)

    * After changes, see absence of accessibility issues.
        ![banners_3_1_without_issues](https://github.com/user-attachments/assets/8e788184-7167-467e-9870-7d3ad619704e)

6. Temporarily edit other banner files to verify no layout problems in worse case.

    * Before changes, see presence of accessibility issues.
        ![banners_6_1_with_issues_axe_DevTools](https://github.com/user-attachments/assets/41d872b8-16c5-47d1-8e63-b855e0e6169b)

    * After changes, see absence of accessibility issues.
        ![banners_6_1_without_issues](https://github.com/user-attachments/assets/f6f06b99-ab74-4262-b8b2-f7574c65f88a)

#### Integration testing

* credentialExpiry/credentialExpiry.test.js
* systemConfig/systemConfig.test.js
* logout.test.js
* userinfo.test.js
