### PR TITLE
fix(tests): backport GKE compatibility fixes to 4.5

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -2,6 +2,7 @@
 PreTests - something to run before test but after resource provisioning.
 """
 
+import os
 import subprocess
 
 
@@ -56,3 +57,15 @@ class PreSystemTests:
             check=True,
             timeout=PreSystemTests.START_PREFETCH_TIMEOUT,
         )
+
+
+class CollectionMethodOverridePreTest:
+    """
+    CollectionPreTest - allows finer control over collection method
+    for individual test jobs
+    """
+    def __init__(self, method):
+        self._collection_method = method
+
+    def run(self):
+        os.environ['COLLECTION_METHOD'] = self._collection_method

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -21,9 +21,11 @@ import services.ProcessBaselineService
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
+import spock.lang.IgnoreIf
 
 @Tag("Parallel")
 @Tag("PZ")
+@IgnoreIf({ Env.COLLECTION_METHOD == "NO_COLLECTION"  })
 class ProcessBaselinesTest extends BaseSpecification {
     @Shared
     private String clusterId

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -15,8 +15,10 @@ import services.AlertService
 import util.Timer
 
 import spock.lang.Tag
+import spock.lang.IgnoreIf
 
 @Tag("PZ")
+@IgnoreIf({ Env.COLLECTION_METHOD == "NO_COLLECTION" })
 class RuntimeViolationLifecycleTest extends BaseSpecification  {
     static final private String APTGETPOLICY = "Ubuntu Package Manager Execution"
 

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -11,7 +11,10 @@ import sys
 from collections import namedtuple
 from pathlib import Path
 
-from pre_tests import PreSystemTests
+from pre_tests import (
+    PreSystemTests,
+    CollectionMethodOverridePreTest
+)
 from ci_tests import QaE2eTestCompatibility
 from post_tests import PostClusterTest, FinalPost
 from runners import ClusterTestSetsRunner
@@ -86,14 +89,21 @@ sets = []
 for test_tuple in test_tuples:
     os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
     test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
+
+    # expected version string is like 74.x.x for ACS 3.74 versions
+    is_3_74_sensor = test_tuple.sensor_version.startswith('74')
+
     sets.append(
         {
             "name": f'version compatibility tests: {test_versions}',
             "test": QaE2eTestCompatibility(test_tuple.central_version, test_tuple.sensor_version),
             "post_test": PostClusterTest(
+                    collect_collector_metrics=not is_3_74_sensor,
                     check_stackrox_logs=True,
                     artifact_destination_prefix=test_versions,
             ),
+            # Collection not supported on 3.74
+            "pre_test": CollectionMethodOverridePreTest("NO_COLLECTION" if is_3_74_sensor else "core_bpf")
         },
     )
 ClusterTestSetsRunner(

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -538,6 +538,12 @@ wait_for_collectors_to_be_operational() {
     local timeout=300
     local retry_interval=10
 
+    if [[ "$COLLECTION_METHOD" == "NO_COLLECTION" ]]; then
+        # With NO_COLLECTION, no collector containers are deployed
+        # so no need to check for readiness
+        return
+    fi
+
     local start_time
     start_time="$(date '+%s')"
     local all_ready="false"


### PR DESCRIPTION
### Description

Backport of #11946 to fix compatibility tests on which would otherwise use eBPF, but should use CORE_BPF (to ensure compatibility with all kernels)

Uses NO_COLLECTION for 3.74 tests, and CORE_BPF for everything else.

### User-facing documentation

~- [ ] CHANGELOG is updated **OR** update is not needed~
~- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

~- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag~
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~- [ ] added unit tests~
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
- [ ] modified existing tests

#### How I validated my change

Validated on previous PR, and CI should be enough to verify that it works in this case.
