### PR TITLE
ROX-25898: CIDR type support in postgres framework

### DIFF
--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -61,6 +61,14 @@ func NilOrUUID(value string) *uuid.UUID {
 	return &id
 }
 
+// NilOrCIDR allows for a proto string to be stored as a CIDR type in Postgres
+func NilOrCIDR(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
 // EmptyOrMap allows for map to be stored explicit as an empty object ({}) rather than null.
 func EmptyOrMap[K comparable, V any, M map[K]V](m M) interface{} {
 	if m == nil {

--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -2,6 +2,7 @@ package pgutils
 
 import (
 	"context"
+	"net"
 	"reflect"
 	"regexp"
 	"strings"
@@ -62,11 +63,15 @@ func NilOrUUID(value string) *uuid.UUID {
 }
 
 // NilOrCIDR allows for a proto string to be stored as a CIDR type in Postgres
-func NilOrCIDR(value string) *string {
+func NilOrCIDR(value string) *net.IPNet {
 	if value == "" {
 		return nil
 	}
-	return &value
+	_, cidr, err := net.ParseCIDR(value)
+	if err != nil {
+		return nil
+	}
+	return cidr
 }
 
 // EmptyOrMap allows for map to be stored explicit as an empty object ({}) rather than null.

--- a/pkg/postgres/pgutils/utils_test.go
+++ b/pkg/postgres/pgutils/utils_test.go
@@ -1,6 +1,7 @@
 package pgutils
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,4 +14,14 @@ func TestPgxpoolDsnToPgxDsn(t *testing.T) {
 		PgxpoolDsnToPgxDsn("pool_min_conns=1 host=localhost port=5432 database=postgres user=who password=password sslmode=disable statement_timeout=600000 pool_max_conns=90"))
 	assert.Equal(t, "host=localhost port=5432 database=postgres user=who password=password sslmode=disable statement_timeout=600000",
 		PgxpoolDsnToPgxDsn(" host=localhost port=5432 database=postgres user=who pool_min_conns=1 password=password sslmode=disable statement_timeout=600000 pool_max_conns=90"))
+}
+
+func TestNilOrCIDR(t *testing.T) {
+	assert.Equal(t, &net.IPNet{
+		IP:   net.IP{0x0a, 0x01, 0x02, 0x00},
+		Mask: net.IPMask{0xff, 0xff, 0xff, 0x00},
+	}, NilOrCIDR("10.1.2.0/24"))
+
+	assert.Equal(t, (*net.IPNet)(nil), NilOrCIDR("invalid"))
+	assert.Equal(t, (*net.IPNet)(nil), NilOrCIDR(""))
 }

--- a/pkg/postgres/types.go
+++ b/pkg/postgres/types.go
@@ -20,6 +20,7 @@ const (
 	IntArray    DataType = "intarray"
 	BigInteger  DataType = "biginteger"
 	UUID        DataType = "uuid"
+	CIDR        DataType = "cidr"
 )
 
 var (
@@ -52,6 +53,8 @@ func DataTypeToSQLType(dataType DataType) string {
 		sqlType = "int[]"
 	case Bytes:
 		sqlType = "bytea"
+	case CIDR:
+		sqlType = "cidr"
 	default:
 		panic(dataType)
 	}

--- a/pkg/search/postgres/query/cidr_query.go
+++ b/pkg/search/postgres/query/cidr_query.go
@@ -10,8 +10,6 @@ import (
 )
 
 func newCIDRQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
-	err := fmt.Errorf("=== newCIDRQuery ! ===")
-	utils.Should(err)
 	whereClause, err := newCIDRQueryWhereClause(ctx.qualifiedColumnName, ctx.value, ctx.queryModifiers...)
 	if err != nil {
 		return nil, err

--- a/pkg/search/postgres/query/cidr_query.go
+++ b/pkg/search/postgres/query/cidr_query.go
@@ -28,7 +28,7 @@ func newCIDRQueryWhereClause(columnName string, value string, queryModifiers ...
 			return WhereClause{}, errors.Wrapf(err, "value %q in search query must be valid CIDR", value)
 		}
 		return WhereClause{
-			Query:  fmt.Sprintf("%s <<= '$$'", columnName),
+			Query:  fmt.Sprintf("%s <<= $$", columnName),
 			Values: []interface{}{cidrVal},
 			equivalentGoFunc: func(foundValue interface{}) bool {
 				foundValueStr, ok := foundValue.(string)

--- a/pkg/search/postgres/query/cidr_query.go
+++ b/pkg/search/postgres/query/cidr_query.go
@@ -1,0 +1,66 @@
+package pgsearch
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	pkgSearch "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func newCIDRQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
+	err := fmt.Errorf("=== newCIDRQuery ! ===")
+	utils.Should(err)
+	whereClause, err := newCIDRQueryWhereClause(ctx.qualifiedColumnName, ctx.value, ctx.queryModifiers...)
+	if err != nil {
+		return nil, err
+	}
+	return qeWithSelectFieldIfNeeded(ctx, &whereClause, nil), nil
+}
+
+func newCIDRQueryWhereClause(columnName string, value string, queryModifiers ...pkgSearch.QueryModifier) (WhereClause, error) {
+	if len(value) == 0 {
+		return WhereClause{}, errors.New("value in search query cannot be empty")
+	}
+
+	if len(queryModifiers) == 0 {
+		_, cidrVal, err := net.ParseCIDR(value)
+		if err != nil {
+			return WhereClause{}, errors.Wrapf(err, "value %q in search query must be valid CIDR", value)
+		}
+		return WhereClause{
+			Query:  fmt.Sprintf("%s <<= '$$'", columnName),
+			Values: []interface{}{cidrVal},
+			equivalentGoFunc: func(foundValue interface{}) bool {
+				foundValueStr, ok := foundValue.(string)
+				if !ok {
+					return false
+				}
+				return IPNetContainsSubnet(cidrVal, foundValueStr)
+			},
+		}, nil
+	}
+	err := fmt.Errorf("unknown query modifier: %s", queryModifiers[0])
+	utils.Should(err)
+	return WhereClause{}, err
+}
+
+func IPNetContainsSubnet(cidr *net.IPNet, sub string) bool {
+	if cidr == nil {
+		return false
+	}
+
+	subIP, subCIDR, err := net.ParseCIDR(sub)
+	if err != nil {
+		return false
+	}
+
+	cidrOnes, _ := cidr.Mask.Size()
+	subOnes, _ := subCIDR.Mask.Size()
+	if subOnes < cidrOnes {
+		return false
+	}
+
+	return cidr.Contains(subIP)
+}

--- a/pkg/search/postgres/query/cidr_query_test.go
+++ b/pkg/search/postgres/query/cidr_query_test.go
@@ -45,6 +45,10 @@ func TestCIDRQuery(t *testing.T) {
 					expectedSelection: true,
 				},
 				{
+					value:             "230.127.112.0/23",
+					expectedSelection: false,
+				},
+				{
 					value:             true, // unexpected type
 					expectedSelection: false,
 				},

--- a/pkg/search/postgres/query/cidr_query_test.go
+++ b/pkg/search/postgres/query/cidr_query_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type PredicatePair struct {
-	value             string
+	value             interface{}
 	expectedSelection bool
 }
 
@@ -43,6 +43,14 @@ func TestCIDRQuery(t *testing.T) {
 				{
 					value:             "230.127.112.128/25",
 					expectedSelection: true,
+				},
+				{
+					value:             true, // unexpected type
+					expectedSelection: false,
+				},
+				{
+					value:             "invalid",
+					expectedSelection: false,
 				},
 			},
 		},
@@ -78,4 +86,6 @@ func TestCIDRQuery(t *testing.T) {
 			}
 		})
 	}
+
+	assert.False(t, IPNetContainsSubnet(nil, ""))
 }

--- a/pkg/search/postgres/query/cidr_query_test.go
+++ b/pkg/search/postgres/query/cidr_query_test.go
@@ -1,0 +1,81 @@
+package pgsearch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type PredicatePair struct {
+	value             string
+	expectedSelection bool
+}
+
+func TestCIDRQuery(t *testing.T) {
+	_, valueCIDR, _ := net.ParseCIDR("230.127.112.0/24")
+
+	cases := []struct {
+		value             string
+		expectErr         bool
+		expectedQuery     string
+		expectedValues    []interface{}
+		goEquivalentPairs *[]PredicatePair
+	}{
+		{
+			value:          valueCIDR.String(),
+			expectedQuery:  "blah <<= '$$'",
+			expectedValues: []interface{}{valueCIDR},
+			goEquivalentPairs: &[]PredicatePair{
+				{
+					value:             "1.1.1.1/32",
+					expectedSelection: false,
+				},
+				{
+					value:             "230.127.112.8/32",
+					expectedSelection: true,
+				},
+				{
+					value:             "230.127.112.8/24",
+					expectedSelection: true,
+				},
+				{
+					value:             "230.127.112.128/25",
+					expectedSelection: true,
+				},
+			},
+		},
+		{
+			value:     "230.127.112.0",
+			expectErr: true,
+		},
+		{
+			value:     "",
+			expectErr: true,
+		},
+		{
+			value:     "invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			actual, err := newCIDRQuery(&queryAndFieldContext{
+				qualifiedColumnName: "blah",
+				value:               c.value,
+			})
+			if c.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.expectedQuery, actual.Where.Query)
+			assert.Equal(t, c.expectedValues, actual.Where.Values)
+			for _, p := range *c.goEquivalentPairs {
+				assert.Equal(t, p.expectedSelection, actual.Where.equivalentGoFunc(p.value), p.value)
+			}
+		})
+	}
+}

