### PR TITLE
ROX-25748: Workload CVE a11y fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -62,7 +62,9 @@ import {
 import DeploymentVulnerabilitiesTable, {
     deploymentWithVulnerabilitiesFragment,
 } from '../Tables/DeploymentVulnerabilitiesTable';
-import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import VulnerabilityStateTabs, {
+    vulnStateTabContentId,
+} from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 const summaryQuery = gql`
@@ -227,6 +229,7 @@ function DeploymentPageVulnerabilities({
             </PageSection>
             <Divider component="div" />
             <PageSection
+                id={vulnStateTabContentId}
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                 component="div"
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -61,7 +61,9 @@ import {
 } from '../../utils/searchUtils';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
-import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import VulnerabilityStateTabs, {
+    vulnStateTabContentId,
+} from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import ExceptionRequestModal, {
     ExceptionRequestModalProps,
@@ -225,6 +227,7 @@ function ImagePageVulnerabilities({
             </PageSection>
             <Divider component="div" />
             <PageSection
+                id={vulnStateTabContentId}
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
                 component="div"
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -81,7 +81,9 @@ import BySeveritySummaryCard, {
     ResourceCountsByCveSeverity,
 } from '../../components/BySeveritySummaryCard';
 import { resourceCountByCveSeverityAndStatusFragment } from '../SummaryCards/CvesByStatusSummaryCard';
-import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import VulnerabilityStateTabs, {
+    vulnStateTabContentId,
+} from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 const workloadCveOverviewCvePath = getOverviewPagePath('Workload', {
@@ -401,7 +403,10 @@ function ImageCvePage() {
                 )}
             </PageSection>
             <Divider component="div" />
-            <PageSection className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1">
+            <PageSection
+                id={vulnStateTabContentId}
+                className="pf-v5-u-display-flex pf-v5-u-flex-direction-column pf-v5-u-flex-grow-1"
+            >
                 <VulnerabilityStateTabs
                     titleOverrides={{ observed: 'Workloads' }}
                     isBox

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -80,7 +80,9 @@ import DeploymentsTableContainer from './DeploymentsTableContainer';
 import ImagesTableContainer, { imageListQuery } from './ImagesTableContainer';
 import WatchedImagesModal from '../WatchedImages/WatchedImagesModal';
 import UnwatchImageModal from '../WatchedImages/UnwatchImageModal';
-import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import VulnerabilityStateTabs, {
+    vulnStateTabContentId,
+} from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import DefaultFilterModal from '../components/DefaultFilterModal';
 import WorkloadCveFilterToolbar from '../components/WorkloadCveFilterToolbar';
@@ -396,7 +398,7 @@ function WorkloadCvesOverviewPage() {
                     )}
                 </Flex>
             </PageSection>
-            <PageSection padding={{ default: 'noPadding' }}>
+            <PageSection id={vulnStateTabContentId} padding={{ default: 'noPadding' }}>
                 <PageSection
                     padding={{ default: 'noPadding' }}
                     component="div"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -59,7 +59,7 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
                     <Button
                         className="pf-v5-u-pt-xs"
                         id={`copy-image-name-button-${id}`}
-                        aria-labelledby={`copy-image-name-text-${id}`}
+                        aria-label={'Copy image name'}
                         type="button"
                         variant="plain"
                         onClick={copyImageName}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -5,6 +5,8 @@ import { VulnerabilityState, isVulnerabilityState, vulnerabilityStates } from 't
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
+export const vulnStateTabContentId = 'vulnerability-state-tab-content';
+
 export type VulnerabilityStateTabsProps = {
     isBox?: TabsProps['isBox'];
     titleOverrides?: {
@@ -42,10 +44,12 @@ function VulnerabilityStateTabs({
             <Tab
                 eventKey="OBSERVED"
                 title={<TabTitleText>{titleOverrides?.observed ?? 'Observed'}</TabTitleText>}
+                tabContentId={vulnStateTabContentId}
             />
             <Tab
                 eventKey="DEFERRED"
                 title={<TabTitleText>{titleOverrides?.deferred ?? 'Deferred'}</TabTitleText>}
+                tabContentId={vulnStateTabContentId}
             />
             <Tab
                 eventKey="FALSE_POSITIVE"
@@ -54,6 +58,7 @@ function VulnerabilityStateTabs({
                         {titleOverrides?.falsePositive ?? 'False positives'}
                     </TabTitleText>
                 }
+                tabContentId={vulnStateTabContentId}
             />
         </Tabs>
     ) : null;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -10,7 +10,7 @@ import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils
 import SearchFilterChips, { FilterChip } from 'Components/PatternFly/SearchFilterChips';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { SearchFilter } from 'types/search';
-import { searchValueAsArray } from 'utils/searchUtils';
+import { getHasSearchApplied, searchValueAsArray } from 'utils/searchUtils';
 
 import { DefaultFilters } from '../types';
 import CVESeverityDropdown from './CVESeverityDropdown';
@@ -157,9 +157,13 @@ function AdvancedFiltersToolbar({
                         )}
                     </ToolbarGroup>
                 )}
-                <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
-                    <SearchFilterChips filterChipGroupDescriptors={filterChipGroupDescriptors} />
-                </ToolbarGroup>
+                {getHasSearchApplied(searchFilter) && (
+                    <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
+                        <SearchFilterChips
+                            filterChipGroupDescriptors={filterChipGroupDescriptors}
+                        />
+                    </ToolbarGroup>
+                )}
             </ToolbarContent>
         </Toolbar>
     );


### PR DESCRIPTION
## Description

### *Fixes the following axe errors in Workload CVEs:*


### Problem reported by axe DevTools

> Ensure ARIA attributes are not prohibited for an element's role

https://dequeuniversity.com/rules/axe/4.10/aria-prohibited-attr?application=AxeChrome2

<div class="pf-v5-c-toolbar__group pf-v5-u-w-100" aria-label="applied search filters"><div class="pf-v5-l-flex pf-m-space-items-xs search-filter-chips"></div></div>

### Analysis

> aria-label attribute cannot be used on a div with no valid role attribute.

### Solution

The offending `div` has no valid role because it is an empty element when no filters are applied. To fix, conditionally render this element only when there are applied filters and valid children.

Bonus! This removes a little bit of extra whitespace in the layout due to the empty element's padding.

---


### Problem reported by axe DevTools

> Ensure all ARIA attributes have valid values

https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=AxeChrome

<button type="button" data-ouia-component-type="PF5/TabButton" data-ouia-safe="true" class="pf-v5-c-tabs__link" id="pf-tab-OBSERVED-pf-1723741011927z7xby7wrjx8" aria-controls="pf-tab-section-OBSERVED-pf-1723741011927z7xby7wrjx8" role="tab" aria-selected="true">

### Analysis

> Invalid ARIA attribute value: aria-controls="pf-tab-section-OBSERVED-pf-1723741011927z7xby7wrjx8"


### Solution

The `aria-controls` attribute is invalid because it does not correspond to the `id` attribute of any other element in the DOM. The autogenerated ID does not match another element because these `<Tab>` components are disconnected from their content. To fix, a static value was passed to the `tabContentId` props and used as the `id` field of the element on the page that is controlled by the tab navigation.

---

### Problem reported by axe DevTools

> Ensure all ARIA attributes have valid values

https://dequeuniversity.com/rules/axe/4.10/button-name?application=AxeChrome

<button id="copy-image-name-button-sha256:8b03e4185ecd305bc9b410faac15d486a3b1ef1946196d429245cdd3c7b152eb" aria-labelledby="copy-image-name-text-sha256:8b03e4185ecd305bc9b410faac15d486a3b1ef1946196d429245cdd3c7b152eb" aria-disabled="false" class="pf-v5-c-button pf-m-plain pf-v5-u-pt-xs" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-plain-6">

### Analysis

> aria-label attribute does not exist or is empty
> aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty


### Solution

The `aria-labelledby` attribute is set for these copy buttons, but is never set as the id of an element that can be used as a label. Since there is no element that consistently displays a label value that is appropriate for this button, the attribute was changed to `aria-label="Copy image name"`.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the Workload CVE Overview page => Image tab and see the presence of 16 errors due to the three rule violations:
![image](https://github.com/user-attachments/assets/e69b794c-cc90-4442-b358-e37156329c8a)

Visit the same page after the changes are applied and see zero reported rule violations:
![image](https://github.com/user-attachments/assets/23d77a36-3324-41cb-8f35-ee19ece56656)

Repeat these checks across the following pages, verifying that the axe errors above are not present.

Workload CVE Overview page - CVE, Image and Deployment tabs
Workload CVE page - Image and Deployment tabs
Workload CVE Image page
Workload CVE Deployment page
