### PR TITLE
ROX-25937: Add status and toggle filters for report jobs

### DIFF
--- a/ui/apps/platform/src/Components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CheckboxSelect.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Select, SelectOption, MenuToggle, MenuToggleElement, Badge } from '@patternfly/react-core';
-import { ensureString } from '../utils/utils';
+
+import { ensureString } from 'utils/ensure';
 
 type CheckboxSelectProps = {
     selection: string[];
@@ -9,6 +10,7 @@ type CheckboxSelectProps = {
     isDisabled?: boolean;
     ariaLabelMenu?: string;
     toggleLabel?: string;
+    toggleIcon?: React.ReactNode;
 };
 
 function CheckboxSelect({
@@ -18,6 +20,7 @@ function CheckboxSelect({
     isDisabled = false,
     ariaLabelMenu,
     toggleLabel,
+    toggleIcon,
 }: CheckboxSelectProps) {
     const [isOpen, setIsOpen] = React.useState(false);
 
@@ -42,9 +45,14 @@ function CheckboxSelect({
             onClick={onToggleClick}
             isExpanded={isOpen}
             isDisabled={isDisabled}
+            icon={toggleIcon}
         >
             {toggleLabel}
-            {selection && selection.length > 0 && <Badge isRead>{selection.length}</Badge>}
+            {selection && selection.length > 0 && (
+                <Badge isRead className="pf-v5-u-ml-sm">
+                    {selection.length}
+                </Badge>
+            )}
         </MenuToggle>
     );
 

--- a/ui/apps/platform/src/Components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CheckboxSelect.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement } from 'react';
-import { Select, SelectOption, MenuToggle, MenuToggleElement, Badge } from '@patternfly/react-core';
+import {
+    Select,
+    SelectOption,
+    MenuToggle,
+    MenuToggleElement,
+    Badge,
+    Flex,
+    FlexItem,
+} from '@patternfly/react-core';
 
 import { ensureString } from 'utils/ensure';
 
@@ -47,12 +55,13 @@ function CheckboxSelect({
             isDisabled={isDisabled}
             icon={toggleIcon}
         >
-            {toggleLabel}
-            {selection && selection.length > 0 && (
-                <Badge isRead className="pf-v5-u-ml-sm">
-                    {selection.length}
-                </Badge>
-            )}
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+            >
+                <FlexItem>{toggleLabel}</FlexItem>
+                {selection && selection.length > 0 && <Badge isRead>{selection.length}</Badge>}
+            </Flex>
         </MenuToggle>
     );
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { Flex } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
+import { ensureString } from 'utils/ensure';
 import { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
-import { ensureString, getDefaultAttributeName, getDefaultEntityName } from '../utils/utils';
+import { getDefaultAttributeName, getDefaultEntityName } from '../utils/utils';
 
 import EntitySelector, { SelectedEntity } from './EntitySelector';
 import AttributeSelector, { SelectedAttribute } from './AttributeSelector';

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -8,6 +8,8 @@ import {
 } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
+import CheckboxSelect from 'Components/CheckboxSelect';
+import { ensureString } from 'utils/ensure';
 import { SelectedEntity } from './EntitySelector';
 import { SelectedAttribute } from './AttributeSelector';
 import { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
@@ -16,7 +18,6 @@ import {
     dateConditionMap,
     ensureConditionDate,
     ensureConditionNumber,
-    ensureString,
     ensureStringArray,
     getAttribute,
     getEntity,
@@ -24,8 +25,6 @@ import {
     hasSelectOptions,
     isSelectType,
 } from '../utils/utils';
-
-import CheckboxSelect from './CheckboxSelect';
 import ConditionNumber from './ConditionNumber';
 import SearchFilterAutocomplete from './SearchFilterAutocomplete';
 import ConditionDate from './ConditionDate';

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
@@ -3,7 +3,8 @@ import { Button, DatePicker, Flex, SelectOption } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 
 import { getDate } from 'utils/dateUtils';
-import { dateConditions, ensureString } from '../utils/utils';
+import { ensureString } from 'utils/ensure';
+import { dateConditions } from '../utils/utils';
 
 import SimpleSelect from './SimpleSelect';
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
@@ -3,7 +3,8 @@ import { Button, NumberInput, SelectOption } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 import clamp from 'lodash/clamp';
 
-import { conditions, ensureString } from '../utils/utils';
+import { ensureString } from 'utils/ensure';
+import { conditions } from '../utils/utils';
 
 import SimpleSelect from './SimpleSelect';
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -21,7 +21,7 @@ import SEARCH_AUTOCOMPLETE_QUERY, {
 } from 'queries/searchAutocomplete';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
-import { ensureString } from '../utils/utils';
+import { ensureString } from 'utils/ensure';
 
 type SearchFilterAutocompleteProps = {
     searchCategory: string;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -90,13 +90,6 @@ export function ensureStringArray(value: unknown): string[] {
     return [];
 }
 
-export function ensureString(value: unknown): string {
-    if (typeof value === 'string') {
-        return value;
-    }
-    return '';
-}
-
 export function ensureConditionNumber(value: unknown): { condition: string; number: number } {
     if (
         typeof value === 'object' &&

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -53,7 +53,7 @@ function ViewScanConfigDetail({
     error = null,
 }: ViewScanConfigDetailProps): React.ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isReportJobsEnabled = isFeatureFlagEnabled('ROX_SCAN_SCHEDULE_REPORT_JOBS');
+    const isReportJobsEnabled = !isFeatureFlagEnabled('ROX_SCAN_SCHEDULE_REPORT_JOBS');
 
     const [selectedTab, setSelectedTab] = useState<JobContextTab>('CONFIGURATION_DETAILS');
     const [isTriggeringRescan, setIsTriggeringRescan] = useState(false);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
@@ -3,17 +3,20 @@ import { Switch } from '@patternfly/react-core';
 
 export type MyJobsFilterProps = {
     showOnlyMyJobs: boolean;
-    onToggle: (checked: boolean) => void;
+    onMyJobsFilterChange: (checked: boolean) => void;
 };
 
-function MyJobsFilter({ showOnlyMyJobs, onToggle }: MyJobsFilterProps) {
+function MyJobsFilter({ showOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProps) {
+    // We're using the same label for both "label" and "labelOff" because changing the label between "on" and "off" states was causing confusion.
+    // When the label changes (e.g., from "View only my jobs" to "View all jobs"), users found it unclear what state the switch was in and what they were actually viewing.
+    // By keeping the label consistent, it avoids this confusion and maintains clarity on what the switch controls.
     return (
         <Switch
             id="view-only-my-jobs"
             label="View only my jobs"
             labelOff="View only my jobs"
             isChecked={showOnlyMyJobs}
-            onChange={(_event, checked: boolean) => onToggle(checked)}
+            onChange={(_event, checked: boolean) => onMyJobsFilterChange(checked)}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Switch } from '@patternfly/react-core';
+
+export type MyJobsFilterProps = {
+    showOnlyMyJobs: boolean;
+    onToggle: (checked: boolean) => void;
+};
+
+function MyJobsFilter({ showOnlyMyJobs, onToggle }: MyJobsFilterProps) {
+    return (
+        <Switch
+            id="view-only-my-jobs"
+            label="View only my jobs"
+            labelOff="View only my jobs"
+            isChecked={showOnlyMyJobs}
+            onChange={(_event, checked: boolean) => onToggle(checked)}
+        />
+    );
+}
+
+export default MyJobsFilter;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -72,7 +72,7 @@ function ReportJobs({ scanConfig }: ReportJobsProps) {
         setPage(1);
     };
 
-    const onMyJobsFilterToggle = (checked: boolean) => {
+    const onMyJobsFilterChange = (checked: boolean) => {
         setShowOnlyMyJobs(checked);
         setPage(1);
     };
@@ -93,7 +93,7 @@ function ReportJobs({ scanConfig }: ReportJobsProps) {
                     <ToolbarItem className="pf-v5-u-flex-grow-1" alignSelf="center">
                         <MyJobsFilter
                             showOnlyMyJobs={showOnlyMyJobs}
-                            onToggle={onMyJobsFilterToggle}
+                            onMyJobsFilterChange={onMyJobsFilterChange}
                         />
                     </ToolbarItem>
                     <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -1,5 +1,13 @@
-import React from 'react';
-import { Card, CardBody, Divider } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import {
+    Card,
+    CardBody,
+    Divider,
+    Pagination,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
 
 import {
     ComplianceScanConfigurationStatus,
@@ -7,7 +15,11 @@ import {
 } from 'services/ComplianceScanConfigurationService';
 import JobDetails from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails';
 import ReportJobsTable from 'Components/ReportJobsTable';
+import { RunState } from 'services/ReportsService.types';
+import useURLPagination from 'hooks/useURLPagination';
 import ConfigDetails from './ConfigDetails';
+import ReportStatusFilter from './ReportStatusFilter';
+import MyJobsFilter from './MyJobsFilter';
 
 function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
     const snapshots: ComplianceScanSnapshot[] = [
@@ -45,33 +57,88 @@ type ReportJobsProps = {
 };
 
 function ReportJobs({ scanConfig }: ReportJobsProps) {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const [filteredStatuses, setFilteredStatuses] = useState<RunState[]>([]);
+    const [showOnlyMyJobs, setShowOnlyMyJobs] = React.useState<boolean>(false);
+
+    const onReportStatusFilterChange = (_checked: boolean, selectedStatus: RunState) => {
+        setFilteredStatuses((prevFilteredStatuses) => {
+            const isStatusIncluded = prevFilteredStatuses.includes(selectedStatus);
+            if (isStatusIncluded) {
+                return prevFilteredStatuses.filter((status) => status !== selectedStatus);
+            }
+            return [...prevFilteredStatuses, selectedStatus];
+        });
+        setPage(1);
+    };
+
+    const onMyJobsFilterToggle = (checked: boolean) => {
+        setShowOnlyMyJobs(checked);
+        setPage(1);
+    };
+
     // @TODO: We will eventually make an API request using the scan config id to get the job history
     const complianceScanSnapshots = scanConfig ? createMockData(scanConfig) : [];
 
     return (
-        <ReportJobsTable
-            snapshots={complianceScanSnapshots}
-            getJobId={getJobId}
-            getConfigName={getConfigName}
-            onClearFilters={() => {}}
-            onDeleteDownload={() => {}}
-            renderExpandableRowContent={(snapshot: ComplianceScanSnapshot) => {
-                return (
-                    <>
-                        <Card isFlat>
-                            <CardBody>
-                                <JobDetails
-                                    reportStatus={snapshot.reportStatus}
-                                    isDownloadAvailable={snapshot.isDownloadAvailable}
-                                />
-                                <Divider component="div" className="pf-v5-u-my-md" />
-                                <ConfigDetails scanConfig={snapshot.scanConfig} />
-                            </CardBody>
-                        </Card>
-                    </>
-                );
-            }}
-        />
+        <>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem alignItems="center">
+                        <ReportStatusFilter
+                            selection={filteredStatuses}
+                            onChange={onReportStatusFilterChange}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem className="pf-v5-u-flex-grow-1" alignSelf="center">
+                        <MyJobsFilter
+                            showOnlyMyJobs={showOnlyMyJobs}
+                            onToggle={onMyJobsFilterToggle}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                        <Pagination
+                            toggleTemplate={({ firstIndex, lastIndex }) => (
+                                <span>
+                                    <b>
+                                        {firstIndex} - {lastIndex}
+                                    </b>{' '}
+                                    of <b>many</b>
+                                </span>
+                            )}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            <ReportJobsTable
+                snapshots={complianceScanSnapshots}
+                getJobId={getJobId}
+                getConfigName={getConfigName}
+                onClearFilters={() => {}}
+                onDeleteDownload={() => {}}
+                renderExpandableRowContent={(snapshot: ComplianceScanSnapshot) => {
+                    return (
+                        <>
+                            <Card isFlat>
+                                <CardBody>
+                                    <JobDetails
+                                        reportStatus={snapshot.reportStatus}
+                                        isDownloadAvailable={snapshot.isDownloadAvailable}
+                                    />
+                                    <Divider component="div" className="pf-v5-u-my-md" />
+                                    <ConfigDetails scanConfig={snapshot.scanConfig} />
+                                </CardBody>
+                            </Card>
+                        </>
+                    );
+                }}
+            />
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportStatusFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportStatusFilter.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { SelectList, SelectOption } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+
+import { RunState, runStates } from 'services/ReportsService.types';
+import CheckboxSelect from 'Components/CheckboxSelect';
+
+export type ReportStatusFilterProps = {
+    selection: RunState[];
+    onChange: (checked: boolean, value: RunState) => void;
+};
+
+function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
+    function onChangeHandler(checked: boolean, value: string) {
+        onChange(checked, value as RunState);
+    }
+
+    return (
+        <CheckboxSelect
+            ariaLabelMenu="Filter by report status select menu"
+            toggleLabel="Filter by report status"
+            toggleIcon={<FilterIcon />}
+            selection={selection}
+            onChange={onChangeHandler}
+        >
+            <SelectList>
+                <SelectOption
+                    key={runStates.PREPARING}
+                    value={runStates.PREPARING}
+                    hasCheckbox
+                    isSelected={selection.includes(runStates.PREPARING)}
+                >
+                    Preparing
+                </SelectOption>
+                <SelectOption
+                    key={runStates.WAITING}
+                    value={runStates.WAITING}
+                    hasCheckbox
+                    isSelected={selection.includes(runStates.WAITING)}
+                >
+                    Waiting
+                </SelectOption>
+                <SelectOption
+                    key={runStates.GENERATED}
+                    value={runStates.GENERATED}
+                    hasCheckbox
+                    isSelected={selection.includes(runStates.GENERATED)}
+                >
+                    Download generated
+                </SelectOption>
+                <SelectOption
+                    key={runStates.DELIVERED}
+                    value={runStates.DELIVERED}
+                    hasCheckbox
+                    isSelected={selection.includes(runStates.DELIVERED)}
+                >
+                    Email delivered
+                </SelectOption>
+                <SelectOption
+                    key={runStates.FAILURE}
+                    value={runStates.FAILURE}
+                    hasCheckbox
+                    isSelected={selection.includes(runStates.FAILURE)}
+                >
+                    Error
+                </SelectOption>
+            </SelectList>
+        </CheckboxSelect>
+    );
+}
+
+export default ReportStatusFilter;

--- a/ui/apps/platform/src/utils/ensure.ts
+++ b/ui/apps/platform/src/utils/ensure.ts
@@ -1,0 +1,14 @@
+/**
+ * Helper function to ensure that the provided value is a string.
+ * If the value is a string, it returns the value as is.
+ * If the value is not a string, it returns an empty string.
+ *
+ * @param value - The value to check and ensure as a string
+ * @returns {string} - The original value if it's a string, otherwise an empty string
+ */
+export function ensureString(value: unknown): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    return '';
+}


### PR DESCRIPTION
### Description

This PR does the following:

1. Creates a **ReportStatusFilter** and **MyJobsFilter** component that we can eventually reuse in VM Reporting too
2. I moved the **CheckboxSelect** component out of the **CompoundSearchFilter** directory and into the general components directory. This way, we can reuse it for standalone filters. It should also take a toggle icon now.

> **Note**: We have another **CheckboxSelect** component in `apps/platform/src/Components/PatternFly/CheckboxSelect.tsx` that uses the deprecated PF **Select** component. I'm thinking of doing a separate refactor to use this updated one instead. It should take care of this tech debt item.


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and Quality

- [x] the change is production ready: the change is GA or otherwise, the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes
 
#### How I validated my change

Checked if the UI works as expected
