### PR TITLE
tests(operator): no image pull secrets for operator

### DIFF
--- a/operator/hack/olm-operator-install.sh
+++ b/operator/hack/olm-operator-install.sh
@@ -38,7 +38,6 @@ function main() {
 
   check_version_tag "${operator_version}" "${allow_dirty_tag}"
   create_namespace "${operator_ns}"
-  create_pull_secret "${operator_ns}" "${image_registry}"
   apply_operator_manifests "${operator_ns}" "${image_tag_base}" "${index_version}" "${operator_version}"
 
   if ! [[ "${USE_MIDSTREAM_IMAGES}" == "true" ]]; then

--- a/operator/hack/olm-operator-install.sh
+++ b/operator/hack/olm-operator-install.sh
@@ -17,7 +17,6 @@ function main() {
 
   local -r operator_ns="${1:-}"
   local -r image_tag_base="${2:-}"
-  local -r image_registry="${image_tag_base%%/*}"
 
   case $# in
   3)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

https://quay.io/repository/rhacs-eng/stackrox-operator-bundle and https://quay.io/repository/rhacs-eng/stackrox-operator were made public today. This means we no longer need to have an image pull secret for the operator itself.

A nice side-effect is that there is no longer a delay while we wait for OLM to notice we patched it in.

Note this does not change anything about image pull secrets used by the operands.

Not a user-visible change
- upstream we don't currently ship the operator
- downstream users use a cluster-wide secret anyway

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should be sufficient. I took a look at a few jobs before and after the change and here are anecdotal results (the timing varies a lot depending on OLM's mood at the moment, but it looks like the 5m wait is indeed gone).

<details>
<summary>GKE before: 56s to install, 34s to upgrade</summary>

```
+ ./hack/olm-operator-install.sh stackrox-operator quay.io/rhacs-eng/stackrox-operator 4.6.0-408-g186e6d9800 4.4.0
2024-08-28T21:14:47Z Creating namespace...
namespace/stackrox-operator created
2024-08-28T21:14:47Z Creating image pull secret...
Using authentication token for quay.io from ~/.docker/config.json.
secret/operator-pull-secret created
2024-08-28T21:14:48Z Applying operator manifests...
catalogsource.operators.coreos.com/stackrox-operator-test-index created
operatorgroup.operators.coreos.com/all-namespaces-operator-group created
subscription.operators.coreos.com/stackrox-operator-test-subscription created
2024-08-28T21:14:49Z Waiting for an install plan to be created
subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
2024-08-28T21:15:25Z Verifying that the subscription is progressing to the expected CSV of 4.4.0...
2024-08-28T21:15:26Z Approving install plan install-9fjqw
installplan.operators.coreos.com/install-9fjqw patched
2024-08-28T21:15:27Z Patching image pull secret into 4.4.0 CSV...
clusterserviceversion.operators.coreos.com/rhacs-operator.v4.4.0 patched
2024-08-28T21:15:28Z Waiting for the 4.4.0 CSV to finish installing.
assert is valid
2024-08-28T21:15:43Z Making sure the 4.4.0 operator deployment is available...
deployment.apps/rhacs-operator-controller-manager condition met
make: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
INFO: Wed Aug 28 21:15:43 UTC 2024: Waiting for pre-fetcher of system images to complete...
```

```
    logger.go:42: 21:19:27 | upgrade/20-upgrade-operator | 2024-08-28T21:19:27Z Waiting for an install plan to be created
    logger.go:42: 21:19:28 | upgrade/20-upgrade-operator | subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
    logger.go:42: 21:19:28 | upgrade/20-upgrade-operator | 2024-08-28T21:19:28Z Verifying that the subscription is progressing to the expected CSV of 4.6.0-408-g186e6d9800...
    logger.go:42: 21:19:29 | upgrade/20-upgrade-operator | 2024-08-28T21:19:29Z Approving install plan install-54q6k
    logger.go:42: 21:19:29 | upgrade/20-upgrade-operator | installplan.operators.coreos.com/install-54q6k patched
    logger.go:42: 21:19:29 | upgrade/20-upgrade-operator | 2024-08-28T21:19:29Z Patching image pull secret into 4.6.0-408-g186e6d9800 CSV...
    logger.go:42: 21:19:30 | upgrade/20-upgrade-operator | Error from server (NotFound): clusterserviceversions.operators.coreos.com "rhacs-operator.v4.6.0-408-g186e6d9800" not found
    logger.go:42: 21:19:30 | upgrade/20-upgrade-operator | 2024-08-28T21:19:30Z retrying in 10s...
    logger.go:42: 21:19:41 | upgrade/20-upgrade-operator | clusterserviceversion.operators.coreos.com/rhacs-operator.v4.6.0-408-g186e6d9800 patched
    logger.go:42: 21:19:41 | upgrade/20-upgrade-operator | 2024-08-28T21:19:41Z Waiting for the 4.6.0-408-g186e6d9800 CSV to finish installing.
    logger.go:42: 21:20:00 | upgrade/20-upgrade-operator | assert is valid
    logger.go:42: 21:20:00 | upgrade/20-upgrade-operator | 2024-08-28T21:20:00Z Making sure the 4.6.0-408-g186e6d9800 operator deployment is available...
    logger.go:42: 21:20:01 | upgrade/20-upgrade-operator | deployment.apps/rhacs-operator-controller-manager condition met
    logger.go:42: 21:20:01 | upgrade/20-upgrade-operator | make[1]: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
```
</details>

<details>
<summary>GKE after: 1m27s to install, 21s to upgrade</summary>

```
+ ./hack/olm-operator-install.sh stackrox-operator quay.io/rhacs-eng/stackrox-operator 4.6.0-410-g31ee62847b 4.4.0
2024-08-29T14:14:08Z Creating namespace...
namespace/stackrox-operator created
2024-08-29T14:14:09Z Applying operator manifests...
catalogsource.operators.coreos.com/stackrox-operator-test-index created
operatorgroup.operators.coreos.com/all-namespaces-operator-group created
subscription.operators.coreos.com/stackrox-operator-test-subscription created
2024-08-29T14:14:11Z Waiting for an install plan to be created
error: timed out waiting for the condition on subscriptions/stackrox-operator-test-subscription
2024-08-29T14:15:11Z retrying in 5s...
subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
2024-08-29T14:15:17Z Verifying that the subscription is progressing to the expected CSV of 4.4.0...
2024-08-29T14:15:17Z Approving install plan install-jmnpt
installplan.operators.coreos.com/install-jmnpt patched
2024-08-29T14:15:18Z Waiting for the 4.4.0 CSV to finish installing.
assert is valid
2024-08-29T14:15:35Z Making sure the 4.4.0 operator deployment is available...
deployment.apps/rhacs-operator-controller-manager condition met
make: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
INFO: Thu Aug 29 14:15:36 UTC 2024: Waiting for pre-fetcher of system images to complete...
```

```
logger.go:42: 14:19:34 | upgrade/20-upgrade-operator | 2024-08-29T14:19:34Z Waiting for an install plan to be created
logger.go:42: 14:19:35 | upgrade/20-upgrade-operator | subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
logger.go:42: 14:19:35 | upgrade/20-upgrade-operator | 2024-08-29T14:19:35Z Verifying that the subscription is progressing to the expected CSV of 4.6.0-410-g31ee62847b...
logger.go:42: 14:19:36 | upgrade/20-upgrade-operator | 2024-08-29T14:19:36Z Approving install plan install-55wfr
logger.go:42: 14:19:36 | upgrade/20-upgrade-operator | installplan.operators.coreos.com/install-55wfr patched
logger.go:42: 14:19:36 | upgrade/20-upgrade-operator | 2024-08-29T14:19:36Z Waiting for the 4.6.0-410-g31ee62847b CSV to finish installing.
logger.go:42: 14:19:54 | upgrade/20-upgrade-operator | assert is valid
logger.go:42: 14:19:54 | upgrade/20-upgrade-operator | 2024-08-29T14:19:54Z Making sure the 4.6.0-410-g31ee62847b operator deployment is available...
logger.go:42: 14:19:55 | upgrade/20-upgrade-operator | deployment.apps/rhacs-operator-controller-manager condition met
logger.go:42: 14:19:55 | upgrade/20-upgrade-operator | make[1]: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
```
</details>

<details>
<summary>OCP before: 6m2s to install, 19s to upgrade</summary>
```
+ ./hack/olm-operator-install.sh stackrox-operator quay.io/rhacs-eng/stackrox-operator 4.6.0-408-g186e6d9800 4.4.0
2024-08-28T21:39:59Z Creating namespace...
namespace/stackrox-operator created
2024-08-28T21:39:59Z Creating image pull secret...
Using authentication token for quay.io from ~/.docker/config.json.
secret/operator-pull-secret created
2024-08-28T21:40:02Z Applying operator manifests...
catalogsource.operators.coreos.com/stackrox-operator-test-index created
operatorgroup.operators.coreos.com/all-namespaces-operator-group created
subscription.operators.coreos.com/stackrox-operator-test-subscription created
2024-08-28T21:40:03Z Waiting for an install plan to be created
subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
2024-08-28T21:40:27Z Verifying that the subscription is progressing to the expected CSV of 4.4.0...
2024-08-28T21:40:28Z Approving install plan install-dlgrp
installplan.operators.coreos.com/install-dlgrp patched
2024-08-28T21:40:28Z Patching image pull secret into 4.4.0 CSV...
Error from server (NotFound): clusterserviceversions.operators.coreos.com "rhacs-operator.v4.4.0" not found
2024-08-28T21:40:29Z retrying in 10s...
Error from server (NotFound): clusterserviceversions.operators.coreos.com "rhacs-operator.v4.4.0" not found
2024-08-28T21:40:39Z retrying in 10s...
clusterserviceversion.operators.coreos.com/rhacs-operator.v4.4.0 patched
2024-08-28T21:40:50Z Waiting for the 4.4.0 CSV to finish installing.
assert is valid
2024-08-28T21:46:01Z Making sure the 4.4.0 operator deployment is available...
deployment.apps/rhacs-operator-controller-manager condition met
make: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
INFO: Wed Aug 28 21:46:01 UTC 2024: Waiting for pre-fetcher of system images to complete...
```

```
    logger.go:42: 21:50:09 | upgrade/20-upgrade-operator | make[1]: Entering directory '/go/src/github.com/stackrox/stackrox/operator'
    logger.go:42: 21:50:09 | upgrade/20-upgrade-operator | KUTTL=/go/src/github.com/stackrox/stackrox/operator/.gotools/bin/kubectl-kuttl PATH="/go/src/github.com/stackrox/stackrox/operator//hack:${PATH}" ./hack/olm-operator-upgrade.sh stackrox-operator 4.6.0-408-g186e6d9800
    logger.go:42: 21:50:09 | upgrade/20-upgrade-operator | 2024-08-28T21:50:09Z Waiting for an install plan to be created
    logger.go:42: 21:50:10 | upgrade/20-upgrade-operator | subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
    logger.go:42: 21:50:10 | upgrade/20-upgrade-operator | 2024-08-28T21:50:10Z Verifying that the subscription is progressing to the expected CSV of 4.6.0-408-g186e6d9800...
    logger.go:42: 21:50:11 | upgrade/20-upgrade-operator | 2024-08-28T21:50:11Z Approving install plan install-shccn
    logger.go:42: 21:50:11 | upgrade/20-upgrade-operator | installplan.operators.coreos.com/install-shccn patched
    logger.go:42: 21:50:11 | upgrade/20-upgrade-operator | 2024-08-28T21:50:11Z Patching image pull secret into 4.6.0-408-g186e6d9800 CSV...
    logger.go:42: 21:50:12 | upgrade/20-upgrade-operator | clusterserviceversion.operators.coreos.com/rhacs-operator.v4.6.0-408-g186e6d9800 patched
    logger.go:42: 21:50:12 | upgrade/20-upgrade-operator | 2024-08-28T21:50:12Z Waiting for the 4.6.0-408-g186e6d9800 CSV to finish installing.
    logger.go:42: 21:50:27 | upgrade/20-upgrade-operator | assert is valid
    logger.go:42: 21:50:27 | upgrade/20-upgrade-operator | 2024-08-28T21:50:27Z Making sure the 4.6.0-408-g186e6d9800 operator deployment is available...
    logger.go:42: 21:50:28 | upgrade/20-upgrade-operator | deployment.apps/rhacs-operator-controller-manager condition met
    logger.go:42: 21:50:28 | upgrade/20-upgrade-operator | make[1]: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
```
</details>

<details>
<summary>OCP after: 56s to install, 20s to upgrade</summary>

```
+ ./hack/olm-operator-install.sh stackrox-operator quay.io/rhacs-eng/stackrox-operator 4.6.0-410-g31ee62847b 4.4.0
2024-08-29T14:33:01Z Creating namespace...
namespace/stackrox-operator created
2024-08-29T14:33:01Z Applying operator manifests...
catalogsource.operators.coreos.com/stackrox-operator-test-index created
operatorgroup.operators.coreos.com/all-namespaces-operator-group created
subscription.operators.coreos.com/stackrox-operator-test-subscription created
2024-08-29T14:33:05Z Waiting for an install plan to be created
subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
2024-08-29T14:33:24Z Verifying that the subscription is progressing to the expected CSV of 4.4.0...
2024-08-29T14:33:25Z Approving install plan install-cfjr9
installplan.operators.coreos.com/install-cfjr9 patched
2024-08-29T14:33:25Z Waiting for the 4.4.0 CSV to finish installing.
assert is valid
2024-08-29T14:33:57Z Making sure the 4.4.0 operator deployment is available...
deployment.apps/rhacs-operator-controller-manager condition met
make: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
INFO: Thu Aug 29 14:33:57 UTC 2024: Waiting for pre-fetcher of system images to complete...
```

```
logger.go:42: 14:38:02 | upgrade/20-upgrade-operator | starting test step 20-upgrade-operator
logger.go:42: 14:38:02 | upgrade/20-upgrade-operator | running command: [make -C ../../.. upgrade-via-olm]
logger.go:42: 14:38:02 | upgrade/20-upgrade-operator | make[1]: Entering directory '/go/src/github.com/stackrox/stackrox/operator'
logger.go:42: 14:38:03 | upgrade/20-upgrade-operator | KUTTL=/go/src/github.com/stackrox/stackrox/operator/.gotools/bin/kubectl-kuttl PATH="/go/src/github.com/stackrox/stackrox/operator//hack:${PATH}" ./hack/olm-operator-upgrade.sh stackrox-operator 4.6.0-410-g31ee62847b
logger.go:42: 14:38:03 | upgrade/20-upgrade-operator | 2024-08-29T14:38:03Z Waiting for an install plan to be created
logger.go:42: 14:38:03 | upgrade/20-upgrade-operator | subscription.operators.coreos.com/stackrox-operator-test-subscription condition met
logger.go:42: 14:38:03 | upgrade/20-upgrade-operator | 2024-08-29T14:38:03Z Verifying that the subscription is progressing to the expected CSV of 4.6.0-410-g31ee62847b...
logger.go:42: 14:38:04 | upgrade/20-upgrade-operator | 2024-08-29T14:38:04Z Approving install plan install-8h2ft
logger.go:42: 14:38:05 | upgrade/20-upgrade-operator | installplan.operators.coreos.com/install-8h2ft patched
logger.go:42: 14:38:05 | upgrade/20-upgrade-operator | 2024-08-29T14:38:05Z Waiting for the 4.6.0-410-g31ee62847b CSV to finish installing.
logger.go:42: 14:38:22 | upgrade/20-upgrade-operator | assert is valid
logger.go:42: 14:38:22 | upgrade/20-upgrade-operator | 2024-08-29T14:38:22Z Making sure the 4.6.0-410-g31ee62847b operator deployment is available...
logger.go:42: 14:38:22 | upgrade/20-upgrade-operator | deployment.apps/rhacs-operator-controller-manager condition met
logger.go:42: 14:38:22 | upgrade/20-upgrade-operator | make[1]: Leaving directory '/go/src/github.com/stackrox/stackrox/operator'
```
</details>

