### PR TITLE
ROX-23343: Use different APIVersion of OpenShift auto-sensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.
   - To revert back to synchronous TLS checks set `ROX_SENSOR_LAZY_TLS_CHECKS` to `false` on Sensor.
+- ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
 
 ## [4.5.0]
 

--- a/image/templates/helm/shared/templates/_openshift.tpl
+++ b/image/templates/helm/shared/templates/_openshift.tpl
@@ -20,7 +20,10 @@
 
 {{/* Infer OpenShift, if needed */}}
 {{ if kindIs "invalid" $env.openshift }}
-  {{ $_ := set $env "openshift" (has "apps.openshift.io/v1" $._rox._apiServer.apiResources) }}
+  {{/* The API GroupVersion project.openshift.io/v1 contains the core OpenShift API 'Project' of
+       compatibility level 1, which comes with the strongest stability guarantees among the OpenShift APIs.
+       This API is available in OpenShift 3.x and 4.x. */}}
+  {{ $_ := set $env "openshift" (has "project.openshift.io/v1" $._rox._apiServer.apiResources) }}
 {{ end }}
 
 {{/* Infer openshift version */}}
@@ -29,7 +32,7 @@
   {{ $kubeVersion := semver $.Capabilities.KubeVersion.Version }}
 
   {{/* Default to OpenShift 3 if no openshift resources are available, i.e. in helm template commands */}}
-  {{ if not (has "apps.openshift.io/v1" $._rox._apiServer.apiResources) }}
+  {{ if not (has "project.openshift.io/v1" $._rox._apiServer.apiResources) }}
     {{ $_ := set $._rox.env "openshift" 3 }}
   {{ else if gt $kubeVersion.Minor 11 }}
     {{ $_ := set $env "openshift" 4 }}


### PR DESCRIPTION
### Description

Decided to use the following API:
```
❯ kubectl api-resources --api-group=project.openshift.io 
NAME              SHORTNAMES   APIVERSION                NAMESPACED   KIND
projectrequests                project.openshift.io/v1   false        ProjectRequest
projects                       project.openshift.io/v1   false        Project
```

which is of compatibility level 1 -- I think that's the best we can aim for using the current approach(?).

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation changes are not needed, because we don't (according to my knowledge) leak these technical details into the documentation.

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
