### PR TITLE
ROX-25764: Update compliance stats widget on schedule selection

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -36,6 +36,7 @@ import {
     coverageProfileChecksPath,
     coverageProfileClustersPath,
 } from './compliance.coverage.routes';
+import { createScanConfigFilter } from './compliance.coverage.utils';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
 import ProfileStatsWidget from './components/ProfileStatsWidget';
@@ -69,7 +70,9 @@ function CoveragesPage() {
 
     const fetchProfilesStats = useCallback(async () => {
         setSelectedProfileStats(undefined);
-        const response = await getComplianceProfilesStats();
+        const response = await getComplianceProfilesStats(
+            createScanConfigFilter(selectedScanConfigName)
+        );
         if (response) {
             const profileStats = response.scanStats.find(
                 (profile) => profile.profileName === profileName
@@ -77,7 +80,7 @@ function CoveragesPage() {
             setSelectedProfileStats(profileStats);
         }
         return response;
-    }, [profileName]);
+    }, [profileName, selectedScanConfigName]);
 
     const { isLoading: isLoadingProfilesStats, error: profilesStatsError } =
         useRestQuery(fetchProfilesStats);

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -37,9 +37,15 @@ export type ListComplianceClusterProfileStatsResponse = {
 /**
  * Fetches the scan stats grouped by profile.
  */
-export function getComplianceProfilesStats(): Promise<ListComplianceProfileScanStatsResponse> {
+export function getComplianceProfilesStats(
+    scanConfigSearchFilter: SearchFilter
+): Promise<ListComplianceProfileScanStatsResponse> {
+    const query = getRequestQueryStringForSearchFilter(scanConfigSearchFilter);
+    const params = qs.stringify({ query }, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<ListComplianceProfileScanStatsResponse>(`${complianceResultsStatsBaseUrl}/profiles`)
+        .get<ListComplianceProfileScanStatsResponse>(
+            `${complianceResultsStatsBaseUrl}/profiles?${params}`
+        )
         .then((response) => response.data);
 }
 


### PR DESCRIPTION
### Description

Stats currently update only when changing profiles; they should also reflect the filtered schedule.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Created two separate schedules that both scan on `ocp4-cis`: one with `control-cluster` and the other with `staging-secured-cluster`. When the scan schedule is not filtered, we see combined scan stats. When filtering by an individual schedule, stats should only reflect the selected cluster.

Without schedule filter (both clusters included):
![Screenshot 2024-09-09 at 2 20 40 PM](https://github.com/user-attachments/assets/676fcbeb-91a7-427c-a10f-8b0205e9e8e3)

With schedule filter (only one cluster):
![Screenshot 2024-09-09 at 2 20 59 PM](https://github.com/user-attachments/assets/5e524dee-fc47-46ab-91fe-e7685b2e53a0)


