### PR TITLE
chore(ui): Upgrade TypeScript 5.5.4 and related devDependencies in ui

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -22,7 +22,7 @@
                 "axios": "^0.25.0",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.2",
-                "core-js": "^3.31.1",
+                "core-js": "^3.38.1",
                 "d3-axis": "^1.0.12",
                 "d3-brush": "^3.0.0",
                 "d3-polygon": "^3.0.1",
@@ -90,16 +90,16 @@
                 "yup": "^1.4.0"
             },
             "devDependencies": {
-                "@babel/core": "^7.24.3",
-                "@babel/eslint-parser": "^7.24.1",
+                "@babel/core": "^7.25.2",
+                "@babel/eslint-parser": "^7.25.1",
                 "@babel/plugin-proposal-decorators": "^7.24.1",
                 "@babel/plugin-proposal-private-property-in-object": "7.18.6",
-                "@babel/plugin-transform-flow-strip-types": "^7.24.1",
-                "@babel/plugin-transform-runtime": "^7.24.3",
-                "@babel/preset-env": "^7.24.3",
-                "@babel/preset-react": "^7.24.1",
-                "@babel/preset-typescript": "^7.24.1",
-                "@babel/runtime": "^7.24.1",
+                "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+                "@babel/plugin-transform-runtime": "^7.25.4",
+                "@babel/preset-env": "^7.25.4",
+                "@babel/preset-react": "^7.24.7",
+                "@babel/preset-typescript": "^7.24.7",
+                "@babel/runtime": "^7.25.6",
                 "@tailwindcss/forms": "^0.2.1",
                 "@testing-library/cypress": "^10.0.2",
                 "@testing-library/dom": "^10.1.0",
@@ -147,7 +147,7 @@
                 "redux-saga-test-plan": "^3.7.0",
                 "tailwindcss": "^2.0.3",
                 "ts-jest": "^29.1.4",
-                "typescript": "^5.4.5"
+                "typescript": "^5.5.4"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -223,11 +223,11 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-            "integrity": "sha1-cYtLGYQYCaWLKbaM3oC8Xhqm2a4= sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
+                "@babel/highlight": "^7.24.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -235,30 +235,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
-            "integrity": "sha1-McH2ZDXyqcMpu1cWptYYbFFsN0I= sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
-            "integrity": "sha1-VohkJH6hD71O/wTdoeBfni6phcM= sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.2",
-                "@babel/generator": "^7.24.1",
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.24.1",
-                "@babel/parser": "^7.24.1",
-                "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -280,9 +280,9 @@
             "dev": true
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.1.tgz",
-            "integrity": "sha1-4n7uk+0dJxY3Fl7zqG4rkzI5XDI= sha512-d5guuzMlPeDfZIbpQ8+g1NaCNuAGBBGNECh0HVqz1sjOeVLh2CEaifuOysCH18URW6R7pqXINvf5PaR/dC6jLQ==",
+            "version": "7.25.1",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+            "integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -294,7 +294,7 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.11.0",
-                "eslint": "^7.5.0 || ^8.0.0"
+                "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
             }
         },
         "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
@@ -307,11 +307,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
-            "integrity": "sha1-5n4G9oVopOvxlNHGAUI1NE8EdtA= sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+            "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
             "dependencies": {
-                "@babel/types": "^7.24.0",
+                "@babel/types": "^7.25.6",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -351,37 +351,38 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-            "integrity": "sha1-5/BnN7GX1YCgHt912X4si+mdOII= sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
-            "integrity": "sha1-VCaxCc861HuREg+DKNirG+iwuVY= sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.7.tgz",
+            "integrity": "sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-            "integrity": "sha1-TXkGmxbLzxRhKJ7M+72BUBrjmZE= sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+            "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.23.5",
-                "@babel/helper-validator-option": "^7.23.5",
-                "browserslist": "^4.22.2",
+                "@babel/compat-data": "^7.25.2",
+                "@babel/helper-validator-option": "^7.24.8",
+                "browserslist": "^4.23.1",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -390,19 +391,17 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz",
-            "integrity": "sha1-21i/VxN7YjuRbiSHSrcYjZPX9o8= sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+            "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-member-expression-to-functions": "^7.23.0",
-                "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.24.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.8",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.25.0",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/traverse": "^7.25.4",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -413,12 +412,12 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
-            "integrity": "sha1-XukAk5FOoJY5sBxxHbDWd15Vi+E= sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz",
+            "integrity": "sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
                 "regexpu-core": "^5.3.1",
                 "semver": "^6.3.1"
             },
