### PR TITLE
ROX-26050: Fix empty image name in delegator error message

### DIFF
--- a/central/delegatedregistryconfig/delegator/delegator.go
+++ b/central/delegatedregistryconfig/delegator/delegator.go
@@ -113,7 +113,7 @@ func (d *delegatorImpl) DelegateScanImage(ctx context.Context, imgName *storage.
 
 	image, err := w.Wait(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error delegating scan to cluster %q for %q", clusterID, image.GetName().GetFullName())
+		return nil, errors.Wrapf(err, "error delegating scan to cluster %q for image %q", clusterID, imgName.GetFullName())
 	}
 
 	log.Debugf("Scan response received for %q and image %q", w.ID(), imgName.GetFullName())


### PR DESCRIPTION
### Description

Adjusts an error's message that prior would not include the image full name:

```
error delegating scan to cluster "caee1aa5-eb10-42fd-8637-2813df3d8e49" for "": too many parallel scans to local scanner
```
Notice the empty `""`, it would now become (for example):

```
error delegating scan to cluster "caee1aa5-eb10-42fd-8637-2813df3d8e49" for image "docker.io/library/nginx:latest": too many parallel scans to local scanner
```

The missing image name would only surface on 'early' failures handled here:

https://github.com/stackrox/stackrox/blob/784baf57f42afa59ba78b0c1cb0d0d515cc4cb01/central/image/service/service_impl.go#L680-L686

Failures with the actual scan (such as 404 pulling metadata) were NOT affected.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

To trigger the "too many parallel requests" error, on an OCP infra cluster installed ACS and removed all image scan data from central and scanner v2 db, enabled delegated scanning, and restarted sensor, this triggers a flood of initial scans that takes a few minutes to complete, then ran `roxctl image scan` expected a "too many parallel scans" failure:

Before the fix:

```
$ rctl image scan --image=nginx --force --cluster=remote
...
ERROR:	Scanning image failed: could not scan image: "nginx": rpc error: code = Internal desc = error delegating scan to cluster "669b8897-a8d2-409a-bb32-a014b1d95674" for "": too many parallel scans to local scanner
enrich was not started. Retrying after 3 seconds...
```

After the fix:

```
$ k set image deploy/central *=quay.io/rhacs-eng/main:4.6.x-419-g8bf70c35e2
$ rctl image scan --image=nginx --force --cluster=remote
ERROR:	Scanning image failed: could not scan image: "nginx": rpc error: code = Internal desc = error delegating scan to cluster "669b8897-a8d2-409a-bb32-a014b1d95674" for image "docker.io/library/nginx:latest": too many parallel scans to local scanner
```