### PR TITLE
ROX-25934: Add tab to see 'All report jobs'

### DIFF
--- a/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
+++ b/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Popover, TabAction } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+import { systemConfigPath } from 'routePaths';
+import PopoverBodyContent from './PopoverBodyContent';
+
+type ReportJobsHelpActionProps = {
+    reportType: 'Vulnerability' | 'Scan schedule';
+};
+
+function ReportJobsHelpAction({ reportType }: ReportJobsHelpActionProps) {
+    return (
+        <Popover
+            aria-label="All report jobs help text"
+            bodyContent={
+                <PopoverBodyContent
+                    headerContent="All report jobs"
+                    bodyContent={
+                        <>
+                            This function displays the requested jobs from different users and
+                            includes their statuses accordingly. While the function provides the
+                            ability to monitor and audit your active and past requested jobs, we
+                            suggest configuring the{' '}
+                            <Link to={systemConfigPath}>{reportType} report retention limit</Link>{' '}
+                            based on your needs in order to ensure optimal user experience. All the
+                            report jobs will be kept in your system until they exceed the limit set
+                            by you.
+                        </>
+                    }
+                />
+            }
+            enableFlip
+            position="top"
+        >
+            <TabAction aria-label="Help for report jobs tab">
+                <HelpIcon />
+            </TabAction>
+        </Popover>
+    );
+}
+
+export default ReportJobsHelpAction;

