### PR TITLE
build: Fix downstream UI builds while with `yarn`

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -14,7 +14,7 @@ ROX_PRODUCT_BRANDING ?= $(shell $(MAKE) --quiet --no-print-directory -C .. produ
 export REACT_APP_ROX_PRODUCT_BRANDING := $(ROX_PRODUCT_BRANDING)
 
 deps: apps/platform/yarn.lock $(PACKAGE_JSON_FILES)
-	yarn install --cwd=apps/platform --frozen-lockfile --prefer-offline --network-timeout=$(YARN_NETWORK_TIMEOUT)
+	cd apps/platform && yarn install --frozen-lockfile --prefer-offline --network-timeout=$(YARN_NETWORK_TIMEOUT)
 	@touch deps
 
 .PHONY: printsrcs


### PR DESCRIPTION
### Description

Downstream builds have problems due to Cachito not playing well with `yarn`'s `--cwd`. The simple replacement is to do `cd` instead. Each command in Makefile is executed in a separate shell and so the `cd`-s effect applies only to the line where it's done (verified by surrounding with `pwd`-s).

See https://redhat-internal.slack.com/archives/C02AD1GUA0Y/p1723018428884079 / https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/3327 / https://redhat-internal.slack.com/archives/C02AX10EQJW/p1723027057303309

This PR will be obsolete by https://github.com/stackrox/stackrox/pull/11967 which may be merged soon and so we may just ignore this https://github.com/stackrox/stackrox/pull/12313.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No automated testing changes.

#### How I validated my change

Built downstream https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/3327 / https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=63185991