### PR TITLE
chore: fix versioned vulns job

### DIFF
--- a/.github/actions/download-artifact-with-retry/action.yaml
+++ b/.github/actions/download-artifact-with-retry/action.yaml
@@ -2,10 +2,13 @@ name: Download artifact with retry
 description: Retry wrapper of download-artifact
 inputs:
   name:
-    description: 'Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.'
+    description: 'Name of the artifact to download. If unspecified, all artifacts for the run are downloaded. Optional.'
     required: false
   path:
-    description: 'Destination path. Supports basic tilde expansion. Defaults to $GITHUB_WORKSPACE'
+    description: 'Destination path. Supports basic tilde expansion. Optional. Defaults to $GITHUB_WORKSPACE.'
+    required: false
+  pattern:
+    description: 'A glob pattern to the artifacts that should be downloaded. Ignored if name is specified. Optional.'
     required: false
 runs:
   using: composite
@@ -15,6 +18,7 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
       continue-on-error: true
     - id: download-artifact-try2
       if: steps.download-artifact-try1.outcome == 'failure'
@@ -22,9 +26,11 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
       continue-on-error: true
     - if: steps.download-artifact-try2.outcome == 'failure'
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -1,4 +1,5 @@
-name: Scanner versioned vulnerability bundles update
+name: Scanner versioned vulnerabilities update
+
 on:
   schedule:
   - cron: "30 */4 * * *"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   parse-versions:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}
@@ -37,6 +39,7 @@ jobs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
   prepare-environment:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     runs-on: ubuntu-latest
     outputs:
       manual_url: ${{ steps.set-manual-url.outputs.manual_url }}
@@ -157,15 +160,14 @@ jobs:
         chmod +x scanner/bin/updater
         mkdir vulns
 
-    - name: Create Folder
+    - name: Create bundle output directory
       run: mkdir -p definitions/${{ env.SCANNER_BUNDLE_VERSION }}
 
     - name: Run Updater (single bundle)
       env:
         STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
-        scanner/bin/updater export vulns --manual-url "${{ needs.prepare-environment.outputs.manual_url }}"
-        mv vulns/* definitions/${{ env.SCANNER_BUNDLE_VERSION }}/
+        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${{ env.SCANNER_BUNDLE_VERSION }}"
 
     - name: Run updater (multi bundle)
       env:
@@ -181,7 +183,7 @@ jobs:
         path: definitions
 
   build-upload-pr-vulnerabilities:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     needs:
     - prepare-environment
     runs-on: ubuntu-latest
@@ -214,6 +216,15 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - name: Authenticate with test GCS bucket
+      if: github.event_name == 'pull_request'
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
     - name: Build updater
       run: |
         echo "Building updater for pull request ${{ env.PR_NAME }}..."
@@ -231,23 +242,14 @@ jobs:
         chmod +x scanner/bin/updater
         mkdir vulns
 
-    - name: Create Folder
+    - name: Create bundle output directory
       run: mkdir -p definitions/${{ github.event.pull_request.number }}
-
-    - name: Authenticate with test GCS bucket
-      if: github.event_name == 'pull_request'
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
-
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
 
     - name: Run Updater (single bundle)
       env:
         STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
-        scanner/bin/updater export vulns --manual-url "${{ needs.prepare-environment.outputs.manual_url }}"
+        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${{ github.event.pull_request.number }}"
         mv vulns/* definitions/${{ github.event.pull_request.number }}/
 
     - name: Run updater (multi bundle)
@@ -275,11 +277,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # TODO: What is this?
     - name: Download definitions artifacts
       uses: actions/download-artifact@v4
       with:
         path: downloaded_artifacts
 
+    # TODO: What is this?
     - name: Move files artifacts
       run: rsync -av downloaded_artifacts/*/ definitions_files/
 

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -271,7 +271,6 @@ jobs:
         pattern: "artifact_*"
         path: downloaded_artifacts
 
