### PR TITLE
ROX-25769:  compliance use custom field sort

### DIFF
--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -379,7 +379,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 	cloned.Selects = append(cloned.Selects,
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("pass_count",
+			Filter(search.CompliancePassCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -388,7 +388,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("fail_count",
+			Filter(search.ComplianceFailCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -397,7 +397,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("error_count",
+			Filter(search.ComplianceErrorCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -406,7 +406,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("info_count",
+			Filter(search.ComplianceInfoCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -415,7 +415,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("manual_count",
+			Filter(search.ComplianceManualCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -424,7 +424,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("not_applicable_count",
+			Filter(search.ComplianceNotApplicableCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,
@@ -433,7 +433,7 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 			).Proto(),
 		search.NewQuerySelect(countOn).
 			AggrFunc(aggregatefunc.Count).
-			Filter("inconsistent_count",
+			Filter(search.ComplianceInconsistentCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.ComplianceOperatorCheckStatus,

--- a/central/complianceoperator/v2/checkresults/datastore/stats_views.go
+++ b/central/complianceoperator/v2/checkresults/datastore/stats_views.go
@@ -6,13 +6,13 @@ import (
 
 // ResourceResultCountByClusterScan represents shape of the stats query for compliance operator results
 type ResourceResultCountByClusterScan struct {
-	PassCount          int    `db:"pass_count"`
-	FailCount          int    `db:"fail_count"`
-	ErrorCount         int    `db:"error_count"`
-	InfoCount          int    `db:"info_count"`
-	ManualCount        int    `db:"manual_count"`
-	NotApplicableCount int    `db:"not_applicable_count"`
-	InconsistentCount  int    `db:"inconsistent_count"`
+	PassCount          int    `db:"compliance_pass_count"`
+	FailCount          int    `db:"compliance_fail_count"`
+	ErrorCount         int    `db:"compliance_error_count"`
+	InfoCount          int    `db:"compliance_info_count"`
+	ManualCount        int    `db:"compliance_manual_count"`
+	NotApplicableCount int    `db:"compliance_not_applicable_count"`
+	InconsistentCount  int    `db:"compliance_inconsistent_count"`
 	ClusterID          string `db:"cluster_id"`
 	ClusterName        string `db:"cluster"`
 	ScanConfigName     string `db:"compliance_scan_config_name"`
@@ -21,13 +21,13 @@ type ResourceResultCountByClusterScan struct {
 // ResultStatusCountByCluster represents shape of the stats query for compliance operator results
 // grouped by cluster
 type ResultStatusCountByCluster struct {
-	PassCount          int        `db:"pass_count"`
-	FailCount          int        `db:"fail_count"`
-	ErrorCount         int        `db:"error_count"`
-	InfoCount          int        `db:"info_count"`
-	ManualCount        int        `db:"manual_count"`
-	NotApplicableCount int        `db:"not_applicable_count"`
-	InconsistentCount  int        `db:"inconsistent_count"`
+	PassCount          int        `db:"compliance_pass_count"`
+	FailCount          int        `db:"compliance_fail_count"`
+	ErrorCount         int        `db:"compliance_error_count"`
+	InfoCount          int        `db:"compliance_info_count"`
+	ManualCount        int        `db:"compliance_manual_count"`
+	NotApplicableCount int        `db:"compliance_not_applicable_count"`
+	InconsistentCount  int        `db:"compliance_inconsistent_count"`
 	ClusterID          string     `db:"cluster_id"`
 	ClusterName        string     `db:"cluster"`
 	LastScanTime       *time.Time `db:"compliance_scan_last_executed_time_max"`
@@ -51,25 +51,25 @@ type configurationCount struct {
 
 // ResourceResultCountByProfile represents shape of the stats query for compliance operator results
 type ResourceResultCountByProfile struct {
-	PassCount          int    `db:"pass_count"`
-	FailCount          int    `db:"fail_count"`
-	ErrorCount         int    `db:"error_count"`
-	InfoCount          int    `db:"info_count"`
-	ManualCount        int    `db:"manual_count"`
-	NotApplicableCount int    `db:"not_applicable_count"`
-	InconsistentCount  int    `db:"inconsistent_count"`
+	PassCount          int    `db:"compliance_pass_count"`
+	FailCount          int    `db:"compliance_fail_count"`
+	ErrorCount         int    `db:"compliance_error_count"`
+	InfoCount          int    `db:"compliance_info_count"`
+	ManualCount        int    `db:"compliance_manual_count"`
+	NotApplicableCount int    `db:"compliance_not_applicable_count"`
+	InconsistentCount  int    `db:"compliance_inconsistent_count"`
 	ProfileName        string `db:"compliance_profile_name"`
 }
 
 // ResourceResultsByProfile represents shape of the stats query for compliance operator results
 type ResourceResultsByProfile struct {
-	PassCount          int    `db:"pass_count"`
-	FailCount          int    `db:"fail_count"`
-	ErrorCount         int    `db:"error_count"`
-	InfoCount          int    `db:"info_count"`
-	ManualCount        int    `db:"manual_count"`
-	NotApplicableCount int    `db:"not_applicable_count"`
-	InconsistentCount  int    `db:"inconsistent_count"`
+	PassCount          int    `db:"compliance_pass_count"`
+	FailCount          int    `db:"compliance_fail_count"`
+	ErrorCount         int    `db:"compliance_error_count"`
+	InfoCount          int    `db:"compliance_info_count"`
+	ManualCount        int    `db:"compliance_manual_count"`
+	NotApplicableCount int    `db:"compliance_not_applicable_count"`
+	InconsistentCount  int    `db:"compliance_inconsistent_count"`
 	ProfileName        string `db:"compliance_profile_name"`
 	CheckName          string `db:"compliance_check_name"`
 	RuleName           string `db:"compliance_rule_name"`

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -318,6 +318,15 @@ var (
 	ImagePriority      = newDerivedFieldLabel("Image Risk Priority", ImageRiskScore, SimpleReverseSortDerivationType)
 	ComponentPriority  = newDerivedFieldLabel("Component Risk Priority", ComponentRiskScore, SimpleReverseSortDerivationType)
 
+	// Custom derived fields to support query aliases.  These fields are only supported in pagination sort options.
+	CompliancePassCount          = newDerivedFieldLabelWithType("Compliance Pass Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceFailCount          = newDerivedFieldLabelWithType("Compliance Fail Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceErrorCount         = newDerivedFieldLabelWithType("Compliance Error Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceInfoCount          = newDerivedFieldLabelWithType("Compliance Info Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceManualCount        = newDerivedFieldLabelWithType("Compliance Manual Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceNotApplicableCount = newDerivedFieldLabelWithType("Compliance Not Applicable Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+	ComplianceInconsistentCount  = newDerivedFieldLabelWithType("Compliance Inconsistent Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
+
 	// Max-based derived fields.  These fields are primarily used in pagination.  If used in a select it will correspond
 	// to the type of the reference field and simply provide the max function on that field.
 	ComplianceLastScanMax = newDerivedFieldLabel("Compliance Scan Last Executed Time Max", ComplianceOperatorScanLastExecutedTime, MaxDerivationType)
@@ -542,6 +551,10 @@ func newDerivedFieldLabelWithType(s string, derivedFrom FieldLabel, derivationTy
 
 func (f FieldLabel) String() string {
 	return string(f)
+}
+
+func (f FieldLabel) Alias() string {
+	return strings.ToLower(strings.Join(strings.Fields(string(f)), "_"))
 }
 
 // DerivedFieldLabelMetadata includes metadata showing that a field is derived.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The status field uses a filter grab things like `fail_count`, `pass_count`, etc.  Things like this on the UI.

![image](https://github.com/user-attachments/assets/ad2de0cd-47be-4361-8759-2e368d04350f)

Those values are created using a filter and an a query alias.  We previously had no way to expose an efficient sort on an alias like this.  #12319 introduced the ability to add a custom sort option that can reference an alias.  This enables us to sort on these count values that are based on filters of a single column.  (Note:  This does not support `Other` as `Other` is grouped on the UI.  The API returns the individual counts so if we need to sort `Other` we would have to split it up)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added some unit tests.

Tested all the endpoints that utilize the returning of these fields manually against a cluster.  Exercised both ascending and descending sort.
