### PR TITLE
chore(ui): Add more timestamp output to cypress e2e runs

### DIFF
--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -19,6 +19,15 @@ module.exports = {
         specPattern: 'cypress/integration/**/*.test.{js,ts}',
         viewportHeight: 850, // Viewport options
         viewportWidth: 1440, // Viewport options
+        setupNodeEvents: (on) => {
+            on('task', {
+                beforeSuite(spec) {
+                    // eslint-disable-next-line no-console
+                    console.log(`${new Date().toISOString()} running test suite: ${spec.name}\n`);
+                    return null;
+                },
+            });
+        },
     },
 
     component: {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -106,7 +106,7 @@ describe('Workload CVE overview page tests', () => {
 
             const cvesBySeverityHeader = 'th:contains("CVEs by severity")';
             const prioritizeByNamespaceButton = 'a:contains("Prioritize by namespace view")';
-            const defaultFiltersButton = 'button:contains("Deault filters")';
+            const defaultFiltersButton = 'button:contains("Default filters")';
 
             function assertCveElementsArePresent() {
                 cy.get(cvesBySeverityHeader);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -106,7 +106,7 @@ describe('Workload CVE overview page tests', () => {
 
             const cvesBySeverityHeader = 'th:contains("CVEs by severity")';
             const prioritizeByNamespaceButton = 'a:contains("Prioritize by namespace view")';
-            const defaultFiltersButton = 'button:contains("Default filters")';
+            const defaultFiltersButton = 'button:contains("Deault filters")';
 
             function assertCveElementsArePresent() {
                 cy.get(cvesBySeverityHeader);

--- a/ui/apps/platform/cypress/support/e2e.js
+++ b/ui/apps/platform/cypress/support/e2e.js
@@ -41,3 +41,15 @@ Cypress.on(
         !err.message.includes("Uncaught SyntaxError: Unexpected token '<'") &&
         !err.message.includes("Uncaught SyntaxError: Unexpected token '<'")
 );
+
+// Output timestamps for test suite start and end
+before(() => {
+    cy.task('beforeSuite', Cypress.spec);
+});
+
+// Output timestamp at the point of test failure
+Cypress.on('fail', (err) => {
+    // eslint-disable-next-line no-param-reassign
+    err.name = `${err.name} - ${new Date().toISOString()}`;
+    throw err;
+});


### PR DESCRIPTION
### Description

Adds a couple of logs to Cypress e2e tests to better coordinate the timing of flakes will possible issues in central logs.

1. Logs the current timestamp to the console at the beginning of each Cypress test file
2. Adds the current timestamp to the error log during a test failure in the Cypress UI

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

See addition of timestamp and name of test suite in the text logs:
```
   Running:  accessControl/accessControlPermissionSets.test.js                             (9 of 112)

2024-08-06T19:47:50.780Z running test suite: accessControlPermissionSets.test.js

  Access Control Permission sets
    ✓ cannot find the page if no permission
    ✓ list has heading, button, and table head cells
    ✓ list has default names
    ✓ list link for default Admin goes to form which has label instead of button and disabled input values
    ✓ direct link to default Admin has all read and write access
    ✓ direct link to default Analyst has all (but Administration) read and no write access
    ✓ direct link to default Continuous Integration has limited read and write accesss
    ✓ direct link to default None has no read nor write access
    ✓ direct link to default Sensor Creator has limited read and write access
    ✓ displays message instead of form if entity id does not exist
  10 passing (16s)

  (Results) 
```

See addition of timestamp in output video with a forced test failure:
![image](https://github.com/user-attachments/assets/979fcf20-a60d-4203-8606-fcbbbb743579)

