### PR TITLE
ROX-25677: keep backward compatibility for duration format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   `v1/nodecves/suppress`, `v1/clustercves/suppress` and `v1/imagecves/suppress`
   will be restricted to a [proto JSON format](https://protobuf.dev/programming-guides/proto3/#json:~:text=are%20also%20accepted.-,Duration,-string).
   Only a numeric value representing seconds (with optional fractional seconds for nanosecond precision)
-  followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900").
+  followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900s").
   This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,
   each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
   The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   will be restricted to a [proto JSON format](https://protobuf.dev/programming-guides/proto3/#json:~:text=are%20also%20accepted.-,Duration,-string).
   Only a numeric value representing seconds (with optional fractional seconds for nanosecond precision)
   followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900s").
-  This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,
+  This replaces the current format, which allows a string with a signed sequence of decimal numbers,
   each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
   The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - `roxctl central generate k8s hostpath` and `roxctl central generate openshift hostpath` no longer have the flags `--hostpath`, `--node-selector-key`, and `--node-selector-value`.
 
 ### Deprecated Fatures
+- ROX-25677: The format for specifying durations in JSON requests to
+  `v1/nodecves/suppress`, `v1/clustercves/suppress` and `v1/imagecves/suppress`
+  will be restricted to a simpler format.
+  Only a numeric value representing seconds (with optional fractional seconds for nanosecond precision)
+  followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900").
+  This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,
+  each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
+  The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported in their existing form.
 
 ### Technical Changes
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900").
   This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,
   each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
-  The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported in their existing form.
+  The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported.
 
 ### Technical Changes
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Deprecated Fatures
 - ROX-25677: The format for specifying durations in JSON requests to
   `v1/nodecves/suppress`, `v1/clustercves/suppress` and `v1/imagecves/suppress`
-  will be restricted to a simpler format.
+  will be restricted to a [proto JSON format](https://protobuf.dev/programming-guides/proto3/#json:~:text=are%20also%20accepted.-,Duration,-string).
   Only a numeric value representing seconds (with optional fractional seconds for nanosecond precision)
   followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900").
   This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,

--- a/generated/api/v1/cve_service.pb.go
+++ b/generated/api/v1/cve_service.pb.go
@@ -28,7 +28,13 @@ type SuppressCVERequest struct {
 
 	// These are (NVD) vulnerability identifiers, `cve` field of `storage.CVE`, and *not* the `id` field.
 	// For example, CVE-2021-44832.
-	Cves     []string             `protobuf:"bytes,1,rep,name=cves,proto3" json:"cves,omitempty"`
+	Cves []string `protobuf:"bytes,1,rep,name=cves,proto3" json:"cves,omitempty"`
+	// In JSON format, the Duration type is encoded as a string rather than an object,
+	// where the string ends in the suffix "s" (indicating seconds) and is preceded by the number of seconds,
+	// with nanoseconds expressed as fractional seconds.
+	// For example, 3 seconds with 0 nanoseconds should be encoded in JSON format as "3s",
+	// while 3 seconds and 1 nanosecond should be expressed in JSON format as "3.000000001s",
+	// and 3 seconds and 1 microsecond should be expressed in JSON format as "3.000001s".
 	Duration *durationpb.Duration `protobuf:"bytes,3,opt,name=duration,proto3" json:"duration,omitempty"`
 }
 

--- a/generated/api/v1/cve_service.swagger.json
+++ b/generated/api/v1/cve_service.swagger.json
@@ -266,7 +266,8 @@
           "description": "These are (NVD) vulnerability identifiers, `cve` field of `storage.CVE`, and *not* the `id` field.\nFor example, CVE-2021-44832."
         },
         "duration": {
-          "type": "string"
+          "type": "string",
+          "description": "In JSON format, the Duration type is encoded as a string rather than an object,\nwhere the string ends in the suffix \"s\" (indicating seconds) and is preceded by the number of seconds,\nwith nanoseconds expressed as fractional seconds.\nFor example, 3 seconds with 0 nanoseconds should be encoded in JSON format as \"3s\",\nwhile 3 seconds and 1 nanosecond should be expressed in JSON format as \"3.000000001s\",\nand 3 seconds and 1 microsecond should be expressed in JSON format as \"3.000001s\"."
         }
       }
     },

