### PR TITLE
ROX-25643: Handle missing ranker for ns/cluster

### DIFF
--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -100,14 +100,22 @@ func (ds *datastoreImpl) initializeRanker() {
 		nsScores[deployment.GetNamespaceId()] += riskScore
 	}
 
-	// update namespace risk scores
-	for id, score := range nsScores {
-		ds.nsRanker.Add(id, score)
+	if ds.nsRanker != nil {
+		// update namespace risk scores
+		for id, score := range nsScores {
+			ds.nsRanker.Add(id, score)
+		}
+	} else {
+		log.Warn("Not updating namespace risk scores, no ranker found")
 	}
 
-	// update cluster risk scores
-	for id, score := range clusterScores {
-		ds.clusterRanker.Add(id, score)
+	if ds.clusterRanker != nil {
+		// update cluster risk scores
+		for id, score := range clusterScores {
+			ds.clusterRanker.Add(id, score)
+		}
+	} else {
+		log.Warn("Not updating cluster risk scores, no ranker found")
 	}
 }
 


### PR DESCRIPTION
### Description

Update risk scores only of the ranker is present. This doesn't change anything on the main path, but makes it easier to use deployment datastorage in isolation, e.g. for other tools.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manually validated via creating an isolated tool using the storage in this way.