### PR TITLE
fix(proto): do not use legacy protobuf in custom marshaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Removed Features
 
 ### Deprecated Fatures
+- ROX-25677: The format for specifying durations in JSON requests will soon be restricted to a simpler format.
+  Only a numeric value representing seconds (with optional fractional seconds for nanosecond precision)
+  followed by the s suffix will be accepted (e.g., "0.300s", "-5400s", or "9900").
+  This replaces the current format, which allows a string with a potentially signed sequence of decimal numbers,
+  each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
+  The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported in their existing form.
 
 ### Technical Changes
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.

--- a/pkg/grpc/marshaler.go
+++ b/pkg/grpc/marshaler.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
+)
+
+// Deprecated: customMarshaler is a hack for keeping backward compatibility for duration objects.
+// TODO(ROX-25678): This should be deleted in 4.8.
+type customMarshaler struct {
+	*runtime.JSONPb
+}
+
+func (c customMarshaler) Unmarshal(data []byte, v interface{}) error {
+	unmarshalError := protojson.Unmarshal(data, v.(proto.Message))
+	if unmarshalError == nil {
+		return nil
+	}
+	suppressCVERequest, ok := v.(*v1.SuppressCVERequest)
+	if !ok {
+		return unmarshalError
+	}
+	log.Warnf("DEPRECATED: The duration format only supports seconds: %q", unmarshalError)
+	messageV1 := protoadapt.MessageV1Of(suppressCVERequest)
+	err := jsonpb.Unmarshal(bytes.NewBuffer(data), messageV1)
+	if err != nil {
+		// We want users choose the new format.
+		return unmarshalError
+	}
+	v = protoadapt.MessageV2Of(messageV1)
+	return nil
+}
+
+func (c customMarshaler) NewDecoder(r io.Reader) runtime.Decoder {
+	return customDecoder{
+		unmarshaler:  c,
+		jsonDecoder:  json.NewDecoder(r),
+		protoDecoder: c.JSONPb.NewDecoder(r),
+	}
+}
+
+type customDecoder struct {
+	jsonDecoder  *json.Decoder
+	unmarshaler  customMarshaler
+	protoDecoder runtime.Decoder
+}
+
+func (c customDecoder) Decode(v interface{}) error {
+	x, ok := v.(*v1.SuppressCVERequest)
+	if !ok {
+		return c.protoDecoder.Decode(v)
+	}
+	// Decode into bytes for marshalling
+	var b json.RawMessage
+	if err := c.jsonDecoder.Decode(&b); err != nil {
+		return err
+	}
+	return c.unmarshaler.Unmarshal(b, x)
+}

--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -54,12 +54,12 @@ func (s *supressCveServiceTestErrorImpl) AuthFuncOverride(ctx context.Context, f
 }
 
 func (s *supressCveServiceTestErrorImpl) SuppressCVEs(_ context.Context, req *v1.SuppressCVERequest) (*v1.Empty, error) {
-	return nil, status.Errorf(codes.Canceled, req.Duration.String())
+	return nil, status.Errorf(codes.Canceled, req.String())
 }
 
 func (a *MarshalerTest) TestDurationParsing() {
 	url := "https://localhost:8080/v1/nodecves/suppress"
-	jsonPayload := `{"code":1, "details": [], "error": "seconds:86400", "message":"seconds:86400"}`
+	jsonPayload := `{"code":1, "details": [], "error":"cves:\"XYZ\"  duration:{seconds:86400}", "message":"cves:\"XYZ\"  duration:{seconds:86400}"}`
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 

--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -1,0 +1,85 @@
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type MarshalerTest struct {
+	suite.Suite
+}
+
+func (a *MarshalerTest) SetupTest() {
+	// In order to start the gRPC server, we need to have the MTLS environment variables
+	// pointing to some valid certificate/key pair. In this case we are using the ones
+	// created for local-sensor, which are dummy self-signed certificates.
+	a.T().Setenv("ROX_MTLS_CERT_FILE", "../../tools/local-sensor/certs/cert.pem")
+	a.T().Setenv("ROX_MTLS_KEY_FILE", "../../tools/local-sensor/certs/key.pem")
+	a.T().Setenv("ROX_MTLS_CA_FILE", "../../tools/local-sensor/certs/caCert.pem")
+	a.T().Setenv("ROX_MTLS_CA_KEY_FILE", "../../tools/local-sensor/certs/caKey.pem")
+}
+func Test_MarshallerTest(t *testing.T) {
+	suite.Run(t, new(MarshalerTest))
+}
+
+var _ suite.SetupTestSuite = &MarshalerTest{}
+
+// Testing server error response from gRPC Gateway.
+type supressCveServiceTestErrorImpl struct {
+	v1.UnimplementedNodeCVEServiceServer
+}
+
+func (s *supressCveServiceTestErrorImpl) RegisterServiceServer(grpcServer *grpc.Server) {
+	v1.RegisterNodeCVEServiceServer(grpcServer, s)
+}
+
+func (s *supressCveServiceTestErrorImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, grpcServer *grpc.ClientConn) error {
+	return v1.RegisterNodeCVEServiceHandler(ctx, mux, grpcServer)
+}
+
+func (s *supressCveServiceTestErrorImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+}
+
+func (s *supressCveServiceTestErrorImpl) SuppressCVEs(_ context.Context, req *v1.SuppressCVERequest) (*v1.Empty, error) {
+	return nil, status.Errorf(codes.Canceled, req.Duration.String())
+}
+
+func (a *MarshalerTest) TestDurationParsing() {
+	url := "https://localhost:8080/v1/nodecves/suppress"
+	jsonPayload := `{"code":1, "details": [], "error": "seconds:86400", "message":"seconds:86400"}`
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	api := NewAPI(defaultConf())
+	grpcServiceHandler := &supressCveServiceTestErrorImpl{}
+	api.Register(grpcServiceHandler)
+	a.Assert().NoError(api.Start().Wait())
+	a.T().Cleanup(func() { api.Stop() })
+
+	b := strings.NewReader(`{"cves": ["XYZ"],  "duration": "24h"}`)
+
+	req, err := http.NewRequest(http.MethodPatch, url, b)
+	a.NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	a.NoError(err)
+
+	body, err := io.ReadAll(resp.Body)
+	a.Require().NoError(err)
+
+	bodyStr := string(body)
+	a.Assert().JSONEq(jsonPayload, bodyStr)
+}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -385,19 +385,18 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 	}
 
 	gwMux := runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, customMarshaler{&runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
 				EmitUnpopulated: true,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{
 				DiscardUnknown: true,
 			},
-		}),
+		}}),
 		runtime.WithMetadata(a.requestInfoHandler.AnnotateMD),
 		runtime.WithOutgoingHeaderMatcher(allowCookiesHeaderMatcher),
 		runtime.WithMarshalerOption(
-			"application/json+pretty",
-			&runtime.JSONPb{
+			"application/json+pretty", customMarshaler{&runtime.JSONPb{
 				MarshalOptions: protojson.MarshalOptions{
 					Indent:          "  ",
 					EmitUnpopulated: true,
@@ -405,7 +404,7 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 				UnmarshalOptions: protojson.UnmarshalOptions{
 					DiscardUnknown: true,
 				},
-			},
+			}},
 		),
 		runtime.WithErrorHandler(errorHandler),
 	)


### PR DESCRIPTION
### Description

`github.com/golang/protobuf/jsonpb` is deprecated and since we only need to convert a json to a struct we can do it with this workaround. 

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