--- a/pkg/grpc/marshaler.go
+++ b/pkg/grpc/marshaler.go
@@ -1,0 +1,66 @@
+package grpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
+)
+
+// Deprecated: customMarshaler is a hack for keeping backward compatibility for duration objects.
+// TODO(ROX-25678): This should be deleted in 4.8.
+type customMarshaler struct {
+	*runtime.JSONPb
+}
+
+func (c customMarshaler) Unmarshal(data []byte, v interface{}) error {
+	unmarshalError := protojson.Unmarshal(data, v.(proto.Message))
+	if unmarshalError == nil {
+		return nil
+	}
+	suppressCVERequest, ok := v.(*v1.SuppressCVERequest)
+	if !ok {
+		return unmarshalError
+	}
+	log.Warnf("DEPRECATED: The duration format only supports seconds: %q", unmarshalError)
+	messageV1 := protoadapt.MessageV1Of(suppressCVERequest)
+	err := jsonpb.Unmarshal(bytes.NewBuffer(data), messageV1)
+	if err != nil {
+		// We want users choose the new format.
+		return unmarshalError
+	}
+	return nil
+}
+
+func (c customMarshaler) NewDecoder(r io.Reader) runtime.Decoder {
+	return customDecoder{
+		unmarshaler:  c,
+		jsonDecoder:  json.NewDecoder(r),
+		protoDecoder: c.JSONPb.NewDecoder(r),
+	}
+}
+
+type customDecoder struct {
+	jsonDecoder  *json.Decoder
+	unmarshaler  customMarshaler
+	protoDecoder runtime.Decoder
+}
+
+func (c customDecoder) Decode(v interface{}) error {
+	x, ok := v.(*v1.SuppressCVERequest)
+	if !ok {
+		return c.protoDecoder.Decode(v)
+	}
+	// Decode into bytes for marshalling
+	var b json.RawMessage
+	if err := c.jsonDecoder.Decode(&b); err != nil {
+		return err
+	}
+	return c.unmarshaler.Unmarshal(b, x)
+}

