### PR TITLE
fix(ui): Minor improvements to policy violations search

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -1,0 +1,47 @@
+// If you're adding a new attribute, make sure to add it to "alertAttributes" as well
+
+import { CompoundSearchFilterAttribute } from '../types';
+
+export const ViolationTime: CompoundSearchFilterAttribute = {
+    displayName: 'Violation time',
+    filterChipLabel: 'Violation time',
+    searchTerm: 'Violation Time',
+    inputType: 'date-picker',
+};
+
+export const EntityType: CompoundSearchFilterAttribute = {
+    displayName: 'Entity type',
+    filterChipLabel: 'Entity type',
+    searchTerm: 'Resource Type',
+    inputType: 'select',
+    inputProps: {
+        groupOptions: [
+            {
+                name: 'Workload & Container image',
+                options: [
+                    {
+                        label: 'Deployments & Container images',
+                        value: 'UNKNOWN',
+                    },
+                ],
+            },
+            {
+                name: 'Resource',
+                options: [
+                    { label: 'Cluster role bindings', value: 'CLUSTER_ROLE_BINDINGS' },
+                    { label: 'Cluster roles', value: 'CLUSTER_ROLES' },
+                    { label: 'Configmaps', value: 'CONFIGMAPS' },
+                    { label: 'Egress firewalls', value: 'EGRESS_FIREWALLS' },
+                    { label: 'Network policies', value: 'NETWORK_POLICIES' },
+                    { label: 'Secrets', value: 'SECRETS' },
+                    {
+                        label: 'Security context constraints',
+                        value: 'SECURITY_CONTEXT_CONSTRAINTS',
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+export const alertAttributes = [ViolationTime, EntityType];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/deployment.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/deployment.ts
@@ -30,4 +30,17 @@ export const Annotation: CompoundSearchFilterAttribute = {
     inputType: 'autocomplete',
 };
 
-export const deploymentAttributes = [ID, Name, Label, Annotation];
+export const Inactive: CompoundSearchFilterAttribute = {
+    displayName: 'Status',
+    filterChipLabel: 'Deployment status',
+    searchTerm: 'Inactive Deployment',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { value: 'false', label: 'Active' },
+            { value: 'true', label: 'Inactive' },
+        ],
+    },
+};
+
+export const deploymentAttributes = [ID, Name, Label, Annotation, Inactive];

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -15,13 +15,14 @@ import {
     LifecycleStage as PolicyLifecycleStage,
     Severity as PolicySeverity,
     EnforcementAction as PolicyEnforcementAction,
-    InactiveDeployment as AlertInactiveDeployment,
-    ViolationTime as AlertViolationTime,
-    EntityType as AlertEntityType,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import {
-    ID as ClusterID,
+    ViolationTime as AlertViolationTime,
+    EntityType as AlertEntityType,
+} from 'Components/CompoundSearchFilter/attributes/alert';
+import {
     Name as ClusterName,
+    ID as ClusterID,
 } from 'Components/CompoundSearchFilter/attributes/cluster';
 import {
     ID as NamespaceID,
@@ -30,6 +31,7 @@ import {
 import {
     ID as DeploymentID,
     Name as DeploymentName,
+    Inactive as DeploymentInactive,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
 
 const searchFilterConfig: CompoundSearchFilterConfig = [
@@ -42,25 +44,27 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
             PolicySeverity,
             PolicyLifecycleStage,
             PolicyEnforcementAction,
-            AlertInactiveDeployment,
-            AlertViolationTime,
-            AlertEntityType,
         ],
+    },
+    {
+        displayName: 'Policy violation',
+        searchCategory: 'ALERTS',
+        attributes: [AlertViolationTime, AlertEntityType],
     },
     {
         displayName: 'Cluster',
         searchCategory: 'ALERTS',
-        attributes: [ClusterID, ClusterName],
+        attributes: [ClusterName, ClusterID],
     },
     {
         displayName: 'Namespace',
         searchCategory: 'ALERTS',
-        attributes: [NamespaceID, NamespaceName],
+        attributes: [NamespaceName, NamespaceID],
     },
     {
         displayName: 'Deployment',
         searchCategory: 'ALERTS',
-        attributes: [DeploymentID, DeploymentName],
+        attributes: [DeploymentName, DeploymentID, DeploymentInactive],
     },
 ];
 


### PR DESCRIPTION
### Description

This PR introduces some minor improvements to policy search:

1. Reordering `ID` and `Name` options
2. Moving `Deployment status` under `Deployment`
3. Separating `ViolationTime` and `EntityType` from `Policy` and putting it under `Policy violation` 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing

- [x] inspected CI results

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes

#### How I validated my change

<img width="591" alt="Screenshot 2024-08-15 at 11 00 40 AM" src="https://github.com/user-attachments/assets/5f8c1dd3-49c7-4c03-bc98-6c2789dc95ec">
<img width="1170" alt="Screenshot 2024-08-15 at 11 00 50 AM" src="https://github.com/user-attachments/assets/71a6c954-811b-4f4f-b03c-70aa3cb33f42">

