### PR TITLE
chore(proto): remove legacy timestamp

### DIFF
--- a/pkg/protoconv/time.go
+++ b/pkg/protoconv/time.go
@@ -3,7 +3,6 @@ package protoconv
 import (
 	"time"
 
-	golangTimestamp "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -18,17 +17,6 @@ const (
 	timeFormat         = "2006-01-02T15:04Z"
 	extendedTimeFormat = "2006-01-02T15:04:03Z"
 )
-
-// ConvertGoGoProtoTimeToGolangProtoTime converts the Gogo Timestamp to the golang protobuf timestamp.
-func ConvertGoGoProtoTimeToGolangProtoTime(gogo *timestamppb.Timestamp) *golangTimestamp.Timestamp {
-	if gogo == nil {
-		return nil
-	}
-	return &golangTimestamp.Timestamp{
-		Seconds: gogo.GetSeconds(),
-		Nanos:   gogo.GetNanos(),
-	}
-}
 
 // ConvertTimestampToTimeOrNow converts a proto timestamp to a golang Time, and returns time.Now() if there is an error.
 func ConvertTimestampToTimeOrNow(gogo *timestamppb.Timestamp) time.Time {

--- a/pkg/timestamp/microts.go
+++ b/pkg/timestamp/microts.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -66,8 +66,8 @@ func (ts MicroTS) UnixNanosFraction() int32 {
 }
 
 // Protobuf converts this microtimestamp to a (Google) protobuf representation.
-func (ts MicroTS) Protobuf() *timestamp.Timestamp {
-	return &timestamp.Timestamp{
+func (ts MicroTS) Protobuf() *timestamppb.Timestamp {
+	return &timestamppb.Timestamp{
 		Seconds: ts.UnixSeconds(),
 		Nanos:   ts.UnixNanosFraction(),
 	}

--- a/pkg/timestamp/microts_test.go
+++ b/pkg/timestamp/microts_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGoTimeToMicroTS(t *testing.T) {
@@ -17,7 +17,7 @@ func TestGoTimeToMicroTS(t *testing.T) {
 }
 
 func TestNilGoogleProtobufIsZero(t *testing.T) {
-	var ts *timestamp.Timestamp
+	var ts *timestamppb.Timestamp
 	assert.Zero(t, FromProtobuf(ts))
 }
 


### PR DESCRIPTION
### Description

This cleanup leftovers after proto switch. Since we have a new proto we should use it everywhere.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
