### PR TITLE
chore: Scanner V4 only perform GCS upload from master branch

### DIFF
--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -182,17 +182,18 @@ jobs:
 
     - name: Upload GH artifact
       if: ${{ github.ref_name != 'master' }}
-      uses: actions/upload-artifact@v4
+      uses: ./.github/actions/upload-artifact-with-retry
       with:
         name: ${{ env.ROX_PRODUCT_VERSION }}
         path: ${{ env.ROX_PRODUCT_VERSION }}
+        if-no-files-found: error
 
   send-notification:
     needs:
     - read-release-versions
     - upload-release-vulnerabilities
     runs-on: ubuntu-latest
-    if: failure()
+    if: ${{ failure() && github.ref_name == 'master' }}
     steps:
     - name: Send Slack notification on workflow failure
       run: |

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -115,9 +115,16 @@ jobs:
         df -h
 
     - name: Authenticate with Google Cloud
+      if: github.ref_name == 'master'
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+
+    - name: Authenticate with Google Cloud
+      if: github.ref_name != 'master'
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
@@ -128,7 +135,6 @@ jobs:
         path: .
 
     - name: Update vulnerabilities
-      id: upload-vulnerabilities
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
@@ -162,10 +168,6 @@ jobs:
 
         mkdir ${{ env.ROX_PRODUCT_VERSION }}
 
-        # Save the bundle dir as a job output so that we can create a GH artifact of its
-        # contents in a later step (as needed).
-        echo "VULN_OUTPUT_DIR=$(pwd)/${{ env.ROX_PRODUCT_VERSION }}" >> "$GITHUB_OUTPUT"
-
         # Run updater per release/product version.
         case "${{ env.ROX_PRODUCT_VERSION }}" in
         4.4.*)
@@ -177,21 +179,15 @@ jobs:
             ;;
         esac
 
-        # Upload all bundles if running against master branch.
-        cmd=()
+        bucket="gs://definitions.stackrox.io/v4/vulnerability-bundles"
         if [[ "${{ github.ref_name }}" != "master" ]]; then
-          echo "Ref '${{ github.ref_name }}' is not master."
-          cmd+=(echo "Would do:")
+          # If dispatched from a branch other then master, upload bundles
+          # to a test bucket for inspection.
+          bucket="gs://scanner-v4-test/vulnerability-bundles"
         fi
-        "${cmd[@]}" gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
 
-    - name: Upload GH artifact
-      if: ${{ github.ref_name != 'master' }}
-      uses: ./.github/actions/upload-artifact-with-retry
-      with:
-        name: ${{ env.ROX_PRODUCT_VERSION }}
-        path: ${{ steps.upload-vulnerabilities.outputs.VULN_OUTPUT_DIR }}
-        if-no-files-found: error
+        echo "Copying ${{ env.ROX_PRODUCT_VERSION }} to $bucket"
+        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "$bucket"
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -162,7 +162,7 @@ jobs:
 
         mkdir ${{ env.ROX_PRODUCT_VERSION }}
 
-        # Save the bundle dir as a job output so that we can create a GH artifact of its 
+        # Save the bundle dir as a job output so that we can create a GH artifact of its
         # contents in a later step (as needed).
         echo "VULN_OUTPUT_DIR=$(pwd)/${{ env.ROX_PRODUCT_VERSION }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -184,7 +184,7 @@ jobs:
       if: ${{ github.ref_name != 'master' }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.ROX_PRODUCT_VERSION }} 
+        name: ${{ env.ROX_PRODUCT_VERSION }}
         path: ${{ env.ROX_PRODUCT_VERSION }}
 
   send-notification:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -172,8 +172,20 @@ jobs:
             ;;
         esac
 
-        # Upload all bundles.
-        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
+        # Upload all bundles if running against master branch.
+        cmd=()
+        if [[ "${{ github.ref_name }}" != "master" ]]; then
+          echo "Ref '${{ github.ref_name }}' is not master."
+          cmd+=(echo "Would do:")
+        fi
+        "${cmd[@]}" gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
+
+    - name: Upload GH artifact
+      if: ${{ github.ref_name != 'master' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ROX_PRODUCT_VERSION }} 
+        path: ${{ env.ROX_PRODUCT_VERSION }}
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -128,6 +128,7 @@ jobs:
         path: .
 
     - name: Update vulnerabilities
+      id: upload-vulnerabilities
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
@@ -161,6 +162,10 @@ jobs:
 
         mkdir ${{ env.ROX_PRODUCT_VERSION }}
 
+        # Save the bundle dir as a job output so that we can create a GH artifact of its 
+        # contents in a later step (as needed).
+        echo "VULN_OUTPUT_DIR=$(pwd)/${{ env.ROX_PRODUCT_VERSION }}" >> "$GITHUB_OUTPUT"
+
         # Run updater per release/product version.
         case "${{ env.ROX_PRODUCT_VERSION }}" in
         4.4.*)
@@ -185,7 +190,7 @@ jobs:
       uses: ./.github/actions/upload-artifact-with-retry
       with:
         name: ${{ env.ROX_PRODUCT_VERSION }}
-        path: ${{ env.ROX_PRODUCT_VERSION }}
+        path: ${{ steps.upload-vulnerabilities.outputs.VULN_OUTPUT_DIR}}
         if-no-files-found: error
 
   send-notification:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -190,7 +190,7 @@ jobs:
       uses: ./.github/actions/upload-artifact-with-retry
       with:
         name: ${{ env.ROX_PRODUCT_VERSION }}
-        path: ${{ steps.upload-vulnerabilities.outputs.VULN_OUTPUT_DIR}}
+        path: ${{ steps.upload-vulnerabilities.outputs.VULN_OUTPUT_DIR }}
         if-no-files-found: error
 
   send-notification:


### PR DESCRIPTION
### Description

Changes the `Scanner release vulnerability update` workflow to upload to the user facing GCS bucket when run from master branch, and a test GCS bucket when run from any other branch. 

Also changes slack notifications to only be sent on failures on master branch runs (vs. any branch)

Why:
- Reduces chances of uploading garbage to the user facing GCS bucket
  - Changes in non-master branches may not be tested / valid
- Reduces chances of users experiencing 'flapping data'
  - Any vuln bundle changes uploaded to GCS via a non-master branch will be overwritten by the next scheduled job on master.
- Helps support focus on what's important
  - Notifications sent from non-master runs are a distraction

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No tests added

#### How I validated my change

**Will need to validate on master post merge.**

Manually dispatched: https://github.com/stackrox/stackrox/actions/runs/10496483626

Results pending...

<details>
<summary>Testing from prior change which used GH artifact instead of GCS bucket</summary>

Manually dispatched: https://github.com/stackrox/stackrox/actions/runs/10461669373

Canceled job after first bundle produced - that's all that was needed to validate the functionality on a non-master branch. 

![image](https://github.com/user-attachments/assets/40d20547-7a18-497d-827c-40ae4953eac4)
 

<img width="772" alt="image" src="https://github.com/user-attachments/assets/3fc8e956-eaa1-4dee-b328-525164a39372">

</details>