### PR TITLE
ROX-26130: Make central notifier email library take report name param

### DIFF
--- a/central/complianceoperator/v2/report/manager/complianceReportgenerator/report_gen_impl.go
+++ b/central/complianceoperator/v2/report/manager/complianceReportgenerator/report_gen_impl.go
@@ -254,8 +254,9 @@ func (rg *complianceReportGeneratorImpl) sendEmail(ctx context.Context, zipData 
 		if customSubject != "" {
 			emailSubject = customSubject
 		}
+		reportName := req.ReportSnapshot.Name
 		err = retryableSendReportResults(reportNotifier, repNotifier.GetEmailConfig().GetMailingLists(),
-			zipData, emailSubject, body)
+			zipData, emailSubject, body, reportName)
 		if err != nil {
 			errorList.AddError(errors.Errorf("Error sending compliance report email for notifier %s: %s",
 				repNotifier.GetEmailConfig().GetNotifierId(), err))
@@ -284,9 +285,9 @@ func formatEmailBodywithDetails(subject string, data *formatBody) (string, error
 }
 
 func retryableSendReportResults(reportNotifier notifiers.ReportNotifier, mailingList []string,
-	zippedCSVData *bytes.Buffer, emailSubject, emailBody string) error {
+	zippedCSVData *bytes.Buffer, emailSubject, emailBody, reportName string) error {
 	return retry.WithRetry(func() error {
-		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, emailSubject, emailBody)
+		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, emailSubject, emailBody, reportName)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),

--- a/central/complianceoperator/v2/report/manager/complianceReportgenerator/report_gen_impl.go
+++ b/central/complianceoperator/v2/report/manager/complianceReportgenerator/report_gen_impl.go
@@ -121,9 +121,10 @@ func (rg *complianceReportGeneratorImpl) ProcessReportRequest(req *ComplianceRep
 		ScanConfig:    req.ScanConfigName,
 		Profiles:      len(req.Profiles),
 	}
+	reportName := req.ScanConfigName
 
-	log.Infof("Sending email for scan config %s", req.ScanConfigName)
-	go rg.sendEmail(req.Ctx, zipData, formatEmailBody, formatEmailSub, req.Notifiers)
+	log.Infof("Sending email for scan config %s", reportName)
+	go rg.sendEmail(req.Ctx, zipData, formatEmailBody, formatEmailSub, req.Notifiers, reportName)
 }
 
 // getDataforReport returns map of cluster id and slice of ResultRow
@@ -224,7 +225,7 @@ func (rg *complianceReportGeneratorImpl) getDataforReport(req *ComplianceReportR
 	return resultEmailComplianceReport
 }
 
