### PR TITLE
ROX-25621: Add multi-arch Konflux builds to main image

### DIFF
--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -58,15 +58,19 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
-  # The pipeline regularly takes >1h to finish.
+  # The pipeline regularly takes >2h to finish with multi-arch builds being the slowest.
   timeouts:
-    pipeline: 1h30m0s
+    pipeline: 3h30m0s
 
   pipelineRef:
     name: main-pipeline
 
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  # For all sbom-syft-generate steps:
+  # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container
+  # exits with 137 (OOMKilled):
+  # /tekton/scripts/script-2-h7nll: line 7:    33 Killed                  syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
+  - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
@@ -85,8 +89,30 @@ spec:
           cpu: 4
           memory: 7Gi
     - name: sbom-syft-generate
-      # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container exits with 137 (OOMKilled):
-      # /tekton/scripts/script-2-h7nll: line 7:    33 Killed                  syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+  - pipelineTaskName: build-container-s390x
+    stepSpecs:
+    - name: sbom-syft-generate
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+  - pipelineTaskName: build-container-ppc64le
+    stepSpecs:
+    - name: sbom-syft-generate
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+  - pipelineTaskName: build-container-arm64
+    stepSpecs:
+    - name: sbom-syft-generate
       computeResources:
         limits:
           memory: 3Gi

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -58,9 +58,9 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
-  # The pipeline regularly takes >2h to finish with multi-arch builds being the slowest.
   timeouts:
-    pipeline: 3h30m0s
+    # Slow multiarch builds may take around 2h to finish.
+    pipeline: 2h30m0s
 
   pipelineRef:
     name: main-pipeline

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -281,7 +281,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    timeout: 3h0m0s
+    timeout: 2h0m0s
 
   - name: build-container-ppc64le
     params:
@@ -324,7 +324,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    timeout: 3h0m0s
+    timeout: 2h0m0s
 
   - name: build-container-arm64
     params:
@@ -367,7 +367,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    timeout: 3h0m0s
+    timeout: 2h0m0s
 
   - name: build-image-manifest
     params:

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -8,7 +8,7 @@ spec:
   - name: show-sbom
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
     taskRef:
       params:
       - name: name
@@ -89,10 +89,10 @@ spec:
   results:
   - description: ""
     name: IMAGE_URL
-    value: $(tasks.build-container.results.IMAGE_URL)
+    value: $(tasks.build-image-manifest.results.IMAGE_URL)
   - description: ""
     name: IMAGE_DIGEST
-    value: $(tasks.build-container.results.IMAGE_DIGEST)
+    value: $(tasks.build-image-manifest.results.IMAGE_DIGEST)
   - description: ""
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
@@ -101,7 +101,7 @@ spec:
     value: $(tasks.clone-repository.results.commit)
   - description: ""
     name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+    value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
 
   workspaces:
   - name: git-auth
@@ -113,7 +113,7 @@ spec:
     - name: image-url
       # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
       # As a workaround, we still provide a unique tag that's based on a revision to this task to comply with its
-      # expected input. We later actually add this tag on a built image with apply-tags task.
+      # expected input. We later actually add this tag on a built image with build-image-manifest-konflux task.
       value: $(params.output-image-repo):konflux-$(params.revision)
     - name: rebuild
       value: $(params.rebuild)
@@ -200,10 +200,10 @@ spec:
         value: task
       resolver: bundles
 
-  - name: build-container
+  - name: build-container-amd64
     params:
     - name: IMAGE
-      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-amd64
     - name: DOCKERFILE
       value: $(params.dockerfile)
     - name: CONTEXT
@@ -231,7 +231,7 @@ spec:
       - name: name
         value: buildah-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:e265f6772f199519b39f463fa6b2a245f740228258e200db81ff4e6dc69748f4
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:0b7bf546a63bc90616ea70cef0d3cb7469b21c28ac8a563c750aa6e1111ccce8
       - name: kind
         value: task
       resolver: bundles
@@ -240,27 +240,191 @@ spec:
       operator: in
       values: [ "true" ]
 
-  - name: apply-tags
+  - name: build-container-s390x
     params:
+    - name: PLATFORM
+      value: linux/s390x
     - name: IMAGE
-      value: $(tasks.build-container.results.IMAGE_URL)
-    - name: ADDITIONAL_TAGS
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-s390x
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
       value:
