### PR TITLE
chore(proto): use UnmarshalVTUnsafe in sensor

### DIFF
--- a/sensor/admission-control/settingswatch/common.go
+++ b/sensor/admission-control/settingswatch/common.go
@@ -24,7 +24,7 @@ func decompressAndUnmarshalPolicies(data []byte) (*storage.PolicyList, error) {
 	}
 
 	var policyList storage.PolicyList
-	if err := policyList.UnmarshalVT(runTimePoliciesData); err != nil {
+	if err := policyList.UnmarshalVTUnsafe(runTimePoliciesData); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling decompressed policies data")
 	}
 	return &policyList, nil

--- a/sensor/admission-control/settingswatch/k8s.go
+++ b/sensor/admission-control/settingswatch/k8s.go
@@ -103,7 +103,7 @@ func parseSettings(cm *v1.ConfigMap) (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var config storage.DynamicClusterConfig
-	if err := config.UnmarshalVT(configData); err != nil {
+	if err := config.UnmarshalVTUnsafe(configData); err != nil {
 		return nil, errors.Wrap(err, "could not parse protobuf-encoded config data from configmap")
 	}
 

--- a/sensor/admission-control/settingswatch/mount.go
+++ b/sensor/admission-control/settingswatch/mount.go
@@ -61,7 +61,7 @@ func (m *mountSettingsWatch) OnChange(dir string) (interface{}, error) {
 	}
 
 	var clusterConfig storage.DynamicClusterConfig
-	if err := clusterConfig.UnmarshalVT(configData); err != nil {
+	if err := clusterConfig.UnmarshalVTUnsafe(configData); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling decompressed cluster config data from file %s", configPath)
 	}
 

--- a/sensor/admission-control/settingswatch/persist.go
+++ b/sensor/admission-control/settingswatch/persist.go
@@ -80,7 +80,7 @@ func (p *persister) loadExisting() (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var settings sensor.AdmissionControlSettings
-	if err := settings.UnmarshalVT(bytes); err != nil {
+	if err := settings.UnmarshalVTUnsafe(bytes); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling initial admission control settings from %s", settingsPath)
 	}
 

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -199,7 +199,7 @@ func issuedByStackRoxCA(proxyCert *x509.Certificate) bool {
 
 func (c *Client) parseTLSChallengeResponse(challenge *v1.TLSChallengeResponse) (*v1.TrustInfo, error) {
 	var trustInfo v1.TrustInfo
-	err := trustInfo.UnmarshalVT(challenge.GetTrustInfoSerialized())
+	err := trustInfo.UnmarshalVTUnsafe(challenge.GetTrustInfoSerialized())
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing TrustInfo proto")
 	}

--- a/sensor/tests/helper/trace.go
+++ b/sensor/tests/helper/trace.go
@@ -28,7 +28,7 @@ func (tr *NetworkFlowTraceWriter) Write(data []byte) (int, error) {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 	message := &sensor.NetworkConnectionInfoMessage{}
-	if err := message.UnmarshalVT(data); err != nil {
+	if err := message.UnmarshalVTUnsafe(data); err != nil {
 		return 0, err
 	}
 	select {
@@ -59,7 +59,7 @@ func (tr *ProcessIndicatorTraceWriter) Write(data []byte) (int, error) {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 	message := &sensor.SignalStreamMessage{}
-	if err := message.UnmarshalVT(data); err != nil {
+	if err := message.UnmarshalVTUnsafe(data); err != nil {
 		return 0, err
 	}
 	select {


### PR DESCRIPTION
### Description

This is the continuation of PR that replaces UnmarshalVT with UnmarshalVTUnsafe that reduces number of allocs
- #12494
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
