### PR TITLE
ROX-25337: Adding violation time to the policy violations filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -15,4 +15,11 @@ export const InactiveDeployment: CompoundSearchFilterAttribute = {
     },
 };
 
-export const alertAttributes = [InactiveDeployment];
+export const ViolationTime: CompoundSearchFilterAttribute = {
+    displayName: 'Violation time',
+    filterChipLabel: 'Violation time',
+    searchTerm: 'Violation Time',
+    inputType: 'date-picker',
+};
+
+export const alertAttributes = [InactiveDeployment, ViolationTime];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -317,15 +317,26 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.attributeSelectToggle).click();
         cy.get(selectors.attributeSelectItem('Discovered time')).click();
 
+        cy.get('button[aria-label="Condition selector toggle"]').should('have.text', 'On');
+
+        cy.get('button[aria-label="Condition selector toggle"]').click();
+        cy.get('div[aria-label="Condition selector menu"] li button:contains("After")')
+            .filter((_, element) => {
+                // Get exact value
+                // @TODO: Could be a custom command
+                return Cypress.$(element).text().trim() === 'After';
+            })
+            .click();
+
         selectDatePickerDate('January', '15', '2034');
 
-        cy.get('button[aria-label="Apply date input to search"]').click();
+        cy.get('button[aria-label="Apply condition and date input to search"]').click();
 
         // Check updated date value
         cy.get('@onSearch').should('have.been.calledWithExactly', {
             action: 'ADD',
             category: 'CVE Created Time',
-            value: '01/15/2034',
+            value: '>01/15/2034',
         });
 
         cy.get('input[aria-label="Filter by date"]').should('have.value', '');

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Button, DatePicker, Flex, SelectOption } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+
+import { getDate } from 'utils/dateUtils';
+import { dateConditions, ensureString } from '../utils/utils';
+
+import SimpleSelect from './SimpleSelect';
+
+export type ConditionDate = { condition: string; date: string };
+
+export type ConditionDateProps = {
+    value: ConditionDate;
+    onChange: (value: ConditionDate) => void;
+    onSearch: (value: ConditionDate) => void;
+};
+
+function dateParse(date: string): Date {
+    const split = date.split('/');
+    if (split.length !== 3) {
+        return new Date('Invalid Date');
+    }
+    const month = split[0];
+    const day = split[1];
+    const year = split[2];
+    if (month.length !== 2 || day.length !== 2 || year.length !== 4) {
+        return new Date('Invalid Date');
+    }
+    return new Date(
+        `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00`
+    );
+}
+
+function ConditionDate({ value, onChange, onSearch }: ConditionDateProps) {
+    return (
+        <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+            <SimpleSelect
+                value={value.condition}
+                onChange={(val) =>
+                    onChange({
+                        ...value,
+                        condition: ensureString(val),
+                    })
+                }
+                ariaLabelMenu="Condition selector menu"
+                ariaLabelToggle="Condition selector toggle"
+            >
+                {dateConditions.map((condition) => {
+                    return (
+                        <SelectOption key={condition} value={condition}>
+                            {condition}
+                        </SelectOption>
+                    );
+                })}
+            </SimpleSelect>
+            <DatePicker
+                aria-label="Filter by date"
+                buttonAriaLabel="Filter by date toggle"
+                value={value.date}
+                onChange={(_event, _value) => {
+                    onChange({ ...value, date: _value });
+                }}
+                dateFormat={getDate}
+                dateParse={dateParse}
+                placeholder="MM/DD/YYYY"
+            />
+            <Button
+                variant="control"
+                aria-label="Apply condition and date input to search"
+                onClick={() => {
+                    const date = dateParse(value.date);
+                    if (!Number.isNaN(date.getTime())) {
+                        onSearch(value);
+                        onChange({ ...value, date: '' });
+                    }
+                }}
+            >
+                <ArrowRightIcon />
+            </Button>
+        </Flex>
+    );
+}
+
+export default ConditionDate;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
@@ -57,8 +57,8 @@ function ConditionDate({ value, onChange, onSearch }: ConditionDateProps) {
                 aria-label="Filter by date"
                 buttonAriaLabel="Filter by date toggle"
                 value={value.date}
-                onChange={(_event, _value) => {
-                    onChange({ ...value, date: _value });
+                onChange={(_, newValue) => {
+                    onChange({ ...value, date: newValue });
                 }}
                 dateFormat={getDate}
                 dateParse={dateParse}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -19,7 +19,15 @@ export const conditionMap = {
     'Is less than': '<',
 };
 
+export const dateConditionMap = {
+    Before: '<',
+    On: '', // "=" doesn't work but we can omit the condition to work like an equals
+    After: '>',
+};
+
 export const conditions = Object.keys(conditionMap);
+
+export const dateConditions = Object.keys(dateConditionMap);
 
 export function getEntity(
     config: CompoundSearchFilterConfig,
@@ -102,6 +110,26 @@ export function ensureConditionNumber(value: unknown): { condition: string; numb
     return {
         condition: conditions[0],
         number: 0,
+    };
+}
+
+export function ensureConditionDate(value: unknown): { condition: string; date: string } {
+    if (
+        typeof value === 'object' &&
+        value !== null &&
+        'condition' in value &&
+        'date' in value &&
+        typeof value.condition === 'string' &&
+        typeof value.date === 'string'
+    ) {
+        return {
+            condition: value.condition,
+            date: value.date,
+        };
+    }
+    return {
+        condition: dateConditions[1],
+        date: '',
     };
 }
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -17,17 +17,19 @@ export const conditionMap = {
     'Is equal to': '=',
     'Is less than or equal to': '<=',
     'Is less than': '<',
-};
+} as const;
 
 export const dateConditionMap = {
     Before: '<',
     On: '', // "=" doesn't work but we can omit the condition to work like an equals
     After: '>',
-};
+} as const;
 
-export const conditions = Object.keys(conditionMap);
+export const conditions = Object.keys(conditionMap) as unknown as (keyof typeof conditionMap)[];
 
-export const dateConditions = Object.keys(dateConditionMap);
+export const dateConditions = Object.keys(
+    dateConditionMap
+) as unknown as (keyof typeof dateConditionMap)[];
 
 export function getEntity(
     config: CompoundSearchFilterConfig,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -28,7 +28,10 @@ import {
     ID as DeploymentID,
     Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
-import { InactiveDeployment as AlertInactiveDeployment } from 'Components/CompoundSearchFilter/attributes/alert';
+import {
+    InactiveDeployment as AlertInactiveDeployment,
+    ViolationTime as AlertViolationTime,
+} from 'Components/CompoundSearchFilter/attributes/alert';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
     {
@@ -45,7 +48,7 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Policy violation',
         searchCategory: 'ALERTS',
-        attributes: [AlertInactiveDeployment],
+        attributes: [AlertInactiveDeployment, AlertViolationTime],
     },
     {
         displayName: 'Cluster',


### PR DESCRIPTION
### Description

This PR adds a date picker for the Violation time filter in Policy Violations. This also includes adding the ability to say `Before`, `On`, or `After` on a specific date.



### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="1439" alt="Screenshot 2024-08-07 at 9 40 11 AM" src="https://github.com/user-attachments/assets/d9681eed-04e5-4479-8fa1-4f991fc81b53">


