### PR TITLE
ROX-25689: Versioned vulnerabilities in Offline bundles

### DIFF
--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -1,37 +1,47 @@
 name: Scanner release offline vulnerability bundle update
+
 on:
   schedule:
     - cron: '0 */3 * * *'
-  workflow_dispatch:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 
 jobs:
-  read-release-versions:
+  offline-bundle-matrix:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns'))
     outputs:
       matrix: ${{ steps.output-matrix.outputs.matrix }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-    - name: Generate matrix JSON
+    - name: Create matrix
       id: output-matrix
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "matrix<<$EOF" >> "$GITHUB_OUTPUT"
-        # Extract X.Y versions, ensuring uniqueness
-        grep -oE '^[0-9]+\.[0-9]+' scanner/updater/version/RELEASE_VERSION | sort -u | jq -Rs '{ versions: ( sub("\n$"; "")|split("\n") ) }' | tee -a "$GITHUB_OUTPUT"
+        .github/workflows/scripts/scanner-offline-bundle-matrix.sh | tee -a "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-  upload-release-vulnerabilities:
-    needs: read-release-versions
+  offline-bundle-generate:
+    needs: offline-bundle-matrix
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # If one of the versions fails, it should not stop others from succeeding.
-      max-parallel: 1 # Jobs are memory intensive, so only run one at a time.
+      fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.read-release-versions.outputs.matrix).versions }}
+        versions: ${{ fromJson(needs.offline-bundle-matrix.outputs.matrix).versions }}
     env:
-      ROX_PRODUCT_VERSION: ${{ matrix.version }}
+      VULNERABILITY_VERSION: ${{ matrix.versions.vulnerability_version }}
+      SUPPORTED_RELEASES: ${{ matrix.versions.supported_releases }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -40,31 +50,74 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Authenticate with Google Cloud
+    - name: Generate offline bundle
+      run: |
+        .github/workflows/scripts/scanner-update-offline-bundle.sh \
+            bundle \
+            "$VULNERABILITY_VERSION" \
+            "$SUPPORTED_RELEASES"
+
+    - uses: ./.github/actions/upload-artifact-with-retry
+      with:
+        name: offline-bundle-${{ matrix.versions.vulnerability_version }}
+        path: bundle
+        if-no-files-found: error
+
+  offline-bundle-upload:
+    runs-on: ubuntu-latest
+    needs:
+    - offline-bundle-generate
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        path: bundles
+        pattern: offline-bundle-*
+        merge-multiple: true
+
+    - name: Authenticate with Google Cloud (release)
+      if: github.event_name == 'schedule'
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
+    - name: Authenticate with Google Cloud (pull request)
+      if: github.event_name != 'schedule'
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
 
-    - name: Generate offline vulnerability bundle
+    - name: Upload bundles (release)
+      if: github.event_name == 'schedule'
       run: |
-        case "${{ env.ROX_PRODUCT_VERSION }}" in
-        4.4)
-            .github/workflows/scripts/scanner-update-offline-bundle.sh "${{ env.ROX_PRODUCT_VERSION }}" "vulns.json.zst"
-            ;;
-        *)
-            .github/workflows/scripts/scanner-update-offline-bundle.sh "${{ env.ROX_PRODUCT_VERSION }}" "vulnerabilities.zip"
-            ;;
+        cd bundles
+        gsutil cp scanner-v4-defs-*.zip "gs://definitions.stackrox.io/v4/offline-bundles/"
+
+    - name: Upload bundles (pull request)
+      if: github.event_name != 'schedule'
+      run: |
+        branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+        # Replace / with -, so the branch name isn't truncated when pushed to GCS.
+        dir=${branch////-}
+        case $dir in
+        dev|1.0.0)
+          echo "Branch $dir is disallowed"
+          exit 1
         esac
 
-  send-notification:
+        cd bundles
+        ls -lh
+        gsutil cp -r . "gs://scanner-v4-test/offline-bundles/$dir"
+
+  offline-bundle-notification:
     needs:
-    - read-release-versions
-    - upload-release-vulnerabilities
+    - offline-bundle-matrix
+    - offline-bundle-generate
+    - offline-bundle-upload
     runs-on: ubuntu-latest
-    if: failure()
+    if: github.event_name == 'schedule' && failure()
     steps:
     - name: Send Slack notification on workflow failure
       run: |