--- a/pkg/search/postgres/query/cidr_query_test.go
+++ b/pkg/search/postgres/query/cidr_query_test.go
@@ -25,7 +25,7 @@ func TestCIDRQuery(t *testing.T) {
 	}{
 		{
 			value:          valueCIDR.String(),
-			expectedQuery:  "blah <<= '$$'",
+			expectedQuery:  "blah <<= $$",
 			expectedValues: []interface{}{valueCIDR},
 			goEquivalentPairs: &[]PredicatePair{
 				{

--- a/pkg/search/postgres/query/common.go
+++ b/pkg/search/postgres/query/common.go
@@ -117,6 +117,9 @@ func MatchFieldQuery(dbField *walker.Field, derivedMetadata *walker.DerivedSearc
 	if dbField.SQLType == "uuid" {
 		dataType = postgres.UUID
 	}
+	if dbField.SQLType == "cidr" {
+		dataType = postgres.CIDR
+	}
 	// Derived types map to functions on a field.  For example,
 	// a CountDerivationType will ultimately produce
 	// count(field_x) as field_x_count.  Similarly

--- a/pkg/search/postgres/query/query_functions.go
+++ b/pkg/search/postgres/query/query_functions.go
@@ -67,6 +67,7 @@ var datatypeToQueryFunc = map[postgres.DataType]queryFunction{
 	postgres.EnumArray:   queryOnArray(newEnumQuery, getEnumArrayPostTransformFunc),
 	postgres.IntArray:    queryOnArray(newNumericQuery, getIntArrayPostTransformFunc),
 	postgres.UUID:        newUUIDQuery,
+	postgres.CIDR:        newCIDRQuery,
 	// Map is handled separately.
 }
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -200,6 +200,8 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
         protocompat.NilOrTime({{$field.Getter "obj"}}),
     {{- else if eq $field.SQLType "uuid" }}
         pgutils.NilOrUUID({{$field.Getter "obj"}}),
+    {{- else if eq $field.SQLType "cidr" }}
+        pgutils.NilOrCIDR({{$field.Getter "obj"}}),
     {{- else if eq $field.DataType "map" }}
         pgutils.EmptyOrMap({{$field.Getter "obj"}}),
     {{- else }}


### PR DESCRIPTION
### Description

The ongoing External-IPs effort will leverage PostgreSQL capabilities around the 'cidr' type (efficient querying of columns `Containing` another CIDR).

This PR implements a small binding to deal with the null value, and a search query generator.
