### PR TITLE
ROX-25438: Upgrade to Go 1.22.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -219,7 +219,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -276,7 +276,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -454,7 +454,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -544,7 +544,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -627,7 +627,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -219,7 +219,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -276,7 +276,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -454,7 +454,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -544,7 +544,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -627,7 +627,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -219,7 +219,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -276,7 +276,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -454,7 +454,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -544,7 +544,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -627,7 +627,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -14,7 +14,7 @@ jobs:
   report-e2e-failures-to-slack:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -14,7 +14,7 @@ jobs:
   report-e2e-failures-to-slack:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -14,7 +14,7 @@ jobs:
   report-e2e-failures-to-slack:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -66,7 +66,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -177,7 +177,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -251,7 +251,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -66,7 +66,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -177,7 +177,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -251,7 +251,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -66,7 +66,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -177,7 +177,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -251,7 +251,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-db-init-dump.yaml
+++ b/.github/workflows/scanner-db-init-dump.yaml
@@ -9,7 +9,7 @@ jobs:
   build-updater:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-init-dump.yaml
+++ b/.github/workflows/scanner-db-init-dump.yaml
@@ -9,7 +9,7 @@ jobs:
   build-updater:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-init-dump.yaml
+++ b/.github/workflows/scanner-db-init-dump.yaml
@@ -9,7 +9,7 @@ jobs:
   build-updater:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -75,7 +75,7 @@ jobs:
       - download-nvd
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       volumes:
         # The updater makes heavy use of /tmp files.
         - /tmp:/tmp

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -75,7 +75,7 @@ jobs:
       - download-nvd
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
       volumes:
         # The updater makes heavy use of /tmp files.
         - /tmp:/tmp

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -75,7 +75,7 @@ jobs:
       - download-nvd
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
       volumes:
         # The updater makes heavy use of /tmp files.
         - /tmp:/tmp

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -75,7 +75,7 @@ jobs:
       - download-nvd
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
       volumes:
         # The updater makes heavy use of /tmp files.
         - /tmp:/tmp

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -104,7 +104,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -186,7 +186,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -104,7 +104,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -186,7 +186,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.3
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
       volumes:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
       volumes:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
       volumes:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -212,7 +212,7 @@ jobs:
   local-roxctl-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -250,7 +250,7 @@ jobs:
   shell-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -212,7 +212,7 @@ jobs:
   local-roxctl-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -250,7 +250,7 @@ jobs:
   shell-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -212,7 +212,7 @@ jobs:
   local-roxctl-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -250,7 +250,7 @@ jobs:
   shell-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image (stackrox-test-0.3.67).
+# These versions should match those used in the current CI test image (stackrox-test-0.4.2-1-g54aa4ee227).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.10.0

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image (stackrox-test-0.4.2-1-g54aa4ee227).
+# These versions should match those used in the current CI test image (stackrox-test-0.4.3).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.10.0

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image (stackrox-test-0.4.3).
+# These versions should match those used in the current CI test image (stackrox-test-0.4.4).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.10.0

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.4.3
+stackrox-build-0.4.4

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.4.2-1-g54aa4ee227
+stackrox-build-0.4.3

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.4.2
+stackrox-build-0.4.2-1-g54aa4ee227

