### PR TITLE
ROX-23846: Failed policy enforcement fix in config mgmt

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.js
@@ -87,12 +87,12 @@ const FailedPoliciesAcrossDeployment = ({ deploymentID }) => {
                         accessor: 'name',
                     },
                     {
-                        Header: `Enforced`,
+                        Header: `Enforcing`,
                         headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                         className: `w-1/8 ${defaultColumnClassName}`,
                         Cell: ({ original }) => {
                             const { enforcementActions } = original;
-                            return enforcementActions ? 'Yes' : 'No';
+                            return (enforcementActions ?? []).length > 0 ? 'Yes' : 'No';
                         },
                         accessor: 'enforcementActions',
                     },


### PR DESCRIPTION
### Description

Fixes an issue where the "Enforced" field for Policies on a deployment always displays "Yes" in the Config Mgmt UI, regardless of enforcement status on the policy or if there are any enforced alerts for that policy/deployment combo.

I was unable to find a way with the existing search framework to determine if there were any **enforced alerts for a single deployment**, so this change displays whether or not the policy will enforce at all, but not necessarily whether there was an enforced alert for the deployment. This is in line with what the code currently does, but I don't have context on the intentions as the code in this section is > 5 years old.

> I tried to do this with `alertCount(query: "Enforcement:r/.*")` and similar filters, but could not find a filter that resulted in > 0 alerts when enforcing and 0 alerts when not enforcing.

To better communicate this in the UI, I changed the column header from "Enforced" to "Enforcing".

This can occur when a policy is declared for the BUILD and DEPLOY lifecycles, but is only set to enforce for the BUILD lifecycle. A deployment can fail the policy at DEPLOY time, which will trigger an alert that is not enforced.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit Config Mgmt and view a deployment with failing policies. Note that `1 Test enforce image name` and `Fixable Severity at least Important` are listed as "Enforcing".
![image](https://github.com/user-attachments/assets/ca0ba684-777d-4ca2-9d4a-de868994475b)

Visit the Violations page and filter by the same deployment. Note that only `1 Test enforce image name` is enforced.
![image](https://github.com/user-attachments/assets/8a1847ac-055a-4b14-a8b8-9cdd8d25ad5d)

Visit the policy details pages for `1 Test enforce image name` and `Fixable Severity at least Important` and see that the former enforces and build AND deployment time, while the latter only enforces at build time.
![image](https://github.com/user-attachments/assets/c7f343a8-abb5-499d-8311-3da147e50e8c)
![image](https://github.com/user-attachments/assets/027278ab-c2f3-40fb-946d-503dbf5e60c4)

