### PR TITLE
ROX-25916: Fix accessibility issues because Button contains Link

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -217,7 +217,7 @@ const rules = {
     // However, we can write forbid instead of disallow as the verb in description and message.
 
     'no-Button-Link': {
-        // Forbid Button that has Link element as child to prevent axe DevTools issue:
+        // Forbid Button that has Link or HashLink element as child to prevent axe DevTools issue:
         // Interactive controls must not be nested
         // https://dequeuniversity.com/rules/axe/4.10/nested-interactive
         //
@@ -225,7 +225,7 @@ const rules = {
         meta: {
             type: 'problem',
             docs: {
-                description: 'Forbid Button that has Link element as child',
+                description: 'Forbid Button that has Link or HashLink element as child',
             },
             schema: [],
         },
@@ -234,13 +234,13 @@ const rules = {
                 JSXElement(node) {
                     if (node.openingElement?.name?.name === 'Button') {
                         if (
-                            node.children?.some(
-                                (child) => child.openingElement?.name?.name === 'Link'
+                            node.children?.some((child) =>
+                                ['Link', 'HashLink'].includes(child.openingElement?.name?.name)
                             )
                         ) {
                             context.report({
                                 node,
-                                message: 'Forbid Button that has Link element as child',
+                                message: 'Forbid Button that has Link or HashLink element as child',
                             });
                         }
                     }

--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -216,6 +216,38 @@ const rules = {
     // If your rule only disallows something, prefix it with no.
     // However, we can write forbid instead of disallow as the verb in description and message.
 
+    'no-Button-Link': {
+        // Forbid Button that has Link element as child to prevent axe DevTools issue:
+        // Interactive controls must not be nested
+        // https://dequeuniversity.com/rules/axe/4.10/nested-interactive
+        //
+        // The rule does not forbid Button element with component={LinkShim} prop for link that looks like a button.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Forbid Button that has Link element as child',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'Button') {
+                        if (
+                            node.children?.some(
+                                (child) => child.openingElement?.name?.name === 'Link'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message: 'Forbid Button that has Link element as child',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-Popover-footerContent-headerContent-props': {
         // Forbid props that cause axe DevTools issues:
         // Heading levels should only increase by one

--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -217,7 +217,7 @@ const rules = {
     // However, we can write forbid instead of disallow as the verb in description and message.
 
     'no-Button-Link': {
-        // Forbid Button that has Link or HashLink element as child to prevent axe DevTools issue:
+        // Forbid Button that has Link, HashLink, or a element as child to prevent axe DevTools issue:
         // Interactive controls must not be nested
         // https://dequeuniversity.com/rules/axe/4.10/nested-interactive
         //
@@ -225,7 +225,7 @@ const rules = {
         meta: {
             type: 'problem',
             docs: {
-                description: 'Forbid Button that has Link or HashLink element as child',
+                description: 'Forbid Button that has Link, HashLink, or a element as child',
             },
             schema: [],
         },
@@ -235,12 +235,13 @@ const rules = {
                     if (node.openingElement?.name?.name === 'Button') {
                         if (
                             node.children?.some((child) =>
-                                ['Link', 'HashLink'].includes(child.openingElement?.name?.name)
+                                ['Link', 'HashLink', 'a'].includes(child.openingElement?.name?.name)
                             )
                         ) {
                             context.report({
                                 node,
-                                message: 'Forbid Button that has Link or HashLink element as child',
+                                message:
+                                    'Forbid Button that has Link, HashLink, or a element as child',
                             });
                         }
                     }

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -330,14 +330,13 @@ function AuthProviderForm({
                             ) : (
                                 <ToolbarGroup variant="button-group">
                                     <ToolbarItem>
-                                        <Button variant="link" size="sm">
-                                            <Link
-                                                to="/main/access-control/auth-providers"
-                                                aria-current="page"
-                                            >
-                                                Return to auth providers list
-                                            </Link>
-                                        </Button>
+                                        <Link
+                                            to="/main/access-control/auth-providers"
+                                            aria-current="page"
+                                            className="pf-v5-u-font-size-sm"
+                                        >
+                                            Return to auth providers list
+                                        </Link>
                                     </ToolbarItem>
                                     {testModeSupported(selectedAuthProvider) &&
                                         selectedAuthProvider.id && (

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -326,7 +326,7 @@ function GcsIntegrationForm({
                                                 <a
                                                     href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
                                                     target="_blank"
-                                                    rel="noreferrer"
+                                                    rel="noopener noreferrer"
                                                 >
                                                     Red Hat ACS documentation
                                                 </a>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable no-void */
 import React, { ReactElement } from 'react';
 import {
-    Button,
     Checkbox,
     Form,
     FormSelect,
     PageSection,
+    Text,
     TextInput,
     TextArea,
 } from '@patternfly/react-core';
@@ -18,6 +18,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import IntegrationHelpIcon from '../Components/IntegrationHelpIcon';
 import useIntegrationForm from '../../useIntegrationForm';
 import { IntegrationFormProps } from '../../integrationFormTypes';
@@ -314,20 +315,24 @@ function GcsIntegrationForm({
                             <IntegrationHelpIcon
                                 helpTitle="GCP workload identity"
                                 helpText={
-                                    <div>
-                                        Enables authentication via short-lived tokens using GCP
-                                        workload identities. See the{' '}
-                                        <Button variant="link" isInline>
-                                            <a
-                                                href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                Red Hat ACS documentation
-                                            </a>
-                                        </Button>{' '}
-                                        for more information.
-                                    </div>
+                                    <>
+                                        <Text>
+                                            Enables authentication via short-lived tokens using GCP
+                                            workload identities.
+                                        </Text>
+                                        <Text>
+                                            For more information, see{' '}
+                                            <ExternalLink>
+                                                <a
+                                                    href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    Red Hat ACS documentation
+                                                </a>
+                                            </ExternalLink>
+                                        </Text>
+                                    </>
                                 }
                                 ariaLabel="Help for short-lived tokens"
                             />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -328,7 +328,7 @@ function GcsIntegrationForm({
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                 >
-                                                    Red Hat ACS documentation
+                                                    RHACS documentation
                                                 </a>
                                             </ExternalLink>
                                         </Text>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
@@ -407,7 +407,7 @@ function S3CompatibleIntegrationForm({
                                                 <a
                                                     href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
                                                     target="_blank"
-                                                    rel="noreferrer"
+                                                    rel="noopener noreferrer"
                                                 >
                                                     AWS documentation about virtual hosting
                                                 </a>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
@@ -1,6 +1,15 @@
 /* eslint-disable no-void */
 import React, { ReactElement } from 'react';
-import { Button, Checkbox, Form, FormSelect, PageSection, TextInput } from '@patternfly/react-core';
+import {
+    Checkbox,
+    Form,
+    FormSelect,
+    List,
+    ListItem,
+    PageSection,
+    Text,
+    TextInput,
+} from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import * as yup from 'yup';
 
@@ -11,6 +20,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import SelectSingle from 'Components/SelectSingle';
 import IntegrationHelpIcon from '../Components/IntegrationHelpIcon';
 import useIntegrationForm from '../../useIntegrationForm';
@@ -379,23 +389,31 @@ function S3CompatibleIntegrationForm({
                             <IntegrationHelpIcon
                                 helpTitle="Virtual hosting of buckets"
                                 helpText={
-                                    <div>
-                                        Defines the bucket URL addressing. Virtual-hosted-style
-                                        buckets are addressed as
-                                        https://&#60;bucket&#62;.&#60;endpoint&#62; while path-style
-                                        buckets are addressed as
-                                        https://&#60;endpoint&#62;/&#60;bucket&#62;. See the{' '}
-                                        <Button variant="link" isInline>
-                                            <a
-                                                href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                AWS documentation about virtual hosting
-                                            </a>
-                                        </Button>{' '}
-                                        for more information.
-                                    </div>
+                                    <>
+                                        <Text>Defines the bucket URL addressing:</Text>
+                                        <List className="pf-v5-u-py-sm">
+                                            <ListItem>
+                                                Virtual-hosted-style buckets are addressed as
+                                                https://&#60;bucket&#62;.&#60;endpoint&#62
+                                            </ListItem>
+                                            <ListItem>
+                                                Path-style buckets are addressed as
+                                                https://&#60;endpoint&#62;/&#60;bucket&#62;
+                                            </ListItem>
+                                        </List>
+                                        <Text>
+                                            For more information, see{' '}
+                                            <ExternalLink>
+                                                <a
+                                                    href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    AWS documentation about virtual hosting
+                                                </a>
+                                            </ExternalLink>
+                                        </Text>
+                                    </>
                                 }
                                 ariaLabel="Help for URL style"
                             />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -329,7 +329,7 @@ function S3IntegrationForm({
                                                 <a
                                                     href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
                                                     target="_blank"
-                                                    rel="noreferrer"
+                                                    rel="noopener noreferrer"
                                                 >
                                                     AWS S3 documentation
                                                 </a>
@@ -369,7 +369,7 @@ function S3IntegrationForm({
                                                 <a
                                                     href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
                                                     target="_blank"
-                                                    rel="noreferrer"
+                                                    rel="noopener noreferrer"
                                                 >
                                                     AWS S3 documentation
                                                 </a>
@@ -411,7 +411,7 @@ function S3IntegrationForm({
                                                 <a
                                                     href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
                                                     target="_blank"
-                                                    rel="noreferrer"
+                                                    rel="noopener noreferrer"
                                                 >
                                                     Red Hat ACS documentation
                                                 </a>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -413,7 +413,7 @@ function S3IntegrationForm({
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                 >
-                                                    Red Hat ACS documentation
+                                                    RHACS documentation
                                                 </a>
                                             </ExternalLink>
                                         </Text>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-void */
 import React, { ReactElement } from 'react';
-import { Button, Checkbox, Form, FormSelect, PageSection, TextInput } from '@patternfly/react-core';
+import { Checkbox, Form, FormSelect, PageSection, Text, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
@@ -10,6 +10,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import IntegrationHelpIcon from '../Components/IntegrationHelpIcon';
 import useIntegrationForm from '../../useIntegrationForm';
 import { IntegrationFormProps } from '../../integrationFormTypes';
@@ -315,22 +316,26 @@ function S3IntegrationForm({
                             <IntegrationHelpIcon
                                 helpTitle="AWS S3 endpoint"
                                 helpText={
-                                    <div>
-                                        Modifies the endpoint under which S3 is reached. Note that
-                                        when using a non-AWS service provider, it is recommended to
-                                        create an <em>S3 API Compatible</em> integration instead.
-                                        See the{' '}
-                                        <Button variant="link" isInline>
-                                            <a
-                                                href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                AWS S3 documentation
-                                            </a>
-                                        </Button>{' '}
-                                        for more information.
-                                    </div>
+                                    <>
+                                        <Text>
+                                            Modifies the endpoint under which S3 is reached. Note
+                                            that when using a non-AWS service provider, it is
+                                            recommended to create an <em>S3 API Compatible</em>{' '}
+                                            integration instead.
+                                        </Text>
+                                        <Text>
+                                            For more information, see{' '}
+                                            <ExternalLink>
+                                                <a
+                                                    href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    AWS S3 documentation
+                                                </a>
+                                            </ExternalLink>
+                                        </Text>
+                                    </>
                                 }
                                 ariaLabel="Help for AWS S3 endpoint"
                             />
@@ -356,19 +361,21 @@ function S3IntegrationForm({
                             <IntegrationHelpIcon
                                 helpTitle="AWS S3 region"
                                 helpText={
-                                    <div>
-                                        Specifies the AWS region. See the{' '}
-                                        <Button variant="link" isInline>
-                                            <a
-                                                href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                AWS S3 documentation
-                                            </a>
-                                        </Button>{' '}
-                                        for a complete list of AWS regions.
-                                    </div>
+                                    <>
+                                        <Text>Specifies the AWS region.</Text>
+                                        <Text>
+                                            For a complete list of AWS regions, see{' '}
+                                            <ExternalLink>
+                                                <a
+                                                    href="https://docs.aws.amazon.com/general/latest/gr/s3.html"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    AWS S3 documentation
+                                                </a>
+                                            </ExternalLink>
+                                        </Text>
+                                    </>
                                 }
                                 ariaLabel="Help for AWS S3 region"
                             />
@@ -393,20 +400,24 @@ function S3IntegrationForm({
                             <IntegrationHelpIcon
                                 helpTitle="AWS container IAM role"
                                 helpText={
-                                    <div>
-                                        Enables authentication via short-lived tokens using AWS
-                                        Secure Token Service. See the{' '}
-                                        <Button variant="link" isInline>
-                                            <a
-                                                href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                Red Hat ACS documentation
-                                            </a>
-                                        </Button>{' '}
-                                        for more information.
-                                    </div>
+                                    <>
+                                        <Text>
+                                            Enables authentication via short-lived tokens using AWS
+                                            Secure Token Service.
+                                        </Text>
+                                        <Text>
+                                            For more information, see{' '}
+                                            <ExternalLink>
+                                                <a
+                                                    href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    Red Hat ACS documentation
+                                                </a>
+                                            </ExternalLink>
+                                        </Text>
+                                    </>
                                 }
                                 ariaLabel="Help for short-lived tokens"
                             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/CVESummaryLink.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/CVESummaryLink.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { Button } from '@patternfly/react-core';
 
 import workflowStateContext from 'Containers/workflowStateContext';
 import entityTypes from 'constants/entityTypes';
@@ -16,11 +15,7 @@ function CVESummaryLink({ cve, id }: CVESummaryLinkProps): ReactElement {
     const workflowState = useContext(workflowStateContext);
     const url = workflowState.pushRelatedEntity(entityType, id).toUrl();
 
-    return (
-        <Button variant="link" isInline>
-            <Link to={url}>{cve}</Link>
-        </Button>
-    );
+    return <Link to={url}>{cve}</Link>;
 }
 
 export default CVESummaryLink;

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -35,13 +35,14 @@ body {
     text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
 }
 
-/* PatternFly style for links in classic related entity, widget body, and table cell. */
+/* PatternFly style for links in classic related entity, widget body, and React Table cell plus PatternFly table in classic page. */
 /* Also PatternFly Popover element. */
 
 button[data-testid="related-entity-list-count-value"],
 button[data-testid="related-entity-value"],
 [data-testid="widget-body"] a,
 .rt-td a,
+.pf-v5-c-table td a,
 .pf-v5-c-popover a {
     color: var(--pf-v5-global--link--Color);
 }
@@ -54,6 +55,7 @@ button[data-testid="related-entity-list-count-value"]:hover {
 button[data-testid="related-entity-value"]:hover,
 [data-testid="widget-body"] a:hover,
 .rt-td a:hover,
+.pf-v5-c-table td a:hover,
 .pf-v5-c-popover a:hover {
     color: var(--pf-v5-global--link--Color--hover);
     text-decoration: var(--pf-v5-global--link--TextDecoration--hover);


### PR DESCRIPTION
### Description

Thank you, **David** for suggesting that `a` element has same issue!

### Problem reported by axe DevTools

> Interactive controls must not be nested

https://dequeuniversity.com/rules/axe/4.10/nested-interactive

**Images**

```html
<button aria-disabled="false" class="pf-v5-c-button pf-m-link pf-m-inline" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-18">
```

Related Node

```html
<a href="/main/vulnerability-management/images?workflowState[0][t]=IMAGE&amp;workflowState[0][i]=sha256%3A0a4a31f1922e01645702401ac550fd89346244e2868cb9620f32f87fac0b7a5a&amp;workflowState[1][t]=IMAGE_CVE&amp;workflowState[1][i]=CVE-2022-37434%23alpine%3Av3.13">CVE-2022-37434</a>
```

**Auth providers**

```html
<button aria-disabled="false" class="pf-v5-c-button pf-m-link pf-m-small" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-1">
```

Related node

```html
<a aria-current="page" href="/main/access-control/auth-providers">Return to auth providers list</a>
```

### Analysis

Leftovers from our original idiom for link style that I missed in #12207

### Solution

1. Edit pluginAccessibility.js file.
    * Add negative `no-Button-Link` rule.
        The rule does not forbid `Button` element with `component={LinkShim}` prop for link that looks like a button.
2. Edit trumps.css file.
    * Add selector for PatternFly table in classic page.
3. Edit AuthProviderForm.tsx file.
    * Delete `Button` element and replace `size="sm"` with equivalent `className="pf-v5-u-font-size-sm"` prop.
4. Edit CVESummaryLink.tsx file.
    * Delete `Button` element. Even though this is unreachable code, it is easier to test in local deployment than auth provider page.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Temporarily edit VulnMgmtImageOverview.js file to simulate `ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL` turned off, defer a vulnerability, visit a corresponding image side panel in classic Vulnerability Management Images, and then in table: click **Defer CVE** in row actions

    * Before changes, see presence of accessibility issue.
        ![vulnerability-management_images_id_with_issue](https://github.com/user-attachments/assets/535c1994-c6af-4d44-aa88-96f85a1aa344)

    * After changes, see absence of accessibility issue.
        ![vulnerability-management_images_id_without_issue](https://github.com/user-attachments/assets/5941937d-3748-419b-bf49-05e85bba16cb)

2. Visit /main/access-control/auth-providers (on stagingdb) and then in table body: click auth provider link

    * Before changes, see presence of accessibility issue.
        ![access-control_auth-providers_with_issue](https://github.com/user-attachments/assets/4d718442-7667-4bff-8070-8a163ff83eaf)

3. Visit /main/integrations/backups/s3/create and then click question mark at right of **Short-lived tokens** (for one example out of three occurrences)

    * Before changes, see presence of accessibility issue.
        ![integrations_s3_with_issue](https://github.com/user-attachments/assets/b1f7675d-0890-4f21-a309-1d659cfc8b78)

    * After changes, see absence of accessibility issue.
        ![integrations_s3_without_issue](https://github.com/user-attachments/assets/ab2f41ee-877d-412f-be4c-fb3a1e1d7d08)

4. Visit /main/integrations/backups/s3compatible/create and then click question mark at right of **URL style**

    * Before changes, see presence of accessibility issue.
        ![integrations_s3compatible_with_issue](https://github.com/user-attachments/assets/c2cedcb7-eaf7-4391-aa00-1fac32f76ece)

    * After changes, see absence of accessibility issue.
        ![integrations_s3compatible_without_issue](https://github.com/user-attachments/assets/44350275-582c-4256-92a8-2002c14c188d)

5. Visit /main/integrations/backups/gcs/create and then click question mark at right of **Short-lived tokens**

    * Before changes, see presence of accessibility issue.
        ![integrations_gcs_with_issue](https://github.com/user-attachments/assets/9307a5db-7038-427b-ba19-6aca1d33ef66)

    * After changes, see absence of accessibility issue.
        ![integrations_gcs_without_issue](https://github.com/user-attachments/assets/af1cc3eb-2cd6-40e4-942c-6f4809cc3b15)
