### PR TITLE
chore(proto): use UnmarshalVTUnsafe in singelton

### DIFF
--- a/central/apitoken/datastore/internal/schedulestore/postgres/store.go
+++ b/central/apitoken/datastore/internal/schedulestore/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.NotificationSche
 	}
 
 	var msg storage.NotificationSchedule
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/config/store/postgres/store.go
+++ b/central/config/store/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Config, bool, er
 	}
 
 	var msg storage.Config
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/delegatedregistryconfig/store/postgres/store.go
+++ b/central/delegatedregistryconfig/store/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.DelegatedRegistr
 	}
 
 	var msg storage.DelegatedRegistryConfig
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/installation/store/postgres/store.go
+++ b/central/installation/store/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.InstallationInfo
 	}
 
 	var msg storage.InstallationInfo
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/notifier/encconfig/datastore/store/postgres/store.go
+++ b/central/notifier/encconfig/datastore/store/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.NotifierEncConfi
 	}
 
 	var msg storage.NotifierEncConfig
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
@@ -138,7 +138,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.SensorUpgradeCon
 	}
 
 	var msg storage.SensorUpgradeConfig
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child1.go
@@ -22,7 +22,7 @@ func ConvertTestChild1FromProto(obj *storage.TestChild1) (*TestChild1, error) {
 // ConvertTestChild1ToProto converts Gorm model `TestChild1` to its protobuf type object
 func ConvertTestChild1ToProto(m *TestChild1) (*storage.TestChild1, error) {
 	var msg storage.TestChild1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child1_p4.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child1_p4.go
@@ -23,7 +23,7 @@ func ConvertTestChild1P4FromProto(obj *storage.TestChild1P4) (*TestChild1P4, err
 // ConvertTestChild1P4ToProto converts Gorm model `TestChild1P4` to its protobuf type object
 func ConvertTestChild1P4ToProto(m *TestChild1P4) (*storage.TestChild1P4, error) {
 	var msg storage.TestChild1P4
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child2.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child2.go
@@ -24,7 +24,7 @@ func ConvertTestChild2FromProto(obj *storage.TestChild2) (*TestChild2, error) {
 // ConvertTestChild2ToProto converts Gorm model `TestChild2` to its protobuf type object
 func ConvertTestChild2ToProto(m *TestChild2) (*storage.TestChild2, error) {
 	var msg storage.TestChild2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g2_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g2_grand_child1.go
@@ -24,7 +24,7 @@ func ConvertTestG2GrandChild1FromProto(obj *storage.TestG2GrandChild1) (*TestG2G
 // ConvertTestG2GrandChild1ToProto converts Gorm model `TestG2GrandChild1` to its protobuf type object
 func ConvertTestG2GrandChild1ToProto(m *TestG2GrandChild1) (*storage.TestG2GrandChild1, error) {
 	var msg storage.TestG2GrandChild1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g3_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g3_grand_child1.go
@@ -22,7 +22,7 @@ func ConvertTestG3GrandChild1FromProto(obj *storage.TestG3GrandChild1) (*TestG3G
 // ConvertTestG3GrandChild1ToProto converts Gorm model `TestG3GrandChild1` to its protobuf type object
 func ConvertTestG3GrandChild1ToProto(m *TestG3GrandChild1) (*storage.TestG3GrandChild1, error) {
 	var msg storage.TestG3GrandChild1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g_grand_child1.go
@@ -22,7 +22,7 @@ func ConvertTestGGrandChild1FromProto(obj *storage.TestGGrandChild1) (*TestGGran
 // ConvertTestGGrandChild1ToProto converts Gorm model `TestGGrandChild1` to its protobuf type object
 func ConvertTestGGrandChild1ToProto(m *TestGGrandChild1) (*storage.TestGGrandChild1, error) {
 	var msg storage.TestGGrandChild1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grand_child1.go
@@ -24,7 +24,7 @@ func ConvertTestGrandChild1FromProto(obj *storage.TestGrandChild1) (*TestGrandCh
 // ConvertTestGrandChild1ToProto converts Gorm model `TestGrandChild1` to its protobuf type object
 func ConvertTestGrandChild1ToProto(m *TestGrandChild1) (*storage.TestGrandChild1, error) {
 	var msg storage.TestGrandChild1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
@@ -45,7 +45,7 @@ func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandpa
 // ConvertTestGrandparentToProto converts Gorm model `TestGrandparents` to its protobuf type object
 func ConvertTestGrandparentToProto(m *TestGrandparents) (*storage.TestGrandparent, error) {
 	var msg storage.TestGrandparent
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
@@ -35,7 +35,7 @@ func ConvertTestParent1_Child1RefFromProto(obj *storage.TestParent1_Child1Ref, i
 // ConvertTestParent1ToProto converts Gorm model `TestParent1` to its protobuf type object
 func ConvertTestParent1ToProto(m *TestParent1) (*storage.TestParent1, error) {
 	var msg storage.TestParent1
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent2.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent2.go
@@ -23,7 +23,7 @@ func ConvertTestParent2FromProto(obj *storage.TestParent2) (*TestParent2, error)
 // ConvertTestParent2ToProto converts Gorm model `TestParent2` to its protobuf type object
 func ConvertTestParent2ToProto(m *TestParent2) (*storage.TestParent2, error) {
 	var msg storage.TestParent2
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent3.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent3.go
@@ -23,7 +23,7 @@ func ConvertTestParent3FromProto(obj *storage.TestParent3) (*TestParent3, error)
 // ConvertTestParent3ToProto converts Gorm model `TestParent3` to its protobuf type object
 func ConvertTestParent3ToProto(m *TestParent3) (*storage.TestParent3, error) {
 	var msg storage.TestParent3
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent4.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent4.go
@@ -23,7 +23,7 @@ func ConvertTestParent4FromProto(obj *storage.TestParent4) (*TestParent4, error)
 // ConvertTestParent4ToProto converts Gorm model `TestParent4` to its protobuf type object
 func ConvertTestParent4ToProto(m *TestParent4) (*storage.TestParent4, error) {
 	var msg storage.TestParent4
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_short_circuits.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_short_circuits.go
@@ -23,7 +23,7 @@ func ConvertTestShortCircuitFromProto(obj *storage.TestShortCircuit) (*TestShort
 // ConvertTestShortCircuitToProto converts Gorm model `TestShortCircuits` to its protobuf type object
 func ConvertTestShortCircuitToProto(m *TestShortCircuits) (*storage.TestShortCircuit, error) {
 	var msg storage.TestShortCircuit
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_single_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_single_key_structs.go
@@ -34,7 +34,7 @@ func ConvertTestSingleKeyStructFromProto(obj *storage.TestSingleKeyStruct) (*Tes
 // ConvertTestSingleKeyStructToProto converts Gorm model `TestSingleKeyStructs` to its protobuf type object
 func ConvertTestSingleKeyStructToProto(m *TestSingleKeyStructs) (*storage.TestSingleKeyStruct, error) {
 	var msg storage.TestSingleKeyStruct
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_single_uuid_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_single_uuid_key_structs.go
@@ -34,7 +34,7 @@ func ConvertTestSingleUUIDKeyStructFromProto(obj *storage.TestSingleUUIDKeyStruc
 // ConvertTestSingleUUIDKeyStructToProto converts Gorm model `TestSingleUUIDKeyStructs` to its protobuf type object
 func ConvertTestSingleUUIDKeyStructToProto(m *TestSingleUUIDKeyStructs) (*storage.TestSingleUUIDKeyStruct, error) {
 	var msg storage.TestSingleUUIDKeyStruct
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_structs.go
@@ -52,7 +52,7 @@ func ConvertTestStruct_NestedFromProto(obj *storage.TestStruct_Nested, idx int, 
 // ConvertTestStructToProto converts Gorm model `TestStructs` to its protobuf type object
 func ConvertTestStructToProto(m *TestStructs) (*storage.TestStruct, error) {
 	var msg storage.TestStruct
-	if err := msg.UnmarshalVT(m.Serialized); err != nil {
+	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/tools/generate-helpers/pg-table-bindings/migration_tool.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/migration_tool.go.tpl
@@ -39,7 +39,7 @@
     // Convert{{$schema.TypeName}}ToProto converts Gorm model `{{$schema.Table|upperCamelCase}}` to its protobuf type object
     func Convert{{$schema.TypeName}}ToProto(m *{{$schema.Table|upperCamelCase}}) ({{$schema.Type}}, error) {
         var msg storage.{{$schema.TypeName}}
-        if err := msg.UnmarshalVT(m.Serialized); err != nil {
+        if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
             return nil, err
         }
         return &msg, nil

--- a/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
@@ -172,7 +172,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*{{.Type}}, bool, error) 
 	}
 
 	var msg {{.Type}}
-	if err := msg.UnmarshalVT(data); err != nil {
+	if err := msg.UnmarshalVTUnsafe(data); err != nil {
         return nil, false, err
 	}
 	return &msg, true, nil


### PR DESCRIPTION
### Description

This is the continuation of PR that replaces UnmarshalVT with UnmarshalVTUnsafe that reduces number of allocs
- #12494
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
