### PR TITLE
ROX-26095: fix filter bar accessibility issues

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -33,11 +33,11 @@ export const selectors = {
     searchEntityDropdown:
         '.pf-v5-c-toolbar button[aria-label="compound search filter entity selector toggle"]',
     searchEntityMenuItem:
-        '.pf-v5-c-toolbar div[aria-label="compound search filter entity selector menu"] button',
+        '.pf-v5-c-toolbar [aria-label="compound search filter entity selector menu"] button',
     searchAttributeDropdown:
         '.pf-v5-c-toolbar button[aria-label="compound search filter attribute selector toggle"]',
     searchAttributeMenuItem:
-        '.pf-v5-c-toolbar div[aria-label="compound search filter attribute selector menu"] button',
+        '.pf-v5-c-toolbar [aria-label="compound search filter attribute selector menu"] button',
     searchValueTypeahead: '.pf-v5-c-toolbar input[aria-label^="Filter results by"]',
     searchValueMenuItem: '.pf-v5-c-toolbar div[aria-label="Filter results select menu"] button',
     searchValueApplyButton:

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -39,7 +39,7 @@ export const selectors = {
     searchAttributeMenuItem:
         '.pf-v5-c-toolbar [aria-label="compound search filter attribute selector menu"] button',
     searchValueTypeahead: '.pf-v5-c-toolbar input[aria-label^="Filter results by"]',
-    searchValueMenuItem: '.pf-v5-c-toolbar div[aria-label="Filter results select menu"] button',
+    searchValueMenuItem: '.pf-v5-c-toolbar [aria-label="Filter results select menu"] button',
     searchValueApplyButton:
         '.pf-v5-c-toolbar button[aria-label="Apply autocomplete input to search"]',
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -49,10 +49,10 @@ const clusterSearchFilterConfig = {
 
 const selectors = {
     entitySelectToggle: 'button[aria-label="compound search filter entity selector toggle"]',
-    entitySelectItems: 'div[aria-label="compound search filter entity selector menu"] ul li',
+    entitySelectItems: '[aria-label="compound search filter entity selector menu"] li',
     entitySelectItem: (text) => `${selectors.entitySelectItems} button:contains(${text})`,
     attributeSelectToggle: 'button[aria-label="compound search filter attribute selector toggle"]',
-    attributeSelectItems: 'div[aria-label="compound search filter attribute selector menu"] ul li',
+    attributeSelectItems: '[aria-label="compound search filter attribute selector menu"] li',
     attributeSelectItem: (text) => `${selectors.attributeSelectItems} button:contains(${text})`,
 };
 
@@ -321,7 +321,7 @@ describe(Cypress.spec.relative, () => {
         cy.get('button[aria-label="Condition selector toggle"]').should('have.text', 'On');
 
         cy.get('button[aria-label="Condition selector toggle"]').click();
-        cy.get('div[aria-label="Condition selector menu"] li button:contains("After")')
+        cy.get('[aria-label="Condition selector menu"] li button:contains("After")')
             .filter((_, element) => {
                 // Get exact value
                 // @TODO: Could be a custom command
@@ -365,7 +365,7 @@ describe(Cypress.spec.relative, () => {
 
         // change condition and number value
         cy.get('button[aria-label="Condition selector toggle"]').click();
-        cy.get('div[aria-label="Condition selector menu"] li button:contains("Is less than")')
+        cy.get('[aria-label="Condition selector menu"] li button:contains("Is less than")')
             .filter((_, element) => {
                 // Get exact value
                 // @TODO: Could be a custom command
@@ -426,7 +426,7 @@ describe(Cypress.spec.relative, () => {
 
         const autocompleteMenuToggle =
             'div[aria-labelledby="Filter results menu toggle"] button[aria-label="Menu toggle"]';
-        const autocompleteMenuItems = 'div[aria-label="Filter results select menu"] ul li';
+        const autocompleteMenuItems = '[aria-label="Filter results select menu"] li';
         const autocompleteInput = 'input[aria-label="Filter results by Image name"]';
         const autocompleteSearchButton = 'button[aria-label="Apply autocomplete input to search"]';
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -276,7 +276,6 @@ function SearchFilterAutocomplete({
     return (
         <>
             <Select
-                aria-label="Filter results select menu"
                 isOpen={isOpen}
                 selected={value}
                 onSelect={onSelect}
@@ -285,7 +284,7 @@ function SearchFilterAutocomplete({
                 }}
                 toggle={toggle}
             >
-                <SelectList>
+                <SelectList aria-label="Filter results select menu">
                     {selectOptions.map((option, index) => (
                         <SelectOption
                             key={option.value || option.children}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -284,7 +284,7 @@ function SearchFilterAutocomplete({
                 }}
                 toggle={toggle}
             >
-                <SelectList aria-label="Filter results select menu">
+                <SelectList id="select-typeahead-listbox" aria-label="Filter results select menu">
                     {selectOptions.map((option, index) => (
                         <SelectOption
                             key={option.value || option.children}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
@@ -55,7 +55,6 @@ function SimpleSelect({
 
     return (
         <Select
-            aria-label={ariaLabelMenu}
             isOpen={isOpen}
             selected={value}
             onSelect={onSelect}
@@ -63,7 +62,7 @@ function SimpleSelect({
             toggle={toggle}
             shouldFocusToggleOnSelect
         >
-            <SelectList>{children}</SelectList>
+            <SelectList aria-label={ariaLabelMenu}>{children}</SelectList>
         </Select>
     );
 }


### PR DESCRIPTION
### Description

Fixes accessibility issues in Workload, Node, and Platform CVEs (as well as any other place using the new search filter components).

### Issue

With any of the new filter component dropdowns opened:
![image](https://github.com/user-attachments/assets/dac95abb-f383-49d7-ac17-9ec43210ca8f)

1. Ensure every ARIA input field has an accessible name
2. Ensure ARIA attributes are not prohibited for an element's role

#### Analysis

The `aria-label` attribute was previously placed on the containing `<div>` element via the `<Select>` component, instead of on the visible `<ul>` element via the `<SelectList>` component.

#### Fix

Adjust the placement of the `aria-label` in the reusable `<SimpleSelect>` component so that it targets the semantic rendered menu element.

![image](https://github.com/user-attachments/assets/f5de0e1f-1671-436f-8278-0fc23dc88e5f)

---

### Issue

With the autocomplete dropdown open:
![image](https://github.com/user-attachments/assets/1d3cbb1c-3da0-4740-b8e9-f0c05ad192bc)

1. Ensure all ARIA attributes have valid values

#### Analysis

The `aria-controls` attribute references an element that does not exist.

#### Fix

Add a matching `id` to the element under the control of the text input: the dropdown menu.

![image](https://github.com/user-attachments/assets/05303d7a-73d3-4820-bd68-e7e5eea15486)
(Note that the other two aXe errors are solved by the first fix in this PR.)


### Leftovers

There are aXe errors when either the Fixability or Severity dropdowns are open. These dropdowns use the legacy PatternFly `<Select>` component, so rather than diagnose the a11y issues as-is, these will be migrated to the new `<Select>` component in a follow up.



### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

See the testing information above in the PR description. This test should be repeated for each of the following dropdowns:
1. Entity selector
2. Attribute selector
3. Autocomplete dropdown
4. Numeric condition selector
5. Date condition selector