--- a/pkg/grpc/marshaler.go
+++ b/pkg/grpc/marshaler.go
@@ -34,7 +34,7 @@ func (c customMarshaler) unmarshalBackwardCompatible(data []byte, v interface{},
 	goStruct := SuppressCVERequestGo{}
 	err := json.Unmarshal(data, &goStruct)
 	if err != nil {
-		log.Warnf(err.Error())
+		log.Warn(err)
 		// We want users choose the new format.
 		return unmarshalError
 	}

--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -1,0 +1,86 @@
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type MarshalerTest struct {
+	suite.Suite
+}
+
+func (a *MarshalerTest) SetupTest() {
+	// In order to start the gRPC server, we need to have the MTLS environment variables
+	// pointing to some valid certificate/key pair. In this case we are using the ones
+	// created for local-sensor, which are dummy self-signed certificates.
+	a.T().Setenv("ROX_MTLS_CERT_FILE", "../../tools/local-sensor/certs/cert.pem")
+	a.T().Setenv("ROX_MTLS_KEY_FILE", "../../tools/local-sensor/certs/key.pem")
+	a.T().Setenv("ROX_MTLS_CA_FILE", "../../tools/local-sensor/certs/caCert.pem")
+	a.T().Setenv("ROX_MTLS_CA_KEY_FILE", "../../tools/local-sensor/certs/caKey.pem")
+}
+func Test_MarshallerTest(t *testing.T) {
+	suite.Run(t, new(MarshalerTest))
+}
+
+var _ suite.SetupTestSuite = &MarshalerTest{}
+
+// Testing server error response from gRPC Gateway.
+type supressCveServiceTestErrorImpl struct {
+	v1.UnimplementedNodeCVEServiceServer
+}
+
+func (s *supressCveServiceTestErrorImpl) RegisterServiceServer(grpcServer *grpc.Server) {
+	v1.RegisterNodeCVEServiceServer(grpcServer, s)
+}
+
+func (s *supressCveServiceTestErrorImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, grpcServer *grpc.ClientConn) error {
+	return v1.RegisterNodeCVEServiceHandler(ctx, mux, grpcServer)
+}
+
+func (s *supressCveServiceTestErrorImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+}
+
+func (s *supressCveServiceTestErrorImpl) SuppressCVEs(_ context.Context, req *v1.SuppressCVERequest) (*v1.Empty, error) {
+	return nil, status.Error(codes.Canceled, req.String())
+}
+
+func (a *MarshalerTest) TestDurationParsing() {
+	url := "https://localhost:8080/v1/nodecves/suppress"
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	api := NewAPI(defaultConf())
+	grpcServiceHandler := &supressCveServiceTestErrorImpl{}
+	api.Register(grpcServiceHandler)
+	a.Assert().NoError(api.Start().Wait())
+	a.T().Cleanup(func() { api.Stop() })
+
+	b := strings.NewReader(`{"cves": ["ABC", "XYZ"],  "duration": "24h"}`)
+
+	req, err := http.NewRequest(http.MethodPatch, url, b)
+	a.NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	a.NoError(err)
+
+	body, err := io.ReadAll(resp.Body)
+	a.Require().NoError(err)
+
+	str := `cves:"ABC"  cves:"XYZ"  duration:{seconds:86400}`
+	expected := fmt.Sprintf(`{"code":1, "details": [], "error":%q, "message":%q}`, str, str)
+	a.Assert().JSONEq(expected, string(body))
+}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -385,19 +385,18 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 	}
 
 	gwMux := runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, customMarshaler{&runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
 				EmitUnpopulated: true,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{
 				DiscardUnknown: true,
 			},
-		}),
+		}}),
 		runtime.WithMetadata(a.requestInfoHandler.AnnotateMD),
 		runtime.WithOutgoingHeaderMatcher(allowCookiesHeaderMatcher),
 		runtime.WithMarshalerOption(
-			"application/json+pretty",
-			&runtime.JSONPb{
+			"application/json+pretty", customMarshaler{&runtime.JSONPb{
 				MarshalOptions: protojson.MarshalOptions{
 					Indent:          "  ",
 					EmitUnpopulated: true,
@@ -405,7 +404,7 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 				UnmarshalOptions: protojson.UnmarshalOptions{
 					DiscardUnknown: true,
 				},
-			},
+			}},
 		),
 		runtime.WithErrorHandler(errorHandler),
 	)

--- a/proto/api/v1/cve_service.proto
+++ b/proto/api/v1/cve_service.proto
@@ -14,6 +14,12 @@ message SuppressCVERequest {
   // For example, CVE-2021-44832.
   repeated string cves = 1;
   reserved 2;
+  // In JSON format, the Duration type is encoded as a string rather than an object,
+  // where the string ends in the suffix "s" (indicating seconds) and is preceded by the number of seconds,
+  // with nanoseconds expressed as fractional seconds.
+  // For example, 3 seconds with 0 nanoseconds should be encoded in JSON format as "3s",
+  // while 3 seconds and 1 nanosecond should be expressed in JSON format as "3.000000001s",
+  // and 3 seconds and 1 microsecond should be expressed in JSON format as "3.000001s".
   google.protobuf.Duration duration = 3;
 }
 


### PR DESCRIPTION
### Description

This PR ensures backward compatibility for duration parsing in the JSON API. The updated proto version now exclusively handles durations in seconds, which introduces a breaking change. To mitigate this, we've implemented a custom marshaller that utilizes the previous proto version behaviour by using stdlib json marshaler. Additionally, we've announced the deprecation of the currently supported format, which will be fully removed in version 4.8 (ROX-25678).

The UI also requires updates to avoid using the deprecated format (ROX-25679):
https://github.com/stackrox/stackrox/blob/127dad71566547d3f79ea6d9894e75ad1ddda294/ui/apps/platform/src/constants/timeWindows.ts#L17-L23

For reference, see:

- https://github.com/golang/protobuf/issues/1374
- [Google Protobuf JSON Mapping](https://pkg.go.dev/google.golang.org/protobuf/types/known/durationpb#hdr-JSON_Mapping)

---

- [x] CHANGELOG updated
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
