### PR TITLE
ROX-25763: Clear policy rules when lifecycle changes

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -46,7 +46,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     } | null>(null);
 
     function onChangeLifecycleStage(lifecycleStage: LifecycleStage, isChecked: boolean) {
-        if (values.id) {
+        if (values.policySections.length > 0 && values.policySections[0].policyGroups.length > 0) {
             // for existing policies, warn that changing lifecycles will clear all policy criteria
             setLifeCycleChange({ lifecycleStage, isChecked });
         } else {
@@ -145,8 +145,8 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                 onCancel={onCancelChangeLifecycle}
                 title="Reset policy criteria?"
             >
-                Editing the lifecycle stage will reset and clear any saved criteria for this policy.
-                You will be required to reselect policy criteria in the next step.
+                Editing the lifecycle stage will reset and clear any saved rules for this policy.
+                You will be required to reselect policy rules in the next step.
             </ConfirmationModal>
             <Flex
                 direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -46,7 +46,10 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     } | null>(null);
 
     function onChangeLifecycleStage(lifecycleStage: LifecycleStage, isChecked: boolean) {
-        if (values.policySections.length > 0 && values.policySections[0].policyGroups.length > 0) {
+        const hasNonEmptyPolicyGroup = values.policySections.some(
+            (section) => section.policyGroups.length > 0
+        );
+        if (hasNonEmptyPolicyGroup) {
             // for existing policies, warn that changing lifecycles will clear all policy criteria
             setLifeCycleChange({ lifecycleStage, isChecked });
         } else {


### PR DESCRIPTION
### Description

Policy rules are dependent on the selected lifecycle, which can lead to errors if rules are created and the lifecycle is changed later. To avoid potential issues, we should clear the rules when the lifecycle is modified, similar to the approach used in the edit workflow.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. Select a lifecycle.
2. Add a rule.
3. Return to edit the lifecycle stage selection.
4. Confirm that the rules have been cleared.

![Screenshot 2024-09-09 at 2 56 43 PM](https://github.com/user-attachments/assets/105db76a-6f70-4c72-9763-f534e29dbe44)
