### PR TITLE
ROX-25723: add ecosystem preflight check

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -490,14 +490,18 @@ spec:
       values: [ "false" ]
 
   - name: ecosystem-cert-preflight-checks
-    runAfter:
-      - build-image-manifest-konflux
     params:
     - name: image-url
       value: $(tasks.build-image-manifest.results.IMAGE_URL)
     taskRef:
-      name: ecosystem-cert-preflight-checks
-      version: "0.1"
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -489,6 +489,20 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    runAfter:
+      - build-image-manifest-konflux
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -498,7 +498,7 @@ spec:
       - name: name
         value: ecosystem-cert-preflight-checks
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -507,6 +507,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -336,6 +336,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-container.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -336,24 +336,6 @@ spec:
       operator: in
       values: [ "false" ]
 
-  - name: ecosystem-cert-preflight-checks
-    params:
-    - name: image-url
-      value: $(tasks.build-container.results.IMAGE_URL)
-    taskRef:
-      params:
-      - name: name
-        value: ecosystem-cert-preflight-checks
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values: ["false"]
-
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -500,6 +500,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -37,6 +37,8 @@ RUN dnf upgrade -y --nobest && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
+COPY LICENSE /licenses/LICENSE
+
 COPY image/postgres/scripts \
     /usr/local/bin/
 

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -136,6 +136,8 @@ COPY .konflux/stackrox-data/external-networks/external-networks.zip /stackrox/st
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
 
+COPY LICENSE /licenses/LICENSE
+
 # The following paths are written to in Central.
 RUN chown -R 4000:4000 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl && \
     mkdir -p /var/lib/stackrox && chown -R 4000:4000 /var/lib/stackrox && \

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -39,6 +39,8 @@ RUN microdnf upgrade -y --nobest && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
+COPY LICENSE /licenses/LICENSE
+
 ARG MAIN_IMAGE_TAG
 
 LABEL \

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -52,6 +52,8 @@ RUN microdnf upgrade -y --nobest && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
+COPY LICENSE /licenses/LICENSE
+
 # TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
 ENV ROX_IMAGE_FLAVOR="development_build"
 

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -68,3 +68,5 @@ LABEL com.redhat.openshift.versions="v4.12"
 COPY --from=builder /stackrox/operator/build/bundle/manifests /manifests/
 COPY --from=builder /stackrox/operator/build/bundle/metadata /metadata/
 COPY --from=builder /stackrox/operator/build/bundle/tests/scorecard /tests/scorecard/
+
+COPY LICENSE /licenses/LICENSE

--- a/scanner/image/db/konflux.Dockerfile
+++ b/scanner/image/db/konflux.Dockerfile
@@ -38,6 +38,8 @@ RUN dnf upgrade -y --nobest && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
+COPY LICENSE /licenses/LICENSE
+
 ENV LANG=en_US.utf8
 
 STOPSIGNAL SIGINT

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -73,6 +73,8 @@ RUN microdnf upgrade --nobest && \
     # during the container start.
     chown -R 65534:65534 /etc/pki/ca-trust /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
 
+COPY LICENSE /licenses/LICENSE
+
 # This is equivalent to nobody:nobody.
 USER 65534:65534
 


### PR DESCRIPTION
### Description

Adds ecosystem preflight check (https://github.com/redhat-openshift-ecosystem/openshift-preflight) task to all pipelines in this repository.

~To discuss: add also for operator-bundle? It is "only" a collection of text files and triggers some warnings, see below.~
https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1725522951955559?thread_ts=1725459706.460459&cid=C05TS9N0S7L -> not required for operator-bundle. But adding LICENSE can't hurt, right?

All other components pass the check, if we ignore the issue caused by KFLUXBUGS-1495 that sets the `version` label on container images to an empty string.
 
### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- ~[ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag~
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~[ ] added unit tests~
- ~[ ] added e2e tests~
- ~[ ] added regression tests~
- ~[ ] added compatibility tests~
- ~[ ] modified existing tests~

No new tests are necessary, successful Konflux pipeline runs are sufficient. 

#### How I validated my change

* Konflux pipelines pass
* looking at ecosystem-preflight check task output
