### PR TITLE
ROX-24401: fix operator image tag and supported architectures

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -106,6 +106,10 @@ spec:
     description: This sets the expiration time for intermediate OCI artifacts produced and used during builds after which they can be garbage collected.
     name: oci-artifact-expires-after
     type: string
+  - name: image-tag-makefile-directory
+    description: Directory in which to run "make tag" command.
+    default: "."
+    type: string
 
   results:
   - description: ""
@@ -187,6 +191,8 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: MAKEFILE_DIRECTORY
+      value: $(params.image-tag-makefile-directory)
     taskRef:
       name: determine-image-tag
 

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -48,6 +48,8 @@ spec:
     value: '0'
   - name: clone-fetch-tags
     value: 'true'
+  - name: image-tag-makefile-directory
+    value: 'operator'
 
   workspaces:
   - name: git-auth

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -446,6 +446,9 @@ bundle-post-process: test-bundle-helpers operator-sdk ## Post-process CSV file t
 		$${unreleased_opt} \
 		--no-related-images \
 		--add-supported-arch amd64 \
+		--add-supported-arch arm64 \
+		--add-supported-arch ppc64le \
+		--add-supported-arch s390x \
 		< bundle/manifests/rhacs-operator.clusterserviceversion.yaml \
 		> build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
 # Check that the resulting bundle still passes validations.

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1159,7 +1159,91 @@ spec:
         displayName: Cluster Name
         path: clusterName
       version: v1alpha1
