### PR TITLE
ROX-25761: Improve accessibility of expandable sections in Collections

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -37,6 +37,81 @@ const rules = {
             };
         },
     },
+    'ExpandableSection-isDetached-contentId-toggleId-props': {
+        // Require props to prevent axe DevTools issue:
+        // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+        // https://dequeuniversity.com/rules/axe/4.10/landmark-unique
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'ExpandableSection element with isDetached requires contentId and ToggleId props',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (
+                        node.name?.name === 'ExpandableSection' &&
+                        node.attributes.some(
+                            (nodeAttribute) => nodeAttribute.name?.name === 'isDetached'
+                        )
+                    ) {
+                        if (
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'contentId'
+                            ) ||
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'toggleId'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'ExpandableSection element with isDetached requires contentId and ToggleId props',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
+    'ExpandableSectionToggle-contentId-toggleId-props': {
+        // Require props to prevent axe DevTools issue:
+        // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+        // https://dequeuniversity.com/rules/axe/4.10/landmark-unique
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'ExpandableSectionToggle element requires contentId and toggleId props',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'ExpandableSectionToggle') {
+                        if (
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'contentId'
+                            ) ||
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'toggleId'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'ExpandableSectionToggle element requires contentId and toggleId props',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'Popover-aria-label-prop': {
         // Require prop to prevent axe DevTools issue:
         // ARIA dialog and alertdialog nodes should have an accessible name

--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -20,12 +20,11 @@ const rules = {
                 JSXOpeningElement(node) {
                     if (node.name?.name === 'Alert') {
                         if (
-                            !node.attributes.some((nodeAttribute) => {
-                                return (
+                            !node.attributes.some(
+                                (nodeAttribute) =>
                                     nodeAttribute.name?.name === 'component' &&
                                     nodeAttribute.value?.value === 'p'
-                                );
-                            })
+                            )
                         ) {
                             context.report({
                                 node,
@@ -128,9 +127,9 @@ const rules = {
                 JSXOpeningElement(node) {
                     if (node.name?.name === 'Popover') {
                         if (
-                            !node.attributes.some((nodeAttribute) => {
-                                return nodeAttribute.name?.name === 'aria-label';
-                            })
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'aria-label'
+                            )
                         ) {
                             context.report({
                                 node,
@@ -164,11 +163,11 @@ const rules = {
                     if (node.openingElement?.name?.name === 'Th') {
                         if (node.children?.length === 0) {
                             if (
-                                !node.openingElement?.attributes?.some((nodeAttribute) => {
-                                    return ['expand', 'select', 'screenReaderText'].includes(
+                                !node.openingElement?.attributes?.some((nodeAttribute) =>
+                                    ['expand', 'select', 'screenReaderText'].includes(
                                         nodeAttribute.name?.name
-                                    );
-                                })
+                                    )
+                                )
                             ) {
                                 context.report({
                                     node,
@@ -280,9 +279,9 @@ const rules = {
                 JSXOpeningElement(node) {
                     if (node.name?.name === 'Th') {
                         if (
-                            node.attributes.some((nodeAttribute) => {
-                                return nodeAttribute.name?.name === 'aria-label';
-                            })
+                            node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'aria-label'
+                            )
                         ) {
                             context.report({
                                 node,

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -46,8 +46,11 @@ import { CollectionConfigError } from './errorUtils';
 
 import './CollectionForm.css';
 
-const ruleSectionContentId = 'expandable-rules-section';
-const attachmentSectionContentId = 'expandable-attachment-section';
+const ruleSectionContentId = 'expandable-rules-section-contentId';
+const attachmentSectionContentId = 'expandable-attachment-section-contentId';
+
+const ruleSectionToggleId = 'expandable-rules-section-toggleId';
+const attachmentSectionToggleId = 'expandable-attachment-section-toggleId';
 
 function AttachedCollectionTable({
     collections,
@@ -380,6 +383,7 @@ function CollectionForm({
                 <div className="collection-form-expandable-section">
                     <ExpandableSectionToggle
                         contentId={ruleSectionContentId}
+                        toggleId={ruleSectionToggleId}
                         isExpanded={isRuleSectionOpen}
                         onToggle={ruleSectionOnToggle}
                     >
@@ -401,6 +405,7 @@ function CollectionForm({
                     <ExpandableSection
                         isDetached
                         contentId={ruleSectionContentId}
+                        toggleId={ruleSectionToggleId}
                         isExpanded={isRuleSectionOpen}
                     >
                         <Flex
@@ -460,6 +465,7 @@ function CollectionForm({
                 <div className="collection-form-expandable-section">
                     <ExpandableSectionToggle
                         contentId={attachmentSectionContentId}
+                        toggleId={attachmentSectionToggleId}
                         isExpanded={isAttachmentSectionOpen}
                         onToggle={attachmentSectionOnToggle}
                     >
@@ -478,6 +484,7 @@ function CollectionForm({
                     <ExpandableSection
                         isDetached
                         contentId={attachmentSectionContentId}
+                        toggleId={attachmentSectionToggleId}
                         isExpanded={isAttachmentSectionOpen}
                     >
                         <Flex


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Landmarks should have a unique role or role/label/title (i.e. accessible name) combination

https://dequeuniversity.com/rules/axe/4.10/landmark-unique

```html
<div class="pf-v5-c-expandable-section__content" id="expandable-rules-section" aria-labelledby="expandable-section-toggle-1723488786584mhx9u11lf7f" role="region">
```

Related node:

```html
<div class="pf-v5-c-expandable-section__content" id="expandable-attachment-section" aria-labelledby="expandable-section-toggle-1723488786586cks1i4znbh" role="region">
```

The landmark must have a unique `aria-label`, `aria-labelledby`, or `title` to make landmarks distinguishable

### Analysis

> When passing the `isDetached` property into `<ExpandableSection>`, you must also manually pass in the same `toggleId` and `contentId` properties to both `<ExpandableSection>` and `<ExpandableSectionToggle>`. This will link the content to the toggle via ARIA attributes.

https://www.patternfly.org/components/expandable-section#detached

### Solution

1. Edit pluginAccessibility.js file. Waiting to rebase and then add after we merge another contribution.
    * Add positive `ExpandableSection-isDetached-contentId-toggleId-props` rule.
    * Add positive `ExpandableSectionToggle-contentId-toggleId-props` rule.
2. Add unique `toggleId` prop to each pair `ExpandableSection` and `ExpandableSectionToggle` elements.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618273 - 4618273
        total 151 = 11705849 - 11705698
    * `ls -al build/static/js/*.js | wc`
        files 0 = 175 - 175
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/collections?action=create

    * Before changes, see presence of accessibility issue.
        ![ExpandableSection_with_issue](https://github.com/user-attachments/assets/444e0c4e-4889-4e99-89e7-681d0ef66da0)

    * After changes, see absence of accessibility issue.
        ![ExpandableSection_without_issue](https://github.com/user-attachments/assets/1cf1e286-7e6b-4f79-9c58-f8e7e927ce48)

        See in `button` element that has `pf-v5-c-expandable-section__toggle` class:
        * `aria-controls` attribute corresponds to `contentId` prop of `ExpandableSectionToggle` element.
        * `id` attribute corresponds to `toggleId` prop of `ExpandableSectionToggle` element.

        See in `div` element that has `pf-v5-c-expandable-section__content` class:
        * `id` attribute corresponds to `contentId` prop of `ExpandableSection` element.
        * `aria-labelledby` attribute corresponds to `toggleId` prop of `ExpandableSection` element.

        ![ExpandableSection_Elements](https://github.com/user-attachments/assets/0f369bed-59a5-444b-9a97-8b2f61015cc4)

#### Integration testing

* collections/collectionsCrudWorkflow.test.js
