### PR TITLE
fix(ui): Add pluginGeneric and improve consistency of external links

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -258,12 +258,12 @@ export function interactAndWaitForConfigurationManagementScan(interactionCallbac
 
 export function navigateToSingleEntityPage(entitiesKey) {
     // interactAndWaitForConfigurationManagementEntityPage(() => {
-    //     cy.get('[data-testid="side-panel"] [aria-label="External link"]').click();
+    //     cy.get('[data-testid="side-panel"] [aria-label="link"]').click();
     // }, entitiesKey);
 
     // no longer intercepting on second gql request as on slow connections the
     // second request is not made since it's still waiting on first request
-    cy.get('[data-testid="side-panel"] [aria-label="External link"]').click();
+    cy.get('[data-testid="side-panel"] [aria-label="link"]').click();
     cy.location('pathname').should('contain', getEntityPagePath(entitiesKey)); // contains because it ends with id
     cy.get(`h1 + div:contains("${headingForEntity[entitiesKey]}")`);
 }

--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -343,7 +343,7 @@ function verifyTableLink(
             );
 
             // 4. Visit single page for primary entity.
-            cy.get('[aria-label="External link"]').click(); // does not make requests
+            cy.get('[aria-label="link"]').click(); // does not make requests
 
             // 5. Visit single page list for secondary entities.
             interactAndWaitForVulnerabilityManagementSecondaryEntities(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
@@ -24,7 +24,7 @@ const sidePanelSelectors = {
     sidePanel: '[data-testid="side-panel"]',
     backButton: '[aria-label="Go to preceding breadcrumb"]',
     entityIcon: '[data-testid="entity-icon"]',
-    sidePanelExternalLinkButton: '[aria-label="External link"]',
+    sidePanelExternalLinkButton: '[aria-label="link"]',
     scanDataMessage: '.pf-v5-c-alert__title:contains("CVE data may be inaccurate")',
 };
 

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -41,7 +41,7 @@ const rules = {
             type: 'problem',
             docs: {
                 description:
-                    'Require if Link element has target="_blank" that it has rel="noopener noreferrer" props',
+                    'Require tbat Link element with target="_blank" also has rel="noopener noreferrer" prop',
             },
             schema: [],
         },
@@ -66,7 +66,7 @@ const rules = {
                                 context.report({
                                     node,
                                     message:
-                                        'Require if Link element has target="_blank" that it has rel="noopener noreferrer" props',
+                                        'Require tbat Link element with target="_blank" also has rel="noopener noreferrer" prop',
                                 });
                             }
                         }

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -5,12 +5,12 @@ const rules = {
     // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
 
     'ExternalLink-a': {
-        // Require ExternalLink and a elements for consistent presentation.
-        // For example, ExternalLinkAltIcon follows a element.
+        // Require ExternalLink with anchor element as child for consistent presentation of external links.
         meta: {
             type: 'problem',
             docs: {
-                description: 'Require ExternalLink and a elements for consistent presentation',
+                description:
+                    'Require ExternalLink with anchor element as child for consistent presentation of external links',
             },
             schema: [],
         },
@@ -27,7 +27,7 @@ const rules = {
                             context.report({
                                 node,
                                 message:
-                                    'Require ExternalLink and a elements for consistent presentation',
+                                    'Require ExternalLink with anchor element as child for consistent presentation of external links',
                             });
                         }
                     }

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -81,7 +81,7 @@ const rules = {
             type: 'problem',
             docs: {
                 description:
-                    'Require that a element has target="_blank" rel="noopener noreferrer" props',
+                    'Require that anchor element has target="_blank" and rel="noopener noreferrer" props',
             },
             schema: [],
         },
@@ -104,7 +104,7 @@ const rules = {
                             context.report({
                                 node,
                                 message:
-                                    'Require that a element has target="_blank" rel="noopener noreferrer" props',
+                                    'Require that anchor element has target="_blank" and rel="noopener noreferrer" props',
                             });
                         }
                     }

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -1,0 +1,139 @@
+/* globals module */
+
+const rules = {
+    // ESLint naming convention for positive rules:
+    // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
+
+    'ExternalLink-a': {
+        // Require ExternalLink and a elements for consistent presentation.
+        // For example, ExternalLinkAltIcon follows a element.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require ExternalLink and a elements for consistent presentation',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'a') {
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        if (
+                            ancestors.length >= 1 &&
+                            ancestors[ancestors.length - 1].openingElement?.name?.name !==
+                                'ExternalLink'
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Require ExternalLink and a elements for consistent presentation',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
+    'Link-target-rel': {
+        // Require props for consistent behavior and security of internal links that open in a new tab.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require if Link element has target="_blank" that it has rel="noopener noreferrer" props',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'Link') {
+                        if (
+                            node.attributes.some(
+                                (nodeAttribute) =>
+                                    nodeAttribute.name?.name === 'target' &&
+                                    nodeAttribute.value?.value === '_blank'
+                            )
+                        ) {
+                            if (
+                                !node.attributes.some(
+                                    (nodeAttribute) =>
+                                        nodeAttribute.name?.name === 'rel' &&
+                                        nodeAttribute.value?.value === 'noopener noreferrer'
+                                )
+                            ) {
+                                context.report({
+                                    node,
+                                    message:
+                                        'Require if Link element has target="_blank" that it has rel="noopener noreferrer" props',
+                                });
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
+    'a-target-rel': {
+        // Require props for consistent behavior and security of external links.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require that a element has target="_blank" rel="noopener noreferrer" props',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'a') {
+                        if (
+                            !node.attributes.some(
+                                (nodeAttribute) =>
+                                    nodeAttribute.name?.name === 'target' &&
+                                    nodeAttribute.value?.value === '_blank'
+                            ) ||
+                            !node.attributes.some(
+                                (nodeAttribute) =>
+                                    nodeAttribute.name?.name === 'rel' &&
+                                    nodeAttribute.value?.value === 'noopener noreferrer'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Require that a element has target="_blank" rel="noopener noreferrer" props',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
+
+    // ESLint naming convention for negative rules.
+    // If your rule only disallows something, prefix it with no.
+    // However, we can write forbid instead of disallow as the verb in description and message.
+};
+
+const pluginKey = 'generic'; // key of pluginGeneric in eslint.config.js file
+
+const pluginGeneric = {
+    meta: {
+        name: 'pluginGeneric',
+        version: '0.0.1',
+    },
+    rules,
+    // ...pluginGeneric.configs.recommended.rules means all rules in eslint.config.js file.
+    configs: {
+        recommended: {
+            rules: Object.fromEntries(
+                Object.keys(rules).map((ruleKey) => [`${pluginKey}/${ruleKey}`, 'error'])
+            ),
+        },
+    },
+};
+
+module.exports = pluginGeneric;

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -19,6 +19,7 @@ const pluginTypeScriptESLint = require('@typescript-eslint/eslint-plugin');
 const { browser: browserGlobals, jest: jestGlobals, node: nodeGlobals } = require('globals');
 
 const pluginAccessibility = require('./eslint-plugins/pluginAccessibility');
+const pluginGeneric = require('./eslint-plugins/pluginGeneric');
 
 const parserAndOptions = {
     parser: parserTypeScriptESLint,
@@ -531,12 +532,14 @@ module.exports = [
         // Key of plugin is namespace of its rules.
         plugins: {
             accessibility: pluginAccessibility,
+            generic: pluginGeneric,
             import: pluginImport,
             react: pluginReact,
             'react-hooks': pluginReactHooks,
         },
         rules: {
             ...pluginAccessibility.configs.recommended.rules,
+            ...pluginGeneric.configs.recommended.rules,
 
             'no-restricted-imports': [
                 'error',

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Banner } from '@patternfly/react-core';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import { getProductBranding } from 'constants/productBranding';
 import useRestQuery from 'hooks/useRestQuery';
 import useMetadata from 'hooks/useMetadata';
@@ -31,18 +32,23 @@ function ScannerV4IntegrationBanner() {
             : 'New Scanner V4 now generally available in StackRox 4.5.';
 
     const docsLink = (
-        <a
-            href={getVersionedDocs(version, 'operating/examine-images-for-vulnerabilities.html')}
-            target="_blank"
-            rel="noopener noreferrer"
-        >
-            RHACS documentation
-        </a>
+        <ExternalLink>
+            <a
+                href={getVersionedDocs(
+                    version,
+                    'operating/examine-images-for-vulnerabilities.html'
+                )}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                RHACS documentation
+            </a>
+        </ExternalLink>
     );
 
     return (
         <Banner variant="blue" className="pf-v5-u-text-align-center">
-            {brandedText} Refer to the {docsLink} to learn more.
+            {brandedText} For more information, see {docsLink}
         </Banner>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -1,10 +1,9 @@
 import React, { ReactElement } from 'react';
-import { ExternalLink } from 'react-feather';
 import { differenceInDays } from 'date-fns';
 import { Tooltip } from '@patternfly/react-core';
 
 import { getTime, getDate, getDayOfWeek, getDistanceStrictAsPhrase } from 'utils/dateUtils';
-
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
 import { getVersionedDocs } from 'utils/versioning';
 import HealthStatus from './HealthStatus';
@@ -78,28 +77,26 @@ function CredentialExpiration({
 
     return (
         <HealthStatus icon={icon} iconColor={fgColor}>
-            {isList || healthStatus === 'HEALTHY' ? (
+            {isList || healthStatus !== 'HEALTHY' ? (
                 expirationElement
             ) : (
                 <div>
                     {expirationElement}
                     {version && (
-                        <div className="flex flex-row items-end leading-tight text-tertiary-700">
-                            <a
-                                href={getVersionedDocs(
-                                    version,
-                                    'configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters'
-                                )}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline"
-                                data-testid="reissueCertificatesLink"
-                            >
-                                Re-issue internal certificates
-                            </a>
-                            <span className="flex-shrink-0 ml-2">
-                                <ExternalLink className="h-4 w-4" />
-                            </span>
+                        <div className="flex flex-row items-end leading-tight">
+                            <ExternalLink>
+                                <a
+                                    href={getVersionedDocs(
+                                        version,
+                                        'configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters'
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    data-testid="reissueCertificatesLink"
+                                >
+                                    Re-issue internal certificates
+                                </a>
+                            </ExternalLink>
                         </div>
                     )}
                 </div>

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -77,7 +77,7 @@ function CredentialExpiration({
 
     return (
         <HealthStatus icon={icon} iconColor={fgColor}>
-            {isList || healthStatus !== 'HEALTHY' ? (
+            {isList || healthStatus === 'HEALTHY' ? (
                 expirationElement
             ) : (
                 <div>

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Text } from '@patternfly/react-core';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import ToggleSwitch from 'Components/ToggleSwitch';
 import Select from 'Components/Select';
 import {
@@ -350,19 +351,20 @@ const StaticConfigurationSection = ({
                             title="Kernel support package"
                             component="p"
                         >
-                            <span>
-                                Central doesn’t have the required Kernel support package. Retrieve
-                                it from{' '}
-                                <a
-                                    href="https://install.stackrox.io/collector/support-packages/index.html"
-                                    className="underline text-primary-900"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    stackrox.io
-                                </a>{' '}
-                                and upload it to Central using roxctl.
-                            </span>
+                            <Text>Central does not have the required Kernel support package.</Text>
+                            <Text>
+                                Retrieve it from{' '}
+                                <ExternalLink>
+                                    <a
+                                        href="https://install.stackrox.io/collector/support-packages/index.html"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        stackrox.io
+                                    </a>
+                                </ExternalLink>
+                            </Text>
+                            <Text>Upload it to Central using roxctl</Text>
                         </Alert>
                     )}
                 </div>

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { Link, withRouter } from 'react-router-dom';
-import { ExternalLink } from 'react-feather';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import Query from 'Components/CacheFirstQuery';
 import CloseButton from 'Components/CloseButton';
@@ -56,18 +56,19 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
                 const headerTextComponent = (
                     <div className="w-full flex items-center">
                         <div className="flex items-center" data-testid="side-panel-header">
-                            <Link to={headerUrl} className="w-full flex pf-v5-u-link-color">
-                                <div className="flex flex-1 items-center pl-4 leading-normal font-700">
+                            <Link to={headerUrl} className="w-full flex ml-4">
+                                <div className="flex flex-1 items-center leading-normal">
                                     {linkText}
                                 </div>
                             </Link>
                             <Link
-                                className="mx-2 pf-v5-u-link-color p-1 rounded flex"
+                                className="mx-4 p-1 rounded flex"
                                 to={headerUrl}
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 aria-label="External link"
                             >
-                                <ExternalLink size="14" />
+                                <ExternalLinkAltIcon />
                             </Link>
                         </div>
                     </div>

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.js
@@ -32,7 +32,6 @@ class VerticalBarChart extends Component {
         seriesProps: PropTypes.shape({}),
         tickValues: PropTypes.arrayOf(PropTypes.number),
         tickFormat: PropTypes.func,
-        labelLinks: PropTypes.shape({}),
         onValueClick: PropTypes.func,
         legend: PropTypes.bool,
     };
@@ -43,13 +42,12 @@ class VerticalBarChart extends Component {
         seriesProps: {},
         tickValues: [25, 50, 75, 100],
         tickFormat: (x) => `${x}%`,
-        labelLinks: {},
         onValueClick: null,
         legend: true,
     };
 
     render() {
-        const { tickValues, tickFormat, labelLinks, onValueClick } = this.props;
+        const { tickValues, tickFormat, onValueClick } = this.props;
 
         const data = this.props.data.sort(sortByXValue);
 
@@ -95,16 +93,7 @@ class VerticalBarChart extends Component {
         }));
 
         function formatTicks(value) {
-            let inner = value;
-            if (labelLinks[value]) {
-                inner = (
-                    <a className="underline" href={labelLinks[value]}>
-                        {value}
-                    </a>
-                );
-            }
-
-            return <tspan>{inner}</tspan>;
+            return <tspan>{value}</tspan>;
         }
 
         return (

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import onClickOutside from 'react-onclickoutside';
-import { ExternalLink } from 'react-feather';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
@@ -75,13 +75,13 @@ const SidePanel = ({
         .query(getSearchParams())
         .url();
     const externalLink = (
-        <div className="flex items-center h-full hover:bg-base-300">
+        <div className="flex items-center h-full">
             <Link
                 to={externalURL}
-                aria-label="External link"
+                aria-label="link"
                 className="border-base-400 border-l h-full p-4"
             >
-                <ExternalLink className="h-6 w-6 text-base-600" />
+                <ExternalLinkAltIcon />
             </Link>
         </div>
     );

--- a/ui/apps/platform/src/Containers/Images/VulnsTable.js
+++ b/ui/apps/platform/src/Containers/Images/VulnsTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import Table from 'Components/Table';
 
 const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
@@ -11,14 +12,16 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
             accessor: 'cve',
             Cell: (ci) => (
                 <div>
-                    <a
-                        href={ci.original.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary-600 font-700 pointer-events-auto"
-                    >
-                        {ci.value}
-                    </a>
+                    <ExternalLink>
+                        <a
+                            href={ci.original.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="pointer-events-auto"
+                        >
+                            {ci.value}
+                        </a>
+                    </ExternalLink>
                     <div className="mt-2">{ci.original.summary}</div>
                 </div>
             ),

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -244,7 +244,7 @@ function MachineAccessIntegrationForm({
                                                                                     <a
                                                                                         href="https://golang.org/s/re2syntax"
                                                                                         target="_blank"
-                                                                                        rel="noreferrer"
+                                                                                        rel="noopener noreferrer"
                                                                                     >
                                                                                         Learn how to
                                                                                         use regex

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
@@ -106,7 +106,7 @@ function regularExpressionIcon(): ReactElement {
                             <a
                                 href="https://golang.org/s/re2syntax"
                                 target="_blank"
-                                rel="noreferrer"
+                                rel="noopener noreferrer"
                             >
                                 See RE2 syntax reference
                             </a>

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -141,6 +141,9 @@ class LoginPage extends Component {
         if (authProviderResponse && authProviderResponse.error) {
             const errorKey = authProviderResponse.error.replace('_', ' ');
             const errorMsg = authProviderResponse.error_description || '';
+            // TODO is the link external or internal?
+            /* eslint-disable generic/ExternalLink-a */
+            /* eslint-disable generic/a-target-rel */
             const errorLink = ((url) =>
                 url ? (
                     <span>
@@ -149,6 +152,8 @@ class LoginPage extends Component {
                 ) : (
                     []
                 ))(authProviderResponse.error_uri);
+            /* eslint-enable generic/ExternalLink-a */
+            /* eslint-enable generic/a-target-rel */
             return (
                 <Alert
                     variant="danger"

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -10,6 +10,7 @@ import { Alert, Button, Title, TitleSizes } from '@patternfly/react-core';
 import { AUTH_STATUS } from 'reducers/auth';
 import { selectors } from 'reducers';
 import { ThemeContext } from 'Containers/ThemeProvider';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import LoadingSection from 'Components/PatternFly/LoadingSection';
 import ReduxSelectField from 'Components/forms/ReduxSelectField';
 import ReduxTextField from 'Components/forms/ReduxTextField';
@@ -141,19 +142,18 @@ class LoginPage extends Component {
         if (authProviderResponse && authProviderResponse.error) {
             const errorKey = authProviderResponse.error.replace('_', ' ');
             const errorMsg = authProviderResponse.error_description || '';
-            // TODO is the link external or internal?
-            /* eslint-disable generic/ExternalLink-a */
-            /* eslint-disable generic/a-target-rel */
             const errorLink = ((url) =>
                 url ? (
-                    <span>
-                        (<a href={url}>more info</a>)
-                    </span>
+                    <ExternalLink>
+                        (
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                            more info
+                        </a>
+                        )
+                    </ExternalLink>
                 ) : (
                     []
                 ))(authProviderResponse.error_uri);
-            /* eslint-enable generic/ExternalLink-a */
-            /* eslint-enable generic/a-target-rel */
             return (
                 <Alert
                     variant="danger"

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -4,6 +4,9 @@ import CollapsibleCard from 'Components/CollapsibleCard';
 import NoResultsMessage from 'Components/NoResultsMessage';
 
 const Factor = ({ message, url }) => {
+    // TODO is the link external or internal?
+    /* eslint-disable generic/ExternalLink-a */
+    /* eslint-disable generic/a-target-rel */
     const renderedMessage = url ? (
         <a href={url} target="_blank" rel="noopener noreferrer">
             {message}
@@ -11,6 +14,8 @@ const Factor = ({ message, url }) => {
     ) : (
         message
     );
+    /* eslint-enable generic/ExternalLink-a */
+    /* eslint-enable generic/a-target-rel */
 
     return (
         <div className="px-3">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { ExternalLink } from 'react-feather';
 import { format } from 'date-fns';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import CveType from 'Components/CveType';
 import Metadata from 'Components/Metadata';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import dateTimeFormat from 'constants/dateTimeFormat';
 import entityTypes from 'constants/entityTypes';
 import { isValidURL } from 'utils/urlUtils';
@@ -54,20 +54,13 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
     const operatingSystem = safeData?.operatingSystem;
 
     const linkToMoreInfo = isValidURL(link) ? (
-        <a
-            href={link}
-            className="btn-sm btn-base no-underline p-1"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            data-testid="more-info-link"
-        >
-            <span className="pr-1">View Full CVE Description</span>
-            <ExternalLink size={16} />
-        </a>
+        <ExternalLink>
+            <a href={link} target="_blank" rel="noopener noreferrer">
+                View Full CVE Description
+            </a>
+        </ExternalLink>
     ) : (
-        <span className="text-center text-base-600 bg-base-100 text-sm p-1">
-            Full description unavailable
-        </span>
+        <span>Full description unavailable</span>
     );
 
     const cvssScoreBreakdown = [

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useContext, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
     Card,
     CodeBlock,
@@ -107,9 +108,13 @@ function AffectedComponentsModal({
                                         }}
                                     />
                                     <Td dataLabel="Component">
-                                        <a href={componentURL} target="_blank" rel="noreferrer">
+                                        <Link
+                                            to={componentURL}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
                                             {component.name}
-                                        </a>
+                                        </Link>
                                     </Td>
                                     <Td dataLabel="Version">{component.version}</Td>
                                     <Td dataLabel="Fixed in">{component.fixedIn || '-'}</Td>

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withRouter, Link } from 'react-router-dom';
-import { ExternalLink } from 'react-feather';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
@@ -22,12 +22,8 @@ const WorkflowSidePanel = ({ history, location, children }) => {
     const url = workflowState.getSkimmedStack().toUrl();
     const externalLink = (
         <div className="flex items-center h-full hover:bg-base-300">
-            <Link
-                to={url}
-                aria-label="External link"
-                className="border-base-400 border-l h-full p-4"
-            >
-                <ExternalLink className="h-6 w-6 text-base-600" />
+            <Link to={url} aria-label="link" className="border-base-400 border-l h-full p-4">
+                <ExternalLinkAltIcon />
             </Link>
         </div>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
@@ -50,6 +50,7 @@ function CveSelections({ cves, selectedCVEIds, onAdd, onRemove }: CveSelectionsP
                                     <ExternalLink>
                                         <Link
                                             target="_blank"
+                                            rel="noopener noreferrer"
                                             to={generatePath(vulnerabilitiesWorkloadCveSinglePath, {
                                                 cve,
                                             })}

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -35,11 +35,14 @@ body {
     text-decoration: var(--pf-v5-global--link--TextDecoration) !important;
 }
 
-/* PatternFly style for links in classic related entity, widget body, and React Table cell plus PatternFly table in classic page. */
+/* PatternFly style for links in classic related entity, cluster page, side panel, widget headerComponents, widget body, and React Table cell plus PatternFly table in classic page. */
 /* Also PatternFly Popover element. */
 
 button[data-testid="related-entity-list-count-value"],
 button[data-testid="related-entity-value"],
+[data-testid="cluster-page"] a,
+[data-testid="side-panel"] > div:first-child a,
+[data-testid="widget-header"] + div a,
 [data-testid="widget-body"] a,
 .rt-td a,
 .pf-v5-c-table td a,
@@ -53,6 +56,9 @@ button[data-testid="related-entity-list-count-value"]:hover {
 }
 
 button[data-testid="related-entity-value"]:hover,
+[data-testid="cluster-page"] a:hover,
+[data-testid="side-panel"] > div:first-child a:hover,
+[data-testid="widget-header"] + div a:hover,
 [data-testid="widget-body"] a:hover,
 .rt-td a:hover,
 .pf-v5-c-table td a:hover,


### PR DESCRIPTION
### Description

Write generic lint rules to follow up specific lint rule for accessibility in #12497

1. Add eslint-plugins/pluginGeneric.js file.
    * Add positive `ExternalLink-a`, `Link-target-rel`, and `a-target-rel` lint rules.
2. Edit eslint.config.js file.
    * Import plugin.
    * Add generic recommended rules for product files.

### Changed files

1. Edit ScannerV4IntegrationBanner.tsx file.
    * Rewrite according to lead-in link pattern.
    * Render `ExternalLink` element.
2. Edit CredentialExpiration.tsx file.
    * Render `ExternalLink` element.
3. Edit StaticConfigurationSection.js file.
    * Rewrite as separate sentences.
    * Render `ExternalLink` element.
4. Edit compliance SidePanel.js file.
    * Add `rel="noopener noreferrer"` prop.
    * Replace explicit color with style rules.
    * Replace `ExternalLink` from react-feather with `ExternalLinkAltIcon` from PatternFly.
5. Edit VerticalBarChart.js file.
    * Delete unused `labelLinks` prop.
    * Delete conditional link in `formatTicks` function.
6. Edit configmanagement SidePanel.js file.
    * Edit misleading `aria-label` prop.
    * Replace `ExternalLink` from react-feather with `ExternalLinkAltIcon` from PatternFly.
7. Edit VulnsTable.js file.
    * Render `ExternalLink` element.
    * Delete unnecessary classes, but keep `pointer-events-auto` for hover state.
8. Edit MachineAccessIntegrationForm.tsx and SignatureIntegrationForm.tsx files.
    * Add `noopener` to `rel` prop.
9. Edit VulnMgmtCveOverview.js file.
    * Replace classic button and `ExternalLink` icon from react-feather with `ExternalLink` element.
    * Delete unneeded `nofollow` from `rel` prop.
    * Delete unused `data-testid` prop.
    * Delete unneeded `className` props for `a` and `span` elements.
10. Edit AffectedComponentsModal.tsx file, even though it is unreachable code.
    * Replace `a` element with React Router `Link` element, because it is an internal link that opens in a new tab.
11. Edit CveSelections.tsx file.
    * Add `rel="noopener noreferrer"` prop.
12. Edit trumps.css file.
    * Add selector for cluster page to link style rules.
    * Add selector for side panel to link style rules.
    * Add selector for widget headerComponents to link style rules.

### Residue

1. Investigate whether `a` elements are for external or internal links:
  * LoginPage.js file
  * RiskDetails.js file

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added style lint rules
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
    15 problems in 11 files
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -2 = 4618512 - 4618514
        total -1270 = 11727279 - 11728549
    * `ls -al build/static/js/*.js | wc`
        files 0 = TODO - 176
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/compliance/clusters and then in table body: click cluster link

    * Before changes, see classic style for link and external link.
        ![compliance_SidePanel_with_feather_icon](https://github.com/user-attachments/assets/66a8f1d7-88c1-4d6b-8a59-f8ea30b01060)

    * After changes, see PatternFly style for link and external link.
        ![compliance_SidePanel_with_ExternalLinkAltIcon](https://github.com/user-attachments/assets/31b39de7-d399-4a44-bfc5-99f2a8ec0e7b)

2. Visit /main/configmanagement/images and then in table body: click image link

    * Before changes, see classic style for link in side panel.
        ![configmanagement_SidePanel_with_feather_icon](https://github.com/user-attachments/assets/a0f9426b-1fa7-46fb-ae36-6b8e83518817)

    * After changes, see PatternFly style for link in side panel.
        ![configmanagement_SidePanel_with_ExternalLinkAltIcon](https://github.com/user-attachments/assets/14eb18fd-fac1-441e-b0ce-9107f1a7c8b4)

3. Under **Dockerfile** expand to see vulnerability links.

    * Before changes, see classic style for link.
        ![VulnsTable_with_classic_style](https://github.com/user-attachments/assets/af136d0f-e5b7-4201-b38a-7b55352ae597)

    * After changes, see PatternFly style for link.
        ![VulnsTable_with_PatternFly_style](https://github.com/user-attachments/assets/3ff91a87-b1a7-44b1-9895-ef6bec753e6b)

4. Visit /main/vulnerabilities/workload-cves

    * Before changes, see absence of icon in banner.
        ![ScannerV4IntegrationBanner_without_ExternalLink](https://github.com/user-attachments/assets/130e4621-6cc4-4304-be2c-af337b42e3bd)

    * After changes, see presence of icon in banner.
        ![ScannerV4IntegrationBanner_with_ExternalLink](https://github.com/user-attachments/assets/951f838d-db93-4455-ae4f-777671586523)

5. Visit /main/vulnerabilities/workload-cves, in table body: click **Defer CVE** on kebab menu of a row, and then click **CVE selections** tab.

    * Before changes, see absence of `rel` attribute.
        ![CveSelections_without_rel_prop](https://github.com/user-attachments/assets/ed256a91-8eb7-4a17-a24f-b219be8d4078)

    * After changes, see presence of `rel` attribute.
        ![CveSelections_with_rel_prop png](https://github.com/user-attachments/assets/ad0853c8-fce1-426e-97a9-0c0297701c67)

6. Visit /main/vulnerability-management/image-cves and then in table body: click vulnerability link

    * Before changes, see classic button style for external link.
        ![VulnMgmtCveOverview_with_classic_style](https://github.com/user-attachments/assets/0fce071c-b5bb-49ea-ba6a-63d3d3c94443)

    * After changes, see PatternFly style for external link.
        ![VulnMgmtCveOverview_with_ExternalLink_style](https://github.com/user-attachments/assets/f4693ceb-a1d7-45b5-8c6b-6d3ddaf0a73f)

7. Visit /main/clusters, and then in table body: click cluster link.

    * Before changes, see feather icon for docs link.
        ![CredentialExpiration_with_feather_icon](https://github.com/user-attachments/assets/035c5293-58be-4877-98e5-210d5092b324)

    * After changes, see PatternFly icon for docs link.
        ![CredentialExpiration_with_PatternFly_icon](https://github.com/user-attachments/assets/0b66777b-5c0e-4d93-bd20-2a5f7a71a8aa)

8. Scroll down.

    * Before changes, see classic style for external link.
        ![StaticConfigurationSection_with_classic_style](https://github.com/user-attachments/assets/902b7a62-ea6e-4c51-b60a-e42227b5c51c)

    * After changes, see PatternFly style for external link.
![StaticConfigurationSection_with_PatternFly_style](https://github.com/user-attachments/assets/61aa09f9-c924-4555-84cf-b74e9b351e62)
