### PR TITLE
ROX-25338: Add Active and Resolved tab in Policy Violations

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/types.ts
+++ b/ui/apps/platform/src/Containers/Violations/types.ts
@@ -1,0 +1,3 @@
+export const violationStateTabs = ['ACTIVE', 'RESOLVED'] as const;
+
+export type ViolationStateTab = (typeof violationStateTabs)[number];


### PR DESCRIPTION
### Description

This PR segments the Policy Violations into `Active` and `Resolved` violations. 

The old-style filters allowed you to filter using `Violation State` in the filter. This approach didn't seem like the right way to go about things. We were already pre-filtering the view by `Active` violations. Applying `Violation State: Active` as a filter does nothing, and applying `Violation State: Resolved` as a filter increases the counts since we are showing resolved violations over time.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

https://github.com/user-attachments/assets/974dcee2-da28-415c-9989-e7594f08bd1f

