### PR TITLE
fix(ci): style checks running out of disk space

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -79,6 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.69
+      volumes:
+      - /usr:/mnt/usr
+      - /opt:/mnt/opt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,6 +92,17 @@ jobs:
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+      - name: Free more disk space
+        shell: bash
+        run: |
+          set +e
+          set -x
+          df -h
+          for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL; do
+            rm -rf "/mnt${delete:?}"
+          done
+          df -h
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies


### PR DESCRIPTION
### Description

Style checks have been failing due to disk space (lack thereof). This reclaims even more disk space in hopes we can continue styling.

Copied this over from https://github.com/stackrox/stackrox/blob/master/.github/workflows/scanner-release-vuln-update.yaml

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

This **is** the test!
