### PR TITLE
chore(build): Search podman in more docker output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,24 @@ BENCHTIME ?= 1x
 BENCHTIMEOUT ?= 20m
 BENCHCOUNT ?= 1
 
+podman =
+# docker --version might not contain any traces of podman in the latest
+# version, search for more output
 ifeq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
+	podman = yes
+endif
+
+ifeq (,$(findstring Podman,$(shell docker version 2>/dev/null)))
+	podman = yes
+endif
+
+ifdef podman
+# Disable selinux for local podman builds.
+DOCKER_OPTS=--security-opt label=disable
+else
 # Podman DTRT by running processes unprivileged in containers,
 # but it's UID mapping is more nuanced. Only set user for vanilla docker.
 DOCKER_OPTS=--user "$(shell id -u)"
-else
-# Disable selinux for local podman builds.
-DOCKER_OPTS=--security-opt label=disable
 endif
 
 # Set to empty string to echo some command lines which are hidden by default.

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,10 @@ BENCHCOUNT ?= 1
 podman =
 # docker --version might not contain any traces of podman in the latest
 # version, search for more output
-ifeq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
+ifneq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
 	podman = yes
 endif
-
-ifeq (,$(findstring Podman,$(shell docker version 2>/dev/null)))
+ifneq (,$(findstring Podman,$(shell docker version 2>/dev/null)))
 	podman = yes
 endif
 


### PR DESCRIPTION
### Description

Looks like latest versions of podman do not tell anything about itself in the output of `docker --version`, but does that in `docker version`. Search for both.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

CI is sufficient.

#### How I validated my change

Tested the build manually.