### PR TITLE
ROX-26019: Fix more accessiblity issues for landmarks of live regions

### DIFF
--- a/ui/apps/platform/src/Components/EmailTemplate/EmailTemplateModal.tsx
+++ b/ui/apps/platform/src/Components/EmailTemplate/EmailTemplateModal.tsx
@@ -92,7 +92,7 @@ function EmailTemplateModal({
             actions={actions}
         >
             {renderTemplatePreview ? (
-                <Tabs defaultActiveKey={0} role="region">
+                <Tabs defaultActiveKey={0}>
                     <Tab eventKey={0} title={<TabTitleText>Edit</TabTitleText>}>
                         {emailTemplateForm}
                     </Tab>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -117,7 +117,6 @@ function NodePageVulnerabilities({ nodeId }: NodePageVulnerabilitiesProps) {
                             <CvesByStatusSummaryCard
                                 cveStatusCounts={data.node.nodeCVECountBySeverity}
                                 hiddenStatuses={hiddenStatuses}
-                                isBusy={summaryRequest.loading}
                             />
                         )}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -280,7 +280,6 @@ function ViewVulnReportPage() {
                     className="pf-v5-u-background-color-100"
                     defaultActiveKey={0}
                     aria-label="Report details tabs"
-                    role="region"
                 >
                     <Tab
                         eventKey={0}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -281,7 +281,6 @@ function DeploymentPageVulnerabilities({
                             <CvesByStatusSummaryCard
                                 cveStatusCounts={data.imageCVECountBySeverity}
                                 hiddenStatuses={hiddenStatuses}
-                                isBusy={summaryRequest.loading}
                             />
                         )}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -280,7 +280,6 @@ function ImagePageVulnerabilities({
                                 <CvesByStatusSummaryCard
                                     cveStatusCounts={data.imageCVECountBySeverity}
                                     hiddenStatuses={hiddenStatuses}
-                                    isBusy={loading}
                                 />
                             )}
                         />
@@ -347,7 +346,6 @@ function ImagePageVulnerabilities({
                         </Split>
                         <div
                             className="workload-cves-table-container"
-                            role="region"
                             aria-live="polite"
                             aria-busy={loading ? 'true' : 'false'}
                         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -153,7 +153,6 @@ function CVEsTableContainer({
             <Divider component="div" />
             <div
                 className="workload-cves-table-container"
-                role="region"
                 aria-live="polite"
                 aria-busy={loading ? 'true' : 'false'}
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -68,7 +68,6 @@ function DeploymentsTableContainer({
             <Divider component="div" />
             <div
                 className="workload-cves-table-container"
-                role="region"
                 aria-live="polite"
                 aria-busy={loading ? 'true' : 'false'}
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -76,7 +76,6 @@ function ImagesTableContainer({
             <Divider component="div" />
             <div
                 className="workload-cves-table-container"
-                role="region"
                 aria-live="polite"
                 aria-busy={loading ? 'true' : 'false'}
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -74,22 +74,14 @@ const statusHiddenText = {
 export type CvesByStatusSummaryCardProps = {
     cveStatusCounts: ResourceCountByCveSeverityAndStatus;
     hiddenStatuses: Set<FixableStatus>;
-    isBusy: boolean;
 };
 
 function CvesByStatusSummaryCard({
     cveStatusCounts,
     hiddenStatuses,
-    isBusy,
 }: CvesByStatusSummaryCardProps) {
     return (
-        <Card
-            role="region"
-            aria-live="polite"
-            aria-busy={isBusy ? 'true' : 'false'}
-            isCompact
-            isFlat
-        >
+        <Card isCompact isFlat>
             <CardTitle>CVEs by status</CardTitle>
             <CardBody>
                 <Grid className="pf-v5-u-pl-sm">


### PR DESCRIPTION
### Description

Follow up to fix residue in Vulnerabilities after **Platform CVEs** and **Node CVEs** in #12563

### Problem reported by axe DevTools

> Landmarks should have a unique role or role/label/title (i.e. accessible name) combination

https://dequeuniversity.com/rules/axe/4.10/landmark-unique

```html
<div id="" class="pf-v5-c-card pf-m-compact pf-m-flat" role="region" aria-live="polite" aria-busy="false" data-ouia-component-type="PF5/Card" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Card-2">
```

Related Node

```html
<div class="workload-cves-table-container" role="region" aria-live="polite" aria-busy="false">
```

### Analysis

Landmarks should have a unique role, because multiple elements on page have `role="region"` attribute.

ARIA live region does not require `role="region"` attribute:

https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/#what-are-aria-live-regions%3F

> On an implementation level, a live region (not to be confused with the region landmark) is an element on the page that has been designated as being “live”.

https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/#2.-using-live-region-roles

> When you use `aria-live` to create a live region, the element’s implicit semantics (if it has any) are retained. This means that you can use the appropriate element to represent the component you’re creating, and if the component is getting updated you can then designate it as a live region with the `aria-live` attribute.

### Solution

1. Delete remaining occurrences of `role="region"` prop in src/Containers/Vulnerabilities folder, plus file that was factored out for reuse.
2. Delete `isBusy` prop from `CvesByStatusSummaryCard` element, because integration tests do not depend on it.

### Residue

1. After we replace `aria-busy="true"` selector in integration tests, pivot away from live region for tables.

    https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#live-regions-don%E2%80%99t-handle-rich-text

    > Live regions don’t handle rich text. This means that the semantics of elements like headings, lists, links, buttons, and other structural or interactive elements are not conveyed when the contents of a live region are announced.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4618514 - 4618514
        total -200 = 11728045 - 11728245
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `yarn start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves, click **Images** toggle, and then in table body, click image link

    * Before changes, see presence of accessibility issue.
        ![images_with_issue](https://github.com/user-attachments/assets/de74e8cd-06b8-4ca0-9898-9b4c85ce746f)

    * After changes, see absence of accessibility issue.
        Also see absence of props in `div` element for card.
        Also see presence of `aria-live` and `aria-busy` props in `div` element with `class="workload-cves-table-container"` attribute.
        ![images_without_issue](https://github.com/user-attachments/assets/b1f85043-8da7-4b9c-bb70-13cb33168fd0)

### Integration testing

* vulnerabilities/workloadCves/deploymentSingle.test.js
* vulnerabilities/workloadCves/imageCveSingle.test.js
* vulnerabilities/workloadCves/imageSingle.test.js
* vulnerabilities/workloadCves/namespaceView.test.js
* vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
