### PR TITLE
ROX-21226: conceal addresses from clairify scanner errors

### DIFF
--- a/pkg/errox/utils.go
+++ b/pkg/errox/utils.go
@@ -71,7 +71,7 @@ func ConcealSensitive(err error) error {
 				msg = append(msg, e.Error())
 			}
 			return &wrapErrors{
-				fmt.Sprintf("multiple errors: [%v]", strings.Join(msg, ", ")),
+				fmt.Sprintf("[%s]", strings.Join(msg, ", ")),
 				concealed,
 			}
 		}

--- a/pkg/errox/utils.go
+++ b/pkg/errox/utils.go
@@ -30,7 +30,8 @@ func x[T error](err error) T {
 }
 
 // ConcealSensitive strips sensitive data from some known error types and
-// returns a new error.
+// returns a new error if something has been concealed, and otherwise the
+// original error is returned.
 func ConcealSensitive(err error) error {
 	original := err
 	for err != nil {

--- a/pkg/errox/utils_test.go
+++ b/pkg/errox/utils_test.go
@@ -2,6 +2,7 @@ package errox
 
 import (
 	"net"
+	"net/url"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -34,8 +35,16 @@ func TestConcealSensitive(t *testing.T) {
 			&net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
 			"operation: not found",
 		},
+		"url.Error": {
+			&url.Error{Err: &net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}}, Op: "Get", URL: "URL"},
+			// The url.Error details are not dropped, because url.Error is a
+			// known error type. The wrapped net.OpError is concealed.
+			"Get \"URL\": operation: not found",
+		},
 		"wrapped": {
 			errors.WithMessage(&net.AddrError{Err: "invalid IP address", Addr: "secret"}, "dropped message"),
+			// The "dropped message" is dropped, because the type of the wrapper
+			// is unknown.
 			"address error: invalid IP address",
 		},
 	}

--- a/pkg/errox/utils_test.go
+++ b/pkg/errox/utils_test.go
@@ -1,6 +1,7 @@
 package errox
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"testing"
@@ -46,6 +47,16 @@ func TestConcealSensitive(t *testing.T) {
 			// The "dropped message" is dropped, because the type of the wrapper
 			// is unknown.
 			"address error: invalid IP address",
+		},
+		"%w": {
+			fmt.Errorf("%w", &net.AddrError{Err: "invalid IP address", Addr: "secret"}),
+			"address error: invalid IP address",
+		},
+		"%w %w %w": {
+			fmt.Errorf("%w %w %w", &net.AddrError{Err: "invalid IP address", Addr: "secret"},
+				&net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
+				&net.DNSError{Err: "unknown network", Name: "secret", Server: "server"}),
+			"multiple errors: [address error: invalid IP address, operation: not found, lookup error: unknown network]",
 		},
 	}
 	for name, test := range tests {

--- a/pkg/errox/utils_test.go
+++ b/pkg/errox/utils_test.go
@@ -33,8 +33,8 @@ func TestConcealSensitive(t *testing.T) {
 			"lookup error: unknown network",
 		},
 		"net.OpError": {
-			&net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
-			"operation: not found",
+			&net.OpError{Op: "operation", Net: "tcp", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
+			"operation tcp: not found",
 		},
 		"url.Error": {
 			&url.Error{Err: &net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}}, Op: "Get", URL: "URL"},

--- a/pkg/errox/utils_test.go
+++ b/pkg/errox/utils_test.go
@@ -1,0 +1,48 @@
+package errox
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcealSensitive(t *testing.T) {
+
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"simple": {
+			errors.New("simple"),
+			"simple",
+		},
+		"sentinel": {
+			NotAuthorized,
+			"not authorized",
+		},
+		"net.AddrError": {
+			&net.AddrError{Err: "invalid IP address", Addr: "secret"},
+			"address error: invalid IP address",
+		},
+		"net.DNSError": {
+			&net.DNSError{Err: "unknown network", Name: "secret", Server: "server"},
+			"lookup error: unknown network",
+		},
+		"net.OpError": {
+			&net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
+			"operation: not found",
+		},
+		"wrapped": {
+			errors.WithMessage(&net.AddrError{Err: "invalid IP address", Addr: "secret"}, "dropped message"),
+			"address error: invalid IP address",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, ConcealSensitive(test.err).Error())
+		})
+	}
+	assert.Nil(t, ConcealSensitive(nil))
+}

--- a/pkg/errox/utils_test.go
+++ b/pkg/errox/utils_test.go
@@ -53,10 +53,11 @@ func TestConcealSensitive(t *testing.T) {
 			"address error: invalid IP address",
 		},
 		"%w %w %w": {
-			fmt.Errorf("%w %w %w", &net.AddrError{Err: "invalid IP address", Addr: "secret"},
+			fmt.Errorf("dropped %w wrapping %w message %w",
+				&net.AddrError{Err: "invalid IP address", Addr: "secret"},
 				&net.OpError{Op: "operation", Err: NotFound, Addr: &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}},
 				&net.DNSError{Err: "unknown network", Name: "secret", Server: "server"}),
-			"multiple errors: [address error: invalid IP address, operation: not found, lookup error: unknown network]",
+			"[address error: invalid IP address, operation: not found, lookup error: unknown network]",
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The change hides potentially sensitive addresses from some errors returned by `/v1/images/scan`, when using clairify scanner.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

### Before

```console
me@work$ curl -u admin:password 'https://localhost:8443/v1/images/scan' --data '{"imageName": "ubuntu:23.04"}' -ks | jq
{
  "error": "image enrichment error: error scanning image: docker.io/library/ubuntu:23.04 error: scanning \"docker.io/library/ubuntu:23.04\" with scanner \"Stackrox Scanner\": Get \"https://scanner.stackrox.svc:8080/scanner/sha/sha256:ea1285dffce8a938ef356908d1be741da594310c8dced79b870d66808cb12b0f\": dial tcp 34.118.237.164:8080: connect: connection refused",
  "code": 13,
  "message": "image enrichment error: error scanning image: docker.io/library/ubuntu:23.04 error: scanning \"docker.io/library/ubuntu:23.04\" with scanner \"Stackrox Scanner\": Get \"https://scanner.stackrox.svc:8080/scanner/sha/sha256:ea1285dffce8a938ef356908d1be741da594310c8dced79b870d66808cb12b0f\": dial tcp 34.118.237.164:8080: connect: connection refused",
  "details": []
}
```

### After

```console
me@work$ curl -u admin:password 'https://localhost:8443/v1/images/scan' --data '{"imageName": "ubuntu:23.04"}' -ks | jq
{
  "code": 13,
  "message": "image enrichment error: error scanning image: docker.io/library/ubuntu:23.04 error: scanning \"docker.io/library/ubuntu:23.04\" with scanner \"Stackrox Scanner\": Get \"https://scanner.stackrox.svc:8080/scanner/sha/sha256:ea1285dffce8a938ef356908d1be741da594310c8dced79b870d66808cb12b0f\": dial tcp: connect: connection refused",
  "details": [],
  "error": "image enrichment error: error scanning image: docker.io/library/ubuntu:23.04 error: scanning \"docker.io/library/ubuntu:23.04\" with scanner \"Stackrox Scanner\": Get \"https://scanner.stackrox.svc:8080/scanner/sha/sha256:ea1285dffce8a938ef356908d1be741da594310c8dced79b870d66808cb12b0f\": dial tcp: connect: connection refused"
}

```