### PR TITLE
chore(proto): use UnmarshalVTUnsafe in migrator

### DIFF
--- a/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/notificationschedulestore/postgres_plugin.go
+++ b/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/notificationschedulestore/postgres_plugin.go
@@ -107,7 +107,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.NotificationSche
 	}
 
 	var msg storage.NotificationSchedule
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/migrator/migrations/m_180_to_m_181_move_to_blobstore/schema/convert_blobs.go
+++ b/migrator/migrations/m_180_to_m_181_move_to_blobstore/schema/convert_blobs.go
@@ -22,7 +22,7 @@ func ConvertBlobFromProto(obj *storage.Blob) (*Blobs, error) {
 // ConvertBlobToProto converts Gorm model `Blobs` to its protobuf type object
 func ConvertBlobToProto(m *Blobs) (*storage.Blob, error) {
 	var msg storage.Blob
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_186_to_m_187_add_blob_search/schema/after/convert_blobs.go
+++ b/migrator/migrations/m_186_to_m_187_add_blob_search/schema/after/convert_blobs.go
@@ -25,7 +25,7 @@ func ConvertBlobFromProto(obj *storage.Blob) (*Blobs, error) {
 // ConvertBlobToProto converts Gorm model `Blobs` to its protobuf type object
 func ConvertBlobToProto(m *Blobs) (*storage.Blob, error) {
 	var msg storage.Blob
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_186_to_m_187_add_blob_search/schema/before/convert_blobs.go
+++ b/migrator/migrations/m_186_to_m_187_add_blob_search/schema/before/convert_blobs.go
@@ -22,7 +22,7 @@ func ConvertBlobFromProto(obj *storage.Blob) (*Blobs, error) {
 // ConvertBlobToProto converts Gorm model `Blobs` to its protobuf type object
 func ConvertBlobToProto(m *Blobs) (*storage.Blob, error) {
 	var msg storage.Blob
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/schema/convert_collections.go
+++ b/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/schema/convert_collections.go
@@ -34,7 +34,7 @@ func ConvertResourceCollection_EmbeddedResourceCollectionFromProto(obj *storage.
 // ConvertResourceCollectionToProto converts Gorm model `Collections` to its protobuf type object
 func ConvertResourceCollectionToProto(m *Collections) (*storage.ResourceCollection, error) {
 	var msg storage.ResourceCollection
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/schema/convert_report_configurations.go
+++ b/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/schema/convert_report_configurations.go
@@ -26,7 +26,7 @@ func ConvertReportConfigurationFromProto(obj *storage.ReportConfiguration) (*Rep
 // ConvertReportConfigurationToProto converts Gorm model `ReportConfigurations` to its protobuf type object
 func ConvertReportConfigurationToProto(m *ReportConfigurations) (*storage.ReportConfiguration, error) {
 	var msg storage.ReportConfiguration
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/schema/convert_log_imbues.go
+++ b/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/schema/convert_log_imbues.go
@@ -24,7 +24,7 @@ func ConvertLogImbueFromProto(obj *storage.LogImbue) (*LogImbues, error) {
 // ConvertLogImbueToProto converts Gorm model `LogImbues` to its protobuf type object
 func ConvertLogImbueToProto(m *LogImbues) (*storage.LogImbue, error) {
 	var msg storage.LogImbue
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/test/schema/convert_log_imbues.go
+++ b/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/test/schema/convert_log_imbues.go
@@ -22,7 +22,7 @@ func ConvertLogImbueFromProto(obj *storage.LogImbue) (*LogImbues, error) {
 // ConvertLogImbueToProto converts Gorm model `LogImbues` to its protobuf type object
 func ConvertLogImbueToProto(m *LogImbues) (*storage.LogImbue, error) {
 	var msg storage.LogImbue
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/schema/new/convert_vulnerability_requests.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/schema/new/convert_vulnerability_requests.go
@@ -53,7 +53,7 @@ func ConvertRequestCommentFromProto(obj *storage.RequestComment, idx int, vulner
 // ConvertVulnerabilityRequestToProto converts Gorm model `VulnerabilityRequests` to its protobuf type object
 func ConvertVulnerabilityRequestToProto(m *VulnerabilityRequests) (*storage.VulnerabilityRequest, error) {
 	var msg storage.VulnerabilityRequest
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/schema/convert_listening_endpoints.go
+++ b/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/schema/convert_listening_endpoints.go
@@ -29,7 +29,7 @@ func ConvertProcessListeningOnPortStorageFromProto(obj *storage.ProcessListening
 // ConvertProcessListeningOnPortStorageToProto converts Gorm model `ListeningEndpoints` to its protobuf type object
 func ConvertProcessListeningOnPortStorageToProto(m *ListeningEndpoints) (*storage.ProcessListeningOnPortStorage, error) {
 	var msg storage.ProcessListeningOnPortStorage
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/test/schema/convert_listening_endpoints.go
+++ b/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/test/schema/convert_listening_endpoints.go
@@ -27,7 +27,7 @@ func ConvertProcessListeningOnPortStorageFromProto(obj *storage.ProcessListening
 // ConvertProcessListeningOnPortStorageToProto converts Gorm model `ListeningEndpoints` to its protobuf type object
 func ConvertProcessListeningOnPortStorageToProto(m *ListeningEndpoints) (*storage.ProcessListeningOnPortStorage, error) {
 	var msg storage.ProcessListeningOnPortStorage
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/schema/new/convert_vulnerability_requests.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/schema/new/convert_vulnerability_requests.go
@@ -57,7 +57,7 @@ func ConvertRequestCommentFromProto(obj *storage.RequestComment, idx int, vulner
 // ConvertVulnerabilityRequestToProto converts Gorm model `VulnerabilityRequests` to its protobuf type object
 func ConvertVulnerabilityRequestToProto(m *VulnerabilityRequests) (*storage.VulnerabilityRequest, error) {
 	var msg storage.VulnerabilityRequest
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_notifiers.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_notifiers.go
@@ -22,7 +22,7 @@ func ConvertNotifierFromProto(obj *storage.Notifier) (*Notifiers, error) {
 // ConvertNotifierToProto converts Gorm model `Notifiers` to its protobuf type object
 func ConvertNotifierToProto(m *Notifiers) (*storage.Notifier, error) {
 	var msg storage.Notifier
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_report_configurations.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_report_configurations.go
@@ -36,7 +36,7 @@ func ConvertNotifierConfigurationFromProto(obj *storage.NotifierConfiguration, i
 // ConvertReportConfigurationToProto converts Gorm model `ReportConfigurations` to its protobuf type object
 func ConvertReportConfigurationToProto(m *ReportConfigurations) (*storage.ReportConfiguration, error) {
 	var msg storage.ReportConfiguration
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_report_snapshots.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/schema/convert_report_snapshots.go
@@ -31,7 +31,7 @@ func ConvertReportSnapshotFromProto(obj *storage.ReportSnapshot) (*ReportSnapsho
 // ConvertReportSnapshotToProto converts Gorm model `ReportSnapshots` to its protobuf type object
 func ConvertReportSnapshotToProto(m *ReportSnapshots) (*storage.ReportSnapshot, error) {
 	var msg storage.ReportSnapshot
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_193_to_m_194_policy_updates_for_4_3/schema/convert_policies.go
+++ b/migrator/migrations/m_193_to_m_194_policy_updates_for_4_3/schema/convert_policies.go
@@ -35,7 +35,7 @@ func ConvertPolicyFromProto(obj *storage.Policy) (*Policies, error) {
 // ConvertPolicyToProto converts Gorm model `Policies` to its protobuf type object
 func ConvertPolicyToProto(m *Policies) (*storage.Policy, error) {
 	var msg storage.Policy
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_198_to_m_199_policy_description_and_criteria_updates/schema/convert_policies.go
+++ b/migrator/migrations/m_198_to_m_199_policy_description_and_criteria_updates/schema/convert_policies.go
@@ -35,7 +35,7 @@ func ConvertPolicyFromProto(obj *storage.Policy) (*Policies, error) {
 // ConvertPolicyToProto converts Gorm model `Policies` to its protobuf type object
 func ConvertPolicyToProto(m *Policies) (*storage.Policy, error) {
 	var msg storage.Policy
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policies.go
+++ b/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policies.go
@@ -35,7 +35,7 @@ func ConvertPolicyFromProto(obj *storage.Policy) (*Policies, error) {
 // ConvertPolicyToProto converts Gorm model `Policies` to its protobuf type object
 func ConvertPolicyToProto(m *Policies) (*storage.Policy, error) {
 	var msg storage.Policy
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policy_categories.go
+++ b/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policy_categories.go
@@ -22,7 +22,7 @@ func ConvertPolicyCategoryFromProto(obj *storage.PolicyCategory) (*PolicyCategor
 // ConvertPolicyCategoryToProto converts Gorm model `PolicyCategories` to its protobuf type object
 func ConvertPolicyCategoryToProto(m *PolicyCategories) (*storage.PolicyCategory, error) {
 	var msg storage.PolicyCategory
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policy_category_edges.go
+++ b/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/schema/convert_policy_category_edges.go
@@ -23,7 +23,7 @@ func ConvertPolicyCategoryEdgeFromProto(obj *storage.PolicyCategoryEdge) (*Polic
 // ConvertPolicyCategoryEdgeToProto converts Gorm model `PolicyCategoryEdges` to its protobuf type object
 func ConvertPolicyCategoryEdgeToProto(m *PolicyCategoryEdges) (*storage.PolicyCategoryEdge, error) {
 	var msg storage.PolicyCategoryEdge
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_check_result_v2.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_check_result_v2.go
@@ -32,7 +32,7 @@ func ConvertComplianceOperatorCheckResultV2FromProto(obj *storage.ComplianceOper
 // ConvertComplianceOperatorCheckResultV2ToProto converts Gorm model `ComplianceOperatorCheckResultV2` to its protobuf type object
 func ConvertComplianceOperatorCheckResultV2ToProto(m *ComplianceOperatorCheckResultV2) (*storage.ComplianceOperatorCheckResultV2, error) {
 	var msg storage.ComplianceOperatorCheckResultV2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_profile_v2.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_profile_v2.go
@@ -38,7 +38,7 @@ func ConvertComplianceOperatorProfileV2_RuleFromProto(obj *storage.ComplianceOpe
 // ConvertComplianceOperatorProfileV2ToProto converts Gorm model `ComplianceOperatorProfileV2` to its protobuf type object
 func ConvertComplianceOperatorProfileV2ToProto(m *ComplianceOperatorProfileV2) (*storage.ComplianceOperatorProfileV2, error) {
 	var msg storage.ComplianceOperatorProfileV2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_rule_v2.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_rule_v2.go
@@ -37,7 +37,7 @@ func ConvertRuleControlsFromProto(obj *storage.RuleControls, idx int, compliance
 // ConvertComplianceOperatorRuleV2ToProto converts Gorm model `ComplianceOperatorRuleV2` to its protobuf type object
 func ConvertComplianceOperatorRuleV2ToProto(m *ComplianceOperatorRuleV2) (*storage.ComplianceOperatorRuleV2, error) {
 	var msg storage.ComplianceOperatorRuleV2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_scan_v2.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/schema/new/convert_compliance_operator_scan_v2.go
@@ -28,7 +28,7 @@ func ConvertComplianceOperatorScanV2FromProto(obj *storage.ComplianceOperatorSca
 // ConvertComplianceOperatorScanV2ToProto converts Gorm model `ComplianceOperatorScanV2` to its protobuf type object
 func ConvertComplianceOperatorScanV2ToProto(m *ComplianceOperatorScanV2) (*storage.ComplianceOperatorScanV2, error) {
 	var msg storage.ComplianceOperatorScanV2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/schema/convert_vulnerability_requests.go
+++ b/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/schema/convert_vulnerability_requests.go
@@ -72,7 +72,7 @@ func ConvertApproverFromProto(obj *storage.Approver, idx int, vulnerabilityReque
 // ConvertVulnerabilityRequestToProto converts Gorm model `VulnerabilityRequests` to its protobuf type object
 func ConvertVulnerabilityRequestToProto(m *VulnerabilityRequests) (*storage.VulnerabilityRequest, error) {
 	var msg storage.VulnerabilityRequest
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_image_cve_edges.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_image_cve_edges.go
@@ -26,7 +26,7 @@ func ConvertImageCVEEdgeFromProto(obj *storage.ImageCVEEdge) (*ImageCveEdges, er
 // ConvertImageCVEEdgeToProto converts Gorm model `ImageCveEdges` to its protobuf type object
 func ConvertImageCVEEdgeToProto(m *ImageCveEdges) (*storage.ImageCVEEdge, error) {
 	var msg storage.ImageCVEEdge
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_image_cves.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_image_cves.go
@@ -31,7 +31,7 @@ func ConvertImageCVEFromProto(obj *storage.ImageCVE) (*ImageCves, error) {
 // ConvertImageCVEToProto converts Gorm model `ImageCves` to its protobuf type object
 func ConvertImageCVEToProto(m *ImageCves) (*storage.ImageCVE, error) {
 	var msg storage.ImageCVE
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_images.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_images.go
@@ -54,7 +54,7 @@ func ConvertImageLayerFromProto(obj *storage.ImageLayer, idx int, imageID string
 // ConvertImageToProto converts Gorm model `Images` to its protobuf type object
 func ConvertImageToProto(m *Images) (*storage.Image, error) {
 	var msg storage.Image
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_vulnerability_requests.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/schema/convert_vulnerability_requests.go
@@ -72,7 +72,7 @@ func ConvertApproverFromProto(obj *storage.Approver, idx int, vulnerabilityReque
 // ConvertVulnerabilityRequestToProto converts Gorm model `VulnerabilityRequests` to its protobuf type object
 func ConvertVulnerabilityRequestToProto(m *VulnerabilityRequests) (*storage.VulnerabilityRequest, error) {
 	var msg storage.VulnerabilityRequest
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policies.go
+++ b/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policies.go
@@ -35,7 +35,7 @@ func ConvertPolicyFromProto(obj *storage.Policy) (*Policies, error) {
 // ConvertPolicyToProto converts Gorm model `Policies` to its protobuf type object
 func ConvertPolicyToProto(m *Policies) (*storage.Policy, error) {
 	var msg storage.Policy
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policy_categories.go
+++ b/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policy_categories.go
@@ -22,7 +22,7 @@ func ConvertPolicyCategoryFromProto(obj *storage.PolicyCategory) (*PolicyCategor
 // ConvertPolicyCategoryToProto converts Gorm model `PolicyCategories` to its protobuf type object
 func ConvertPolicyCategoryToProto(m *PolicyCategories) (*storage.PolicyCategory, error) {
 	var msg storage.PolicyCategory
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policy_category_edges.go
+++ b/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/schema/convert_policy_category_edges.go
@@ -23,7 +23,7 @@ func ConvertPolicyCategoryEdgeFromProto(obj *storage.PolicyCategoryEdge) (*Polic
 // ConvertPolicyCategoryEdgeToProto converts Gorm model `PolicyCategoryEdges` to its protobuf type object
 func ConvertPolicyCategoryEdgeToProto(m *PolicyCategoryEdges) (*storage.PolicyCategoryEdge, error) {
 	var msg storage.PolicyCategoryEdge
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/schema/new/convert_clusters.go
+++ b/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/schema/new/convert_clusters.go
@@ -26,7 +26,7 @@ func ConvertClusterFromProto(obj *storage.Cluster) (*Clusters, error) {
 // ConvertClusterToProto converts Gorm model `Clusters` to its protobuf type object
 func ConvertClusterToProto(m *Clusters) (*storage.Cluster, error) {
 	var msg storage.Cluster
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/schema/old/convert_clusters.go
+++ b/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/schema/old/convert_clusters.go
@@ -24,7 +24,7 @@ func ConvertClusterFromProto(obj *storage.Cluster) (*Clusters, error) {
 // ConvertClusterToProto converts Gorm model `Clusters` to its protobuf type object
 func ConvertClusterToProto(m *Clusters) (*storage.Cluster, error) {
 	var msg storage.Cluster
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_images.go
+++ b/migrator/migrations/postgreshelper/schema/convert_images.go
@@ -54,7 +54,7 @@ func ConvertImageLayerFromProto(obj *storage.ImageLayer, idx int, images_Id stri
 // ConvertImageToProto converts Gorm model `Images` to its protobuf type object
 func ConvertImageToProto(m *Images) (*storage.Image, error) {
 	var msg storage.Image
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/version/convert_versions.go
+++ b/migrator/version/convert_versions.go
@@ -28,7 +28,7 @@ func ConvertVersionToProto(m *schema.Versions) (*storage.Version, error) {
 	// During the transition to not use serialized, we may be coming from a database
 	// that uses it.  So if serialized is not nil, we will need to use that
 	if m.Serialized != nil {
-		if err := msg.UnmarshalVT(m.Serialized); err != nil {
+		if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 			return nil, err
 		}
 		return &msg, nil


### PR DESCRIPTION
### Description

This is the continuation of PR that replaces UnmarshalVT with UnmarshalVTUnsafe that reduces number of allocs
- #12494
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
