### PR TITLE
ROX-25722: Add metrics to sensor registry store

### DIFF
--- a/pkg/images/integration/set_impl.go
+++ b/pkg/images/integration/set_impl.go
@@ -62,7 +62,7 @@ func (e *setImpl) UpdateImageIntegration(integration *storage.ImageIntegration) 
 		switch category {
 		case storage.ImageIntegrationCategory_REGISTRY:
 			isRegistry = true
-			if err := e.registrySet.UpdateImageIntegration(integration); err != nil {
+			if _, err := e.registrySet.UpdateImageIntegration(integration); err != nil {
 				errorList.AddError(err)
 			}
 		case storage.ImageIntegrationCategory_SCANNER:

--- a/pkg/registries/mocks/set.go
+++ b/pkg/registries/mocks/set.go
@@ -122,6 +122,20 @@ func (mr *MockSetMockRecorder) IsEmpty() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmpty", reflect.TypeOf((*MockSet)(nil).IsEmpty))
 }
 
+// Len mocks base method.
+func (m *MockSet) Len() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Len")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Len indicates an expected call of Len.
+func (mr *MockSetMockRecorder) Len() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockSet)(nil).Len))
+}
+
 // Match mocks base method.
 func (m *MockSet) Match(image *storage.ImageName) bool {
 	m.ctrl.T.Helper()
@@ -151,11 +165,12 @@ func (mr *MockSetMockRecorder) RemoveImageIntegration(id any) *gomock.Call {
 }
 
 // UpdateImageIntegration mocks base method.
-func (m *MockSet) UpdateImageIntegration(integration *storage.ImageIntegration) error {
+func (m *MockSet) UpdateImageIntegration(integration *storage.ImageIntegration) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateImageIntegration", integration)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateImageIntegration indicates an expected call of UpdateImageIntegration.

--- a/pkg/registries/set.go
+++ b/pkg/registries/set.go
@@ -16,8 +16,9 @@ type Set interface {
 	GetRegistryByImage(image *storage.Image) types.Registry
 
 	IsEmpty() bool
+	Len() int
 	Clear()
-	UpdateImageIntegration(integration *storage.ImageIntegration) error
+	UpdateImageIntegration(integration *storage.ImageIntegration) (bool, error)
 	RemoveImageIntegration(id string) error
 }
 

--- a/pkg/registries/set_impl.go
+++ b/pkg/registries/set_impl.go
@@ -151,7 +151,7 @@ func (e *setImpl) Clear() {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	e.integrations = make(map[string]types.ImageRegistry)
+	clear(e.integrations)
 }
 
 // UpdateImageIntegration updates the integration with the matching id to a new configuration.

--- a/pkg/registries/set_impl.go
+++ b/pkg/registries/set_impl.go
@@ -181,8 +181,8 @@ func (e *setImpl) RemoveImageIntegration(id string) error {
 }
 
 func (e *setImpl) Len() int {
-	e.lock.Lock()
-	defer e.lock.Unlock()
+	e.lock.RLock()
+	defer e.lock.RUnlock()
 
 	return len(e.integrations)
 }

--- a/pkg/registries/set_impl_test.go
+++ b/pkg/registries/set_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newFakeRegistry(name, username, password, url string, auto bool) *fakeRegistry {
@@ -117,4 +118,31 @@ func TestSetImpl_GetAllUnique(t *testing.T) {
 	uniqueRegistries := set.GetAllUnique()
 
 	assert.ElementsMatch(t, uniqueRegistries, []types.ImageRegistry{reg1, reg2, reg3, reg4})
+}
+
+func TestSetImpl_Clear(t *testing.T) {
+	integration := func(id string) *storage.ImageIntegration {
+		return &storage.ImageIntegration{
+			Id:                id,
+			Name:              id,
+			Type:              types.DockerType,
+			IntegrationConfig: &storage.ImageIntegration_Docker{},
+		}
+	}
+
+	factory := NewFactory(FactoryOptions{})
+
+	set := NewSet(factory)
+	assert.Equal(t, 0, set.Len())
+
+	_, err := set.UpdateImageIntegration(integration("a"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, set.Len())
+
+	set.Clear()
+	assert.Equal(t, 0, set.Len())
+
+	_, err = set.UpdateImageIntegration(integration("b"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, set.Len())
 }

--- a/pkg/registries/set_impl_test.go
+++ b/pkg/registries/set_impl_test.go
@@ -146,3 +146,33 @@ func TestSetImpl_Clear(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, set.Len())
 }
+
+func TestUpdateImageIntegration(t *testing.T) {
+	integration := func(id string) *storage.ImageIntegration {
+		return &storage.ImageIntegration{
+			Id:                id,
+			Name:              id,
+			Type:              types.DockerType,
+			IntegrationConfig: &storage.ImageIntegration_Docker{},
+		}
+	}
+
+	t.Run("bool return correctly indicates if entry existed in set", func(t *testing.T) {
+		factory := NewFactory(FactoryOptions{})
+		set := NewSet(factory)
+
+		fresh, err := set.UpdateImageIntegration(integration("a"))
+		require.NoError(t, err)
+		assert.True(t, fresh)
+
+		// Repeat the same upsert, this time a prior entry should exist.
+		fresh, err = set.UpdateImageIntegration(integration("a"))
+		require.NoError(t, err)
+		assert.False(t, fresh)
+
+		// A different ID should yield a fresh insert.
+		fresh, err = set.UpdateImageIntegration(integration("b"))
+		require.NoError(t, err)
+		assert.True(t, fresh)
+	})
+}

--- a/sensor/common/registry/metrics/metrics.go
+++ b/sensor/common/registry/metrics/metrics.go
@@ -14,7 +14,7 @@ func init() {
 		PullSecretEntriesCount,
 		PullSecretEntriesSize,
 		CentralIntegrationsCount,
-		TLSCheckCacheHitCount,
+		TLSCheckCount,
 		TLSCheckDuration,
 	)
 }
@@ -56,18 +56,18 @@ var (
 		Help:      "Current number of stored image integrations from Central",
 	})
 
-	TLSCheckCacheHitCount = prometheus.NewCounter(prometheus.CounterOpts{
+	TLSCheckCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "registry_store_tls_check_cache_hit_count",
-		Help:      "The total number of TLS Checks that used the cache",
+		Name:      "registry_store_tls_check_count",
+		Help:      "The total number of TLS checks requested via the registry store",
 	})
 
 	TLSCheckDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "registry_store_tls_check_duration_seconds",
-		Help:      "Time taken in seconds to perform a TLS check on a registry host",
+		Help:      "Time taken in seconds to perform a TLS check on a registry host (does not include TLS check cache hits)",
 	})
 )
 
