### PR TITLE
ROX-25885: Fix accessibility of contrast in Configuration Management

### DIFF
--- a/ui/apps/platform/src/Components/ExportButton.js
+++ b/ui/apps/platform/src/Components/ExportButton.js
@@ -3,16 +3,15 @@ import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import onClickOutside from 'react-onclickoutside';
 import { toast } from 'react-toastify';
+import { Button } from '@patternfly/react-core';
 
 import downloadCSV from 'services/CSVDownloadService';
 import WorkflowPDFExportButton from 'Components/WorkflowPDFExportButton';
-import Button from 'Components/Button';
+import ButtonClassic from 'Components/Button';
 import useCaseTypes from 'constants/useCaseTypes';
 import entityTypes from 'constants/entityTypes';
 import { addBrandedTimestampToString } from 'utils/dateUtils';
 
-const btnClassName =
-    'btn border-primary-600 bg-primary-600 text-base-100 w-48 hover:bg-primary-700 hover:border-primary-700';
 const queryParamMap = {
     [entityTypes.CLUSTER]: 'clusterId',
     [entityTypes.STANDARD]: 'standardId',
@@ -136,13 +135,19 @@ class ExportButton extends Component {
         return !!this.props.pdfId || this.isCsvSupported() ? (
             <div className={`absolute right-0 z-20 flex flex-col text-base-600 ${wrapperClass}`}>
                 <div className="arrow-up self-end mr-5" />
-                <ul className=" bg-base-100 border-2 border-primary-600 rounded">
-                    <li className="p-4 border-b border-base-400">
+                <ul
+                    className="bg-base-100 rounded"
+                    style={{
+                        borderColor: 'var(--pf-v5-global--primary-color--100)',
+                        borderWidth: 2,
+                    }}
+                >
+                    <li className="p-4 border-b">
                         <div className="flex">
                             {!!this.props.pdfId && (
                                 <WorkflowPDFExportButton
                                     id={this.props.pdfId}
-                                    className={`${btnClassName}  min-w-48 ${
+                                    className={`min-w-48 ${
                                         this.isCsvSupported() ? 'mr-2' : 'w-full'
                                     }`}
                                     tableOptions={this.props.tableOptions}
@@ -154,14 +159,12 @@ class ExportButton extends Component {
                             )}
                             {this.isCsvSupported() && (
                                 <Button
-                                    data-testid="download-csv-button"
-                                    className={btnClassName}
-                                    type="button"
+                                    variant="primary"
                                     onClick={this.downloadCSVFile}
-                                    text={csvButtonText}
                                     isLoading={csvIsDownloading}
-                                    loaderSize={14}
-                                />
+                                >
+                                    {csvButtonText}
+                                </Button>
                             )}
                         </div>
                     </li>
@@ -181,7 +184,7 @@ class ExportButton extends Component {
     render() {
         return (
             <div className="relative pl-2">
-                <Button
+                <ButtonClassic
                     className={this.props.className}
                     disabled={this.props.disabled}
                     text="Export"

--- a/ui/apps/platform/src/Components/RelatedEntity.js
+++ b/ui/apps/platform/src/Components/RelatedEntity.js
@@ -51,7 +51,7 @@ const RelatedEntity = ({
         <button
             data-testid="related-entity-value"
             type="button"
-            className="h-full w-full no-underline text-primary-700 hover:bg-primary-100"
+            className="h-full w-full"
             onClick={onClick}
         >
             {content}

--- a/ui/apps/platform/src/Components/RelatedEntityListCount.js
+++ b/ui/apps/platform/src/Components/RelatedEntityListCount.js
@@ -24,13 +24,13 @@ const RelatedEntityListCount = ({ match, location, history, name, value, entityT
         history.push(url);
     }
 
-    const content = <div className="text-6xl text-lg text-primary-700">{value}</div>;
+    const content = <div className="text-6xl">{value}</div>;
 
     const result = (
         <button
             type="button"
             disabled={value === 0}
-            className="h-full w-full no-underline text-primary-700 hover:bg-primary-100"
+            className="h-full w-full"
             onClick={onClick}
             data-testid="related-entity-list-count-value"
         >

--- a/ui/apps/platform/src/Components/WorkflowPDFExportButton.js
+++ b/ui/apps/platform/src/Components/WorkflowPDFExportButton.js
@@ -5,7 +5,7 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import dateFns from 'date-fns';
 import computedStyleToInlineStyle from 'computed-style-to-inline-style';
-import Button from 'Components/Button';
+import { Button } from '@patternfly/react-core';
 import { enhanceWordBreak } from 'utils/pdfUtils';
 import { getProductBranding } from 'constants/productBranding';
 
@@ -286,13 +286,14 @@ class WorkflowPDFExportButton extends Component {
     render() {
         return (
             <Button
+                variant="primary"
                 isLoading={this.props.isExporting}
-                disabled={this.props.isExporting}
-                dataTestId="download-pdf-button"
+                isDisabled={this.props.isExporting}
                 className={this.props.className}
-                text="Download Page as PDF"
                 onClick={this.saveFn}
-            />
+            >
+                Download Page as PDF
+            </Button>
         );
     }
 }

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -35,20 +35,28 @@ body {
     text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
 }
 
-/* PatternFly style for links in classic widget body and table cell. */
+/* PatternFly style for links in classic related entity, widget body, and table cell. */
 /* Also PatternFly Popover element. */
 
+button[data-testid="related-entity-list-count-value"],
+button[data-testid="related-entity-value"],
 [data-testid="widget-body"] a,
 .rt-td a,
 .pf-v5-c-popover a {
     color: var(--pf-v5-global--link--Color);
 }
 
+button[data-testid="related-entity-list-count-value"]:hover {
+    color: var(--pf-v5-global--link--Color--hover);
+    /* but no underline */
+}
+
+button[data-testid="related-entity-value"]:hover,
 [data-testid="widget-body"] a:hover,
 .rt-td a:hover,
 .pf-v5-c-popover a:hover {
-  color: var(--pf-v5-global--link--Color--hover);
-  text-decoration: var(--pf-v5-global--link--TextDecoration--hover);
+    color: var(--pf-v5-global--link--Color--hover);
+    text-decoration: var(--pf-v5-global--link--TextDecoration--hover);
 }
 
 .pf-v5-c-page__sidebar {


### PR DESCRIPTION
### Description

Compliance dashboard also has issue with **Export** button.

### Problems reported by axe DevTools

> Elements must meet minimum color contrast ratios

https://dequeuniversity.com/rules/axe/4.10/color-contrast

**ExportButton** components

```html
<div class="flex items-center">Download Page as PDF</div>
```

Element has insufficient color contrast of 2.28 (foreground color: #ffffff, background color: #5fb2f7, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1

Related Node

```html
<button type="button" class="btn border-primary-600 bg-primary-600 text-base-100 w-48 hover:bg-primary-700 hover:border-primary-700  min-w-48 w-full" data-testid="download-pdf-button"><div class="flex items-center">Download Page as PDF</div></button>
```

**RelatedEntity** components

```html
<div>remote</div>
```

Element has insufficient color contrast of 3.65 (foreground color: #468bc3, background color: #ffffff, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1

Related Node

```html
<div class="widget flex flex-col shadow rounded relative rounded bg-base-100 mx-4 min-w-48 min-h-48 mb-4" data-testid="related-entity">
```

### Analysis

1. `ExportButton` component renders `button` element with Tailwind classes:
    * `text-base-100`
    * `bg-primary-600`
    * `hover:bg-primary-700`
2. `RelatedEntity` component renders `button` element with Tailwind classes:
    * `text-primary-700`
    * `hover:bg-primary-100`
3. `RelatedEntityListCount` component does similar, but avoids issue because of larger text size.

### Solution

1. Edit ExportButton.js and WorkflowPDFExportButton.js files to render PatternFly `Button` element with `variant="primary"` prop.
2. Edit RelatedEntity.js, RelatedEntityListCount.js, and trumps.css files to render `button` element with PatternFly classes for links.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618433 - 4618433
        total -259 = 11710506 - 11710765
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/configmanagement and then click **Export**

    * Before changes, see presence of accessibility issue.
        ![configmanagement-Export_with_issue](https://github.com/user-attachments/assets/eadf6054-a0f9-42a5-aed0-532cb4068db4)

    * After changes, see absence of accessibility issue.
        ![configmanagement-Export_without_issue](https://github.com/user-attachments/assets/59eef48c-61d5-4b1a-aed7-7b39be15ff7e)

2. Visit /main/configmanagement/namespaces, and then in table: click a namespace link

    * Before changes, see presence of accessibility issue.
        ![configmanagement_namespaces_with_issue](https://github.com/user-attachments/assets/180e980e-ed18-46da-add1-647b3ecee911)

    * After changes, see absence of accessibility issue.
        ![configmanagement_namespaces_without_issue](https://github.com/user-attachments/assets/5323fd29-d296-4cad-9670-3afa8367e23d)

3. Visit /main/compliance, click **Scan environment**, and then click **Export**

    * Before changes, see presence of accessibility issue.
        ![compliance_Export_with_issue](https://github.com/user-attachments/assets/31d86d55-20d6-45e4-9581-4b08ab944e1d)

    * After changes, see absence of accessibility issue.
        ![compliance_Export_without_issue](https://github.com/user-attachments/assets/c578227b-cb12-4c69-b0fc-f3fd60beddd8)

4. Visit /main/vulnerability-management/image-cves or node-cves or cluster-cves, and then click **Export**

    Ditto before and after for **Download Evidence as CSV** button