### PR TITLE
fix(ui): Disable npm postinstall scripts on konflux builds

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -69,6 +69,14 @@ COPY --chown=default . .
 # This sets branding during UI build time. This is to make sure UI is branded as commercial RHACS (not StackRox).
 # ROX_PRODUCT_BRANDING is also set in the resulting image so that Central Go code knows its RHACS.
 ENV ROX_PRODUCT_BRANDING="RHACS_BRANDING"
+# Default execution of the `npm ci` command causes postinstall scripts to run and spawn a new child process
+# for each script. When building in konflux for s390x and ppc64le architectures, spawing 
+# these child processes causes excessive memory usage and ENOMEM errors, resulting
+# in build failures. Currently the only postinstall scripts that run for the UI dependencies are:
+#   `core-js` prints a banner with links for donations
+#   `cypress` downloads the Cypress binary from the internet
+# In the case of building the `rhacs-main-container`, all of these install scripts can be safely ignored.
+ENV UI_PKG_INSTALL_EXTRA_ARGS="--ignore-scripts"
 
 RUN make -C ui build
 

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -70,7 +70,7 @@ COPY --chown=default . .
 # ROX_PRODUCT_BRANDING is also set in the resulting image so that Central Go code knows its RHACS.
 ENV ROX_PRODUCT_BRANDING="RHACS_BRANDING"
 # Default execution of the `npm ci` command causes postinstall scripts to run and spawn a new child process
-# for each script. When building in konflux for s390x and ppc64le architectures, spawing 
+# for each script. When building in konflux for s390x and ppc64le architectures, spawing
 # these child processes causes excessive memory usage and ENOMEM errors, resulting
 # in build failures. Currently the only postinstall scripts that run for the UI dependencies are:
 #   `core-js` prints a banner with links for donations

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -10,7 +10,7 @@ ROX_PRODUCT_BRANDING ?= $(shell $(MAKE) --quiet --no-print-directory -C .. produ
 export REACT_APP_ROX_PRODUCT_BRANDING := $(ROX_PRODUCT_BRANDING)
 
 deps: apps/platform/package.json apps/platform/package-lock.json
-	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-fund
+	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-fund --no-audit $(UI_PKG_INSTALL_EXTRA_ARGS)
 	@touch deps
 
 .PHONY: printsrcs

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -10,7 +10,7 @@ ROX_PRODUCT_BRANDING ?= $(shell $(MAKE) --quiet --no-print-directory -C .. produ
 export REACT_APP_ROX_PRODUCT_BRANDING := $(ROX_PRODUCT_BRANDING)
 
 deps: apps/platform/package.json apps/platform/package-lock.json
-	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-fund --no-audit $(UI_PKG_INSTALL_EXTRA_ARGS)
+	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-fund $(UI_PKG_INSTALL_EXTRA_ARGS)
 	@touch deps
 
 .PHONY: printsrcs


### PR DESCRIPTION
### Description

Adds the `--ignore-scripts` option to `npm ci` when building in konflux pipelines.

There is [an issue](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1724060332345539) when building in konflux for s390x and ppc64le architectures that causes npm to error out with `ENOMEM` errors during the dependency installation phase.

I suspect, but have not proven, that this could be related to this issue: https://github.com/nodejs/node/issues/25382 where child processes request as much memory as the parent process. Further evidence of this was detected when running `npm ci` with `--loglevel warn --foreground-scripts` which causes `preinstall`/`postinstall`/etc modules scripts to be run in serial after the modules are downloaded. The logs showed that there were four instances of a `postinstall` script being called, and four instances of `ENOMEM` due to a nodejs spawn call.

Digging into the postinstall scripts revealed the following:
- three instances were due to `core-js` and were simple log messages asking for donations
- the fourth instance was `cypress` reaching out to the internet to install the Cypress binary (which would violate the network-less konflux build, and is not needed for this stage in the pipeline)

Adding the `--ignore-scripts` option to `npm ci` ignores these scripts and has resulted in a 100% success rate in konflux builds so far, without the additional need to tweak memory settings.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