-func (rg *complianceReportGeneratorImpl) sendEmail(ctx context.Context, zipData *bytes.Buffer, emailBody *formatBody, formatEmailSub *formatSubject, notifiersList []*storage.NotifierConfiguration) {
+func (rg *complianceReportGeneratorImpl) sendEmail(ctx context.Context, zipData *bytes.Buffer, emailBody *formatBody, formatEmailSub *formatSubject, notifiersList []*storage.NotifierConfiguration, reportName string) {
 
 	errorList := errorhelpers.NewErrorList("Error sending compliance report email notifications")
 	for _, repNotifier := range notifiersList {
@@ -254,7 +255,6 @@ func (rg *complianceReportGeneratorImpl) sendEmail(ctx context.Context, zipData 
 		if customSubject != "" {
 			emailSubject = customSubject
 		}
-		reportName := req.ReportSnapshot.Name
 		err = retryableSendReportResults(reportNotifier, repNotifier.GetEmailConfig().GetMailingLists(),
 			zipData, emailSubject, body, reportName)
 		if err != nil {

--- a/central/notifiers/acscsemail/acscsemail.go
+++ b/central/notifiers/acscsemail/acscsemail.go
@@ -106,9 +106,9 @@ func (e *acscsEmail) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, c
 	return e.send(ctx, &msg)
 }
 
-func (e *acscsEmail) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText string) error {
+func (e *acscsEmail) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText, reportName string) error {
 	// using empty from here because the From header will be set by the managed service
-	msg := email.BuildReportMessage(recipients, "", subject, messageText, zippedReportData)
+	msg := email.BuildReportMessage(recipients, "", subject, messageText, zippedReportData, reportName)
 	return e.send(ctx, &msg)
 }
 

--- a/central/notifiers/acscsemail/acscsemail_test.go
+++ b/central/notifiers/acscsemail/acscsemail_test.go
@@ -39,8 +39,9 @@ func TestReportNotify(t *testing.T) {
 		actualMsg = msg
 		return nil
 	})
+	sampleReportName := "Test Report"
 
-	err := acscsEmail.ReportNotify(context.Background(), &attachBuf, expectTo, expectedSubject, "here is your report")
+	err := acscsEmail.ReportNotify(context.Background(), &attachBuf, expectTo, expectedSubject, "here is your report", sampleReportName)
 	mockController.Finish()
 
 	require.NoError(t, err, "unexpected error for ReportNotify")
@@ -50,7 +51,7 @@ func TestReportNotify(t *testing.T) {
 	msgStr := string(actualMsg.RawMessage)
 
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
-	expectedFilePrefix := fmt.Sprintf("%s_Vulnerability_Report", branding.GetProductNameShort())
+	expectedFilePrefix := fmt.Sprintf("%s_Test_Report", branding.GetProductNameShort())
 	// report file
 	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
 	assert.Contains(t, msgStr, "Content-Type: application/zip\r\n")

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	log                     = logging.LoggerForModule(option.EnableAdministrationEvents())
-	reportNameValidator     = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+	reportNameValidator     = regexp.MustCompile(`[^a-zA-Z0-9- ]+`)
 	reportFilenameValidator = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 )
 
@@ -598,7 +598,7 @@ func PlainTextAlert(alert *storage.Alert, uiEndpoint string, mitreStore mitreDS.
 func BuildReportMessage(recipients []string, from, subject, messageText string, zippedReportData *bytes.Buffer, reportName string) Message {
 	brandName := branding.GetProductNameShort()
 
-	sanitizedReportName := reportNameValidator.ReplaceAllString(reportName, " ")
+	sanitizedReportName := reportNameValidator.ReplaceAllString(reportName, "")
 	if len(sanitizedReportName) > 80 {
 		sanitizedReportName = sanitizedReportName[0:80]
 	}

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	log                     = logging.LoggerForModule(option.EnableAdministrationEvents())
-	reportNameValidator     = regexp.MustCompile(`[^a-zA-Z0-9] +`)
+	reportNameValidator     = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
 	reportFilenameValidator = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 )
 

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -36,7 +36,8 @@ import (
 )
 
 var (
-	log = logging.LoggerForModule(option.EnableAdministrationEvents())
+	log                     = logging.LoggerForModule(option.EnableAdministrationEvents())
+	reportFilenameValidator = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 )
 
 const (
@@ -612,8 +613,7 @@ func BuildReportMessage(recipients []string, from, subject, messageText string, 
 		EmbedLogo: true,
 	}
 
-	reg := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	baseFilename := reg.ReplaceAllString(boundedReportName, "_")
+	baseFilename := reportFilenameValidator.ReplaceAllString(boundedReportName, "_")
 	if zippedReportData != nil {
 		msg.Attachments = map[string][]byte{
 			fmt.Sprintf("%s_%s_%s.zip", brandName, baseFilename, time.Now().Format("02_January_2006")): zippedReportData.Bytes(),

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -612,7 +612,7 @@ func BuildReportMessage(recipients []string, from, subject, messageText string, 
 		EmbedLogo: true,
 	}
 
-	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")
+	reg := regexp.MustCompile(`[^a-zA-Z0-9]+`)
 	baseFilename := reg.ReplaceAllString(boundedReportName, "_")
 	if zippedReportData != nil {
 		msg.Attachments = map[string][]byte{

--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -35,7 +35,7 @@ func TestBuildReportMessage(t *testing.T) {
 	brandName := branding.GetProductNameShort()
 	expectedSubjectHeader := fmt.Sprintf("Subject: %s report %s for ", brandName, reportName[0:80])
 
-	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")
+	reg := regexp.MustCompile(`[^a-zA-Z0-9]+`)
 	baseFilename := reg.ReplaceAllString(reportName[0:80], "_")
 	expectedReportAttachmentHeader := fmt.Sprintf("Content-Disposition: attachment; filename=%s_%s_", brandName, baseFilename)
 

--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildReportMessage(t *testing.T) {
@@ -32,23 +32,24 @@ func TestBuildReportMessage(t *testing.T) {
 	msgBytes := msg.Bytes()
 	msgStr := string(msgBytes)
 
-	brandName := branding.GetProductNameShort()
-	expectedSubjectHeader := fmt.Sprintf("Subject: %s report %s for ", brandName, reportName[0:80])
+	// subject header should have special characters changed to spaces, and report name limited to 80 characters for safety
+	expectedSubjectHeader := "StackRox report Mystery Inc fixable and non-fixable critical important and moderate vulnerabilit for "
 
-	reg := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	baseFilename := reg.ReplaceAllString(reportName[0:80], "_")
-	expectedReportAttachmentHeader := fmt.Sprintf("Content-Disposition: attachment; filename=%s_%s_", brandName, baseFilename)
+	// filename header should have all non-alphanumerics collapsed to underscores, and report name limited to 80 characters for safety
+	expectedReportAttachmentHeader := "Content-Disposition: attachment; filename=StackRox_Mystery_Inc_fixable_and_non_fixable_critical_important_and_moderate_vulnerabilit_"
 
 	expectedBody := fmt.Sprintf("<div>\r\n%s\r\n</div>\r\n", messageText)
 
 	assert.Contains(t, msgStr, "From: velma@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "To: scooby@stackrox.com,shaggy@stackrox.com\r\n")
 	assert.Contains(t, msgStr, expectedSubjectHeader)
+	// assert.Contains(t, msgStr, expectedSubjectHeader)
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
 	assert.Contains(t, msgStr, "Content-Type: application/zip\r\n")
 	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
 	assert.Contains(t, msgStr, expectedReportAttachmentHeader)
+	// assert.Contains(t, msgStr, expectedReportAttachmentHeader)
 
 	assert.Contains(t, msgStr, "Content-Type: image/png; name=logo.png\r\n")
 	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
@@ -60,9 +61,8 @@ func TestBuildReportMessage(t *testing.T) {
 	assert.Contains(t, msgStr, expectedBody)
 
 	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
-	if assert.NoError(t, err) {
-		assert.Equal(t, expectedFinalBoundary, lastBoundary)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expectedFinalBoundary, lastBoundary)
 }
 
 func TestEmailMsgWithAttachment(t *testing.T) {
@@ -105,9 +105,8 @@ func TestEmailMsgWithAttachment(t *testing.T) {
 	assert.Contains(t, msgStr, "<div>\r\nHow you doin'?\r\n</div>\r\n")
 
 	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
-	if assert.NoError(t, err) {
-		assert.Equal(t, expectedFinalBoundary, lastBoundary)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expectedFinalBoundary, lastBoundary)
 }
 
 func obtainLastAndExpectedBoundaryString(msgStr string) (string, string, error) {
@@ -172,9 +171,8 @@ func TestEmailMsgWithMultipleAttachments(t *testing.T) {
 	assert.Contains(t, msgStr, "<div>\r\nHow you doin'?\r\n</div>\r\n")
 
 	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
-	if assert.NoError(t, err) {
-		assert.Equal(t, expectedFinalBoundary, lastBoundary)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expectedFinalBoundary, lastBoundary)
 }
 
 func TestEmailMsgNoAttachmentsWithLogo(t *testing.T) {
@@ -202,9 +200,8 @@ func TestEmailMsgNoAttachmentsWithLogo(t *testing.T) {
 	assert.Contains(t, msgStr, "How you doin'?\r\n")
 
 	lastBoundary, expectedFinalBoundary, err := obtainLastAndExpectedBoundaryString(msgStr)
-	if assert.NoError(t, err) {
-		assert.Equal(t, expectedFinalBoundary, lastBoundary)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expectedFinalBoundary, lastBoundary)
 }
 
 func TestEmailMsgNoAttachments(t *testing.T) {

--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -33,7 +33,7 @@ func TestBuildReportMessage(t *testing.T) {
 	msgStr := string(msgBytes)
 
 	// subject header should have special characters changed to spaces, and report name limited to 80 characters for safety
-	expectedSubjectHeader := "StackRox report Mystery Inc fixable and non-fixable critical important and moderate vulnerabilit for "
+	expectedSubjectHeader := "Subject: StackRox report Mystery Inc fixable and non-fixable critical important and moderate vulnerabilit for "
 
 	// filename header should have all non-alphanumerics collapsed to underscores, and report name limited to 80 characters for safety
 	expectedReportAttachmentHeader := "Content-Disposition: attachment; filename=StackRox_Mystery_Inc_fixable_and_non_fixable_critical_important_and_moderate_vulnerabilit_"

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -44,7 +44,7 @@ import (
 const (
 	deploymentsPaginationLimit = 50
 
-	reportQueryPostgres = `query getVulnReportData($scopequery: String, 
+	reportQueryPostgres = `query getVulnReportData($scopequery: String,
 							$cvequery: String, $pagination: Pagination) {
 							deployments: deployments(query: $scopequery, pagination: $pagination) {
 								clusterName
@@ -266,6 +266,7 @@ func (s *scheduler) updateLastRunStatus(req *ReportRequest, err error) error {
 func (s *scheduler) sendReportResults(req *ReportRequest) error {
 	rc := req.ReportConfig
 
+	reportName := rc.Name
 	notifier := s.notificationProcessor.GetNotifier(req.Ctx, rc.GetEmailConfig().GetNotifierId())
 	reportNotifier, ok := notifier.(notifiers.ReportNotifier)
 	if !ok {
@@ -299,7 +300,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 
 	if err = retry.WithRetry(func() error {
 		return reportNotifier.ReportNotify(req.Ctx, zippedCSVData,
-			rc.GetEmailConfig().GetMailingLists(), "", messageText)
+			rc.GetEmailConfig().GetMailingLists(), "", messageText, reportName)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -170,8 +170,9 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 				emailSubject = customSubject
 			}
 			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHTML)
+			reportName := req.ReportSnapshot.Name
 			err := rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),
-				zippedCSVData, emailSubject, emailBodyWithConfigDetails)
+				zippedCSVData, emailSubject, emailBodyWithConfigDetails, reportName)
 			if err != nil {
 				errorList.AddError(errors.Errorf("Error sending email for notifier '%s': %s",
 					notifierSnap.GetEmailConfig().GetNotifierId(), err))
@@ -344,9 +345,9 @@ func execQuery[T any](rg *reportGeneratorImpl, gqlQuery, opName, scopeQuery, cve
 /* Utility Functions */
 
 func (rg *reportGeneratorImpl) retryableSendReportResults(reportNotifier notifiers.ReportNotifier, mailingList []string,
-	zippedCSVData *bytes.Buffer, emailSubject, emailBody string) error {
+	zippedCSVData *bytes.Buffer, emailSubject, emailBody, baseFilename string) error {
 	return retry.WithRetry(func() error {
-		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, emailSubject, emailBody)
+		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, emailSubject, emailBody, baseFilename)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),

--- a/pkg/notifiers/mocks/report_notifier.go
+++ b/pkg/notifiers/mocks/report_notifier.go
@@ -71,17 +71,17 @@ func (mr *MockReportNotifierMockRecorder) ProtoNotifier() *gomock.Call {
 }
 
 // ReportNotify mocks base method.
-func (m *MockReportNotifier) ReportNotify(arg0 context.Context, arg1 *bytes.Buffer, arg2 []string, arg3, arg4 string) error {
+func (m *MockReportNotifier) ReportNotify(arg0 context.Context, arg1 *bytes.Buffer, arg2 []string, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportNotify", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "ReportNotify", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportNotify indicates an expected call of ReportNotify.
-func (mr *MockReportNotifierMockRecorder) ReportNotify(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockReportNotifierMockRecorder) ReportNotify(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportNotify", reflect.TypeOf((*MockReportNotifier)(nil).ReportNotify), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportNotify", reflect.TypeOf((*MockReportNotifier)(nil).ReportNotify), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Test mocks base method.

--- a/pkg/notifiers/report_notifier.go
+++ b/pkg/notifiers/report_notifier.go
@@ -11,5 +11,5 @@ import (
 type ReportNotifier interface {
 	Notifier
 	// ReportNotify triggers the plugins to send a notification about a report
-	ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText string) error
+	ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText, reportName string) error
 }


### PR DESCRIPTION
### Description

While we were testing a sample Compliance Report, we discovered that the filename contained the hard-coded string "Vulnerability_Report", from the original use-case of reports for CVEs only.

This change fixes that by using the actual user-specified Report Name from the Report configuration in place of that hard-coded string.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x]  documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

1. Updated existing automated test
2. Deployed this PR build, and sent samples of both kinds of reports and then inspected their filenames

[Updated, 2024-09-20, after addressing PR comments]:
![Screenshot 2024-09-20 at 5 39 47 PM](https://github.com/user-attachments/assets/0d0ab866-fa80-46eb-bb18-f093f23a6a83)


Vulnerability Report named "Van3"
![Screenshot 2024-09-16 at 9 51 05 AM](https://github.com/user-attachments/assets/3e456c41-e589-4746-83cd-ad1cc262d4ea)


Compliance report named "van-scooby-1"
![Screenshot 2024-09-16 at 9 53 22 AM](https://github.com/user-attachments/assets/7ae88abe-e816-4973-b3f6-e27d899aa547)


