### PR TITLE
RXO-22359: Update Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
     "includePaths": [
       // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)
       // to have less PR noise.
-      "**/konflux.*Dockerfile",
+      "**/*konflux*.Dockerfile",
     ],
   },
   "enabledManagers": [
@@ -35,6 +35,4 @@
     "tekton",
     "dockerfile",
   ],
-  // TODO: remove once debugged. See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721809083784519
-  "printConfig": true
 }


### PR DESCRIPTION
### Description

Simply copied settings from Scanner repo.
I hope this is it, and the config should serve us (and not the other way around).

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No automated testing.

#### How I validated my change

Only ran Renovate validator cli.