### PR TITLE
chore(e2e): Update cypress 13.14.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -115,7 +115,7 @@
                 "@types/segment-analytics": "^0.0.38",
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
                 "@typescript-eslint/parser": "^6.21.0",
-                "cypress": "^13.12.0",
+                "cypress": "^13.14.2",
                 "eslint": "^8.56.0",
                 "eslint-import-resolver-typescript": "^3.6.1",
                 "eslint-plugin-cypress": "^2.15.1",
@@ -148,6 +148,9 @@
                 "tailwindcss": "^2.0.3",
                 "ts-jest": "^29.1.4",
                 "typescript": "^5.4.5"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -8513,13 +8516,13 @@
             "integrity": "sha1-w0+CJqlLuxDDLMDXFK/flCKR/EE= sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
         },
         "node_modules/cypress": {
-            "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.12.0.tgz",
-            "integrity": "sha1-Gk6om3+mhV4yvALq9eJfxFueJz8= sha512-udzS2JilmI9ApO/UuqurEwOvThclin5ntz7K0BtnHBs+tg2Bl9QShLISXpSEMDv/u8b6mqdoAdyKeZiSqKWL8g==",
+            "version": "13.14.2",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
+            "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@cypress/request": "^3.0.0",
+                "@cypress/request": "^3.0.1",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
@@ -8558,7 +8561,7 @@
                 "request-progress": "^3.0.0",
                 "semver": "^7.5.3",
                 "supports-color": "^8.1.1",
-                "tmp": "~0.2.1",
+                "tmp": "~0.2.3",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -22140,15 +22143,12 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ= sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
             "dev": true,
-            "dependencies": {
-                "rimraf": "^3.0.0"
-            },
             "engines": {
-                "node": ">=8.17.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
@@ -23849,18 +23849,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/workbox-build/node_modules/pretty-bytes": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
-            "integrity": "sha1-DOzaUKdKlBWJSYARzyMnWqgrM54= sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/workbox-build/node_modules/source-map": {

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -137,7 +137,7 @@
         "@types/segment-analytics": "^0.0.38",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
-        "cypress": "^13.12.0",
+        "cypress": "^13.14.2",
         "eslint": "^8.56.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-cypress": "^2.15.1",


### PR DESCRIPTION
### Description


https://docs.cypress.io/guides/references/changelog#13-14-0

* Added new `experimentalJustInTimeCompile` configuration option for component testing. This option will only compile resources directly related to your spec, compiling them 'just-in-time' before spec execution. This should result in improved memory management and performance for component tests in cypress open and cypress run modes, in particular for large component testing suites.
    https://docs.cypress.io/guides/references/experiments#Experimental-Just-In-Time-Compile
* `.type({upArrow})` and `.type({downArrow})` now also works for date, month, week, time, datetime-local and range input types. 
* Updated `detect-port` from 1.3.0 to 1.6.1.

https://docs.cypress.io/guides/references/changelog#13-13-3

* Updated `image-size` from 0.8.3 to 1.1.1.

https://docs.cypress.io/guides/references/changelog#13-13-2

* Improved performance of `reduce` in a method within our proxy.
* Updated `@cypress/request` from 3.0.0 to 3.0.1.
* Updated `chrome-remote-interface` from 0.33.0 to 0.33.2.
* Updated `mime` from 2.4.4 to 2.6.0.
* Updated `strip-ansi` from 6.0.0 to 6.0.1.

https://docs.cypress.io/guides/references/changelog#13-13-1

* Updated `jquery` from 3.1.1 to 3.4.1.
* Replaced `json-lint` with `json-parse-even-better-errors`.
    This removes the CVE-2021-23358 vulnerability being reported in security scans.
* Updated `minimatch` from 3.0.4 to 3.1.2.

https://docs.cypress.io/guides/references/changelog#13-13-0

* Updated `launch-editor` from 2.3.0 to 2.8.0.
* Updated `memfs` from 3.4.12 to 3.5.3.
* Updated `tmp` from 0.2.1 to 0.2.3.
* Updated `ws` from 5.2.3 to 5.2.4.

### Procedure

In ui/apps/platform folder:

```sh
npm install -save-dev cypress@^13.14.2
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform
4. `npm run cypress-open` in ui/apps/platform

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js

### Component testing

* src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
* src/Components/TableStateTemplates/TbodyUnified.cy.jsx