### PR TITLE
chore(proto): replace proto.MessgeType

### DIFF
--- a/central/graphql/generator/codegen/typewalk.go
+++ b/central/graphql/generator/codegen/typewalk.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	generator2 "github.com/stackrox/rox/central/graphql/generator"
 	"github.com/stackrox/rox/pkg/protoreflect"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -61,7 +61,7 @@ func (ctx *walkState) walkUnions(p reflect.Type) (output []unionData) {
 			if len(msgTypeName) > 1 && msgTypeName[0] == '.' {
 				msgTypeName = msgTypeName[1:]
 			}
-			msgType := proto.MessageType(msgTypeName)
+			msgType := protoutils.MessageType(msgTypeName)
 			if msgType == nil {
 				continue
 			}

--- a/pkg/protoutils/message.go
+++ b/pkg/protoutils/message.go
@@ -1,0 +1,17 @@
+package protoutils
+
+import (
+	"reflect"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// MessageType is a replacement for deprecated github.com/golang/protobuf/proto.MessageType
+func MessageType(typ string) reflect.Type {
+	mt, err := protoregistry.GlobalTypes.FindMessageByName(protoreflect.FullName(typ))
+	if err != nil {
+		return nil
+	}
+	return reflect.TypeOf(mt.Zero().Interface())
+}

--- a/pkg/protoutils/message_test.go
+++ b/pkg/protoutils/message_test.go
@@ -1,0 +1,28 @@
+package protoutils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestMessageType(t *testing.T) {
+	tests := []struct {
+		given    string
+		expected reflect.Type
+	}{
+		{given: "", expected: nil},
+		{given: "unknown.type", expected: nil},
+		{given: "storage.Cluster", expected: reflect.TypeOf(&storage.Cluster{})},
+		{given: "google.protobuf.Any", expected: reflect.TypeOf(&anypb.Any{})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.given, func(t *testing.T) {
+			actual := MessageType(tt.given)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/tools/deserialize-proto/main.go
+++ b/tools/deserialize-proto/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest/conn"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"k8s.io/utils/env"
@@ -48,7 +49,7 @@ func main() {
 		log.Fatal("must provide --type")
 	}
 
-	mt := proto.MessageType(*protobufType)
+	mt := protoutils.MessageType(*protobufType)
 	if mt == nil {
 		log.Fatalf("type %s could not be resolved to a protobuf message type", *protobufType)
 	}

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -8,9 +8,9 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
@@ -26,7 +26,7 @@ func parseReferencesAndInjectPeerSchemas(schema *walker.Schema, refs []string) (
 			refTable = pgutils.NamingStrategy.TableName(stringutils.GetAfter(refObjType, "."))
 		}
 
-		refMsgType := proto.MessageType(refObjType)
+		refMsgType := protoutils.MessageType(refObjType)
 		if refMsgType == nil {
 			log.Fatalf("could not find message for type: %s", refObjType)
 		}

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -16,13 +16,13 @@ import (
 	_ "embed"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	_ "github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/mathutil"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/readable"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/utils"
@@ -191,7 +191,7 @@ func main() {
 	c.RunE = func(*cobra.Command, []string) error {
 		typ := stringutils.OrDefault(props.RegisteredType, props.Type)
 		fmt.Println(readable.Time(time.Now()), "Generating for", typ)
-		mt := proto.MessageType(typ)
+		mt := protoutils.MessageType(typ)
 		if mt == nil {
 			log.Fatalf("could not find message for type: %s", typ)
 		}


### PR DESCRIPTION
### Description

This PR switches to new proto implementation. The goal is to drop this dependency as it's deprecated.

https://pkg.go.dev/github.com/golang/protobuf/proto#MessageType

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
