### PR TITLE
fix: proper use of proto OneOf wrapper in migration 202 to 203

### DIFF
--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_impl.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_impl.go
@@ -251,14 +251,7 @@ func createVulnerabilityRequest(cve string, now, expiry *protocompat.Timestamp) 
 			},
 		},
 		Req: &storage.VulnerabilityRequest_DeferralReq{
-			DeferralReq: &storage.DeferralRequest{
-				Expiry: &storage.RequestExpiry{
-					ExpiryType: storage.RequestExpiry_TIME,
-					Expiry: &storage.RequestExpiry_ExpiresOn{
-						ExpiresOn: expiry,
-					},
-				},
-			},
+			DeferralReq: getDeferralRequest(expiry),
 		},
 		Entities: &storage.VulnerabilityRequest_Cves{
 			Cves: &storage.VulnerabilityRequest_CVEs{
@@ -277,4 +270,27 @@ func exceptionName(cve string) string {
 // Creates a deterministic UUID from CVE string the specified namespace.
 func exceptionID(cve string) string {
 	return uuid.NewV5(systemGeneratedUUIDNS, exceptionName(cve)).String()
+}
+
+func getDeferralRequest(expiry *protocompat.Timestamp) *storage.DeferralRequest {
+	if expiry == nil {
+		return &storage.DeferralRequest{
+			Expiry: &storage.RequestExpiry{
+				// Expiry is a OneOf type, and the OneOf wrapper types should be
+				// filled with valid data. Reflection-based proto encoding would
+				// panic on a non-nil *storage.RequestExpiry_ExpiresOn wrapping
+				// a nil timestamp object.
+				Expiry:     nil,
+				ExpiryType: storage.RequestExpiry_TIME,
+			},
+		}
+	}
+	return &storage.DeferralRequest{
+		Expiry: &storage.RequestExpiry{
+			ExpiryType: storage.RequestExpiry_TIME,
+			Expiry: &storage.RequestExpiry_ExpiresOn{
+				ExpiresOn: expiry,
+			},
+		},
+	}
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The upgrade of the grpc dependency to 1.66 also pulls an update of VTProto which changes some the encoding behaviour of empty oneOf types (to encode similarly to github.com/golang/protobuf/proto).

After investigation of the (reflection-based) encoding behaviour of the golang protobuf library, it turns out the way the vulnerability requests are built from CVE exceptions is flawed as it generated a non-nil oneOf wrapper type wrapping around a nil object.

This fixes the way this specific object is encoded in the test corner case of `cve-2023-138`.

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ _update is not needed_
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ _is not needed_

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->
<!--
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
- [x] automated tests already exist for the impacted piece of code
#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Stripped of the generated encoding code, and tested how `proto.Marshal` encodes the system-built vulnerability request.

The existing CI should ensure that the refactor does not break the existing tests.