### PR TITLE
ROX-25972: Fix accessibility issue of Tabs with nav element

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginAccessibility.js
+++ b/ui/apps/platform/eslint-plugins/pluginAccessibility.js
@@ -4,7 +4,7 @@ const rules = {
     // ESLint naming convention for positive rules:
     // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
 
-    'Alert-component-prop': {
+    'Alert-component': {
         // Require alternative markup to prevent axe DevTools issue:
         // Heading levels should only increase by one
         // https://dequeuniversity.com/rules/axe/4.9/heading-order
@@ -78,7 +78,7 @@ const rules = {
             };
         },
     },
-    'Chart-ariaTitle-prop': {
+    'Chart-ariaTitle': {
         // Require prop for aria-labelledby attribute to prevent axe DevTools issue:
         // <svg> elements with an img role must have an alternative text
         // https://dequeuniversity.com/rules/axe/4.10/svg-img-alt
@@ -108,7 +108,7 @@ const rules = {
             };
         },
     },
-    'ExpandableSection-isDetached-contentId-toggleId-props': {
+    'ExpandableSection-isDetached-contentId-toggleId': {
         // Require props to prevent axe DevTools issue:
         // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
         // https://dequeuniversity.com/rules/axe/4.10/landmark-unique
@@ -148,7 +148,7 @@ const rules = {
             };
         },
     },
-    'ExpandableSectionToggle-contentId-toggleId-props': {
+    'ExpandableSectionToggle-contentId-toggleId': {
         // Require props to prevent axe DevTools issue:
         // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
         // https://dequeuniversity.com/rules/axe/4.10/landmark-unique
@@ -183,7 +183,7 @@ const rules = {
             };
         },
     },
-    'Popover-aria-label-prop': {
+    'Popover-aria-label': {
         // Require prop to prevent axe DevTools issue:
         // ARIA dialog and alertdialog nodes should have an accessible name
         // https://dequeuniversity.com/rules/axe/4.9/aria-dialog-name
@@ -213,7 +213,7 @@ const rules = {
             };
         },
     },
-    'Th-screenReaderText-prop': {
+    'Th-screenReaderText': {
         // Require prop to prevent axe DevTools issue:
         // Table header text should not be empty
         // https://dequeuniversity.com/rules/axe/4.9/empty-table-header
@@ -291,7 +291,7 @@ const rules = {
             };
         },
     },
-    'no-Popover-footerContent-headerContent-props': {
+    'no-Popover-footerContent-headerContent': {
         // Forbid props that cause axe DevTools issues:
         // Heading levels should only increase by one
         // https://dequeuniversity.com/rules/axe/4.9/heading-order
@@ -332,6 +332,39 @@ const rules = {
             };
         },
     },
+    'no-Tabs-component': {
+        // Forbid Tabs element with component="nav" prop to prevent axe DevTools issue:
+        // Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
+        // https://dequeuniversity.com/rules/axe/4.10/landmark-unique
+        //
+        // For the record, accessibility issue is when main element has multiple nav elements.
+        // For accessibility, consistency, and semantics, let Tabs render default div element.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Forbid Tabs element with component prop',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'Tabs') {
+                        if (
+                            node.attributes.some(
+                                (nodeAttribute) => nodeAttribute.name?.name === 'component'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message: 'Forbid Tabs element with component prop',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-Td-in-Thead': {
         // Forbid work-around to prevent axe DevTools issue:
         // Table header text should not be empty
@@ -363,7 +396,7 @@ const rules = {
             };
         },
     },
-    'no-Th-aria-label-prop': {
+    'no-Th-aria-label': {
         // Forbid work-around to prevent axe DevTools issue:
         // Table header text should not be empty
         // https://dequeuniversity.com/rules/axe/4.9/empty-table-header

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -6,7 +6,6 @@ import {
     PageSection,
     Tab,
     Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
@@ -192,7 +191,6 @@ function CheckDetails() {
                 onSelect={(_e, key) => {
                     setActiveTabKey(key);
                 }}
-                component={TabsComponent.nav}
                 className="pf-v5-u-pl-md pf-v5-u-background-color-100 pf-v5-u-flex-shrink-0"
             >
                 <Tab

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -219,7 +219,6 @@ function ViolationsTablePage(): ReactElement {
                         setSearchFilter({});
                         setActiveViolationStateTab(tab);
                     }}
-                    component="nav"
                 >
                     <Tab eventKey="ACTIVE" title={<TabTitleText>Active</TabTitleText>} />
                     <Tab eventKey="RESOLVED" title={<TabTitleText>Resolved</TabTitleText>} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -237,7 +237,6 @@ function ExceptionRequestDetailsPage() {
                     <Tabs
                         activeKey={selectedContext}
                         onSelect={handleTabClick}
-                        component="nav"
                         className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
                     >
                         <Tab

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -78,7 +78,6 @@ function ExceptionRequestsPage() {
                 <Tabs
                     activeKey={activeTabKey}
                     onSelect={handleTabClick}
-                    component="nav"
                     className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
                 >
                     <Tab

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -10,7 +10,6 @@ import {
     Bullseye,
     Tab,
     Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -91,7 +90,6 @@ function NodePage() {
                                 setActiveTabKey(key);
                                 // pagination.setPage(1);
                             }}
-                            component={TabsComponent.nav}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -9,7 +9,6 @@ import {
     Bullseye,
     Tab,
     Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -97,7 +96,6 @@ function ClusterPage() {
                                 setActiveTabKey(key);
                                 // pagination.setPage(1);
                             }}
-                            component={TabsComponent.nav}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             role="region"
                         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -8,7 +8,6 @@ import {
     Tab,
     TabTitleText,
     Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 import { gql, useQuery } from '@apollo/client';
@@ -108,7 +107,6 @@ function DeploymentPage() {
                                 setActiveTabKey(key);
                                 pagination.setPage(1);
                             }}
-                            component={TabsComponent.nav}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                             mountOnEnter
                             unmountOnExit

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -11,7 +11,6 @@ import {
     Skeleton,
     Tab,
     Tabs,
-    TabsComponent,
     TabTitleText,
     Title,
     Alert,
@@ -168,7 +167,6 @@ function ImagePage() {
                             setActiveTabKey(key);
                             pagination.setPage(1);
                         }}
-                        component={TabsComponent.nav}
                         className="pf-v5-u-pl-md pf-v5-u-background-color-100"
                         mountOnEnter
                         unmountOnExit

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -38,7 +38,6 @@ function VulnerabilityStateTabs({
                     onChange(tab);
                 }
             }}
-            component="nav"
             isBox={isBox}
         >
             <Tab


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

> Landmarks should have a unique role or role/label/title (i.e. accessible name) combination

https://dequeuniversity.com/rules/axe/4.10/landmark-unique

**DeploymentPage**

```html
<nav class="pf-v5-c-tabs pf-v5-u-pl-md pf-v5-u-background-color-100" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-1">
```

Related Node

```html
<nav class="pf-v5-c-tabs pf-m-box" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-2">
```

**ImagePage**

```html
<nav class="pf-v5-c-tabs pf-v5-u-pl-md pf-v5-u-background-color-100" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-3">
```

Related Node

```html
<nav class="pf-v5-c-tabs pf-m-box" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-4">
```

### Analysis

1. Accessibility issue: `DeploymentPage` and `ImagePage` render two `Tabs` elements, each of which render `nav` element.

2. Consistency issue: even considering that results include classic `Tabs` elements, the majority of PatternFly `Tabs` elements do **not** have `component` prop.

Find in Files: `component="nav"` 4 results in 4 files
* ViolationsTablePage.tsx
* ExceptionRequestDetailsPage.tsx
* ExceptionRequestsPage.tsx
* VulnerabilityStateTabs.tsx

Find in Files: `component={TabsComponent.nav}` 5 results in 5 files
* CheckDetailsPage.tsx
* NodePage.tsx
* ClusterPage.tsx
* DeploymentPage.tsx
* ImagePage.tsx

Find in Files: `<Tabs` 27 results in 25 files

Addendum

Find in Files `nav` in cypress to find any selectors affected (there are none) did bring to my attention that PatternFly `Breadcrumb` renders `nav` element with `aria-label="Breadcrumb"` attribute. Therefore it is unique, and also seems semantic.

### Solution

1. Edit pluginAccessibility.js file.
    * Add negative `no-Tabs-component` lint rule.
    * Omit `prop` suffix to simplify convention for rule names.
2. For accessibility and consistency omit `component` prop so `Tabs` renders `div` element.
    * To prevent unexpected issue to render two `nav` elements when one does not cause an issue
    * Unlike `nav` element of left navigation, even one `nav` element for tabs in page seems semantically suspect and possibly confusing.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added style lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618514 - 4618514
        total -114 = 11727337 - 11727451
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves

2. Click **Deployments** toggle, and then in table body: click deployment link

    * Before changes, see presence of accessibility issue because of `nav` elements.
        ![DeploymentPage_with_issue](https://github.com/user-attachments/assets/570ac281-8711-43ba-90bb-d92c953bf9cf)

    * After changes, see absence of accessibility issue because of `div` elements.
        ![DeploymentPage_without_issue](https://github.com/user-attachments/assets/f7206db6-38df-4fd4-99d5-d17615f34666)

3. Click **Images** toggle, and then in table body: click image link

    * Before changes, see presence of accessibility issue because of `nav` elements.
        ![ImagePage_with_issue](https://github.com/user-attachments/assets/5dfd1109-14c4-4eb9-978f-56321ee040b4)

    * After changes, see absence of accessibility issue because of `div` elements.
        ![ImagePage_without_issue](https://github.com/user-attachments/assets/38cc26bb-82af-4290-bd24-00ee838b1ec6)

4. Visit /main/vulnerabilities/exception-management

    * Before changes, see that `Tabs` renders `nav` element.
        ![ExceptionRequestsPage_with_nav](https://github.com/user-attachments/assets/ed774c35-7bf1-41b2-b754-d1f0a6550192)

    * After changes, see that `Tabs` renders `div` element.
        ![ExceptionRequestsPage_with_div](https://github.com/user-attachments/assets/4ee00f24-507a-4d56-835f-df0d07edcf20)

5. Visit /main/violations

    * Before changes, see that `Tabs` renders `nav` element.
        ![ViolationsTablePage_with_nav](https://github.com/user-attachments/assets/616db091-aeef-4a77-8370-9d23c22381df)

    * After changes, see that `Tabs` renders `div` element.
        ![ViolationsTablePage_with_div](https://github.com/user-attachments/assets/3c6cc97b-b9d4-49ee-b480-8caa49a9039d)
