### PR TITLE
Install CO from upstream catalog for ACS e2e testing

### DIFF
--- a/tests/e2e/yaml/compliance-operator/subscription.yaml
+++ b/tests/e2e/yaml/compliance-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: stable
+  channel: alpha
   name: compliance-operator
-  source: redhat-operators
+  source: compliance-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Initially, we setup the ACS e2e testing to use the upstream Compliance
Operator images built from each upstream commit to
ComplianceAsCode/compliance-operator, but it was disabled earlier this
year to work around an issue.

  https://github.com/stackrox/stackrox/pull/10042

This commit re-enables installing from upstream sources so that we can
test and integrate upstream changes from the compliance operator sooner.
