### PR TITLE
chore(proto): replace jsonpb with protojson

### DIFF
--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -1,7 +1,6 @@
 package pagerduty
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	pd "github.com/PagerDuty/go-pagerduty"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
 	"github.com/stackrox/rox/generated/storage"
@@ -207,11 +205,11 @@ type marshalableAlert storage.Alert
 
 // MarshalJSON marshals alert data to bytes, following jsonpb rules.
 func (a *marshalableAlert) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	if err := (&jsonpb.Marshaler{}).Marshal(&buf, (*storage.Alert)(a)); err != nil {
+	bytes, err := jsonutil.MarshalToString((*storage.Alert)(a))
+	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	return []byte(bytes), nil
 }
 
 // UnmarshalJSON unmarshals alert JSON bytes into an Alert object, following jsonpb rules.

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -205,11 +205,11 @@ type marshalableAlert storage.Alert
 
 // MarshalJSON marshals alert data to bytes, following jsonpb rules.
 func (a *marshalableAlert) MarshalJSON() ([]byte, error) {
-	bytes, err := jsonutil.MarshalToString((*storage.Alert)(a))
+	payload, err := jsonutil.MarshalToString((*storage.Alert)(a))
 	if err != nil {
 		return nil, err
 	}
-	return []byte(bytes), nil
+	return []byte(payload), nil
 }
 
 // UnmarshalJSON unmarshals alert JSON bytes into an Alert object, following jsonpb rules.

--- a/central/notifiers/splunk/splunk.go
+++ b/central/notifiers/splunk/splunk.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -21,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -165,7 +165,7 @@ func (s *splunk) sendEvent(ctx context.Context, msg protocompat.Message, sourceT
 	}
 
 	var data bytes.Buffer
-	err = new(jsonpb.Marshaler).Marshal(&data, splunkEvent)
+	err = jsonutil.Marshal(&data, splunkEvent)
 	if err != nil {
 		return err
 	}

--- a/central/splunk/violations.go
+++ b/central/splunk/violations.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/generated/api/integrations"
@@ -16,6 +15,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/violationmessages/printer"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/search"
@@ -93,7 +93,7 @@ func newViolationsHandler(alertDS datastore.DataStore, pagination paginationSett
 			httputil.WriteError(w, err)
 			return
 		}
