### PR TITLE
ROX-25617: Add display value for external policy origin in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
@@ -16,7 +16,7 @@ import { NotifierIntegration } from 'types/notifier.proto';
 import { BasePolicy } from 'types/policy.proto';
 import MitreAttackVectorsViewContainer from 'Containers/MitreAttackVectors/MitreAttackVectorsViewContainer';
 
-import { formatCategories, formatType } from '../policies.utils';
+import { formatCategories, getPolicyOriginLabel } from '../policies.utils';
 import Notifier from './Notifier';
 
 type PolicyOverviewProps = {
@@ -33,7 +33,6 @@ function PolicyOverview({
     const {
         categories,
         description,
-        isDefault,
         notifiers: notifierIds,
         rationale,
         remediation,
@@ -56,7 +55,7 @@ function PolicyOverview({
                         desc={<PolicySeverityIconText severity={severity} />}
                     />
                     <DescriptionListItem term="Categories" desc={formatCategories(categories)} />
-                    <DescriptionListItem term="Type" desc={formatType(isDefault)} />
+                    <DescriptionListItem term="Origin" desc={getPolicyOriginLabel(policy)} />
                     <DescriptionListItem term="Description" desc={description} />
                     <DescriptionListItem term="Rationale" desc={rationale} />
                     <DescriptionListItem term="Guidance" desc={remediation} />

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -554,6 +554,7 @@ function getPolicy(errors: { id?: boolean; name?: boolean } = {}): ImportPolicie
                     criteriaLocked: false,
                     mitreVectorsLocked: false,
                     eventSource: 'NOT_APPLICABLE',
+                    source: 'IMPERATIVE',
                 },
                 errors: errorResponse,
             },

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -36,12 +36,13 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { policiesBasePath } from 'routePaths';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { SearchFilter } from 'types/search';
-import { columns, defaultPolicyLabel, userPolicyLabel } from './PoliciesTable.utils';
+import { columns } from './PoliciesTable.utils';
 import {
     LabelAndNotifierIdsForType,
     formatLifecycleStages,
     formatNotifierCountsWithLabelStrings,
     getLabelAndNotifierIdsForTypes,
+    getPolicyOriginLabel,
 } from '../policies.utils';
 
 import './PoliciesTable.css';
@@ -420,9 +421,7 @@ function PoliciesTable({
                                     <Td dataLabel="Status">
                                         <PolicyDisabledIconText isDisabled={disabled} />
                                     </Td>
-                                    <Td dataLabel="Origin">
-                                        {isDefault ? defaultPolicyLabel : userPolicyLabel}
-                                    </Td>
+                                    <Td dataLabel="Origin">{getPolicyOriginLabel(policy)}</Td>
                                     <Td dataLabel="Notifiers">
                                         {notifierCountsWithLabelStrings.length === 0 ? (
                                             '-'

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -1,15 +1,6 @@
 import { sortSeverity, sortAsciiCaseInsensitive, sortValueByLength } from 'sorters/sorters';
 import { ListPolicy } from 'types/policy.proto';
-
-export const defaultPolicyLabel = 'System';
-export const userPolicyLabel = 'User';
-
-function sortPolicyOrigin(a, b) {
-    const aOrigin = a ? defaultPolicyLabel : userPolicyLabel;
-    const bOrigin = b ? defaultPolicyLabel : userPolicyLabel;
-
-    return sortAsciiCaseInsensitive(aOrigin, bOrigin);
-}
+import { getPolicyOriginLabel } from '../policies.utils';
 
 export const columns = [
     {
@@ -25,7 +16,9 @@ export const columns = [
     {
         Header: 'Origin',
         accessor: 'isDefault',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => sortPolicyOrigin(a.isDefault, b.isDefault),
+        sortMethod: (a: ListPolicy, b: ListPolicy) =>
+            sortAsciiCaseInsensitive(getPolicyOriginLabel(a), getPolicyOriginLabel(b)),
+        width: 20 as const,
     },
     {
         Header: 'Notifiers',

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -1,5 +1,5 @@
 import { ClientPolicy, Policy } from 'types/policy.proto';
-import { getClientWizardPolicy, getServerPolicy } from './policies.utils';
+import { getClientWizardPolicy, getPolicyOriginLabel, getServerPolicy } from './policies.utils';
 
 describe('policies.utils', () => {
     describe('getClientWizardPolicy', () => {
@@ -108,6 +108,7 @@ describe('policies.utils', () => {
                 criteriaLocked: false,
                 mitreVectorsLocked: false,
                 isDefault: false,
+                source: 'IMPERATIVE',
             };
 
             const clientPolicy: ClientPolicy = {
@@ -273,6 +274,7 @@ describe('policies.utils', () => {
                         ],
                     },
                 ],
+                source: 'IMPERATIVE',
             };
 
             expect(getClientWizardPolicy(serverPolicy)).toEqual(clientPolicy);
@@ -381,6 +383,7 @@ describe('policies.utils', () => {
                 criteriaLocked: false,
                 mitreVectorsLocked: false,
                 isDefault: false,
+                source: 'IMPERATIVE',
             };
 
             const clientPolicy: ClientPolicy = {
@@ -546,9 +549,27 @@ describe('policies.utils', () => {
                         ],
                     },
                 ],
+                source: 'IMPERATIVE',
             };
 
             expect(getServerPolicy(clientPolicy)).toEqual(serverPolicy);
+        });
+    });
+
+    describe('getPolicyOriginLabel', () => {
+        it('should return the origin display value for a policy', () => {
+            expect(
+                getPolicyOriginLabel({ isDefault: true, source: 'IMPERATIVE' } as const)
+            ).toEqual('System');
+            expect(
+                getPolicyOriginLabel({ isDefault: false, source: 'IMPERATIVE' } as const)
+            ).toEqual('Locally managed');
+            expect(
+                getPolicyOriginLabel({ isDefault: true, source: 'DECLARATIVE' } as const)
+            ).toEqual('System');
+            expect(
+                getPolicyOriginLabel({ isDefault: false, source: 'DECLARATIVE' } as const)
+            ).toEqual('Externally managed');
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -26,6 +26,7 @@ import {
     PolicyGroup,
     PolicyDeploymentExclusion,
     PolicyImageExclusion,
+    ListPolicy,
 } from 'types/policy.proto';
 import { SearchFilter } from 'types/search';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
@@ -69,6 +70,7 @@ export const initialPolicy: ClientPolicy = {
     mitreAttackVectors: [],
     criteriaLocked: false,
     mitreVectorsLocked: false,
+    source: 'IMPERATIVE',
 };
 
 export type PoliciesSearch = {
@@ -181,12 +183,6 @@ export function getExcludedImageNames(exclusions: PolicyExclusion[]): string[] {
         });
 
     return excludedImageNames;
-}
-
-// isDefault
-
-export function formatType(isDefault: boolean): string {
-    return isDefault ? 'System default' : 'User generated';
 }
 
 // lifecycleStages
@@ -710,4 +706,14 @@ export function getEmptyPolicyFieldCard(fieldKey) {
         negate: false,
         fieldKey,
     };
+}
+
+export function getPolicyOriginLabel({
+    isDefault,
+    source,
+}: Pick<ListPolicy, 'isDefault' | 'source'>) {
+    if (isDefault) {
+        return 'System';
+    }
+    return source === 'IMPERATIVE' ? 'Locally managed' : 'Externally managed';
 }

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -9,6 +9,7 @@ export type ListPolicy = {
     lastUpdated: string | null; // ISO 8601 date string
     eventSource: PolicyEventSource;
     readonly isDefault: boolean; // Indicates the policy is a default policy if true and a custom policy if false.
+    readonly source: 'IMPERATIVE' | 'DECLARATIVE';
 };
 
 export const policySeverities = [


### PR DESCRIPTION
### Description

Updates the "Origin" column on the policies table to account for new, externally managed policies. This also replaces the "Type" field on policy detail pages with "Origin" for consistency in naming, since both sections communicate the same information but using a different term.

Depends on #12659 

_Note that a follow up conversation is on the agenda with UX to determine how closely we should align Access Control sections with the below terminology._

Before:
|`Policy.isDefault`|`Policy.source`|display text|
|-----------------|-----------------|-----------|
|true|`undefined`|**System**|
|false|`undefined`|**User**|

After
|`Policy.isDefault`|`Policy.source`|display text|
|-----------------|-----------------|-----------|
|true|IMPERATIVE|**System**|
|true|DECLARATIVE|**System**|
|false|IMPERATIVE|**Locally managed**|
|false|DECLARATIVE|**Externally managed**|

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the policies page and view the field values:
![image](https://github.com/user-attachments/assets/b8eefaf7-debe-4650-9ae3-ba75e0636c6d)
Test sorting:
![image](https://github.com/user-attachments/assets/bfabe127-5c97-4514-a323-2314db99ebbf)
![image](https://github.com/user-attachments/assets/1206c1e7-02c0-4d91-9419-b9d7c06962b0)

Visit a Policy detail page and see "Type" replaced with "Origin", and using the same data values from the table:
![image](https://github.com/user-attachments/assets/17b6b6e0-f569-49b1-b43d-37c205dcdda8)

Visit a Policy detail page via Violations and see the same:
![image](https://github.com/user-attachments/assets/e1a9b4c7-d60c-4105-a5da-7c8798e26b1c)