-    # Why bother with this?
     - name: Move files artifacts
       run: rsync -av downloaded_artifacts/*/ definitions_files/
 

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -121,6 +121,7 @@ jobs:
     env:
       SCANNER_BUNDLE_VERSION: ${{ matrix.version }}
       ROX_GIT_REF: ${{ matrix.ref }}
+      STACKROX_NVD_ZIP_PATH: nvd.zip
     steps:
     - name: Free up disk space
       shell: bash
@@ -143,35 +144,26 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Build updater
-      run: |
-        echo "Building updater for version ${{ env.SCANNER_BUNDLE_VERSION }} on branch ${{ env.ROX_GIT_REF }}..."
-        make tag
-        make -C scanner bin/updater
-
     - name: Download NVD
       uses: ./.github/actions/download-artifact-with-retry
       with:
         name: nvd
         path: nvd.zip
 
-    - name: Set Updater
+    - name: Build updater
       run: |
-        chmod +x scanner/bin/updater
-        mkdir vulns
+        echo "Building updater for version ${{ env.SCANNER_BUNDLE_VERSION }} based on git ref ${{ env.ROX_GIT_REF }}..."
+        make tag
+        make -C scanner bin/updater
 
     - name: Create bundle output directory
       run: mkdir -p definitions/${{ env.SCANNER_BUNDLE_VERSION }}
 
     - name: Run Updater (single bundle)
-      env:
-        STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
         scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${{ env.SCANNER_BUNDLE_VERSION }}"
 
     - name: Run updater (multi bundle)
-      env:
-        STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
         scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
         zip definitions/${{ env.SCANNER_BUNDLE_VERSION }}/vulnerabilities.zip bundles/*.json.zst
@@ -194,6 +186,8 @@ jobs:
       - /tmp:/tmp
       - /usr:/mnt/usr
       - /opt:/mnt/opt
+    env:
+      STACKROX_NVD_ZIP_PATH: nvd.zip
     steps:
     - name: Free up disk space
       shell: bash
@@ -225,42 +219,32 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
 
-    - name: Build updater
-      run: |
-        echo "Building updater for pull request ${{ env.PR_NAME }}..."
-        make tag
-        make -C scanner bin/updater
-
     - name: Download NVD
       uses: ./.github/actions/download-artifact-with-retry
       with:
         name: nvd
         path: nvd.zip
 
-    - name: Set Updater
+    - name: Build updater
       run: |
-        chmod +x scanner/bin/updater
-        mkdir vulns
+        echo "Building updater for pull request ${{ env.PR_NAME }}..."
+        make tag
+        make -C scanner bin/updater
 
     - name: Create bundle output directory
       run: mkdir -p definitions/${{ github.event.pull_request.number }}
 
     - name: Run Updater (single bundle)
-      env:
-        STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
         scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${{ github.event.pull_request.number }}"
-        mv vulns/* definitions/${{ github.event.pull_request.number }}/
 
     - name: Run updater (multi bundle)
-      env:
-        STACKROX_NVD_ZIP_PATH: nvd.zip
       run: |
         scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
         zip definitions/${{ github.event.pull_request.number }}/vulnerabilities.zip bundles/*.json.zst
 
     # PR owner is responsible for verifying vulnerability bundles are generated
-    - name: Update PR vulnerabilities
+    - name: Upload PR vulnerabilities
       run: |
         branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
         # Replace / with -, so the branch name isn't truncated when pushed to GCS.
@@ -275,15 +259,19 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+    # Checkout to run ./.github/actions/download-artifact-with-retry
     - uses: actions/checkout@v4
-
-    # TODO: What is this?
-    - name: Download definitions artifacts
-      uses: actions/download-artifact@v4
       with:
+        fetch-depth: 0
+
+    - uses: ./.github/actions/download-artifact-with-retry
+      with:
+        # Only download vulnerability bundles.
+        # This avoids accidentally downloading nvd.zip.
+        pattern: "artifact_*"
         path: downloaded_artifacts
 
-    # TODO: What is this?
+    # Why bother with this?
     - name: Move files artifacts
       run: rsync -av downloaded_artifacts/*/ definitions_files/
 

--- a/.github/workflows/scripts/scanner-get-released-tags.sh
+++ b/.github/workflows/scripts/scanner-get-released-tags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Print a JSON containing all scanner vulnerability bundle streams, as directed
-# by the `VULNERABILITY_BUNDLE_VERSION` file.
+# Print a JSON containing all Scanner V4 vulnerability bundle streams,
+# as directed by `scanner/updater/version/VULNERABILITY_BUNDLE_VERSION`.
 
 set -euo pipefail
 
@@ -14,7 +14,7 @@ while read -r ver tag _; do
     version_map[$ver]="$tag"
 done < <(./.github/workflows/scripts/scanner-output-release-versions.sh | jq -r '.versions[] | "\(.version) \(.tag)"')
 