-		err = (&jsonpb.Marshaler{}).Marshal(w, res)
+		err = jsonutil.Marshal(w, res)
 		if err != nil {
 			log.Warn("Error writing violations response: ", err)
 			panic(http.ErrAbortHandler)

--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -14,13 +14,13 @@ import (
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/random"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/testutils"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -109,7 +109,7 @@ func getTestImages() ([]*storage.Image, error) {
 	defer func() { _ = zipReader.Close() }()
 
 	jsonReader := json.NewDecoder(zipReader)
-	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: true}
+	unmarshaler := jsonutil.JSONUnmarshaler()
 
 	images := make([]*storage.Image, 0, 500)
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4
 	github.com/google/certificate-transparency-go v1.2.1
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49
 	github.com/google/go-cmp v0.6.0
@@ -302,6 +301,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/cel-go v0.17.7 // indirect

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -426,7 +426,7 @@ func TestGetSerializedAuthStatusData(t *testing.T) {
 
 	buf, err := getSerializedAuthStatusData(testAuthStatus)
 	assert.NoError(t, err)
-	assert.JSONEq(t, expectedSerializedTestAuthStatus, buf.String())
+	assert.JSONEq(t, expectedSerializedTestAuthStatus, string(buf))
 }
 
 func TestUserMetadataURLError(t *testing.T) {

--- a/pkg/httputil/error.go
+++ b/pkg/httputil/error.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	grpc_errors "github.com/stackrox/rox/pkg/grpc/errors"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -68,10 +68,8 @@ func ErrorFromStatus(status HTTPStatus) HTTPError {
 // It's useful when you have to write an http method.
 func WriteGRPCStyleError(w http.ResponseWriter, c codes.Code, err error) {
 	userErr := status.New(c, err.Error()).Proto()
-	m := jsonpb.Marshaler{}
-
 	w.WriteHeader(runtime.HTTPStatusFromCode(c))
-	_ = m.Marshal(w, userErr)
+	_ = jsonutil.Marshal(w, userErr)
 }
 
 // WriteGRPCStyleErrorf writes a gRPC-style error to an http response writer.
@@ -94,7 +92,7 @@ func WriteGRPCStyleErrorf(w http.ResponseWriter, c codes.Code, format string, ar
 func WriteError(w http.ResponseWriter, err error) {
 	w.WriteHeader(StatusFromError(err))
 	st := grpc_errors.ErrToGrpcStatus(err)
-	_ = new(jsonpb.Marshaler).Marshal(w, st.Proto())
+	_ = jsonutil.Marshal(w, st.Proto())
 }
 
 // WriteErrorf is a convenience method that is equivalent to calling

--- a/pkg/httputil/error_test.go
+++ b/pkg/httputil/error_test.go
@@ -26,7 +26,7 @@ func TestWriteError(t *testing.T) {
 			incomingErr:         nil,
 			grpcCode:            codes.OK,
 			expectedStatus:      200,
-			expectedMessage:     "",
+			expectedMessage:     "{}",
 			expectedGRPCMessage: "",
 		},
 		{
@@ -68,7 +68,7 @@ func TestWriteError(t *testing.T) {
 			WriteError(writer, tt.incomingErr)
 			assert.Equal(t, tt.expectedStatus, writer.Code)
 			data := writer.Body.String()
-			if len(data) > 0 {
+			if len(tt.expectedMessage) > 0 {
 				assert.JSONEq(t, tt.expectedMessage, data)
 			} else {
 				assert.Equal(t, tt.expectedMessage, data)

--- a/pkg/jsonutil/proto.go
+++ b/pkg/jsonutil/proto.go
@@ -10,24 +10,31 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const indent = "  "
+const (
+	pretty  = "  "
+	compact = ""
+)
 
 var errNil = errors.New("Marshal called with nil")
 
 // Marshal marshals the given [proto.Message] in the JSON format.
 func Marshal(out io.Writer, msg proto.Message) error {
-	return marshal(out, msg, "")
+	return marshal(out, msg, compact)
 }
 
 // MarshalPretty marshals the given [proto.Message] in the JSON format
 // with two space indentation.
 func MarshalPretty(out io.Writer, msg proto.Message) error {
-	return marshal(out, msg, indent)
+	return marshal(out, msg, pretty)
 }
 
 // MarshalToString serializes a protobuf message as JSON in string form.
 func MarshalToString(msg proto.Message) (string, error) {
-	return marshalToString(msg, indent)
+	return marshalToString(msg, pretty)
+}
+
+func MarshalToCompactString(msg proto.Message) (string, error) {
+	return marshalToString(msg, compact)
 }
 
 func marshal(out io.Writer, msg proto.Message, indent string) error {
@@ -58,7 +65,7 @@ func marshalToString(msg proto.Message, indent string) (string, error) {
 		return "", errors.Wrap(err, "failed to marshal JSON")
 	}
 	buffer := bytes.NewBuffer(make([]byte, 0, len(b)))
-	if indent == "" {
+	if indent == compact {
 		err = json.Compact(buffer, b)
 	} else {
 		err = json.Indent(buffer, b, "", indent)

--- a/pkg/jsonutil/proto_test.go
+++ b/pkg/jsonutil/proto_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 //go:embed testdata/compat.alert.json
-var compat string
+var compactJson string
 
 //go:embed testdata/pretty.alert.json
-var pretty string
+var prettyJson string
 
 func TestNil(t *testing.T) {
 	output, err := MarshalToString(nil)
@@ -38,7 +38,7 @@ func TestMarshal(t *testing.T) {
 	output := &bytes.Buffer{}
 	err := Marshal(output, alert())
 	assert.NoError(t, err)
-	assert.Equal(t, compat, output.String())
+	assert.Equal(t, compactJson, output.String())
 }
 
 func TestMarshalPretty(t *testing.T) {
@@ -46,14 +46,14 @@ func TestMarshalPretty(t *testing.T) {
 	output := &bytes.Buffer{}
 	err := MarshalPretty(output, alert())
 	assert.NoError(t, err)
-	assert.Equal(t, pretty, output.String())
+	assert.Equal(t, prettyJson, output.String())
 }
 
 func TestMarshalString(t *testing.T) {
 	t.Parallel()
 	output, err := MarshalToString(alert())
 	assert.NoError(t, err)
-	assert.Equal(t, pretty, output)
+	assert.Equal(t, prettyJson, output)
 }
 
 func alert() *storage.Alert {

--- a/pkg/notifiers/prune.go
+++ b/pkg/notifiers/prune.go
@@ -1,11 +1,10 @@
 package notifiers
 
 import (
-	"bytes"
 	"sort"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -58,18 +57,18 @@ func filterProcesses(processes []*storage.ProcessIndicator, maxSize int, currSiz
 		return processes
 	}
 
-	marshaler := new(jsonpb.Marshaler)
+	marshaler := new(protojson.MarshalOptions)
 	// Clean Process first then prune
 	for _, p := range processes {
 		cleanProcessIndicator(p)
 	}
 
 	for i := len(processes) - 1; i >= 0; i-- {
-		var data bytes.Buffer
-		if err := marshaler.Marshal(&data, processes[i]); err != nil {
+		data, err := marshaler.Marshal(processes[i])
+		if err != nil {
 			log.Error(err)
 		}
-		*currSize -= data.Len()
+		*currSize -= len(data)
 		if *currSize < maxSize {
 			return processes[:i]
 		}
@@ -81,14 +80,14 @@ func filterViolations(violations []*storage.Alert_Violation, maxSize int, currSi
 	if *currSize < maxSize {
 		return violations
 	}
-	marshaler := new(jsonpb.Marshaler)
+	marshaler := new(protojson.MarshalOptions)
 
 	for i := len(violations) - 1; i >= 0; i-- {
-		var data bytes.Buffer
-		if err := marshaler.Marshal(&data, violations[i]); err != nil {
+		data, err := marshaler.Marshal(violations[i])
+		if err != nil {
 			log.Error(err)
 		}
-		*currSize -= data.Len()
+		*currSize -= len(data)
 		if *currSize < maxSize {
 			return violations[:i]
 		}
@@ -101,13 +100,13 @@ func PruneAlert(alert *storage.Alert, maxSize int) {
 	maxSize -= sizeBuffer
 
 	// Get current size and then determine how to trim more in terms of violations
-	var data bytes.Buffer
-	marshaler := new(jsonpb.Marshaler)
-	if err := marshaler.Marshal(&data, alert); err != nil {
+	marshaler := new(protojson.MarshalOptions)
+	data, err := marshaler.Marshal(alert)
+	if err != nil {
 		log.Error(err)
 	}
 
-	currSize := data.Len()
+	currSize := len(data)
 	filterDeploymentMaps(alert.GetDeployment(), maxSize, &currSize)
 
 	if alert.ProcessViolation != nil {

--- a/pkg/notifiers/prune.go
+++ b/pkg/notifiers/prune.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -56,15 +57,13 @@ func filterProcesses(processes []*storage.ProcessIndicator, maxSize int, currSiz
 	if *currSize < maxSize {
 		return processes
 	}
-
-	marshaler := new(protojson.MarshalOptions)
 	// Clean Process first then prune
 	for _, p := range processes {
 		cleanProcessIndicator(p)
 	}
 
 	for i := len(processes) - 1; i >= 0; i-- {
-		data, err := marshaler.Marshal(processes[i])
+		data, err := jsonutil.MarshalToCompactString(processes[i])
 		if err != nil {
 			log.Error(err)
 		}
@@ -80,10 +79,8 @@ func filterViolations(violations []*storage.Alert_Violation, maxSize int, currSi
 	if *currSize < maxSize {
 		return violations
 	}
-	marshaler := new(protojson.MarshalOptions)
-
 	for i := len(violations) - 1; i >= 0; i-- {
-		data, err := marshaler.Marshal(violations[i])
+		data, err := jsonutil.MarshalToCompactString(violations[i])
 		if err != nil {
 			log.Error(err)
 		}

--- a/pkg/notifiers/prune.go
+++ b/pkg/notifiers/prune.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/jsonutil"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -97,8 +96,7 @@ func PruneAlert(alert *storage.Alert, maxSize int) {
 	maxSize -= sizeBuffer
 
 	// Get current size and then determine how to trim more in terms of violations
-	marshaler := new(protojson.MarshalOptions)
-	data, err := marshaler.Marshal(alert)
+	data, err := jsonutil.MarshalToCompactString(alert)
 	if err != nil {
 		log.Error(err)
 	}

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	metricsPkg "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/process/filter"
@@ -17,6 +16,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
+	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/client-go/kubernetes"
 	v1Listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -167,14 +167,14 @@ func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 	}
 
 	var eventsOutput []string
-	marshaler := jsonpb.Marshaler{}
+	marshaler := protojson.MarshalOptions{}
 	for _, e := range events.ForwardMessages {
-		ev, err := marshaler.MarshalToString(e)
+		ev, err := marshaler.Marshal(e)
 		if err != nil {
 			log.Warnf("Error marshaling msg: %s\n", err.Error())
 			return events
 		}
-		eventsOutput = append(eventsOutput, ev)
+		eventsOutput = append(eventsOutput, string(ev))
 	}
 
 	jsonLine, err := json.Marshal(InformerK8sMsg{

--- a/sensor/upgrader/bundle/fetcher.go
+++ b/sensor/upgrader/bundle/fetcher.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/upgrader/upgradectx"
 )
@@ -28,7 +28,7 @@ func (f *fetcher) FetchBundle() (Contents, error) {
 		Id: f.ctx.ClusterID(),
 	}
 	var buf bytes.Buffer
-	if err := new(jsonpb.Marshaler).Marshal(&buf, resByID); err != nil {
+	if err := jsonutil.Marshal(&buf, resByID); err != nil {
 		return nil, utils.ShouldErr(err)
 	}
 

--- a/tools/deserialize-proto/main_test.go
+++ b/tools/deserialize-proto/main_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPrintProtoMessages(t *testing.T) {
@@ -108,10 +108,11 @@ func TestPrintProtoMessages(t *testing.T) {
 			err := printProtoMessagesFromStdin(tc.in, tmpOut, tc.msg)
 			if tc.err != nil {
 				assert.ErrorIs(t, err, tc.err)
+				assert.Empty(t, tmpOut.String())
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tc.out.String(), tmpOut.String())
 			}
-			assert.Equal(t, tc.out.String(), tmpOut.String())
 		})
 	}
 }

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -96,7 +96,10 @@ var (
 			replacement: "a logger",
 		},
 		"github.com/gogo/protobuf/jsonpb": {
-			replacement: "github.com/golang/protobuf/jsonpb",
+			replacement: "google.golang.org/protobuf/encoding/protojson",
+		},
+		"github.com/golang/protobuf/jsonpb": {
+			replacement: "google.golang.org/protobuf/encoding/protojson",
 		},
 		"k8s.io/helm/...": {
 			replacement: "package from helm.sh/v3",


### PR DESCRIPTION
### Description

This PR replaces deprecated jsonpb with protojson. To make minimal changes the new function is created in `jsonutil` that creates new marshaler, use it and then writes to provided buffer.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
