### PR TITLE
ROX-25662: Fix accessibility issues with header for global modals

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,4 +1,5 @@
 import React, { ElementType, ReactElement, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { PageSection } from '@patternfly/react-core';
 
@@ -51,6 +52,7 @@ import ErrorBoundary from 'Components/PatternFly/ErrorBoundary/ErrorBoundary';
 import usePermissions, { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import useAnalytics from 'hooks/useAnalytics';
+import { selectors } from 'reducers';
 
 import asyncComponent from './AsyncComponent';
 import InviteUsersModal from './InviteUsers/InviteUsersModal';
@@ -245,6 +247,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     }, [location, analyticsPageVisit]);
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForInviting = hasReadWriteAccess('Access');
+    const showInviteModal = useSelector(selectors.inviteSelector);
 
     const { isDarkMode } = useTheme();
 
@@ -270,7 +273,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                         })}
                     <Route component={NotFoundPage} />
                 </Switch>
-                {hasWriteAccessForInviting && <InviteUsersModal />}
+                {hasWriteAccessForInviting && showInviteModal && <InviteUsersModal />}
             </ErrorBoundary>
         </div>
     );

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -28,6 +28,7 @@ function MainPage(): ReactElement {
     const isLoadingPublicConfig = useSelector(selectors.isLoadingPublicConfigSelector);
     const isLoadingCentralCapabilities = useSelector(selectors.getIsLoadingCentralCapabilities);
     const [isLoadingClustersCount, setIsLoadingClustersCount] = useState(false);
+    const showFeedbackModal = useSelector(selectors.feedbackSelector);
 
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
 
@@ -88,7 +89,7 @@ function MainPage(): ReactElement {
                 >
                     Feedback
                 </Button>
-                <AcsFeedbackModal />
+                {showFeedbackModal && <AcsFeedbackModal />}
                 <Page
                     mainContainerId="main-page-container"
                     header={<Header />}


### PR DESCRIPTION
### Description

Follow up #12209

### Problem reported by axe DevTools

> Document should not have more than one banner landmark

https://dequeuniversity.com/rules/axe/4.9/landmark-no-duplicate-banner

> Ensures landmarks are unique

https://dequeuniversity.com/rules/axe/4.9/landmark-unique

For both:

```html
<header class="pf-v5-c-page__header ignore-react-onclickoutside theme-dark">
```

Related node:

```html
<header class="pf-v5-c-modal-box__header">
```

### Analysis

Thank you **David** for observing transient changes in browser Elements pane.

Initial elements:

```html
<body class="theme-light">
<div id=="root">
<!-- This HTML file is a template, and so on. -->
<div></div>
<div></div>
<svg></svg>
```

Click **Manage CIDR blocks** button:

```html
<body class="theme-light pf-v5-c-backdrop__open">
<div id=="root" aria-hidden="true">
<!-- This HTML file is a template, and so on. -->
<div aria-hidden="true"></div>
<div aria-hidden="true"></div>
<svg aria-hidden="true"></svg>
<div></div>
```

But then it becomes:

```html
<body class="theme-light">
<div id=="root">
<!-- This HTML file is a template, and so on. -->
<div></div>
<div aria-hidden="true"></div>
<svg></svg>
<div></div>
```

It looks like PatternFly does not expect multiple instances of `Modal` element.

Or at least does not expect that `isOpen={true}` state change for an instance causes an update to any other instances.

1. 3 initially empty `div` elements correspond to `AcsFeedbackModal` and `InviteUsersModal` and `CIDRFormModal` elements in `isOpen={false}` state.
    * https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/MainPage/MainPage.tsx#L129
    * https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/MainPage/Body.tsx#L273
    * https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx#L443-L447
2. Initial attributes added when `CIDRFormModal` has `isOpen` state because of `componentDidUpdate` in PatternFly `Modal` element:
    https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Modal/Modal.tsx#L206-L207
3. Initial attributes removed because of `componentDidUpdate` in the other 2 PatternFly `Modal` elements:
    https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Modal/Modal.tsx#L209-L210

### Solution

1. Replace unconditional with conditional rendering:
    * `AcsFeedbackModal` in `MainPage` component
    * `InviteUsersModal` in `Body` component

To minimize changes, I left the modal elements alone: they independently determine `isOpen` from Redux store, although conditional rendering means that `true` has become the only possible the value in the component.

Initial elements include empty `div` element without conditional rendering of route-specific modal:

```html
<body class="theme-light">
<div id=="root">
<!-- This HTML file is a template, and so on. -->
<svg></svg>
<div></div>
```

Click **Manage CIDR blocks** button:

```html
<body class="theme-light pf-v5-c-backdrop__open">
<div id=="root" aria-hidden="true">
<!-- This HTML file is a template, and so on. -->
<svg aria-hidden="true"></svg>
<div>…</div>
```

### Residue

1. Investigate possible side-effect that because `h1` element of page is temporarily hidden, it becomes an accessibility issue if modal does not render `h1` element.
2. Discuss among team pro and con of conditional rendering for `Modal` elements.

Here is draft lint rule that reports 48 occurrences without conditional rendering, not including 2 changed in this contribution.

```js
const rules = {
    'Modal-conditional-rendering': {
        // Require conditional rendering for consistency and to prevent axe DevTools issues:
        // Document should not have more than one banner landmark
        // https://dequeuniversity.com/rules/axe/4.9/landmark-no-duplicate-banner
        // Ensures landmarks are unique
        // https://dequeuniversity.com/rules/axe/4.9/landmark-unique
        meta: {
            type: 'problem',
            docs: {
                description: 'Require that Modal element has conditional rendering',
            },
            schema: [],
        },
        create(context) {
            return {
                JSXElement(node) {
                    if (node.openingElement?.name?.name?.endsWith('Modal')) {
                        if (node.openingElement?.name?.name === 'Modal') {
                            return; // ignore element from react-modal package
                        }

                        const ancestors = context.sourceCode.getAncestors(node);
                        if (
                            node.openingElement?.name?.name === 'Modal' &&
                            ancestors.length >= 1 &&
                            ancestors[ancestors.length - 1].type === 'ReturnStatement'
                        ) {
                            return; // okay for component to return Modal element
                        }
                        if (
                            ancestors.length >= 1 &&
                            ancestors[ancestors.length - 1].operator !== '&&'
                        ) {
                            context.report({
                                node,
                                message: 'Require that Modal element has conditional rendering',
                            });
                        }
                    }
                },
            };
        },
    },
};
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 72 = 4618273 - 4618201
        total 72 = 11701302 - 11701230
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui

#### Manual testing

1. Visit /main/network-graph, and then click **Manage CIDR blocks** button.

    * Before changes, see presence of **landmark** accessibility issues.
        ![network-graph_with_issues](https://github.com/user-attachments/assets/6815eda2-f3d3-4628-bfe4-675f313f779e)

    * After changes, see absence of **landmark** accessibility issues.
        ![network-graph_without_issues](https://github.com/user-attachments/assets/465cfb1d-b6e2-447f-a961-e350781c45f7)

2. Close modal, click icon at upper-right, and then click **Invite users**.

    * See `aria-hidden="true"` attribute and lack of accessibility issues, even though `CIDRFormModal` element lacks conditional rendering.

    * See requests to get current data:
        GET /v1/authProviders
        GET /v1/roles
        GET /v1/groups

    ![InviteUsersModal](https://github.com/user-attachments/assets/6c2ff6eb-6b74-4d9a-a45b-f7011a95abb1)

3. Visit /main/vulnerabilities/reports, click **Create report**, click **Select a collection** and then click **Create collection**.

    * Before changes, see presence of **landmark** accessibility issues.
        ![vulnerabilities_reports_with_issues](https://github.com/user-attachments/assets/62b77dfa-7b71-4aa4-8c01-bbb0a1ddb0f9)

    * After changes, see fewer **landmark** accessibility issues, because the form itself has non-unique landmarks with `role="region"` for **Collection rules** and **Attached collections**.
        ![vulnerabilities_reports_with_fewer_issues](https://github.com/user-attachments/assets/e3188e1e-53ed-45d0-82c5-8e2ec51e5b85)

4. Visit /main/system-health, and then click **Show administrative usage** button.

    * Before changes, see presence of **landmark** accessibility issues and presence of modal-specific issue.
        ![system-health_with_issues](https://github.com/user-attachments/assets/73a58dfd-c8ab-42fa-8535-4d6a61f7b1fe)

    * After changes, see absence of **landmark** accessibility issues but presence of modal-specific issue.
        ![system-health_with_fewer_issues](https://github.com/user-attachments/assets/90e138a8-fb68-448d-9a76-04d09278b864)

5. Close modal, click **Feedback**.
    ![AcsFeedbackModal](https://github.com/user-attachments/assets/e4406d04-ec90-481d-a869-0fde1fc92f4d)