@@ -106,9 +106,9 @@ func SetCentralIntegrationCount(value int) {
 	CentralIntegrationsCount.Set(float64(value))
 }
 
-// IncrementTlSCheckCacheHitCount adds to the total count of TLS check cache hits.
-func IncrementTLSCheckCacheHitCount() {
-	TLSCheckCacheHitCount.Inc()
+// IncrementTLSCheckCount adds to the total count of TLS check requests made via the registry store.
+func IncrementTLSCheckCount() {
+	TLSCheckCount.Inc()
 }
 
 // ObserveTLSCheckDuration observes the time in seconds taken to perform a TLS check.

--- a/sensor/common/registry/metrics/metrics.go
+++ b/sensor/common/registry/metrics/metrics.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		ClusterLocalHostsCount,
+		GlobalSecretEntriesCount,
+		PullSecretEntriesCount,
+		PullSecretEntriesSize,
+		CentralIntegrationsCount,
+	)
+}
+
+// Registry store metrics.
+var (
+	ClusterLocalHostsCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "registry_store_cluster_local_hosts_count",
+		Help:      "Current number of cluster local (i.e. OCP Internal Registry) hosts inserted into the registry store",
+	})
+
+	GlobalSecretEntriesCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "registry_store_global_secret_entries_count",
+		Help:      "Current number of stored global registry entries",
+	})
+
+	PullSecretEntriesCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "registry_store_pull_secret_entries_count",
+		Help:      "Current number of stored pull secret entries",
+	})
+
+	PullSecretEntriesSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "registry_store_pull_secret_entries_size",
+		Help:      "Rough size in bytes of the currently stored pull secret entries",
+	})
+
+	CentralIntegrationsCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "registry_store_central_integrations_count",
+		Help:      "Current number of stored image integrations from Central.",
+	})
+)
+
+// IncrementClusterLocalHostsCount adds to the count of stored cluster local registry hosts.
+func IncrementClusterLocalHostsCount() {
+	ClusterLocalHostsCount.Add(1)
+}
+
+// SetGlobalSecretEntriesCount updates the count of global secret entries in the registry store.
+func SetGlobalSecretEntriesCount(size int) {
+	GlobalSecretEntriesCount.Set(float64(size))
+}
+
+// IncrementPullSecretEntriesCount adds to the count of pull secret entries in the registry store.
+func IncrementPullSecretEntriesCount(value int) {
+	PullSecretEntriesCount.Add(float64(value))
+}
+
+// DecrementPullSecretEntriesCount subtracts from the count of pull secrets in the registry store.
+func DecrementPullSecretEntriesCount(value int) {
+	PullSecretEntriesCount.Sub(float64(value))
+}
+
+// IncrementPullSecretEntriesSize adds to the total size of pull secret entries in the registry store.
+func IncrementPullSecretEntriesSize(value int) {
+	PullSecretEntriesSize.Add(float64(value))
+}
+
+// DecrementPullSecretEntriesSize subtracts from the total size of pull secret entries in the registry store.
+func DecrementPullSecretEntriesSize(value int) {
+	PullSecretEntriesSize.Sub(float64(value))
+}
+
+// SetCentralIntegrationCount updates the count of image integrations from Central in the registry store.
+func SetCentralIntegrationCount(size int) {
+	CentralIntegrationsCount.Set(float64(size))
+}
+
+// ResetRegistryStoreMetrics resets the counts of all registry store metrics.
+func ResetRegistryStoreMetrics() {
+	ClusterLocalHostsCount.Set(0)
+	GlobalSecretEntriesCount.Set(0)
+	PullSecretEntriesCount.Set(0)
+	PullSecretEntriesSize.Set(0)
+	CentralIntegrationsCount.Set(0)
+}