--- a/.github/workflows/scripts/scanner-offline-bundle-matrix.sh
+++ b/.github/workflows/scripts/scanner-offline-bundle-matrix.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Print the mapping of StackRox releases to scanner vulnerability bundle schema
+# versions. One entry per line, separated by whitespace.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# GITHUB_URL_PATTERN points to vulnerability version file for a given branch/tag.
+GITHUB_URL_PATTERN="https://raw.githubusercontent.com/stackrox/stackrox/%s/scanner/VULNERABILITY_VERSION"
+
+RELEASE_VERSION_FILE="scanner/updater/version/RELEASE_VERSION"
+
+[ -f $RELEASE_VERSION_FILE ] || {
+    echo "error: release version file does not exist: $RELEASE_VERSION_FILE"
+    exit 1
+}
+
+# version_object() prints a JSON object for a bundle version and its supported releases.
+version_object() {
+    local vuln_version=${1?:"missing positional argument 'vuln_version'"}
+    local releases=${2?:"missing positional argument 'releases'"}
+    cat <<EOF
+  {
+    "vulnerability_version": "$vuln_version",
+    "supported_releases": "$releases"
+  }
+EOF
+
+}
+
+main() {
+    # Iterate over all tags that look like StackRox release tags, and output a JSON
+    # array.
+    local vuln_version
+    local vuln_version_url
+
+    declare -A releases
+
+    while read -r tag version _; do
+        # Sanity check.
+        if echo "$version" | grep -q '^[0-4]\.[0-3]'; then
+            echo >&2 "info: skipping pre-V4 tag: $version"
+            continue
+        fi
+        case "$version" in
+            4.4.*|4.5.*)
+                # This is hard-coded to "v1", the initial vulnerability schema
+                # version.
+                vuln_version="v1"
+                ;;
+            *)
+                # Check the vuln version from the repository.
+                # shellcheck disable=SC2059
+                vuln_version_url=$(printf "$GITHUB_URL_PATTERN" "$tag")
+                echo >&2 "info: get vulnerability version: $vuln_version_url"
+                vuln_version=$(curl \
+                                   --fail \
+                                   --silent \
+                                   --show-error \
+                                   --max-time 30 \
+                                   --retry 3 \
+                                   "$vuln_version_url")
+                if [[ -z "$vuln_version" ]]; then
+                    echo >&2 "error: failed to read vulnerability version: URL returned empty"
+                    exit 1
+                fi
+                ;;
+        esac
+        # Words separated by white spaces.
+        releases[$vuln_version]+="$version "
+    done < <("$DIR"/scanner-output-release-versions.sh | jq -r '.versions[] | "\(.tag) \(.version)"')
+    echo '{"versions": ['
+    for v in "${!releases[@]}"; do
+        version_object "$vuln_version" "${releases[$v]% *}"
+        echo ,
+    done
+
+    # Manual entries for backward compatibility with previous releases, where
+    # offline bundle version is tied to the release, not the vulnerability
+    # schema.
+    version_object "4.4.0" "$(grep ^4.4 scanner/updater/version/RELEASE_VERSION | paste -sd ' ')"
+    echo ,
+    version_object "4.5.0" "$(grep ^4.5 scanner/updater/version/RELEASE_VERSION | paste -sd ' ')"
+    echo ']}'
+}
+
+main


### PR DESCRIPTION
### Description

This PR modifies the offline bundle workflow to create offline bundles versioned by vulnerability schema versions, keeping backward compatibility with 4.4 and 4.5 releases.

Changes:

