### PR TITLE
chore(ci): rename scanner-v4-tests to scanner-v4-install-tests

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -48,7 +48,7 @@ if [[ "${JOB_NAME:-}" =~ -eks- ]]; then
     set_ci_shared_export USER_ARNS "$(aws sts get-caller-identity | jq -r '.Arn')"
 fi
 
-if [[ "${JOB_NAME:-}" =~ ocp-.*-scanner-v4-tests.* ]]; then
-    info "Setting worker node type for OCP Scanner V4 tests to e2-standard-16"
+if [[ "${JOB_NAME:-}" =~ ocp-.*-scanner-v4-install-tests.* ]]; then
+    info "Setting worker node type for OCP Scanner V4 installation tests to e2-standard-16"
     set_ci_shared_export WORKER_NODE_TYPE e2-standard-16
 fi

--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -47,8 +47,3 @@ if [[ "${JOB_NAME:-}" =~ -eks- ]]; then
     aws sts get-caller-identity | jq -r '.Arn'
     set_ci_shared_export USER_ARNS "$(aws sts get-caller-identity | jq -r '.Arn')"
 fi
-
-if [[ "${JOB_NAME:-}" =~ ocp-.*-scanner-v4-install-tests.* ]]; then
-    info "Setting worker node type for OCP Scanner V4 installation tests to e2-standard-16"
-    set_ci_shared_export WORKER_NODE_TYPE e2-standard-16
-fi

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -290,20 +290,20 @@ class ScaleTest(BaseTest):
         )
 
 
-class ScannerV4Test(BaseTest):
+class ScannerV4InstallTest(BaseTest):
     TEST_TIMEOUT = 240 * 60
     TEST_OUTPUT_DIR = "/tmp/scanner-v4-logs"
 
     def run(self):
-        print("Executing the ScannerV4 Test")
+        print("Executing the Scanner V4 Test")
 
         def set_dirs_after_start():
             # let post test know where results are
-            self.test_outputs = [ScannerV4Test.TEST_OUTPUT_DIR]
+            self.test_outputs = [ScannerV4InstallTest.TEST_OUTPUT_DIR]
 
         self.run_with_graceful_kill(
-            ["tests/e2e/run-scanner-v4.sh", ScannerV4Test.TEST_OUTPUT_DIR],
-            ScannerV4Test.TEST_TIMEOUT,
+            ["tests/e2e/run-scanner-v4-install.sh", ScannerV4InstallTest.TEST_OUTPUT_DIR],
+            ScannerV4InstallTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )
 

--- a/scripts/ci/jobs/gke_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_install_tests.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run the Scanner V4 tests in a GKE cluster
+Run the Scanner V4 installation tests in a GKE cluster
 """
 import os
 from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests
-from ci_tests import ScannerV4Test
+from ci_tests import ScannerV4InstallTest
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
@@ -16,13 +16,13 @@ os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"
 
 ClusterTestRunner(
-    cluster=GKECluster("scanner-v4-test", machine_type="e2-standard-8"),
+    cluster=GKECluster("scanner-v4-install-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),
-    test=ScannerV4Test(),
+    test=ScannerV4InstallTest(),
     post_test=PostClusterTest(
         # Stackrox is torn down as part of each test execution so data
         # collection and standard log checks are skipped in this post suite
-        # step. The scanner-v4 test teardown() handles debug collection.
+        # step. The scanner-v4-install test teardown() handles debug collection.
         collect_collector_metrics=False,
         collect_central_artifacts=False,
         check_stackrox_logs=False,

--- a/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run the Scanner V4 tests in an OCP cluster
+Run the Scanner V4 installation tests in an OCP cluster
 """
 import os
 from runners import ClusterTestRunner
 from clusters import AutomationFlavorsCluster
-from ci_tests import ScannerV4Test
+from ci_tests import ScannerV4InstallTest
 from pre_tests import PreSystemTests
 from post_tests import PostClusterTest, FinalPost
 
@@ -19,11 +19,11 @@ os.environ["ENABLE_OPERATOR_TESTS"] = "true"
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),
     pre_test=PreSystemTests(),
-    test=ScannerV4Test(),
+    test=ScannerV4InstallTest(),
     post_test=PostClusterTest(
-        # Stackrox is torn down as part of each test execution so data
+        # StackRox is torn down as part of each test execution so data
         # collection and standard log checks are skipped in this post suite
-        # step. The scanner-v4 test teardown() handles debug collection.
+        # step. The scanner-v4-install test teardown() handles debug collection.
         collect_collector_metrics=False,
         collect_central_artifacts=False,
         check_stackrox_logs=False,

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -243,7 +243,7 @@ EOF
 
     _deploy_stackrox
 
-    # Verify that Scanner v2 and V4 are up.
+    # Verify that Scanner V2 and V4 are up.
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
     verify_deployment_scannerV4_env_var_set "stackrox" "central"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Runs Scanner V4 tests using the Bats testing framework.
+# Runs Scanner V4 installation tests using the Bats testing framework.
 
 init() {
     ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")"/../.. && pwd)"
@@ -234,7 +234,7 @@ central:
 EOF
     ROX_CENTRAL_EXTRA_HELM_VALUES_FILE="${_ROX_CENTRAL_EXTRA_HELM_VALUES_FILE}" CENTRAL_CHART_DIR_OVERRIDE="${_CENTRAL_CHART_DIR_OVERRIDE}" _deploy_stackrox
 
-    # Upgrade to HEAD chart without explicit disabling of Scanner v4.
+    # Upgrade to HEAD chart without explicit disabling of Scanner V4.
     info "Upgrading StackRox using HEAD Helm chart"
     MAIN_IMAGE_TAG="${main_image_tag}"
 
@@ -243,7 +243,7 @@ EOF
 
     _deploy_stackrox
 
-    # Verify that Scanner v2 and v4 are up.
+    # Verify that Scanner v2 and V4 are up.
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
@@ -251,7 +251,7 @@ EOF
 }
 
 @test "Fresh installation of HEAD Helm chart with Scanner V4 disabled and enabling it later" {
-    info "Installing StackRox using HEAD Helm chart with Scanner v4 disabled and enabling it later"
+    info "Installing StackRox using HEAD Helm chart with Scanner V4 disabled and enabling it later"
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=helm
     ROX_SCANNER_V4=false _deploy_stackrox
@@ -281,8 +281,8 @@ EOF
 
 }
 
-@test "Fresh installation of HEAD Helm chart with Scanner v4 enabled" {
-    info "Installing StackRox using HEAD Helm chart with Scanner v4 enabled"
+@test "Fresh installation of HEAD Helm chart with Scanner V4 enabled" {
+    info "Installing StackRox using HEAD Helm chart with Scanner V4 enabled"
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=helm
     # shellcheck disable=SC2030,SC2031
@@ -296,11 +296,11 @@ EOF
     verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
 }
 
-@test "Fresh installation of HEAD Helm charts with Scanner v4 enabled in multi-namespace mode" {
+@test "Fresh installation of HEAD Helm charts with Scanner V4 enabled in multi-namespace mode" {
     local central_namespace="$CUSTOM_CENTRAL_NAMESPACE"
     local sensor_namespace="$CUSTOM_SENSOR_NAMESPACE"
 
-    info "Installing StackRox using HEAD Helm chart with Scanner v4 enabled in multi-namespace mode"
+    info "Installing StackRox using HEAD Helm chart with Scanner V4 enabled in multi-namespace mode"
 
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=helm
@@ -579,7 +579,7 @@ EOT
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
 }
 
-@test "Upgrade from old version without Scanner V4 support to the version which supports Scanner v4" {
+@test "Upgrade from old version without Scanner V4 support to the version which supports Scanner V4" {
     if [[ "$CI" = "true" ]]; then
         setup_default_TLS_certs
     fi

--- a/tests/e2e/run-scanner-v4-install.sh
+++ b/tests/e2e/run-scanner-v4-install.sh
@@ -10,7 +10,7 @@ export SCANNER_V4_LOG_DIR="$1"
 REPORTS_DIR=$(mktemp -d)
 FAILED=0
 
-echo "Worker node types for Scanner V4 tests:"
+echo "Worker node types for Scanner V4 installation tests:"
 kubectl get nodes -o json | \
     jq -jr '.items[] | .metadata.name, ": ", .metadata.labels."beta.kubernetes.io/instance-type", "\n"'
 echo
@@ -20,7 +20,7 @@ bats \
     --verbose-run \
     --report-formatter junit \
     --output "${REPORTS_DIR}" \
-    "${ROOT}/tests/e2e/run-scanner-v4.bats" || FAILED=1
+    "${ROOT}/tests/e2e/run-scanner-v4-install.bats" || FAILED=1
 
 info "Saving junit XML report..."
 store_test_results "${REPORTS_DIR}" reports


### PR DESCRIPTION
### Description

The current Scanner V4 installation tests are simply called `scanner-v4-tests`, which has brought some confusion among the team. As the team works towards creating Scanner V4 CI tests, we believe it'd make more sense to change the name of these tests to "install tests".

This is accompanied by https://github.com/openshift/release/pull/56006.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

OpenShift CI is a pain to test, so may just test it live...

The OpenShift CI tests know which script to run based on the job's name. In the accompanying PR, you can see the job names changes to include "install". For example, `gke-scanner-v4-tests` --> `gke-scanner-v4-install-tests`. This is eventually converted to `gke_scanner_v4_install_tests.py` in `.openshift-ci/dispatch.sh`, which now exists due to this PR.
