### PR TITLE
chore(lint): lint ./tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
   build-tags:
   - integration
   - sql_integration
+  - test_e2e
   modules-download-mode: readonly
   go: "1.21"
 


### PR DESCRIPTION
### Description

golangci-lint currently does not run on e2e tests. This PR adds this tag to litner configuration:
- #12146
---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
