### PR TITLE
fix: wait up to 10 minutes for prefetch metrics api

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -692,7 +692,7 @@ image_prefetcher_await_set() {
     local attempt=0
     local service="service/${name}-metrics"
     while [[ -z $(kubectl -n "${ns}" get "${service}" -o jsonpath="{.status.loadBalancer.ingress}" 2>/dev/null) ]]; do
-        if [ "$attempt" -lt "30" ]; then
+        if [ "$attempt" -lt "60" ]; then
             info "Waiting for ${service} to obtain endpoint ..."
             ((attempt++))
             sleep 10


### PR DESCRIPTION
I have one case where the metrics service did not start in the time provided: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-12-merge-qa-e2e-tests/1822150284407738368

The code is waiting 15m and then up to 60s.

`kubectl rollout status daemonset "$name" -n "$ns" --timeout 15m`

then

```

    while [[ -z $(kubectl -n "${ns}" get "${service}" -o jsonpath="{.status.loadBalancer.ingress}" 2>/dev/null) ]]; do
        if [ "$attempt" -lt "10" ]; then
            info "Waiting for ${service} to obtain endpoint ..."
            ((attempt++))
            sleep 10

```

Is it not waiting long enough in the loop checking for the endpoint?

 

```
  Type    Reason                Age   From                Message
  ----    ------                ----  ----                -------
  Normal  EnsuringLoadBalancer  2m4s  service-controller  Ensuring load balancer
  Normal  EnsuredLoadBalancer   96s   service-controller  Ensured load balancer
```

```
9m53s       Normal    Scheduled              pod/stackrox-images-metrics-844fbcf9b-rp266                                    default-scheduler, default-scheduler-rox-ci-07738368-mp2gg-master-0.c.acs-san-stackroxci.internal   Successfully assigned prefetch-images/stackrox-images-metrics-844fbcf9b-rp266 to rox-ci-07738368-mp2gg-worker-b-s42z2         9m53s        1       stackrox-images-metrics-844fbcf9b-rp266.17ea4b3545d3d13e
8m6s        Normal    AddedInterface         pod/stackrox-images-metrics-844fbcf9b-rp266                                    multus                                                                                              Add eth0 [10.131.0.25/23] from ovn-kubernetes                                                                                 8m6s         1       stackrox-images-metrics-844fbcf9b-rp266.17ea4b4e105e5c76
7m48s       Normal    Pulled                 pod/stackrox-images-metrics-844fbcf9b-rp266    spec.containers{aggregator}     kubelet, rox-ci-07738368-mp2gg-worker-b-s42z2                                                       Container image "quay.io/stackrox-io/image-prefetcher:v0.2.2" already present on machine                                      7m48s        1       stackrox-images-metrics-844fbcf9b-rp266.17ea4b5252fe8083
7m14s       Normal    Created                pod/stackrox-images-metrics-844fbcf9b-rp266    spec.containers{aggregator}     kubelet, rox-ci-07738368-mp2gg-worker-b-s42z2                                                       Created container aggregator                                                                                                  7m14s        1       stackrox-images-metrics-844fbcf9b-rp266.17ea4b5a31229850
7m14s       Normal    Started                pod/stackrox-images-metrics-844fbcf9b-rp266    spec.containers{aggregator}     kubelet, rox-ci-07738368-mp2gg-worker-b-s42z2                                                       Started container aggregator                                                                                                  7m14s        1       stackrox-images-metrics-844fbcf9b-rp266.17ea4b5a3311480a
9m53s       Normal    SuccessfulCreate       replicaset/stackrox-images-metrics-844fbcf9b                                   replicaset-controller                                                                               Created pod: stackrox-images-metrics-844fbcf9b-rp266                                                                          9m53s        1       stackrox-images-metrics-844fbcf9b.17ea4b354407dcc1
9m53s       Normal    ScalingReplicaSet      deployment/stackrox-images-metrics                                             deployment-controller                                                                               Scaled up replica set stackrox-images-metrics-844fbcf9b to 1                                                                  9m53s        1       stackrox-images-metrics.17ea4b353fc2c328
2m58s       Normal    EnsuringLoadBalancer   service/stackrox-images-metrics                                                service-controller                                                                                  Ensuring load balancer                                                                                                        2m58s        1       stackrox-images-metrics.17ea4b95cc8aa5b3
2m30s       Normal    EnsuredLoadBalancer    service/stackrox-images-metrics                                                service-controller                                                                                  Ensured load balancer                                                                                                         2m30s        1       stackrox-images-metrics.17ea4b9c620d012b
```