### PR TITLE
ROX-26098: Edit policyCriteriaDescriptors before accessibility fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKey.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKey.tsx
@@ -15,7 +15,7 @@ function PolicyCriteriaKey({ fieldKey }) {
         <div ref={drag} className="pf-v5-u-p-sm pf-v5-u-mb-md policy-criteria-key">
             <Flex alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
                 <span className="draggable-grip" />
-                {shortName || name}
+                {shortName}
             </Flex>
         </div>
     );

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -74,8 +74,8 @@ function getPolicyFieldsAsTree(existingGroups, descriptors): TreeViewDataItem[] 
             })
             .map<TreeViewDataItem>((child: Descriptor) => ({
                 name: child.longName,
-                title: child.shortName || child.name,
-                id: kebabCase(child.shortName),
+                title: child.shortName,
+                id: kebabCase(child.name),
             })),
     }));
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
@@ -68,7 +68,9 @@ function PolicyGroupCard({
         ]);
     }
 
-    const headerLongText = group.negate ? descriptor.negatedName : descriptor.longName;
+    const hasNot = !readOnly && 'negatedName' in descriptor && descriptor.negatedName;
+    const headerLongText =
+        group.negate && 'negatedName' in descriptor ? descriptor.negatedName : descriptor.longName;
 
     return (
         <>
@@ -77,7 +79,7 @@ function PolicyGroupCard({
                     actions={{
                         actions: (
                             <>
-                                {descriptor.negatedName && !readOnly && (
+                                {hasNot && (
                                     <>
                                         <Divider
                                             component="div"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
@@ -1,0 +1,85 @@
+import { policyCriteriaDescriptors } from './policyCriteriaDescriptors';
+
+// Enforce consistency of whicheverName properties in policy criteria descriptors.
+
+// Add allowed items if unit tests fail for new rules that follow the rules (pardon pun).
+
+// Items that are allowed independent of context.
+const allowListForItems = [
+    'CPU',
+    'CVE',
+    'Dockerfile',
+    "doesn't",
+    "don't",
+    'IPC',
+    'Kubernetes',
+    'MUST',
+    'NOT',
+    'OS',
+    'PID',
+    'RBAC',
+    'UID',
+    'USER',
+];
+
+// Items that are allowed only in the content of an entire string.
+const allowListForNames = ['Common Vulnerability Scoring System (CVSS) score'];
+
+function isInitialUpperCase(item: string) {
+    return /^[A-Z]/.test(item);
+}
+
+function isLowerCase(item: string) {
+    return /^[a-z]+$/.test(item);
+}
+
+function hasSentenceCase(otherName: string) {
+    return (
+        allowListForNames.includes(otherName) ||
+        otherName
+            .split(' ')
+            .every((item, i) =>
+                i === 0
+                    ? isInitialUpperCase(item)
+                    : allowListForItems.includes(item) || isLowerCase(item)
+            )
+    );
+}
+
+describe('policyCriteriaDescriptors', () => {
+    policyCriteriaDescriptors.forEach((descriptor) => {
+        const { longName, name, shortName } = descriptor;
+
+        describe(`descriptor of "${name}"`, () => {
+            if (typeof longName === 'string') {
+                test(`longName "${longName}" should not equal shortName`, () => {
+                    expect(longName !== shortName).toEqual(true);
+                });
+
+                test(`longName "${longName}" should have sentence case`, () => {
+                    expect(hasSentenceCase(longName)).toEqual(true);
+                });
+            }
+
+            if ('negatedName' in descriptor && typeof descriptor.negatedName === 'string') {
+                const { negatedName } = descriptor;
+
+                test(`negatedName "${negatedName}" should not equal longName`, () => {
+                    expect(negatedName !== longName).toEqual(true);
+                });
+
+                test(`negatedName "${negatedName}" should not equal shortName`, () => {
+                    expect(negatedName !== shortName).toEqual(true);
+                });
+
+                test(`negatedName "${negatedName}" should have sentence case`, () => {
+                    expect(hasSentenceCase(negatedName)).toEqual(true);
+                });
+            }
+
+            test(` shortName "${shortName}" should have sentence case`, () => {
+                expect(hasSentenceCase(shortName)).toEqual(true);
+            });
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -3,7 +3,7 @@ import qs from 'qs';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {
-    policyConfigurationDescriptor,
+    policyCriteriaDescriptors,
     auditLogDescriptor,
     imageSigningCriteriaName,
     Descriptor,
@@ -716,7 +716,7 @@ export function getPolicyDescriptors(
     lifecycleStages: LifecycleStage[]
 ) {
     const unfilteredDescriptors =
-        eventSource === 'AUDIT_LOG_EVENT' ? auditLogDescriptor : policyConfigurationDescriptor;
+        eventSource === 'AUDIT_LOG_EVENT' ? auditLogDescriptor : policyCriteriaDescriptors;
 
     const descriptors = unfilteredDescriptors.filter((unfilteredDescriptor) => {
         const { featureFlagDependency } = unfilteredDescriptor;


### PR DESCRIPTION
### Description

Prerequisite to fix accessibility of `input` and `select` elements in policy wizard.

### Principles

1. `name` has **Title Case**.
    * It corresponds to backend field names:
        https://github.com/stackrox/stackrox/blob/master/pkg/booleanpolicy/fieldnames/list.go
    * It is for `fieldName` in payload, response, and form state.
    * It is for `id` or `key` props.
    * It is **not** for rendered text.
2. `shortName` has **Sentence case**.
    * It is for field title in form and modal (also for drag-and-drop).
3. `longName` has **Sentence case**.
    * It is for field subtitle in form and modal.
    * It is for all field types.
4. `negatedName` has **Sentence case**.
    * It is for field subtitle in form.
    * It is **not** for `'group'`, `radioGroup`, or `'tableModal'` field types.
5. `label`
    * It seems to be fallback to match field in section and in modal.
    * It is for `label` with `Select` element.

### Changes

1. Edit policyCriteriaDescriptors.tsx file.
    * Replace `cpuResource` and `memoryResource` with only the shared `subCompnent` arrays, so `policyConfigurationDescriptor` consists entirely of literal objects.
    * Define `SubComponent` types.
    * Make `shortName` required and add missing property values to remove need for `name` fallback.
    * Factor out `canBooleanLogic` and `negatedName` properties to include or exclude from descriptor types.
    * Separate `RadioGroupStringDescriptor` from `RadioGroupDescriptor` type.
    * Rename `policyConfigurationDescriptor` as `policyCriteriaDescriptors` to prevent confusion.
2. Add policyCriteriaDescriptors.test.ts file.
    * Prevent multiple properties with the same value.
    * Verify **Sentence case** for `longName`, `negatedName`, and `shortName` properties. With allow lists for acronyms.
3. Edit PolicyCriteriaKey.tsx file (backward looking).
    * Delete fallback from `shortName` to `name` because `shortName` is now required.
3. Edit PolicyCriteriaModal.tsx file (forward looking).
    * Delete fallback from `shortName` to `name` because `shortName` is now required.
    * Replace `shortName` with `name` as value of `id` prop.
4. Edit PolicyGroupCard.tsx file.
    * Add type guard for `negatedName` property.
    * Factor our `hasNot` for clarity and to prevent indentation changes.

### Residue

1. Make `label` property required in `BaseSubComponent` type and provide 10 missing values for second-level `input` and `select` elements.
2. Investigate possible solutions for labels of first-level `input` and `select` elements.
3. Evaluate existing `placeholder` values also pro and con of `FormHelperText` as an alternative.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -114 = 4618437 - 4618551
        total 4330 = 11704380 - 11700050
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Done: will paste steps on Monday.

#### Integration testing

* policies/policyWizardStep3.test.js locally with `ROX_POLICY_CRITERIA_MODAL` feature flag
* policies/policyWizardStep3.test.js in CI without `ROX_POLICY_CRITERIA_MODAL` feature flag

#### Unit testing

* src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
