### PR TITLE
ROX-26121: Do not assert on presence of central in NG test

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -25,9 +25,13 @@ describe('Network Graph deployment sidebar', () => {
         cy.get(
             `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`
         );
-        cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`
-        ).should('not.exist');
+
+        // With the addition of the compliance node indexer, it is possible for a flow to exist between central and collector
+        // https://github.com/stackrox/stackrox/pull/12573
+        //
+        // cy.get(
+        //  `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`
+        // ).should('not.exist');
         cy.get(
             `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("scanner")`
         ).should('not.exist');


### PR DESCRIPTION
### Description

A recent change has made it so that a network flow is displayed between `collector` and `central` when running on OCP clusters, which breaks existing e2e tests.

This fix disables the assertion on the presence or absence of `central` when the filter is applied in order to get tests green again. When @Maddosaurus returns from OOO we will confirm whether or not this should be the expected behavior on OCP _and_ GKE clusters moving forward, and update this test again if needed.

For more context: https://redhat-internal.slack.com/archives/CFMQ5C2TT/p1726047673403259

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI