### PR TITLE
ROX-22701: Prevent deleting default policies through the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.
   - To revert back to synchronous TLS checks set `ROX_SENSOR_LAZY_TLS_CHECKS` to `false` on Sensor.
 - ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
+- ROX-22701: Prevent deleting default policies through the API
 
 ## [4.5.0]
 

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -320,10 +320,14 @@ func (s *serviceImpl) DeletePolicy(ctx context.Context, request *v1.ResourceByID
 		return nil, errors.Wrap(errox.InvalidArgs, "A policy id must be specified to delete a Policy")
 	}
 
+	policy, exists, err := s.policies.GetPolicy(ctx, request.GetId())
+	if !exists || err != nil {
+		return &v1.Empty{}, nil
+	}
+
 	// Note: default policies cannot be deleted, only disabled
-	policy, _, _ := s.policies.GetPolicy(ctx, request.GetId())
-	if policy.IsDefault == true {
-		return nil, errors.Wrap(errox.NotImplemented, "A default Policy cannot be deleted. (You can disable a default policy, but not delete it.)")
+	if policy.IsDefault {
+		return nil, errors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
 	}
 
 	if err := s.policies.RemovePolicy(ctx, request.GetId()); err != nil {

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -314,10 +314,16 @@ func (s *serviceImpl) PatchPolicy(ctx context.Context, request *v1.PatchPolicyRe
 	return s.PutPolicy(ctx, policy)
 }
 
-// DeletePolicy deletes an policy from the system.
+// DeletePolicy deletes a policy from the system.
 func (s *serviceImpl) DeletePolicy(ctx context.Context, request *v1.ResourceByID) (*v1.Empty, error) {
 	if request.GetId() == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "A policy id must be specified to delete a Policy")
+	}
+
+	// Note: default policies cannot be deleted, only disabled
+	policy, _, _ := s.policies.GetPolicy(ctx, request.GetId())
+	if policy.IsDefault == true {
+		return nil, errors.Wrap(errox.NotImplemented, "A default Policy cannot be deleted. (You can disable a default policy, but not delete it.)")
 	}
 
 	if err := s.policies.RemovePolicy(ctx, request.GetId()); err != nil {

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -897,3 +897,84 @@ func getFakeVector(tactic string, techniques ...string) *storage.MitreAttackVect
 
 	return resp
 }
+
+func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
+	s.T().Log("foo")
+	ctx := context.Background()
+	basePolicy := fixtures.GetPolicy()
+	policies := make([]*storage.Policy, 4)
+	for i := 0; i < 4; i++ {
+		p := basePolicy.CloneVT()
+		p.Id = fmt.Sprintf("policy-%d", i)
+		policies = append(policies, p)
+	}
+	listPolicies := convertPoliciesToListPolicies(policies)
+	policyDisabledBaseQuery := &v1.Query_BaseQuery{
+		BaseQuery: &v1.BaseQuery{
+			Query: &v1.BaseQuery_MatchFieldQuery{
+				MatchFieldQuery: &v1.MatchFieldQuery{Field: search.Disabled.String(), Value: "false"},
+			},
+		},
+	}
+
+	cases := []struct {
+		name          string
+		request       *v1.RawQuery
+		expectedQuery *v1.Query
+	}{
+		{
+			name:          "Empty query, get all policies",
+			request:       &v1.RawQuery{},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: maxPoliciesReturned, Offset: 0}},
+		},
+		{
+			name:          "Empty query, paginate",
+			request:       &v1.RawQuery{Pagination: &v1.Pagination{Limit: 2}},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: 2, Offset: 0}},
+		},
+		{
+			name:          "Empty query, paginate and offset",
+			request:       &v1.RawQuery{Pagination: &v1.Pagination{Limit: 20, Offset: 4}},
+			expectedQuery: &v1.Query{Pagination: &v1.QueryPagination{Limit: 20, Offset: 4}},
+		},
+		{
+			name:    "Non-empty query gets parsed properly",
+			request: &v1.RawQuery{Query: search.NewQueryBuilder().AddBools(search.Disabled, false).Query()},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: maxPoliciesReturned, Offset: 0},
+			},
+		},
+		{
+			name: "Non-empty query gets parsed properly, paginate",
+			request: &v1.RawQuery{
+				Query:      search.NewQueryBuilder().AddBools(search.Disabled, false).Query(),
+				Pagination: &v1.Pagination{Limit: 2},
+			},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: 2, Offset: 0},
+			},
+		},
+		{
+			name: "Non-empty query gets parsed properly, limit pagination to max and offset",
+			request: &v1.RawQuery{
+				Query:      search.NewQueryBuilder().AddBools(search.Disabled, false).Query(),
+				Pagination: &v1.Pagination{Limit: 2000, Offset: 50},
+			},
+			expectedQuery: &v1.Query{
+				Query:      policyDisabledBaseQuery,
+				Pagination: &v1.QueryPagination{Limit: 1000, Offset: 50},
+			},
+		},
+	}
+	for _, c := range cases {
+		s.T().Run(c.name, func(t *testing.T) {
+			s.policies.EXPECT().SearchRawPolicies(ctx, c.expectedQuery).Return(policies, nil).Times(1)
+			resp, err := s.tested.ListPolicies(ctx, c.request)
+			s.NoError(err)
+			s.NotNil(resp)
+			protoassert.SlicesEqual(s.T(), listPolicies, resp.Policies)
+		})
+	}
+}

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -916,6 +916,6 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 	resp, err := s.tested.DeletePolicy(ctx, fakeResourceByIDRequest)
 
 	// assert
