### PR TITLE
ROX-25609: Add secured cluster upgrader metrics

### DIFF
--- a/central/sensor/service/connection/upgradecontroller/metrics.go
+++ b/central/sensor/service/connection/upgradecontroller/metrics.go
@@ -1,0 +1,31 @@
+package upgradecontroller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(upgraderTriggered)
+}
+
+var (
+	upgraderTriggered = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "upgrader_triggered_total",
+		Help:      "Number of times the upgrader was triggered.",
+	}, []string{"centralVersion", "sensorVersion", "clusterID", "triggerOrigin", "upgradeType"})
+)
+
+func registerUpgraderTriggered(sensorVersion, origin, clusterID string, process *storage.ClusterUpgradeStatus_UpgradeProcessStatus, upgraderActive bool) {
+	if upgraderActive {
+		upgraderTriggered.With(prometheus.Labels{
+			"centralVersion": process.GetTargetVersion(),
+			"sensorVersion":  sensorVersion,
+			"clusterID":      clusterID,
+			"triggerOrigin":  origin,
+			"upgradeType":    process.GetType().String()}).Inc()
+	}
+}

--- a/central/sensor/service/connection/upgradecontroller/metrics.go
+++ b/central/sensor/service/connection/upgradecontroller/metrics.go
@@ -8,6 +8,7 @@ import (
 
 func init() {
 	prometheus.MustRegister(upgraderTriggered)
+	prometheus.MustRegister(upgraderErrors)
 }
 
 var (
@@ -17,9 +18,15 @@ var (
 		Name:      "upgrader_triggered_total",
 		Help:      "Number of times the upgrader was triggered.",
 	}, []string{"centralVersion", "sensorVersion", "clusterID", "triggerOrigin", "upgradeType"})
+	upgraderErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "upgrader_errors_total",
+		Help:      "Number of times the upgrader returned error.",
+	}, []string{"centralVersion", "sensorVersion", "clusterID", "error", "upgradeType"})
 )
 
-func registerUpgraderTriggered(sensorVersion, origin, clusterID string, process *storage.ClusterUpgradeStatus_UpgradeProcessStatus, upgraderActive bool) {
+func observeUpgraderTriggered(sensorVersion, origin, clusterID string, process *storage.ClusterUpgradeStatus_UpgradeProcessStatus, upgraderActive bool) {
 	if upgraderActive {
 		upgraderTriggered.With(prometheus.Labels{
 			"centralVersion": process.GetTargetVersion(),
@@ -28,4 +35,19 @@ func registerUpgraderTriggered(sensorVersion, origin, clusterID string, process 
 			"triggerOrigin":  origin,
 			"upgradeType":    process.GetType().String()}).Inc()
 	}
+}
+
+func observeUpgraderError(sensorVersion, clusterID, err string, process *storage.ClusterUpgradeStatus_UpgradeProcessStatus) {
+	upgradeType := "unknown"
+	centralVersion := "unknown"
+	if process != nil {
+		upgradeType = process.GetType().String()
+		centralVersion = process.GetTargetVersion()
+	}
+	upgraderErrors.With(prometheus.Labels{
+		"centralVersion": centralVersion,
+		"sensorVersion":  sensorVersion,
+		"clusterID":      clusterID,
+		"error":          err,
+		"upgradeType":    upgradeType}).Inc()
 }

--- a/central/sensor/service/connection/upgradecontroller/metrics.go
+++ b/central/sensor/service/connection/upgradecontroller/metrics.go
@@ -38,6 +38,9 @@ func observeUpgraderTriggered(sensorVersion, origin, clusterID string, process *
 }
 
 func observeUpgraderError(sensorVersion, clusterID, err string, process *storage.ClusterUpgradeStatus_UpgradeProcessStatus) {
+	if err == "" {
+		return
+	}
 	upgradeType := "unknown"
 	centralVersion := "unknown"
 	if process != nil {

--- a/central/sensor/service/connection/upgradecontroller/process_check_ins.go
+++ b/central/sensor/service/connection/upgradecontroller/process_check_ins.go
@@ -168,6 +168,5 @@ func (u *upgradeController) doProcessCheckInFromSensor(req *central.UpgradeCheck
 	default:
 		return errors.Errorf("Unknown or malformed upgrade check-in from sensor: %+v", req)
 	}
-
 	return u.setUpgradeProgress(req.GetUpgradeProcessId(), nextState, detail)
 }

--- a/central/sensor/service/connection/upgradecontroller/register_connection.go
+++ b/central/sensor/service/connection/upgradecontroller/register_connection.go
@@ -88,7 +88,7 @@ func (u *upgradeController) maybeTriggerAutoUpgrade() {
 		log.Errorf("Cannot automatically trigger auto-upgrade for sensor in cluster %s: %v", u.clusterID, err)
 	} else {
 		u.makeProcessActive(cluster, process)
-		registerUpgraderTriggered(u.getSensorVersion(), "new-connection-reconciliation", u.clusterID, process, u.active != nil)
+		observeUpgraderTriggered(u.getSensorVersion(), "new-connection-reconciliation", u.clusterID, process, u.active != nil)
 	}
 }
 

--- a/central/sensor/service/connection/upgradecontroller/register_connection.go
+++ b/central/sensor/service/connection/upgradecontroller/register_connection.go
@@ -88,6 +88,7 @@ func (u *upgradeController) maybeTriggerAutoUpgrade() {
 		log.Errorf("Cannot automatically trigger auto-upgrade for sensor in cluster %s: %v", u.clusterID, err)
 	} else {
 		u.makeProcessActive(cluster, process)
+		registerUpgraderTriggered(u.getSensorVersion(), "new-connection-reconciliation", u.clusterID, process, u.active != nil)
 	}
 }
 

--- a/central/sensor/service/connection/upgradecontroller/trigger.go
+++ b/central/sensor/service/connection/upgradecontroller/trigger.go
@@ -113,6 +113,7 @@ func (u *upgradeController) doTriggerCertRotation() (common.MessageInjector, *ce
 	cluster := u.getCluster()
 	process := newCertRotationProcess()
 	u.makeProcessActive(cluster, process)
+	registerUpgraderTriggered(u.getSensorVersion(), "cert-rotation", u.clusterID, process, u.active != nil)
 	return u.activeSensorConn.conn, u.active.trigger, nil
 }
 
@@ -142,6 +143,6 @@ func (u *upgradeController) doTriggerUpgrade() (common.MessageInjector, *central
 	}
 
 	u.makeProcessActive(cluster, process)
-
+	registerUpgraderTriggered(u.getSensorVersion(), "ui-click", u.clusterID, process, u.active != nil)
 	return u.activeSensorConn.conn, u.active.trigger, nil
 }

