### PR TITLE
chore(ui): Upgrade TypeScript 5.6.2 plus types devDependencies in ui

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -106,11 +106,11 @@
                 "@testing-library/jest-dom": "^6.5.0",
                 "@testing-library/react": "^16.0.1",
                 "@testing-library/user-event": "^14.5.2",
-                "@types/jest": "^29.5.12",
-                "@types/lodash": "^4.17.4",
+                "@types/jest": "^29.5.13",
+                "@types/lodash": "^4.17.7",
                 "@types/pluralize": "^0.0.33",
-                "@types/qs": "^6.9.15",
-                "@types/react": "^18.3.3",
+                "@types/qs": "^6.9.16",
+                "@types/react": "^18.3.6",
                 "@types/react-dom": "^18.3.0",
                 "@types/react-redux": "^7.1.33",
                 "@types/segment-analytics": "^0.0.38",
@@ -147,7 +147,7 @@
                 "redux-saga-test-plan": "^3.7.0",
                 "tailwindcss": "^2.0.3",
                 "ts-jest": "^29.2.5",
-                "typescript": "^5.5.4"
+                "typescript": "^5.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -4911,9 +4911,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.12",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+            "version": "29.5.13",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.13.tgz",
+            "integrity": "sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -4943,9 +4943,9 @@
             "dev": true
         },
         "node_modules/@types/lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-AwO2SVjuBwBZ46cYQEilUVn+ILc= sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
+            "version": "4.17.7",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+            "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -4991,9 +4991,9 @@
             "dev": true
         },
         "node_modules/@types/qs": {
-            "version": "6.9.15",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-            "integrity": "sha1-rd6KBg7JwwWoLeG6vBBW5zvWTc4= sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+            "version": "6.9.16",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+            "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
             "dev": true
         },
         "node_modules/@types/raf": {
@@ -5009,9 +5009,9 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.3.3",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-            "integrity": "sha1-lnkCCJUxiwkV16OrAE2S0zN1xF8= sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+            "version": "18.3.6",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.6.tgz",
+            "integrity": "sha512-CnGaRYNu2iZlkGXGrOYtdg5mLK8neySj0woZ4e2wF/eli2E6Sazmq5X+Nrj6OBrrFVQfJWTUFeqAzoRhWQXYvg==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -19882,18 +19882,6 @@
                 "strip-ansi": "^6.0.1"
             }
         },
-        "node_modules/renderkid/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk= sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/request-progress": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -21062,17 +21050,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc= sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk= sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
@@ -22240,9 +22217,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -102,6 +102,7 @@
         "test-watch": "react-app-rewired test",
         "lint": "eslint --quiet .",
         "lint:fix": "eslint --fix --quiet .",
+        "tsc": "tsc",
         "cypress-open": "./scripts/cypress.sh open --config defaultCommandTimeout=8000",
         "cypress-spec": "./scripts/cypress.sh run --spec",
         "cypress-component": "./scripts/cypress-component.sh open --component",
@@ -128,11 +129,11 @@
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
-        "@types/jest": "^29.5.12",
-        "@types/lodash": "^4.17.4",
+        "@types/jest": "^29.5.13",
+        "@types/lodash": "^4.17.7",
         "@types/pluralize": "^0.0.33",
-        "@types/qs": "^6.9.15",
-        "@types/react": "^18.3.3",
+        "@types/qs": "^6.9.16",
+        "@types/react": "^18.3.6",
         "@types/react-dom": "^18.3.0",
         "@types/react-redux": "^7.1.33",
         "@types/segment-analytics": "^0.0.38",
