### PR TITLE
chore(scanner): bump vuln timeout

### DIFF
--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func tryExport(outputDir string) error {
-	const timeout = 1 * time.Hour
+	const timeout = 2 * time.Hour
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
### Description

Later releases increased this timeout. Some older version of 4.4.z have failed due to timeout. This protects future versions from dealing with this timeout

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

not needed

#### How I validated my change

I didn't