### PR TITLE
ROX-26240: sanitize error

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -889,7 +889,8 @@ func getOptionalQueryParams(opts *debugDumpOptions, u *url.URL) error {
 	if timeSince != "" {
 		t, err := time.Parse(layout, timeSince)
 		if err != nil {
-			return errors.Wrapf(err, "invalid timestamp value: %q\n", t)
+			log.Error(err)
+			return errors.Errorf("invalid time since value: %q\n", url.QueryEscape(timeSince))
 		}
 		opts.since = t
 	} else {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This is part of the effort to triage SAST findings.  There is a slim chance that the error converting a time could leak some unencoded user input.  So I updated it to log the time error and then to provide back to the user an encoded version of the input.  Possible this still fails the findings.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Before the change (Notice the script tags in the output have no escaping):
```
dashrews-mac:stackrox dashrews$ roxctl --insecure-skip-tls-verify -e central-stackrox.apps.ds-09-19-toothsome-kittens-s.ocp.infra.rox.systems:443 -p $(cat deploy/openshift/central-deploy/password) central debug download-diagnostics --since "2006-01-02T14:06:06.000Z"
INFO:	Downloading diagnostic bundle...
INFO:	Successfully wrote diagnostic zip file to "stackrox_diagnostic_2024_09_19_14_21_33.zip"
dashrews-mac:stackrox dashrews$ roxctl --insecure-skip-tls-verify -e central-stackrox.apps.ds-09-19-toothsome-kittens-s.ocp.infra.rox.systems:443 -p $(cat deploy/openshift/central-deploy/password) central debug download-diagnostics --since "<script>alert(document.cookie)</script>"
INFO:	Downloading diagnostic bundle...
ERROR:	could not download zip: expected status code 200, but received 400. Response Body: invalid timestamp value: "0001-01-01 00:00:00 +0000 UTC"
: parsing time "<script>alert(document.cookie)</script>" as "2006-01-02T15:04:05.000Z": cannot parse "<script>alert(document.cookie)</script>" as "2006"
```

After this PR:
- Output
```
dashrews-mac:stackrox dashrews$ roxctl --insecure-skip-tls-verify -e central-stackrox.apps.ds-09-19-toothsome-kittens-s.ocp.infra.rox.systems:443 -p $(cat deploy/openshift/central-deploy/password) central debug download-diagnostics --since "2006-01-02T14:06:06.000"
INFO:	Downloading diagnostic bundle...
ERROR:	could not download zip: expected status code 200, but received 400. Response Body: invalid time since value: "2006-01-02T14%3A06%3A06.000"
dashrews-mac:stackrox dashrews$ roxctl --insecure-skip-tls-verify -e central-stackrox.apps.ds-09-19-toothsome-kittens-s.ocp.infra.rox.systems:443 -p $(cat deploy/openshift/central-deploy/password) central debug download-diagnostics --since "2006-01-02T14:06:06.000Z"
INFO:	Downloading diagnostic bundle...
INFO:	Successfully wrote diagnostic zip file to "stackrox_diagnostic_2024_09_19_14_08_37.zip"
dashrews-mac:stackrox dashrews$ roxctl --insecure-skip-tls-verify -e central-stackrox.apps.ds-09-19-toothsome-kittens-s.ocp.infra.rox.systems:443 -p $(cat deploy/openshift/central-deploy/password) central debug download-diagnostics --since "<script>alert(document.cookie)</script>"
INFO:	Downloading diagnostic bundle...
ERROR:	could not download zip: expected status code 200, but received 400. Response Body: invalid time since value: "%3Cscript%3Ealert%28document.cookie%29%3C%2Fscript%3E"
```
- Logs
```
debug/service: 2024/09/19 14:07:17.464091 service.go:892: Error: parsing time "14:06:06.018014" as "2006-01-02T15:04:05.000Z": cannot parse "14:06:06.018014" as "2006"
debug/service: 2024/09/19 14:07:51.207936 service.go:892: Error: parsing time "2006-01-02T14:06:06" as "2006-01-02T15:04:05.000Z": cannot parse "" as ".000"
debug/service: 2024/09/19 14:08:28.360040 service.go:892: Error: parsing time "2006-01-02T14:06:06.000" as "2006-01-02T15:04:05.000Z": cannot parse "" as "Z"
debug/service: 2024/09/19 14:08:37.666942 service.go:875: Info: Started writing diagnostic bundle "stackrox_diagnostic_2024_09_19_14_08_37.zip" with options: {logs:3 telemetryMode:6 withCPUProfile:false withLogImbue:true withAccessControl:true withNotifiers:true withCentral:true clusters:[] since:{wall:0 ext:63271807566 loc:<nil>} withComplianceOperator:false withDBOnly:false}
debug/service: 2024/09/19 14:08:57.788024 service.go:774: Info: Finished writing data to the diagnostic bundle
debug/service: 2024/09/19 14:10:01.169559 service.go:892: Error: parsing time "<script>alert(document.cookie)</script>" as "2006-01-02T15:04:05.000Z": cannot parse "<script>alert(document.cookie)</script>" as "2006"
```
