### PR TITLE
ci(scanner): stop building single-bundle dev vulns

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -146,12 +146,6 @@ jobs:
         chmod +x /usr/local/bin/updater
         mkdir vulns
 
-    - name: Run updater (single bundle)
-      env:
-        STACKROX_NVD_ZIP_PATH: nvd.zip
-      run: |
-        updater export vulns --manual-url "$MANUAL_URL"
-
     - name: Run updater (multi bundle)
       env:
         STACKROX_NVD_ZIP_PATH: nvd.zip


### PR DESCRIPTION
### Description

These are no longer needed for current and future releases, so why bother making them?

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Added `pr-update-scanner-vulns` label. Check out the dev vulns job and see this no longer runs