### PR TITLE
ROX-25540: Update Helm charts

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -249,7 +249,7 @@ spec:
         name: host-root-ro
     {{- if eq ._rox.env.openshift 4 }}
       - hostPath:
-        path: /usr/share
+          path: /usr/share
         name: usr-share-ro
       - name: index-volume
         emptyDir: {}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -131,6 +131,10 @@ spec:
               resource: limits.cpu
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
+        - name: ROX_NODE_INDEX_ENABLED
+          value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
+        - name: ROX_NODE_INDEX_HOST_PATH
+          value: "/hostindex"
         - name: ROX_METRICS_PORT
         {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"
@@ -176,6 +180,11 @@ spec:
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
+        - mountPath: /hostindex/usr/share
+          name: usr-share-ro
+          readOnly: true
+        - mountPath: /tmp
+          name: index-volume
       {{- if eq ._rox.env.openshift 4 }}
       - name: node-inventory
         image: {{ quote ._rox.image.scanner.fullRef }}
@@ -216,6 +225,9 @@ spec:
           path: /usr/lib
         name: usr-lib-ro
       - hostPath:
+          path: /usr/share
+        name: usr-share-ro
+      - hostPath:
           path: /sys/
         name: sys-ro
       - hostPath:
@@ -243,6 +255,8 @@ spec:
       - name: cache-volume
         emptyDir:
           sizeLimit: 200Mi
+      - name: index-volume
+        emptyDir: {}
       [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
       {{- if ._rox.collector.containerd.enabled }}
       - name: containerd-sock

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -132,11 +132,11 @@ spec:
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
         - name: ROX_NODE_INDEX_ENABLED
-          value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
-      {{ if eq ._rox.env.openshift 4 }}
+          value: {{ eq ._rox.env.openshift 4 | quote }}
+      {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"
-      {{ end }}
+      {{- end }}
         - name: ROX_METRICS_PORT
         {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"
@@ -182,13 +182,13 @@ spec:
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
-      {{ if eq ._rox.env.openshift 4 }}
+      {{- if eq ._rox.env.openshift 4 }}
         - mountPath: /hostindex/usr/share
           name: usr-share-ro
           readOnly: true
         - mountPath: /tmp
           name: index-volume
-      {{ end }}
+      {{- end }}
       {{- if eq ._rox.env.openshift 4 }}
       - name: node-inventory
         image: {{ quote ._rox.image.scanner.fullRef }}
@@ -228,7 +228,6 @@ spec:
       - hostPath:
           path: /usr/lib
         name: usr-lib-ro
-
       - hostPath:
           path: /sys/
         name: sys-ro
@@ -248,13 +247,13 @@ spec:
       - hostPath:
           path: /
         name: host-root-ro
-    {{ if eq ._rox.env.openshift 4 }}
+    {{- if eq ._rox.env.openshift 4 }}
       - hostPath:
         path: /usr/share
         name: usr-share-ro
       - name: index-volume
         emptyDir: {}
-    {{ end }}
+    {{- end }}
       - name: etc-ssl
         emptyDir: {}
       - name: etc-pki-volume

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -133,8 +133,10 @@ spec:
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
         - name: ROX_NODE_INDEX_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
+      {{ if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"
+      {{ end }}
         - name: ROX_METRICS_PORT
         {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"
@@ -180,11 +182,13 @@ spec:
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
+      {{ if eq ._rox.env.openshift 4 }}
         - mountPath: /hostindex/usr/share
           name: usr-share-ro
           readOnly: true
         - mountPath: /tmp
           name: index-volume
+      {{ end }}
       {{- if eq ._rox.env.openshift 4 }}
       - name: node-inventory
         image: {{ quote ._rox.image.scanner.fullRef }}
@@ -224,9 +228,7 @@ spec:
       - hostPath:
           path: /usr/lib
         name: usr-lib-ro
-      - hostPath:
-          path: /usr/share
-        name: usr-share-ro
+
       - hostPath:
           path: /sys/
         name: sys-ro
@@ -246,6 +248,13 @@ spec:
       - hostPath:
           path: /
         name: host-root-ro
+    {{ if eq ._rox.env.openshift 4 }}
+      - hostPath:
+        path: /usr/share
+        name: usr-share-ro
+      - name: index-volume
+        emptyDir: {}
+    {{ end }}
       - name: etc-ssl
         emptyDir: {}
       - name: etc-pki-volume
@@ -255,8 +264,7 @@ spec:
       - name: cache-volume
         emptyDir:
           sizeLimit: 200Mi
-      - name: index-volume
-        emptyDir: {}
+
       [<- if .FeatureFlags.ROX_COLLECTOR_RUNTIME_CONFIG >]
       {{- if ._rox.collector.containerd.enabled }}
       - name: containerd-sock


### PR DESCRIPTION
### Description

For Node Indexing to work on the compliance container, some changes to the Helm chart are needed.
Namely, we are mounting a small part of the Node filesystem as read only, and set the fitting environment variables.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Used the updated Helm chart to deploy, then manually changed the images to the ones from #12448, which contain the new code. 
Used the updated Helm chart to deploy to OpenShift 4 and to  a GKE cluster. On the GKE cluster I verified that the deployment is functional and does not contain any of the settings needed for Node Indexing.