-# Read the versions and their corresponding tags from the VULNERABILITY_BUNDLE_VERSION file.
+# Read the versions and their corresponding tags from `scanner/updater/version/VULNERABILITY_BUNDLE_VERSION`.
 while read -r line; do
     # Skip lines that are comments or empty
     echo "$line" | grep -qE '^\s*(#.*|$)' && continue
@@ -49,4 +49,4 @@ json_output=$(printf "%s," "${json_array[@]}" | sed 's/,$//')
 json_output="[$json_output]"
 
 # Print the final JSON output
-echo "$json_output"
+echo "$json_output" | jq

--- a/.github/workflows/scripts/scanner-output-release-versions.sh
+++ b/.github/workflows/scripts/scanner-output-release-versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Print a JSON containing all scanner vulnerability bundle streams, as directed
-# by the `RELEASE_VERSION` file.
+# by the `scanner/updater/version/RELEASE_VERSION` file.
 
 set -euo pipefail
 

--- a/scanner/updater/version/RELEASE_VERSION
+++ b/scanner/updater/version/RELEASE_VERSION
@@ -1,7 +1,7 @@
-# This file serves as a list of Stackrox versions.
-# As Scanner and Stackrox versions are aligned, the scanner updater is responsible for updating vulnerability data across all versions listed in this file.
-# Subsequently, this updated data is uploaded to Google Storage.
-# For each individual version of Scanner's vulnerability updater, corresponding vulnerability data is collected and then seamlessly uploaded to Google Storage.
+# This file serves as a list of StackRox versions.
+# As Scanner V4 and StackRox versions are aligned, the vulnerability updaters are responsible for updating vulnerability data across all versions listed in this file.
+# Subsequently, this updated data is uploaded to Google Cloud Storage.
+# For each individual version of Scanner V4's vulnerability updater, corresponding vulnerability data is collected and then seamlessly uploaded to Google Cloud Storage.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 4.4.0
 4.4.1

--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -1,8 +1,8 @@
-# This file lists ACS Scanner v4 vulnerability definitions versions.
-# Each vulnerability definitions version is linked to a product tag.
-# The scanner updaters for the associated tag are responsible for regularly updating the vulnerability data for the associated definition bundle.
-# The updated data is then uploaded to Google Storage.
-# Each vulnerability definition version serves the Scanner requesting it, and the definitions are imported to that specific Scanner.
+# This file lists Scanner V4 vulnerability definitions versions.
+# Each vulnerability bundle version is linked to a git reference, which may be changed.
+# The vulnerability updater for each associated reference is responsible for regularly updating the vulnerabilities for the associated bundle.
+# The updated data is uploaded to Google Cloud Storage.
+# Each vulnerability bundle version serves the Scanner V4 requesting it, which is, by default, based on the version specified in scanner/VULNERABILITY_VERSION in the related Scanner V4 tag.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v1 4.5.2


### PR DESCRIPTION
### Description

I noticed current runs for this job are uploading vulnerability bundles for all PRs, even without the label. This PR ensures that label must be included before bothering to create bundles for the PR. While I was here, I also did other miscellaneous fixes. All fixes done here are:

* Don't bother running `parse-versions`, `prepare-environment`, and `build-upload-pr-vulnerabilities` in PRs unless the `pr-update-scanner-vulns` label is set
* Removed `Set Updater` steps in jobs, as it's not needed
* Moved setting `STACKROX_NVD_ZIP_PATH: nvd.zip` to be job-global, as the file is always hardcoded to nvd.zip wherever it's used
* Moved a few steps around
* Updated `upload-definitions`'s `checkout` steps and swapped `actions/download-artifac@v4` with `./.github/actions/download-artifact-with-retry`, so we can retry
* [**IMPORTANT**] ensure `upload-definitions` only handles vulnerability bundle files. Previously, it also downloaded `nvd.zip` and uploaded this file to every vuln bundle version, but this is unnecessary
* Cleaned up comments in other files
* Added `jq` to the output of `.github/workflows/scripts/scanner-get-released-tags.sh` for readability

See https://github.com/stackrox/stackrox/actions/runs/10815866690 for a current example `master` run

See https://github.com/stackrox/stackrox/actions/runs/10819079955 for a current example PR run

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

This IS the test

#### How I validated my change

CI
