### PR TITLE
ROX-25939: Add report jobs table

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
@@ -30,7 +30,7 @@ function NotifierConfigurationView({
         <>
             <Flex direction={{ default: 'column' }}>
                 <FlexItem>
-                    <Title headingLevel="h3">Delivery destinations</Title>
+                    <Title headingLevel="h2">Delivery destinations</Title>
                 </FlexItem>
                 <FlexItem flex={{ default: 'flexNone' }}>
                     {notifierConfigurations.length === 0 ? (

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
@@ -10,6 +10,7 @@ import useIndexKey from 'hooks/useIndexKey';
 import { NotifierConfiguration } from 'services/ReportsService.types';
 
 export type NotifierConfigurationViewProps = {
+    headingLevel: 'h2' | 'h3';
     customBodyDefault: string;
     customSubjectDefault: string;
     notifierConfigurations: NotifierConfiguration[];
@@ -17,6 +18,7 @@ export type NotifierConfigurationViewProps = {
 };
 
 function NotifierConfigurationView({
+    headingLevel,
     customBodyDefault,
     customSubjectDefault,
     notifierConfigurations,
@@ -30,7 +32,7 @@ function NotifierConfigurationView({
         <>
             <Flex direction={{ default: 'column' }}>
                 <FlexItem>
-                    <Title headingLevel="h2">Delivery destinations</Title>
+                    <Title headingLevel={headingLevel}>Delivery destinations</Title>
                 </FlexItem>
                 <FlexItem flex={{ default: 'flexNone' }}>
                     {notifierConfigurations.length === 0 ? (

--- a/ui/apps/platform/src/Components/ReportJobsTable.tsx
+++ b/ui/apps/platform/src/Components/ReportJobsTable.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { Bullseye, Button, Text } from '@patternfly/react-core';
+import {
+    ActionsColumn,
+    ExpandableRowContent,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
+
+import useSet from 'hooks/useSet';
+import useAuthStatus from 'hooks/useAuthStatus';
+import { ReportSnapshot } from 'services/ReportsService.types';
+import { saveFile } from 'services/DownloadService';
+import { getDateTime } from 'utils/dateUtils';
+import ReportJobStatus from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus';
+import { ComplianceScanSnapshot } from 'services/ComplianceScanConfigurationService';
+import EmptyStateTemplate from './EmptyStateTemplate';
+
+export type ReportJobsTableProps<T> = {
+    snapshots: T[];
+    getJobId: (data: T) => string;
+    getConfigName: (data: T) => string;
+    onClearFilters: () => void;
+    onDeleteDownload: (reportId) => void;
+    renderExpandableRowContent: (snapshot: T) => React.ReactNode;
+};
+
+type Snapshot = ReportSnapshot | ComplianceScanSnapshot;
+
+const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
+
+const onDownload = (snapshot: Snapshot, jobId: string, configName: string) => () => {
+    const { completedAt } = snapshot.reportStatus;
+    const filename = `${configName}-${completedAt}`;
+    const sanitizedFilename = filename.replaceAll(filenameSanitizerRegex, '_');
+    return saveFile({
+        method: 'get',
+        url: `/api/reports/jobs/download?id=${jobId}`,
+        data: null,
+        timeout: 300000,
+        name: `${sanitizedFilename}.zip`,
+    });
+};
+
+function ReportJobsTable<T extends Snapshot>({
+    snapshots,
+    getJobId,
+    getConfigName,
+    onClearFilters,
+    onDeleteDownload,
+    renderExpandableRowContent,
+}: ReportJobsTableProps<T>) {
+    const { currentUser } = useAuthStatus();
+    const expandedRowSet = useSet<string>();
+
+    return (
+        <Table aria-label="Jobs table" variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>
+                        <span className="pf-v5-screen-reader">Row expansion</span>
+                    </Th>
+                    <Th width={25}>Completed</Th>
+                    <Th width={25}>Status</Th>
+                    <Th width={50}>Requestor</Th>
+                    <Th>
+                        <span className="pf-v5-screen-reader">Row actions</span>
+                    </Th>
+                </Tr>
+            </Thead>
+            {snapshots.length === 0 && (
+                <Tbody>
+                    <Tr>
+                        <Td colSpan={5}>
+                            <Bullseye>
+                                <EmptyStateTemplate title="No report jobs found" headingLevel="h2">
+                                    <Text>Clear any search value and try again</Text>
+                                    <Button variant="link" onClick={onClearFilters}>
+                                        Clear filters
+                                    </Button>
+                                </EmptyStateTemplate>
+                            </Bullseye>
+                        </Td>
+                    </Tr>
+                </Tbody>
+            )}
+            {snapshots.map((snapshot, rowIndex) => {
+                const { user, reportStatus, isDownloadAvailable } = snapshot;
+                const jobId = getJobId(snapshot);
+                const configName = getConfigName(snapshot);
+                const isExpanded = expandedRowSet.has(jobId);
+                const areDownloadActionsDisabled = currentUser.userId !== user.id;
+
+                const rowActions = [
+                    {
+                        title: <span className="pf-v5-u-danger-color-100">Delete download</span>,
+                        onClick: (event) => {
+                            event.preventDefault();
+                            onDeleteDownload(jobId);
+                        },
+                    },
+                ];
+
+                return (
+                    <Tbody key={jobId} isExpanded={isExpanded}>
+                        <Tr>
+                            <Td
+                                expand={{
+                                    rowIndex,
+                                    isExpanded,
+                                    onToggle: () => expandedRowSet.toggle(jobId),
+                                }}
+                            />
+                            <Td dataLabel="Completed">
+                                {reportStatus.completedAt
+                                    ? getDateTime(reportStatus.completedAt)
+                                    : '-'}
+                            </Td>
+                            <Td dataLabel="Status">
+                                <ReportJobStatus
+                                    reportStatus={reportStatus}
+                                    isDownloadAvailable={isDownloadAvailable}
+                                    areDownloadActionsDisabled={areDownloadActionsDisabled}
+                                    onDownload={onDownload(snapshot, jobId, configName)}
+                                />
+                            </Td>
+                            <Td dataLabel="Requester">{user.name}</Td>
+                            <Td isActionCell>
+                                {isDownloadAvailable && (
+                                    <ActionsColumn
+                                        items={rowActions}
+                                        isDisabled={areDownloadActionsDisabled}
+                                    />
+                                )}
+                            </Td>
+                        </Tr>
+                        <Tr isExpanded={isExpanded}>
+                            <Td colSpan={5}>
+                                <ExpandableRowContent>
+                                    {renderExpandableRowContent(snapshot)}
+                                </ExpandableRowContent>
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </Table>
+    );
+}
+
+export default ReportJobsTable;

--- a/ui/apps/platform/src/Components/ReportJobsTable.tsx
+++ b/ui/apps/platform/src/Components/ReportJobsTable.tsx
@@ -39,6 +39,7 @@ const onDownload = (snapshot: Snapshot, jobId: string, configName: string) => ()
     const sanitizedFilename = filename.replaceAll(filenameSanitizerRegex, '_');
     return saveFile({
         method: 'get',
+        // @TODO: We may need to allow passing specific endpoints depending on backend
         url: `/api/reports/jobs/download?id=${jobId}`,
         data: null,
         timeout: 300000,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -5,6 +5,8 @@ import {
     AlertActionCloseButton,
     Breadcrumb,
     BreadcrumbItem,
+    Card,
+    CardBody,
     Divider,
     Flex,
     FlexItem,
@@ -177,7 +179,15 @@ function ViewScanConfigDetail({
             )}
             {selectedTab === 'CONFIGURATION_DETAILS' && (
                 <PageSection isCenterAligned id={configDetailsTabId}>
-                    <ConfigDetails isLoading={isLoading} error={error} scanConfig={scanConfig} />
+                    <Card isFlat>
+                        <CardBody>
+                            <ConfigDetails
+                                isLoading={isLoading}
+                                error={error}
+                                scanConfig={scanConfig}
+                            />
+                        </CardBody>
+                    </Card>
                 </PageSection>
             )}
             {selectedTab === 'ALL_REPORT_JOBS' && (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -182,7 +182,7 @@ function ViewScanConfigDetail({
             )}
             {selectedTab === 'ALL_REPORT_JOBS' && (
                 <PageSection isCenterAligned id={allReportJobsTabId}>
-                    <ReportJobs />
+                    <ReportJobs scanConfig={scanConfig} />
                 </PageSection>
             )}
         </>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -96,6 +96,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                 />
                 {isComplianceReportingEnabled && (
                     <NotifierConfigurationView
+                        headingLevel={headingLevel}
                         customBodyDefault={getBodyDefault(formikValues.profiles)}
                         customSubjectDefault={getSubjectDefault(
                             formikValues.parameters.name,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -84,6 +84,7 @@ function ConfigDetails({ isLoading, error, scanConfig }: ConfigDetailsProps) {
                 />
                 {isComplianceReportingEnabled && (
                     <NotifierConfigurationView
+                        headingLevel={headingLevel}
                         customBodyDefault={getBodyDefault(scanConfig.scanConfig.profiles)}
                         customSubjectDefault={getSubjectDefault(
                             scanConfig.scanName,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
     Alert,
     Bullseye,
-    Card,
-    CardBody,
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
@@ -54,56 +52,47 @@ function ConfigDetails({ isLoading, error, scanConfig }: ConfigDetailsProps) {
 
     if (scanConfig) {
         return (
-            <Card>
-                <CardBody>
-                    <Flex
-                        direction={{ default: 'column' }}
-                        spaceItems={{ default: 'spaceItemsLg' }}
-                    >
-                        <ScanConfigParametersView
-                            headingLevel={headingLevel}
-                            scanName={scanConfig.scanName}
-                            description={scanConfig.scanConfig.description}
-                            scanSchedule={scanConfig.scanConfig.scanSchedule}
-                        >
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Last run</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    {scanConfig.lastExecutedTime
-                                        ? getTimeWithHourMinuteFromISO8601(
-                                              scanConfig.lastExecutedTime
-                                          )
-                                        : 'Scan is in progress'}
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Last updated</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    {getTimeWithHourMinuteFromISO8601(scanConfig.lastUpdatedTime)}
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                        </ScanConfigParametersView>
-                        <ScanConfigClustersTable
-                            headingLevel={headingLevel}
-                            clusterScanStatuses={scanConfig.clusterStatus}
-                        />
-                        <ScanConfigProfilesView
-                            headingLevel={headingLevel}
-                            profiles={scanConfig.scanConfig.profiles}
-                        />
-                        {isComplianceReportingEnabled && (
-                            <NotifierConfigurationView
-                                customBodyDefault={getBodyDefault(scanConfig.scanConfig.profiles)}
-                                customSubjectDefault={getSubjectDefault(
-                                    scanConfig.scanName,
-                                    scanConfig.scanConfig.profiles
-                                )}
-                                notifierConfigurations={scanConfig.scanConfig.notifiers}
-                            />
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <ScanConfigParametersView
+                    headingLevel={headingLevel}
+                    scanName={scanConfig.scanName}
+                    description={scanConfig.scanConfig.description}
+                    scanSchedule={scanConfig.scanConfig.scanSchedule}
+                >
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Last run</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {scanConfig.lastExecutedTime
+                                ? getTimeWithHourMinuteFromISO8601(scanConfig.lastExecutedTime)
+                                : 'Scan is in progress'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Last updated</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {getTimeWithHourMinuteFromISO8601(scanConfig.lastUpdatedTime)}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                </ScanConfigParametersView>
+                <ScanConfigClustersTable
+                    headingLevel={headingLevel}
+                    clusterScanStatuses={scanConfig.clusterStatus}
+                />
+                <ScanConfigProfilesView
+                    headingLevel={headingLevel}
+                    profiles={scanConfig.scanConfig.profiles}
+                />
+                {isComplianceReportingEnabled && (
+                    <NotifierConfigurationView
+                        customBodyDefault={getBodyDefault(scanConfig.scanConfig.profiles)}
+                        customSubjectDefault={getSubjectDefault(
+                            scanConfig.scanName,
+                            scanConfig.scanConfig.profiles
                         )}
-                    </Flex>
-                </CardBody>
-            </Card>
+                        notifierConfigurations={scanConfig.scanConfig.notifiers}
+                    />
+                )}
+            </Flex>
         );
     }
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -14,6 +14,7 @@ import {
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
 import {
     getBodyDefault,
     getSubjectDefault,
@@ -23,9 +24,15 @@ import ScanConfigParametersView from './ScanConfigParametersView';
 import ScanConfigClustersTable from './ScanConfigClustersTable';
 import ScanConfigProfilesView from './ScanConfigProfilesView';
 
+export type ConfigDetailsProps = {
+    scanConfig?: ComplianceScanConfigurationStatus;
+    isLoading?: boolean;
+    error?: Error | string | null;
+};
+
 const headingLevel = 'h2';
 
-function ConfigDetails({ isLoading, error, scanConfig }) {
+function ConfigDetails({ isLoading, error, scanConfig }: ConfigDetailsProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -1,23 +1,12 @@
 import React from 'react';
-import { Bullseye, Button, Card, CardBody, Text } from '@patternfly/react-core';
-import {
-    ActionsColumn,
-    ExpandableRowContent,
-    Table,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
+import { Card, CardBody } from '@patternfly/react-core';
 
-import EmptyStateTemplate from 'Components/EmptyStateTemplate';
-import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
-import useSet from 'hooks/useSet';
-import { getDateTime } from 'utils/dateUtils';
-import ReportJobStatus from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus';
-import useAuthStatus from 'hooks/useAuthStatus';
+import {
+    ComplianceScanConfigurationStatus,
+    ComplianceScanSnapshot,
+} from 'services/ComplianceScanConfigurationService';
 import JobDetails from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails';
+import ReportJobsTable from 'Components/ReportJobsTable';
 import ConfigDetails from './ConfigDetails';
 
 type ReportJobsProps = {
@@ -25,13 +14,9 @@ type ReportJobsProps = {
 };
 
 function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
-    const snapshots = [
+    const snapshots: ComplianceScanSnapshot[] = [
         {
-            scanScheduleConfigId: scanConfig.id,
-            scanSchedulReportJobId: 'ab1c03ae-9707-43d1-932d-f948afb67b53',
-            name: scanConfig.scanName,
-            description: scanConfig.scanConfig.description,
-            schedule: scanConfig.scanConfig.scanSchedule,
+            reportJobId: 'ab1c03ae-9707-43d1-932d-f948afb67b53',
             reportStatus: {
                 completedAt: '2024-08-27T00:01:40.569402380Z',
                 errorMsg:
@@ -40,128 +25,52 @@ function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
                 reportRequestType: 'SCHEDULED',
                 runState: 'FAILURE',
             },
-            notifiers: [],
             user: {
                 id: 'sso:3e30efee-45f0-49d3-aec1-2861fcb3faf6:c02da449-f1c9-4302-afc7-3cbf450f2e0c',
                 name: 'Test User',
             },
             isDownloadAvailable: false,
-            clusters: [], // @TODO: Figure this out
-            profiles: [], // @TODO: Figure this out
+            scanConfig,
         },
-    ] as const;
+    ];
     return snapshots;
 }
 
-function ReportJobs({ scanConfig }: ReportJobsProps) {
-    const { currentUser } = useAuthStatus();
-    const expandedRowSet = useSet<string>();
+function getJobId(snapshot: ComplianceScanSnapshot) {
+    return snapshot.scanConfig.id;
+}
 
-    const scanConfigSnapshots = scanConfig ? createMockData(scanConfig) : [];
+function getConfigName(snapshot: ComplianceScanSnapshot) {
+    return snapshot.scanConfig.scanName;
+}
+
+function ReportJobs({ scanConfig }: ReportJobsProps) {
+    // @TODO: We will eventually make an API request using the scan config id to get the job history
+    const complianceScanSnapshots = scanConfig ? createMockData(scanConfig) : [];
 
     return (
-        <Table aria-label="Scan schedule report jobs table" variant="compact">
-            <Thead>
-                <Tr>
-                    <Th>
-                        <span className="pf-v5-screen-reader">Row expansion</span>
-                    </Th>
-                    <Th width={25}>Completed</Th>
-                    <Th width={25}>Status</Th>
-                    <Th width={50}>Requestor</Th>
-                    <Th>
-                        <span className="pf-v5-screen-reader">Row actions</span>
-                    </Th>
-                </Tr>
-            </Thead>
-            {scanConfigSnapshots.length === 0 && (
-                <Tbody>
-                    <Tr>
-                        <Td colSpan={5}>
-                            <Bullseye>
-                                <EmptyStateTemplate title="No report jobs found" headingLevel="h2">
-                                    <Text>Clear any search value and try again</Text>
-                                    <Button variant="link" onClick={() => {}}>
-                                        Clear filters
-                                    </Button>
-                                </EmptyStateTemplate>
-                            </Bullseye>
-                        </Td>
-                    </Tr>
-                </Tbody>
-            )}
-            {scanConfigSnapshots.map((scanConfigSnapshot, rowIndex) => {
-                const { scanScheduleReportJobId, reportStatus, user, isDownloadAvailable } =
-                    scanConfigSnapshot;
-                const isExpanded = expandedRowSet.has(scanScheduleReportJobId);
-                const areDownloadActionsDisabled = currentUser.userId !== user.id;
-
-                function onDownload() {
-                    // TODO: Download logic
-                }
-
-                const rowActions = [
-                    {
-                        title: <span className="pf-v5-u-danger-color-100">Delete download</span>,
-                        onClick: (event) => {
-                            event.preventDefault();
-                            // @TODO: Delete logic
-                        },
-                    },
-                ];
-
+        <ReportJobsTable
+            snapshots={complianceScanSnapshots}
+            getJobId={getJobId}
+            getConfigName={getConfigName}
+            onClearFilters={() => {}}
+            onDeleteDownload={() => {}}
+            renderExpandableRowContent={(snapshot: ComplianceScanSnapshot) => {
                 return (
-                    <Tbody key={scanScheduleReportJobId} isExpanded={isExpanded}>
-                        <Tr>
-                            <Td
-                                expand={{
-                                    rowIndex,
-                                    isExpanded,
-                                    onToggle: () => expandedRowSet.toggle(scanScheduleReportJobId),
-                                }}
-                            />
-                            <Td dataLabel="Completed">
-                                {reportStatus.completedAt
-                                    ? getDateTime(reportStatus.completedAt)
-                                    : '-'}
-                            </Td>
-                            <Td dataLabel="Status">
-                                <ReportJobStatus
-                                    reportStatus={scanConfigSnapshot.reportStatus}
-                                    isDownloadAvailable={scanConfigSnapshot.isDownloadAvailable}
-                                    areDownloadActionsDisabled={areDownloadActionsDisabled}
-                                    onDownload={onDownload}
+                    <>
+                        <Card>
+                            <CardBody>
+                                <JobDetails
+                                    reportStatus={snapshot.reportStatus}
+                                    isDownloadAvailable={snapshot.isDownloadAvailable}
                                 />
-                            </Td>
-                            <Td dataLabel="Requester">{user.name}</Td>
-                            <Td isActionCell>
-                                {isDownloadAvailable && (
-                                    <ActionsColumn
-                                        items={rowActions}
-                                        isDisabled={areDownloadActionsDisabled}
-                                    />
-                                )}
-                            </Td>
-                        </Tr>
-                        <Tr isExpanded={isExpanded}>
-                            <Td colSpan={5}>
-                                <ExpandableRowContent>
-                                    <Card>
-                                        <CardBody>
-                                            <JobDetails
-                                                reportStatus={reportStatus}
-                                                isDownloadAvailable={isDownloadAvailable}
-                                            />
-                                        </CardBody>
-                                    </Card>
-                                    <ConfigDetails scanConfig={scanConfig} />
-                                </ExpandableRowContent>
-                            </Td>
-                        </Tr>
-                    </Tbody>
+                            </CardBody>
+                        </Card>
+                        <ConfigDetails scanConfig={snapshot.scanConfig} />
+                    </>
                 );
-            })}
-        </Table>
+            }}
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -9,10 +9,6 @@ import JobDetails from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVul
 import ReportJobsTable from 'Components/ReportJobsTable';
 import ConfigDetails from './ConfigDetails';
 
-type ReportJobsProps = {
-    scanConfig: ComplianceScanConfigurationStatus | undefined;
-};
-
 function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
     const snapshots: ComplianceScanSnapshot[] = [
         {
@@ -43,6 +39,10 @@ function getJobId(snapshot: ComplianceScanSnapshot) {
 function getConfigName(snapshot: ComplianceScanSnapshot) {
     return snapshot.scanConfig.scanName;
 }
+
+type ReportJobsProps = {
+    scanConfig: ComplianceScanConfigurationStatus | undefined;
+};
 
 function ReportJobs({ scanConfig }: ReportJobsProps) {
     // @TODO: We will eventually make an API request using the scan config id to get the job history

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -1,7 +1,168 @@
 import React from 'react';
+import { Bullseye, Button, Card, CardBody, Text } from '@patternfly/react-core';
+import {
+    ActionsColumn,
+    ExpandableRowContent,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
 
-function ReportJobs() {
-    return <div />;
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
+import useSet from 'hooks/useSet';
+import { getDateTime } from 'utils/dateUtils';
+import ReportJobStatus from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus';
+import useAuthStatus from 'hooks/useAuthStatus';
+import JobDetails from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails';
+import ConfigDetails from './ConfigDetails';
+
+type ReportJobsProps = {
+    scanConfig: ComplianceScanConfigurationStatus | undefined;
+};
+
+function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
+    const snapshots = [
+        {
+            scanScheduleConfigId: scanConfig.id,
+            scanSchedulReportJobId: 'ab1c03ae-9707-43d1-932d-f948afb67b53',
+            name: scanConfig.scanName,
+            description: scanConfig.scanConfig.description,
+            schedule: scanConfig.scanConfig.scanSchedule,
+            reportStatus: {
+                completedAt: '2024-08-27T00:01:40.569402380Z',
+                errorMsg:
+                    "Error sending email notifications:  error: Error sending email for notifier 'fc99e179-57c1-4ba2-8e59-45dbf184c78c': Connection failed",
+                reportNotificationMethod: 'EMAIL',
+                reportRequestType: 'SCHEDULED',
+                runState: 'FAILURE',
+            },
+            notifiers: [],
+            user: {
+                id: 'sso:3e30efee-45f0-49d3-aec1-2861fcb3faf6:c02da449-f1c9-4302-afc7-3cbf450f2e0c',
+                name: 'Test User',
+            },
+            isDownloadAvailable: false,
+            clusters: [], // @TODO: Figure this out
+            profiles: [], // @TODO: Figure this out
+        },
+    ] as const;
+    return snapshots;
+}
+
+function ReportJobs({ scanConfig }: ReportJobsProps) {
+    const { currentUser } = useAuthStatus();
+    const expandedRowSet = useSet<string>();
+
+    const scanConfigSnapshots = scanConfig ? createMockData(scanConfig) : [];
+
+    return (
+        <Table aria-label="Scan schedule report jobs table" variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>
+                        <span className="pf-v5-screen-reader">Row expansion</span>
+                    </Th>
+                    <Th width={25}>Completed</Th>
+                    <Th width={25}>Status</Th>
+                    <Th width={50}>Requestor</Th>
+                    <Th>
+                        <span className="pf-v5-screen-reader">Row actions</span>
+                    </Th>
+                </Tr>
+            </Thead>
+            {scanConfigSnapshots.length === 0 && (
+                <Tbody>
+                    <Tr>
+                        <Td colSpan={5}>
+                            <Bullseye>
+                                <EmptyStateTemplate title="No report jobs found" headingLevel="h2">
+                                    <Text>Clear any search value and try again</Text>
+                                    <Button variant="link" onClick={() => {}}>
+                                        Clear filters
+                                    </Button>
+                                </EmptyStateTemplate>
+                            </Bullseye>
+                        </Td>
+                    </Tr>
+                </Tbody>
+            )}
+            {scanConfigSnapshots.map((scanConfigSnapshot, rowIndex) => {
+                const { scanScheduleReportJobId, reportStatus, user, isDownloadAvailable } =
+                    scanConfigSnapshot;
+                const isExpanded = expandedRowSet.has(scanScheduleReportJobId);
+                const areDownloadActionsDisabled = currentUser.userId !== user.id;
+
+                function onDownload() {
+                    // TODO: Download logic
+                }
+
+                const rowActions = [
+                    {
+                        title: <span className="pf-v5-u-danger-color-100">Delete download</span>,
+                        onClick: (event) => {
+                            event.preventDefault();
+                            // @TODO: Delete logic
+                        },
+                    },
+                ];
+
+                return (
+                    <Tbody key={scanScheduleReportJobId} isExpanded={isExpanded}>
+                        <Tr>
+                            <Td
+                                expand={{
+                                    rowIndex,
+                                    isExpanded,
+                                    onToggle: () => expandedRowSet.toggle(scanScheduleReportJobId),
+                                }}
+                            />
+                            <Td dataLabel="Completed">
+                                {reportStatus.completedAt
+                                    ? getDateTime(reportStatus.completedAt)
+                                    : '-'}
+                            </Td>
+                            <Td dataLabel="Status">
+                                <ReportJobStatus
+                                    reportStatus={scanConfigSnapshot.reportStatus}
+                                    isDownloadAvailable={scanConfigSnapshot.isDownloadAvailable}
+                                    areDownloadActionsDisabled={areDownloadActionsDisabled}
+                                    onDownload={onDownload}
+                                />
+                            </Td>
+                            <Td dataLabel="Requester">{user.name}</Td>
+                            <Td isActionCell>
+                                {isDownloadAvailable && (
+                                    <ActionsColumn
+                                        items={rowActions}
+                                        isDisabled={areDownloadActionsDisabled}
+                                    />
+                                )}
+                            </Td>
+                        </Tr>
+                        <Tr isExpanded={isExpanded}>
+                            <Td colSpan={5}>
+                                <ExpandableRowContent>
+                                    <Card>
+                                        <CardBody>
+                                            <JobDetails
+                                                reportStatus={reportStatus}
+                                                isDownloadAvailable={isDownloadAvailable}
+                                            />
+                                        </CardBody>
+                                    </Card>
+                                    <ConfigDetails scanConfig={scanConfig} />
+                                </ExpandableRowContent>
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </Table>
+    );
 }
 
 export default ReportJobs;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardBody } from '@patternfly/react-core';
+import { Card, CardBody, Divider } from '@patternfly/react-core';
 
 import {
     ComplianceScanConfigurationStatus,
@@ -58,15 +58,16 @@ function ReportJobs({ scanConfig }: ReportJobsProps) {
             renderExpandableRowContent={(snapshot: ComplianceScanSnapshot) => {
                 return (
                     <>
-                        <Card>
+                        <Card isFlat>
                             <CardBody>
                                 <JobDetails
                                     reportStatus={snapshot.reportStatus}
                                     isDownloadAvailable={snapshot.isDownloadAvailable}
                                 />
+                                <Divider component="div" className="pf-v5-u-my-md" />
+                                <ConfigDetails scanConfig={snapshot.scanConfig} />
                             </CardBody>
                         </Card>
-                        <ConfigDetails scanConfig={snapshot.scanConfig} />
                     </>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
@@ -23,7 +23,7 @@ function JobDetails({ reportStatus, isDownloadAvailable }: JobDetailsProps): Rea
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem>
-                <Title headingLevel="h3">Job details</Title>
+                <Title headingLevel="h2">Job details</Title>
             </FlexItem>
             <FlexItem flex={{ default: 'flexNone' }}>
                 <DescriptionList

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
@@ -10,15 +10,15 @@ import {
 } from '@patternfly/react-core';
 
 import { getDateTime } from 'utils/dateUtils';
-import { ReportSnapshot } from 'services/ReportsService.types';
+import { ReportStatus } from 'services/ReportsService.types';
 import { getReportStatusText } from '../utils';
 
 export type JobDetailsProps = {
-    reportSnapshot: ReportSnapshot;
+    reportStatus: ReportStatus;
+    isDownloadAvailable: boolean;
 };
 
-function JobDetails({ reportSnapshot }: JobDetailsProps): ReactElement {
-    const { isDownloadAvailable, reportStatus } = reportSnapshot;
+function JobDetails({ reportStatus, isDownloadAvailable }: JobDetailsProps): ReactElement {
     const { reportRequestType, completedAt } = reportStatus;
     return (
         <Flex direction={{ default: 'column' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -67,6 +67,8 @@ const sortOptions = {
 
 const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
 
+const headingLevel = 'h2';
+
 function ReportJobs({ reportId }: RunHistoryProps) {
     const { currentUser } = useAuthStatus();
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
@@ -339,6 +341,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                                     />
                                                     <FlexItem>
                                                         <ReportParametersDetails
+                                                            headingLevel={headingLevel}
                                                             formValues={formValues}
                                                         />
                                                     </FlexItem>
@@ -348,6 +351,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                                     />
                                                     <FlexItem>
                                                         <NotifierConfigurationView
+                                                            headingLevel={headingLevel}
                                                             customBodyDefault={defaultEmailBody}
                                                             customSubjectDefault={getDefaultEmailSubject(
                                                                 formValues.reportParameters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -327,7 +327,10 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                                 <Flex>
                                                     <FlexItem>
                                                         <JobDetails
-                                                            reportSnapshot={reportSnapshot}
+                                                            reportStatus={reportStatus}
+                                                            isDownloadAvailable={
+                                                                isDownloadAvailable
+                                                            }
                                                         />
                                                     </FlexItem>
                                                     <Divider

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -64,6 +64,8 @@ export type TabTitleProps = {
 const configDetailsTabId = 'VulnReportsConfigDetails';
 const allReportJobsTabId = 'VulnReportsConfigReportJobs';
 
+const headingLevel = 'h2';
+
 function ViewVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
@@ -289,9 +291,13 @@ function ViewVulnReportPage() {
                 <PageSection isCenterAligned id={configDetailsTabId}>
                     <Card>
                         <CardBody>
-                            <ReportParametersDetails formValues={reportFormValues} />
+                            <ReportParametersDetails
+                                headingLevel={headingLevel}
+                                formValues={reportFormValues}
+                            />
                             <Divider component="div" className="pf-v5-u-py-md" />
                             <NotifierConfigurationView
+                                headingLevel={headingLevel}
                                 customBodyDefault={defaultEmailBody}
                                 customSubjectDefault={getDefaultEmailSubject(
                                     reportFormValues.reportParameters.reportName,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
@@ -19,10 +19,14 @@ import {
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 
 export type ReportParametersDetailsProps = {
+    headingLevel: 'h2' | 'h3';
     formValues: ReportFormValues;
 };
 
-function ReportParametersDetails({ formValues }: ReportParametersDetailsProps): ReactElement {
+function ReportParametersDetails({
+    headingLevel,
+    formValues,
+}: ReportParametersDetailsProps): ReactElement {
     const cveSeverities =
         formValues.reportParameters.cveSeverities.length !== 0 ? (
             formValues.reportParameters.cveSeverities.map((severity) => (
@@ -53,7 +57,7 @@ function ReportParametersDetails({ formValues }: ReportParametersDetailsProps): 
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem>
-                <Title headingLevel="h2">Report parameters</Title>
+                <Title headingLevel={headingLevel}>Report parameters</Title>
             </FlexItem>
             <FlexItem flex={{ default: 'flexNone' }}>
                 <DescriptionList

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
@@ -53,7 +53,7 @@ function ReportParametersDetails({ formValues }: ReportParametersDetailsProps): 
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem>
-                <Title headingLevel="h3">Report parameters</Title>
+                <Title headingLevel="h2">Report parameters</Title>
             </FlexItem>
             <FlexItem flex={{ default: 'flexNone' }}>
                 <DescriptionList

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ScheduleDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ScheduleDetails.tsx
@@ -37,7 +37,7 @@ function ScheduleDetails({ formValues }: ScheduleDetailsProps): ReactElement {
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem>
-                <Title headingLevel="h3">Schedule details</Title>
+                <Title headingLevel="h2">Schedule details</Title>
             </FlexItem>
             <FlexItem flex={{ default: 'flexNone' }}>
                 <TextContent>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
@@ -31,6 +31,8 @@ export type ReportReviewFormParams = {
     formValues: ReportFormValues;
 };
 
+const headingLevel = 'h3';
+
 function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactElement {
     return (
         <>
@@ -47,9 +49,10 @@ function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactE
                 padding={{ default: 'noPadding' }}
                 className="pf-v5-u-py-lg pf-v5-u-px-lg"
             >
-                <ReportParametersDetails formValues={formValues} />
+                <ReportParametersDetails headingLevel={headingLevel} formValues={formValues} />
                 <Divider component="div" className="pf-v5-u-py-md" />
                 <NotifierConfigurationView
+                    headingLevel={headingLevel}
                     customBodyDefault={defaultEmailBody}
                     customSubjectDefault={getDefaultEmailSubject(
                         formValues.reportParameters.reportName,

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -7,7 +7,7 @@ import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import { ComplianceProfileSummary, complianceV2Url } from './ComplianceCommon';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
-import { NotifierConfiguration } from './ReportsService.types';
+import { NotifierConfiguration, ReportStatus } from './ReportsService.types';
 import { Empty } from './types';
 
 const complianceScanConfigBaseUrl = `${complianceV2Url}/scan/configurations`;
@@ -77,6 +77,15 @@ export type ComplianceScanConfigurationStatus = {
     lastUpdatedTime: string; // ISO 8601 date string
     modifiedBy: SlimUser;
     lastExecutedTime: string | null; // either ISO 8601 date string or null when scan is in progress
+};
+
+// @TODO: This may change and be moved around depending on how backend implements it.
+export type ComplianceScanSnapshot = {
+    reportJobId: string;
+    reportStatus: ReportStatus;
+    user: SlimUser;
+    isDownloadAvailable: boolean;
+    scanConfig: ComplianceScanConfigurationStatus;
 };
 
 export type ListComplianceScanConfigurationsResponse = {


### PR DESCRIPTION
### Description

This PR does the following:

1. We created a new `ReportJobsTable` component that takes care of rendering the jobs table. We will use this table for both Compliance and VM Reports. We'll use it for Compliance first.
2. I removed the card-specific components from `ConfigDetails`, allowing both `JobDetails` and `ConfigDetails` to be combined and grouped within a card in the expandable section of the jobs table.
3. I added a type for the `ConfigDetails` props.
4. I created a `ReportJobs` component that will do data-fetching (eventually) and render the data in the `ReportJobsTable` component. For now, I'm just using mock data.
5. I modified `JobDetails` to take `reportStatus` and `isDownloadAvailable` instead of `reportSnapshot` so its more reusable in the Compliance context.
6. I added a new type called `ComplianceScanSnapshot` that is similar to but different from `ReportSnapshot`. This may change depending on what Luis does on the backend. 
7. I changed the `h3` headers to `h2` headers in VM Reports to be consistent in both places.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes
 
#### How I validated my change

<img width="721" alt="Screenshot 2024-09-13 at 9 28 45 AM" src="https://github.com/user-attachments/assets/9c473d69-1466-4200-a63a-08143235177d">

![Screenshot 2024-09-13 at 9 29 10 AM](https://github.com/user-attachments/assets/bb390112-8613-40e8-9ff4-3b9c14d980a9)
