### PR TITLE
ROX-26003: fix TestNodeIndexerSuite

### DIFF
--- a/compliance/index/v4/node_test.go
+++ b/compliance/index/v4/node_test.go
@@ -58,7 +58,7 @@ func (s *nodeIndexerSuite) TestRunRespositoryScanner() {
 	repositories, err := runRepositoryScanner(context.TODO(), layer)
 	s.NoError(err)
 
-	s.Len(repositories, 2)
+	s.Len(repositories, 4)
 	s.NoError(layer.Close())
 }
 
@@ -110,7 +110,7 @@ func (s *nodeIndexerSuite) TestIndexerE2E() {
 	s.NotNil(report)
 	s.True(report.Success)
 	s.Len(report.GetContents().GetPackages(), 106, "Expected number of installed packages differs")
-	s.Len(report.GetContents().GetRepositories(), 2, "Expected number of discovered repositories differs")
+	s.Len(report.GetContents().GetRepositories(), 4, "Expected number of discovered repositories differs")
 }
 
 func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {


### PR DESCRIPTION
### Description

This PR fixes failing `TestNodeIndexerSuite` that for some reasons started discovering more repositories than before.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