-  description: "Why use Red Hat Advanced Cluster Security for Kubernetes?"
+  description: "## Why use Red Hat Advanced Cluster Security for Kubernetes?\n\nProtecting\
+    \ cloud-native applications requires significant changes in how we approach security\u2014\
+    we must apply controls earlier in the application development life cycle, use\
+    \ the infrastructure itself to apply controls, and keep up with increasingly rapid\
+    \ release schedules.\n\n\nRed Hat\xAE Advanced Cluster Security for Kubernetes,\
+    \ powered by StackRox technology, protects your vital applications across build,\
+    \ deploy, and runtime. Our software deploys in your infrastructure and integrates\
+    \ with your DevOps tooling and workflows to deliver better security and compliance.\
+    \ The policy engine includes hundreds of built-in controls to enforce DevOps and\
+    \ security best practices, industry standards such as CIS Benchmarks and National\
+    \ Institute of Standards Technology (NIST) guidelines, configuration management\
+    \ of both containers and Kubernetes, and runtime security.\n\nRed Hat Advanced\
+    \ Cluster Security for Kubernetes provides a Kubernetes-native architecture for\
+    \ container security, enabling DevOps and InfoSec teams to operationalize security.\n\
+    \n## Features and Benefits\n\n**Kubernetes-native security:**\n1. Increases protection.\n\
+    1. Eliminates blind spots, providing staff with insights into critical vulnerabilities\
+    \ and threat vectors.\n1. Reduces time and costs.\n1. Reduces the time and effort\
+    \ needed to implement security and streamlines security analysis, investigation,\
+    \ and remediation using the rich context Kubernetes provides.\n1. Increases scalability\
+    \ and portability.\n1. Provides scalability and resiliency native to Kubernetes,\
+    \ avoiding operational conflict and complexity that can result from out-of-band\
+    \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
+    \nRed Hat provides the RHACS Operator by using the following update channels in\
+    \ the Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version\
+    \ and patches to the most recent version.\n  Using the `stable` channel and configuring\
+    \ automatic operator upgrades ensures that the most recent RHACS version is deployed.\n\
+    * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version\
+    \ and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).\n\n\
+    Note that the `latest` channel is deprecated and is not updated after RHACS version\
+    \ 3.74. Newer versions are published to the `stable` channel.\n\n**RHACS comes\
+    \ with two custom resources:**\n\n1. **Central Services** - Central is a deployment\
+    \ required on only one cluster in your environment. Users interact with RHACS\
+    \ via the user interface or APIs on Central. Central also sends notifications\
+    \ for violations and interacts with integrations. Users may select exposures for\
+    \ Central that best meet their environment.\n\n2. **Secured Cluster Services**\
+    \ - Secured cluster services are placed on each cluster you manage and report\
+    \ back to Central. These services allow users to enforce policies and monitor\
+    \ your OpenShift and Kubernetes clusters. Secured Cluster Services come as two\
+    \ Deployments (Sensor and Admission Controller) and one DaemonSet (Collector).\n\
+    \n### Central Services Explained\n\n| Service                          | Deployment\
+    \ Type | Description     |\n| :------------------------------- | :--------------\
+    \ | :-------------- |\n| Central                          | Deployment      |\
+    \ Users interact with Red Hat Advanced Cluster Security through the user interface\
+    \ or APIs on Central. Central also sends notifications for violations and interacts\
+    \ with integrations. |\n| Central DB                       | Deployment      |\
+    \ Central DB is a PostgreSQL-based persistent storage for the data collected and\
+    \ managed by Central. |\n| Scanner                          | Deployment     \
+    \ | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes\
+    \ and reports vulnerabilities for images. Scanner uses HPA to scale the number\
+    \ of replicas based on workload. |\n| Scanner DB                       | Deployment\
+    \      | Scanner DB is a cache for vulnerability definitions to serve vulnerability\
+    \ scanning use cases throughout the software development life cycle. |\n\n###\
+    \ Secured Cluster Services Explained\n\n| Service                          | Deployment\
+    \ Type | Description     |\n| :------------------------------- | :--------------\
+    \ | :-------------- |\n| Sensor                           | Deployment      |\
+    \ Sensor analyzes and monitors Kubernetes in secured clusters. |\n| Collector\
+    \                        | DaemonSet       | Analyzes and monitors container activity\
+    \ on Kubernetes nodes.|\n| Admission Controller             | Deployment     \
+    \ | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle.\
+    \ |\n\n### Central Custom Resource\n\nCentral Services is the configuration template\
+    \ for RHACS Central deployment. For all customization options, please visit the\
+    \ RHACS documentation.\n\n### SecuredCluster Custom Resource\n\nSecuredCluster\
+    \ is the configuration template for the RHACS Secured Cluster services.\n\n####\
+    \ Installation Prerequisites\n\nBefore deploying a SecuredCluster resource, you\
+    \ need to create a cluster init bundle secret.\n\n- **Through the RHACS UI:**\
+    \ To create a cluster init bundle secret through the RHACS UI, navigate to `Platform\
+    \ Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner.\
+    \ Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download\
+    \ Kubernetes secrets file`, and store the file under a name of your choice (for\
+    \ example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl` CLI:** To create\
+    \ a cluster init bundle secret through the `roxctl` command-line interface, run\
+    \ `roxctl central init-bundles generate <name> --output-secrets <file name>`.\
+    \ Choose any `name` and `file name` that you like.\n\nRun `oc project` and check\
+    \ that it reports the correct namespace where you intend to deploy SecuredCluster.\
+    \ In case you want to install SecuredCluster to a different namespace, select\
+    \ it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`.\
+    \ If you have chosen a name other than `init-bundle.yaml`, specify that file name\
+    \ instead.\n\n#### Required Fields\n\nThe following attributes are required to\
+    \ be specified. For all customization options, please visit the RHACS documentation.\n\
+    \n| Parameter          | Description     |\n| :----------------- | :--------------\
+    \ |\n| `clusterName`      | The name given to this secured cluster. The cluster\
+    \ will appear with this name in RHACS user interface. |\n| `centralEndpoint` \
+    \ | This field should specify the address of the Central endpoint, including the\
+    \ port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
+    \ Resource is in the same cluster and namespace as Central. |\n"
   displayName: Advanced Cluster Security for Kubernetes
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAgAElEQVR4nO3dv48cRf7/8VefLvbO55Pb2+S2doix2CbldHdDaOtOnhALgrkICQKWACRnexIIspvV54RDxiBImUU4ZkY4Z9bOv8z4H6hvUN3r2WV/dFdXd/WP50Mq7Z2Z7qnZH6+peVd1dWSMEQCg+/4UugMAgHoQ+ADQEwQ+APQEgQ8APUHgA0BPEPgA0BMEPgD0BIEPAD3x59AdwFlRFCWh+wB4tDLGrEJ3AlbElbbViKIolhRLGkoabH2VpP0gnQKa5Tj9upa02PrKm0RFCHwP0lH5cKvtBe0Q0A1L2TeAhaSFMWYetjvtR+AXFEXRQFKy1Qh3oD5LSfOsGWPWQXvTMgR+DlEUDSWN0kbAA82xlDSTNDPGLEJ3pukI/EukIT+WDfndsL0BkMOJbPhPCf+LEfhb0onWcdoIeaC9TiRNZcN/FbYrzUHgS4qiaCwb8qyeAbrnWDb4p6E7ElpvAz+dfJ2I0TzQF9mo/7Cvk729C/y0bJMF/U7IvgAIYqNXwb8K25V69Sbw06A/kPQgaEcANMmRpIO+BH/nA3+rdPNx6L4AaKxP1INST6cDP4qiieyontINgOtsZEf7h6E7UpVOBn661cFUTMYCKO5E0riLWzl0KvDT8s1U0t8DdwVA+z2RDf7OlHk6sx9+Wr5ZibAH4MffJa3SbOmE1o/w01H9TFw0BaA6x5JGbR/tt3qEH0XRSHZUT9gDqNK+7Gh/FLojZbQy8KMoGkRRdCjpG7ECB0A9diR9E0XRYVpZaJ3WlXTSC6hmYptiAOEsZUs8q9AdKaJVI/z049RChD2AsPYkLdpW4mlN4Kcz5ZRwADRFVuJpzSqeVpR0oiiaij1wADTXkTFmHLoT12l04LPkEkCLNH7pZmMDPw37uajXA2iPpaSkqaHfyBp+uhJnLsIeQLvsSZo3ddlm40b46c3D52JyFkB7bWRH+o26mXqjRviEPYCO2JEd6Q9Dd2RbY0b46UeglQh7AN2xkRQ3pabfiBH+1gQtYQ+gS7KRfiNq+sEDn9U4ADquMRO5wQNf7IsDoPv2ZLMuqKCBn15By0VVAPpgP828YIIFfrr/BNslAOiTByH33gmySifdYe6b2p8YAJrhHWNM7SWe2gM/vYp2IVbkAOivjaRh3fvp11rS2doMjbAH0Gc7kmZ1r9ypu4Z/IFbkAIBks/CgziesraRD3R4ALlRbPb+WwGfbBAC4VG3bL9RV0qFuDwAX21FNF2VVHvjpmlMurgKAy+3XsT6/0pIOpRwAyK3y0k7VI/ypCHsAyGNHNjMrU9kIP4qiRNKPlZwcALrrLWPMvIoTVxn4K0m7lZwcALrrxBgTV3HiSko66eQDYQ8Axe1WNYHrfYTPRC0AlFbJBG4VI/yJCHsAKGNHNku98jrCT3fC/M3bCQGg317zuaOm7xH+gefzAUCfHfg8mbcRPqN7AKiEt1G+zxF+sNt2AUCHectWLyN8VuYAQGW8rdjxNcJnZQ4AVMPbih1fI/yVuNAKAKri5erb0iP8KIrGIuwBoEq7adaW4qOkU7oTAIBrjcueoFRJh6WYAFCrUks0y47wxyWPBwDkNy5zcNkR/krU7wGgLqUmb51H+FEUDUXYA0CddtPsdVKmpDMucSwAwM3Y9UDnkg7lHAAIwrms4zTCp5wDAME4l3VcSzojx+MAAOU5ZTCBDwDt45TBhWv46c6Yv7s8GQDAm/8puoOmywg/cTgGAOBXUvQAAh8A2ikpegCBDwDtlBQ9wKWG7+cmuACAUowxUZHHFxrhR1GUFOoNAKAyRTO5aEmn0MkBAJUqdAFW0cCPCz4eAFCdSgPfeZc2AIB3hTK50KQtE7YA0CxFJm5zj/DT2xkCABqkSDYXKenkPikAoDZx3gcWCXzq9wDQPLmzuUjgDxw6AgCoVu5sZoQPAO3GCB8AeqKSET4AoMVyr8NnDT66IEmSM/9/Pp8H6QfgU961+H+uuiNAKMPh8LQlSaK9vb0LH7dcLjWfz7VYLE4b0EWM8NEJg8FASZKchvtwONTOzo7TuTabjRaLxembwHw+13pd6E5yQK3yjvAJfLRSkiSnwT4cDrW7u1vp852cnJyO/ufzOaUgNAqBj87YLssMh8NLSzN1Wy6XZz4JUApCKAQ+WimO4zPhvr+/H7pLhRwfH595E1itVqG7hB4g8NF4g8HgTLgnSeJcd2+qzWZzZi5gsVgwHwDvCHw0znbNvUmlmbplpaDtOQGgDAIfQcVxfCbg21aaqVtWCsreACgFoQgCH7XxuSQSFktDUQSBj8qcD/eql0TCypaGbr8JABKBD0/yXq2KMLhKGBKBDwfZksgs3Km7t9Px8fGZNwHmA7qPwMeVzi+J7Etp5uTk5LQUkiRJb17z9oQwS0O7h8DHGefDvQ+lme2Jz8uCbvuNr08TzttLQ7PvDdqLwO+xtl+t6srX0sa+LinlKuH2IvB7ghFqPSNUPiFRCmoyAr+jzm9FQA06jL7PgVAKahYCv2NGo5EODw97ESptXWXSx1VOJycnmkwmms1mobvSawR+h0ynUz148CB0NyrR9S2Gm7q1s29HR0caj8ehu9FbBH5HjEYjffPNN6G74QVXilpdvVL5nXfeYaQfCIHfEavVqpWBwF4w+XVlL6KTkxPFcRy6G71E4HfAcDjUL7/8ErobubDbo19tXRr6+uuvd64s1wZ5A//PVXcE7po6WtpeqdHn0kyVVquVptPpmX/bfgNo6gqtwWAQugu4AoGPK3HHpuY4f/P0PtwxDH4R+A0WIli52rI91uv1H94E+nqVNfIh8Hus60si+2i1Wmm1Wp1ZLdOXpaG4HoHfE+evVqXu3h/Zz317TmB7K44uLQ3F1Qj8Djq/JJLSDM67rBTU9qWhuIYxJleTZGj1tiRJTFHj8Th4v2ndaOPxuPDvX5Ikwfvdx5Y3x/8kdAojefjC71L3EPgA0BMEPgD0BIEPAD1B4ANATxD4ANATBD4A9ASBDwA9QeADQE8Q+ADQEwQ+APQEgQ8APUHgA0BPEPgA0BMEPgD0BIEPAD3BHa/QG3fSdjv9KklvXPLYl5J+lbRJvz5Lvz6vuI9AlQh8dNYtSXclvZ1+vVHg2Bt69Wbw9ta/v5D0s6QfJH3voY9AnQh8dM592ZB++7oHOrgp6V7aXsqG/mPZNwGg6Qh8dMKOpHdlw/5mTc95Q6/C/6ls8H9d03MDLpi0Res9lLSU9IHqC/vz3pD0uaSfZMtHQBMR+Gitu7JB/6mK1eerdFvSt5L+KzuHADQJgY/W2ZH0mWywhhrRX+dt2dH+/dAdAbYQ+GiVO5K+k63XN90N2TLPF7JvUkBoBD5a4y+yYX87dEcKuifbb0o8CI3ARyvcl/R/ak6tvqjbsiWeO9c9EKgQgY/Guy9bGmm7G7IjfUIfoRD4aLSuhH2G0EdIXHiFxqoj7LM9c867bI8dH7LQf1PszYN6EfhopDuySy99eya7HcJTvdoc7TK30n68ITth7HMJ6A3Ztfp/vaYPgE8EPhpnRzYMfU3QvpD0lWzQFxlRP0/b95I+lA3/d2XD30ffbsu+qb3n4VxAHtTw0ThfyM9o+oWk9yXtSfpS5csnv8qG856kR7LloLLuiYuzUB8CH43yF/nZ5fKRbI28is3MNlvnf+rhfJ+JNfqoB4GP4O7I7otzV3Z0X8YLSfuygVx1bfy5bA3+o5LnuaHyrxvIgxo+anNXdgL0juyI1vcVs88UZhL0S9n98L+Te23/DdnvD/vqo0oEPip1V7ZO7Wui8zKPZSdWQ614+VX2zaZM6H8hOz8AVIWSDipxX3br4m9lA7/KsH8mO5kaenljFvquk7k3xQQuqkXgw6ss6D9XPVsXZ2WcpshC39UHvjoCXIDAhxe3ZMsZdQW9ZEfSTRjZn/er3Cdyb4o7ZqE6BD5Kuy+7E2SV2xFc5JEu3hahCb6U9IPjsfd8dgTYQuCjlC9kR/V1b1v8VDZUm+xDudXz74kbpqAaBD6c7MiWcEKNRh8Fet4insv9TekvPjsCpAh8FJaFfd0lnMxTtWe9+ldyG+X7uNoYOI/AR2GhbzPYhtF9ZiO37R2YuEUVCHwU8oXChv1jtWd0n/nK4Zgb4iYp8I/AR24PFXYFyWO1cyvh57LXCxRF4MM3tlZALndUzUVBz2TLHtnNSO7IzhFszw/8IDtKbtvIftv3Kv7JKOQnKXQTgY9cvpCfpZcvZcPvh/RrX7hso8wIH74R+LjWfZUfbb6UXaL4lZp3ZWwdXD6dsBYfvlHDx5V2VP7esk9lbxZSxx71Tfai4ONvixujwC8CH1d6V+VKOY9kNxMre3vBLnD5Hixkl8GyTBM+EPi4Upntet9Xu9bMN9UbsttMfyHKPCiHwMel7st958uPVM39ZPvsnuzW02y7AFcEPi7lenn/D2r+xmZtdUPS/6n8vAr6icDHhXbkFvjZHvWo1rvixucojsDHhVwnCUPeV7Zv7onQRzEEPi7kshPmC1G3v0oVVwrfk93yAsiDwMeFXEb4hP3VHld03k/Fsk3kQ+DjQi5X1lYVaF3xXG47Z+bBkk3kQeDjD1yu7nwhLq7K40NV88Z4U3YiF7gKgY8/cAn8pt5MvInek/Q3ud/k/DIPxSgfVyPw4QWBX8zPkv4h6X8lDSX9U+VH/jfEKB9XI/CBwJ7LbhX9nmz4u2ylnCmzFQa6j8AHGuS57GZzrqP9m2LrBVyOwAca6D25h77LNRToBwIfvbAjO6n5naT/l7bv1OyJzg9VfA99iTX5uByBDy+afDu++7K7TH6qs6PfN9J/W6qZte+N3LaX5l64uAyBjz9wWU/fxMC/K+knSZ/r6pu43Egf85OaNzr+Wozy4Q+Bjz9wCfybak7o35K98vRbFRvt3tarG4006daCVezBg34i8HEhl6WB97z3opgdSR/IjtTL9OVeeo4P1Iz6PlcwwxcCHxdyuZDqvsIF5H29Cuky9+DN3NCrN48m1vcBFwQ+LuQywg9xpecd2dU2n8v9doxXuZme+zs1p2QFuCLwcaHvZe9eVdRD1VP/3pGttR+rnnXnb6TPFWJXyiaUldANBD4u9b3DMTck/dd3R875QHYpZYg5g+xG4h/U+JxcOQtfCHxcyvVKz9uq5tZ7d/UqbH3U6V1l9f2lql/+eFdupSpW9uAiBD4u9bPc1oBLfu+3eku2hv6tqqnTu7op26fvVF0Zy+WThOvPDN1H4ONKLld6ZrLQd61B70j6TNJCzd4f5g3ZPn4mv/X2h3J73YzucRkCH1dyvdIzc09uK1weypZM2rS/+7uyffZxU/H7sts+uPB9YxV0B4GPa71X8vjbsqGfd/T7hWzYhazTu7oh23fXclb2qeZzx+Nfym2yHf1A4ONaP6v8qPGGbJBd576qXX3zVPYmI2VvNHKdeyp2wVa2m+dPKvephrDHVQh85PKe3Nblb7un60f5VS13fCF7H9m/ym5VkN1o5G+qbpIz72u5Ixv0n6r8pHSZORd0H4GPXDay92At66pavusSxKu8lPSRpD1dPJn5c/rfPlL5N7Tzbur6ZZvZCiQfr/ux2HcHVyPwkdvPssHYFo9lw/zLHI/9Mn1s2RuJF/WZ/MxVvJS9YQpwFQIfhXyp+kOxqKeS9mXLUJsCx23SY/ZVbX0/c0vS257OVfS1op8IfBRW5n6rVZYcXkj6p2xt3mW3z8yv6Tn+qWovYvJ1sdZjMVmLfAh8OHEJ/apqzC9lJyv35Df4vk/P+Uj+6/u+PFP5ZbPoDwIfzt6T9H7Ox2ah7NsPkt6s6NyZR+lzNO2Cpmeyn0SAvAj8jhkOh7U+39eyNe+rSh8v9Go5pG9fVXTe856nz+VTmbLTD7Lf0yrr9kmSVHh2hEDgd8xgMKj9OX+VHQF/JDvZ+TJtT2U/AbypcuHWVRu5zYU8kl0iyyQtivpz6A6gGzayK3jyLIHEKx/K7nefZ2nmC9kyGpujwRUjfCCgjWxp5tkVj3kh+0npsovHgLwY4XdMiJIOyslKYvdl1+XvbP37M9l5khDiOA70zKgKgd9gi8Wi8DF1T9rCn68VLtwv4hL4Lr+zqA8lnQZbr9ehuwAUwu9ssxH4HcPHcPjCp8XuIfAbbrlcFnr87u5uRT1B3+zsFLthY9HfVdSPwG84l4/ITNyiLJdPipRzmo/Ab7jValX4GD6KoyyXwHf5XUW9CPyGc/kjoo6PslwGDQR+8xH4DeeyzI3AR1ksyewmAr/hXOqibHqFslxG+NTwm4/Ab7j5fF74GEb4KMsl8F1+V1EvAr8FTk5OCj1+d3e3Nyt13tWrrQiqtJM+Vx/EcVx4SWbR31GEQeC3gEtttC9lnbclLSU9rPA5HqbP4ev+s03HhG13EfgtwJ46V7sh6VPZUL7r8bx303N+qnzbF3eFy2CBck47EPgtwAg/n5uSvpX0ncrdIPxWeo5v03P2jctggRU67RAZY/I9MIryPRDeDQYD/f7774WPi6Kogt5U565syPrySPa2hHnvDJXV6T/w2Ie/qX172OfNhG2vvfYaZZ2AjDG5/tgZ4bfAer12mhTr4yh/2weyJZn7OR57P32sz7Bvo9FoVPiYk5MTwr4lCPyWcKmRuvzxhvSz7L1wfboh6XNJP+ni+v7d9L99Lv91+pdq3+jeZZBAOac9CPyWcAn8No7wH1V03tuy5aL/ytbob6X/+9v0v1WhqtdSJdbfdxs1/JaI41i//fZb4ePaWFv9QtK9Cs+ffYqocuXNY9kbjrcN9ft2oobfMavVyqmO37ayjmSD8iP5L+9kbqi6sH8p2/c2hr1UfE976vftQuC3yGw2K3zMeDz235EafClpT3ak3BaPZfv8ZeiOlFC0Hk85p10I/BZx+ePa29tr7d46G9mR8r6kp4H7cpWnsn18T/mXgDbVdDqt9PEIi8Bvkdlsps2meKS0sayz7VdJf5X0vqQXgfuy7YVsn/4q28cumM/nOjo6yvXYo6MjRvgtQ+C3jEtZZzKZVNCT+n0t6U3Z1S9V1ffzeJn24c20T10zHo+vDf2jo6PWlgv7jMBvGZfA393dbeUSzYts9CpsQ9T3H+vVm07byzdXGY/Heuedd/TkyZMz//7kyRO99dZbhH1LsSyzhdbrdeHta7s6Irsr6TNVt5Y+80zSh2rfhVToB5ZldpjLKP/Bgwed3CP/Z9kR9/uqpszzMj33myLs0X4Efgu5rozoSi3/Il/LLon0eXXro/ScXazTo58o6bTUarXS7u5uoWM2m43iOO78vUdvyZZ5XG9Y8oNs+ea5tx4B1aKk03GHh4eFj9nZ2en0KD/zXNI/ZLcmLrKM80V6zD9E2KObGOG3lOse+X0Z5W97KLvt8WXbKWTLLNt8hSz6jRF+x63X69wXyGzryyh/W7ZNwyPZ1TaZZ3pVpyfs0QeM8FvMdQfNPo7ygS5jhN8Dq9VKx8fHhY/b2dlxmgMA0G6M8FsuSRL9+OOPTse+/vrr3K0I6ABG+D0xn8+dRvmS20ofAO1F4HfAwcGB03H7+/u9m8AF+oySTkfM53Pt7+8XPm6z2Wg4HHLXIqDF8pZ0CPyOGA6H+uWXX5yOPT4+7sxuml0wGo2UJInTDcXzWq1Wms/nms1mrNbqgLyBL2NMribJ0JrdptOpcXVwcBC8/31vw+HQLBYL55+hi/V6bcbjcfDXTivXTN4cz/3ABrwo2tVtMBiY9Xrt/MefJEnw19DXNhwOS/3syiL0290Mgd/PNplMnP/o1+u1GQwGwV9DH9t8Pnf+ufkSx3Hw7wPNrRkCv7+tTFlgsVgE73/f2nA4dP55+XR4eBj8e0FzayZnjrMss4PK3Nlqb2/Peb99uGnKTeaZuO8+Ar+DFouFPvnkE+fjHzx44Ly2H+21t7cXuguoGIHfUQcHB1oul87Hf/zxx528By7QZwR+h5UN7P/85z+Efg246A21yVvsVwMmJmjFW5lVOxmW7FXbyi6n9Sn094Lm1gyrdGhZm81mpYOA0K+2jcfj0j8jH0J/H2huzRD4tKwNBgMvV3AS+tW2JoR+6O8Bza0ZAp+23XxdyTmdToO/li63JEm8fCJzFfr109yaIfBp59toNPISCrPZjCtyA/8cq6r5h35tNLdmCHzaRc1X2WCxWJjhcBj89fStHRwcePn5XSb066O5NUPg0y5rh4eHXsJhvV6b0WgU/PX0oQ0Gg1r22wn9OmluzRD4tKtama2Uz5tOp5R4KmxJktS2bDP0a6W5NUPg065rPkN/tVqxvbLnNhgMvH0ayyv0a6a5NUPg0/I0n6FvjN1xkdF++TYajcxqtfL6s8kj9OumuTVD4NPyNt+hz12U3FscxyzLpBVuhsCnFWm+Q98YY+bzOWWenG0wGFS+AieP0N8HmlszBD6taKuqXjydTrmb0hXt4OCAvXRopZoh8GkurcrL+wn+V20wGJjJZFJZnX61WjmdO/T3hebWDIFPc21VLwPsc6knjuPKR/SLxcJ53X7o7w/NrRkCn1amxXHsZcO1q6xWKzOZTHqxqidJkkrmSc7bvi8tgd+fZgh8Wtk2GAxqCSljbLmna1ftZqP5OpZXXnTVM4Hfn2YIfJqvNh6Pa5tUXK/XrQ7/OI7NZDKp/NPRtsViceHcCIHfn2YIfJrPVkeJ57z1em1ms5mZTCaN3ahtMBiY0WhkDg8Pg1wodXBwcGnfCPxetdjkyPHI/oyvF0VRvgei0w4ODvTxxx8Hee7NZqP5fK7FYnH6db1e19qH4XB42pIk0d7eXq3Pn1kulxqPx1osFpc+Zj6fa39/v9B5oygq2zUEYIzJ9YMj8FFYHMeaTqeFw6QKJycnWq1Wms/nknT6tcybwXA41GAwUBzHiuNYw+FQcRwHC/dtm81Gh4eHOjg4uPaxBH5/EPio3Hg81uHhoXZ2dkJ35UrZm8JVmvDmdZ0nT55oMplc+1oyRQN/uVxqOBw69g4h5Q18avi0Uq0pWwJ0metOpJPJpNDzbC/ppLWrGSZtaXW2OI5rW8LZF6vVqtQmdIPBIPfqqvV6zVXQLW6GwKeFaAR/eWWDfrvlvXk9u5u2u5kKAn8e+kXR2tMI/uJ8Bv12Gw6Hly4Z5cY1nWhzkzPHi0zaziXt53owkIrjWOPxWJPJpPGTu6EcHx/r8PBQs9ms0ucZjUZnJmUXi0Xlz4laHBtjklyPzPvOIGmm8O9ktBa38Xhc+8VbTbVer83h4SF1c5qPNjMVlHQOGvDCaB1ocRwHuzI1tNlsRr2c5rsdmAoCf9KAF0brWBsOh50P/yzk+7ArKC1Im5gKaviJpB9zPRhwMBwONRqNlCRJKy6EuszJyYnm87lms5nm83nt2z+gd94yxszzPLBI4MeSfnPuElDAYDBQkiSne9Y0+Q0gC/jtPX6AGr1mjFnleWDuwJfYXgFhbW9clrW6V/4sl0utVqugG7gB20zebRVUPPAXksLvIAVsSZJEg8HgdMlhtvmZZD8p5Nn0bLPZnBmZZ0G+Wq3ONKBhlsaY3BsgFQ38qaQHDp0CAPh3ZIwZ533wnwqenOIkADRHoUwm8AGgvQplcqGSjsTELQA0RZEJW6n4CF+Slg7HAAD8KpzFLoE/dzgGAODXvOgBBD4AtNO86AEuNfyBpN+LPhEAwKv/McYUuuqv8Ag/fQLq+AAQzrJo2EtuJR3J7o0PAAjDKYMJfABoH6cMLlzDPz0wilaSdp0OBgC4OjHGxC4Huo7wJUb5ABCCc/aWCfxpiWMBAG6mrgc6l3QkyjoAUDPnco5UboQvMcoHgDpNyxxcdoQfi9seAkBdct/O8CKlRvjpEx+XOQcAIJfjMmEvlS/pSJR1AKAO07InKFXSOT0Jk7cAUKVSk7UZHyN8iVE+AFRp6uMkvkb4A0krSTulTwYA2LaRFLtslnaelxF+2pGpj3MBAM6Y+gh7ydMIX2KJJgBUpNRSzG2+avjZEs0jX+cDAOjIV9hLHkf4EqN8APDM2+he8jjCl05H+Z/4PCcA9NQnPsNe8jzCl1ixAwAeeFuZs83rCF86XbFz4Pu8ANAjB77DXqpghH96Yq6+BQAXXq6qvYj3Ef6WcYXnBoCuGld14soC3xgzl/SkqvMDQAc9SbOzEpWVdCQmcAGggEomardVWdJhAhcA8qtkonZbpSP80yeJormk/cqfCADa6dgYk1T9JHUFPqUdALhY5aWcTKUlnUz6QsZ1PBcAtMy4jrCXagp8STLGzCT9u67nA4AW+HeajbWopaRz+mS2tDOXtFfbkwJAMy0lJXWN7qWaA1863VFzIer5APprI2noe3O069RW0smkL3Bc9/MCQIOM6w57KUDgS6f1/H+FeG4ACOxfddbtt9Ve0jnz5FE0lfQgWAcAoF5HxphxqCcPGvgSF2UB6I1aLq66SpCSzjkj2dlqAOiqpWzWBRU88NMlSYkIfQDdVPvyy8sEL+lk2H4BQAfVtm1CHsFH+Jmtkf4mcFcAwIeNGjKyzzQm8CXJGLMQoQ+g/bKwX4TuyLZGBb50GvqxqOkDaKelbBmnUWEvNTDwJSZyAbRWYyZoL9LIwJfOhP5x4K4AQB7HanDYSw0OfMmGfnqhwlHovgDAFY6MMY0Oe6nhgZ9JL0Vm7x0ATfSvkNslFNGYdfh5RFE0kjQVa/UBhLeR3fUyyEZoLloV+NLpfvozcRMVAOEsJY1CbHFcRitKOtvSb3AibpcIIIx/y07OrkJ3pKjWjfC3UeIBUKPWlXDOa3XgS6d78MzEFssAqnMsW8Jp9Cqc67SupHPe1tLNf4ktGQD4tZFdhdP4JZd5tH6Evy0d7U8l/T1wVwC03xPZEk7rgz7TqcDPRFGUyAb/btieAGihE9mgn4fuiG+tL+lcxBgzN8bEoswDIL+sfBN3Meyljo7wt6Vlnomkj0P3BUBjfSLpsEvlm4t0PvAz6QVbB5IeBO0IgCY5knTQxjX1LnoT+Jk0+CeSxmL9PtBHG9k5vsO+BH2md4Gf2Sr1jHX30CkAAADvSURBVMXkLtAHJ3oV9J0u3Vymt4G/LYqisWzwc/EW0D3HkqbGmGnojoRG4G9Jyz1jMeoH2i4bzU/7Vra5CoF/iSiKhrLBPxLhD7TBiew2K9Mm3k+2CQj8HNLwH6WNbZmB5ljKhvyMkL8egV9QOtmbbDXeAID6LCXNs9bXyVdXBL4H6VYOw63GmwBQ3lLSImtdvfq1TgR+RdIJ4Fj2DWCw9VViNRAg2dUzkrSWDfXs64qJ1moQ+A2y9SYBdMWCsktzEPgA0BOd3C0TAPBHBD4A9ASBDwA9QeADQE8Q+ADQEwQ+APQEgQ8APUHgA0BP/H9f56NLOEVbbgAAAABJRU5ErkJggg==
@@ -1395,3 +1479,4 @@ spec:
   skips:
   - rhacs-operator.v4.1.0
   version: 0.0.1
+

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1159,91 +1159,7 @@ spec:
         displayName: Cluster Name
         path: clusterName
       version: v1alpha1
-  description: "## Why use Red Hat Advanced Cluster Security for Kubernetes?\n\nProtecting\
-    \ cloud-native applications requires significant changes in how we approach security\u2014\
-    we must apply controls earlier in the application development life cycle, use\
-    \ the infrastructure itself to apply controls, and keep up with increasingly rapid\
-    \ release schedules.\n\n\nRed Hat\xAE Advanced Cluster Security for Kubernetes,\
-    \ powered by StackRox technology, protects your vital applications across build,\
-    \ deploy, and runtime. Our software deploys in your infrastructure and integrates\
-    \ with your DevOps tooling and workflows to deliver better security and compliance.\
-    \ The policy engine includes hundreds of built-in controls to enforce DevOps and\
-    \ security best practices, industry standards such as CIS Benchmarks and National\
-    \ Institute of Standards Technology (NIST) guidelines, configuration management\
-    \ of both containers and Kubernetes, and runtime security.\n\nRed Hat Advanced\
-    \ Cluster Security for Kubernetes provides a Kubernetes-native architecture for\
-    \ container security, enabling DevOps and InfoSec teams to operationalize security.\n\
-    \n## Features and Benefits\n\n**Kubernetes-native security:**\n1. Increases protection.\n\
-    1. Eliminates blind spots, providing staff with insights into critical vulnerabilities\
-    \ and threat vectors.\n1. Reduces time and costs.\n1. Reduces the time and effort\
-    \ needed to implement security and streamlines security analysis, investigation,\
-    \ and remediation using the rich context Kubernetes provides.\n1. Increases scalability\
-    \ and portability.\n1. Provides scalability and resiliency native to Kubernetes,\
-    \ avoiding operational conflict and complexity that can result from out-of-band\
-    \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
-    \nRed Hat provides the RHACS Operator by using the following update channels in\
-    \ the Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version\
-    \ and patches to the most recent version.\n  Using the `stable` channel and configuring\
-    \ automatic operator upgrades ensures that the most recent RHACS version is deployed.\n\
-    * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version\
-    \ and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).\n\n\
-    Note that the `latest` channel is deprecated and is not updated after RHACS version\
-    \ 3.74. Newer versions are published to the `stable` channel.\n\n**RHACS comes\
-    \ with two custom resources:**\n\n1. **Central Services** - Central is a deployment\
-    \ required on only one cluster in your environment. Users interact with RHACS\
-    \ via the user interface or APIs on Central. Central also sends notifications\
-    \ for violations and interacts with integrations. Users may select exposures for\
-    \ Central that best meet their environment.\n\n2. **Secured Cluster Services**\
-    \ - Secured cluster services are placed on each cluster you manage and report\
-    \ back to Central. These services allow users to enforce policies and monitor\
-    \ your OpenShift and Kubernetes clusters. Secured Cluster Services come as two\
-    \ Deployments (Sensor and Admission Controller) and one DaemonSet (Collector).\n\
-    \n### Central Services Explained\n\n| Service                          | Deployment\
-    \ Type | Description     |\n| :------------------------------- | :--------------\
-    \ | :-------------- |\n| Central                          | Deployment      |\
-    \ Users interact with Red Hat Advanced Cluster Security through the user interface\
-    \ or APIs on Central. Central also sends notifications for violations and interacts\
-    \ with integrations. |\n| Central DB                       | Deployment      |\
-    \ Central DB is a PostgreSQL-based persistent storage for the data collected and\
-    \ managed by Central. |\n| Scanner                          | Deployment     \
-    \ | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes\
-    \ and reports vulnerabilities for images. Scanner uses HPA to scale the number\
-    \ of replicas based on workload. |\n| Scanner DB                       | Deployment\
-    \      | Scanner DB is a cache for vulnerability definitions to serve vulnerability\
-    \ scanning use cases throughout the software development life cycle. |\n\n###\
-    \ Secured Cluster Services Explained\n\n| Service                          | Deployment\
-    \ Type | Description     |\n| :------------------------------- | :--------------\
-    \ | :-------------- |\n| Sensor                           | Deployment      |\
-    \ Sensor analyzes and monitors Kubernetes in secured clusters. |\n| Collector\
-    \                        | DaemonSet       | Analyzes and monitors container activity\
-    \ on Kubernetes nodes.|\n| Admission Controller             | Deployment     \
-    \ | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle.\
-    \ |\n\n### Central Custom Resource\n\nCentral Services is the configuration template\
-    \ for RHACS Central deployment. For all customization options, please visit the\
-    \ RHACS documentation.\n\n### SecuredCluster Custom Resource\n\nSecuredCluster\
-    \ is the configuration template for the RHACS Secured Cluster services.\n\n####\
-    \ Installation Prerequisites\n\nBefore deploying a SecuredCluster resource, you\
-    \ need to create a cluster init bundle secret.\n\n- **Through the RHACS UI:**\
-    \ To create a cluster init bundle secret through the RHACS UI, navigate to `Platform\
-    \ Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner.\
-    \ Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download\
-    \ Kubernetes secrets file`, and store the file under a name of your choice (for\
-    \ example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl` CLI:** To create\
-    \ a cluster init bundle secret through the `roxctl` command-line interface, run\
-    \ `roxctl central init-bundles generate <name> --output-secrets <file name>`.\
-    \ Choose any `name` and `file name` that you like.\n\nRun `oc project` and check\
-    \ that it reports the correct namespace where you intend to deploy SecuredCluster.\
-    \ In case you want to install SecuredCluster to a different namespace, select\
-    \ it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`.\
-    \ If you have chosen a name other than `init-bundle.yaml`, specify that file name\
-    \ instead.\n\n#### Required Fields\n\nThe following attributes are required to\
-    \ be specified. For all customization options, please visit the RHACS documentation.\n\
-    \n| Parameter          | Description     |\n| :----------------- | :--------------\
-    \ |\n| `clusterName`      | The name given to this secured cluster. The cluster\
-    \ will appear with this name in RHACS user interface. |\n| `centralEndpoint` \
-    \ | This field should specify the address of the Central endpoint, including the\
-    \ port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
-    \ Resource is in the same cluster and namespace as Central. |\n"
+  description: "Why use Red Hat Advanced Cluster Security for Kubernetes?"
   displayName: Advanced Cluster Security for Kubernetes
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAgAElEQVR4nO3dv48cRf7/8VefLvbO55Pb2+S2doix2CbldHdDaOtOnhALgrkICQKWACRnexIIspvV54RDxiBImUU4ZkY4Z9bOv8z4H6hvUN3r2WV/dFdXd/WP50Mq7Z2Z7qnZH6+peVd1dWSMEQCg+/4UugMAgHoQ+ADQEwQ+APQEgQ8APUHgA0BPEPgA0BMEPgD0BIEPAD3x59AdwFlRFCWh+wB4tDLGrEJ3AlbElbbViKIolhRLGkoabH2VpP0gnQKa5Tj9upa02PrKm0RFCHwP0lH5cKvtBe0Q0A1L2TeAhaSFMWYetjvtR+AXFEXRQFKy1Qh3oD5LSfOsGWPWQXvTMgR+DlEUDSWN0kbAA82xlDSTNDPGLEJ3pukI/EukIT+WDfndsL0BkMOJbPhPCf+LEfhb0onWcdoIeaC9TiRNZcN/FbYrzUHgS4qiaCwb8qyeAbrnWDb4p6E7ElpvAz+dfJ2I0TzQF9mo/7Cvk729C/y0bJMF/U7IvgAIYqNXwb8K25V69Sbw06A/kPQgaEcANMmRpIO+BH/nA3+rdPNx6L4AaKxP1INST6cDP4qiieyontINgOtsZEf7h6E7UpVOBn661cFUTMYCKO5E0riLWzl0KvDT8s1U0t8DdwVA+z2RDf7OlHk6sx9+Wr5ZibAH4MffJa3SbOmE1o/w01H9TFw0BaA6x5JGbR/tt3qEH0XRSHZUT9gDqNK+7Gh/FLojZbQy8KMoGkRRdCjpG7ECB0A9diR9E0XRYVpZaJ3WlXTSC6hmYptiAOEsZUs8q9AdKaJVI/z049RChD2AsPYkLdpW4mlN4Kcz5ZRwADRFVuJpzSqeVpR0oiiaij1wADTXkTFmHLoT12l04LPkEkCLNH7pZmMDPw37uajXA2iPpaSkqaHfyBp+uhJnLsIeQLvsSZo3ddlm40b46c3D52JyFkB7bWRH+o26mXqjRviEPYCO2JEd6Q9Dd2RbY0b46UeglQh7AN2xkRQ3pabfiBH+1gQtYQ+gS7KRfiNq+sEDn9U4ADquMRO5wQNf7IsDoPv2ZLMuqKCBn15By0VVAPpgP828YIIFfrr/BNslAOiTByH33gmySifdYe6b2p8YAJrhHWNM7SWe2gM/vYp2IVbkAOivjaRh3fvp11rS2doMjbAH0Gc7kmZ1r9ypu4Z/IFbkAIBks/CgziesraRD3R4ALlRbPb+WwGfbBAC4VG3bL9RV0qFuDwAX21FNF2VVHvjpmlMurgKAy+3XsT6/0pIOpRwAyK3y0k7VI/ypCHsAyGNHNjMrU9kIP4qiRNKPlZwcALrrLWPMvIoTVxn4K0m7lZwcALrrxBgTV3HiSko66eQDYQ8Axe1WNYHrfYTPRC0AlFbJBG4VI/yJCHsAKGNHNku98jrCT3fC/M3bCQGg317zuaOm7xH+gefzAUCfHfg8mbcRPqN7AKiEt1G+zxF+sNt2AUCHectWLyN8VuYAQGW8rdjxNcJnZQ4AVMPbih1fI/yVuNAKAKri5erb0iP8KIrGIuwBoEq7adaW4qOkU7oTAIBrjcueoFRJh6WYAFCrUks0y47wxyWPBwDkNy5zcNkR/krU7wGgLqUmb51H+FEUDUXYA0CddtPsdVKmpDMucSwAwM3Y9UDnkg7lHAAIwrms4zTCp5wDAME4l3VcSzojx+MAAOU5ZTCBDwDt45TBhWv46c6Yv7s8GQDAm/8puoOmywg/cTgGAOBXUvQAAh8A2ikpegCBDwDtlBQ9wKWG7+cmuACAUowxUZHHFxrhR1GUFOoNAKAyRTO5aEmn0MkBAJUqdAFW0cCPCz4eAFCdSgPfeZc2AIB3hTK50KQtE7YA0CxFJm5zj/DT2xkCABqkSDYXKenkPikAoDZx3gcWCXzq9wDQPLmzuUjgDxw6AgCoVu5sZoQPAO3GCB8AeqKSET4AoMVyr8NnDT66IEmSM/9/Pp8H6QfgU961+H+uuiNAKMPh8LQlSaK9vb0LH7dcLjWfz7VYLE4b0EWM8NEJg8FASZKchvtwONTOzo7TuTabjRaLxembwHw+13pd6E5yQK3yjvAJfLRSkiSnwT4cDrW7u1vp852cnJyO/ufzOaUgNAqBj87YLssMh8NLSzN1Wy6XZz4JUApCKAQ+WimO4zPhvr+/H7pLhRwfH595E1itVqG7hB4g8NF4g8HgTLgnSeJcd2+qzWZzZi5gsVgwHwDvCHw0znbNvUmlmbplpaDtOQGgDAIfQcVxfCbg21aaqVtWCsreACgFoQgCH7XxuSQSFktDUQSBj8qcD/eql0TCypaGbr8JABKBD0/yXq2KMLhKGBKBDwfZksgs3Km7t9Px8fGZNwHmA7qPwMeVzi+J7Etp5uTk5LQUkiRJb17z9oQwS0O7h8DHGefDvQ+lme2Jz8uCbvuNr08TzttLQ7PvDdqLwO+xtl+t6srX0sa+LinlKuH2IvB7ghFqPSNUPiFRCmoyAr+jzm9FQA06jL7PgVAKahYCv2NGo5EODw97ESptXWXSx1VOJycnmkwmms1mobvSawR+h0ynUz148CB0NyrR9S2Gm7q1s29HR0caj8ehu9FbBH5HjEYjffPNN6G74QVXilpdvVL5nXfeYaQfCIHfEavVqpWBwF4w+XVlL6KTkxPFcRy6G71E4HfAcDjUL7/8ErobubDbo19tXRr6+uuvd64s1wZ5A//PVXcE7po6WtpeqdHn0kyVVquVptPpmX/bfgNo6gqtwWAQugu4AoGPK3HHpuY4f/P0PtwxDH4R+A0WIli52rI91uv1H94E+nqVNfIh8Hus60si+2i1Wmm1Wp1ZLdOXpaG4HoHfE+evVqXu3h/Zz317TmB7K44uLQ3F1Qj8Djq/JJLSDM67rBTU9qWhuIYxJleTZGj1tiRJTFHj8Th4v2ndaOPxuPDvX5Ikwfvdx5Y3x/8kdAojefjC71L3EPgA0BMEPgD0BIEPAD1B4ANATxD4ANATBD4A9ASBDwA9QeADQE8Q+ADQEwQ+APQEgQ8APUHgA0BPEPgA0BMEPgD0BIEPAD3BHa/QG3fSdjv9KklvXPLYl5J+lbRJvz5Lvz6vuI9AlQh8dNYtSXclvZ1+vVHg2Bt69Wbw9ta/v5D0s6QfJH3voY9AnQh8dM592ZB++7oHOrgp6V7aXsqG/mPZNwGg6Qh8dMKOpHdlw/5mTc95Q6/C/6ls8H9d03MDLpi0Res9lLSU9IHqC/vz3pD0uaSfZMtHQBMR+Gitu7JB/6mK1eerdFvSt5L+KzuHADQJgY/W2ZH0mWywhhrRX+dt2dH+/dAdAbYQ+GiVO5K+k63XN90N2TLPF7JvUkBoBD5a4y+yYX87dEcKuifbb0o8CI3ARyvcl/R/ak6tvqjbsiWeO9c9EKgQgY/Guy9bGmm7G7IjfUIfoRD4aLSuhH2G0EdIXHiFxqoj7LM9c867bI8dH7LQf1PszYN6EfhopDuySy99eya7HcJTvdoc7TK30n68ITth7HMJ6A3Ztfp/vaYPgE8EPhpnRzYMfU3QvpD0lWzQFxlRP0/b95I+lA3/d2XD30ffbsu+qb3n4VxAHtTw0ThfyM9o+oWk9yXtSfpS5csnv8qG856kR7LloLLuiYuzUB8CH43yF/nZ5fKRbI28is3MNlvnf+rhfJ+JNfqoB4GP4O7I7otzV3Z0X8YLSfuygVx1bfy5bA3+o5LnuaHyrxvIgxo+anNXdgL0juyI1vcVs88UZhL0S9n98L+Te23/DdnvD/vqo0oEPip1V7ZO7Wui8zKPZSdWQ614+VX2zaZM6H8hOz8AVIWSDipxX3br4m9lA7/KsH8mO5kaenljFvquk7k3xQQuqkXgw6ss6D9XPVsXZ2WcpshC39UHvjoCXIDAhxe3ZMsZdQW9ZEfSTRjZn/er3Cdyb4o7ZqE6BD5Kuy+7E2SV2xFc5JEu3hahCb6U9IPjsfd8dgTYQuCjlC9kR/V1b1v8VDZUm+xDudXz74kbpqAaBD6c7MiWcEKNRh8Fet4insv9TekvPjsCpAh8FJaFfd0lnMxTtWe9+ldyG+X7uNoYOI/AR2GhbzPYhtF9ZiO37R2YuEUVCHwU8oXChv1jtWd0n/nK4Zgb4iYp8I/AR24PFXYFyWO1cyvh57LXCxRF4MM3tlZALndUzUVBz2TLHtnNSO7IzhFszw/8IDtKbtvIftv3Kv7JKOQnKXQTgY9cvpCfpZcvZcPvh/RrX7hso8wIH74R+LjWfZUfbb6UXaL4lZp3ZWwdXD6dsBYfvlHDx5V2VP7esk9lbxZSxx71Tfai4ONvixujwC8CH1d6V+VKOY9kNxMre3vBLnD5Hixkl8GyTBM+EPi4Upntet9Xu9bMN9UbsttMfyHKPCiHwMel7st958uPVM39ZPvsnuzW02y7AFcEPi7lenn/D2r+xmZtdUPS/6n8vAr6icDHhXbkFvjZHvWo1rvixucojsDHhVwnCUPeV7Zv7onQRzEEPi7kshPmC1G3v0oVVwrfk93yAsiDwMeFXEb4hP3VHld03k/Fsk3kQ+DjQi5X1lYVaF3xXG47Z+bBkk3kQeDjD1yu7nwhLq7K40NV88Z4U3YiF7gKgY8/cAn8pt5MvInek/Q3ud/k/DIPxSgfVyPw4QWBX8zPkv4h6X8lDSX9U+VH/jfEKB9XI/CBwJ7LbhX9nmz4u2ylnCmzFQa6j8AHGuS57GZzrqP9m2LrBVyOwAca6D25h77LNRToBwIfvbAjO6n5naT/l7bv1OyJzg9VfA99iTX5uByBDy+afDu++7K7TH6qs6PfN9J/W6qZte+N3LaX5l64uAyBjz9wWU/fxMC/K+knSZ/r6pu43Egf85OaNzr+Wozy4Q+Bjz9wCfybak7o35K98vRbFRvt3tarG4006daCVezBg34i8HEhl6WB97z3opgdSR/IjtTL9OVeeo4P1Iz6PlcwwxcCHxdyuZDqvsIF5H29Cuky9+DN3NCrN48m1vcBFwQ+LuQywg9xpecd2dU2n8v9doxXuZme+zs1p2QFuCLwcaHvZe9eVdRD1VP/3pGttR+rnnXnb6TPFWJXyiaUldANBD4u9b3DMTck/dd3R875QHYpZYg5g+xG4h/U+JxcOQtfCHxcyvVKz9uq5tZ7d/UqbH3U6V1l9f2lql/+eFdupSpW9uAiBD4u9bPc1oBLfu+3eku2hv6tqqnTu7op26fvVF0Zy+WThOvPDN1H4ONKLld6ZrLQd61B70j6TNJCzd4f5g3ZPn4mv/X2h3J73YzucRkCH1dyvdIzc09uK1weypZM2rS/+7uyffZxU/H7sts+uPB9YxV0B4GPa71X8vjbsqGfd/T7hWzYhazTu7oh23fXclb2qeZzx+Nfym2yHf1A4ONaP6v8qPGGbJBd576qXX3zVPYmI2VvNHKdeyp2wVa2m+dPKvephrDHVQh85PKe3Nblb7un60f5VS13fCF7H9m/ym5VkN1o5G+qbpIz72u5Ixv0n6r8pHSZORd0H4GPXDay92At66pavusSxKu8lPSRpD1dPJn5c/rfPlL5N7Tzbur6ZZvZCiQfr/ux2HcHVyPwkdvPssHYFo9lw/zLHI/9Mn1s2RuJF/WZ/MxVvJS9YQpwFQIfhXyp+kOxqKeS9mXLUJsCx23SY/ZVbX0/c0vS257OVfS1op8IfBRW5n6rVZYcXkj6p2xt3mW3z8yv6Tn+qWovYvJ1sdZjMVmLfAh8OHEJ/apqzC9lJyv35Df4vk/P+Uj+6/u+PFP5ZbPoDwIfzt6T9H7Ox2ah7NsPkt6s6NyZR+lzNO2Cpmeyn0SAvAj8jhkOh7U+39eyNe+rSh8v9Go5pG9fVXTe856nz+VTmbLTD7Lf0yrr9kmSVHh2hEDgd8xgMKj9OX+VHQF/JDvZ+TJtT2U/AbypcuHWVRu5zYU8kl0iyyQtivpz6A6gGzayK3jyLIHEKx/K7nefZ2nmC9kyGpujwRUjfCCgjWxp5tkVj3kh+0npsovHgLwY4XdMiJIOyslKYvdl1+XvbP37M9l5khDiOA70zKgKgd9gi8Wi8DF1T9rCn68VLtwv4hL4Lr+zqA8lnQZbr9ehuwAUwu9ssxH4HcPHcPjCp8XuIfAbbrlcFnr87u5uRT1B3+zsFLthY9HfVdSPwG84l4/ITNyiLJdPipRzmo/Ab7jValX4GD6KoyyXwHf5XUW9CPyGc/kjoo6PslwGDQR+8xH4DeeyzI3AR1ksyewmAr/hXOqibHqFslxG+NTwm4/Ab7j5fF74GEb4KMsl8F1+V1EvAr8FTk5OCj1+d3e3Nyt13tWrrQiqtJM+Vx/EcVx4SWbR31GEQeC3gEtttC9lnbclLSU9rPA5HqbP4ev+s03HhG13EfgtwJ46V7sh6VPZUL7r8bx303N+qnzbF3eFy2CBck47EPgtwAg/n5uSvpX0ncrdIPxWeo5v03P2jctggRU67RAZY/I9MIryPRDeDQYD/f7774WPi6Kogt5U565syPrySPa2hHnvDJXV6T/w2Ie/qX172OfNhG2vvfYaZZ2AjDG5/tgZ4bfAer12mhTr4yh/2weyJZn7OR57P32sz7Bvo9FoVPiYk5MTwr4lCPyWcKmRuvzxhvSz7L1wfboh6XNJP+ni+v7d9L99Lv91+pdq3+jeZZBAOac9CPyWcAn8No7wH1V03tuy5aL/ytbob6X/+9v0v1WhqtdSJdbfdxs1/JaI41i//fZb4ePaWFv9QtK9Cs+ffYqocuXNY9kbjrcN9ft2oobfMavVyqmO37ayjmSD8iP5L+9kbqi6sH8p2/c2hr1UfE976vftQuC3yGw2K3zMeDz235EafClpT3ak3BaPZfv8ZeiOlFC0Hk85p10I/BZx+ePa29tr7d46G9mR8r6kp4H7cpWnsn18T/mXgDbVdDqt9PEIi8Bvkdlsps2meKS0sayz7VdJf5X0vqQXgfuy7YVsn/4q28cumM/nOjo6yvXYo6MjRvgtQ+C3jEtZZzKZVNCT+n0t6U3Z1S9V1ffzeJn24c20T10zHo+vDf2jo6PWlgv7jMBvGZfA393dbeUSzYts9CpsQ9T3H+vVm07byzdXGY/Heuedd/TkyZMz//7kyRO99dZbhH1LsSyzhdbrdeHta7s6Irsr6TNVt5Y+80zSh2rfhVToB5ZldpjLKP/Bgwed3CP/Z9kR9/uqpszzMj33myLs0X4Efgu5rozoSi3/Il/LLon0eXXro/ScXazTo58o6bTUarXS7u5uoWM2m43iOO78vUdvyZZ5XG9Y8oNs+ea5tx4B1aKk03GHh4eFj9nZ2en0KD/zXNI/ZLcmLrKM80V6zD9E2KObGOG3lOse+X0Z5W97KLvt8WXbKWTLLNt8hSz6jRF+x63X69wXyGzryyh/W7ZNwyPZ1TaZZ3pVpyfs0QeM8FvMdQfNPo7ygS5jhN8Dq9VKx8fHhY/b2dlxmgMA0G6M8FsuSRL9+OOPTse+/vrr3K0I6ABG+D0xn8+dRvmS20ofAO1F4HfAwcGB03H7+/u9m8AF+oySTkfM53Pt7+8XPm6z2Wg4HHLXIqDF8pZ0CPyOGA6H+uWXX5yOPT4+7sxuml0wGo2UJInTDcXzWq1Wms/nms1mrNbqgLyBL2NMribJ0JrdptOpcXVwcBC8/31vw+HQLBYL55+hi/V6bcbjcfDXTivXTN4cz/3ABrwo2tVtMBiY9Xrt/MefJEnw19DXNhwOS/3syiL0290Mgd/PNplMnP/o1+u1GQwGwV9DH9t8Pnf+ufkSx3Hw7wPNrRkCv7+tTFlgsVgE73/f2nA4dP55+XR4eBj8e0FzayZnjrMss4PK3Nlqb2/Peb99uGnKTeaZuO8+Ar+DFouFPvnkE+fjHzx44Ly2H+21t7cXuguoGIHfUQcHB1oul87Hf/zxx528By7QZwR+h5UN7P/85z+Efg246A21yVvsVwMmJmjFW5lVOxmW7FXbyi6n9Sn094Lm1gyrdGhZm81mpYOA0K+2jcfj0j8jH0J/H2huzRD4tKwNBgMvV3AS+tW2JoR+6O8Bza0ZAp+23XxdyTmdToO/li63JEm8fCJzFfr109yaIfBp59toNPISCrPZjCtyA/8cq6r5h35tNLdmCHzaRc1X2WCxWJjhcBj89fStHRwcePn5XSb066O5NUPg0y5rh4eHXsJhvV6b0WgU/PX0oQ0Gg1r22wn9OmluzRD4tKtama2Uz5tOp5R4KmxJktS2bDP0a6W5NUPg065rPkN/tVqxvbLnNhgMvH0ayyv0a6a5NUPg0/I0n6FvjN1xkdF++TYajcxqtfL6s8kj9OumuTVD4NPyNt+hz12U3FscxyzLpBVuhsCnFWm+Q98YY+bzOWWenG0wGFS+AieP0N8HmlszBD6taKuqXjydTrmb0hXt4OCAvXRopZoh8GkurcrL+wn+V20wGJjJZFJZnX61WjmdO/T3hebWDIFPc21VLwPsc6knjuPKR/SLxcJ53X7o7w/NrRkCn1amxXHsZcO1q6xWKzOZTHqxqidJkkrmSc7bvi8tgd+fZgh8Wtk2GAxqCSljbLmna1ftZqP5OpZXXnTVM4Hfn2YIfJqvNh6Pa5tUXK/XrQ7/OI7NZDKp/NPRtsViceHcCIHfn2YIfJrPVkeJ57z1em1ms5mZTCaN3ahtMBiY0WhkDg8Pg1wodXBwcGnfCPxetdjkyPHI/oyvF0VRvgei0w4ODvTxxx8Hee7NZqP5fK7FYnH6db1e19qH4XB42pIk0d7eXq3Pn1kulxqPx1osFpc+Zj6fa39/v9B5oygq2zUEYIzJ9YMj8FFYHMeaTqeFw6QKJycnWq1Wms/nknT6tcybwXA41GAwUBzHiuNYw+FQcRwHC/dtm81Gh4eHOjg4uPaxBH5/EPio3Hg81uHhoXZ2dkJ35UrZm8JVmvDmdZ0nT55oMplc+1oyRQN/uVxqOBw69g4h5Q18avi0Uq0pWwJ0metOpJPJpNDzbC/ppLWrGSZtaXW2OI5rW8LZF6vVqtQmdIPBIPfqqvV6zVXQLW6GwKeFaAR/eWWDfrvlvXk9u5u2u5kKAn8e+kXR2tMI/uJ8Bv12Gw6Hly4Z5cY1nWhzkzPHi0zaziXt53owkIrjWOPxWJPJpPGTu6EcHx/r8PBQs9ms0ucZjUZnJmUXi0Xlz4laHBtjklyPzPvOIGmm8O9ktBa38Xhc+8VbTbVer83h4SF1c5qPNjMVlHQOGvDCaB1ocRwHuzI1tNlsRr2c5rsdmAoCf9KAF0brWBsOh50P/yzk+7ArKC1Im5gKaviJpB9zPRhwMBwONRqNlCRJKy6EuszJyYnm87lms5nm83nt2z+gd94yxszzPLBI4MeSfnPuElDAYDBQkiSne9Y0+Q0gC/jtPX6AGr1mjFnleWDuwJfYXgFhbW9clrW6V/4sl0utVqugG7gB20zebRVUPPAXksLvIAVsSZJEg8HgdMlhtvmZZD8p5Nn0bLPZnBmZZ0G+Wq3ONKBhlsaY3BsgFQ38qaQHDp0CAPh3ZIwZ533wnwqenOIkADRHoUwm8AGgvQplcqGSjsTELQA0RZEJW6n4CF+Slg7HAAD8KpzFLoE/dzgGAODXvOgBBD4AtNO86AEuNfyBpN+LPhEAwKv/McYUuuqv8Ag/fQLq+AAQzrJo2EtuJR3J7o0PAAjDKYMJfABoH6cMLlzDPz0wilaSdp0OBgC4OjHGxC4Huo7wJUb5ABCCc/aWCfxpiWMBAG6mrgc6l3QkyjoAUDPnco5UboQvMcoHgDpNyxxcdoQfi9seAkBdct/O8CKlRvjpEx+XOQcAIJfjMmEvlS/pSJR1AKAO07InKFXSOT0Jk7cAUKVSk7UZHyN8iVE+AFRp6uMkvkb4A0krSTulTwYA2LaRFLtslnaelxF+2pGpj3MBAM6Y+gh7ydMIX2KJJgBUpNRSzG2+avjZEs0jX+cDAOjIV9hLHkf4EqN8APDM2+he8jjCl05H+Z/4PCcA9NQnPsNe8jzCl1ixAwAeeFuZs83rCF86XbFz4Pu8ANAjB77DXqpghH96Yq6+BQAXXq6qvYj3Ef6WcYXnBoCuGld14soC3xgzl/SkqvMDQAc9SbOzEpWVdCQmcAGggEomardVWdJhAhcA8qtkonZbpSP80yeJormk/cqfCADa6dgYk1T9JHUFPqUdALhY5aWcTKUlnUz6QsZ1PBcAtMy4jrCXagp8STLGzCT9u67nA4AW+HeajbWopaRz+mS2tDOXtFfbkwJAMy0lJXWN7qWaA1863VFzIer5APprI2noe3O069RW0smkL3Bc9/MCQIOM6w57KUDgS6f1/H+FeG4ACOxfddbtt9Ve0jnz5FE0lfQgWAcAoF5HxphxqCcPGvgSF2UB6I1aLq66SpCSzjkj2dlqAOiqpWzWBRU88NMlSYkIfQDdVPvyy8sEL+lk2H4BQAfVtm1CHsFH+Jmtkf4mcFcAwIeNGjKyzzQm8CXJGLMQoQ+g/bKwX4TuyLZGBb50GvqxqOkDaKelbBmnUWEvNTDwJSZyAbRWYyZoL9LIwJfOhP5x4K4AQB7HanDYSw0OfMmGfnqhwlHovgDAFY6MMY0Oe6nhgZ9JL0Vm7x0ATfSvkNslFNGYdfh5RFE0kjQVa/UBhLeR3fUyyEZoLloV+NLpfvozcRMVAOEsJY1CbHFcRitKOtvSb3AibpcIIIx/y07OrkJ3pKjWjfC3UeIBUKPWlXDOa3XgS6d78MzEFssAqnMsW8Jp9Cqc67SupHPe1tLNf4ktGQD4tZFdhdP4JZd5tH6Evy0d7U8l/T1wVwC03xPZEk7rgz7TqcDPRFGUyAb/btieAGihE9mgn4fuiG+tL+lcxBgzN8bEoswDIL+sfBN3Meyljo7wt6Vlnomkj0P3BUBjfSLpsEvlm4t0PvAz6QVbB5IeBO0IgCY5knTQxjX1LnoT+Jk0+CeSxmL9PtBHG9k5vsO+BH2md4Gf2Sr1jHX30CkAAADvSURBVMXkLtAHJ3oV9J0u3Vymt4G/LYqisWzwc/EW0D3HkqbGmGnojoRG4G9Jyz1jMeoH2i4bzU/7Vra5CoF/iSiKhrLBPxLhD7TBiew2K9Mm3k+2CQj8HNLwH6WNbZmB5ljKhvyMkL8egV9QOtmbbDXeAID6LCXNs9bXyVdXBL4H6VYOw63GmwBQ3lLSImtdvfq1TgR+RdIJ4Fj2DWCw9VViNRAg2dUzkrSWDfXs64qJ1moQ+A2y9SYBdMWCsktzEPgA0BOd3C0TAPBHBD4A9ASBDwA9QeADQE8Q+ADQEwQ+APQEgQ8APUHgA0BP/H9f56NLOEVbbgAAAABJRU5ErkJggg==
@@ -1479,4 +1395,3 @@ spec:
   skips:
   - rhacs-operator.v4.1.0
   version: 0.0.1
-


### PR DESCRIPTION
### Description

* Passing the `operator` Makefile directory ensures the operator image has the `x.y.0-...` tag format
* marking the additional architectures in the operator bundle 

### User-facing documentation

- [x] update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~[ ] added unit tests~
- ~[ ] added e2e tests~
- ~[ ] added regression tests~
- ~[ ] added compatibility tests~
- ~[ ] modified existing tests~
- ~[ ] existing tests pass

#### How I validated my change

Used [instructions](https://github.com/stackrox/stackrox/tree/master/operator#launch-the-operator-on-the-cluster-with-olm-and-the-bundle) to deploy the operator with OLM from the bundle and steps from https://issues.redhat.com/browse/ROX-23707 to deploy ACS. 