-      - konflux-$(params.revision)
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
+      - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: ACTIVATION_KEY
+      value: subscription-manager-activation-key
     taskRef:
       params:
       - name: name
-        value: apply-tags
+        value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:8a8c1342bfa0b263361cbbc28036750ebc3d7c2460230b14d641170b812dddcc
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:232dcb1252e99bfafa66d13dfabf49bed7815bac29816cb5b243977ccd52ac12
       - name: kind
         value: task
       resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values: [ "true" ]
+    timeout: 3h0m0s
+
+  - name: build-container-ppc64le
+    params:
+    - name: PLATFORM
+      value: linux/ppc64le
+    - name: IMAGE
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-ppc64le
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
+      - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: ACTIVATION_KEY
+      value: subscription-manager-activation-key
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:232dcb1252e99bfafa66d13dfabf49bed7815bac29816cb5b243977ccd52ac12
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values: [ "true" ]
+    timeout: 3h0m0s
+
+  - name: build-container-arm64
+    params:
+    - name: PLATFORM
+      value: linux/arm64
+    - name: IMAGE
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-arm64
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - VERSIONS_SUFFIX=$(params.output-tag-suffix)
+      - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: ACTIVATION_KEY
+      value: subscription-manager-activation-key
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:232dcb1252e99bfafa66d13dfabf49bed7815bac29816cb5b243977ccd52ac12
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values: [ "true" ]
+    timeout: 3h0m0s
+
+  - name: build-image-manifest
+    params:
+    - name: IMAGE
+      value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container-amd64.results.IMAGE_REF)
+      - $(tasks.build-container-s390x.results.IMAGE_REF)
+      - $(tasks.build-container-ppc64le.results.IMAGE_REF)
+      - $(tasks.build-container-arm64.results.IMAGE_REF)
+    taskRef:
+      params:
+      - name: name
+        value: build-image-manifest
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:fd0a0cf019621d6b577f1b9ab774bb1832f7cba61b4ceee2fd1bffc96895abf9
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values: [ "true" ]
+
+  - name: build-image-manifest-konflux
+    params:
+    - name: IMAGE
+      value: $(params.output-image-repo):konflux-$(params.revision)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container-amd64.results.IMAGE_REF)
+      - $(tasks.build-container-s390x.results.IMAGE_REF)
+      - $(tasks.build-container-ppc64le.results.IMAGE_REF)
+      - $(tasks.build-container-arm64.results.IMAGE_REF)
+    taskRef:
+      params:
+      - name: name
+        value: build-image-manifest
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:fd0a0cf019621d6b577f1b9ab774bb1832f7cba61b4ceee2fd1bffc96895abf9
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values: [ "true" ]
 
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-container-amd64.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -282,12 +446,72 @@ spec:
       operator: in
       values: [ "true" ]
 
-  - name: deprecated-base-image-check
+  - name: deprecated-base-image-check-amd64
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-container-amd64.results.IMAGE_URL)
     - name: IMAGE_DIGEST
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+
+  - name: deprecated-base-image-check-s390x
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container-s390x.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container-s390x.results.IMAGE_DIGEST)
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+
+  - name: deprecated-base-image-check-ppc64le
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container-ppc64le.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:4ec00cf88c55a64eebaac0fe661cdb8dc8d3586d3a288f54400fbf2b5f06b408
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+
+  - name: deprecated-base-image-check-arm64
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container-arm64.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container-arm64.results.IMAGE_DIGEST)
     taskRef:
       params:
       - name: name
@@ -305,9 +529,9 @@ spec:
   - name: clair-scan
     params:
     - name: image-digest
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-manifest.results.IMAGE_DIGEST)
     - name: image-url
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
     taskRef:
       params:
       - name: name
@@ -343,9 +567,9 @@ spec:
   - name: clamav-scan
     params:
     - name: image-digest
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-manifest.results.IMAGE_DIGEST)
     - name: image-url
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
     taskRef:
       params:
       - name: name
@@ -363,9 +587,9 @@ spec:
   - name: sbom-json-check
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
     - name: IMAGE_DIGEST
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-manifest.results.IMAGE_DIGEST)
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
### Description

Per title, replaces <https://github.com/stackrox/stackrox/pull/12054>.

Tracking build issues in:

- https://issues.redhat.com/browse/KFLUXBUGS-1523
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1723056835366329

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No changes to automated tests.

#### How I validated my change

Only Konflux CI.