### PR TITLE
ROX-25963: Add lint rule for accessiblity of CardHeader onExpand

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -36,6 +36,48 @@ const rules = {
             };
         },
     },
+    'CardHeader-onExpand-toggleButtonProps-prop': {
+        // Require prop for aria-label attribute to prevent axe DevTools issue:
+        // Buttons must have discernable text
+        // https://dequeuniversity.com/rules/axe/4.10/button-name
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require that CardHeader element with onExpand has toggleButtonProps prop with aria-label property',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'CardHeader') {
+                        if (
+                            node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'onExpand'
+                            )
+                        ) {
+                            if (
+                                !node.attributes.some(
+                                    (nodeAttribute) =>
+                                        nodeAttribute.name?.name === 'toggleButtonProps' &&
+                                        nodeAttribute.value?.expression?.properties?.some(
+                                            (property) => property?.key?.value === 'aria-label'
+                                        )
+                                )
+                            ) {
+                                context.report({
+                                    node,
+                                    message:
+                                        'Require that CardHeader element with onExpand has toggleButtonProps prop with aria-label property',
+                                });
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
     'Chart-ariaTitle-prop': {
         // Require prop for aria-labelledby attribute to prevent axe DevTools issue:
         // <svg> elements with an img role must have an alternative text

--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -36,7 +36,7 @@ const rules = {
             };
         },
     },
-    'CardHeader-onExpand-toggleButtonProps-prop': {
+    'CardHeader-onExpand-toggleButtonProps': {
         // Require prop for aria-label attribute to prevent axe DevTools issue:
         // Buttons must have discernable text
         // https://dequeuniversity.com/rules/axe/4.10/button-name


### PR DESCRIPTION
### Description

Follow up with prevention after remediation in #11774
### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule for style tests
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform for example of K8sCard.tsx file:
    * no error with `toggleButtonProps` prop and `aria-label` property
    * error with temporary edit to delete `aria-label` property.
    * error with temporary edit to delete `toggleButtonProps` prop.
