### PR TITLE
fix: wait to gke-destroy if cluster is ronconciling

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -329,7 +329,7 @@ teardown_gke_cluster() {
 
     for i in {1..10}; do
         gcloud container clusters describe "${CLUSTER_NAME}" --format "flattened(status)"
-        if [[ "$(gcloud container clusters describe "${CLUSTER_NAME}" --format 'get(status)')" != "PROVISIONING" ]]; then
+        if [[ ! "$(gcloud container clusters describe "${CLUSTER_NAME}" --format 'get(status)')" =~ PROVISIONING|RECONCILING ]]; then
             break
         fi
         info "Before deleting, waiting for cluster ${CLUSTER_NAME} to leave provisioning state (wait $i of 10)"


### PR DESCRIPTION
GKE clusters may be in reconciling state and this can also block cluster deletion.

```
status: RECONCILING
ERROR: (gcloud.container.clusters.delete) Some requests did not succeed: - ResponseError: code=400, message=Operation operation-1723562860856-e922acc1-9c06-45a4-973a-3719024fe971 is currently repairing cluster rox-ci-upgrade-test-1823359127112388608. Please wait and try again once it is done.
```
(https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-upgrade-tests/1823359127112388608)