### PR TITLE
ROX-26018: Introduce NodeIndexer configuration

### DIFF
--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -94,7 +94,7 @@ func (c *Compliance) Start() {
 		}
 	}
 
-	if env.NodeScanningV4Enabled.BooleanSetting() {
+	if env.NodeIndexEnabled.BooleanSetting() {
 		log.Infof("Node Index v4 enabled")
 	}
 
@@ -148,7 +148,7 @@ func (c *Compliance) manageNodeScanLoop(ctx context.Context) <-chan *sensor.MsgF
 					c.cache = msg.CloneVT()
 					nodeInventoriesC <- msg
 				}
-				if env.NodeScanningV4Enabled.BooleanSetting() {
+				if env.NodeIndexEnabled.BooleanSetting() {
 					log.Infof("Creating v4 Node Index Report")
 					report, err := c.nodeIndexer.IndexNode(ctx)
 					if err != nil {

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"time"
 
 	"github.com/stackrox/rox/compliance/collection/compliance"
 	v4 "github.com/stackrox/rox/compliance/index/v4"
@@ -17,12 +16,7 @@ func init() {
 
 func main() {
 	np := &compliance.EnvNodeNameProvider{}
-	cfg := &v4.NodeIndexerConfig{
-		DisableAPI:         false,
-		API:                env.NodeIndexContainerAPI.Setting(), // TODO(ROX-25540): Set in sync with Scanner via Helm charts
-		Repo2CPEMappingURL: env.NodeIndexMappingURL.Setting(),   // TODO(ROX-25540): Set in sync with Scanner via Helm charts
-		Timeout:            10 * time.Second,
-	}
+	cfg := v4.NewNodeIndexerConfigFromEnv()
 
 	scanner := compliance.NewNodeInventoryComponentScanner(np)
 	scanner.Connect(env.NodeScanningEndpoint.Setting())

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackrox/rox/compliance/collection/compliance"
 	v4 "github.com/stackrox/rox/compliance/index/v4"
@@ -16,10 +17,16 @@ func init() {
 
 func main() {
 	np := &compliance.EnvNodeNameProvider{}
+	cfg := &v4.NodeIndexerConfig{
+		DisableAPI:         false,
+		API:                env.NodeIndexContainerAPI.Setting(), // TODO(ROX-25540): Set in sync with Scanner via Helm charts
+		Repo2CPEMappingURL: env.NodeIndexMappingURL.Setting(),   // TODO(ROX-25540): Set in sync with Scanner via Helm charts
+		Timeout:            10 * time.Second,
+	}
 
 	scanner := compliance.NewNodeInventoryComponentScanner(np)
 	scanner.Connect(env.NodeScanningEndpoint.Setting())
-	nodeIndexer := v4.NewNodeIndexer()
+	nodeIndexer := v4.NewNodeIndexer(cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -37,6 +37,15 @@ type NodeIndexerConfig struct {
 	Timeout            time.Duration
 }
 
+func NewNodeIndexerConfigFromEnv() *NodeIndexerConfig {
+	return &NodeIndexerConfig{
+		DisableAPI:         false,
+		API:                env.NodeIndexContainerAPI.Setting(), // TODO(ROX-25540): Set in sync with Scanner via Helm charts
+		Repo2CPEMappingURL: env.NodeIndexMappingURL.Setting(),   // TODO(ROX-25540): Set in sync with Scanner via Helm charts
+		Timeout:            10 * time.Second,
+	}
+}
+
 type localNodeIndexer struct {
 	config *NodeIndexerConfig
 }

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -54,7 +54,7 @@ func (l *localNodeIndexer) IndexNode(ctx context.Context) (r *v4.IndexReport, er
 		Files:         map[string]claircore.File{},
 	}
 
-	layer, err := constructLayer(ctx, layerDigest, env.NodeScanningV4HostPath.Setting())
+	layer, err := constructLayer(ctx, layerDigest, env.NodeIndexHostPath.Setting())
 	if err != nil {
 		return nil, err
 	}

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -30,12 +30,20 @@ var (
 	log         = logging.LoggerForModule()
 )
 
+type NodeIndexerConfig struct {
+	DisableAPI         bool
+	API                string
+	Repo2CPEMappingURL string
+	Timeout            time.Duration
+}
+
 type localNodeIndexer struct {
+	config *NodeIndexerConfig
 }
 
 // NewNodeIndexer creates a new node indexer
-func NewNodeIndexer() compliance.NodeIndexer {
-	return &localNodeIndexer{}
+func NewNodeIndexer(config *NodeIndexerConfig) compliance.NodeIndexer {
+	return &localNodeIndexer{config: config}
 }
 
 // GetIntervals
@@ -64,7 +72,7 @@ func (l *localNodeIndexer) IndexNode(ctx context.Context) (r *v4.IndexReport, er
 		}
 	}()
 
-	reps, err := runRepositoryScanner(ctx, layer)
+	reps, err := runRepositoryScanner(ctx, l.config, layer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to run repository scanner")
 	}
@@ -140,14 +148,14 @@ func filterPackages(_ context.Context, pck []*claircore.Package) []*claircore.Pa
 	return filtered
 }
 
-func runRepositoryScanner(ctx context.Context, l *claircore.Layer) ([]*claircore.Repository, error) {
+func runRepositoryScanner(ctx context.Context, cfg *NodeIndexerConfig, l *claircore.Layer) ([]*claircore.Repository, error) {
 	c := http.DefaultClient
 	sc := rhel.RepositoryScanner{}
 	config := rhel.RepositoryScannerConfig{
-		DisableAPI:         false,
-		API:                "https://catalog.redhat.com/api/containers/",
-		Repo2CPEMappingURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
-		Timeout:            10 * time.Second,
+		DisableAPI:         cfg.DisableAPI,
+		API:                cfg.API,
+		Repo2CPEMappingURL: cfg.Repo2CPEMappingURL,
+		Timeout:            cfg.Timeout,
 	}
 
 	var buf bytes.Buffer

--- a/compliance/index/v4/node_test.go
+++ b/compliance/index/v4/node_test.go
@@ -32,7 +32,7 @@ func createConfig(server string) *NodeIndexerConfig {
 }
 
 func createTestServer() *httptest.Server {
-	mappingData := strings.NewReader(`{"data":{"rhocp-4.16-for-rhel-9-x86_64-rpms":{"cpes":["cpe:/a:redhat:openshift:4.16::el9"]},"rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4":{"cpes":["cpe:/o:redhat:rhel_eus:9.4::baseos"]}}}`)
+	mappingData := `{"data":{"rhocp-4.16-for-rhel-9-x86_64-rpms":{"cpes":["cpe:/a:redhat:openshift:4.16::el9"]},"rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4":{"cpes":["cpe:/o:redhat:rhel_eus:9.4::baseos"]}}})`
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "") {
@@ -40,12 +40,7 @@ func createTestServer() *httptest.Server {
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("last-modified", "Mon, 02 Jan 2006 15:04:05 MST")
-		if _, err := mappingData.Seek(0, io.SeekStart); err != nil {
-			log.Error(err)
-		}
-		if _, err := io.Copy(w, mappingData); err != nil {
-			log.Error(err)
-		}
+		w.Write([]byte(mappingData))
 	}))
 	return s
 }

--- a/pkg/env/node_scan_v4.go
+++ b/pkg/env/node_scan_v4.go
@@ -12,5 +12,5 @@ var (
 	NodeIndexContainerAPI = RegisterSetting("ROX_NODE_INDEX_CONTAINER_API", WithDefault("https://catalog.redhat.com/api/containers/"))
 
 	// NodeIndexMappingURL Defines the endpoint for the RepositoryScanner to download mapping information from
-	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://access.redhat.com/security/data/metrics/repository-to-cpe.json"))
+	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://central.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe"))
 )

--- a/pkg/env/node_scan_v4.go
+++ b/pkg/env/node_scan_v4.go
@@ -1,10 +1,16 @@
 package env
 
 var (
-	// NodeScanningV4HostPath sets the path where the R/O host node filesystem is mounted to the container
-	// that should be scanned by Scanners NodeIndexer
-	NodeScanningV4HostPath = RegisterSetting("ROX_NODE_SCANNING_V4_HOST_PATH", WithDefault("/host"))
+	// NodeIndexEnabled defines whether Compliance will actually run indexing code
+	NodeIndexEnabled = RegisterBooleanSetting("ROX_NODE_INDEX_ENABLED", false)
 
-	// NodeScanningV4Enabled defines whether Compliance will actually run scanning code
-	NodeScanningV4Enabled = RegisterBooleanSetting("ROX_NODE_SCANNING_V4_ENABLED", false)
+	// NodeIndexHostPath sets the path where the R/O host node filesystem is mounted to the container
+	// that should be scanned by Scanners NodeIndexer
+	NodeIndexHostPath = RegisterSetting("ROX_NODE_INDEX_HOST_PATH", WithDefault("/host"))
+
+	// NodeIndexContainerAPI .
+	NodeIndexContainerAPI = RegisterSetting("ROX_NODE_INDEX_CONTAINER_API", WithDefault("https://catalog.redhat.com/api/containers/"))
+
+	// NodeIndexMappingURL .
+	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://access.redhat.com/security/data/metrics/repository-to-cpe.json"))
 )

--- a/pkg/env/node_scan_v4.go
+++ b/pkg/env/node_scan_v4.go
@@ -8,9 +8,9 @@ var (
 	// that should be scanned by Scanners NodeIndexer
 	NodeIndexHostPath = RegisterSetting("ROX_NODE_INDEX_HOST_PATH", WithDefault("/host"))
 
-	// NodeIndexContainerAPI .
+	// NodeIndexContainerAPI Defines the API endpoint for the RepositoryScanner to reach out to
 	NodeIndexContainerAPI = RegisterSetting("ROX_NODE_INDEX_CONTAINER_API", WithDefault("https://catalog.redhat.com/api/containers/"))
 
-	// NodeIndexMappingURL .
+	// NodeIndexMappingURL Defines the endpoint for the RepositoryScanner to download mapping information from
 	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://access.redhat.com/security/data/metrics/repository-to-cpe.json"))
 )


### PR DESCRIPTION
### Description

This is a follow up to https://github.com/stackrox/stackrox/pull/12555.
After a change in the Red Hat Repo to CPE mapping json the unit test started failing, as it is dynamically pulling the latest mapping information from Red Hat.

This PR introduces a configuration structure for the NodeIndexer to configure the called URLs (amongst other options).
This allows us to test against a statically served mapping JSON, removing the dependency on Red Hat infrastructure.
Additionally, this configuration is needed to be in sync with Scanner v4 settings, as it utilizes the same scanners that the NodeIndexer uses, and ideally both Indexers are configured identically.

I recommend to review the PR by looking at the separate commits one after the other.


### User-facing documentation

- [x] ~~CHANGELOG is updated **OR**~~ update is not needed
- [x] ~~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Running the unit tests locally without Network connection
