### PR TITLE
ROX-26104: add index on policy id to alert table

### DIFF
--- a/generated/storage/policy.pb.go
+++ b/generated/storage/policy.pb.go
@@ -394,7 +394,7 @@ type Policy struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id              string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Policy ID,store,hidden" sql:"pk"`                   // @gotags: search:"Policy ID,store,hidden" sql:"pk"
+	Id              string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Policy ID,store,hidden" sql:"pk,index=btree"`                   // @gotags: search:"Policy ID,store,hidden" sql:"pk,index=btree"
 	Name            string           `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Policy,store" sql:"unique"`               // @gotags: search:"Policy,store" sql:"unique"
 	Description     string           `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty" search:"Description"` // @gotags: search:"Description"
 	Rationale       string           `protobuf:"bytes,4,opt,name=rationale,proto3" json:"rationale,omitempty"`

--- a/pkg/postgres/schema/alerts.go
+++ b/pkg/postgres/schema/alerts.go
@@ -46,7 +46,7 @@ const (
 // Alerts holds the Gorm model for Postgres table `alerts`.
 type Alerts struct {
 	ID                       string                              `gorm:"column:id;type:uuid;primaryKey"`
-	PolicyID                 string                              `gorm:"column:policy_id;type:varchar"`
+	PolicyID                 string                              `gorm:"column:policy_id;type:varchar;index:alerts_policy_id,type:btree"`
 	PolicyName               string                              `gorm:"column:policy_name;type:varchar"`
 	PolicyDescription        string                              `gorm:"column:policy_description;type:varchar"`
 	PolicyDisabled           bool                                `gorm:"column:policy_disabled;type:bool"`

--- a/pkg/postgres/schema/policies.go
+++ b/pkg/postgres/schema/policies.go
@@ -45,7 +45,7 @@ const (
 
 // Policies holds the Gorm model for Postgres table `policies`.
 type Policies struct {
-	ID                 string           `gorm:"column:id;type:varchar;primaryKey"`
+	ID                 string           `gorm:"column:id;type:varchar;primaryKey;index:policies_id,type:btree"`
 	Name               string           `gorm:"column:name;type:varchar;unique"`
 	Description        string           `gorm:"column:description;type:varchar"`
 	Disabled           bool             `gorm:"column:disabled;type:bool"`

--- a/proto/storage/policy.proto
+++ b/proto/storage/policy.proto
@@ -11,7 +11,7 @@ option java_package = "io.stackrox.proto.storage";
 
 //Next tag: 28
 message Policy {
-  string id = 1; // @gotags: search:"Policy ID,store,hidden" sql:"pk"
+  string id = 1; // @gotags: search:"Policy ID,store,hidden" sql:"pk,index=btree"
   string name = 2; // @gotags: search:"Policy,store" sql:"unique"
   string description = 3; // @gotags: search:"Description"
   string rationale = 4;


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The customer is experience frequent timeouts with the following query:
```
select "alerts".serialized from alerts where (alerts.Policy_Id = $1 and ((alerts.State = $2) or (alerts.State = $3)))
```

There is not an index on the `Policy_Id` and the `or` on `state` negates the index on `state` causing a full table scan.

(Note:  the `and ((alerts.State = $2) or (alerts.State = $3))` gets blanketly added to almost all queries of alerts in a non-obvious way.  I'm not a huge fan of that nor the `or`.  But that is a battle for another day.)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Before this change, query such as:
```
select "alerts".serialized from alerts where (alerts.Policy_Id = 'dce17697-1b72-49d2-b18a-05d893cd9368' and ((alerts.State = 0) or (alerts.State = 2)))
```
would explain as:
```
 Seq Scan on alerts as alerts (rows=49 loops=1)
Filter: (((policy_id)::text = 'dce17697-1b72-49d2-b18a-05d893cd9368'::text) AND ((state = 0) OR (state = 2)))
Rows Removed by Filter: 50
```

after this change
```
"Bitmap Heap Scan on alerts  (cost=65.15..1760.55 rows=5062 width=24) (actual time=0.542..7.976 rows=5279 loops=1)"
"  Recheck Cond: ((policy_id)::text = 'dce17697-1b72-49d2-b18a-05d893cd9368'::text)"
"  Filter: ((state = 0) OR (state = 2))"
"  Heap Blocks: exact=1533"
"  ->  Bitmap Index Scan on alerts_policy_id  (cost=0.00..63.89 rows=5280 width=0) (actual time=0.411..0.411 rows=5279 loops=1)"
"        Index Cond: ((policy_id)::text = 'dce17697-1b72-49d2-b18a-05d893cd9368'::text)"
"Planning Time: 0.167 ms"
"Execution Time: 8.455 ms"
```