### PR TITLE
ROX-25886: Fix accessibility of contrast in System Configuration

### DIFF
--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -66,3 +66,11 @@ a[href="/main/search"] {
 .pf-v5-c-popover__close + .pf-v5-c-popover__body > .pf-v5-c-popover__header {
     padding-inline-end: var(--pf-v5-c-popover__close--sibling--PaddingRight);
 }
+
+/*
+ * Fix lack of color contrast in label of ChromePicker element.
+ */
+.chrome-picker input,
+.chrome-picker label {
+    color: var(--pf-v5-global--Color--100) !important; /* instead of #969696 */
+}


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Elements must meet minimum color contrast ratio thresholds

https://dequeuniversity.com/rules/axe/4.10/color-contrast

Element has insufficient color contrast of 2.95 (foreground color: #969696, background color: #ffffff, font size: 8.3pt (11px), font weight: normal). Expected contrast ratio of 4.5:1

```html
<label for="rc-editable-input-1" style="text-transform: uppercase; font-size: 11px; line-height: 11px; color: rgb(150, 150, 150); text-align: center; display: block; margin-top: 12px;">hex</label>
```

Related Node

```html
<div class="chrome-picker " style="width: 225px; background: rgb(255, 255, 255); border-radius: 2px; box-shadow: rgba(0, 0, 0, 0.3) 0px 0px 2px, rgba(0, 0, 0, 0.3) 0px 4px 8px; box-sizing: initial; font-family: Menlo;">
```

### Analysis

Default `color` on `input` that has suffienient contrast ratio but inconsistent with PatternFly:
https://github.com/casesandberg/react-color/blob/master/src/components/chrome/ChromeFields.js#L146

Default `color` of `label` that has insufficient contrast ratio:
https://github.com/casesandberg/react-color/blob/master/src/components/chrome/ChromeFields.js#L158

No way to provide style override.
https://github.com/casesandberg/react-color/blob/master/src/components/chrome/Chrome.js#L134-L141

### Solution

1. Edit /src/css/acs.css file.
    * Add style rules which must have `!important` to override inline style.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/systemConfig, click **Edit**, turn on **Header configuration**, and then click under **Text color**

    * Before changes, see presence of accessibility issue for **color contrast ratio**.
        ![ColorPicker_with_issue](https://github.com/user-attachments/assets/dac66fae-bf5f-4c4f-99df-4216dd288c17)

    * After changes, see absence of accessibility issue for **color contrast ratio**.
        ![ColorPicker_without_issue](https://github.com/user-attachments/assets/f03fd07e-1dfb-4c71-9ff4-d5abe8e65816)
