### PR TITLE
fix(sensor-connection): Reset the ok and stop signals on reconnection

### DIFF
--- a/pkg/concurrency/signal.go
+++ b/pkg/concurrency/signal.go
@@ -5,6 +5,15 @@ import (
 	"unsafe"
 )
 
+// ReadOnlySignal provides an interface to inspect a Signal without modifying it.
+type ReadOnlySignal interface {
+	WaitC() WaitableChan
+	Done() <-chan struct{}
+	IsDone() bool
+	Wait()
+	Snapshot() WaitableChan
+}
+
 // Signal implements a signalling facility. Unlike sync.Cond, it is based on channels and can hence be used
 // in `select` statements.
 // There are two ways to instantiate a Signal. The preferred way is by calling `NewSignal()`, which will return a signal

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -75,7 +75,7 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 	// Both signals should not be in a triggered state at the same time.
 	// If we run into this situation something went wrong with the handling of these signals.
 	if f.stopSignal.IsDone() && f.okSignal.IsDone() {
-		log.Warn("the stopSignal and the okSignal are both triggered")
+		log.Warn("Unexpected: the stopSignal and the okSignal are both triggered")
 	}
 	f.stopSignal.Reset()
 	f.okSignal.Reset()

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -40,13 +40,13 @@ func NewCentralConnectionFactory(centralClient *Client) CentralConnectionFactory
 	}
 }
 
-// OkSignal returns a concurrency.Signal that is sends signal once connection object is successfully established
+// OkSignal returns a concurrency.ReadOnlySignal that is sends signal once connection object is successfully established
 // and the util.LazyClientConn pointer is swapped.
 func (f *centralConnectionFactoryImpl) OkSignal() concurrency.ReadOnlySignal {
 	return &f.okSignal
 }
 
-// StopSignal returns a concurrency.Signal that alerts if there is an error trying to establish gRPC connection.
+// StopSignal returns a concurrency.ReadOnlyErrorSignal that alerts if there is an error trying to establish gRPC connection.
 func (f *centralConnectionFactoryImpl) StopSignal() concurrency.ReadOnlyErrorSignal {
 	return &f.stopSignal
 }

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -19,8 +19,8 @@ import (
 // more easily mocked when writing unit/integration tests.
 type CentralConnectionFactory interface {
 	SetCentralConnectionWithRetries(ptr *util.LazyClientConn, certLoader CertLoader)
-	StopSignal() *concurrency.ErrorSignal
-	OkSignal() *concurrency.Signal
+	StopSignal() concurrency.ReadOnlyErrorSignal
+	OkSignal() concurrency.ReadOnlySignal
 }
 
 type centralConnectionFactoryImpl struct {
@@ -42,12 +42,12 @@ func NewCentralConnectionFactory(centralClient *Client) CentralConnectionFactory
 
 // OkSignal returns a concurrency.Signal that is sends signal once connection object is successfully established
 // and the util.LazyClientConn pointer is swapped.
-func (f *centralConnectionFactoryImpl) OkSignal() *concurrency.Signal {
+func (f *centralConnectionFactoryImpl) OkSignal() concurrency.ReadOnlySignal {
 	return &f.okSignal
 }
 
 // StopSignal returns a concurrency.Signal that alerts if there is an error trying to establish gRPC connection.
-func (f *centralConnectionFactoryImpl) StopSignal() *concurrency.ErrorSignal {
+func (f *centralConnectionFactoryImpl) StopSignal() concurrency.ReadOnlyErrorSignal {
 	return &f.stopSignal
 }
 

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -72,6 +72,11 @@ func (f *centralConnectionFactoryImpl) getCentralGRPCPreferences() (*v1.Preferen
 // f.okSignal is used if the connection is successful and f.stopSignal if the
 // connection failed to start. Hence, both signals are reset here.
 func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *util.LazyClientConn, certLoader CertLoader) {
+	// Both signals should not be in a triggered state at the same time.
+	// If we run into this situation something went wrong with the handling of these signals.
+	if f.stopSignal.IsDone() && f.okSignal.IsDone() {
+		log.Warn("the stopSignal and the okSignal are both triggered")
+	}
 	f.stopSignal.Reset()
 	f.okSignal.Reset()
 	opts := []clientconn.ConnectionOption{clientconn.UseServiceCertToken(true)}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -438,8 +438,6 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		case <-s.centralConnectionFactory.StopSignal().WaitC():
 			// Save the error before retrying
 			err := wrapOrNewError(s.centralConnectionFactory.StopSignal().Err(), "communication stopped")
-			// Reset the ok and stop signals
-			s.centralConnectionFactory.Reset()
 			// Connection is still broken, report and try again
 			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
 			return err
@@ -477,7 +475,6 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			// Communication either ended or there was an error. Either way we should retry.
 			// Send notification to all components that we are running in offline mode
 			s.changeState(common.SensorComponentEventOfflineMode)
-			s.centralConnectionFactory.Reset()
 			s.reconnect.Store(true)
 			// Trigger goroutine that will attempt the connection. s.centralConnectionFactory.*Signal() should be
 			// checked to probe connection state.

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -55,13 +55,13 @@ func (f *fakeGRPCClient) SetCentralConnectionWithRetries(ptr *util.LazyClientCon
 
 // StopSignal returns a signal that is sent if there is an error.
 // This signal is never called.
-func (f *fakeGRPCClient) StopSignal() *concurrency.ErrorSignal {
+func (f *fakeGRPCClient) StopSignal() concurrency.ReadOnlyErrorSignal {
 	return &f.stopSig
 }
 
 // OkSignal returns a signal that is sent if connection was swapped.
 // This signal is triggered instantly on calling SetCentralConnectionWithRetries.
-func (f *fakeGRPCClient) OkSignal() *concurrency.Signal {
+func (f *fakeGRPCClient) OkSignal() concurrency.ReadOnlySignal {
 	return &f.okSig
 }
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The `okSignal` and the `stopSignal` should be in the **un-triggered** state when we attempt to reconnect to central. If they're not reset then we can land in a situation where both are triggered and the `select` statement [here](https://github.com/stackrox/stackrox/blob/967702465ce812f74aec0b0cb26f2ae959d4e49d/sensor/common/sensor/sensor.go#L434-L442) will randomly choose one of them. In such a case, if `stopSignal` is chosen we will retry when unnecessary (potentially infinite times) leading to slow reconnects.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Manual testing
- [x] Integration test should pass
