### PR TITLE
ROX-24410: Remove not-processed events from deduper on re-connect

### DIFF
--- a/central/hash/manager/deduper.go
+++ b/central/hash/manager/deduper.go
@@ -122,9 +122,8 @@ func (d *deduperImpl) StartSync() {
 	d.hashLock.Lock()
 	defer d.hashLock.Unlock()
 
-	for _, v := range d.received {
-		v.processed = false
-	}
+	// We need to process received but not successfully processed events.
+	d.received = make(map[string]*entry)
 
 	// Mark all hashes as unseen when a new sensor connection is created
 	for _, v := range d.successfullyProcessed {


### PR DESCRIPTION
### Description

**TESTING!!! - DO NOT MERGE YET!!!**

The theory is that because the connection with the sensor is closed (client closed / some error), all queues for that connection are also closed. The state of queues can be that they are not fully processed.

But deduper keeps state of received messages after connection is established again. That will cause that the deduper will dedupe some messages that are not processed.

This PR is changing handling of deduper on reconnect to drop information about received messages, because they are not processed and they should be processed again.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no changes made in tests (there is another PR with a test that reproduces this behavior)

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

_there is another PR with a test that reproduces this behavior_
