### PR TITLE
chore(ci): only notify failed master builds

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -223,7 +223,7 @@ jobs:
     needs:
     - upload-vulnerabilities
     runs-on: ubuntu-latest
-    if: failure()
+    if: ${{ failure() && github.ref_name == 'master' }}
     steps:
     - name: Send Slack notification on workflow failure
       run: |


### PR DESCRIPTION
### Description

Inspired by https://github.com/stackrox/stackrox/pull/12453. This prevents PR builds of dev vulns from notifying the team. There is currently too much noise when testing, so this removes it.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

This is the test

#### How I validated my change

no