--- a/central/activecomponent/updater/updater_impl_test.go
+++ b/central/activecomponent/updater/updater_impl_test.go
@@ -879,7 +879,6 @@ func (s *acUpdaterTestSuite) TestUpdater_Update() {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase // TODO: delete for go 1.22.
 		s.T().Run(testCase.description, func(t *testing.T) {
 			s.mockAggregator.EXPECT().GetAndPrune(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(_ func(string) bool, deploymentsSet set.StringSet) map[string][]*aggregatorPkg.ProcessUpdate {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -186,8 +186,32 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECore() {
 }
 
 func (s *ImageCVEViewTestSuite) TestGetImageCVECoreSAC() {
-	for _, tc := range s.testCases() {
-		for key, sacTC := range s.sacTestCases() {
+	// Note: The new loop variable semantics introduced in go1.22 breaks these
+	// tests when using loop variables in closures such that the test code
+	// expects those loop variables to change on each iteration of the loop.
+	// The problem stems from what a closure captures, or "sees", loop
+	// variables on each iteration. Before go1.22, loop variables had per-loop
+	// scope, which is to say that any closure inside the loop using loop
+	// variables would have the reference of the loop variable updated on each
+	// iteration. In go1.22+, loop variables have per-iteration scope, which,
+	// for closures inside the loop, means that when a given closure first
+	// captures the variable, that value will always be used in that particular
+	// closure.
+	// To get around this, we define variables outside the loop and then set
+	// those variables to the loop variables on each iteration, then use the
+	// variables in the outer scope (relative to the loop) in the closure,
+	// effectively achieving per-loop scoped variables.
+	// References and further reading:
+	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
+	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
+	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
+	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
+	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+	var tc testCase
+	var key string
+	var sacTC map[string]bool
+	for _, tc = range s.testCases() {
+		for key, sacTC = range s.sacTestCases() {
 			s.T().Run(fmt.Sprintf("Image %s %s", key, tc.desc), func(t *testing.T) {
 				testCtxs := testutils.GetNamespaceScopedTestContexts(tc.ctx, s.T(), resources.Image)
 				ctx := testCtxs[key]
@@ -217,7 +241,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECoreSAC() {
 	}
 
 	// Testing one query against deployment access is sufficient.
-	tc := s.testCases()[0]
+	tc = s.testCases()[0]
 	s.T().Run(fmt.Sprintf("Deployment read access %s", tc.desc), func(t *testing.T) {
 		ctx := sac.WithGlobalAccessScopeChecker(tc.ctx,
 			sac.AllowFixedScopes(
@@ -253,8 +277,32 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDs() {
 }
 
 func (s *ImageCVEViewTestSuite) TestGetImageIDsSAC() {
-	for _, tc := range s.testCases() {
-		for key, sacTC := range s.sacTestCases() {
+	// Note: The new loop variable semantics introduced in go1.22 breaks these
+	// tests when using loop variables in closures such that the test code
+	// expects those loop variables to change on each iteration of the loop.
+	// The problem stems from what a closure captures, or "sees", loop
+	// variables on each iteration. Before go1.22, loop variables had per-loop
+	// scope, which is to say that any closure inside the loop using loop
+	// variables would have the reference of the loop variable updated on each
+	// iteration. In go1.22+, loop variables have per-iteration scope, which,
+	// for closures inside the loop, means that when a given closure first
+	// captures the variable, that value will always be used in that particular
+	// closure.
+	// To get around this, we define variables outside the loop and then set
+	// those variables to the loop variables on each iteration, then use the
+	// variables in the outer scope (relative to the loop) in the closure,
+	// effectively achieving per-loop scoped variables.
+	// References and further reading:
+	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
+	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
+	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
+	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
+	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+	var tc testCase
+	var key string
+	var sacTC map[string]bool
+	for _, tc = range s.testCases() {
+		for key, sacTC = range s.sacTestCases() {
 			s.T().Run(fmt.Sprintf("Image %s %s", key, tc.desc), func(t *testing.T) {
 				// Such testcases are meant only for Get().
 				if tc.expectedErr != "" {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -187,10 +187,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECore() {
 
 func (s *ImageCVEViewTestSuite) TestGetImageCVECoreSAC() {
 	for _, tc := range s.testCases() {
-		tc := tc
 		for key, sacTC := range s.sacTestCases() {
-			key := key
-			sacTC := sacTC
 			s.T().Run(fmt.Sprintf("Image %s %s", key, tc.desc), func(t *testing.T) {
 				testCtxs := testutils.GetNamespaceScopedTestContexts(tc.ctx, s.T(), resources.Image)
 				ctx := testCtxs[key]
@@ -220,7 +217,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECoreSAC() {
 	}
 
 	// Testing one query against deployment access is sufficient.
-	tc = s.testCases()[0]
+	tc := s.testCases()[0]
 	s.T().Run(fmt.Sprintf("Deployment read access %s", tc.desc), func(t *testing.T) {
 		ctx := sac.WithGlobalAccessScopeChecker(tc.ctx,
 			sac.AllowFixedScopes(
@@ -256,32 +253,8 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDs() {
 }
 
 func (s *ImageCVEViewTestSuite) TestGetImageIDsSAC() {
-	// Note: The new loop variable semantics introduced in go1.22 breaks these
-	// tests when using loop variables in closures such that the test code
-	// expects those loop variables to change on each iteration of the loop.
-	// The problem stems from what a closure captures, or "sees", loop
-	// variables on each iteration. Before go1.22, loop variables had per-loop
-	// scope, which is to say that any closure inside the loop using loop
-	// variables would have the reference of the loop variable updated on each
-	// iteration. In go1.22+, loop variables have per-iteration scope, which,
-	// for closures inside the loop, means that when a given closure first
-	// captures the variable, that value will always be used in that particular
-	// closure.
-	// To get around this, we define variables outside the loop and then set
-	// those variables to the loop variables on each iteration, then use the
-	// variables in the outer scope (relative to the loop) in the closure,
-	// effectively achieving per-loop scoped variables.
-	// References and further reading:
-	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
-	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
-	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
-	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
-	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
-	var tc testCase
-	var key string
-	var sacTC map[string]bool
-	for _, tc = range s.testCases() {
-		for key, sacTC = range s.sacTestCases() {
+	for _, tc := range s.testCases() {
+		for key, sacTC := range s.sacTestCases() {
 			s.T().Run(fmt.Sprintf("Image %s %s", key, tc.desc), func(t *testing.T) {
 				// Such testcases are meant only for Get().
 				if tc.expectedErr != "" {
@@ -296,7 +269,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDsSAC() {
 				assert.NoError(t, err)
 
 				// Wrap image filter with sac filter.
-				matchFilter := tc.matchFilter
+				matchFilter := *tc.matchFilter
 				baseImageMatchFilter := matchFilter.matchImage
 				matchFilter.withImageFilter(func(image *storage.Image) bool {
 					if sacTC[image.GetId()] {
@@ -305,7 +278,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDsSAC() {
 					return false
 				})
 
-				expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, tc.matchFilter)
+				expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, &matchFilter)
 				assert.ElementsMatch(t, expectedAffectedImages, actualAffectedImageIDs)
 			})
 		}
@@ -373,32 +346,8 @@ func (s *ImageCVEViewTestSuite) TestCountImageCVECore() {
 }
 
 func (s *ImageCVEViewTestSuite) TestCountImageCVECoreSAC() {
-	// Note: The new loop variable semantics introduced in go1.22 breaks these
-	// tests when using loop variables in closures such that the test code
-	// expects those loop variables to change on each iteration of the loop.
-	// The problem stems from what a closure captures, or "sees", loop
-	// variables on each iteration. Before go1.22, loop variables had per-loop
-	// scope, which is to say that any closure inside the loop using loop
-	// variables would have the reference of the loop variable updated on each
-	// iteration. In go1.22+, loop variables have per-iteration scope, which,
-	// for closures inside the loop, means that when a given closure first
-	// captures the variable, that value will always be used in that particular
-	// closure.
-	// To get around this, we define variables outside the loop and then set
-	// those variables to the loop variables on each iteration, then use the
-	// variables in the outer scope (relative to the loop) in the closure,
-	// effectively achieving per-loop scoped variables.
-	// References and further reading:
-	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
-	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
-	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
-	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
-	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
-	var tc testCase
-	var key string
-	var sacTC map[string]bool
-	for _, tc = range s.testCases() {
-		for key, sacTC = range s.sacTestCases() {
+	for _, tc := range s.testCases() {
+		for key, sacTC := range s.sacTestCases() {
 			if tc.skipCountTests {
 				continue
 			}
@@ -415,7 +364,7 @@ func (s *ImageCVEViewTestSuite) TestCountImageCVECoreSAC() {
 				assert.NoError(t, err)
 
 				// Wrap image filter with sac filter.
-				matchFilter := tc.matchFilter
+				matchFilter := *tc.matchFilter
 				baseImageMatchFilter := matchFilter.matchImage
 				matchFilter.withImageFilter(func(image *storage.Image) bool {
 					if sacTC[image.GetId()] {
@@ -424,7 +373,7 @@ func (s *ImageCVEViewTestSuite) TestCountImageCVECoreSAC() {
 					return false
 				})
 
-				expected := compileExpected(s.testImages, matchFilter, tc.readOptions, tc.less)
+				expected := compileExpected(s.testImages, &matchFilter, tc.readOptions, tc.less)
 				assert.Equal(t, len(expected), actual)
 			})
 		}

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -346,8 +346,32 @@ func (s *ImageCVEViewTestSuite) TestCountImageCVECore() {
 }
 
 func (s *ImageCVEViewTestSuite) TestCountImageCVECoreSAC() {
-	for _, tc := range s.testCases() {
-		for key, sacTC := range s.sacTestCases() {
+	// Note: The new loop variable semantics introduced in go1.22 breaks these
+	// tests when using loop variables in closures such that the test code
+	// expects those loop variables to change on each iteration of the loop.
+	// The problem stems from what a closure captures, or "sees", loop
+	// variables on each iteration. Before go1.22, loop variables had per-loop
+	// scope, which is to say that any closure inside the loop using loop
+	// variables would have the reference of the loop variable updated on each
+	// iteration. In go1.22+, loop variables have per-iteration scope, which,
+	// for closures inside the loop, means that when a given closure first
+	// captures the variable, that value will always be used in that particular
+	// closure.
+	// To get around this, we define variables outside the loop and then set
+	// those variables to the loop variables on each iteration, then use the
+	// variables in the outer scope (relative to the loop) in the closure,
+	// effectively achieving per-loop scoped variables.
+	// References and further reading:
+	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
+	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
+	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
+	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
+	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+	var tc testCase
+	var key string
+	var sacTC map[string]bool
+	for _, tc = range s.testCases() {
+		for key, sacTC = range s.sacTestCases() {
 			if tc.skipCountTests {
 				continue
 			}

--- a/central/views/nodecve/view_test.go
+++ b/central/views/nodecve/view_test.go
@@ -186,31 +186,8 @@ func (s *NodeCVEViewTestSuite) TestGetNodeCVECore() {
 }
 
 func (s *NodeCVEViewTestSuite) TestGetNodeCVECoreSAC() {
-	// Note: The new loop variable semantics introduced in go1.22 breaks these
-	// tests when using loop variables in closures such that the test code
-	// expects those loop variables to change on each iteration of the loop.
-	// The problem stems from what a closure captures, or "sees", loop
-	// variables on each iteration. Before go1.22, loop variables had per-loop
-	// scope, which is to say that any closure inside the loop using loop
-	// variables would have the reference of the loop variable updated on each
-	// iteration. In go1.22+, loop variables have per-iteration scope, which,
-	// for closures inside the loop, means that when a given closure first
-	// captures the variable, that value will always be used in that particular
-	// closure.
-	// To get around this, we define variables outside the loop and then set
-	// those variables to the loop variables on each iteration, then use the
-	// variables in the outer scope (relative to the loop) in the closure,
-	// effectively achieving per-loop scoped variables.
-	// References and further reading:
-	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
-	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
-	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
-	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
-	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
-	var tc testCase
-	var sacTC sacTestCase
-	for _, tc = range s.testCases() {
-		for _, sacTC = range s.sacTestCases(tc.ctx) {
+	for _, tc := range s.testCases() {
+		for _, sacTC := range s.sacTestCases(tc.ctx) {
 			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
 				actual, err := s.cveView.Get(sacTC.ctx, tc.q)
 				if tc.expectedErr != "" {
@@ -220,7 +197,7 @@ func (s *NodeCVEViewTestSuite) TestGetNodeCVECoreSAC() {
 				assert.NoError(t, err)
 
 				// Wrap cluster filter with sac filter.
-				matchFilter := tc.matchFilter
+				matchFilter := *tc.matchFilter
 				baseNodeMatchFilter := matchFilter.matchNode
 				matchFilter.withNodeFilter(func(node *storage.Node) bool {
 					if sacTC.visibleNodes.Contains(node.GetId()) {
@@ -229,7 +206,7 @@ func (s *NodeCVEViewTestSuite) TestGetNodeCVECoreSAC() {
 					return false
 				})
 
-				expected := s.compileExpectedCVECores(tc.matchFilter)
+				expected := s.compileExpectedCVECores(&matchFilter)
 				assert.Equal(t, len(expected), len(actual))
 				assert.ElementsMatch(t, expected, actual)
 			})
@@ -287,31 +264,8 @@ func (s *NodeCVEViewTestSuite) TestCountNodeCVECore() {
 }
 
 func (s *NodeCVEViewTestSuite) TestCountNodeCVECoreSAC() {
-	// Note: The new loop variable semantics introduced in go1.22 breaks these
-	// tests when using loop variables in closures such that the test code
-	// expects those loop variables to change on each iteration of the loop.
-	// The problem stems from what a closure captures, or "sees", loop
-	// variables on each iteration. Before go1.22, loop variables had per-loop
-	// scope, which is to say that any closure inside the loop using loop
-	// variables would have the reference of the loop variable updated on each
-	// iteration. In go1.22+, loop variables have per-iteration scope, which,
-	// for closures inside the loop, means that when a given closure first
-	// captures the variable, that value will always be used in that particular
-	// closure.
-	// To get around this, we define variables outside the loop and then set
-	// those variables to the loop variables on each iteration, then use the
-	// variables in the outer scope (relative to the loop) in the closure,
-	// effectively achieving per-loop scoped variables.
-	// References and further reading:
-	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
-	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
-	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
-	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
-	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
-	var tc testCase
-	var sacTC sacTestCase
-	for _, tc = range s.testCases() {
-		for _, sacTC = range s.sacTestCases(tc.ctx) {
+	for _, tc := range s.testCases() {
+		for _, sacTC := range s.sacTestCases(tc.ctx) {
 			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
 				actual, err := s.cveView.Count(sacTC.ctx, tc.q)
 				if tc.expectedErr != "" {
@@ -321,7 +275,7 @@ func (s *NodeCVEViewTestSuite) TestCountNodeCVECoreSAC() {
 				assert.NoError(t, err)
 
 				// Wrap cluster filter with sac filter.
-				matchFilter := tc.matchFilter
+				matchFilter := *tc.matchFilter
 				baseClusterMatchFilter := matchFilter.matchNode
 				matchFilter.withNodeFilter(func(node *storage.Node) bool {
 					if sacTC.visibleNodes.Contains(node.GetId()) {
@@ -330,7 +284,7 @@ func (s *NodeCVEViewTestSuite) TestCountNodeCVECoreSAC() {
 					return false
 				})
 
-				expected := s.compileExpectedCVECores(tc.matchFilter)
+				expected := s.compileExpectedCVECores(&matchFilter)
 				assert.Equal(t, len(expected), actual)
 			})
 		}

--- a/central/views/nodecve/view_test.go
+++ b/central/views/nodecve/view_test.go
@@ -186,8 +186,31 @@ func (s *NodeCVEViewTestSuite) TestGetNodeCVECore() {
 }
 
 func (s *NodeCVEViewTestSuite) TestGetNodeCVECoreSAC() {
-	for _, tc := range s.testCases() {
-		for _, sacTC := range s.sacTestCases(tc.ctx) {
+	// Note: The new loop variable semantics introduced in go1.22 breaks these
+	// tests when using loop variables in closures such that the test code
+	// expects those loop variables to change on each iteration of the loop.
+	// The problem stems from what a closure captures, or "sees", loop
+	// variables on each iteration. Before go1.22, loop variables had per-loop
+	// scope, which is to say that any closure inside the loop using loop
+	// variables would have the reference of the loop variable updated on each
+	// iteration. In go1.22+, loop variables have per-iteration scope, which,
+	// for closures inside the loop, means that when a given closure first
+	// captures the variable, that value will always be used in that particular
+	// closure.
+	// To get around this, we define variables outside the loop and then set
+	// those variables to the loop variables on each iteration, then use the
+	// variables in the outer scope (relative to the loop) in the closure,
+	// effectively achieving per-loop scoped variables.
+	// References and further reading:
+	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
+	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
+	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
+	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
+	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+	var tc testCase
+	var sacTC sacTestCase
+	for _, tc = range s.testCases() {
+		for _, sacTC = range s.sacTestCases(tc.ctx) {
 			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
 				actual, err := s.cveView.Get(sacTC.ctx, tc.q)
 				if tc.expectedErr != "" {

--- a/central/views/nodecve/view_test.go
+++ b/central/views/nodecve/view_test.go
@@ -264,8 +264,31 @@ func (s *NodeCVEViewTestSuite) TestCountNodeCVECore() {
 }
 
 func (s *NodeCVEViewTestSuite) TestCountNodeCVECoreSAC() {
-	for _, tc := range s.testCases() {
-		for _, sacTC := range s.sacTestCases(tc.ctx) {
+	// Note: The new loop variable semantics introduced in go1.22 breaks these
+	// tests when using loop variables in closures such that the test code
+	// expects those loop variables to change on each iteration of the loop.
+	// The problem stems from what a closure captures, or "sees", loop
+	// variables on each iteration. Before go1.22, loop variables had per-loop
+	// scope, which is to say that any closure inside the loop using loop
+	// variables would have the reference of the loop variable updated on each
+	// iteration. In go1.22+, loop variables have per-iteration scope, which,
+	// for closures inside the loop, means that when a given closure first
+	// captures the variable, that value will always be used in that particular
+	// closure.
+	// To get around this, we define variables outside the loop and then set
+	// those variables to the loop variables on each iteration, then use the
+	// variables in the outer scope (relative to the loop) in the closure,
+	// effectively achieving per-loop scoped variables.
+	// References and further reading:
+	// - https://web.archive.org/web/20240905192132/https://go.dev/blog/go1.22
+	// - https://web.archive.org/web/20240905181916/https://go.dev/blog/loopvar-preview
+	// - https://web.archive.org/web/20240905191855/https://go.dev/wiki/LoopvarExperiment
+	// - https://web.archive.org/web/20240905192225/https://go.googlesource.com/proposal/+/master/design/60078-loopvar.md
+	// - https://web.archive.org/web/20240905191656/https://go101.org/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+	var tc testCase
+	var sacTC sacTestCase
+	for _, tc = range s.testCases() {
+		for _, sacTC = range s.sacTestCases(tc.ctx) {
 			s.T().Run(fmt.Sprintf("SAC desc: %s; test desc: %s ", sacTC.desc, tc.desc), func(t *testing.T) {
 				actual, err := s.cveView.Count(sacTC.ctx, tc.q)
 				if tc.expectedErr != "" {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/stackrox/rox
 
 go 1.22
 
+toolchain go1.22.5
+
 require (
 	cloud.google.com/go/artifactregistry v1.14.13
 	cloud.google.com/go/compute/metadata v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.21.8
-
-toolchain go1.21.9
+go 1.22
 
 require (
 	cloud.google.com/go/artifactregistry v1.14.13

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -27,7 +27,7 @@ RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
 RUN /tmp/.konflux/subscription-manager-bro.sh cleanup
 
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS go-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS go-builder
 
 RUN dnf -y install --allowerasing make automake gcc gcc-c++ coreutils binutils diffutils zlib-devel bzip2-devel lz4-devel cmake jq
 

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -5,7 +5,7 @@
 # - https://issues.redhat.com/browse/RHTAPBUGS-865 - openshift-golang-builder is not considered to be a valid base image.
 #
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
-# We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
+# We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.22 should provide enough stability.
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -6,7 +6,7 @@
 #
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -1,6 +1,6 @@
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 

--- a/operator/tools/controller-gen/go.mod
+++ b/operator/tools/controller-gen/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/rox/operator/tools/controller-gen
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.5
 
 require sigs.k8s.io/controller-tools v0.14.0
 

--- a/operator/tools/operator-sdk/go.mod
+++ b/operator/tools/operator-sdk/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/rox/operator/tools/operator-sdk
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.5
 
 require (
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0

--- a/operator/tools/yq/go.mod
+++ b/operator/tools/yq/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/rox/operator/tools/yq
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.5
 
 require github.com/mikefarah/yq/v4 v4.44.3
 

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.3
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.4
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.3
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.2
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/scanner/hack/quay/go.mod
+++ b/scanner/hack/quay/go.mod
@@ -1,3 +1,5 @@
 module github.com/stackrox/rox/scanner/hack/quay
 
-go 1.20
+go 1.22
+
+toolchain go1.22.5

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=ubi8-minimal
 ARG BASE_TAG=latest
 
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
 
 ENV GOFLAGS=""
 # TODO(ROX-24276): re-enable release builds for fast stream.

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227 "$@"
     exit 0
 fi
 

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.2-1-g54aa4ee227 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3 "$@"
     exit 0
 fi
 

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.3 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4 "$@"
     exit 0
 fi
 

--- a/tests/performance/scale/go.mod
+++ b/tests/performance/scale/go.mod
@@ -1,6 +1,8 @@
 module github.com/stackrox/stackrox/performance-scale-tests
 
-go 1.20
+go 1.22
+
+toolchain go1.22.5
 
 require (
 	github.com/cloud-bulldozer/go-commons v1.0.11

--- a/tools/check-workflow-run/go.mod
+++ b/tools/check-workflow-run/go.mod
@@ -1,6 +1,8 @@
 module github.com/stackrox/stackrox/tools/check-workflow-run
 
-go 1.21.7
+go 1.22
+
+toolchain go1.22.5
 
 require (
 	github.com/google/go-github/v61 v61.0.0

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/stackrox/tools/linters
 
-go 1.21
+go 1.22
 
-toolchain go1.21.8
+toolchain go1.22.5
 
 require (
 	github.com/golangci/golangci-lint v1.59.1

--- a/tools/proto/go.mod
+++ b/tools/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/proto
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bufbuild/buf v1.36.0

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/stackrox/tools/test
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.5
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0


### PR DESCRIPTION
### Description

Upgrades Go to 1.22.5. A few tests broke due to the loop variable semantics change in Go 1.22, but @parametalol helped me fix them up.

To generate a list of all code affected by the Go 1.22 loopvar change, refer to this document: https://go.dev/wiki/LoopvarExperiment#can-i-see-a-list-of-places-in-my-code-affected-by-the-change

Related PRs:
- https://github.com/stackrox/rox-ci-image/pull/214
- https://github.com/openshift/release/pull/56066
- https://github.com/stackrox/scanner/pull/1634
- https://github.com/openshift/release/pull/56367
- https://github.com/stackrox/rox-ci-image/pull/215
- https://github.com/openshift/release/pull/56518
- https://github.com/openshift/release/pull/56519

This also resolves https://issues.redhat.com/browse/ROX-8730

---

Supplemental information about the test fixes (please see the comments in the code changes for the initial explanation) regarding the difference between per-loop vs per-iteration scoped loop variables and closures:
Suppose you have the following Go program:
```go
package main

import "fmt"

func main() {
	elements := []int{1, 2, 3}
	var functions []func()
	for _, v := range elements {
		f := func() {
			fmt.Println(v)
		}
		functions = append(functions, f)
		for _, f := range functions {
			f()
		}
	}
}
```
The output for this program when using Go 1.21 would be:
```
❯ go run main.go
1
2
2
3
3
3
```
And in Go 1.22:
```
❯ go run main.go
1
1
2
1
2
3
```
The difference lies in what the closure sees when it's created. In our case and for our tests, we prefer the Go 1.21 semantics (however, please read Go's loopvar blog to understand why this is broadly problematic in non-test code).

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is sufficient (though, I did run all unit and integration tests locally as well)