### PR TITLE
fix: Modify chown path from /etc/pki to /etc/pki/ca-trust

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -65,7 +65,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`
     # during the container start.
-    chown -R 4000:4000 /etc/pki /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl && \
+    chown -R 4000:4000 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl && \
     mkdir -p /var/lib/stackrox && chown -R 4000:4000 /var/lib/stackrox && \
     mkdir -p /var/log/stackrox && chown -R 4000:4000 /var/log/stackrox && \
     mkdir -p /var/cache/stackrox && chown -R 4000:4000 /var/cache/stackrox && \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -136,7 +136,7 @@ COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/docs/api/v
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
 
 # The following paths are written to in Central.
-RUN chown -R 4000:4000 /etc/pki /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl && \
+RUN chown -R 4000:4000 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl && \
     mkdir -p /var/lib/stackrox && chown -R 4000:4000 /var/lib/stackrox && \
     mkdir -p /var/log/stackrox && chown -R 4000:4000 /var/log/stackrox && \
     mkdir -p /var/cache/stackrox && chown -R 4000:4000 /var/cache/stackrox && \

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -45,7 +45,7 @@ RUN microdnf upgrade --nobest && \
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`
     # during the container start.
-    chown -R 65534:65534 /etc/pki /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
+    chown -R 65534:65534 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -71,7 +71,7 @@ RUN microdnf upgrade --nobest && \
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`
     # during the container start.
-    chown -R 65534:65534 /etc/pki /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
+    chown -R 65534:65534 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534


### PR DESCRIPTION
### Description

In https://github.com/stackrox/scanner/pull/1588 I discovered that updated Konflux build tasks treat `/etc/pki/entitlements` in a special way, that's due to added support for subscription-manager activation.
This, however, clashes with `chown ... /etc/pki` that we do historically (https://github.com/stackrox/scanner/pull/229)  in `Dockerfile`-s resulting in build-time errors like
```
chown: changing ownership of '/etc/pki/entitlement': Operation not permitted
```

I scanned the code and it seems that we only modify `/etc/pki/ca-trust` so we don't need to chown the entire `/etc/pki`.

<details>
<summary>Here are few relevant fragments</summary>

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml#L104-L109

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/operator/tests/upgrade/upgrade/040-assert-no-stackrox-db-volume-non-openshift.yaml#L26-L28

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/scanner/e2etests/helmchart/templates/scanner-deployment.yaml#L72-L73

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/sensor/kubernetes/upgrade/deployment.go#L190-L193

</details>

`/etc/pki/injected-ca-trust/` gets mounted in ACS manifests, and it's not something that exists in vanilla ubi/rhel containers. Therefore, there's no need to cover it with `chown` during build.

<details>
<summary>Some hints about that directory designation</summary>

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/image/templates/helm/shared/templates/_injected-ca-bundle.tpl#L1-L29

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/pkg/auth/authproviders/openshift/backend_impl.go#L39-L42

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/central/auth/m2m/verifier.go#L23-L25

https://github.com/stackrox/stackrox/blob/04d711a6702831b48c1c7c0770b1d6cef1fb9733/operator/tests/common/central-volumes-assert-openshift.yaml#L63-L65

</details>

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No contributions to the automated testing. Instead, relying on the existing one to cover me.

#### How I validated my change

`/etc/pki/ca-trust` functionality is needed to add extra CAs for the product to trust. I hope our tests cover that and CI will catch problems.

Asked Merliners https://redhat-internal.slack.com/archives/C02L9F6KR25/p1723136145082409

Manually tested CA injection on OpenShift ([reference doc](https://docs.openshift.com/container-platform/4.16/networking/configuring-a-custom-pki.html#nw-proxy-configure-object_configuring-a-custom-pki)).
1. Create a custom CA on the cluster
```bash
$ cat my-ca.yaml 
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-rh-ca-bundle
  namespace: openshift-config
data:
  ca-bundle.crt: |
    -----BEGIN CERTIFICATE-----
    MIIGXjCCBEagAwIBAgIEeIXl3TANBgkqhkiG9[...redacted...]
    -----END CERTIFICATE-----
```
2. Modify `Proxy` resource to use that CA `kubectl edit proxy cluster` making
```yaml
spec:
  trustedCA:
    name: my-rh-ca-bundle
```
3. Deploy operator `ROX_PRODUCT_BRANDING=RHACS_BRANDING make deploy-via-olm`.
4. Add image pull secrets
```bash
$ NAMESPACE="stackrox-operator" make stackrox-image-pull-secret
```
6. Create Central CR in OCP console.
7. Exec into Central pod and check the certificate got processed
```bash
$ kubectl -n stackrox-operator exec -it deploy/central -- /bin/bash
$ cd /etc/pki
grep 'MIIGXjCCBEagAwIBAgIEeIXl3' ca-trust/extracted/pem/tls-ca-bundle.pem 
MIIGXjCCBEagAwIBAgIEeIXl3TANBgkqh[...redacted...]
```