1. Create a matrix based on vulnerability schema found across all supported releases, as defined by `scanner/updater/version/RELEASE_VERSIONS` file.
2. For each execution in the matrix, create a corresponding `scanner-v4-defs-<schema version>.zip` bundle; 4.[45].x releases will be created as well, to ensure backward compatibility.
3. Upload each generated bundle to Github.
4. Download from GitHub and upload to GCP buckets, different locations based workflow triggers (dev or release).

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Currently Scanner does not have integration tests infra or automated UTs for the workflow scripts.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. Run the workflow from the branch trigger (here's [one example](https://github.com/stackrox/stackrox/actions/runs/10624730248).
2. Verify the contents of  the generated bundles

**Content verification**

Expect the following `manifest.json`:

```
{
  "version": "4.4",
  "created": "2024-08-30T00:35:53+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 "
}

{
  "version": "4.5",
  "created": "2024-08-30T00:35:55+00:00",
  "release_versions": "4.5.0 4.5.1 "
}

{
  "version": "v1",
  "created": "2024-08-30T00:36:16+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 4.5.0 4.5.1"
}
```

Using GitHub bundles:

```
for v in 4.4.0 4.5.0 v1; do
  unzip -l offline-bundle-$v.zip
  unzip offline-bundle-$v.zip scanner-v4-defs-${v%.0}.zip
  unzip -l scanner-v4-defs-${v%.0}.zip
  unzip  scanner-v4-defs-${v%.0}.zip -d scanner-v4-defs-${v%.0}
  ls -l scanner-v4-defs-${v%.0}
  cat scanner-v4-defs-${v%.0}/manifest.json
done
Archive:  offline-bundle-4.4.0.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
168339282  2024-08-30 00:35   scanner-v4-defs-4.4.zip
---------                     -------
168339282                     1 file
Archive:  offline-bundle-4.4.0.zip
  inflating: scanner-v4-defs-4.4.zip  
Archive:  scanner-v4-defs-4.4.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      127  2024-08-29 17:35   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
169616507  2024-08-29 17:35   vulns.json.zst
---------                     -------
171966645                     4 files
Archive:  scanner-v4-defs-4.4.zip
  inflating: scanner-v4-defs-4.4/container-name-repos-map.json  
  inflating: scanner-v4-defs-4.4/manifest.json  
  inflating: scanner-v4-defs-4.4/repository-to-cpe.json  
  inflating: scanner-v4-defs-4.4/vulns.json.zst  
total 167948
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       127 Aug 29 17:35 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 169616507 Aug 29 17:35 vulns.json.zst
{
  "version": "4.4",
  "created": "2024-08-30T00:35:53+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 "
}
Archive:  offline-bundle-4.5.0.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
168380237  2024-08-30 00:35   scanner-v4-defs-4.5.zip
---------                     -------
168380237                     1 file
Archive:  offline-bundle-4.5.0.zip
  inflating: scanner-v4-defs-4.5.zip  
Archive:  scanner-v4-defs-4.5.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      103  2024-08-29 17:35   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
168263648  2024-08-29 17:35   vulnerabilities.zip
---------                     -------
170613762                     4 files
Archive:  scanner-v4-defs-4.5.zip
  inflating: scanner-v4-defs-4.5/container-name-repos-map.json  
  inflating: scanner-v4-defs-4.5/manifest.json  
  inflating: scanner-v4-defs-4.5/repository-to-cpe.json  
 extracting: scanner-v4-defs-4.5/vulnerabilities.zip  
total 166624
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       103 Aug 29 17:35 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 168263648 Aug 29 17:35 vulnerabilities.zip
{
  "version": "4.5",
  "created": "2024-08-30T00:35:55+00:00",
  "release_versions": "4.5.0 4.5.1 "
}
Archive:  offline-bundle-v1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
168380254  2024-08-30 00:36   scanner-v4-defs-v1.zip
---------                     -------
168380254                     1 file
Archive:  offline-bundle-v1.zip
  inflating: scanner-v4-defs-v1.zip  
Archive:  scanner-v4-defs-v1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      137  2024-08-29 17:36   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
168263648  2024-08-29 17:36   vulnerabilities.zip
---------                     -------
170613796                     4 files
Archive:  scanner-v4-defs-v1.zip
  inflating: scanner-v4-defs-v1/container-name-repos-map.json  
  inflating: scanner-v4-defs-v1/manifest.json  
  inflating: scanner-v4-defs-v1/repository-to-cpe.json  
 extracting: scanner-v4-defs-v1/vulnerabilities.zip  
total 166620
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       137 Aug 29 17:36 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 168263648 Aug 29 17:36 vulnerabilities.zip
{
  "version": "v1",
  "created": "2024-08-30T00:36:16+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 4.5.0 4.5.1"
}
```

Do the same for the bundles stored in the development GCP bucket:

```
for v in 4.4.0 4.5.0 v1; do
  wget https://storage.googleapis.com/scanner-v4-test/offline-bundles/jvdm-versioned-vulns-offline/scanner-v4-defs-${v%.0}.zip                                                
  unzip -l scanner-v4-defs-${v%.0}.zip
  unzip  scanner-v4-defs-${v%.0}.zip -d scanner-v4-defs-${v%.0}
  ls -l scanner-v4-defs-${v%.0}
  cat scanner-v4-defs-${v%.0}/manifest.json
done
--2024-08-30 11:34:00--  https://storage.googleapis.com/scanner-v4-test/offline-bundles/jvdm-versioned-vulns-offline/scanner-v4-defs-4.4.zip
Resolving storage.googleapis.com (storage.googleapis.com)... 2607:f8b0:400a:80b::201b, 2607:f8b0:400a:800::201b, 2607:f8b0:400a:803::201b, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|2607:f8b0:400a:80b::201b|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 168339282 (161M) [application/zip]
Saving to: ‘scanner-v4-defs-4.4.zip’

scanner-v4-defs-4.4.zip       100%[==============================================>] 160.54M  25.3MB/s    in 6.9s    

2024-08-30 11:34:07 (23.3 MB/s) - ‘scanner-v4-defs-4.4.zip’ saved [168339282/168339282]

Archive:  scanner-v4-defs-4.4.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      127  2024-08-29 17:35   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
169616507  2024-08-29 17:35   vulns.json.zst
---------                     -------
171966645                     4 files
Archive:  scanner-v4-defs-4.4.zip
  inflating: scanner-v4-defs-4.4/container-name-repos-map.json  
  inflating: scanner-v4-defs-4.4/manifest.json  
  inflating: scanner-v4-defs-4.4/repository-to-cpe.json  
  inflating: scanner-v4-defs-4.4/vulns.json.zst  
total 167948
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       127 Aug 29 17:35 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 169616507 Aug 29 17:35 vulns.json.zst
{
  "version": "4.4",
  "created": "2024-08-30T00:35:53+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 "
}
--2024-08-30 11:34:10--  https://storage.googleapis.com/scanner-v4-test/offline-bundles/jvdm-versioned-vulns-offline/scanner-v4-defs-4.5.zip
Resolving storage.googleapis.com (storage.googleapis.com)... 2607:f8b0:400a:805::201b, 2607:f8b0:400a:80b::201b, 2607:f8b0:400a:803::201b, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|2607:f8b0:400a:805::201b|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 168380237 (161M) [application/zip]
Saving to: ‘scanner-v4-defs-4.5.zip’

scanner-v4-defs-4.5.zip       100%[==============================================>] 160.58M  13.8MB/s    in 10s     

2024-08-30 11:34:20 (15.4 MB/s) - ‘scanner-v4-defs-4.5.zip’ saved [168380237/168380237]

Archive:  scanner-v4-defs-4.5.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      103  2024-08-29 17:35   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
168263648  2024-08-29 17:35   vulnerabilities.zip
---------                     -------
170613762                     4 files
Archive:  scanner-v4-defs-4.5.zip
  inflating: scanner-v4-defs-4.5/container-name-repos-map.json  
  inflating: scanner-v4-defs-4.5/manifest.json  
  inflating: scanner-v4-defs-4.5/repository-to-cpe.json  
 extracting: scanner-v4-defs-4.5/vulnerabilities.zip  
total 166620
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       103 Aug 29 17:35 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 168263648 Aug 29 17:35 vulnerabilities.zip
{
  "version": "4.5",
  "created": "2024-08-30T00:35:55+00:00",
  "release_versions": "4.5.0 4.5.1 "
}
--2024-08-30 11:34:22--  https://storage.googleapis.com/scanner-v4-test/offline-bundles/jvdm-versioned-vulns-offline/scanner-v4-defs-v1.zip
Resolving storage.googleapis.com (storage.googleapis.com)... 2607:f8b0:400a:800::201b, 2607:f8b0:400a:805::201b, 2607:f8b0:400a:803::201b, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|2607:f8b0:400a:800::201b|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 168380254 (161M) [application/zip]
Saving to: ‘scanner-v4-defs-v1.zip’

scanner-v4-defs-v1.zip        100%[==============================================>] 160.58M  17.5MB/s    in 10s     

2024-08-30 11:34:32 (15.7 MB/s) - ‘scanner-v4-defs-v1.zip’ saved [168380254/168380254]

Archive:  scanner-v4-defs-v1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    81557  2024-08-28 17:20   container-name-repos-map.json
      137  2024-08-29 17:36   manifest.json
  2268454  2024-08-28 17:20   repository-to-cpe.json
168263648  2024-08-29 17:36   vulnerabilities.zip
---------                     -------
170613796                     4 files
Archive:  scanner-v4-defs-v1.zip
  inflating: scanner-v4-defs-v1/container-name-repos-map.json  
  inflating: scanner-v4-defs-v1/manifest.json  
  inflating: scanner-v4-defs-v1/repository-to-cpe.json  
 extracting: scanner-v4-defs-v1/vulnerabilities.zip  
total 166620
-rw-r--r-- 1 jvdm jvdm     81557 Aug 28 17:20 container-name-repos-map.json
-rw-r--r-- 1 jvdm jvdm       137 Aug 29 17:36 manifest.json
-rw-r--r-- 1 jvdm jvdm   2268454 Aug 28 17:20 repository-to-cpe.json
-rw-r--r-- 1 jvdm jvdm 168263648 Aug 29 17:36 vulnerabilities.zip
{
  "version": "v1",
  "created": "2024-08-30T00:36:16+00:00",
  "release_versions": "4.4.0 4.4.1 4.4.2 4.4.3 4.4.4 4.4.5 4.5.0 4.5.1"
}
```