### PR TITLE
ROX-25643: Add NewStorage method for namespace datastore

### DIFF
--- a/central/namespace/datastore/datastore.go
+++ b/central/namespace/datastore/datastore.go
@@ -7,9 +7,11 @@ import (
 	"github.com/pkg/errors"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/namespace/datastore/internal/store"
+	pgStore "github.com/stackrox/rox/central/namespace/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	pg "github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -46,6 +48,14 @@ func New(nsStore store.Store, deploymentDataStore deploymentDataStore.DataStore,
 		namespaceRanker:   namespaceRanker,
 		formattedSearcher: formatSearcherV2(nsStore, namespaceRanker),
 	}
+}
+
+// Constructor of the namespace storage takes a Store object as an argument,
+// but it's an internal type which could not be constructed outside. Such
+// approach limits the ways how namespace storage could be instantiated to only
+// the singleton. This method allows to avoid the limitation.
+func NewStorage(db pg.DB) store.Store {
+	return pgStore.New(db)
 }
 
 var (


### PR DESCRIPTION
### Description

Currently the implementation limits the ways how the datastore could be instantiated only to the singleton. Allow it to be used in isolation as well via providing a method to get the Store object.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manually validated via creating a tool that uses the storage in this way.