--- a/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
+++ b/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
@@ -15,26 +15,25 @@ function ReportJobsHelpAction({ reportType }: ReportJobsHelpActionProps) {
     const { hasReadWriteAccess } = usePermissions();
     const hasAdministrationReadWriteAccess = hasReadWriteAccess('Administration');
 
-    const bodyContent = hasAdministrationReadWriteAccess ? (
+    const bodyContent = (
         <>
-            This function displays requested jobs from various users, including their statuses. You
-            can monitor and audit both active and past job requests. For an optimal experience, we
-            recommend configuring the{' '}
-            <ExternalLink>
-                <a href={systemConfigPath} target="_blank" rel="noreferrer">
-                    {reportType} report retention limit
-                </a>
-            </ExternalLink>{' '}
-            to suit your needs. Report jobs will remain in the system until they exceed the limit
-            you set.
-        </>
-    ) : (
-        <>
-            This function shows requested jobs from various users, including their statuses. While
-            you can track and audit your active and past job requests, any changes to the{' '}
-            <b>{reportType} report retention limit</b> must be configured by your administrator to
-            ensure an optimal experience. Reports will remain in the system until they exceed the
-            retention limit set by the administrator.
+            <div>
+                This function displays the requested jobs from different users and includes their
+                statuses accordingly. While the function provides the ability to monitor and audit
+                your active and past requested jobs, we suggest configuring the{' '}
+                <strong>{reportType} report retention limit</strong> based on your needs in order to
+                ensure optimal user experience. All the report jobs will be kept in your system
+                until they exceed the limit set by you.
+            </div>
+            {hasAdministrationReadWriteAccess && (
+                <div className="pf-v5-u-mt-sm">
+                    <ExternalLink>
+                        <a href={systemConfigPath} target="_blank" rel="noopener noreferrer">
+                            System Configuration
+                        </a>
+                    </ExternalLink>
+                </div>
+            )}
         </>
     );
 

--- a/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
+++ b/ui/apps/platform/src/Components/ReportJobsHelpAction.tsx
@@ -1,35 +1,48 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Popover, TabAction } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 import { systemConfigPath } from 'routePaths';
+import usePermissions from 'hooks/usePermissions';
 import PopoverBodyContent from './PopoverBodyContent';
+import ExternalLink from './PatternFly/IconText/ExternalLink';
 
 type ReportJobsHelpActionProps = {
     reportType: 'Vulnerability' | 'Scan schedule';
 };
 
 function ReportJobsHelpAction({ reportType }: ReportJobsHelpActionProps) {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasAdministrationReadWriteAccess = hasReadWriteAccess('Administration');
+
+    const bodyContent = hasAdministrationReadWriteAccess ? (
+        <>
+            This function displays requested jobs from various users, including their statuses. You
+            can monitor and audit both active and past job requests. For an optimal experience, we
+            recommend configuring the{' '}
+            <ExternalLink>
+                <a href={systemConfigPath} target="_blank" rel="noreferrer">
+                    {reportType} report retention limit
+                </a>
+            </ExternalLink>{' '}
+            to suit your needs. Report jobs will remain in the system until they exceed the limit
+            you set.
+        </>
+    ) : (
+        <>
+            This function shows requested jobs from various users, including their statuses. While
+            you can track and audit your active and past job requests, any changes to the{' '}
+            <b>{reportType} report retention limit</b> must be configured by your administrator to
+            ensure an optimal experience. Reports will remain in the system until they exceed the
+            retention limit set by the administrator.
+        </>
+    );
+
     return (
         <Popover
             aria-label="All report jobs help text"
             bodyContent={
-                <PopoverBodyContent
-                    headerContent="All report jobs"
-                    bodyContent={
-                        <>
-                            This function displays the requested jobs from different users and
-                            includes their statuses accordingly. While the function provides the
-                            ability to monitor and audit your active and past requested jobs, we
-                            suggest configuring the{' '}
-                            <Link to={systemConfigPath}>{reportType} report retention limit</Link>{' '}
-                            based on your needs in order to ensure optimal user experience. All the
-                            report jobs will be kept in your system until they exceed the limit set
-                            by you.
-                        </>
-                    }
-                />
+                <PopoverBodyContent headerContent="All report jobs" bodyContent={bodyContent} />
             }
             enableFlip
             position="top"

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -165,14 +165,12 @@ function ViewScanConfigDetail({
                             tabContentId={configDetailsTabId}
                             eventKey="CONFIGURATION_DETAILS"
                             title={<TabTitleText>Configuration details</TabTitleText>}
-                            aria-label="Configuration details tab"
                         />
                         <Tab
                             tabContentId={allReportJobsTabId}
                             eventKey="ALL_REPORT_JOBS"
                             title={<TabTitleText>All report jobs</TabTitleText>}
                             actions={<ReportJobsHelpAction reportType="Scan schedule" />}
-                            aria-label="Report jobs tab"
                         />
                     </Tabs>
                 </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -41,6 +41,9 @@ type ViewScanConfigDetailProps = {
     error?: Error | string | null;
 };
 
+const configDetailsTabId = 'ComplianceScanConfigDetails';
+const allReportJobsTabId = 'ComplianceScanConfigReportJobs';
+
 function ViewScanConfigDetail({
     hasWriteAccessForCompliance,
     scanConfig,
@@ -159,11 +162,13 @@ function ViewScanConfigDetail({
                         aria-label="Scan schedule details tabs"
                     >
                         <Tab
+                            tabContentId={configDetailsTabId}
                             eventKey="CONFIGURATION_DETAILS"
                             title={<TabTitleText>Configuration details</TabTitleText>}
                             aria-label="Configuration details tab"
                         />
                         <Tab
+                            tabContentId={allReportJobsTabId}
                             eventKey="ALL_REPORT_JOBS"
                             title={<TabTitleText>All report jobs</TabTitleText>}
                             actions={<ReportJobsHelpAction reportType="Scan schedule" />}
@@ -172,12 +177,16 @@ function ViewScanConfigDetail({
                     </Tabs>
                 </PageSection>
             )}
-            <PageSection isCenterAligned>
-                {selectedTab === 'CONFIGURATION_DETAILS' && (
+            {selectedTab === 'CONFIGURATION_DETAILS' && (
+                <PageSection isCenterAligned id={configDetailsTabId}>
                     <ConfigDetails isLoading={isLoading} error={error} scanConfig={scanConfig} />
-                )}
-                {selectedTab === 'ALL_REPORT_JOBS' && <ReportJobs />}
-            </PageSection>
+                </PageSection>
+            )}
+            {selectedTab === 'ALL_REPORT_JOBS' && (
+                <PageSection isCenterAligned id={allReportJobsTabId}>
+                    <ReportJobs />
+                </PageSection>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -5,26 +5,20 @@ import {
     AlertActionCloseButton,
     Breadcrumb,
     BreadcrumbItem,
-    Bullseye,
-    Card,
-    CardBody,
-    DescriptionListDescription,
-    DescriptionListGroup,
-    DescriptionListTerm,
     Divider,
     Flex,
     FlexItem,
     PageSection,
-    Spinner,
+    Tab,
+    Tabs,
+    TabTitleText,
     Title,
 } from '@patternfly/react-core';
 
 import { complianceEnhancedSchedulesPath } from 'routePaths';
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
 import useAlert from 'hooks/useAlert';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import {
     ComplianceScanConfigurationStatus,
     runComplianceReport,
@@ -32,18 +26,13 @@ import {
 } from 'services/ComplianceScanConfigurationService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import {
-    getBodyDefault,
-    getSubjectDefault,
-    getTimeWithHourMinuteFromISO8601,
-} from './compliance.scanConfigs.utils';
-import ScanConfigParametersView from './components/ScanConfigParametersView';
-import ScanConfigProfilesView from './components/ScanConfigProfilesView';
-import ScanConfigClustersTable from './components/ScanConfigClustersTable';
-
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { JobContextTab } from 'types/reportJob';
+import { ensureJobContextTab } from 'utils/reportJob';
 import ScanConfigActionDropdown from './ScanConfigActionDropdown';
-
-const headingLevel = 'h2';
+import ConfigDetails from './components/ConfigDetails';
+import ReportJobs from './components/ReportJobs';
+import ReportJobsHelpAction from '../../../Components/ReportJobsHelpAction';
 
 type ViewScanConfigDetailProps = {
     hasWriteAccessForCompliance: boolean;
@@ -58,11 +47,13 @@ function ViewScanConfigDetail({
     isLoading,
     error = null,
 }: ViewScanConfigDetailProps): React.ReactElement {
-    const [isTriggeringRescan, setIsTriggeringRescan] = useState(false);
-    const { alertObj, setAlertObj, clearAlertObj } = useAlert();
-
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
+    const isReportJobsEnabled = isFeatureFlagEnabled('ROX_SCAN_SCHEDULE_REPORT_JOBS');
+
+    const [selectedTab, setSelectedTab] = useState<JobContextTab>('CONFIGURATION_DETAILS');
+    const [isTriggeringRescan, setIsTriggeringRescan] = useState(false);
+
+    const { alertObj, setAlertObj, clearAlertObj } = useAlert();
 
     function handleRunScanConfig(scanConfigResponse: ComplianceScanConfigurationStatus) {
         clearAlertObj();
@@ -158,80 +149,34 @@ function ViewScanConfigDetail({
                     </>
                 )}
             </PageSection>
-            <Divider component="div" />
+            {isReportJobsEnabled && (
+                <PageSection variant="light" className="pf-v5-u-py-0">
+                    <Tabs
+                        activeKey={selectedTab}
+                        onSelect={(_e, tab) => {
+                            setSelectedTab(ensureJobContextTab(tab));
+                        }}
+                        aria-label="Scan schedule details tabs"
+                    >
+                        <Tab
+                            eventKey="CONFIGURATION_DETAILS"
+                            title={<TabTitleText>Configuration details</TabTitleText>}
+                            aria-label="Configuration details tab"
+                        />
+                        <Tab
+                            eventKey="ALL_REPORT_JOBS"
+                            title={<TabTitleText>All report jobs</TabTitleText>}
+                            actions={<ReportJobsHelpAction reportType="Scan schedule" />}
+                            aria-label="Report jobs tab"
+                        />
+                    </Tabs>
+                </PageSection>
+            )}
             <PageSection isCenterAligned>
-                {isLoading ? (
-                    <Bullseye>
-                        <Spinner />
-                    </Bullseye>
-                ) : (
-                    error && (
-                        <Alert
-                            variant="warning"
-                            title="Unable to fetch scan schedule"
-                            component="p"
-                            isInline
-                        >
-                            {getAxiosErrorMessage(error)}
-                        </Alert>
-                    )
+                {selectedTab === 'CONFIGURATION_DETAILS' && (
+                    <ConfigDetails isLoading={isLoading} error={error} scanConfig={scanConfig} />
                 )}
-                {!isLoading && scanConfig && (
-                    <Card>
-                        <CardBody>
-                            <Flex
-                                direction={{ default: 'column' }}
-                                spaceItems={{ default: 'spaceItemsLg' }}
-                            >
-                                <ScanConfigParametersView
-                                    headingLevel={headingLevel}
-                                    scanName={scanConfig.scanName}
-                                    description={scanConfig.scanConfig.description}
-                                    scanSchedule={scanConfig.scanConfig.scanSchedule}
-                                >
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>Last run</DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            {scanConfig.lastExecutedTime
-                                                ? getTimeWithHourMinuteFromISO8601(
-                                                      scanConfig.lastExecutedTime
-                                                  )
-                                                : 'Scan is in progress'}
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>Last updated</DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            {getTimeWithHourMinuteFromISO8601(
-                                                scanConfig.lastUpdatedTime
-                                            )}
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                </ScanConfigParametersView>
-                                <ScanConfigClustersTable
-                                    headingLevel={headingLevel}
-                                    clusterScanStatuses={scanConfig.clusterStatus}
-                                />
-                                <ScanConfigProfilesView
-                                    headingLevel={headingLevel}
-                                    profiles={scanConfig.scanConfig.profiles}
-                                />
-                                {isComplianceReportingEnabled && (
-                                    <NotifierConfigurationView
-                                        customBodyDefault={getBodyDefault(
-                                            scanConfig.scanConfig.profiles
-                                        )}
-                                        customSubjectDefault={getSubjectDefault(
-                                            scanConfig.scanName,
-                                            scanConfig.scanConfig.profiles
-                                        )}
-                                        notifierConfigurations={scanConfig.scanConfig.notifiers}
-                                    />
-                                )}
-                            </Flex>
-                        </CardBody>
-                    </Card>
-                )}
+                {selectedTab === 'ALL_REPORT_JOBS' && <ReportJobs />}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -45,7 +45,7 @@ function ConfigDetails({ isLoading, error, scanConfig }) {
         );
     }
 
-    if (!isLoading && scanConfig) {
+    if (scanConfig) {
         return (
             <Card>
                 <CardBody>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+    Alert,
+    Bullseye,
+    Card,
+    CardBody,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    Spinner,
+} from '@patternfly/react-core';
+
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
+import {
+    getBodyDefault,
+    getSubjectDefault,
+    getTimeWithHourMinuteFromISO8601,
+} from '../compliance.scanConfigs.utils';
+import ScanConfigParametersView from './ScanConfigParametersView';
+import ScanConfigClustersTable from './ScanConfigClustersTable';
+import ScanConfigProfilesView from './ScanConfigProfilesView';
+
+const headingLevel = 'h2';
+
+function ConfigDetails({ isLoading, error, scanConfig }) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <Alert variant="warning" title="Unable to fetch scan schedule" component="p" isInline>
+                {getAxiosErrorMessage(error)}
+            </Alert>
+        );
+    }
+
+    if (!isLoading && scanConfig) {
+        return (
+            <Card>
+                <CardBody>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsLg' }}
+                    >
+                        <ScanConfigParametersView
+                            headingLevel={headingLevel}
+                            scanName={scanConfig.scanName}
+                            description={scanConfig.scanConfig.description}
+                            scanSchedule={scanConfig.scanConfig.scanSchedule}
+                        >
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Last run</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {scanConfig.lastExecutedTime
+                                        ? getTimeWithHourMinuteFromISO8601(
+                                              scanConfig.lastExecutedTime
+                                          )
+                                        : 'Scan is in progress'}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Last updated</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {getTimeWithHourMinuteFromISO8601(scanConfig.lastUpdatedTime)}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </ScanConfigParametersView>
+                        <ScanConfigClustersTable
+                            headingLevel={headingLevel}
+                            clusterScanStatuses={scanConfig.clusterStatus}
+                        />
+                        <ScanConfigProfilesView
+                            headingLevel={headingLevel}
+                            profiles={scanConfig.scanConfig.profiles}
+                        />
+                        {isComplianceReportingEnabled && (
+                            <NotifierConfigurationView
+                                customBodyDefault={getBodyDefault(scanConfig.scanConfig.profiles)}
+                                customSubjectDefault={getSubjectDefault(
+                                    scanConfig.scanName,
+                                    scanConfig.scanConfig.profiles
+                                )}
+                                notifierConfigurations={scanConfig.scanConfig.notifiers}
+                            />
+                        )}
+                    </Flex>
+                </CardBody>
+            </Card>
+        );
+    }
+}
+
+export default ConfigDetails;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ReportJobs() {
+    return <div />;
+}
+
+export default ReportJobs;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -61,6 +61,9 @@ export type TabTitleProps = {
     children: string;
 };
 
+const configDetailsTabId = 'VulnReportsConfigDetails';
+const allReportJobsTabId = 'VulnReportsConfigReportJobs';
+
 function ViewVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
@@ -270,18 +273,20 @@ function ViewVulnReportPage() {
                     aria-label="Report details tabs"
                 >
                     <Tab
+                        tabContentId={configDetailsTabId}
                         eventKey="CONFIGURATION_DETAILS"
                         title={<TabTitleText>Configuration details</TabTitleText>}
                     />
                     <Tab
+                        tabContentId={allReportJobsTabId}
                         eventKey="ALL_REPORT_JOBS"
                         title={<TabTitleText>All report jobs</TabTitleText>}
                         actions={<ReportJobsHelpAction reportType="Vulnerability" />}
                     />
                 </Tabs>
             </PageSection>
-            <PageSection isCenterAligned>
-                {selectedTab === 'CONFIGURATION_DETAILS' && (
+            {selectedTab === 'CONFIGURATION_DETAILS' && (
+                <PageSection isCenterAligned id={configDetailsTabId}>
                     <Card>
                         <CardBody>
                             <ReportParametersDetails formValues={reportFormValues} />
@@ -310,9 +315,13 @@ function ViewVulnReportPage() {
                             <ScheduleDetails formValues={reportFormValues} />
                         </CardBody>
                     </Card>
-                )}
-                {selectedTab === 'ALL_REPORT_JOBS' && <ReportJobs reportId={reportId} />}
-            </PageSection>
+                </PageSection>
+            )}
+            {selectedTab === 'ALL_REPORT_JOBS' && (
+                <PageSection isCenterAligned id={allReportJobsTabId}>
+                    <ReportJobs reportId={reportId} />
+                </PageSection>
+            )}
             <DeleteModal
                 title="Permanently delete report?"
                 isOpen={isDeleteModalOpen}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -272,13 +272,11 @@ function ViewVulnReportPage() {
                     <Tab
                         eventKey="CONFIGURATION_DETAILS"
                         title={<TabTitleText>Configuration details</TabTitleText>}
-                        aria-label="Configuration details tab"
                     />
                     <Tab
                         eventKey="ALL_REPORT_JOBS"
                         title={<TabTitleText>All report jobs</TabTitleText>}
                         actions={<ReportJobsHelpAction reportType="Vulnerability" />}
-                        aria-label="Report jobs tab"
                     />
                 </Tabs>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Link, useHistory, useParams, generatePath } from 'react-router-dom';
+import { useHistory, useParams, generatePath } from 'react-router-dom';
 import {
     Alert,
     AlertActionCloseButton,
@@ -17,9 +17,8 @@ import {
     Tabs,
     Tab,
     TabTitleText,
-    TabTitleIcon,
-    TabAction,
-    Popover,
+    Card,
+    CardBody,
 } from '@patternfly/react-core';
 import {
     Dropdown,
@@ -27,10 +26,10 @@ import {
     DropdownItem,
     DropdownSeparator,
 } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon, ClipboardCheckIcon, HelpIcon, HomeIcon } from '@patternfly/react-icons';
+import { CaretDownIcon } from '@patternfly/react-icons';
 
 import { vulnerabilityReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
-import { systemConfigPath, vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
 import useDeleteModal, {
@@ -41,12 +40,14 @@ import { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal
 import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import PageTitle from 'Components/PageTitle';
-import PopoverBodyContent from 'Components/PopoverBodyContent';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import usePermissions from 'hooks/usePermissions';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 
+import ReportJobsHelpAction from 'Components/ReportJobsHelpAction';
+import { JobContextTab } from 'types/reportJob';
+import { ensureJobContextTab } from 'utils/reportJob';
 import EmailTemplatePreview from '../components/EmailTemplatePreview';
 import ReportParametersDetails from '../components/ReportParametersDetails';
 import ScheduleDetails from '../components/ScheduleDetails';
@@ -60,25 +61,11 @@ export type TabTitleProps = {
     children: string;
 };
 
-function TabTitle({ icon, children }: TabTitleProps): ReactElement {
-    return (
-        <Flex alignItems={{ default: 'alignItemsCenter' }}>
-            {icon && (
-                <FlexItem>
-                    <TabTitleIcon>{icon}</TabTitleIcon>
-                </FlexItem>
-            )}
-            <FlexItem>
-                <TabTitleText>{children}</TabTitleText>
-            </FlexItem>
-        </Flex>
-    );
-}
-
 function ViewVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
     const [isActionsDropdownOpen, setIsActionsDropdownOpen] = useState(false);
+    const [selectedTab, setSelectedTab] = useState<JobContextTab>('CONFIGURATION_DETAILS');
 
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
     const hasWriteAccessForReport =
@@ -274,23 +261,31 @@ function ViewVulnReportPage() {
                     )}
                 </Flex>
             </PageSection>
-            <Divider component="div" />
-            <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
+            <PageSection variant="light" className="pf-v5-u-py-0">
                 <Tabs
-                    className="pf-v5-u-background-color-100"
-                    defaultActiveKey={0}
+                    activeKey={selectedTab}
+                    onSelect={(_e, tab) => {
+                        setSelectedTab(ensureJobContextTab(tab));
+                    }}
                     aria-label="Report details tabs"
                 >
                     <Tab
-                        eventKey={0}
-                        title={<TabTitle icon={<HomeIcon />}>Configuration details</TabTitle>}
+                        eventKey="CONFIGURATION_DETAILS"
+                        title={<TabTitleText>Configuration details</TabTitleText>}
                         aria-label="Configuration details tab"
-                    >
-                        <PageSection
-                            variant="light"
-                            padding={{ default: 'noPadding' }}
-                            className="pf-v5-u-py-lg pf-v5-u-px-lg"
-                        >
+                    />
+                    <Tab
+                        eventKey="ALL_REPORT_JOBS"
+                        title={<TabTitleText>All report jobs</TabTitleText>}
+                        actions={<ReportJobsHelpAction reportType="Vulnerability" />}
+                        aria-label="Report jobs tab"
+                    />
+                </Tabs>
+            </PageSection>
+            <PageSection isCenterAligned>
+                {selectedTab === 'CONFIGURATION_DETAILS' && (
+                    <Card>
+                        <CardBody>
                             <ReportParametersDetails formValues={reportFormValues} />
                             <Divider component="div" className="pf-v5-u-py-md" />
                             <NotifierConfigurationView
@@ -315,55 +310,10 @@ function ViewVulnReportPage() {
                             />
                             <Divider component="div" className="pf-v5-u-py-md" />
                             <ScheduleDetails formValues={reportFormValues} />
-                        </PageSection>
-                    </Tab>
-                    <Tab
-                        eventKey={1}
-                        title={<TabTitle icon={<ClipboardCheckIcon />}>All report jobs</TabTitle>}
-                        aria-label="Report jobs tab"
-                        actions={
-                            <>
-                                <Popover
-                                    aria-label="All report jobs help text"
-                                    bodyContent={
-                                        <PopoverBodyContent
-                                            headerContent="All report jobs"
-                                            bodyContent={
-                                                <>
-                                                    This function displays the requested jobs from
-                                                    different users and includes their statuses
-                                                    accordingly. While the function provides the
-                                                    ability to monitor and audit your active and
-                                                    past requested jobs, we suggest configuring the{' '}
-                                                    <Link to={systemConfigPath}>
-                                                        Vulnerability report retention limit
-                                                    </Link>{' '}
-                                                    based on your needs in order to ensure optimal
-                                                    user experience. All the report jobs will be
-                                                    kept in your system until they exceed the limit
-                                                    set by you.
-                                                </>
-                                            }
-                                        />
-                                    }
-                                    enableFlip
-                                    position="top"
-                                >
-                                    <TabAction aria-label="Help for report jobs tab">
-                                        <HelpIcon />
-                                    </TabAction>
-                                </Popover>
-                            </>
-                        }
-                    >
-                        <PageSection
-                            padding={{ default: 'noPadding' }}
-                            className="pf-v5-u-py-lg pf-v5-u-px-lg"
-                        >
-                            <ReportJobs reportId={reportId} />
-                        </PageSection>
-                    </Tab>
-                </Tabs>
+                        </CardBody>
+                    </Card>
+                )}
+                {selectedTab === 'ALL_REPORT_JOBS' && <ReportJobs reportId={reportId} />}
             </PageSection>
             <DeleteModal
                 title="Permanently delete report?"

--- a/ui/apps/platform/src/types/reportJob.ts
+++ b/ui/apps/platform/src/types/reportJob.ts
@@ -1,0 +1,2 @@
+export const jobContextTabs = ['CONFIGURATION_DETAILS', 'ALL_REPORT_JOBS'] as const;
+export type JobContextTab = (typeof jobContextTabs)[number];

--- a/ui/apps/platform/src/utils/reportJob.ts
+++ b/ui/apps/platform/src/utils/reportJob.ts
@@ -1,0 +1,8 @@
+import { JobContextTab, jobContextTabs } from 'types/reportJob';
+
+export function ensureJobContextTab(value: unknown): JobContextTab {
+    if (typeof value === 'string' && jobContextTabs.includes(value as JobContextTab)) {
+        return value as JobContextTab;
+    }
+    return 'CONFIGURATION_DETAILS';
+}


### PR DESCRIPTION
### Description

This PR splits the Scan schedule details page into tabs that show configuration details and all report jobs. This also includes some layout/styling changes to VM reports

## Compliance Scan Schedule Details (Before)
<img width="1439" alt="Screenshot 2024-08-29 at 9 12 10 AM" src="https://github.com/user-attachments/assets/7795ea83-a0da-4817-a4b8-fb61b7346e63">

## Compliance Scan Schedule Details (After)
<img width="1437" alt="Screenshot 2024-08-29 at 9 11 02 AM" src="https://github.com/user-attachments/assets/42a2c43f-4822-4172-ad90-96a02e48481a">
<img width="1438" alt="Screenshot 2024-08-29 at 9 11 09 AM" src="https://github.com/user-attachments/assets/e8271318-7b27-4644-bc06-c9f8ebffa005">
<img width="1439" alt="Screenshot 2024-08-29 at 9 14 50 AM" src="https://github.com/user-attachments/assets/520a9cc1-9eb9-4d6c-95a0-1f954ff47ab2">

## VM Reports Details (Before)
<img width="1439" alt="Screenshot 2024-08-29 at 9 11 53 AM" src="https://github.com/user-attachments/assets/41263bae-043e-4910-87aa-0f9b5b0835fc">
<img width="722" alt="Screenshot 2024-08-29 at 9 11 59 AM" src="https://github.com/user-attachments/assets/5842be22-678f-41c4-9d62-3f767c8f4ab6">
<img width="1440" alt="Screenshot 2024-08-29 at 9 14 30 AM" src="https://github.com/user-attachments/assets/26dee2dd-9bc1-44fa-bcfb-6ecc691c3565">

## VM Reports Details (After)
<img width="1439" alt="Screenshot 2024-08-29 at 9 11 20 AM" src="https://github.com/user-attachments/assets/e451420a-2938-4a55-bf79-fa628f22f87e">
<img width="721" alt="Screenshot 2024-08-29 at 9 11 27 AM" src="https://github.com/user-attachments/assets/cee68e5e-c39d-4508-83dc-a6f4f696be6a">
<img width="1439" alt="Screenshot 2024-08-29 at 9 14 42 AM" src="https://github.com/user-attachments/assets/821e891c-e51d-4240-ac2b-f28e80b5cac7">


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes
 
#### How I validated my change

Checked if the UI works as expected
