### PR TITLE
ROX-26012: Fix accessiblity issues for landmarks of live regions

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -75,7 +75,6 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -91,7 +91,6 @@ function NodePage() {
                                 // pagination.setPage(1);
                             }}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
-                            role="region"
                         >
                             <Tab eventKey={vulnTabKey} title={vulnTabKey} />
                             <Tab eventKey={detailTabKey} title={detailTabKey} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -105,7 +105,6 @@ function AffectedNodesTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -117,7 +117,6 @@ function CVEsTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={loading ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -75,7 +75,6 @@ function NodesTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={loading ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -67,7 +67,6 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -97,7 +97,6 @@ function ClusterPage() {
                                 // pagination.setPage(1);
                             }}
                             className="pf-v5-u-pl-md pf-v5-u-background-color-100"
-                            role="region"
                         >
                             <Tab eventKey={vulnTabKey} title={vulnTabKey} />
                             <Tab eventKey={detailTabKey} title={detailTabKey} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -103,7 +103,6 @@ function CVEsTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={loading ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -110,7 +110,6 @@ function ClustersTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={loading ? 'true' : 'false'}
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -72,7 +72,6 @@ function AffectedClustersTable({
         <Table
             borders={tableState.type === 'COMPLETE'}
             variant="compact"
-            role="region"
             aria-live="polite"
             aria-busy={tableState.type === 'LOADING' ? 'true' : 'false'}
         >


### PR DESCRIPTION
### Description

### Problem reported by axe DevTools

Manual testing steps:

1. Visit /main/vulnerabilities/platform-cves: Overview CVEsTable.tsx file

    > Certain ARIA roles must be contained by particular parents

    https://dequeuniversity.com/rules/axe/4.10/aria-required-parent

    ````html
    <tbody role="rowgroup" class="pf-v5-c-table__tbody">
    ```

    > Required ARIA parents role not present: grid, table, treegrid

2. In table body, click vulnerability link: AffectedClustersTable.tsx file

    Ditto

3. Go back, and then click **Clusters**: ClustersTable.tsx file

    Ditto

4. In table body: click cluster link: Cluster CVEsTable.tsx file

    Ditto

    > Landmarks should have a unique role or role/label/title (i.e. accessible name) combination

    https://dequeuniversity.com/rules/axe/4.10/landmark-unique

    ```html
    <div class="pf-v5-c-tabs pf-v5-u-pl-md pf-v5-u-background-color-100" data-ouia-component-type="PF5/Tabs" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Tabs-6" role="region">
    ```

    Related Node

    ```html
    <table role="region" class="pf-v5-c-table pf-m-grid-md pf-m-compact" data-ouia-component-type="PF5/Table" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Table-6" aria-live="polite" aria-busy="false">
    ```

### Analysis

* Required ARIA parents role not present, because `table` element has `role="region"` attribute.

* Landmarks should have a unique role, because multiple elements on page have `role="region"` attribute.

ARIA live region does not require `role="region"` attribute:

https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/#what-are-aria-live-regions%3F

> On an implementation level, a live region (not to be confused with the region landmark) is an element on the page that has been designated as being “live”.

https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/#2.-using-live-region-roles

> When you use `aria-live` to create a live region, the element’s implicit semantics (if it has any) are retained. This means that you can use the appropriate element to represent the component you’re creating, and if the component is getting updated you can then designate it as a live region with the `aria-live` attribute.

### Solution

1. Delete `role="region"` prop in **Platform CVEs** and **Node CVEs**.

### Residue

1. Delete `role="region"` prop elsewhere in src/Containers/Vulnerabilities folder: 

    * src/Components/EmailTemplate/EmailTemplateModal.tsx: `Tabs` element
    * src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx: `Tabs` element
    * src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx: `div` element with `className="workload-cves-table-container"` prop
    * src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx: `div` element with `className="workload-cves-table-container"` prop
    * src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx: `div` element with `className="workload-cves-table-container"` prop
    * src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx: `div` element with `className="workload-cves-table-container"` prop
    * src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx: `Card` element

2. After we replace `aria-busy="true"` selector in integration tests, pivot away from live region for tables.

    https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#live-regions-don%E2%80%99t-handle-rich-text

    > Live regions don’t handle rich text. This means that the semantics of elements like headings, lists, links, buttons, and other structural or interactive elements are not conveyed when the contents of a live region are announced.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618514 - 4618514
        total -140 = 11728245 - 11728385
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/platform-cves: Overview CVEsTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![Cluster_Overview_CVEsTable_with_issue](https://github.com/user-attachments/assets/0da1445a-9bb9-429b-a0b0-1bfc5143f9a4)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

2. In table body, click vulnerability link: AffectedClustersTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![AffectedClustersTable_with_issue](https://github.com/user-attachments/assets/5ba37d50-7765-4eee-b528-8ec89cd2ca87)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

3. Go back, and then click **Clusters**: ClustersTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![ClustersTable_with_issue](https://github.com/user-attachments/assets/c38b1eb3-d010-4b28-b23f-975dd50acd13)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

4. In table body: click cluster link: ClusterPage.tsx and Cluster CVEsTable.tsx files

    * Before changes, see presence of issues for roles and landmarks, because explicit `role="region"` props.
        ![Cluster_CVEsTable_with_issues](https://github.com/user-attachments/assets/21ef8a76-7e77-4430-9ea3-5883675377d7)

    * After changes, see presence of issues for roles and landmarks, because no `role` for `Tabs` and default `role="grid"` for `Table` element.

5. Visit /main/vulnerabilities/node-cves: Overview CVEsTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![Node_Overview_CVEsTable_with_issue](https://github.com/user-attachments/assets/90cd5a55-741d-4c7d-b896-27a904c8d673)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

6. In table body, click vulnerability link: AffectedNodesTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![AffectedNodesTable_with_issue](https://github.com/user-attachments/assets/0d101b44-8c28-4b66-be84-cdf0d2b19b57)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

7. Go back, and then click **Nodes**: NodesTable.tsx file

    * Before changes, see presence of issue for roles, because explicit `role="region"` prop.
        ![NodesTable_with_issue](https://github.com/user-attachments/assets/1ff81747-b94c-44d0-8aa9-a27cb3958c53)

    * After changes, see absence of issue for roles, because default `role="grid"` for `Table` element.

8. In table body: click node link: NodePage.tsx and Node CVEsTable.tsx files

    * Before changes, see presence of issues for roles and landmarks, because explicit `role="region"` props.
        ![Node_CVEsTable_with_issues](https://github.com/user-attachments/assets/e2982005-fcb3-4b46-b962-dc926da386ee)

    * After changes, see presence of issues for roles and landmarks, because no `role` for `Tabs` and default `role="grid"` for `Table` element.
