### PR TITLE
ROX-25884: Add contentId prop for accessibity of empty Tab elements

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -26,7 +26,8 @@ describe('Clusters', () => {
             );
         }, staticResponseMapForClusters);
 
-        cy.get('h2:contains("Secure clusters with a reusable init bundle")');
+        // Replace with h2 if refactoring restores h1 element with Clusters
+        cy.get('h1:contains("Secure clusters with a reusable init bundle")');
         // Button text depends whether or not init bundles exist.
         cy.get('button:contains("View installation methods")');
     });

--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -213,6 +213,38 @@ const rules = {
             };
         },
     },
+    'Tab-empty-contentId': {
+        // Require that empty Tab element has tabContentId prop to prevent axe DevTools issue:
+        // ARIA attributes must conform to valid values
+        // https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require that empty Tab element has tabContentId prop',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'Tab') {
+                        if (node.children?.length === 0) {
+                            if (
+                                !node.openingElement?.attributes?.some(
+                                    (nodeAttribute) => nodeAttribute.name?.name === 'tabContentId'
+                                )
+                            ) {
+                                context.report({
+                                    node,
+                                    message: 'Require that empty Tab element has tabContentId prop',
+                                });
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
     'Th-screenReaderText': {
         // Require prop to prevent axe DevTools issue:
         // Table header text should not be empty
@@ -438,7 +470,7 @@ const pluginKey = 'accessibility'; // key of pluginAccessibility in eslint.confi
 
 const pluginAccessibility = {
     meta: {
-        name: 'pluginAccessibility',
+        name: 'accessibility',
         version: '0.0.1',
     },
     rules,

--- a/ui/apps/platform/src/Components/GroupedTabs.js
+++ b/ui/apps/platform/src/Components/GroupedTabs.js
@@ -5,7 +5,7 @@ import upperFirst from 'lodash/upperFirst';
 
 import { useTheme } from 'Containers/ThemeProvider';
 
-const Tab = ({ text, index, active, to }) => (
+const GroupedTab = ({ text, index, active, to }) => (
     <li
         className={`flex flex-grow items-center border-t border-base-400 ${
             active ? 'bg-primary-200' : 'bg-base-100'
@@ -19,7 +19,7 @@ const Tab = ({ text, index, active, to }) => (
     </li>
 );
 
-Tab.propTypes = {
+GroupedTab.propTypes = {
     text: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     active: PropTypes.bool.isRequired,
@@ -58,7 +58,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
                         } flex border-l border-base-400 border-r`}
                     >
                         {grouppedTabs.map((datum, i) => (
-                            <Tab
+                            <GroupedTab
                                 key={datum.value}
                                 index={i}
                                 text={datum.text}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
@@ -7,6 +7,7 @@ import {
     FlexItem,
     Modal,
     Tab,
+    TabContent,
     TabTitleText,
     Tabs,
 } from '@patternfly/react-core';
@@ -17,6 +18,9 @@ import SecureClusterUsingOperator from './SecureClusterUsingOperator';
 type TabKey = 'Operator' | 'Helm';
 
 const headingLevel = 'h2';
+
+const idHelm = 'SecureClusterUsingHelm';
+const idOperator = 'SecureClusterUsingOperator';
 
 export type SecureClusterModalProps = {
     isModalOpen: boolean;
@@ -49,15 +53,27 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
             <Flex direction={{ default: 'column' }}>
                 <FlexItem>
                     <Tabs activeKey={activeKey} onSelect={onSelect}>
-                        <Tab eventKey="Operator" title={<TabTitleText>Operator</TabTitleText>} />
-                        <Tab eventKey="Helm" title={<TabTitleText>Helm chart</TabTitleText>} />
+                        <Tab
+                            eventKey="Operator"
+                            tabContentId={idOperator}
+                            title={<TabTitleText>Operator</TabTitleText>}
+                        />
+                        <Tab
+                            eventKey="Helm"
+                            tabContentId={idHelm}
+                            title={<TabTitleText>Helm chart</TabTitleText>}
+                        />
                     </Tabs>
                     <Divider component="div" />
                 </FlexItem>
                 {activeKey === 'Operator' ? (
-                    <SecureClusterUsingOperator headingLevel={headingLevel} />
+                    <TabContent id={idOperator}>
+                        <SecureClusterUsingOperator headingLevel={headingLevel} />
+                    </TabContent>
                 ) : (
-                    <SecureClusterUsingHelmChart headingLevel={headingLevel} />
+                    <TabContent id={idHelm}>
+                        <SecureClusterUsingHelmChart headingLevel={headingLevel} />
+                    </TabContent>
                 )}
                 <Alert
                     variant="info"

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -31,6 +31,8 @@ import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
 
 import SecureClusterModal from './InitBundles/SecureClusterModal';
 
+const headingLevel = 'h1'; // Replace with h2 if refactoring restores h1 element with Clusters
+
 /*
  * Comments about data flow:
  *
@@ -115,7 +117,7 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                         <EmptyStateHeader
                             titleText="Secure clusters with a reusable init bundle"
                             icon={<EmptyStateIcon icon={CloudSecurityIcon} />}
-                            headingLevel="h2"
+                            headingLevel={headingLevel}
                         />
                         <EmptyStateBody>
                             <Flex

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -40,6 +40,8 @@ import './ViolationsTablePage.css';
 
 const searchCategory = 'ALERTS';
 
+const tabContentId = 'ViolationsTable';
+
 function ViolationsTablePage(): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvancedFiltersEnabled = isFeatureFlagEnabled('ROX_POLICY_VIOLATIONS_ADVANCED_FILTERS');
@@ -220,11 +222,19 @@ function ViolationsTablePage(): ReactElement {
                         setActiveViolationStateTab(tab);
                     }}
                 >
-                    <Tab eventKey="ACTIVE" title={<TabTitleText>Active</TabTitleText>} />
-                    <Tab eventKey="RESOLVED" title={<TabTitleText>Resolved</TabTitleText>} />
+                    <Tab
+                        eventKey="ACTIVE"
+                        tabContentId={tabContentId}
+                        title={<TabTitleText>Active</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey="RESOLVED"
+                        tabContentId={tabContentId}
+                        title={<TabTitleText>Resolved</TabTitleText>}
+                    />
                 </Tabs>
             </PageSection>
-            <PageSection variant="default">
+            <PageSection variant="default" id={tabContentId}>
                 {isLoadingAlerts && (
                     <Bullseye>
                         <Spinner size="xl" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -12,6 +12,7 @@ import {
     PageSection,
     Spinner,
     Tab,
+    TabContent,
     TabTitleText,
     Tabs,
     Title,
@@ -75,6 +76,8 @@ export function getCVEsForUpdatedRequest(exception: VulnerabilityException): str
     }
     return exception.cves;
 }
+
+const tabContentId = 'ExceptionRequestDetails';
 
 function ExceptionRequestDetailsPage() {
     const { requestId } = useParams();
@@ -241,26 +244,32 @@ function ExceptionRequestDetailsPage() {
                     >
                         <Tab
                             eventKey="PENDING_UPDATE"
+                            tabContentId={tabContentId}
                             title={<TabTitleText>Requested update</TabTitleText>}
                         />
                         <Tab
                             eventKey="CURRENT"
+                            tabContentId={tabContentId}
                             title={<TabTitleText>Latest approved</TabTitleText>}
                         />
                     </Tabs>
                 )}
-
-                <PageSection>
-                    <RequestOverview exception={vulnerabilityException} context={selectedContext} />
-                </PageSection>
-                <PageSection>
-                    <RequestCVEsTable
-                        cves={relevantCVEs}
-                        scope={scope}
-                        expandedRowSet={expandedRowSet}
-                        vulnerabilityState={vulnerabilityState}
-                    />
-                </PageSection>
+                <TabContent id={tabContentId}>
+                    <PageSection>
+                        <RequestOverview
+                            exception={vulnerabilityException}
+                            context={selectedContext}
+                        />
+                    </PageSection>
+                    <PageSection>
+                        <RequestCVEsTable
+                            cves={relevantCVEs}
+                            scope={scope}
+                            expandedRowSet={expandedRowSet}
+                            vulnerabilityState={vulnerabilityState}
+                        />
+                    </PageSection>
+                </TabContent>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -60,6 +60,10 @@ function ExceptionRequestsPage() {
         history.push(url);
     };
 
+    /* eslint-disable accessibility/Tab-empty-contentId-prop */
+    // ROX-25890 after React Router upgrade:
+    // Add tabContentId prop to Tab elements.
+    // Add TabContent elements with id props in routes.
     return (
         <>
             <PageTitle title="Exception Management" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -60,7 +60,7 @@ function ExceptionRequestsPage() {
         history.push(url);
     };
 
-    /* eslint-disable accessibility/Tab-empty-contentId-prop */
+    /* eslint-disable accessibility/Tab-empty-contentId */
     // ROX-25890 after React Router upgrade:
     // Add tabContentId prop to Tab elements.
     // Add TabContent elements with id props in routes.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -9,6 +9,7 @@ import {
     Skeleton,
     Bullseye,
     Tab,
+    TabContent,
     Tabs,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -25,6 +26,9 @@ import { getOverviewPagePath } from '../../utils/searchUtils';
 import NodePageHeader, { NodeMetadata, nodeMetadataFragment } from './NodePageHeader';
 import NodePageVulnerabilities from './NodePageVulnerabilities';
 import NodePageDetails from './NodePageDetails';
+
+const idDetails = 'NodePageDetails';
+const idVulnerabilities = 'NodePageVulnerabilities';
 
 const nodeCveOverviewPath = getOverviewPagePath('Node', {
     entityTab: 'Node',
@@ -93,8 +97,16 @@ function NodePage() {
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                         >
-                            <Tab eventKey={vulnTabKey} title={vulnTabKey} />
-                            <Tab eventKey={detailTabKey} title={detailTabKey} />
+                            <Tab
+                                eventKey={vulnTabKey}
+                                tabContentId={idVulnerabilities}
+                                title={vulnTabKey}
+                            />
+                            <Tab
+                                eventKey={detailTabKey}
+                                tabContentId={idDetails}
+                                title={detailTabKey}
+                            />
                         </Tabs>
                     </PageSection>
                     <PageSection
@@ -105,8 +117,16 @@ function NodePage() {
                         role="tabpanel"
                         tabIndex={0}
                     >
-                        {activeTabKey === vulnTabKey && <NodePageVulnerabilities nodeId={nodeId} />}
-                        {activeTabKey === detailTabKey && <NodePageDetails nodeId={nodeId} />}
+                        {activeTabKey === vulnTabKey && (
+                            <TabContent id={idVulnerabilities}>
+                                <NodePageVulnerabilities nodeId={nodeId} />
+                            </TabContent>
+                        )}
+                        {activeTabKey === detailTabKey && (
+                            <TabContent id={idDetails}>
+                                <NodePageDetails nodeId={nodeId} />
+                            </TabContent>
+                        )}
                     </PageSection>
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -8,6 +8,7 @@ import {
     Skeleton,
     Bullseye,
     Tab,
+    TabContent,
     Tabs,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
@@ -25,6 +26,9 @@ import { detailsTabValues } from '../../types';
 import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
 import ClusterPageDetails from './ClusterPageDetails';
 import ClusterPageVulnerabilities from './ClusterPageVulnerabilities';
+
+const idDetails = 'ClusterPageDetails';
+const idVulnerabilities = 'ClusterPageVulnerabilities';
 
 const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
     entityTab: 'Cluster',
@@ -99,8 +103,16 @@ function ClusterPage() {
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                         >
-                            <Tab eventKey={vulnTabKey} title={vulnTabKey} />
-                            <Tab eventKey={detailTabKey} title={detailTabKey} />
+                            <Tab
+                                eventKey={vulnTabKey}
+                                tabContentId={idVulnerabilities}
+                                title={vulnTabKey}
+                            />
+                            <Tab
+                                eventKey={detailTabKey}
+                                tabContentId={idDetails}
+                                title={detailTabKey}
+                            />
                         </Tabs>
                     </PageSection>
                     <PageSection
@@ -109,10 +121,14 @@ function ClusterPage() {
                         className="pf-v5-u-display-flex pf-v5-u-flex-direction-column"
                     >
                         {activeTabKey === vulnTabKey && (
-                            <ClusterPageVulnerabilities clusterId={clusterId} />
+                            <TabContent id={idVulnerabilities}>
+                                <ClusterPageVulnerabilities clusterId={clusterId} />
+                            </TabContent>
                         )}
                         {activeTabKey === detailTabKey && (
-                            <ClusterPageDetails clusterId={clusterId} />
+                            <TabContent id={idDetails}>
+                                <ClusterPageDetails clusterId={clusterId} />
+                            </TabContent>
                         )}
                     </PageSection>
                 </>


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> ARIA attributes must conform to valid values

https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value

```html
<button type="button" data-ouia-component-type="PF5/TabButton" data-ouia-safe="true" class="pf-v5-c-tabs__link" id="pf-tab-ACTIVE-pf-1724248588744l3gaytp96j" aria-controls="pf-tab-section-ACTIVE-pf-1724248588744l3gaytp96j" role="tab" aria-selected="true">
```

### Analysis

Circular reference in which `aria-controls` refers to `id` of `button` element.

> identifies the element (or elements) whose contents or presence are controlled by the element on which this attribute is set

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls

> If a `<TabContent>` component is defined outside of a `<Tabs>` component, use the `tabContentRef` and `tabContentId` properties

https://www.patternfly.org/components/tabs#with-separate-content

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Tabs/Tab.tsx#L80

### Solution

Use `TabContent` element to encapsulate `id` and corresponding `tabContentId` values in the same file.

Convention: use component name as value as simple way to prevent `id` collisions.

1. Edit pluginAccessibility.js file.
    * Add positive `Tab-empty-contentId-prop` rule.
    * Improve `name` to be more intuitive in ignore comments.
2. Edit GroupedTabs.js file.
    * Rename classic `Tab` as `GroupedTab` so that lint rule does not report irrelevant error.
3. Edit SecureClusterModal.tsx file file.
    * Add `id` to `TabContent` and corresponding `tabContentId` props to `Tab` elements.
4. Edit NoClusterPage.tsx file.
    * Replace `h2` with `h1` to fix accessibility issue because of last-minute change that removed `h1` element.
5. Edit ViolationsTablePage.tsx file.
    * Add `id` to `PageSection` and corresponding `tabContentId` props to `Tab` elements.
6. Edit ExceptionRequestDetailsPage.tsx file.
    * Add `id` to `TabContent` and corresponding `tabContentId` props to `Tab` elements.
7. Edit ExceptionRequestsPage.tsx file.
    * Add lint ignore comment to prevent merge conflicts with React Router upgrade.
8. Edit NodePage.tsx file.
    * Add `id` to `TabContent` and corresponding `tabContentId` props to `Tab` elements.
9. Edit ClusterPage.tsx file.
    * Add `id` to `TabContent` and corresponding `tabContentId` props to `Tab` elements.

### Residue

1. Delete container-specific accessibility issues on these pages.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618433 - 4618433
        total 680 = 11711445 - 11710765
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Temporarily edit ClustersTablePanel to simulate no clusters, visit /main/clusters, and then click **View installation methods**

    * Before changes, see presence of accessibility issue.
        ![SecureClusterModal_with_issue](https://github.com/user-attachments/assets/1b56d8c0-8495-46b3-99a7-2656ffcf3689)

    * After changes, see absence of accessibility issue.
        ![SecureClusterModal_without_issue](https://github.com/user-attachments/assets/f29aecd4-e3a4-47fe-b3a6-71645ffb4697)

2. Visit /main/violations

    * Before changes, see presence of accessibility issue.

    * After changes, see absence of accessibility issue.

3. Visit /main/vulnerabilities/workload-cves, request deferral of vulnerability, visit /main/vulnerabilities/exception-management, approve, and then update.

    * Before changes, see presence of accessibility issue.
        ![violations_Tab_with_issue](https://github.com/user-attachments/assets/62f6ea59-c18a-442b-97bf-0a47eee5582a)

    * After changes, see absence of accessibility issue.
        ![violations_Tab_without_issue png](https://github.com/user-attachments/assets/60123bec-0a1e-47a6-bc87-e1d6daa67cb4)

4. Visit /main/vulnerabilities/exception-management

    * See presence of accessibility issue. Follow up to fix after React Router upgrade.
        ![exception-management_Tab_with_issue](https://github.com/user-attachments/assets/e487ad76-c2ad-4fae-837b-f542d9772324)

5. Visit /main/vulnerabilities/platform-cves, click **Clusters**, and then click cluster link

    * Before changes, see presence of accessibility issue.
        ![clusters_id_with_issue](https://github.com/user-attachments/assets/7d8429a1-852f-4c7f-b9f5-dfac3871fe16)

    * After changes, see absence of accessibility issue.
        ![clusters_id_without_issue](https://github.com/user-attachments/assets/765be9a8-8967-4a4a-ab8b-bac1e66da187)

6. Visit /main/vulnerabilities/node-cves, click **Nodes**, and then click node link

    * Before changes, see presence of accessibility issue.
        ![nodes_id_with_issue](https://github.com/user-attachments/assets/820ac2c9-bc69-4e81-bb0e-f66f2453d3e5)

    * After changes, see absence of accessibility issue.
        ![nodes_id_without_issue](https://github.com/user-attachments/assets/a7d359da-8c74-45b1-b6ef-5ef8f3987bec)

#### Integration testing

* clusters/redirectFromDashboard.test.js
