### PR TITLE
ROX-25717: Improve the text for configuring cluster for updates

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -56,7 +56,8 @@ function ClusterDeployment({
                     >
                         <Title headingLevel="h3">1. Download files</Title>
                         <Text>Download the required configuration files, keys, and scripts.</Text>
-                        <Text>Enabling automatic upgrades creates a powerful service account in your secured cluster.</Text>
+                        <Text>Enabling automatic upgrades creates a powerful service account in your</Text>
+                        <Text>secured cluster that will be used to perform the upgrades.</Text>
                         <Switch
                             label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."
                             labelOff="Automatic upgrades OFF: Will not upgrade secured clusters automatically."

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -55,9 +55,11 @@ function ClusterDeployment({
                         spaceItems={{ default: 'spaceItemsMd' }}
                     >
                         <Title headingLevel="h3">1. Download files</Title>
-                        <Text>Download the required configuration files, keys, and scripts.</Text>
-                        <Text>Enabling automatic upgrades creates a powerful service account in</Text>
-                        <Text>your secured cluster that will be used to perform the upgrades.</Text>
+                        <Text>
+                            Download the required configuration files, keys, and scripts.
+                            Enabling automatic upgrades creates a powerful service account in
+                            your secured cluster that will be used to perform the upgrades.
+                        </Text>
                         <Switch
                             label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."
                             labelOff="Automatic upgrades OFF: Will not upgrade secured clusters automatically."

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -56,9 +56,9 @@ function ClusterDeployment({
                     >
                         <Title headingLevel="h3">1. Download files</Title>
                         <Text>
-                            Download the required configuration files, keys, and scripts.
-                            Enabling automatic upgrades creates a powerful service account in
-                            your secured cluster that will be used to perform the upgrades.
+                            Download the required configuration files, keys, and scripts. Enabling
+                            automatic upgrades creates a powerful service account in your secured
+                            cluster that will be used to perform the upgrades.
                         </Text>
                         <Switch
                             label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -61,7 +61,7 @@ function ClusterDeployment({
                             cluster that will be used to perform the upgrades.
                         </Text>
                         <Switch
-                            label="Automatic upgrades ON: Secured clusters are upgraded automatically when behind Central's version."
+                            label="Automatic upgrades ON: Secured Clusters are upgraded automatically to match Central's version."
                             labelOff="Automatic upgrades OFF: Secured clusters are not upgraded automatically."
                             onChange={toggleSA}
                             isChecked={createUpgraderSA}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -56,9 +56,10 @@ function ClusterDeployment({
                     >
                         <Title headingLevel="h3">1. Download files</Title>
                         <Text>Download the required configuration files, keys, and scripts.</Text>
+                        <Text>Enabling automatic upgrades creates a powerful service account in your secured cluster.</Text>
                         <Switch
-                            label="Cluster is configured to allow future automatic upgrades"
-                            labelOff="Click to configure cluster to allow future automatic upgrades"
+                            label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."
+                            labelOff="Automatic upgrades OFF: Will not upgrade secured clusters automatically."
                             onChange={toggleSA}
                             isChecked={createUpgraderSA}
                         />

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -56,8 +56,8 @@ function ClusterDeployment({
                     >
                         <Title headingLevel="h3">1. Download files</Title>
                         <Text>Download the required configuration files, keys, and scripts.</Text>
-                        <Text>Enabling automatic upgrades creates a powerful service account in your</Text>
-                        <Text>secured cluster that will be used to perform the upgrades.</Text>
+                        <Text>Enabling automatic upgrades creates a powerful service account in</Text>
+                        <Text>your secured cluster that will be used to perform the upgrades.</Text>
                         <Switch
                             label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."
                             labelOff="Automatic upgrades OFF: Will not upgrade secured clusters automatically."

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -61,8 +61,8 @@ function ClusterDeployment({
                             cluster that will be used to perform the upgrades.
                         </Text>
                         <Switch
-                            label="Automatic upgrades ON: Will upgrade secured clusters with versions behind central's."
-                            labelOff="Automatic upgrades OFF: Will not upgrade secured clusters automatically."
+                            label="Automatic upgrades ON: Secured clusters are upgraded automatically when behind Central's version."
+                            labelOff="Automatic upgrades OFF: Secured clusters are not upgraded automatically."
                             onChange={toggleSA}
                             isChecked={createUpgraderSA}
                         />


### PR DESCRIPTION
### Description

Improve the explanation of what toggling the automatic upgrade button does in the UI

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Created a cluster and had a look at the UI

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/b237283a-1941-46c9-a49b-51613696860d">
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/97f078b9-bce4-4104-a43d-097decced21b">
