### PR TITLE
ROX-24169: option for zero value scrubbing

### DIFF
--- a/pkg/secrets/scrub_test.go
+++ b/pkg/secrets/scrub_test.go
@@ -232,6 +232,11 @@ func TestScrubSecretsWithoutPasswordSetWithReplacement(t *testing.T) {
 	ScrubSecretsFromStructWithReplacement(testStruct, ScrubReplacementStr)
 	assert.NotEmpty(t, testStruct.Password)
 	assert.Equal(t, testStruct.Name, "name")
+
+	testStruct = &toplevel{Name: "name", Password: ""}
+	ScrubSecretsFromStructWithReplacement(testStruct, ScrubReplacementStr, WithScrubZeroValues(false))
+	assert.Empty(t, testStruct.Password)
+	assert.Equal(t, testStruct.Name, "name")
 }
 
 func TestScrubSecretsFromStructWithReplacement(t *testing.T) {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds an option to proto scrubbing which avoids replacing zero values. This is useful to indicate via the API if a field has been set or not. Concretely, I want to use this distinction to confirm via the UI if a cloud source integration with a deprecated API token field has been set (`credentials.secret`). Without this change, the payload

```json
{"credentials": {"secret": "", "clientId": "id", "clientSecret": "secret"}}
``` 

would be scrubbed to (note that `***` is returned regardless of original values)

```json
{"credentials": {"secret": "***", "clientId": "***", "clientSecret": "***"}}
``` 

This makes it indistinguishable from the deprecated 
```json
{"credentials": {"secret": "token", "clientId": "", "clientSecret": ""}}
```

With this PR, the scrubbed value of the line above is

```json
{"credentials": {"secret": "***", "clientId": "", "clientSecret": ""}}
```

which makes it possible to show a banner in the UI if `credentials.secret` is not empty.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
