### PR TITLE
chore(ui): Remove jsx-a11y from ESLint config

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -4,7 +4,6 @@ const path = require('node:path');
 
 const parserTypeScriptESLint = require('@typescript-eslint/parser');
 
-const pluginAccessibilityJSX = require('eslint-plugin-jsx-a11y');
 const pluginCypress = require('eslint-plugin-cypress');
 const pluginESLint = require('@eslint/js'); // eslint-disable-line import/no-extraneous-dependencies
 const pluginESLintComments = require('eslint-plugin-eslint-comments');
@@ -533,7 +532,6 @@ module.exports = [
         plugins: {
             accessibility: pluginAccessibility,
             import: pluginImport,
-            'jsx-a11y': pluginAccessibilityJSX,
             react: pluginReact,
             'react-hooks': pluginReactHooks,
         },
@@ -564,26 +562,6 @@ module.exports = [
                     devDependencies: [
                         path.join(__dirname, 'src/test-utils/*'), // TODO delete renderWithRedux.js
                     ],
-                },
-            ],
-
-            // TODO compare eslint-plugin-jsx-a11y recommended and strict config to former airbnb-config-react react-a11y config.
-
-            // TODO Reconfigure for using react-router Link
-            'jsx-a11y/anchor-is-valid': [
-                'error',
-                {
-                    components: ['Link'],
-                    specialLink: ['to', 'hrefLeft', 'hrefRight'],
-                    aspects: ['noHref', 'invalidHref', 'preferButton'],
-                },
-            ],
-
-            'jsx-a11y/label-has-associated-control': [
-                'error',
-                {
-                    assert: 'either',
-                    depth: 12,
                 },
             ],
 

--- a/ui/apps/platform/src/Components/TextSelect/TextSelect.js
+++ b/ui/apps/platform/src/Components/TextSelect/TextSelect.js
@@ -35,14 +35,11 @@ const TextSelect = ({ ...rest }) => {
     // axe DevTools reports a theoretical issue: Form elements must have labels.
     // One of its suggestions is to enclose the form element in a label element.
     // Thankfully that does not affect the layout.
-    // However, jsx-a11y rule only accepts label as sibling, not enclosing.
-    /* eslint-disable jsx-a11y/label-has-associated-control */
     return (
         <label>
             <Select styles={selectStyles} isSearchable={false} {...rest} components={components} />
         </label>
     );
-    /* eslint-enable jsx-a11y/label-has-associated-control */
 };
 
 export default TextSelect;

--- a/ui/apps/platform/src/Components/ToggleSwitch/ToggleSwitch.js
+++ b/ui/apps/platform/src/Components/ToggleSwitch/ToggleSwitch.js
@@ -1,9 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-associated-control */
-/**
- * disabled the rule above, because we are using an extra <label> element
- *   as the visual "slider" in the toggle
- */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import set from 'lodash/set';
@@ -73,5 +67,3 @@ ToggleSwitch.defaultProps = {
 };
 
 export default ToggleSwitch;
-
-/* eslint-enable jsx-a11y/label-has-associated-control */


### PR DESCRIPTION
### Description

~My bad to base on another branch without need :(~ rebased to remove commits

These lint rules apply to HTML elements and attributes, therefore have continually decreasing relevance because continually increasing proportion of UI code renders HTML indirectly via PatternFly elements.

### Residue

1. Remove from `devDependencies` after change from yarn to npm.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