--- a/central/sensor/service/connection/upgradecontroller/trigger.go
+++ b/central/sensor/service/connection/upgradecontroller/trigger.go
@@ -113,7 +113,7 @@ func (u *upgradeController) doTriggerCertRotation() (common.MessageInjector, *ce
 	cluster := u.getCluster()
 	process := newCertRotationProcess()
 	u.makeProcessActive(cluster, process)
-	registerUpgraderTriggered(u.getSensorVersion(), "cert-rotation", u.clusterID, process, u.active != nil)
+	observeUpgraderTriggered(u.getSensorVersion(), "cert-rotation", u.clusterID, process, u.active != nil)
 	return u.activeSensorConn.conn, u.active.trigger, nil
 }
 
@@ -143,6 +143,6 @@ func (u *upgradeController) doTriggerUpgrade() (common.MessageInjector, *central
 	}
 
 	u.makeProcessActive(cluster, process)
-	registerUpgraderTriggered(u.getSensorVersion(), "ui-click", u.clusterID, process, u.active != nil)
+	observeUpgraderTriggered(u.getSensorVersion(), "ui-click", u.clusterID, process, u.active != nil)
 	return u.activeSensorConn.conn, u.active.trigger, nil
 }

--- a/central/sensor/service/connection/upgradecontroller/upgrade_controller_impl.go
+++ b/central/sensor/service/connection/upgradecontroller/upgrade_controller_impl.go
@@ -97,7 +97,11 @@ func (u *upgradeController) do(doFn func() error) (err error) {
 		} else if err != nil {
 			errForMetric = err.Error()
 		}
-		observeUpgraderError(u.getSensorVersion(), u.clusterID, errForMetric, u.active.status)
+		var process *storage.ClusterUpgradeStatus_UpgradeProcessStatus
+		if u.active != nil {
+			process = u.active.status
+		}
+		observeUpgraderError(u.getSensorVersion(), u.clusterID, errForMetric, process)
 	}()
 
 	u.mutex.Lock()

--- a/central/sensor/service/connection/upgradecontroller/upgrade_controller_impl.go
+++ b/central/sensor/service/connection/upgradecontroller/upgrade_controller_impl.go
@@ -65,7 +65,9 @@ func (u *upgradeController) initialize() error {
 	upgradeStatus.UpgradabilityStatusReason = ""
 
 	u.upgradeStatus = upgradeStatus
-	u.makeProcessActive(cluster, upgradeStatus.GetMostRecentProcess())
+	process := upgradeStatus.GetMostRecentProcess()
+	u.makeProcessActive(cluster, process)
+	registerUpgraderTriggered(u.getSensorVersion(), "central-initialization", u.clusterID, process, u.active != nil)
 
 	if err := u.flushUpgradeStatus(); err != nil {
 		return errors.Wrap(err, "persisting upgrade status to DB")
@@ -120,4 +122,11 @@ func (u *upgradeController) shouldAutoTriggerUpgrade() bool {
 		}
 	}
 	return true
+}
+
+func (u *upgradeController) getSensorVersion() string {
+	if u.activeSensorConn == nil {
+		return ""
+	}
+	return u.activeSensorConn.sensorVersion
 }


### PR DESCRIPTION
### Description

This PR adds prometheus metric for counting the triggers of the upgrader.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Deployed to the cluster and triggered various actions

Examplary record:
```
# HELP rox_central_upgrader_triggered_total Number of times the upgrader was triggered.
# TYPE rox_central_upgrader_triggered_total counter
rox_central_upgrader_triggered_total{centralVersion="4.6.x-255-g51668cac50",clusterID="63e84bed-4d36-4d8a-8bbc-fcf2f15c00d9",sensorVersion="",triggerOrigin="new-connection-reconciliation",upgradeType="UPGRADE"} 1
rox_central_upgrader_triggered_total{centralVersion="4.6.x-255-g51668cac50",clusterID="63e84bed-4d36-4d8a-8bbc-fcf2f15c00d9",sensorVersion="4.5.0",triggerOrigin="ui-click",upgradeType="UPGRADE"} 1
```
