### PR TITLE
ROX-25785: Add title for accessibility of chart on dashboard

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -36,6 +36,36 @@ const rules = {
             };
         },
     },
+    'Chart-ariaTitle-prop': {
+        // Require prop for aria-labelledby attribute to prevent axe DevTools issue:
+        // <svg> elements with an img role must have an alternative text
+        // https://dequeuniversity.com/rules/axe/4.10/svg-img-alt
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Chart element requires ariaTitle prop',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'Chart') {
+                        if (
+                            !node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'ariaTitle'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message: 'Chart element requires ariaTitle prop',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'ExpandableSection-isDetached-contentId-toggleId-props': {
         // Require props to prevent axe DevTools issue:
         // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -240,6 +240,7 @@ function ViolationsByPolicyCategoryChart({
         <div ref={setWidgetContainer}>
             <Chart
                 ariaDesc="Number of violations by policy category, grouped by severity"
+                ariaTitle="Policy violations by category"
                 domainPadding={{ x: [20, 20] }}
                 events={getInteractiveLegendEvents({
                     chartNames: [Object.values(severityLabels)],


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> svg elements with img role must have an alternative text

https://dequeuniversity.com/rules/axe/4.9/svg-img-alt

```html
<svg width="483.5" height="260" role="img" aria-describedby="victory-container-1-desc" viewBox="0 0 483.5 260" style="pointer-events: all; width: 100%; height: 100%;">
```

### Analysis

> `aria-labelledby` attribute does not exist, references elements that do not exist or references elements that are empty

One `Chart` element lacks `ariaTitle` prop.

### Solution

1. Edit pluginAccessibility.js file. Waiting until after we merge other contributions to rebase and then add rule.
    * Add positive `Chart-ariaTitle-prop` rule.
2. Add unique `ariaTitle` prop to `Chart` element.

### Residue

1. Fix other accessibility issue: Interactive controls must not be nested

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

#### Manual testing

1. Visit /main/dashboard

    * Before changes, see presence of accessibility issue for **alternative text**.
        ![ViolationsByPolicyCategoryChart_with_issue](https://github.com/user-attachments/assets/5942d15e-9f40-474b-8b76-c6ae5aab57fa)

    * After changes, see absence of accessibility issue for **alternative text** because of `aria-labelledby` attribute.
        ![ViolationsByPolicyCategoryChart_Elements](https://github.com/user-attachments/assets/7557321f-06ac-4b3e-8537-d0b55c48eb9b)