@@ -169,7 +170,7 @@
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.5.4"
+        "typescript": "^5.6.2"
     },
     "resolutions": {
         "@jest/types": "^29.6.3",

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -268,7 +268,7 @@ export function formatVulnerabilityData(
         const uniqueComponents = new Set(allVulnerableComponents.map((c) => c.name));
         const affectedComponentsText =
             uniqueComponents.size === 1
-                ? uniqueComponents.values().next().value
+                ? (uniqueComponents.values().next().value as string)
                 : `${uniqueComponents.size} components`;
 
         const vulnerabilityImages = images


### PR DESCRIPTION
### Description

https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/

https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#disallowed-nullish-and-truthy-checks

> the compiler now errors when it can syntactically determine a truthy or nullish check will always evaluate in a specific way.

> Note that certain expressions are still allowed, even if they are always truthy or nullish. Specifically, `true`, `false`, `0`, and `1` are all still allowed despite always being truthy or falsy.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#region-prioritized-diagnostics-in-editors

> When TypeScript’s language service is asked for the diagnostics for a file (things like errors, suggestions, and deprecations), it would typically require checking the *entire file*. Most of the time this is fine, but in extremely large files it can incur a delay.

> Instead of just requesting diagnostics for a set of files, editors can now also provide a relevant region of a given file – and the intent is that this will typically be the region of the file that is currently visible to a user.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#granular-commit-characters

> TypeScript’s language service now provides its own *commit characters* for each completion item. Commit characters are specific characters that, when typed, will automatically commit the currently-suggested completion item.

> What this means is that over time your editor will now more frequently commit to the currently-suggested completion item when you type certain characters.

What’s next?

https://github.com/microsoft/TypeScript/issues/59905

TypeScript 5.7 Final Release target is 2024-11-21 around sprint 4.7C

### Errors

```
src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts:255:5 - error TS2322: Type '{ vulnerabilityId: string; cve: string; operatingSystem: string; severity: "UNKNOWN_VULNERABILITY_SEVERITY" | "LOW_VULNERABILITY_SEVERITY" | "MODERATE_VULNERABILITY_SEVERITY" | "IMPORTANT_VULNERABILITY_SEVERITY" | "CRITICAL_VULNERABILITY_SEVERITY"; ... 5 more ...; pendingExceptionCount: number; }[]' is not assignable to type 'FormattedDeploymentVulnerability[]'.
  Type '{ vulnerabilityId: string; cve: string; operatingSystem: string; severity: "UNKNOWN_VULNERABILITY_SEVERITY" | "LOW_VULNERABILITY_SEVERITY" | "MODERATE_VULNERABILITY_SEVERITY" | "IMPORTANT_VULNERABILITY_SEVERITY" | "CRITICAL_VULNERABILITY_SEVERITY"; ... 5 more ...; pendingExceptionCount: number; }' is not assignable to type 'FormattedDeploymentVulnerability'.
    Types of property 'affectedComponentsText' are incompatible.
      Type 'string | undefined' is not assignable to type 'string'.
        Type 'undefined' is not assignable to type 'string'.

255     return deployment.imageVulnerabilities.map((vulnerability) => {
        ~~~~~~

Found 1 error in src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts:255
```

Apparently a side-effect for work on iterators (that I omitted from the high points).

Because `uniqueComponents.size === 1` add `as string` type assertion.

Although `[...uniqueComponents]` would be even clearer, TypeScript compiler sees `"target": "es5"` even though webpack and babel use `"browserslist": ["Chrome >= 80"]` from package.json file.

### Residue

1. Investige whether compile and Visual Studio Code editor can play by the same rules as build.
2. Even if not, what are pro and con of `downlevelIteration` option?
    https://www.typescriptlang.org/tsconfig/#downlevelIteration

### Bonus

1. Update 4 types packages which affect compile and lint.
2. Add `npm run tsc` to `scripts`, because `npm run build` takes several minutes and seems to stop at first compile error.
    Note: although `yarn tsc` was possible without need to add to `scripts`, even better to make the command visible (beyond necessity to do so).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -2043 = 4616822 - 4618865
        total -1838 = 11699313 - 11701151
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves, click **Deployments**, and then in table body, click deployment link:

    * Before change: see presence of TypeScript error and name if one component in **Affected components**
        ![WorkloadCVEs_deployment](https://github.com/user-attachments/assets/370045b1-2950-41da-bc52-81e8019e23c0)

    * After change: see absence of TypeScript error and ditto in **Affected components**

#### Integration testing

* vulnerabilities/workload-cves/deploymentSingle.test.js
