### PR TITLE
fix: do not run GC every update cycle

### DIFF
--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -154,7 +154,6 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 	vulnUpdater, err := vuln.New(ctx, vuln.Opts{
 		Store:         store,
 		Locker:        locker,
-		Pool:          pool,
 		MetadataStore: metadataStore,
 		Client:        client,
 		URL:           cfg.VulnerabilitiesURL,

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/klauspost/compress/zstd"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore"
@@ -62,12 +61,11 @@ var (
 
 // Opts represents Updater options.
 //
-// Store, Locker, Pool, MetadataStore, and URL are required.
+// Store, Locker, MetadataStore, and URL are required.
 // The rest are optional.
 type Opts struct {
 	Store         datastore.MatcherStore
 	Locker        *ctxlock.Locker
-	Pool          *pgxpool.Pool
 	MetadataStore postgres.MatcherMetadataStore
 
 	Client         *http.Client
@@ -91,7 +89,6 @@ type Updater struct {
 
 	store         datastore.MatcherStore
 	locker        updates.LockSource
-	pool          *pgxpool.Pool
 	metadataStore postgres.MatcherMetadataStore
 
 	client         *http.Client
@@ -128,7 +125,6 @@ func New(ctx context.Context, opts Opts) (*Updater, error) {
 
 		store:         opts.Store,
 		locker:        opts.Locker,
-		pool:          opts.Pool,
 		metadataStore: opts.MetadataStore,
 
 		client:         opts.Client,
@@ -186,8 +182,8 @@ func fillOpts(opts *Opts) error {
 }
 
 func validate(opts Opts) error {
-	if opts.Store == nil || opts.Locker == nil || opts.Pool == nil || opts.MetadataStore == nil {
-		return errors.New("must provide a Store, a Locker, a Pool, and a MetadataStore")
+	if opts.Store == nil || opts.Locker == nil || opts.MetadataStore == nil {
+		return errors.New("must provide a Store, a Locker, and a MetadataStore")
 	}
 	if _, err := url.Parse(opts.URL); err != nil {
 		return fmt.Errorf("invalid URL: %q", opts.URL)
@@ -353,23 +349,31 @@ func (u *Updater) Initialized(ctx context.Context) bool {
 //
 // Note: periodic full GC will not be started.
 func (u *Updater) Update(ctx context.Context) error {
+	var (
+		updated bool
+		err     error
+	)
 	if features.ScannerV4MultiBundle.Enabled() {
-		if err := u.runMultiBundleUpdate(ctx); err != nil {
-			return err
-		}
+		updated, err = u.runMultiBundleUpdate(ctx)
 	} else {
-		if err := u.runSingleBundleUpdate(ctx); err != nil {
-			return err
-		}
+		updated, err = u.runSingleBundleUpdate(ctx)
 	}
-	if !u.skipGC {
+	if err != nil {
+		return err
+	}
+
+	// Only bother running the GC when it's not disabled
+	// and when the vulnerabilities have been updated.
+	if !u.skipGC && updated {
 		u.runGC(ctx)
 	}
+
 	return nil
 }
 
-// runSingleBundleUpdate updates the vulnerability data with one single bundle.
-func (u *Updater) runSingleBundleUpdate(ctx context.Context) error {
+// runSingleBundleUpdate updates the vulnerability data with one single bundle and
+// returns a bool indicating if any updates actually happened.
+func (u *Updater) runSingleBundleUpdate(ctx context.Context) (bool, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.runSingleBundleUpdate")
 
 	// Use TryLock instead of Lock to prevent simultaneous updates.
@@ -379,7 +383,7 @@ func (u *Updater) runSingleBundleUpdate(ctx context.Context) error {
 		zlog.Info(ctx).
 			Str("lock", updateName).
 			Msg("did not obtain lock, skipping update run")
-		return nil
+		return false, nil
 	}
 
 	prevTimestamp, err := u.metadataStore.GetLastVulnerabilityUpdate(ctx)
@@ -387,7 +391,7 @@ func (u *Updater) runSingleBundleUpdate(ctx context.Context) error {
 		zlog.Debug(ctx).
 			Err(err).
 			Msg("did not get previous vuln update timestamp")
-		return err
+		return false, err
 	}
 	zlog.Info(ctx).
 		Str("timestamp", prevTimestamp.Format(http.TimeFormat)).
@@ -395,12 +399,12 @@ func (u *Updater) runSingleBundleUpdate(ctx context.Context) error {
 
 	f, timestamp, err := u.fetch(ctx, prevTimestamp)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if f == nil {
 		// Nothing to update at this time.
 		zlog.Info(ctx).Msg("no new vulnerability update")
-		return nil
+		return false, nil
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -413,27 +417,28 @@ func (u *Updater) runSingleBundleUpdate(ctx context.Context) error {
 
 	dec, err := zstd.NewReader(f)
 	if err != nil {
-		return fmt.Errorf("creating zstd reader: %w", err)
+		return false, fmt.Errorf("creating zstd reader: %w", err)
 	}
 	defer dec.Close()
 
 	if err := u.importFunc(ctx, dec); err != nil {
-		return err
+		return false, err
 	}
 
 	if err := u.metadataStore.SetLastVulnerabilityUpdate(ctx, postgres.SingleBundleUpdateKey, timestamp); err != nil {
-		return err
+		return false, err
 	}
 
 	if u.initialized.CompareAndSwap(false, true) {
 		zlog.Info(ctx).Msg("finished initial updater run: setting updater to initialized")
 	}
 
-	return nil
+	return true, nil
 }
 
-// runMultiBundleUpdate updates the vulnerability data with a multi-bundle.
-func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
+// runMultiBundleUpdate updates the vulnerability data with a multi-bundle and
+// returns a bool indicating if any updates actually happened.
+func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.runMultiBundleUpdate")
 
 	prevTime, err := u.metadataStore.GetLastVulnerabilityUpdate(ctx)
@@ -441,7 +446,7 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 		zlog.Debug(ctx).
 			Err(err).
 			Msg("did not get previous vuln update timestamp")
-		return err
+		return false, err
 	}
 	zlog.Info(ctx).
 		Time("timestamp", prevTime).
@@ -449,12 +454,12 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 
 	zipFile, zipTime, err := u.fetch(ctx, prevTime)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if zipFile == nil {
 		// Nothing to update at this time.
 		zlog.Info(ctx).Msg("no new vulnerability update")
-		return nil
+		return false, nil
 	}
 	defer func() {
 		if err := zipFile.Close(); err != nil {
@@ -467,11 +472,11 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 
 	zipInfo, err := zipFile.Stat()
 	if err != nil {
-		return err
+		return false, err
 	}
 	zipReader, err := zip.NewReader(zipFile, zipInfo.Size())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Iterate through each vulnerability bundle in the .zip archive
@@ -483,7 +488,7 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 		zlog.Info(ctx).Msg("starting bundle update")
 		if err := u.updateBundle(ctx, bundleF, zipTime, prevTime); err != nil {
 			zlog.Error(ctx).Err(err).Msg("updating bundle failed")
-			return fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
+			return false, fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
 		}
 		zlog.Info(ctx).Msg("completed bundle update")
 	}
@@ -492,12 +497,12 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) error {
 	// Safe to be run concurrently.
 	err = u.metadataStore.GCVulnerabilityUpdates(ctx, names, zipTime)
 	if err != nil {
-		return fmt.Errorf("cleaning vuln updates: %w", err)
+		return false, fmt.Errorf("cleaning vuln updates: %w", err)
 	}
 
 	_ = u.Initialized(ctx)
 
-	return nil
+	return true, nil
 }
 
 func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time.Time, prevTime time.Time) error {

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -349,6 +349,8 @@ func (u *Updater) Initialized(ctx context.Context) bool {
 //
 // Note: periodic full GC will not be started.
 func (u *Updater) Update(ctx context.Context) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.Update")
+
 	var (
 		updated bool
 		err     error
@@ -366,6 +368,9 @@ func (u *Updater) Update(ctx context.Context) error {
 	// and when the vulnerabilities have been updated.
 	if !u.skipGC && updated {
 		u.runGC(ctx)
+	} else if !u.skipGC {
+		// Only log if GC is enabled to reduce noise when GC is disabled.
+		zlog.Info(ctx).Msg("no vulnerability updates: skipping GC")
 	}
 
 	return nil

--- a/scanner/updater/import.go
+++ b/scanner/updater/import.go
@@ -36,7 +36,6 @@ func Load(ctx context.Context, connString, vulnsURL string) error {
 	updater, err := vuln.New(ctx, vuln.Opts{
 		Store:         store,
 		Locker:        locker,
-		Pool:          pool,
 		MetadataStore: metadataStore,
 		URL:           vulnsURL,
 		SkipGC:        true,


### PR DESCRIPTION
### Description

When testing [VEX support](https://github.com/stackrox/stackrox/pull/12452), I noticed Scanner V4 DB's CPU was periodically active. Looking at the Scanner V4 Matcher logs, I realized that the GC is run upon every successful update cycle, even if that means there was nothing updated (success in this case just means there were no errors).

This PR now limits the GC to only run upon update cycles that not only don't error out, but also actually update something.

It's not perfect, as it's still possible a Matcher replica that does nothing towards updating the vulnerabilities runs the GC[1], but that's ok, as it's not nearly as common as this scenario.

[1] Imagine there are two Matcher replicas and there are new vulnerability updates. It is possible (highly unlikely, though) that only one of the Matchers handles all the updates when reading the "multi-bundle". But, if this were to happen and somehow both Matchers were able to get the GC lock without any kind of contention, then both Matchers will run a GC cycle. This is highly unlikely, so it's ok to ignore. We should care more about the way more common case that there are no vulnerability updates, and we still run the GC for no real reason.

I also found we needlessly require a `pgxpool` when creating a vuln updater, so I remove that here, too

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Here is what I saw in my VEX PR testing:

<img width="1361" alt="Screenshot 2024-09-12 at 2 41 28 PM" src="https://github.com/user-attachments/assets/95415148-5b74-413b-a616-c2246e0fa7cc">

Here is what I see now:

<img width="1390" alt="Screenshot 2024-09-16 at 3 22 54 PM" src="https://github.com/user-attachments/assets/d9b3eacb-6d81-4e7a-a65f-e950a8291db8">

Note the scale of the graph. This shows activity every few hours, instead of every few minutes