### PR TITLE
ROX-25610: Disallow coercing of selected cluster-names to Helm types

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -312,6 +312,6 @@ metadata:
     {{- $_ := include "srox.getAnnotationTemplate" (list . "helm-hook_secret" $annotations) -}}
     {{- include "srox.annotations" (list . "secret" "helm-effective-cluster-name" $annotations) | nindent 4 }}
 data:
-  cluster-name: {{ ._rox.clusterName | base64 }}
+  cluster-name: {{ ._rox.clusterName | b64enc }}
 {{- end}}
 [<- end >]


### PR DESCRIPTION
### Description

The problematic part is located at the end of the `image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl` file:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: helm-effective-cluster-name
  namespace: {{ ._rox._namespace }}
  labels:
    {{- include "srox.labels" (list . "secret" "helm-effective-cluster-name") | nindent 4 }}
    auto-upgrade.stackrox.io/component: sensor
  annotations:
    {{- $annotations := dict -}}
    {{- $_ := include "srox.getAnnotationTemplate" (list . "helm-hook_secret" $annotations) -}}
    {{- include "srox.annotations" (list . "secret" "helm-effective-cluster-name" $annotations) | nindent 4 }}
stringData:
  cluster-name: |
    {{- ._rox.clusterName | nindent 4 }}
```

The `cluster-name` contains:
- base64-encoded data on Helm installation
- plait text when bundle is generated for legacy installation method

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Helm installation (`./deploy/openshift/central.sh`)
    - :x: quoting the name `"remote"` (`cluster-name: InJlbW90ZSIK`) does not work - Sensor and AC do not start
    - ✅  not quoting the name `remote` (`cluster-name: cmVtb3RlCg==`) works 
- Zip bundle
   - ✅ quoting the name `"remote"` (`cluster-name: InJlbW90ZSIK`) works
   - ✅ not quoting the name `remote` (`cluster-name: cmVtb3RlCg==`) works
