### PR TITLE
fix(proto): do not use legacy proto in protoassert

### DIFF
--- a/operator/pkg/common/extensions/secret_reconciliator_test.go
+++ b/operator/pkg/common/extensions/secret_reconciliator_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stackrox/rox/operator/pkg/common/labels"
 	"github.com/stackrox/rox/operator/pkg/types"
 	"github.com/stackrox/rox/operator/pkg/utils/testutils"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -192,7 +192,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_PassingVa
 	err = s.client.Get(context.Background(), key, secret)
 	s.Require().NoError(err)
 
-	protoassert.Equal(s.T(), initSecret, secret)
+	assert.Equal(s.T(), initSecret, secret)
 }
 
 func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_FailingValidation_ShouldFix() {
@@ -246,7 +246,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingUnmanaged_Passing
 	secret := &v1.Secret{}
 	err = s.client.Get(context.Background(), key, secret)
 	s.Require().NoError(err)
-	protoassert.Equal(s.T(), initSecret, secret)
+	assert.Equal(s.T(), initSecret, secret)
 }
 
 func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingUnmanaged_FailingValidation_ShouldDoNothingAndFail() {
@@ -274,5 +274,5 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingUnmanaged_Failing
 	err = s.client.Get(context.Background(), key, secret)
 	s.Require().NoError(err)
 
-	protoassert.Equal(s.T(), initSecret, secret)
+	assert.Equal(s.T(), initSecret, secret)
 }

--- a/pkg/protoconv/networkpolicy/conversion_test.go
+++ b/pkg/protoconv/networkpolicy/conversion_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/k8sutil"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stretchr/testify/assert"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
@@ -249,7 +248,7 @@ func TestToRoxNetworkPolicyRoundTrip(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()
 			k8sPolicy := RoxNetworkPolicyWrap{NetworkPolicy: protoNetworkPolicy}.ToKubernetesNetworkPolicy()
-			protoassert.Equal(t, np, k8sPolicy)
+			assert.Equal(t, np.String(), k8sPolicy.String())
 		})
 	}
 }
@@ -295,7 +294,7 @@ func TestYamlKubernetesNetworkPolicyRoundTrip(t *testing.T) {
 
 			assert.NoError(t, err, "k8s policy generation should succeed")
 			assert.Equal(t, 1, len(k8sPolicies), "expected one policy from the yaml")
-			protoassert.Equal(t, np, k8sPolicies[0])
+			assert.Equal(t, np, k8sPolicies[0])
 		})
 	}
 }
@@ -310,7 +309,7 @@ func TestYamlRoxNetworkPolicyRoundTrip(t *testing.T) {
 
 			assert.NoError(t, err, "rox policy generation should succeed")
 			assert.Equal(t, 1, len(roxPolicies), "expected one policy from the yaml")
-			protoassert.Equal(t, np, RoxNetworkPolicyWrap{NetworkPolicy: roxPolicies[0]}.ToKubernetesNetworkPolicy())
+			assert.Equal(t, np, RoxNetworkPolicyWrap{NetworkPolicy: roxPolicies[0]}.ToKubernetesNetworkPolicy())
 		})
 	}
 }

--- a/sensor/upgrader/plan/preserve_test.go
+++ b/sensor/upgrader/plan/preserve_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/k8sutil"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/sensor/upgrader/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,7 +152,7 @@ func TestPreserveResources(t *testing.T) {
 	var mergedDS v1.DaemonSet
 	require.NoError(t, convert(scheme.Scheme, newDSUnstructured, &mergedDS))
 
-	protoassert.Equal(t, expectedMergedDS, &mergedDS)
+	assert.Equal(t, expectedMergedDS, &mergedDS)
 }
 
 func TestPreserveTolerations(t *testing.T) {
@@ -250,7 +249,7 @@ func TestPreserveTolerations(t *testing.T) {
 	var mergedDeploy v1.Deployment
 	require.NoError(t, convert(scheme.Scheme, newDeployUnstructured, &mergedDeploy))
 
-	protoassert.Equal(t, expectedMergedDeploy, &mergedDeploy)
+	assert.Equal(t, expectedMergedDeploy, &mergedDeploy)
 }
 
 func Test_applyPreservedProperties(t *testing.T) {


### PR DESCRIPTION
### Description

Since we switched to proto v2 there is no need to use the old lib in `protoassert`. This also fixes some of not valid usage of `protoassert`

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