@@ -430,9 +429,9 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.1.tgz",
-            "integrity": "sha1-+txj8ML/PI0C7ZBdzqdHxbD7dP0= sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
+            "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
@@ -445,71 +444,41 @@
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
-        "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-            "integrity": "sha1-lhWdth00op26RUyVn1rkpkm6kWc= sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-            "integrity": "sha1-H5o829WyaYpnDDDSc1+a+V7VJ1k= sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-            "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.23.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha1-wBoAfawFwIWRTo+2UrM521DYI7s= sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-            "integrity": "sha1-kmPojMXkHTnsGMmj4OztWaPn02Y= sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+            "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.23.0"
+                "@babel/traverse": "^7.24.8",
+                "@babel/types": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-            "integrity": "sha1-asR25tFox8I/87o89PeEHUasgSg= sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dependencies": {
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-            "integrity": "sha1-19EsPF0wr1s8D8qyptUhd3Pi0PE= sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+            "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/traverse": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -519,35 +488,35 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-            "integrity": "sha1-8hUxqcy/9kT90Va0B3wW/ww/YJ4= sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+            "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-            "integrity": "sha1-lFaBkxpS8Vzoef1bhs4trm09fyo= sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+            "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
-            "integrity": "sha1-e2jhy0+pZNKZb9Bjcj+0jsqEmOA= sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
+            "integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-wrap-function": "^7.22.20"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-wrap-function": "^7.25.0",
+                "@babel/traverse": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -557,14 +526,14 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
-            "integrity": "sha1-cIW9GdSgt+2PQFwe1zzLcPMjq8E= sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+            "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-member-expression-to-functions": "^7.23.0",
-                "@babel/helper-optimise-call-expression": "^7.22.5"
+                "@babel/helper-member-expression-to-functions": "^7.24.8",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/traverse": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -574,99 +543,89 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-            "integrity": "sha1-STg1fcfXgrgO1tuwOg+6PSKx1d4= sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-            "integrity": "sha1-AH8VJAtXUcU3xA53q7TonuqqiEc= sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+            "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-            "integrity": "sha1-MixhtzEMCZf+TDI5VWZ/GPzvuRw= sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-            "integrity": "sha1-lHjHB/68u+Hds4o9kaLgVK5iLYM= sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-            "integrity": "sha1-xK4ALGHSh55yRYHZZmVYPbwdwOA= sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-            "integrity": "sha1-kHo/vUUjQmKFNl0SBsQjxMVSAwc= sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+            "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
-            "integrity": "sha1-FTUrC5v7EPycdvefY0LADjQRpWk= sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
+            "integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.22.19"
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
-            "integrity": "sha1-GD5EcUueujbDA45EJRZYex4KGpQ= sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+            "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-            "integrity": "sha1-P1OVA+/IPTxZCAoQ5mNDBuA3DSY= sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -678,7 +637,7 @@
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0= sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -689,7 +648,7 @@
         "node_modules/@babel/highlight/node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ= sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -702,7 +661,7 @@
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "engines": {
                 "node": ">=4"
             }
@@ -710,7 +669,7 @@
         "node_modules/@babel/highlight/node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8= sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -719,9 +678,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-            "integrity": "sha1-HkFtNic5P6sctbDy8XlqEArpEzo= sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+            "dependencies": {
+                "@babel/types": "^7.25.6"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -729,13 +691,44 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.1.tgz",
-            "integrity": "sha1-tkXZuowrxbevUPD+lJ+e2+sHyM8= sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==",
+        "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+            "version": "7.25.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.3.tgz",
+            "integrity": "sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/traverse": "^7.25.3"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.0.tgz",
+            "integrity": "sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.24.8"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
+            "integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -745,14 +738,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.1.tgz",
-            "integrity": "sha1-2oJh8ml/D0GwhVuR06IKH7/ScdM= sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.7.tgz",
+            "integrity": "sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/plugin-transform-optional-chaining": "^7.24.1"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -762,13 +755,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.1.tgz",
-            "integrity": "sha1-EYHZaFmEyR1le43fFPBIemurKYg= sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.0.tgz",
+            "integrity": "sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/traverse": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -938,7 +931,7 @@
         "node_modules/@babel/plugin-syntax-class-static-block": {
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY= sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
@@ -968,7 +961,7 @@
         "node_modules/@babel/plugin-syntax-dynamic-import": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-            "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM= sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
@@ -980,7 +973,7 @@
         "node_modules/@babel/plugin-syntax-export-namespace-from": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha1-AolkqbqA28CUyRXEh618TnpmRlo= sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.3"
@@ -990,12 +983,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-flow": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.1.tgz",
-            "integrity": "sha1-h1wl40KNeJbIdYl2X8i50y8kvY0= sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
+            "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1005,12 +998,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.1.tgz",
-            "integrity": "sha1-2zqtckFToA6qwRWj+4mN5UTjSXE= sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
+            "integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1020,12 +1013,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
-            "integrity": "sha1-xmuWbGO3FMTuxQj89XY7Hy04EJM= sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+            "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1059,12 +1052,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
-            "integrity": "sha1-P2ygS4yEGBHbw8XF+DeTTg1ibBA= sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1176,12 +1169,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
-            "integrity": "sha1-s7zFHzltFfNZFoP5AjneFDwHaEQ= sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+            "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1207,12 +1200,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.1.tgz",
-            "integrity": "sha1-K/JjYXBgycxFvNv0krjMgFCCvyc= sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
+            "integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1222,15 +1215,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
-            "integrity": "sha1-j6euSBsQB2jMmELIYXgIxTUri4k= sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+            "integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-remap-async-to-generator": "^7.22.20",
-                "@babel/plugin-syntax-async-generators": "^7.8.4"
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-remap-async-to-generator": "^7.25.0",
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/traverse": "^7.25.4"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1240,14 +1233,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.1.tgz",
-            "integrity": "sha1-DiIHA7ifIhaADOexxTywz1IcN/Q= sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.7.tgz",
+            "integrity": "sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-remap-async-to-generator": "^7.22.20"
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-remap-async-to-generator": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1257,12 +1250,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.1.tgz",
-            "integrity": "sha1-HJR5niD81cTUWJUju8V7dpKXk4A= sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
+            "integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1272,12 +1265,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.1.tgz",
-            "integrity": "sha1-J68YPX9trYkFMSVsekUBnfdorB8= sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
+            "integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1287,13 +1280,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.1.tgz",
-            "integrity": "sha1-vL8a72umCFz93sn8jViHHPAR/Ck= sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+            "integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-class-features-plugin": "^7.25.4",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1303,13 +1296,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.1.tgz",
-            "integrity": "sha1-TjfvzKHZ8vy5CNG66LVrS26eHLY= sha512-FUHlKCn6J3ERiu8Dv+4eoz7w8+kFLSyeVG4vDAikwADGjUCoHw/JHokyGtr8OR4UjpwPVivyF+h8Q5iv/JmrtA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
+            "integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-class-static-block": "^7.14.5"
             },
             "engines": {
@@ -1320,18 +1313,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.1.tgz",
-            "integrity": "sha1-W8j8Fg7ZY3gYS8EAQq9H9QiE3LE= sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+            "integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-replace-supers": "^7.24.1",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-replace-supers": "^7.25.0",
+                "@babel/traverse": "^7.25.4",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -1344,20 +1335,20 @@
         "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4= sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.1.tgz",
-            "integrity": "sha1-vH54f44CHsz7Z3r18TwpqZNO2Kc= sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
+            "integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/template": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/template": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1367,12 +1358,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.1.tgz",
-            "integrity": "sha1-segkOvSgIGhBlzeGKSuMjdhEc0U= sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
+            "integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1382,13 +1373,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.1.tgz",
-            "integrity": "sha1-1WkT0vEnlcyZMIAbhMb4xHUTrBM= sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.7.tgz",
+            "integrity": "sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1398,12 +1389,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.1.tgz",
-            "integrity": "sha1-U0enl/6CuNCXSdEOn1uDZlrbyog= sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.7.tgz",
+            "integrity": "sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1412,13 +1403,29 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.1.tgz",
-            "integrity": "sha1-KlpJlZIBlw3Qml/KhWy2UeREOd0= sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==",
+        "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.0.tgz",
+            "integrity": "sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-create-regexp-features-plugin": "^7.25.0",
+                "@babel/helper-plugin-utils": "^7.24.8"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-dynamic-import": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.7.tgz",
+            "integrity": "sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3"
             },
             "engines": {
@@ -1429,13 +1436,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.1.tgz",
-            "integrity": "sha1-ZlDr61vVwBLV9fkKJmE6CBYui6Q= sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.7.tgz",
+            "integrity": "sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1445,12 +1452,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.1.tgz",
-            "integrity": "sha1-8DNUH8A24++y3LWO7a/U9rgHis0= sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.7.tgz",
+            "integrity": "sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
             },
             "engines": {
@@ -1461,13 +1468,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-flow-strip-types": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.1.tgz",
-            "integrity": "sha1-+o0KFGUG6hldoWcdOO7UWSQrLcw= sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz",
+            "integrity": "sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/plugin-syntax-flow": "^7.24.1"
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/plugin-syntax-flow": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1477,13 +1484,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
-            "integrity": "sha1-Z0SERrZ6tsCRNgzjcX59OlniAv0= sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
+            "integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1493,14 +1500,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.1.tgz",
-            "integrity": "sha1-jLpvdzBibMTf5MovpRYhWgWSs2E= sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==",
+            "version": "7.25.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
+            "integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-compilation-targets": "^7.24.8",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/traverse": "^7.25.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1510,12 +1517,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.1.tgz",
-            "integrity": "sha1-COY2m2KrPop7YQiRUbFhGAyCmfc= sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.7.tgz",
+            "integrity": "sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-json-strings": "^7.8.3"
             },
             "engines": {
@@ -1526,12 +1533,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.1.tgz",
-            "integrity": "sha1-ChmCKXr4Pms8lJcmhgZ99YjFwJY= sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
+            "integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1541,12 +1548,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.1.tgz",
-            "integrity": "sha1-cZ2K3tGqlLj7NOOnha6FGOJM+kA= sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.7.tgz",
+            "integrity": "sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
             },
             "engines": {
@@ -1557,12 +1564,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.1.tgz",
-            "integrity": "sha1-iW0jYByS9DeviwE3GtNL63XfRIk= sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
+            "integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1572,13 +1579,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.1.tgz",
-            "integrity": "sha1-ttgp7RUlhTaXfpx8xkN4FIcf+jk= sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.7.tgz",
+            "integrity": "sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1588,14 +1595,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
-            "integrity": "sha1-5xuh0NaeBJoiv5Czhn4mOCPT8bk= sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+            "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-simple-access": "^7.22.5"
+                "@babel/helper-module-transforms": "^7.24.8",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-simple-access": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1605,15 +1612,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.1.tgz",
-            "integrity": "sha1-K5Ylo9TkRbq6yXiNrsOQlOaxHj4= sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
+            "integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-transforms": "^7.25.0",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/traverse": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1623,13 +1630,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.1.tgz",
-            "integrity": "sha1-aSIMZmU6Gc8sCHK5x2K5pIuL6+8= sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.7.tgz",
+            "integrity": "sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1639,13 +1646,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
-            "integrity": "sha1-Z/4Y7ozgLVfIVRheJ+PclZsumR8= sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.24.7.tgz",
+            "integrity": "sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1655,12 +1662,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.1.tgz",
-            "integrity": "sha1-KcWZiPo9AVfeHIcaKM2DCWNjzDQ= sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.7.tgz",
+            "integrity": "sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1670,12 +1677,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.1.tgz",
-            "integrity": "sha1-DNSUu5fLB9QovWUWMsudQUBROYg= sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
+            "integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
             },
             "engines": {
@@ -1686,12 +1693,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.1.tgz",
-            "integrity": "sha1-W8AZzls0NcHK3zchXlXkM9Z01Og= sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.7.tgz",
+            "integrity": "sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4"
             },
             "engines": {
@@ -1702,15 +1709,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.1.tgz",
-            "integrity": "sha1-WjznPK8OeHGgLhwx6LRzCTryQf8= sha512-XjD5f0YqOtebto4HGISLNfiNMTTs6tbkFf2TOqJlYKYmbo+mN9Dnpl4SRoofiziuOWMIyq3sZEUqLo3hLITFEA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.7.tgz",
+            "integrity": "sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.24.1"
+                "@babel/plugin-transform-parameters": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1720,13 +1727,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.1.tgz",
-            "integrity": "sha1-5x1qsTSDzKie2VpHT1Qrv8IKBSA= sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
+            "integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-replace-supers": "^7.24.1"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1736,12 +1743,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.1.tgz",
-            "integrity": "sha1-kqPQ7+hHunIvGkUIZpsjE0Zp4to= sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.7.tgz",
+            "integrity": "sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
             },
             "engines": {
@@ -1752,13 +1759,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.1.tgz",
-            "integrity": "sha1-JuWIrL7c4as1GaxAzHSOOAxSkeY= sha512-n03wmDt+987qXwAgcBlnUUivrZBPZ8z1plL0YvgQalLm+ZE5BMhGm94jhxXtA1wzv1Cu2aaOv1BM9vbVttrzSg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
+            "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             },
             "engines": {
@@ -1769,12 +1776,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.1.tgz",
-            "integrity": "sha1-mDwV0RTaGQUGx1thbOsPgXr8xRA= sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
+            "integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1784,13 +1791,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.1.tgz",
-            "integrity": "sha1-oPqhrofv8Hfh5HpeyBw67zg9wVo= sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+            "integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-class-features-plugin": "^7.25.4",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1800,14 +1807,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.1.tgz",
-            "integrity": "sha1-dWRD1AAnT4+3iWdClizBufJcH2o= sha512-pTHxDVa0BpUbvAgX3Gat+7cSciXqUcY9j2VZKTbSB6+VQGpNgNO9ailxTGHSXlqOnX1Hcx1Enme2+yv7VqP9bg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.7.tgz",
+            "integrity": "sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
             },
             "engines": {
@@ -1818,12 +1825,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.1.tgz",
-            "integrity": "sha1-1qmuq5bwN0n07r6wtuqOkOyViCU= sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
+            "integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1848,12 +1855,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.1.tgz",
-            "integrity": "sha1-VU4+GiXRgfBAz2mLk/0omgO/3Ns= sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+            "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1863,16 +1870,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.23.4.tgz",
-            "integrity": "sha1-OT+ZGFEQzqhxhOpHvLSnsMLjkxI= sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+            "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-jsx": "^7.23.3",
-                "@babel/types": "^7.23.4"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/types": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1882,12 +1889,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
-            "integrity": "sha1-5xa27b75cqkhZc1p2S8SVffnPoc= sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.7.tgz",
+            "integrity": "sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.22.5"
+                "@babel/plugin-transform-react-jsx": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1897,13 +1904,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.1.tgz",
-            "integrity": "sha1-yGvOIqU5VjMSENJo5JoP8G45JHA= sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.7.tgz",
+            "integrity": "sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1913,12 +1920,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.1.tgz",
-            "integrity": "sha1-Ylt1RbrlI2O9wfu9xyUrUEZAnIw= sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.7.tgz",
+            "integrity": "sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "regenerator-transform": "^0.15.2"
             },
             "engines": {
@@ -1929,12 +1936,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.1.tgz",
-            "integrity": "sha1-jecp9ey6r1z4O2feE7rTiiG+V8E= sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.7.tgz",
+            "integrity": "sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1944,15 +1951,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.3.tgz",
-            "integrity": "sha1-3FitSjGBCokFUDZcySLh/1rLXX8= sha512-J0BuRPNlNqlMTRJ72eVptpt9VcInbxO6iP3jaxr+1NPhC0UkKL+6oeX6VXMEYdADnuqmMmsBspt4d5w8Y/TCbQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+            "integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.3",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.1",
+                "babel-plugin-polyfill-corejs3": "^0.10.6",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
                 "semver": "^6.3.1"
             },
@@ -1964,12 +1971,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.1.tgz",
-            "integrity": "sha1-upoJFEz1XTXsa5OjIlO+ytjuW1U= sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
+            "integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1979,13 +1986,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.1.tgz",
-            "integrity": "sha1-oaz5FSy/aQ5NoLoQeQs6x9Kys5E= sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
+            "integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1995,12 +2002,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.1.tgz",
-            "integrity": "sha1-8D5nKRLG4gPtjW4CcdnCET3AMbk= sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.7.tgz",
+            "integrity": "sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2010,12 +2017,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.1.tgz",
-            "integrity": "sha1-FeIWaHOjDYYX4+LMrbhmQ9Mnqrc= sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
+            "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2025,12 +2032,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.1.tgz",
-            "integrity": "sha1-aDH3hkcIDewET36faAA9mUJPlMc= sha512-CBfU4l/A+KruSUoW+vTQthwcAdwuqbpRNB8HQKlZABwHRhsdHZ9fezp4Sn18PeAlYxTNiLMlx4xUBV3AWfg1BA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.8.tgz",
+            "integrity": "sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2040,15 +2047,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.1.tgz",
-            "integrity": "sha1-XAXii7dsff59bFvtmVEyT9LTqwc= sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+            "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/plugin-syntax-typescript": "^7.24.1"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.25.0",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/plugin-syntax-typescript": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2058,12 +2066,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.1.tgz",
-            "integrity": "sha1-+z+hZnZUmsfHRJ25s0JhSYXCo6Q= sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.7.tgz",
+            "integrity": "sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2073,13 +2081,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.1.tgz",
-            "integrity": "sha1-VnBP1NmdqB5enwwMk8q9kdvEiJ4= sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.7.tgz",
+            "integrity": "sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2089,13 +2097,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.1.tgz",
-            "integrity": "sha1-V8PBkdaPmYrEa3CDgMHOTRNTY4U= sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.7.tgz",
+            "integrity": "sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2105,13 +2113,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.1.tgz",
-            "integrity": "sha1-weoXWwKvz/yc9XqcRlgyZiUWW38= sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+            "integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.2",
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2121,26 +2129,28 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.3.tgz",
-            "integrity": "sha1-8/E4yET/7qw3JZeynFG1JZ6DI6M= sha512-fSk430k5c2ff8536JcPvPWK4tZDwehWLGlBp0wrsBUjZVdeQV6lePbwKWZaZfK2vnh/1kQX1PzAJWsnBmVgGJA==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+            "integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.24.1",
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-validator-option": "^7.23.5",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.1",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.1",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.1",
+                "@babel/compat-data": "^7.25.4",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-validator-option": "^7.24.8",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.3",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.0",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-class-properties": "^7.12.13",
                 "@babel/plugin-syntax-class-static-block": "^7.14.5",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-import-assertions": "^7.24.1",
-                "@babel/plugin-syntax-import-attributes": "^7.24.1",
+                "@babel/plugin-syntax-import-assertions": "^7.24.7",
+                "@babel/plugin-syntax-import-attributes": "^7.24.7",
                 "@babel/plugin-syntax-import-meta": "^7.10.4",
                 "@babel/plugin-syntax-json-strings": "^7.8.3",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
@@ -2152,59 +2162,60 @@
                 "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.24.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.24.3",
-                "@babel/plugin-transform-async-to-generator": "^7.24.1",
-                "@babel/plugin-transform-block-scoped-functions": "^7.24.1",
-                "@babel/plugin-transform-block-scoping": "^7.24.1",
-                "@babel/plugin-transform-class-properties": "^7.24.1",
-                "@babel/plugin-transform-class-static-block": "^7.24.1",
-                "@babel/plugin-transform-classes": "^7.24.1",
-                "@babel/plugin-transform-computed-properties": "^7.24.1",
-                "@babel/plugin-transform-destructuring": "^7.24.1",
-                "@babel/plugin-transform-dotall-regex": "^7.24.1",
-                "@babel/plugin-transform-duplicate-keys": "^7.24.1",
-                "@babel/plugin-transform-dynamic-import": "^7.24.1",
-                "@babel/plugin-transform-exponentiation-operator": "^7.24.1",
-                "@babel/plugin-transform-export-namespace-from": "^7.24.1",
-                "@babel/plugin-transform-for-of": "^7.24.1",
-                "@babel/plugin-transform-function-name": "^7.24.1",
-                "@babel/plugin-transform-json-strings": "^7.24.1",
-                "@babel/plugin-transform-literals": "^7.24.1",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
-                "@babel/plugin-transform-member-expression-literals": "^7.24.1",
-                "@babel/plugin-transform-modules-amd": "^7.24.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.1",
-                "@babel/plugin-transform-modules-systemjs": "^7.24.1",
-                "@babel/plugin-transform-modules-umd": "^7.24.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
-                "@babel/plugin-transform-new-target": "^7.24.1",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.1",
-                "@babel/plugin-transform-numeric-separator": "^7.24.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.24.1",
-                "@babel/plugin-transform-object-super": "^7.24.1",
-                "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
-                "@babel/plugin-transform-optional-chaining": "^7.24.1",
-                "@babel/plugin-transform-parameters": "^7.24.1",
-                "@babel/plugin-transform-private-methods": "^7.24.1",
-                "@babel/plugin-transform-private-property-in-object": "^7.24.1",
-                "@babel/plugin-transform-property-literals": "^7.24.1",
-                "@babel/plugin-transform-regenerator": "^7.24.1",
-                "@babel/plugin-transform-reserved-words": "^7.24.1",
-                "@babel/plugin-transform-shorthand-properties": "^7.24.1",
-                "@babel/plugin-transform-spread": "^7.24.1",
-                "@babel/plugin-transform-sticky-regex": "^7.24.1",
-                "@babel/plugin-transform-template-literals": "^7.24.1",
-                "@babel/plugin-transform-typeof-symbol": "^7.24.1",
-                "@babel/plugin-transform-unicode-escapes": "^7.24.1",
-                "@babel/plugin-transform-unicode-property-regex": "^7.24.1",
-                "@babel/plugin-transform-unicode-regex": "^7.24.1",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.24.1",
+                "@babel/plugin-transform-arrow-functions": "^7.24.7",
+                "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+                "@babel/plugin-transform-async-to-generator": "^7.24.7",
+                "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
+                "@babel/plugin-transform-block-scoping": "^7.25.0",
+                "@babel/plugin-transform-class-properties": "^7.25.4",
+                "@babel/plugin-transform-class-static-block": "^7.24.7",
+                "@babel/plugin-transform-classes": "^7.25.4",
+                "@babel/plugin-transform-computed-properties": "^7.24.7",
+                "@babel/plugin-transform-destructuring": "^7.24.8",
+                "@babel/plugin-transform-dotall-regex": "^7.24.7",
+                "@babel/plugin-transform-duplicate-keys": "^7.24.7",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.0",
+                "@babel/plugin-transform-dynamic-import": "^7.24.7",
+                "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
+                "@babel/plugin-transform-export-namespace-from": "^7.24.7",
+                "@babel/plugin-transform-for-of": "^7.24.7",
+                "@babel/plugin-transform-function-name": "^7.25.1",
+                "@babel/plugin-transform-json-strings": "^7.24.7",
+                "@babel/plugin-transform-literals": "^7.25.2",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+                "@babel/plugin-transform-member-expression-literals": "^7.24.7",
+                "@babel/plugin-transform-modules-amd": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+                "@babel/plugin-transform-modules-systemjs": "^7.25.0",
+                "@babel/plugin-transform-modules-umd": "^7.24.7",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+                "@babel/plugin-transform-new-target": "^7.24.7",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+                "@babel/plugin-transform-numeric-separator": "^7.24.7",
+                "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+                "@babel/plugin-transform-object-super": "^7.24.7",
+                "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.8",
+                "@babel/plugin-transform-parameters": "^7.24.7",
+                "@babel/plugin-transform-private-methods": "^7.25.4",
+                "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+                "@babel/plugin-transform-property-literals": "^7.24.7",
+                "@babel/plugin-transform-regenerator": "^7.24.7",
+                "@babel/plugin-transform-reserved-words": "^7.24.7",
+                "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+                "@babel/plugin-transform-spread": "^7.24.7",
+                "@babel/plugin-transform-sticky-regex": "^7.24.7",
+                "@babel/plugin-transform-template-literals": "^7.24.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.24.8",
+                "@babel/plugin-transform-unicode-escapes": "^7.24.7",
+                "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
+                "@babel/plugin-transform-unicode-regex": "^7.24.7",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.4",
+                "babel-plugin-polyfill-corejs3": "^0.10.6",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.31.0",
+                "core-js-compat": "^3.37.1",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -2241,17 +2252,17 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.1.tgz",
-            "integrity": "sha1-JFDCrFzEmO9hAabKVHTeJR4zqpU= sha512-eFa8up2/8cZXLIpkafhaADTXSnl7IsUFCYenRWrARBz0/qZwcT0RBXpys0LJU4+WfPoF2ZG6ew6s2V6izMCwRA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.7.tgz",
+            "integrity": "sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-validator-option": "^7.23.5",
-                "@babel/plugin-transform-react-display-name": "^7.24.1",
-                "@babel/plugin-transform-react-jsx": "^7.23.4",
-                "@babel/plugin-transform-react-jsx-development": "^7.22.5",
-                "@babel/plugin-transform-react-pure-annotations": "^7.24.1"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-transform-react-display-name": "^7.24.7",
+                "@babel/plugin-transform-react-jsx": "^7.24.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.24.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2261,16 +2272,16 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.1.tgz",
-            "integrity": "sha1-ib3xOjFJoXs7KiycYlR/BtuIRew= sha512-1DBaMmRDpuYQBPWD8Pf/WEwCrtgRHxsZnP4mIy9G/X+hFfbI47Q2G4t1Paakld84+qsk2fSsUPMKg71jkoOOaQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
+            "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/helper-validator-option": "^7.23.5",
-                "@babel/plugin-syntax-jsx": "^7.24.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.1",
-                "@babel/plugin-transform-typescript": "^7.24.1"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+                "@babel/plugin-transform-typescript": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2286,9 +2297,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-            "integrity": "sha1-Qx+aeU0XO1NyDmmmRkq8bw4qXFc= sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+            "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -2297,31 +2308,28 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-            "integrity": "sha1-xqUkqpOkoF1mqvMWVCWPrmnYfVA= sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+            "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-            "integrity": "sha1-1lw2rJ3RcoIXXR5KPEnVt5iPUww= sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+            "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.1",
-                "@babel/generator": "^7.24.1",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.6",
+                "@babel/parser": "^7.25.6",
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -2338,12 +2346,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-            "integrity": "sha1-O5UfQ1qS5zM+ugW3Vm/Sl5YOob8= sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.23.4",
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-string-parser": "^7.24.8",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -6724,13 +6732,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-            "integrity": "sha1-eJrIJAWtZkwgR20CM7SFKB3rnHc= sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+            "version": "0.10.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+            "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.1",
-                "core-js-compat": "^3.36.1"
+                "@babel/helper-define-polyfill-provider": "^0.6.2",
+                "core-js-compat": "^3.38.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -7078,9 +7086,9 @@
             "peer": true
         },
         "node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha1-jzrMK75zr3ITOZQwiQ+GxjpWdKs= sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7096,10 +7104,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -7311,9 +7319,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001599",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
-            "integrity": "sha1-Vxz08/FQbfm/Qfy7bRDV0BeBe84= sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
+            "version": "1.0.30001660",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+            "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7919,9 +7927,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.31.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.1.tgz",
-            "integrity": "sha1-8rDuqb6doN7yxf7OcQZKfl1odlM= sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==",
+            "version": "3.38.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+            "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -7929,12 +7937,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.36.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-            "integrity": "sha1-GBhpXXLJnCXWIdypTmiD4ZDOo8g= sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+            "version": "3.38.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+            "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.0"
+                "browserslist": "^4.23.3"
             },
             "funding": {
                 "type": "opencollective",
@@ -10065,9 +10073,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.714",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.714.tgz",
-            "integrity": "sha1-cI/cjVveyCTkH+ixsOEK9QihCUY= sha512-OfnVHt+nMRH9Ua5koH/2gKlCAXbG+u1yXwLKyBVqNboBV34ZTwb846RUe8K5mtE1uhz0BXoMarZ13JCQr+sBtQ=="
+            "version": "1.5.19",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.19.tgz",
+            "integrity": "sha512-kpLJJi3zxTR1U828P+LIUDZ5ohixyo68/IcYOHLqnbTPr/wdgn4i1ECvmALN9E16JPA6cvCG5UG79gVwVdEK5w=="
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -10324,9 +10332,9 @@
             "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA= sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "engines": {
                 "node": ">=6"
             }
@@ -16134,9 +16142,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws= sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
         },
         "node_modules/nopt": {
             "version": "1.0.10",
@@ -16757,9 +16765,9 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw= sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
         },
         "node_modules/picomatch": {
             "version": "2.3.0",
@@ -20065,7 +20073,7 @@
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
-            "integrity": "sha1-W7rli1IgmOvfCbyi+Dg4kpABx6Q= sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+            "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.4"
@@ -22535,9 +22543,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-            "integrity": "sha1-QszvLFcf29D2cYsdH15uXvAG9hE= sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -22658,9 +22666,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha1-PF5PXAg2Yb0472S2Mowm7WyCSMQ= sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -22676,8 +22684,8 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -26,7 +26,7 @@
         "axios": "^0.25.0",
         "computed-style-to-inline-style": "^3.0.0",
         "connected-react-router": "^6.9.2",
-        "core-js": "^3.31.1",
+        "core-js": "^3.38.1",
         "d3-axis": "^1.0.12",
         "d3-brush": "^3.0.0",
         "d3-polygon": "^3.0.1",
@@ -112,16 +112,16 @@
         "eject": "react-app-rewired eject"
     },
     "devDependencies": {
-        "@babel/core": "^7.24.3",
-        "@babel/eslint-parser": "^7.24.1",
+        "@babel/core": "^7.25.2",
+        "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-proposal-decorators": "^7.24.1",
         "@babel/plugin-proposal-private-property-in-object": "7.18.6",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.1",
-        "@babel/plugin-transform-runtime": "^7.24.3",
-        "@babel/preset-env": "^7.24.3",
-        "@babel/preset-react": "^7.24.1",
-        "@babel/preset-typescript": "^7.24.1",
-        "@babel/runtime": "^7.24.1",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-runtime": "^7.25.4",
+        "@babel/preset-env": "^7.25.4",
+        "@babel/preset-react": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/runtime": "^7.25.6",
         "@tailwindcss/forms": "^0.2.1",
         "@testing-library/cypress": "^10.0.2",
         "@testing-library/dom": "^10.1.0",
@@ -169,7 +169,7 @@
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "typescript": "^5.5.4"
     },
     "resolutions": {
         "@jest/types": "^29.6.3",
@@ -222,7 +222,7 @@
             "react-dom": "^18.0.0"
         },
         "react-scripts": {
-            "typescript": "5.4.5"
+            "typescript": "5.5.4"
         },
         "react-select": {
             "react": "^18.0.0",

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -82,7 +82,7 @@ export function getDefaultAttributeName(
 
 export function ensureStringArray(value: unknown): string[] {
     if (Array.isArray(value) && value.every((element) => typeof element === 'string')) {
-        return value as string[];
+        return value;
     }
     if (value === 'string') {
         return [value];

--- a/ui/apps/platform/src/Containers/Collections/errorUtils.ts
+++ b/ui/apps/platform/src/Containers/Collections/errorUtils.ts
@@ -33,6 +33,10 @@ export function parseConfigError(err: Error): CollectionConfigError {
     const rawMessage = getAxiosErrorMessage(err);
 
     if (/create a loop/.test(rawMessage)) {
+        // Work around error in TypeScript 5.5.4 upgrade because build does not use target in tsconfig.json file.
+        // error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         const errorRegex = /^edge between '[0-9a-fA-F-]*' and '(?<loopId>[0-9a-fA-F-]*)'/;
         const matches = errorRegex.exec(rawMessage);
         const loopId = matches?.groups?.loopId;


### PR DESCRIPTION
### Description

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#inferred-type-predicates

    > TypeScript now infers a type predicate for the `filter` function.

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#control-flow-narrowing-for-constant-indexed-accesses

    > TypeScript is now able to narrow expressions of the form `obj[key]` when both `obj` and `key` are effectively constant.

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-jsdoc-import-tag

    > TypeScript now supports a new `@import` comment tag that has the same syntax as ECMAScript imports.

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#regular-expression-syntax-checking

    > TypeScript now does basic syntax checking on regular expressions!

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#support-for-new-ecmascript-set-methods

    > TypeScript 5.5 declares new proposed methods for the ECMAScript Set type.

    > Some of these methods, like `union`, `intersection`, `difference`, and `symmetricDifference`, take another `Set` and return a new `Set` as the result.
    
    > The other methods, `isSubsetOf`, `isSupersetOf`, and `isDisjointFrom`, take another `Set` and return a `boolean`. None of these methods mutate the original `Set`s.

    This is an example why TypeScript update requires corresponding update to Babel devDependencies.

* https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#undefined-is-no-longer-a-definable-type-name

    > TypeScript has always disallowed type alias names that conflict with built-in types. Due to a bug, this logic didn’t also apply to the built-in type `undefined`. In 5.5, this is now correctly identified as an error.

### Errors

1. `npm run lint` in ui/apps/platform

    src/github.com/stackrox/stackrox/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx

    > This assertion is unnecessary since it does not change the type of the expression

    ```ts
    if (Array.isArray(value) && value.every((element) => typeof element === 'string')) {
        return value as string[];
    }
    ```

    **Analysis**: TypeScript now infers a type predicate for the filter function.

    **Solution**: Delete `as string[]` type assertion.

2. `npm run build` in ui/apps/platform

    src/Containers/Collections/errorUtils.ts
    
    > error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

    ```ts
    const errorRegex = /^edge between '[0-9a-fA-F-]*' and '(?<loopId>[0-9a-fA-F-]*)'/;
    ```

    **Analysis**: TypeScript now does basic syntax checking on regular expressions!

    TypeScript target version did not seem to matter, because Babel compiles according to package.json file:

    ```
    "browserslist": [
        "Chrome >= 80"
    ]
    ```

    **Solution**: Too bad, so sad: add ignore comments.

### Problem

Upgrade TypeScript alone does not provide consistent lint and build.

For example, outdated babel plugins seem like a reason why ui had build errors for TypeScript 4.9 `satisfies` operator.

### Analysis

1. babel-preset-react-app package has become unmaintained

    * It includes the following which are outdated:

        ```
        "@babel/core" "^7.16.0"
        "@babel/plugin-transform-flow-strip-types" "^7.16.0"
        "@babel/plugin-transform-react-display-name" "^7.16.0"
        "@babel/plugin-transform-runtime" "^7.16.4"
        "@babel/preset-env" "^7.16.4"
        "@babel/preset-react" "^7.16.0"
        "@babel/preset-typescript" "^7.16.0"
        "@babel/runtime" "^7.16.3"
        ```

    * It includes 1 proposal plugin which is outdated:

        ```
        "@babel/plugin-proposal-decorators" "^7.16.4"
        ```

    * It includes 5 proposal plugins which have been superseded by transform plugins:

        ```
        "@babel/plugin-proposal-class-properties" "^7.16.0"
        "@babel/plugin-proposal-nullish-coalescing-operator" "^7.16.0"
        "@babel/plugin-proposal-numeric-separator" "^7.16.0"
        "@babel/plugin-proposal-optional-chaining" "^7.16.0"
        "@babel/plugin-proposal-private-methods" "^7.16.0"
        ```

### Solution

Update the following at least as often as TypeScript.

1. Upgrade babel preset-typescript and other packages for consistent build.
    * `devDependencies` in ui/apps/platform/package.json file because babel-preset-react-app requires earlier **minor** versions.
    * Merge versions of babel dependencies for clarity and because it has a domino effect to remove unneeded older versions.
2. Update core-js in `dependencies` in ui/apps/platform/package.json file.

### Procedure

1. `npm outdated` in ui/apps/platform folder.
    * Update versions in package.json file according to pattern of changes in previous TypeScript update.
    * Remember to update versions in `overrides` if needed.
2. `npm install` in ui/apps/platform folder to update package-lock.json file.
    * Click through package-lock.json changes in Visual Studio side-by-side comparison.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -9 = 4618862 - 4618871
        total 1012 = 11701147 - 11700135
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/dashboard