### PR TITLE
ROX-11587: Prevent port 0 from being used as a server

### DIFF
--- a/pkg/netutil/ephemeral_port.go
+++ b/pkg/netutil/ephemeral_port.go
@@ -1,5 +1,7 @@
 package netutil
 
+import "math"
+
 type (
 	// EphemeralPortConfidence is a numeric value indicating the confidence that a port is an ephemeral port. The higher
 	// the value, the more confident we are that the port is ephemeral.
@@ -17,6 +19,10 @@ const (
 // is the client by determining for which port there is the higher confidence that it is ephemeral.
 func IsEphemeralPort(port uint16) EphemeralPortConfidence {
 	switch {
+	// Port 0 means collector failed to get the port number, this happens
+	// in connectionless UDP messages sometimes.
+	case port == 0:
+		return math.MaxInt
 	// IANA range
 	case port >= 49152:
 		return 4

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -307,7 +307,6 @@ class NetworkFlowTest extends BaseSpecification {
     @Tag("NetworkFlowVisualization")
     // TODO: additional handling may be needed for P/Z, skipping for 1st release
     @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
-    @IgnoreIf({ true }) // ROX-16849 this test is flaking in many cluster flavors
     def "Verify ports are greater than 0"() {
         given:
         "ACS is running"

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -1122,3 +1122,104 @@ func Test_connection_IsExternal(t *testing.T) {
 		})
 	}
 }
+
+func Test_getConnection_direction(t *testing.T) {
+	tests := []struct {
+		localPort  uint32
+		remotePort uint32
+		protocol   storage.L4Protocol
+		role       sensor.ClientServerRole
+		expected   bool
+	}{
+		{
+			localPort:  0,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   false,
+		}, {
+			localPort:  0,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   false,
+		}, {
+			localPort:  53,
+			remotePort: 0,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   true,
+		}, {
+			localPort:  53,
+			remotePort: 0,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   true,
+		}, {
+			localPort:  50000,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   false,
+		}, {
+			localPort:  50000,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   false,
+		}, {
+			localPort:  53,
+			remotePort: 50000,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   true,
+		}, {
+			localPort:  53,
+			remotePort: 50000,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   true,
+		}, {
+			localPort:  50000,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_TCP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   false,
+		}, {
+			localPort:  50000,
+			remotePort: 53,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_TCP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   true,
+		}, {
+			localPort:  53,
+			remotePort: 50000,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_TCP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   false,
+		}, {
+			localPort:  53,
+			remotePort: 50000,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_TCP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		networkConn := sensor.NetworkConnection{
+			SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+			LocalAddress: &sensor.NetworkAddress{
+				Port: tt.localPort,
+			},
+			RemoteAddress: &sensor.NetworkAddress{
+				Port: tt.remotePort,
+			},
+			Protocol: tt.protocol,
+			Role:     tt.role,
+		}
+		conn := getConnection(&networkConn)
+		assert.NotNil(t, conn)
+		assert.Equal(t, tt.expected, conn.incoming, "local: %d, remote: %d, protocol: %s, role: %s", tt.localPort, tt.remotePort, storage.L4Protocol_name[int32(tt.protocol)], sensor.ClientServerRole_name[int32(tt.role)])
+	}
+}

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -1156,6 +1156,21 @@ func Test_getConnection_direction(t *testing.T) {
 			role:       sensor.ClientServerRole_ROLE_SERVER,
 			expected:   true,
 		}, {
+			// Having both ports set to 0 should be impossible, it means we've
+			// failed to get lots of information about the connection and is
+			// more likely the event will not leave collector.
+			localPort:  0,
+			remotePort: 0,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_CLIENT,
+			expected:   false,
+		}, {
+			localPort:  0,
+			remotePort: 0,
+			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
+			role:       sensor.ClientServerRole_ROLE_SERVER,
+			expected:   false,
+		}, {
 			localPort:  50000,
 			remotePort: 53,
 			protocol:   storage.L4Protocol_L4_PROTOCOL_UDP,
@@ -1218,7 +1233,8 @@ func Test_getConnection_direction(t *testing.T) {
 			Protocol: tt.protocol,
 			Role:     tt.role,
 		}
-		conn := getConnection(&networkConn)
+		conn, err := processConnection(&networkConn)
+		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 		assert.Equal(t, tt.expected, conn.incoming, "local: %d, remote: %d, protocol: %s, role: %s", tt.localPort, tt.remotePort, storage.L4Protocol_name[int32(tt.protocol)], sensor.ClientServerRole_name[int32(tt.role)])
 	}


### PR DESCRIPTION

### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->
Collector sometimes doesn't get the port number of some sockets, this may be due to it missing some syscall or the kernel simply not filling in the data. This last case most commonly happens with connectionless UDP messaging, where the kernel leaves the side that starts the communication empty.

In any case, we shouldn't be showing port 0 in the network graph, so this patch will make it so port 0 takes the least precedence, so it will only show up if both sides of the connection are 0.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added unit tests to ensure port 0 is not picked when using UDP.
Currently working on some changes for OCP Virt integration that make port 0 show up consistently, fixed with this change.