### PR TITLE
ROX-25827: Configure Central DB to be more verbose

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -27,3 +27,31 @@ lc_time = 'en_US.utf8'			# locale for time formatting
 
 default_text_search_config = 'pg_catalog.english'
 shared_preload_libraries = 'pg_stat_statements'	# StackRox customized
+
+# Logging. For more details, see
+# https://www.postgresql.org/docs/current/runtime-config-logging.html
+
+# It's convenienv for troubleshooting to log which client has connected and
+# disconnected and when.
+log_connections = 'on'
+log_disconnections = 'on'
+
+# Checkpoints might affect IO throughput.
+log_checkpoints = 'on'
+
+# Make excessive locking visible, since it could affect query latency.
+log_lock_waits = 'on'
+
+# It's useful for troubleshooting to log any query, that took longer than
+# 500ms. Just in case if there is any sensitive information in the query
+# parameters, do not log them, only the query itself.
+log_min_duration_statement = 500
+log_parameter_max_length = 0
+
+# Creating temporary files might indicate switching query plan to a worse one
+# due to lack of memory. Log any activity with temporary files larger than 1024 bytes.
+log_temp_files = 1024
+
+# Autovacuum has to keep up with the data growth. Log any autovacuum activity,
+# that took longer than 500ms.
+log_autovacuum_min_duration = 500


### PR DESCRIPTION
### Description

The default logging configuration doesn't provide much information. Extend it to log essential details, which will be useful for troubleshooting, but not produce a torrent of logs.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

CI is sufficient

#### How I validated my change

Config changes were applied to a running central db and the resulting logs were verified.