-	errors.Is(err, expectedError)
-	s.Nil(resp)
+        s.Require().Error(err, tc.expectedErr)
+	s.Require().Nil(resp)
 }

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -908,7 +908,7 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 		Id:        mockRequestOneID.PolicyIds[0],
 		IsDefault: true,
 	}
-	expectedError := errors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
+	expectedErr := errors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
 	s.policies.EXPECT().GetPolicy(ctx, mockPolicy.Id).Return(mockPolicy, true, nil)
 
 	// act
@@ -916,6 +916,6 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 	resp, err := s.tested.DeletePolicy(ctx, fakeResourceByIDRequest)
 
 	// assert
-        s.Require().Error(err, tc.expectedErr)
+	s.Require().Error(err, expectedErr)
 	s.Require().Nil(resp)
 }


### PR DESCRIPTION
### Description

As the title says, check in an API DELETE request, if the specified policy is a default one, and if it is, have the API return a helpful error message instead.


### User-facing documentation

- [x] CHANGELOG is updated

### Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

First, added a unit test to prevent regression in the future.

Second, to test manually end-to-end, I deployed an image from this PR, then I made a `curl` call to try to delete one of ACS's default policies, "30-Day Scan Age".

```
$ curl 'https://localhost:3000/v1/policies/a3eb6dbe-e9ca-451a-919b-216cf7ee11f5' \
>   -X 'DELETE' \
>   -H 'Accept: application/json, text/plain, */*' \
>   -H 'Accept-Language: en-US,en;q=0.9' \
>   -H 'Authorization: Bearer ...   
>   -H 'Accept-Language: en-US,en;q=0.9' \
>   -H 'Connection: keep-alive' \
>   -H 'Cookie: ajs_user_id=OkHeTkS1+VtT9LZ/1ubKdf8JMiRxYBJZJcVzDcOaWPc=; ajs_anonymous_id=fff7321e-1479-4b15-bb55-067006ea8455; analytics_session_id=1719349290659; analytics_session_id.last_access=1719349378775' \
>   -H 'Origin: https://localhost:3000' \
>   -H 'Referer: https://localhost:3000/main/policy-management/policies' \
>   -H 'Sec-Fetch-Dest: empty' \
>   -H 'Sec-Fetch-Mode: cors' \
>   -H 'Sec-Fetch-Site: same-origin' \
>   --insecure

{"code":3, "message":"A default policy cannot be deleted. (You can disable a default policy, but not delete it.): invalid arguments", "details":[], "error":"A default policy cannot be deleted. (You can disable a default policy, but not delete it.): invalid arguments"}
```

Observe that this DELETE call now returns the new error.
