### PR TITLE
fix: NVD data missing from latest ACS bundles

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -133,7 +133,8 @@ jobs:
         STACKROX_NVD_API_CALL_INTERVAL: 6s
       run: |
         # Use fully qualified path to refer to the NVD bundle
-        export STACKROX_NVD_ZIP_PATH="$(pwd)/nvd.zip"
+        STACKROX_NVD_ZIP_PATH="$(pwd)/nvd.zip"
+        export STACKROX_NVD_ZIP_PATH
 
         DOWNLOAD_URL="https://github.com/stackrox/stackrox/archive/refs/tags/${{ env.ROX_PRODUCT_TAG }}.zip"
         FILE_NAME=$(basename "$DOWNLOAD_URL")

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -131,8 +131,10 @@ jobs:
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
-        STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
+        # Use fully qualified path to refer to the NVD bundle
+        export STACKROX_NVD_ZIP_PATH="$(pwd)/nvd.zip"
+
         DOWNLOAD_URL="https://github.com/stackrox/stackrox/archive/refs/tags/${{ env.ROX_PRODUCT_TAG }}.zip"
         FILE_NAME=$(basename "$DOWNLOAD_URL")
         if ! wget "$DOWNLOAD_URL" -O "$FILE_NAME"; then


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/e83f96d6-aa1e-4644-a6d0-c08387f3bd63)

```
2024-08-16T19:51:07.2144164Z ***"level":"warn","bundle":"nvd","component":"libvuln/updates/Manager.Run","error":"stat nvd.zip: no such file or directory","updater":"nvd","time":"2024-08-16T19:51:07Z","message":"failed configuring updater, excluding from current run"***
```

This appears to be caused by the directory change in the `Update vulnerabilities` step of job `upload-release-vulnerabilities` in workflow`Scanner release vulnerability update`:

![image](https://github.com/user-attachments/assets/7b1bc012-63db-44a6-bf3e-9fc514ae4871)


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

Pending manual dispatch to verify: https://github.com/stackrox/stackrox/actions/runs/10426645191