### PR TITLE
fix(sensor-connection): Reset the ok and stop signals on reconnection

### DIFF
--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -436,9 +436,13 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			// Connection is up, we can try to create a new central communication
 			s.changeState(common.SensorComponentEventCentralReachable)
 		case <-s.centralConnectionFactory.StopSignal().WaitC():
+			// Save the error before retrying
+			err := wrapOrNewError(s.centralConnectionFactory.StopSignal().Err(), "connection couldn't be re-established")
+			// Reset the ok and stop signals
+			s.centralConnectionFactory.Reset()
 			// Connection is still broken, report and try again
 			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
-			return wrapOrNewError(s.centralConnectionFactory.StopSignal().Err(), "connection couldn't be re-established")
+			return err
 		}
 
 		// At this point, we know that connection factory reported that connection is up.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The okSignal and the stopSignal should be in the un-triggered state when we attempt to reconnect to central. If they're not reset then we can land in a situation where both are triggered and the select statement [here](https://github.com/stackrox/stackrox/blob/967702465ce812f74aec0b0cb26f2ae959d4e49d/sensor/common/sensor/sensor.go#L434-L442) will randomly choose one of them. In such a case, if stopSignal is chosen we will retry when unnecessary (potentially infinite times) leading to slow reconnects.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Manual test
- [x] Integration test should pass
- [x] This was tested in #12451
