### PR TITLE
ROX-25472: Add Microsoft Sentinel feature flag

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -27,6 +27,7 @@ var (
 
 // registerFeature registers and returns a new feature flag, configured with the
 // provided options.
+// If no option is provided the feature is disabled by default.
 func registerFeature(name, envVar string, options ...option) FeatureFlag {
 	if !strings.HasPrefix(envVar, "ROX_") {
 		panic(fmt.Sprintf("invalid env var: %s, must start with ROX_", envVar))

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -122,4 +122,7 @@ var (
 
 	// PolicyAsCode enables policy definition and lifecycle changes to be managed in external repositories.
 	PolicyAsCode = registerFeature("Enables policy definition and lifecycle changes to be managed in external repositories.", "ROX_POLICY_AS_CODE", unchangeableInProd)
+
+	// MicrosoftSentinelNotifier enables the Microsoft Sentinel notifier.
+	MicrosoftSentinelNotifier = registerFeature("Enable the Microsoft Sentinel notifier", "ROX_MICROSOFT_SENTINEL")
 )


### PR DESCRIPTION
### Description

ROX-25472: Add Microsoft Sentinel feature flag

This PR adds a feature flag to disable/enable the Microsoft Sentinel notifier.

### User-facing documentation

- [ ] ~~CHANGELOG is updated **OR** update is not needed~~
- [ ] ~~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

#### How I validated my change
 
 - Run feature flag unit tests locally
 - CI
 - Build successfull