### PR TITLE
feat(scanner): Use versioned bundles

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -29,7 +29,7 @@ matcher:
 {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
-  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
+  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VULNERABILITY_VERSION
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: "{{ ._rox.scannerV4.matcher.logLevel }}"
 grpc_listen_addr: 0.0.0.0:8443


### PR DESCRIPTION
### Description

This is very simple change to change the default Scanner Matcher configuration to pass the bundle schema version instead of the StackRox release when pulling vulnerabilities. This is possible now that we are publishing versioned bundles and [configuration has been changed to support this](https://github.com/stackrox/stackrox/pull/12394).

### User-facing documentation

- [X] CHANGELOG is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [X] The change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [X] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

Tests for this functionality were covered/performed in the linked PRs.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. Create a scanner image with a release tag: `make -C scanner image-scanner GOTAGS=release`
2. Deploy StackRox Central to a Openshift cluster.
3. Observe logs containing the correct bundle version being requested from Central:
   ```
   {"level":"info","host":"scanner-v4-matcher-7dd948d5d5-wjzp9","component":"matcher/updater/vuln/Updater.fetch","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=v1","attempt":1,"time":"2024-09-10T05:07:24Z","message":"fetching vuln update"}
   ```
4. Observe vulnerabilities being pulled successfully:
   ```
   {"level":"info","host":"scanner-v4-matcher-7dd948d5d5-wjzp9","component":"matcher/updater/vuln/Updater.runMultiBundleUpdate","bundle":"bundles/alpine.json.zst","time":"2024-09-10T05:07:28Z","message":"starting bundle update"}
   {"level":"info","host":"scanner-v4-matcher-7dd948d5d5-wjzp9","bundle":"bundles/alpine.json.zst","component":"matcher/updater/vuln/Updater.Import","updater":"alpine-community-v3.8-updater","time":"2024-09-10T05:07:28Z","message":"fingerprint match, skipping"}
   {"level":"info","host":"scanner-v4-matcher-7dd948d5d5-wjzp9","bundle":"bundles/alpine.json.zst","component":"matcher/updater/vuln/Updater.Import","updater":"alpine-main-v3.14-updater","time":"2024-09-10T05:07:28Z","message":"fingerprint match, skipping"}
   ```
5. Perform one image scan, and inspect results: `roxctl -p <random-password> --insecure-skip-tls-verify --endpoint localhost:8443 image scan --force --image='ubuntu:16.04'jq -r '.scan.components[] | .vulns[]? | .cve'


