### PR TITLE
ROX-25655: Fix accessibility issue of contrast in SimulationFrame

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/CodeCompareIcon.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/CodeCompareIcon.tsx
@@ -9,6 +9,7 @@ function CodeCompareIcon() {
             width="1em"
             viewBox="0 0 512 512"
             role="img"
+            aria-hidden="true"
             style={{ verticalAlign: '-0.125em' }}
         >
             {/* <!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --> */}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
@@ -11,31 +11,33 @@ type SimulationFrameProps = {
 function SimulationFrame({ isSimulating, children }: SimulationFrameProps) {
     let style = {};
     if (isSimulating) {
-        style = { position: 'relative', border: '5px solid rgb(115,188,247)' };
+        style = { position: 'relative', border: '5px solid var(--pf-v5-global--info-color--100' };
     } else {
         style = {};
     }
+    // Simulation frame and rectangle at upper left have same colors as inline info alert:
+    // border and icon have same color
+    // background color
+    // text has same (ordinary) color as title or body for sufficient color contrast
     return (
         <div className="pf-ri__topology-section" style={style}>
             {children}
             {isSimulating && (
                 <Flex
-                    className="pf-v5-u-p-sm"
+                    className="pf-v5-u-p-sm pf-v5-u-background-color-info"
                     style={{
-                        backgroundColor: 'rgb(224,233,242)',
                         position: 'absolute',
                         left: '0',
                         top: '0',
                         zIndex: 100,
                     }}
                     alignItems={{ default: 'alignItemsCenter' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
                 >
                     <FlexItem>
                         <ScreenIcon className="pf-v5-u-info-color-100" />
                     </FlexItem>
-                    <FlexItem>
-                        <div className="pf-v5-u-info-color-100">Simulated view</div>
-                    </FlexItem>
+                    <FlexItem>Simulated view</FlexItem>
                 </Flex>
             )}
         </div>


### PR DESCRIPTION
### Description

### Problems reported by axe DevTools

> Elements must meet minimum color contrast ratio thresholds

> Element has insufficient color contrast of 2.43 (foreground color: #2b9af3, background color: #e0e9f2, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1

https://dequeuniversity.com/rules/axe/4.9/color-contrast

```html
<div class="pf-v5-u-info-color-100">Simulated view</div>
```

> `<svg>` elements with an img role must have an alternative text

https://dequeuniversity.com/rules/axe/4.9/svg-img-alt

```html
<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" role="img" style="vertical-align: -0.125em;">
```

### Analysis

https://www.patternfly.org/accessibility/design-for-accessibility

> As long as you follow our recommendations, any UI built with PatternFly components should have proper contrast between colors, making them distinguishable for users with different types of color perception and light sensitivity.

> If you go beyond our recommendations to combine PatternFly colors in other ways, please be sure to check your color contrast with a contrast checker. When you alter the colors and/or icons used in PatternFly components, know that they may no longer be accessible for all users.

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx

* Frame border color: `rgb(115,188,247)`
* Frame upper left background color; `rgb(224, 233, 242)`
* Frame upper left icon and text color: `pf-v5-u-info-color-100`

Summary:
1. The `rgb` colors seem like outside of PatternFly palette.
2. Comparison to PatternFly info alert:
    * Positive: left icon has same color as icon in info alert.
    * Negative: border should also have color.
    * Negative: text should not have that color.

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/simulation/CodeCompareIcon.tsx

Aha, no `aria-label="hidden"` prop which is how PatternFly icons prevent the second accessibility issue.

### Solution

1. Edit SimulationFrame.tsx file:
    * Use info alert color for border and icon.
    * Use inline info alert background color for `Flex` element at upper left of frame.
    * Space flex items 8px small consistent with icon-to-title spacer in `Alert` element and also for padding of `Flex` element.
    * Remove color from text for consistency with title or body of alerts because needed for sufficient color contrast.
2. Edit CodeCompareIcon.tsx file:
    * Add `aria-hidden="true"` prop for consistency with PatternFly icons.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/css/*.css`
        main.js 0 = 979712 - 979712
        total 0 = 2003970 - 2003970
    * `ls -al build/static/css/*.css | wc`
        files 0 = 42 - 42
    * `wc build/static/js/*.js`
        main.js 0 = 4617941 - 4617941
        total 7 = 11700962 - 11700955
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/network-graph, select cluster and namespace, click **Network policy generator**, and then click **Generate and simulate network policies**.

    * Before changes, see presence of accessibility issue.
        ![with_issues](https://github.com/user-attachments/assets/299dcb91-d784-4146-ba19-6379f61ad15a)

    * After changes, see absence of accessibility issue.
        ![without_issues](https://github.com/user-attachments/assets/cc68b8e5-c962-44d5-a6fe-b5175caae82e)

#### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js