--- a/sensor/common/registry/metrics/metrics.go
+++ b/sensor/common/registry/metrics/metrics.go
@@ -71,14 +71,14 @@ var (
 	})
 )
 
-// IncrementClusterLocalHostsCount adds to the count of stored cluster local registry hosts.
-func IncrementClusterLocalHostsCount() {
-	ClusterLocalHostsCount.Add(1)
+// SetClusterLocalHostsCount updates the count of stored cluster local registry hosts.
+func SetClusterLocalHostsCount(count int) {
+	ClusterLocalHostsCount.Set(float64(count))
 }
 
 // SetGlobalSecretEntriesCount updates the count of global secret entries in the registry store.
-func SetGlobalSecretEntriesCount(size int) {
-	GlobalSecretEntriesCount.Set(float64(size))
+func SetGlobalSecretEntriesCount(count int) {
+	GlobalSecretEntriesCount.Set(float64(count))
 }
 
 // IncrementPullSecretEntriesCount adds to the count of pull secret entries in the registry store.
@@ -102,8 +102,8 @@ func DecrementPullSecretEntriesSize(value int) {
 }
 
 // SetCentralIntegrationCount updates the count of image integrations from Central in the registry store.
-func SetCentralIntegrationCount(size int) {
-	CentralIntegrationsCount.Set(float64(size))
+func SetCentralIntegrationCount(value int) {
+	CentralIntegrationsCount.Set(float64(value))
 }
 
 // IncrementTlSCheckCacheHitCount adds to the total count of TLS check cache hits.

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -357,7 +357,7 @@ func (rs *Store) addClusterLocalRegistryHost(host string) {
 	if rs.clusterLocalRegistryHosts.Add(trimmed) {
 		log.Infof("Added cluster local registry host %q", trimmed)
 
-		metrics.IncrementClusterLocalHostsCount()
+		metrics.SetClusterLocalHostsCount(len(rs.clusterLocalRegistryHosts))
 	}
 }
 

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -561,10 +561,12 @@ func (rs *Store) DeleteSecret(namespace, secretName string) bool {
 		return false
 	}
 
+	var deletedEntries int
+	var deletedBytes int
 	if hostToRegistry, ok := secretNameToHost[secretName]; ok {
-		metrics.DecrementPullSecretEntriesCount(len(hostToRegistry))
+		deletedEntries += len(hostToRegistry)
 		for _, reg := range hostToRegistry {
-			metrics.DecrementPullSecretEntriesSize(reg.Source().SizeVT())
+			deletedBytes += reg.Source().SizeVT()
 		}
 
 		delete(secretNameToHost, secretName)
@@ -575,6 +577,8 @@ func (rs *Store) DeleteSecret(namespace, secretName string) bool {
 		}
 
 		log.Debugf("Deleted secret %q from namespace %q", secretName, namespace)
+		metrics.DecrementPullSecretEntriesCount(deletedEntries)
+		metrics.DecrementPullSecretEntriesSize(deletedBytes)
 		return true
 	}
 

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -561,10 +561,8 @@ func (rs *Store) DeleteSecret(namespace, secretName string) bool {
 		return false
 	}
 
-	var deletedEntries int
-	var deletedBytes int
 	if hostToRegistry, ok := secretNameToHost[secretName]; ok {
-		deletedEntries += len(hostToRegistry)
+		var deletedBytes int
 		for _, reg := range hostToRegistry {
 			deletedBytes += reg.Source().SizeVT()
 		}
@@ -577,7 +575,7 @@ func (rs *Store) DeleteSecret(namespace, secretName string) bool {
 		}
 
 		log.Debugf("Deleted secret %q from namespace %q", secretName, namespace)
-		metrics.DecrementPullSecretEntriesCount(deletedEntries)
+		metrics.DecrementPullSecretEntriesCount(len(hostToRegistry))
 		metrics.DecrementPullSecretEntriesSize(deletedBytes)
 		return true
 	}

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -132,6 +132,8 @@ func (rs *Store) Cleanup() {
 	rs.cleanupClusterLocalRegistryHosts()
 	rs.cleanupDelegatedRegistryConfig()
 	rs.tlsCheckCache.Cleanup()
+
+	metrics.ResetRegistryStoreMetrics()
 }
 
 func (rs *Store) cleanupRegistries() {
@@ -220,12 +222,20 @@ func (rs *Store) upsertRegistry(namespace, registry string, dce config.DockerCon
 	// the appropriate prefix
 	registry = urlfmt.TrimHTTPPrefixes(registry)
 	name := genIntegrationName(pullSecretNamePrefix, namespace, "", registry)
-	err := regs.UpdateImageIntegration(createImageIntegration(registry, dce, name))
+
+	ii := createImageIntegration(registry, dce, name)
+	inserted, err := regs.UpdateImageIntegration(ii)
 	if err != nil {
 		return errors.Wrapf(err, "updating registry store with registry %q", registry)
 	}
 
 	log.Debugf("Upserted registry %q for namespace %q into store", registry, namespace)
+
+	if inserted {
+		// A new entry was inserted (not updated).
+		metrics.IncrementPullSecretEntriesCount(1)
+		metrics.IncrementPullSecretEntriesSize(ii.SizeVT())
+	}
 
 	return nil
 }
@@ -260,12 +270,14 @@ func (rs *Store) getRegistryForImageInNamespace(image *storage.ImageName, namesp
 func (rs *Store) upsertGlobalRegistry(registry string, dce config.DockerConfigEntry) error {
 	var err error
 	name := genIntegrationName(globalRegNamePrefix, "", "", registry)
-	err = rs.globalRegistries.UpdateImageIntegration(createImageIntegration(registry, dce, name))
+	_, err = rs.globalRegistries.UpdateImageIntegration(createImageIntegration(registry, dce, name))
 	if err != nil {
 		return errors.Wrapf(err, "updating registry store with registry %q", registry)
 	}
 
 	log.Debugf("Upserted global registry %q into store", registry)
+
+	metrics.SetGlobalSecretEntriesCount(rs.globalRegistries.Len())
 
 	return nil
 }
@@ -344,6 +356,8 @@ func (rs *Store) addClusterLocalRegistryHost(host string) {
 
 	if rs.clusterLocalRegistryHosts.Add(trimmed) {
 		log.Infof("Added cluster local registry host %q", trimmed)
+
+		metrics.IncrementClusterLocalHostsCount()
 	}
 }
 
@@ -359,13 +373,15 @@ func (rs *Store) hasClusterLocalRegistryHost(host string) bool {
 // UpsertCentralRegistryIntegrations upserts registry integrations from Central into the store.
 func (rs *Store) UpsertCentralRegistryIntegrations(iis []*storage.ImageIntegration) {
 	for _, ii := range iis {
-		err := rs.centralRegistryIntegrations.UpdateImageIntegration(ii)
+		_, err := rs.centralRegistryIntegrations.UpdateImageIntegration(ii)
 		if err != nil {
 			log.Errorf("Failed to upsert registry integration %q: %v", ii.GetId(), err)
 		} else {
 			log.Debugf("Upserted registry integration %q (%q)", ii.GetName(), ii.GetId())
 		}
 	}
+
+	metrics.SetCentralIntegrationCount(rs.centralRegistryIntegrations.Len())
 }
 
 // DeleteCentralRegistryIntegrations deletes registry integrations from the store.
@@ -378,6 +394,8 @@ func (rs *Store) DeleteCentralRegistryIntegrations(ids []string) {
 			log.Debugf("Deleted registry integration %q", id)
 		}
 	}
+
+	metrics.SetCentralIntegrationCount(rs.centralRegistryIntegrations.Len())
 }
 
 // GetCentralRegistries returns registry integrations sync'd from Central that match the
@@ -516,6 +534,12 @@ func (rs *Store) upsertPullSecretByNameNoLock(namespace, secretName, registryAdd
 		secretNameToHost[secretName] = hostToRegistry
 	}
 
+	if _, ok := hostToRegistry[registryAddr]; !ok {
+		// Only increment if an entry will be inserted.
+		metrics.IncrementPullSecretEntriesCount(1)
+		metrics.IncrementPullSecretEntriesSize(reg.Source().SizeVT())
+	}
+
 	hostToRegistry[registryAddr] = reg
 }
 
@@ -534,7 +558,12 @@ func (rs *Store) DeleteSecret(namespace, secretName string) bool {
 		return false
 	}
 
-	if _, ok := secretNameToHost[secretName]; ok {
+	if hostToRegistry, ok := secretNameToHost[secretName]; ok {
+		metrics.DecrementPullSecretEntriesCount(len(hostToRegistry))
+		for _, reg := range hostToRegistry {
+			metrics.DecrementPullSecretEntriesSize(reg.Source().SizeVT())
+		}
+
 		delete(secretNameToHost, secretName)
 
 		if len(secretNameToHost) == 0 {
@@ -572,7 +601,6 @@ func (rs *Store) GetPullSecretRegistries(image *storage.ImageName, namespace str
 	if len(imagePullSecrets) > 0 {
 		// Return matching registries referenced by the image pull secrets.
 		return rs.getPullSecretRegistriesNoLock(secretNameToHost, image, imagePullSecrets), nil
-
 	}
 
 	// If no pull secrets were provided, we assume that all matching registries

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -706,6 +706,8 @@ func TestRegistryStore_SecretDelete(t *testing.T) {
 	})
 }
 
+// TestRegistyStore_Metrics ensures that metrics are calculated as expected
+// as data is added/removed from the store.
 func TestRegistyStore_Metrics(t *testing.T) {
 	dce := config.DockerConfigEntry{Username: "username", Password: "password"}
 	dc := config.DockerConfig{"example.com": dce}

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -906,13 +906,12 @@ func TestRegistyStore_Metrics(t *testing.T) {
 
 	t.Run("No crash on negative gauge", func(t *testing.T) {
 		// The size in bytes of an image integration is calculated when it is inserted into
-		// the store. It's possible that the object inserted changes internally after insertion.
-		// When the integration is deleted, the number of metric bytes deleted may not be
-		// exactly the same. For now this should be 'ok' as the number of bytes is only
-		// a rough estimate and not the actual amount of 'memory consumed', the bytes should
-		// still be 'statistically' relevant and provide a meaningful relative size for
-		// comparison / troubleshooting. This test ensures that if the gauge goes into
-		// a 'negative value' nothing will break.
+		// the store. It's possible that the integration changes internally after insertion.
+		// When the integration is deleted its size may be different creating a skew in the
+		// size metric. This should be OK as the number of bytes is only a rough estimate and
+		// not the actual amount of 'memory consumed'. The byte count should still be
+		// 'statistically' relevant and provide a meaningful relative size for comparison.
+		// This test ensures that if the gauge goes into a 'negative value' nothing will break.
 		testutils.MustUpdateFeature(t, features.SensorPullSecretsByName, true)
 		c := metrics.PullSecretEntriesSize
 		metrics.ResetRegistryMetrics()

--- a/sensor/common/registry/tlscheck_cache.go
+++ b/sensor/common/registry/tlscheck_cache.go
@@ -89,12 +89,13 @@ func (c *tlsCheckCacheImpl) Cleanup() {
 // CheckTLS performs a TLS check on a registry or returns the result from a
 // previous check. Returns true for skip if there was a previous error.
 func (c *tlsCheckCacheImpl) CheckTLS(ctx context.Context, registry string) (secure bool, skip bool, err error) {
+	metrics.IncrementTLSCheckCount()
+
 	// First check the cache for an entry, and, if found, perform
 	// the TLS check. This is an optimization to avoid unnecessary
 	// allocations on cache hits.
 	entry, ok := c.results.Get(registry)
 	if ok {
-		metrics.IncrementTLSCheckCacheHitCount()
 		return entry.checkTLS(ctx, registry, c.checkTLSFunc)
 	}
 

--- a/sensor/common/registry/tlscheck_cache_test.go
+++ b/sensor/common/registry/tlscheck_cache_test.go
@@ -118,7 +118,7 @@ func TestMetrics(t *testing.T) {
 	cache := newTLSCheckCache(alwaysSecureCheckTLS)
 	_, _, err := cache.CheckTLS(ctx, "fake")
 
-	c := metrics.TLSCheckCacheHitCount
+	c := metrics.TLSCheckCount
 	// Counter metrics cannot be reset, so use the current
 	// value as a base and test relative changes.
 	base := testutil.ToFloat64(c)

--- a/sensor/common/registry/tlscheck_cache_test.go
+++ b/sensor/common/registry/tlscheck_cache_test.go
@@ -119,7 +119,7 @@ func TestMetrics(t *testing.T) {
 	_, _, err := cache.CheckTLS(ctx, "fake")
 
 	c := metrics.TLSCheckCacheHitCount
-	// Counter metrics cannot be reset, so use the the current
+	// Counter metrics cannot be reset, so use the current
 	// value as a base and test relative changes.
 	base := testutil.ToFloat64(c)
 


### PR DESCRIPTION
### Description

This PR adds metrics for various aspects of Sensors registry store to assist troubleshooting and provide insight into the current state of the store.

PR stacked on top of:
- https://github.com/stackrox/stackrox/pull/12360

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Deployed ACS to OCP 4.16 infra cluster, setup port-forward to sensor metrics port (9090), and observed metrics with pull secrets by name feature on / off:

With Pull Secrets by Name DISABLED:

```sh
$ curl 127.0.0.1:9090/metrics | grep registry_store

# HELP rox_sensor_registry_store_central_integrations_count Current number of stored image integrations from Central
# TYPE rox_sensor_registry_store_central_integrations_count gauge
rox_sensor_registry_store_central_integrations_count 8
# HELP rox_sensor_registry_store_cluster_local_hosts_count Current number of cluster local (i.e. OCP Internal Registry) hosts inserted into the registry store
# TYPE rox_sensor_registry_store_cluster_local_hosts_count gauge
rox_sensor_registry_store_cluster_local_hosts_count 3
# HELP rox_sensor_registry_store_global_secret_entries_count Current number of stored global registry entries
# TYPE rox_sensor_registry_store_global_secret_entries_count gauge
rox_sensor_registry_store_global_secret_entries_count 4
# HELP rox_sensor_registry_store_pull_secret_entries_count Current number of stored pull secret entries
# TYPE rox_sensor_registry_store_pull_secret_entries_count gauge
rox_sensor_registry_store_pull_secret_entries_count 216
# HELP rox_sensor_registry_store_pull_secret_entries_size Rough size in bytes of the currently stored pull secret entries
# TYPE rox_sensor_registry_store_pull_secret_entries_size gauge
rox_sensor_registry_store_pull_secret_entries_size 344968
# HELP rox_sensor_registry_store_tls_check_count The total number of TLS checks requested via the registry store
# TYPE rox_sensor_registry_store_tls_check_count counter
rox_sensor_registry_store_tls_check_count 4
# HELP rox_sensor_registry_store_tls_check_duration_seconds Time taken in seconds to perform a TLS check on a registry host (does not include TLS check cache hits)
# TYPE rox_sensor_registry_store_tls_check_duration_seconds histogram
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.005"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.01"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.025"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.05"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.1"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.25"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="1"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="2.5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="10"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="+Inf"} 1
rox_sensor_registry_store_tls_check_duration_seconds_sum 0.076623415
rox_sensor_registry_store_tls_check_duration_seconds_count 1
```
`344817` Bytes ~= `0.3` MiB

`rox_sensor_registry_store_tls_check_count` - `rox_sensor_registry_store_tls_check_duration_seconds_count` = # of cache hits = 3

With Pull Secrets by Name ENABLED:

```sh
$ oc set env deploy/sensor ROX_SENSOR_PULL_SECRETS_BY_NAME=true
$ curl 127.0.0.1:9090/metrics | grep registry_store

# HELP rox_sensor_registry_store_central_integrations_count Current number of stored image integrations from Central
# TYPE rox_sensor_registry_store_central_integrations_count gauge
rox_sensor_registry_store_central_integrations_count 8
# HELP rox_sensor_registry_store_cluster_local_hosts_count Current number of cluster local (i.e. OCP Internal Registry) hosts inserted into the registry store
# TYPE rox_sensor_registry_store_cluster_local_hosts_count gauge
rox_sensor_registry_store_cluster_local_hosts_count 3
# HELP rox_sensor_registry_store_global_secret_entries_count Current number of stored global registry entries
# TYPE rox_sensor_registry_store_global_secret_entries_count gauge
rox_sensor_registry_store_global_secret_entries_count 4
# HELP rox_sensor_registry_store_pull_secret_entries_count Current number of stored pull secret entries
# TYPE rox_sensor_registry_store_pull_secret_entries_count gauge
rox_sensor_registry_store_pull_secret_entries_count 1129
# HELP rox_sensor_registry_store_pull_secret_entries_size Rough size in bytes of the currently stored pull secret entries
# TYPE rox_sensor_registry_store_pull_secret_entries_size gauge
rox_sensor_registry_store_pull_secret_entries_size 1.885448e+06
# HELP rox_sensor_registry_store_tls_check_count The total number of TLS checks requested via the registry store
# TYPE rox_sensor_registry_store_tls_check_count counter
rox_sensor_registry_store_tls_check_count 5
# HELP rox_sensor_registry_store_tls_check_duration_seconds Time taken in seconds to perform a TLS check on a registry host (does not include TLS check cache hits)
# TYPE rox_sensor_registry_store_tls_check_duration_seconds histogram
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.005"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.01"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.025"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.05"} 0
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.1"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.25"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="0.5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="1"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="2.5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="5"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="10"} 1
rox_sensor_registry_store_tls_check_duration_seconds_bucket{le="+Inf"} 1
rox_sensor_registry_store_tls_check_duration_seconds_sum 0.080492124
rox_sensor_registry_store_tls_check_duration_seconds_count 1
```

`1.885068e+06` Bytes ~= `1.8` MiB

`rox_sensor_registry_store_tls_check_count` - `rox_sensor_registry_store_tls_check_duration_seconds_count` = # of cache hits = 4