### PR TITLE
chore(proto): use UnmarshalVTUnsafe in pkg

### DIFF
--- a/pkg/cryptoutils/cryptocodec/crypto_codec_test.go
+++ b/pkg/cryptoutils/cryptocodec/crypto_codec_test.go
@@ -38,7 +38,7 @@ func TestGCMEncryptionDecryption(t *testing.T) {
 	assert.NoError(t, err)
 	decryptedBytes := []byte(decryptedText)
 	decryptedCreds := &storage.AWSSecurityHub_Credentials{}
-	err = decryptedCreds.UnmarshalVT(decryptedBytes)
+	err = decryptedCreds.UnmarshalVTUnsafe(decryptedBytes)
 	assert.NoError(t, err)
 	protoassert.Equal(t, originalCreds, decryptedCreds)
 }

--- a/pkg/grpc/common/authn/servicecerttoken/token.go
+++ b/pkg/grpc/common/authn/servicecerttoken/token.go
@@ -32,7 +32,7 @@ func ParseToken(token string, maxLeeway time.Duration) (*x509.Certificate, error
 	}
 
 	var auth central.ServiceCertAuth
-	if err := auth.UnmarshalVT(authBytes); err != nil {
+	if err := auth.UnmarshalVTUnsafe(authBytes); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal service cert auth structure")
 	}
 

--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -44,10 +44,10 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 	require.NoError(t, err, "missing or corrupted config data in config map")
 
 	var policyList storage.PolicyList
-	require.NoError(t, policyList.UnmarshalVT(policiesData), "could not unmarshal policies list")
+	require.NoError(t, policyList.UnmarshalVTUnsafe(policiesData), "could not unmarshal policies list")
 
 	var config storage.DynamicClusterConfig
-	require.NoError(t, config.UnmarshalVT(configData), "could not unmarshal config")
+	require.NoError(t, config.UnmarshalVTUnsafe(configData), "could not unmarshal config")
 
 	cc := centralgrpc.GRPCConnectionToCentral(t)
 
@@ -111,7 +111,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		require.NoError(t, err, "missing or corrupted config data in config map")
 
 		var newPolicyList storage.PolicyList
-		require.NoError(t, newPolicyList.UnmarshalVT(newPoliciesData), "could not unmarshal policies list")
+		require.NoError(t, newPolicyList.UnmarshalVTUnsafe(newPoliciesData), "could not unmarshal policies list")
 		assert.Len(t, newPolicyList.GetPolicies(), len(policyList.GetPolicies())+1, "expected one additional policy")
 		numMatches := 0
 		for _, policy := range newPolicyList.GetPolicies() {
@@ -122,7 +122,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 		assert.Equal(t, 1, numMatches, "expected new policy list to contain new policy exactly once")
 
 		var newConfig storage.DynamicClusterConfig
-		require.NoError(t, newConfig.UnmarshalVT(newConfigData), "could not unmarshal config")
+		require.NoError(t, newConfig.UnmarshalVTUnsafe(newConfigData), "could not unmarshal config")
 		assert.True(t, (&newConfig).EqualVT(&config), "new and old config should be equal")
 	})
 }


### PR DESCRIPTION
### Description

This is the continuation of PR that replaces UnmarshalVT with UnmarshalVTUnsafe that reduces number of allocs
- #12494
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
