### PR TITLE
tests(operator): call handle_e2e_progress_failures too

### DIFF
--- a/scripts/ci/jobs/gke_operator_e2e_tests.py
+++ b/scripts/ci/jobs/gke_operator_e2e_tests.py
@@ -17,5 +17,5 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=OperatorE2eTest(operator_cluster_type="gke"),
     post_test=PostClusterTest(collect_central_artifacts=False),
-    final_post=FinalPost(handle_e2e_progress_failures=False),
+    final_post=FinalPost(),
 ).run()

--- a/scripts/ci/jobs/ocp_operator_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_operator_e2e_tests.py
@@ -17,5 +17,5 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=OperatorE2eTest(),
     post_test=PostClusterTest(collect_central_artifacts=False),
-    final_post=FinalPost(handle_e2e_progress_failures=False),
+    final_post=FinalPost(),
 ).run()

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1214,6 +1214,18 @@ _EO_DETAILS_
         save_junit_failure "${images_available[@]}" "${build_details}"
     fi
 
+    case "$CI_JOB_NAME" in
+    *gke-upgrade-tests)
+        record_upgrade_test_progess
+        ;;
+    *operator-e2e-tests)
+        check_deployment=false
+        ;;
+    *)
+        info "No job specific progress markers are saved for: ${CI_JOB_NAME}"
+        ;;
+    esac
+
     if $check_deployment; then
         if [[ -f "${STATE_DEPLOYED}" ]]; then
             save_junit_success "${stackrox_deployed[@]}"
@@ -1223,19 +1235,6 @@ _EO_DETAILS_
     else
         save_junit_skipped "${stackrox_deployed[@]}"
     fi
-
-    record_job_specific_progress
-}
-
-record_job_specific_progress() {
-    case "$CI_JOB_NAME" in
-    *gke-upgrade-tests)
-        record_upgrade_test_progess
-        ;;
-    *)
-        info "No job specific progress markers are saved for: ${CI_JOB_NAME}"
-        ;;
-    esac
 }
 
 record_upgrade_test_progess() {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Operator e2e jobs were not calling the piece of code responsible for recording image availability issues. This was likely because the same piece of code is also checking the status of stackrox deployment in a place which is not happening for operator e2e jobs.

This refactors the code a little such that only the necessary part is executed within operator jobs.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] check that necessary records appear in BigQuery:

Ran the following query before and after creating this PR:

```
SELECT
  *
FROM
  `acs-san-stackroxci.ci_metrics.stackrox_tests`
WHERE
  Classname = 'Image_Availability'
  AND JobName LIKE '%operator%'
LIMIT
  20
```

Before: `no results`

After:

![image](https://github.com/user-attachments/assets/7798800b-2e94-4640-a407-b356e69aab74)
