### PR TITLE
ROX-25770: vm custom sort field

### DIFF
--- a/central/views/common/queries.go
+++ b/central/views/common/queries.go
@@ -22,7 +22,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("critical_severity_count",
+			Filter(search.CriticalSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -32,7 +32,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("fixable_critical_severity_count",
+			Filter(search.FixableCriticalSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -43,7 +43,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("important_severity_count",
+			Filter(search.ImportantSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -53,7 +53,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("fixable_important_severity_count",
+			Filter(search.FixableImportantSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -64,7 +64,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("moderate_severity_count",
+			Filter(search.ModerateSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -74,7 +74,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("fixable_moderate_severity_count",
+			Filter(search.FixableModerateSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -85,7 +85,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("low_severity_count",
+			Filter(search.LowSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,
@@ -95,7 +95,7 @@ func WithCountBySeverityAndFixabilityQuery(q *v1.Query, countOn search.FieldLabe
 		search.NewQuerySelect(countOn).
 			Distinct().
 			AggrFunc(aggregatefunc.Count).
-			Filter("fixable_low_severity_count",
+			Filter(search.FixableLowSeverityCount.Alias(),
 				search.NewQueryBuilder().
 					AddExactMatches(
 						search.Severity,

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -327,6 +327,16 @@ var (
 	ComplianceNotApplicableCount = newDerivedFieldLabelWithType("Compliance Not Applicable Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
 	ComplianceInconsistentCount  = newDerivedFieldLabelWithType("Compliance Inconsistent Count", ComplianceOperatorCheckStatus, CustomFieldType, postgres.Integer)
 
+	// VM custom fields for sorting severity counts
+	CriticalSeverityCount         = newDerivedFieldLabelWithType("Critical Severity Count", Severity, CustomFieldType, postgres.Integer)
+	FixableCriticalSeverityCount  = newDerivedFieldLabelWithType("Fixable Critical Severity Count", Severity, CustomFieldType, postgres.Integer)
+	ImportantSeverityCount        = newDerivedFieldLabelWithType("Important Severity Count", Severity, CustomFieldType, postgres.Integer)
+	FixableImportantSeverityCount = newDerivedFieldLabelWithType("Fixable Important Severity Count", Severity, CustomFieldType, postgres.Integer)
+	ModerateSeverityCount         = newDerivedFieldLabelWithType("Moderate Severity Count", Severity, CustomFieldType, postgres.Integer)
+	FixableModerateSeverityCount  = newDerivedFieldLabelWithType("Fixable Moderate Severity Count", Severity, CustomFieldType, postgres.Integer)
+	LowSeverityCount              = newDerivedFieldLabelWithType("Low Severity Count", Severity, CustomFieldType, postgres.Integer)
+	FixableLowSeverityCount       = newDerivedFieldLabelWithType("Fixable Low Severity Count", Severity, CustomFieldType, postgres.Integer)
+
 	// Max-based derived fields.  These fields are primarily used in pagination.  If used in a select it will correspond
 	// to the type of the reference field and simply provide the max function on that field.
 	ComplianceLastScanMax = newDerivedFieldLabel("Compliance Scan Last Executed Time Max", ComplianceOperatorScanLastExecutedTime, MaxDerivationType)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The severity field uses a filter to get the counts by severity.  This is in support of things like the UI below:
![image](https://github.com/user-attachments/assets/871a4852-49c0-4adf-aa64-18578e324041)



Those values are created using a filter and an a query alias. We previously had no way to expose an efficient sort on an alias like this. https://github.com/stackrox/stackrox/pull/12319 introduced the ability to add a custom sort option that can reference an alias. This enables us to sort on these count values that are based on filters of a single column.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added some unit tests.

Tested all the endpoints that utilize the returning of these fields manually against a cluster. Exercised both ascending and descending sort.  Tested in a graphql editor setting the following sort options and verifying that the order of data returned, was first by `important` and then by `critical`.

![image](https://github.com/user-attachments/assets/a760be79-3a09-406e-9469-e39813d0291b)

