### PR TITLE
tests: TestTLSChallenge improvements

### DIFF
--- a/tests/cert_test.go
+++ b/tests/cert_test.go
@@ -43,8 +43,7 @@ func TestCustomCert(t *testing.T) {
 		t.Skip("No test CA pem specified")
 	}
 
-	centralCN := os.Getenv("ROX_TEST_CENTRAL_CN")
-	require.NotEmpty(t, centralCN)
+	centralCN := mustGetEnv(t, "ROX_TEST_CENTRAL_CN")
 
 	trustPool := x509.NewCertPool()
 	ok := trustPool.AppendCertsFromPEM([]byte(testCentralCertCAPEM))

--- a/tests/client_ca_test.go
+++ b/tests/client_ca_test.go
@@ -221,8 +221,7 @@ func TestClientCAAuthWithMultipleVerifiedChains(t *testing.T) {
 func TestClientCARequested(t *testing.T) {
 	t.Parallel()
 
-	clientCAFile := os.Getenv("CLIENT_CA_PATH")
-	require.NotEmpty(t, clientCAFile, "no client CA file path set")
+	clientCAFile := mustGetEnv(t, "CLIENT_CA_PATH")
 	pemBytes, err := os.ReadFile(clientCAFile)
 	require.NoErrorf(t, err, "Could not read client CA file %s", clientCAFile)
 	caCert, err := helpers.ParseCertificatePEM(pemBytes)

--- a/tests/common.go
+++ b/tests/common.go
@@ -83,6 +83,13 @@ func testContexts(t *testing.T, name string, timeout time.Duration) (testCtx con
 	return
 }
 
+// mustGetEnv calls os.GetEnv and fails the test if result is empty.
+func mustGetEnv(t *testing.T, varName string) string {
+	val := os.Getenv(varName)
+	require.NotEmptyf(t, val, "Environment variable %q must be set.", varName)
+	return val
+}
+
 func retrieveDeployment(service v1.DeploymentServiceClient, deploymentID string) (*storage.Deployment, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/tests/common.go
+++ b/tests/common.go
@@ -69,7 +69,7 @@ func testContexts(t *testing.T, name string, timeout time.Duration) (testCtx con
 		overallCancel func()
 		testCancel    func()
 	)
-	cleanupTimeout := 15 * time.Minute
+	cleanupTimeout := 10 * time.Minute
 	t.Logf("Running %s with a timeout of %s plus %s for cleanup", name, timeout, cleanupTimeout)
 	overallTimeout := timeout + cleanupTimeout
 	overallErr := fmt.Errorf("overall %s test+cleanup timeout of %s reached", name, overallTimeout)

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -353,27 +353,27 @@ func TestEndpoints(t *testing.T) {
 	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
 		t.Skip("Skipping endpoints test on OCP: TODO(ROX-24688)")
 	}
-	userCert, err := tls.LoadX509KeyPair(os.Getenv("CLIENT_CERT_PATH"), os.Getenv("CLIENT_KEY_PATH"))
+	userCert, err := tls.LoadX509KeyPair(mustGetEnv(t, "CLIENT_CERT_PATH"), mustGetEnv(t, "CLIENT_KEY_PATH"))
 	require.NoError(t, err, "failed to load user certificate")
 
-	serviceCert, err := tls.LoadX509KeyPair(os.Getenv("SERVICE_CERT_FILE"), os.Getenv("SERVICE_KEY_FILE"))
+	serviceCert, err := tls.LoadX509KeyPair(mustGetEnv(t, "SERVICE_CERT_FILE"), mustGetEnv(t, "SERVICE_KEY_FILE"))
 	require.NoError(t, err, "failed to load service certificate")
 
 	trustPool := x509.NewCertPool()
-	serviceCAPEMBytes, err := os.ReadFile(os.Getenv("SERVICE_CA_FILE"))
+	serviceCAPEMBytes, err := os.ReadFile(mustGetEnv(t, "SERVICE_CA_FILE"))
 	require.NoError(t, err, "failed to load service CA file")
 	serviceCACert, err := helpers.ParseCertificatePEM(serviceCAPEMBytes)
 	require.NoError(t, err, "failed to parse service CA cert")
 	trustPool.AddCert(serviceCACert)
 
-	defaultCAPEMBytes, err := os.ReadFile(os.Getenv("DEFAULT_CA_FILE"))
+	defaultCAPEMBytes, err := os.ReadFile(mustGetEnv(t, "DEFAULT_CA_FILE"))
 	require.NoError(t, err, "failed to load default CA file")
 	defaultCACert, err := helpers.ParseCertificatePEM(defaultCAPEMBytes)
 	require.NoError(t, err, "failed to parse default CA cert")
 	trustPool.AddCert(defaultCACert)
 
 	defaultCertDNSName := os.Getenv("ROX_TEST_CENTRAL_CN")
-	require.NotEmpty(t, defaultCertDNSName, "missing default certificate DNS name")
+	require.NotEmpty(t, defaultCertDNSName, "missing default certificate DNS name: $ROX_TEST_CENTRAL_CN")
 
 	testCtx := &endpointsTestContext{
 		allServerNames: []string{defaultCertDNSName, "central.stackrox"},

--- a/tests/tls_challenge_test.go
+++ b/tests/tls_challenge_test.go
@@ -7,7 +7,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -122,8 +121,8 @@ func (ts *TLSChallengeSuite) installImagePullSecret() {
 	configBytes, err := json.Marshal(config.DockerConfigJSON{
 		Auths: map[string]config.DockerConfigEntry{
 			"https://quay.io": {
-				Username: os.Getenv("REGISTRY_USERNAME"),
-				Password: os.Getenv("REGISTRY_PASSWORD"),
+				Username: mustGetEnv(ts.T(), "REGISTRY_USERNAME"),
+				Password: mustGetEnv(ts.T(), "REGISTRY_PASSWORD"),
 			},
 		},
 	})

--- a/tests/tls_challenge_test.go
+++ b/tests/tls_challenge_test.go
@@ -63,7 +63,7 @@ func (ts *TLSChallengeSuite) SetupSuite() {
 	ts.originalCentralEndpoint = ts.getDeploymentEnvVal(ts.ctx, s, sensorDeployment, sensorContainer, centralEndpointVar)
 	ts.logf("Original value is %q. (Will restore this value on cleanup.)", ts.originalCentralEndpoint)
 
-	ts.setupProxy(proxyNs, ts.originalCentralEndpoint)
+	ts.setupProxy(ts.originalCentralEndpoint)
 }
 
 func (ts *TLSChallengeSuite) TearDownSuite() {
@@ -95,22 +95,22 @@ func (ts *TLSChallengeSuite) TestTLSChallenge() {
 	waitUntilCentralSensorConnectionIs(ts.T(), ts.ctx, storage.ClusterHealthStatus_HEALTHY)
 }
 
-func (ts *TLSChallengeSuite) setupProxy(proxyNs string, centralEndpoint string) {
+func (ts *TLSChallengeSuite) setupProxy(centralEndpoint string) {
 	name := "nginx-loadbalancer"
 	nginxLabels := map[string]string{"app": "nginx"}
 	nginxTLSSecretName := "nginx-tls-conf" //nolint:gosec // G101
 	nginxConfigName := "nginx-proxy-conf"
 	ts.logf("Setting up nginx proxy in namespace %q...", proxyNs)
-	ts.createProxyNamespace(proxyNs)
-	ts.installImagePullSecret(proxyNs)
-	ts.createProxyTLSSecret(proxyNs, nginxTLSSecretName)
-	ts.createProxyConfigMap(proxyNs, centralEndpoint, nginxConfigName)
+	ts.createProxyNamespace()
+	ts.installImagePullSecret()
+	ts.createProxyTLSSecret(nginxTLSSecretName)
+	ts.createProxyConfigMap(centralEndpoint, nginxConfigName)
 	ts.createService(ts.ctx, proxyNs, name, nginxLabels, map[int32]int32{443: 8443})
-	ts.createProxyDeployment(proxyNs, name, nginxLabels, nginxConfigName, nginxTLSSecretName)
+	ts.createProxyDeployment(name, nginxLabels, nginxConfigName, nginxTLSSecretName)
 	ts.logf("Nginx proxy is now set up in namespace %q.", proxyNs)
 }
 
-func (ts *TLSChallengeSuite) createProxyNamespace(proxyNs string) {
+func (ts *TLSChallengeSuite) createProxyNamespace() {
 	_, err := ts.k8s.CoreV1().Namespaces().Create(ts.ctx, &v1.Namespace{ObjectMeta: metaV1.ObjectMeta{Name: proxyNs}}, metaV1.CreateOptions{})
 	if apiErrors.IsAlreadyExists(err) {
 		return
@@ -118,7 +118,7 @@ func (ts *TLSChallengeSuite) createProxyNamespace(proxyNs string) {
 	ts.Require().NoError(err, "cannot create proxy namespace %q", proxyNs)
 }
 
-func (ts *TLSChallengeSuite) installImagePullSecret(proxyNs string) {
+func (ts *TLSChallengeSuite) installImagePullSecret() {
 	configBytes, err := json.Marshal(config.DockerConfigJSON{
 		Auths: map[string]config.DockerConfigEntry{
 			"https://quay.io": {
@@ -131,7 +131,7 @@ func (ts *TLSChallengeSuite) installImagePullSecret(proxyNs string) {
 	ts.ensureSecretExists(ts.ctx, proxyNs, proxyImagePullSecretName, v1.SecretTypeDockerConfigJson, map[string][]byte{v1.DockerConfigJsonKey: configBytes})
 }
 
-func (ts *TLSChallengeSuite) createProxyTLSSecret(proxyNs string, nginxTLSSecretName string) {
+func (ts *TLSChallengeSuite) createProxyTLSSecret(nginxTLSSecretName string) {
 	var certChain []byte
 	certChain = append(certChain, leafCert...)
 	certChain = append(certChain, additionalCA...)
@@ -141,7 +141,7 @@ func (ts *TLSChallengeSuite) createProxyTLSSecret(proxyNs string, nginxTLSSecret
 	})
 }
 
-func (ts *TLSChallengeSuite) createProxyConfigMap(proxyNs string, centralEndpoint string, nginxConfigName string) {
+func (ts *TLSChallengeSuite) createProxyConfigMap(centralEndpoint string, nginxConfigName string) {
 	const nginxConfigTmpl = `
 server {
     listen 8443 ssl http2;
@@ -167,7 +167,7 @@ server {
 	})
 }
 
-func (ts *TLSChallengeSuite) createProxyDeployment(proxyNs string, name string, nginxLabels map[string]string, nginxConfigName string, nginxTLSSecretName string) {
+func (ts *TLSChallengeSuite) createProxyDeployment(name string, nginxLabels map[string]string, nginxConfigName string, nginxTLSSecretName string) {
 	d := &appsV1.Deployment{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:   name,

--- a/tests/tls_challenge_test.go
+++ b/tests/tls_challenge_test.go
@@ -54,7 +54,7 @@ type TLSChallengeSuite struct {
 
 func (ts *TLSChallengeSuite) SetupSuite() {
 	ts.KubernetesSuite.SetupSuite()
-	ts.ctx, ts.cleanupCtx, ts.cancel = testContexts(ts.T(), "TestTLSChallenge", 20*time.Minute)
+	ts.ctx, ts.cleanupCtx, ts.cancel = testContexts(ts.T(), "TestTLSChallenge", 15*time.Minute)
 
 	// Check sanity before test.
 	waitUntilCentralSensorConnectionIs(ts.T(), ts.ctx, storage.ClusterHealthStatus_HEALTHY)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

1. The primary change is to explicitly refer to the image pull secret in the pod template rather than patch the default service account, since the latter seems unreliable.
  In [this flake](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/12292/pull-ci-stackrox-stackrox-master-ocp-4-16-nongroovy-e2e-tests/1820850312693420032) the nginx image for the proxy failed to pull due to `unauthorized: access to the requested resource is not authorized`. Upon inspection, the `default` service account was lacking the necessary image pull secret reference (which the test did patch in on setup).
  I don't know if this means it does the patching in a wrong way, which becomes a no-op in some corner case, or some other operation reverted its patch somehow (though the only write operation I see in the audit log was token subresource creation by the kubelet). I [asked for some advice](https://kubernetes.slack.com/archives/C0EG7JC6T/p1723007241694119) since this really puzzles me.
  Either way, this method seems unreliable, so I'm changing it to an explicit reference to the pull secret in the pod template, which has the additional benefit of being a bit quicker.
3. While at it, also adjust the timeouts so that things fit in the overall 30m timeout for every test.
4. Implement a `mustGetEnv` that shouts if an env variable isn't present
5. Use the `proxyNs` const directly
6. FTR I'm **not** drop build flags from `common*.go` because it's [not that simple](https://github.com/stackrox/stackrox/pull/12292#discussion_r1708619419).

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] run this multiple times to make sure it's solid