### PR TITLE
chore(proto): use EqualVT in protoassert

### DIFF
--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -925,7 +925,7 @@ func (s *patchAlertTests) TestSnoozeAlert() {
 	s.NoError(err)
 
 	s.Equal(fakeAlert.State, storage.ViolationState_SNOOZED)
-	protoassert.Equal(s.T(), fakeAlert.SnoozeTill, snoozeTill)
+	assert.Equal(s.T(), fakeAlert.SnoozeTill.AsTime(), snoozeTill.AsTime())
 }
 
 func (s *patchAlertTests) TestSnoozeAlertWithSnoozeTillInThePast() {

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -647,17 +647,17 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
 			s.NoError(postUpdateErr)
 			s.True(postUpdateFound)
 			if c.ExpectError {
-				protoassert.Equal(s.T(), oldSensorExpiry, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				protoassert.Equal(s.T(), oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry.AsTime(), preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
+				s.Equal(oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
 				s.ErrorIs(updateErr, c.ExpectedError)
-				protoassert.Equal(s.T(), oldSensorExpiry, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				protoassert.Equal(s.T(), oldSensorCertNotBefore, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
+				s.Equal(oldSensorCertNotBefore.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())
 			} else {
-				protoassert.Equal(s.T(), oldSensorExpiry, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				protoassert.Equal(s.T(), oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorExpiry.AsTime(), preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
+				s.Equal(oldSensorCertNotBefore.AsTime(), preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())
 				s.NoError(updateErr)
-				protoassert.Equal(s.T(), newSensorExpiry, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-				protoassert.Equal(s.T(), newSensorCertNotBefore, postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(newSensorExpiry.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
+				s.Equal(newSensorCertNotBefore.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())
 			}
 			// Revert to pre-test state
 			err := s.datastore.UpdateClusterCertExpiryStatus(globalReadWriteCtx, clusterID, oldCertExpiryStatus)
@@ -665,8 +665,8 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
 			fetchedCluster, found, err := s.datastore.GetCluster(globalReadWriteCtx, clusterID)
 			s.Require().NoError(err)
 			s.Require().True(found)
-			protoassert.Equal(s.T(), oldSensorExpiry, fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry())
-			protoassert.Equal(s.T(), oldSensorCertNotBefore, fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+			s.Equal(oldSensorExpiry.AsTime(), fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
+			s.Equal(oldSensorCertNotBefore.AsTime(), fetchedCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())
 		})
 	}
 }
@@ -726,19 +726,19 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterHealth() {
 			if c.ExpectError {
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				protoassert.Equal(s.T(), oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact().AsTime(), preUpdateCluster.GetHealthStatus().GetLastContact().AsTime())
 				s.ErrorIs(updateErr, c.ExpectedError)
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				protoassert.Equal(s.T(), oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact().AsTime(), preUpdateCluster.GetHealthStatus().GetLastContact().AsTime())
 			} else {
 				s.Equal(oldHealthStatus.GetCollectorHealthStatus(), preUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(oldHealthStatus.GetOverallHealthStatus(), preUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				protoassert.Equal(s.T(), oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(oldHealthStatus.GetLastContact().AsTime(), preUpdateCluster.GetHealthStatus().GetLastContact().AsTime())
 				s.NoError(updateErr)
 				s.Equal(newHealthStatus.GetCollectorHealthStatus(), postUpdateCluster.GetHealthStatus().GetCollectorHealthStatus())
 				s.Equal(newHealthStatus.GetOverallHealthStatus(), postUpdateCluster.GetHealthStatus().GetOverallHealthStatus())
-				protoassert.Equal(s.T(), newHealthStatus.GetLastContact(), postUpdateCluster.GetHealthStatus().GetLastContact())
+				s.Equal(newHealthStatus.GetLastContact().AsTime(), postUpdateCluster.GetHealthStatus().GetLastContact().AsTime())
 			}
 			// Revert to pre-test state
 			err := s.datastore.UpdateClusterHealth(globalReadWriteCtx, clusterID, oldHealthStatus)
@@ -748,7 +748,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterHealth() {
 			s.Require().True(found)
 			s.Require().Equal(oldHealthStatus.GetCollectorHealthStatus(), fetchedCluster.GetHealthStatus().GetCollectorHealthStatus())
 			s.Require().Equal(oldHealthStatus.GetOverallHealthStatus(), fetchedCluster.GetHealthStatus().GetOverallHealthStatus())
-			protoassert.Equal(s.T(), oldHealthStatus.GetLastContact(), preUpdateCluster.GetHealthStatus().GetLastContact())
+			s.Equal(oldHealthStatus.GetLastContact().AsTime(), preUpdateCluster.GetHealthStatus().GetLastContact().AsTime())
 		})
 	}
 }
@@ -956,28 +956,28 @@ func (s *clusterDatastoreSACSuite) TestUpdateAuditLogFileStates() {
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
 					s.Require().NotNil(preUpdateCluster.GetAuditLogState()[k])
-					protoassert.Equal(s.T(), oldAuditLogFileState[k].GetCollectLogsSince(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Equal(oldAuditLogFileState[k].GetCollectLogsSince().AsTime(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince().AsTime())
 				}
 				s.ErrorIs(updateErr, c.ExpectedError)
 				s.Require().Equal(len(oldAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
 					s.Require().NotNil(postUpdateCluster.GetAuditLogState()[k])
-					protoassert.Equal(s.T(), oldAuditLogFileState[k].GetCollectLogsSince(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Equal(oldAuditLogFileState[k].GetCollectLogsSince().AsTime(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince().AsTime())
 				}
 			} else {
 				s.Require().Equal(len(oldAuditLogFileState), len(preUpdateCluster.GetAuditLogState()))
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), preUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
 					s.Require().NotNil(preUpdateCluster.GetAuditLogState()[k])
-					protoassert.Equal(s.T(), oldAuditLogFileState[k].GetCollectLogsSince(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Equal(oldAuditLogFileState[k].GetCollectLogsSince().AsTime(), preUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince().AsTime())
 				}
 				s.NoError(updateErr)
 				s.Require().Equal(len(newAuditLogFileState), len(postUpdateCluster.GetAuditLogState()))
 				for k := range newAuditLogFileState {
 					s.Require().Equal(newAuditLogFileState[k].GetLastAuditId(), postUpdateCluster.GetAuditLogState()[k].GetLastAuditId())
 					s.Require().NotNil(postUpdateCluster.GetAuditLogState()[k])
-					protoassert.Equal(s.T(), newAuditLogFileState[k].GetCollectLogsSince(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Equal(newAuditLogFileState[k].GetCollectLogsSince().AsTime(), postUpdateCluster.GetAuditLogState()[k].GetCollectLogsSince().AsTime())
 				}
 				// Revert to pre-test state
 				err := s.datastore.UpdateAuditLogFileStates(globalReadWriteCtx, clusterID, oldAuditLogFileState)
@@ -989,7 +989,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateAuditLogFileStates() {
 				for k := range oldAuditLogFileState {
 					s.Require().Equal(oldAuditLogFileState[k].GetLastAuditId(), fetchedCluster.GetAuditLogState()[k].GetLastAuditId())
 					s.Require().NotNil(fetchedCluster.GetAuditLogState()[k])
-					protoassert.Equal(s.T(), oldAuditLogFileState[k].GetCollectLogsSince(), fetchedCluster.GetAuditLogState()[k].GetCollectLogsSince())
+					s.Equal(oldAuditLogFileState[k].GetCollectLogsSince().AsTime(), fetchedCluster.GetAuditLogState()[k].GetCollectLogsSince().AsTime())
 				}
 			}
 		})

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -648,7 +648,7 @@ func (s *clusterDatastoreSACSuite) TestUpdateClusterCertExpiryStatus() {
 			s.True(postUpdateFound)
 			if c.ExpectError {
 				s.Equal(oldSensorExpiry.AsTime(), preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
-				s.Equal(oldSensorCertNotBefore, preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore())
+				s.Equal(oldSensorCertNotBefore.AsTime(), preUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())
 				s.ErrorIs(updateErr, c.ExpectedError)
 				s.Equal(oldSensorExpiry.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertExpiry().AsTime())
 				s.Equal(oldSensorCertNotBefore.AsTime(), postUpdateCluster.GetStatus().GetCertExpiryStatus().GetSensorCertNotBefore().AsTime())

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
@@ -229,7 +229,7 @@ func (s *complianceScanDataStoreTestSuite) TestUpsertScan() {
 	retrievedObject, found, err := s.dataStore.GetScan(s.hasReadCtx, testScan3.GetId())
 	s.Require().NoError(err)
 	s.Require().True(found)
-	protoassert.Equal(s.T(), testScan3.LastExecutedTime, retrievedObject.LastExecutedTime)
+	s.Equal(testScan3.LastExecutedTime.AsTime(), retrievedObject.LastExecutedTime.AsTime())
 }
 
 func (s *complianceScanDataStoreTestSuite) TestDeleteScanByCluster() {

--- a/central/credentialexpiry/service/service_impl_test.go
+++ b/central/credentialexpiry/service/service_impl_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	grpctestutils "github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/pkg/mtls"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -176,7 +175,7 @@ func TestGetScannerV4CertExpiry(t *testing.T) {
 				} else {
 					expectedExpiry, err := protocompat.ConvertTimeToTimestampOrError(*tc.expiryExpected)
 					require.NoError(t, err)
-					protoassert.Equal(t, expectedExpiry, actual.Expiry)
+					assert.Equal(t, expectedExpiry.AsTime(), actual.Expiry.AsTime())
 				}
 			}
 		})

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -195,7 +195,7 @@ func (s *serviceImplTestSuite) TestDatabaseBackupStatus() {
 	s.NoError(err)
 	actual, err := srv.GetDatabaseBackupStatus(ctx, &v1.Empty{})
 	s.NoError(err)
-	protoassert.Equal(s.T(), expected, actual)
+	protoassert.Equal(s.T(), expected.BackupInfo, actual.BackupInfo)
 }
 
 func (s *serviceImplTestSuite) TestGetCentralCapabilities() {

--- a/central/processbaseline/datastore/datastore_impl_test.go
+++ b/central/processbaseline/datastore/datastore_impl_test.go
@@ -92,7 +92,7 @@ func (suite *ProcessBaselineDataStoreTestSuite) createAndStoreBaseline(key *stor
 	suite.NoError(err)
 	suite.NotNil(id)
 	suite.NotNil(baseline.Created)
-	protoassert.Equal(suite.T(), baseline.Created, baseline.LastUpdate)
+	suite.Equal(baseline.Created.AsTime(), baseline.LastUpdate.AsTime())
 	suite.True(protocompat.CompareTimestamps(baseline.StackRoxLockedTimestamp, baseline.Created) >= 0)
 
 	suite.Equal(suite.mustSerializeKey(key), id)

--- a/central/vulnmgmt/vulnerabilityrequest/service/service_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/service/service_impl_test.go
@@ -55,7 +55,7 @@ func (s *VulnRequestServiceTestSuite) TestDeferVulnerabilityCreatesDeferRequest(
 
 	resp, err := s.service.DeferVulnerability(allAllowedCtx, req)
 	s.NoError(err)
-	protoassert.Equal(s.T(), req.GetExpiresOn(), resp.GetRequestInfo().GetDeferralReq().GetExpiry().GetExpiresOn())
+	s.Equal(req.GetExpiresOn().AsTime(), resp.GetRequestInfo().GetDeferralReq().GetExpiry().GetExpiresOn().AsTime())
 }
 
 func (s *VulnRequestServiceTestSuite) TestCreateRequests() {

--- a/migrator/migrations/m_183_to_m_184_move_declarative_config_health/migration_test.go
+++ b/migrator/migrations/m_183_to_m_184_move_declarative_config_health/migration_test.go
@@ -12,7 +12,6 @@ import (
 	integrationHealthStore "github.com/stackrox/rox/migrator/migrations/m_183_to_m_184_move_declarative_config_health/integrationhealth/store"
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
@@ -83,7 +82,7 @@ func TestMigration(t *testing.T) {
 	assert.Equal(t, unhealthyDeclarativeConfigName, config.GetName())
 	assert.Equal(t, unhealthyDeclarativeConfig.GetErrorMessage(), config.GetErrorMessage())
 	assert.Equal(t, unhealthyDeclarativeConfig.GetStatus().String(), config.GetStatus().String())
-	protoassert.Equal(t, unhealthyDeclarativeConfig.GetLastTimestamp(), config.GetLastTimestamp())
+	assert.Equal(t, unhealthyDeclarativeConfig.GetLastTimestamp().AsTime(), config.GetLastTimestamp().AsTime())
 
 	config, exists, err = healthStore.Get(ctx, healthyDeclarativeConfigID)
 	assert.NoError(t, err)
@@ -91,5 +90,5 @@ func TestMigration(t *testing.T) {
 	assert.Equal(t, healthyDeclarativeConfigName, config.GetName())
 	assert.Equal(t, healthyDeclarativeConfig.GetErrorMessage(), config.GetErrorMessage())
 	assert.Equal(t, healthyDeclarativeConfig.GetStatus().String(), config.GetStatus().String())
-	protoassert.Equal(t, healthyDeclarativeConfig.GetLastTimestamp(), config.GetLastTimestamp())
+	assert.Equal(t, healthyDeclarativeConfig.GetLastTimestamp().AsTime(), config.GetLastTimestamp().AsTime())
 }

--- a/pkg/protocompat/empty_test.go
+++ b/pkg/protocompat/empty_test.go
@@ -3,11 +3,12 @@ package protocompat
 import (
 	"testing"
 
-	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestEmpty(t *testing.T) {
 	refEmpty := &Empty{}
 
-	protoassert.Equal(t, refEmpty, ProtoEmpty())
+	assert.True(t, proto.Equal(refEmpty, ProtoEmpty()))
 }

--- a/pkg/protocompat/time_test.go
+++ b/pkg/protocompat/time_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -72,7 +71,7 @@ func TestConvertTimeToTimestampOrError(t *testing.T) {
 
 	protoTS1, errTS1 := ConvertTimeToTimestampOrError(time1)
 	assert.NoError(t, errTS1)
-	protoassert.Equal(t, &timestamppb.Timestamp{Seconds: seconds1, Nanos: nanos1}, protoTS1)
+	assert.Equal(t, (&timestamppb.Timestamp{Seconds: seconds1, Nanos: nanos1}).AsTime(), protoTS1.AsTime())
 }
 
 func TestConvertTimestampToTimeOrNil(t *testing.T) {
@@ -110,7 +109,7 @@ func TestConvertTimeToTimestampOrNil(t *testing.T) {
 	time1 := time.Unix(seconds1, int64(nanos1))
 
 	protoTS1 := ConvertTimeToTimestampOrNil(&time1)
-	protoassert.Equal(t, &timestamppb.Timestamp{Seconds: seconds1, Nanos: nanos1}, protoTS1)
+	assert.Equal(t, (&timestamppb.Timestamp{Seconds: seconds1, Nanos: nanos1}).AsTime(), protoTS1.AsTime())
 
 	timeInvalid := time.Date(0, 12, 25, 23, 59, 59, 0, time.UTC)
 	protoTSInvalid := ConvertTimeToTimestampOrNil(&timeInvalid)
@@ -250,5 +249,5 @@ func TestDurationProto(t *testing.T) {
 		Nanos:   5,
 	}
 	protoDuration := DurationProto(timeDuration)
-	protoassert.Equal(t, expectedProtoDuration, protoDuration)
+	assert.Equal(t, expectedProtoDuration.AsDuration(), protoDuration.AsDuration())
 }

--- a/pkg/protocompat/uint32_test.go
+++ b/pkg/protocompat/uint32_test.go
@@ -3,7 +3,7 @@ package protocompat
 import (
 	"testing"
 
-	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -14,7 +14,7 @@ func TestProtoUInt32Value(t *testing.T) {
 	}
 
 	val1 := ProtoUInt32Value(input1)
-	protoassert.Equal(t, expectedVal1, val1)
+	assert.Equal(t, expectedVal1.Value, val1.Value)
 
 	input2 := uint32(1234567890)
 	expectedVal2 := &wrapperspb.UInt32Value{
@@ -22,5 +22,5 @@ func TestProtoUInt32Value(t *testing.T) {
 	}
 
 	val2 := ProtoUInt32Value(input2)
-	protoassert.Equal(t, expectedVal2, val2)
+	assert.Equal(t, expectedVal2.Value, val2.Value)
 }

--- a/pkg/protoconv/time_test.go
+++ b/pkg/protoconv/time_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +34,7 @@ func TestConvertTimeString(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			protoassert.Equal(t, c.output, ConvertTimeString(c.input))
+			assert.Equal(t, c.output.AsTime(), ConvertTimeString(c.input).AsTime())
 		})
 	}
 }

--- a/pkg/protoutils/time_test.go
+++ b/pkg/protoutils/time_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -61,7 +60,7 @@ func TestRoundTimestamp(t *testing.T) {
 		Nanos:   123456789,
 	}
 	notRounded := RoundTimestamp(tsInvalid, time.Microsecond)
-	protoassert.Equal(t, tsInvalid, notRounded)
+	assert.Equal(t, tsInvalid.AsTime(), notRounded.AsTime())
 
 	ts1 := &timestamppb.Timestamp{
 		Seconds: 1510860932,

--- a/pkg/scanners/scannerv4/scannerv4_test.go
+++ b/pkg/scanners/scannerv4/scannerv4_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	s4ClientMocks "github.com/stackrox/rox/pkg/scannerv4/client/mocks"
 	"github.com/stretchr/testify/assert"
@@ -68,7 +67,7 @@ func TestGetVulnDefinitionsInfo(t *testing.T) {
 				assert.Nil(t, vdi)
 			} else {
 				require.NoError(t, err)
-				protoassert.Equal(t, tc.clientRet.GetLastVulnerabilityUpdate(), vdi.GetLastUpdatedTimestamp())
+				assert.Equal(t, tc.clientRet.GetLastVulnerabilityUpdate().AsTime(), vdi.GetLastUpdatedTimestamp().AsTime())
 			}
 		})
 	}


### PR DESCRIPTION
### Description

This is the follow-up to address https://github.com/stackrox/stackrox/pull/12335#pullrequestreview-2228330829
It changes protoassert to use EqualVT instead of `proto.Equal` as default types does not have `EqualVT` we need to use `proto.Equal` on them or convert to native types (e.g. duration or time)

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
