### PR TITLE
chore(scanner): manual entry for CVE-2020-10683

### DIFF
--- a/scanner/e2etests/testdata/image_tests.json
+++ b/scanner/e2etests/testdata/image_tests.json
@@ -2061,5 +2061,37 @@
                 ]
             }
         ]
+    },
+    {
+        "image": "quay.io/rhacs-eng/qa:dom4j-CVE-2020-10683",
+        "registry": "https://quay.io",
+        "username": "QUAY_RHACS_ENG_RO_USERNAME",
+        "password": "QUAY_RHACS_ENG_RO_PASSWORD",
+        "source": "NVD",
+        "namespace": "debian:11",
+        "expected_features": [
+            {
+                "Name": "org.dom4j:dom4j",
+                "Version": "1.6.1",
+                "Location": "usr/local/tomcat/webapps/cve-app.war",
+                "AddedBy": "idk",
+                "Vulnerabilities": [
+                    {
+                        "Name": "CVE-2020-10683",
+                        "Description": "dom4j allows External Entities by default which might enable XXE attacks",
+                        "Severity": "Critical",
+                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-10683",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Score": 9.8,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/scanner/updater/manual/vulns.yaml
+++ b/scanner/updater/manual/vulns.yaml
@@ -3,6 +3,27 @@
 # Use this data with caution and prioritize official updates when they become available.
 
 vulnerabilities:
+# Vuln: CVE-2020-10683/GHSA-hwj3-m3p6-hj38
+# Reason: The vuln table has an entry for GHSA-hwj3-m3p6-hj38, but osv.dev
+# seems to attribute it to dom4j:dom4j for versions [0, 1.6.1].
+# Later versions seem to be attributed to org.dom4j:dom4j, which is what
+# Scanner V4 finds.
+# Source: https://osv-vulnerabilities.storage.googleapis.com/Maven/GHSA-hwj3-m3p6-hj38.json
+- Name: CVE-2020-10683
+  Description: dom4j allows External Entities by default which might enable XXE attacks
+  Issued: '2020-06-05T16:13:36Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2020-10683
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: 'org.dom4j:dom4j'
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=0&lastAffected=1.6.1
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2
+
 # Vuln: CVE-2022-22963/GHSA-6v73-fgf6-w5j7
 # Reason: The vuln table has an entry for GHSA-6v73-fgf6-w5j7, but Scanner V4
 # may have trouble determining the groupID when pom.properties is missing.


### PR DESCRIPTION
### Description

When reviewing https://issues.redhat.com/browse/CLAIRDEV-93, I was curious if we were able to find the vulnerabilities in the test image. We found 2/3. I added a manual entry here so we may find hte third.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added e2e tests

#### How I validated my change

CI with labels 
