### PR TITLE
ROX-25812: Change role for accessibility of chart links on dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Chart, ChartAxis, ChartBar, ChartLabelProps } from '@patternfly/react-charts';
+import {
+    Chart,
+    ChartAxis,
+    ChartBar,
+    ChartContainer,
+    ChartLabelProps,
+} from '@patternfly/react-charts';
 
 import useResizeObserver from 'hooks/useResizeObserver';
 import {
@@ -119,6 +125,7 @@ function AgingImagesChart({ searchFilter, timeRanges, timeRangeCounts }: AgingIm
             <Chart
                 ariaDesc="Aging images grouped by date of last update"
                 ariaTitle="Aging images"
+                containerComponent={<ChartContainer role="figure" />}
                 domainPadding={{ x: [50, 50] }}
                 height={defaultChartHeight}
                 width={widgetContainerResizeEntry?.contentRect.width} // Victory defaults to 450

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Chart, ChartAxis, ChartBar, ChartGroup, ChartLabelProps } from '@patternfly/react-charts';
+import {
+    Chart,
+    ChartAxis,
+    ChartBar,
+    ChartContainer,
+    ChartGroup,
+    ChartLabelProps,
+} from '@patternfly/react-charts';
 
 import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
 import useResizeObserver from 'hooks/useResizeObserver';
@@ -38,6 +45,7 @@ function ComplianceLevelsByStandardChart({
             <Chart
                 ariaDesc="Compliance coverage percentages by standard across the selected resource scope"
                 ariaTitle="Compliance coverage by standard"
+                containerComponent={<ChartContainer role="figure" />}
                 domainPadding={{ x: [20, 20] }}
                 height={defaultChartHeight}
                 width={widgetContainerResizeEntry?.contentRect.width}

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -3,11 +3,12 @@ import { useHistory } from 'react-router-dom';
 import {
     Chart,
     ChartAxis,
-    ChartStack,
     ChartBar,
-    ChartTooltip,
+    ChartContainer,
     ChartLabelProps,
     ChartLegend,
+    ChartStack,
+    ChartTooltip,
     getInteractiveLegendEvents,
     getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
@@ -246,6 +247,7 @@ function ViolationsByPolicyCategoryChart({
                     legendName: 'legend',
                     onLegendClick,
                 })}
+                containerComponent={<ChartContainer role="figure" />}
                 legendComponent={<ChartLegend name="legend" data={getLegendData()} />}
                 legendPosition="bottom"
                 height={chartHeight}


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Interactive controls must not be nested

https://dequeuniversity.com/rules/axe/4.9/nested-interactive

> Focusable elements with an interactive control ancestor (any element that accepts user input such as button or anchor elements) are not announced by screen readers and create an empty tab stop. That is, you could tab to the element but the screen reader will not announce its name, role, or state.

```html
<svg width="483.5" height="260" role="img" aria-labelledby="victory-container-8-title" aria-describedby="victory-container-8-desc" viewBox="0 0 483.5 260" style="pointer-events: all; width: 100%; height: 100%;">
```

Element has focusable descendants

```html
<a href="/main/vulnerability-management/images?s[Image Created Time]=30d-90d&amp;sort[0][id]=Image Created Time&amp;sort[0][desc]=false">
```

```html
<a href="/main/vulnerability-management/images?s[Image Created Time]=90d-180d&amp;sort[0][id]=Image Created Time&amp;sort[0][desc]=false">
```

```html
<a href="/main/vulnerability-management/images?s[Image Created Time]=180d-365d&amp;sort[0][id]=Image Created Time&amp;sort[0][desc]=false">
```

```html
<a href="/main/vulnerability-management/images?s[Image Created Time]=>
```

### Analysis

Dashboard components have links:
* AgingImagesChart.tsx
* ComplianceLevelsByStandardChart.tsx
* ViolationsByPolicyCategoryCategories.tsx

Search result from Stack Overflow suggests `role="figure"` instead of `role="img"` attribute for `svg` element.
https://stackoverflow.com/questions/57564291/aria-role-for-svg-that-contains-links

Thanks to **Dan Labrecque** for help in patternfly-a11y channel:
* suggested `containerComponent` prop of `Chart` element
* directed my attention to a PatternFly demo that has `role="figure"` prop:
https://github.com/patternfly/patternfly-react/blob/main/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md?plain=1#L705

### Solution

1. Add `containerComponent={<ChartContainer role="figure" />}` prop to `Chart` elements.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change


1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618433 - 4618433
        total 165 = 11702966 - 11702801
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/dashboard (if needed click **Go to compliance**, click **Scan environment**, and then go back).

    * Before changes, see presence of accessibility issue for **interactive controls**.
        ![Chart_with_issue](https://github.com/user-attachments/assets/3402fb50-aca8-4a8c-a2ba-f32fec5961d0)

    * After changes, see absence of accessibility issue for **interactive controls** because of `role="figure"` attribute.
        ![Chart_without_issue](https://github.com/user-attachments/assets/5c6156b9-8651-4bc1-b4c4-121b9322f8f6)

    Side effect of role change: axe DevTools does not report accessibility issue for absence of `aria-labelledby` attribute fixed in #12421
    Better to require it via lint rule, in case some screen readers read it.

#### Component testing

* src/Containers/Dashboard/Widgets/AgingImages.cy.jsx
* src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.cy.jsx
* src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.cy.jsx
