### PR TITLE
ROX-25932: Add generate download button for compliance reporting

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -21,6 +21,7 @@ import { scanConfigDetailsPath } from './compliance.scanConfigs.routes';
 export type ScanConfigActionDropdownProps = {
     handleRunScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
     handleSendReport: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    handleGenerateDownload: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
     isScanning: boolean;
     scanConfigResponse: ComplianceScanConfigurationStatus;
 };
@@ -28,12 +29,14 @@ export type ScanConfigActionDropdownProps = {
 function ScanConfigActionDropdown({
     handleRunScanConfig,
     handleSendReport,
+    handleGenerateDownload,
     isScanning,
     scanConfigResponse,
 }: ScanConfigActionDropdownProps): ReactElement {
     const history = useHistory();
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isComplianceReportingEnabled = isFeatureFlagEnabled('ROX_COMPLIANCE_REPORTING');
+    const isReportJobsEnabled = isFeatureFlagEnabled('ROX_SCAN_SCHEDULE_REPORT_JOBS');
 
     const [isOpen, setIsOpen] = useState(false);
 
@@ -102,6 +105,20 @@ function ScanConfigActionDropdown({
             </DropdownItem>
         );
         /* eslint-enable no-nested-ternary */
+    }
+
+    if (isComplianceReportingEnabled && isReportJobsEnabled) {
+        dropdownItems.push(
+            <DropdownItem
+                key="Generate download"
+                component="button"
+                onClick={() => {
+                    handleGenerateDownload(scanConfigResponse);
+                }}
+            >
+                Generate download
+            </DropdownItem>
+        );
     }
 
     return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -15,6 +15,7 @@ export type ScanConfigActionsColumnProps = {
     handleDeleteScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
     handleRunScanConfig: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
     handleSendReport: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
+    handleGenerateDownload: (scanConfigResponse: ComplianceScanConfigurationStatus) => void;
     scanConfigResponse: ComplianceScanConfigurationStatus;
 };
 
@@ -22,6 +23,7 @@ function ScanConfigActionsColumn({
     handleDeleteScanConfig,
     handleRunScanConfig,
     handleSendReport,
+    handleGenerateDownload,
     scanConfigResponse,
 }: ScanConfigActionsColumnProps): ReactElement {
     const history = useHistory();
@@ -76,6 +78,13 @@ function ScanConfigActionsColumn({
             },
         },
         /* eslint-enable no-nested-ternary */
+        {
+            title: 'Generate download',
+            onClick: (event) => {
+                event.preventDefault();
+                handleGenerateDownload(scanConfigResponse);
+            },
+        },
         {
             isSeparator: true,
         },

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -24,10 +24,10 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
 
-import { complianceEnhancedCoveragePath, complianceEnhancedSchedulesPath } from 'routePaths';
+import { complianceEnhancedSchedulesPath } from 'routePaths';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import PageTitle from 'Components/PageTitle';
@@ -81,7 +81,6 @@ function ScanConfigsTablePage({
     >([]);
     const [scanConfigDeletionErrors, setScanConfigDeletionErrors] = useState<Error[]>([]);
     const [isDeletingScanConfigs, setIsDeletingScanConfigs] = useState(false);
-    const history = useHistory();
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
@@ -159,7 +158,7 @@ function ScanConfigsTablePage({
 
     function handleSendReport(scanConfigResponse: ComplianceScanConfigurationStatus) {
         clearAlertObj();
-        runComplianceReport(scanConfigResponse.id)
+        runComplianceReport(scanConfigResponse.id, 'EMAIL')
             .then(() => {
                 setAlertObj({
                     type: 'success',
@@ -170,6 +169,24 @@ function ScanConfigsTablePage({
                 setAlertObj({
                     type: 'danger',
                     title: 'Could not send a report',
+                    children: getAxiosErrorMessage(error),
+                });
+            });
+    }
+
+    function handleGenerateDownload(scanConfigResponse: ComplianceScanConfigurationStatus) {
+        clearAlertObj();
+        runComplianceReport(scanConfigResponse.id, 'DOWNLOAD')
+            .then(() => {
+                setAlertObj({
+                    type: 'success',
+                    title: 'The report generation has started and will be available for download once complete',
+                });
+            })
+            .catch((error) => {
+                setAlertObj({
+                    type: 'danger',
+                    title: 'Could not generate a report',
                     children: getAxiosErrorMessage(error),
                 });
             });
@@ -208,6 +225,7 @@ function ScanConfigsTablePage({
                                 handleDeleteScanConfig={handleDeleteScanConfig}
                                 handleRunScanConfig={handleRunScanConfig}
                                 handleSendReport={handleSendReport}
+                                handleGenerateDownload={handleGenerateDownload}
                                 scanConfigResponse={scanSchedule}
                             />
                         </Td>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -86,11 +86,29 @@ function ViewScanConfigDetail({
 
     function handleSendReport(scanConfigResponse: ComplianceScanConfigurationStatus) {
         clearAlertObj();
-        runComplianceReport(scanConfigResponse.id)
+        runComplianceReport(scanConfigResponse.id, 'EMAIL')
             .then(() => {
                 setAlertObj({
                     type: 'success',
                     title: 'Successfully requested to send a report',
+                });
+            })
+            .catch((error) => {
+                setAlertObj({
+                    type: 'danger',
+                    title: 'Could not send a report',
+                    children: getAxiosErrorMessage(error),
+                });
+            });
+    }
+
+    function handleGenerateDownload(scanConfigResponse: ComplianceScanConfigurationStatus) {
+        clearAlertObj();
+        runComplianceReport(scanConfigResponse.id, 'DOWNLOAD')
+            .then(() => {
+                setAlertObj({
+                    type: 'success',
+                    title: 'The report generation has started and will be available for download once complete',
                 });
             })
             .catch((error) => {
@@ -131,6 +149,7 @@ function ViewScanConfigDetail({
                                     <ScanConfigActionDropdown
                                         handleRunScanConfig={handleRunScanConfig}
                                         handleSendReport={handleSendReport}
+                                        handleGenerateDownload={handleGenerateDownload}
                                         isScanning={
                                             isTriggeringRescan /* ||
                                             scanConfig.lastExecutedTime === null */

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -198,11 +198,16 @@ export type ComplianceRunReportResponse = {
 /*
  * Run an on demand compliance report for the scan configuration ID.
  */
-export function runComplianceReport(scanConfigId: string): Promise<ComplianceRunReportResponse> {
+export function runComplianceReport(
+    scanConfigId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    scanNotificationMethod: 'EMAIL' | 'DOWNLOAD'
+): Promise<ComplianceRunReportResponse> {
+    const body = { scanConfigId };
+    // @TODO: Add the scanNotificationMethod to the PUT Body when the API can handle it
+    // const body = { scanConfigId, scanNotificationMethod };
     return axios
-        .put<ComplianceRunReportResponse>(`${complianceScanConfigBaseUrl}/reports/run`, {
-            scanConfigId,
-        })
+        .put<ComplianceRunReportResponse>(`${complianceScanConfigBaseUrl}/reports/run`, body)
         .then((response) => {
             return response.data;
         });


### PR DESCRIPTION
### Description

This PR does the following:

1. Add an option in the actions dropdown to "Generate download".
2. Add an option in the table row actions to "Generate download".
3. Update the `runComplianceReport` function to work for both sending a report and generating a download.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and Quality

- [x] the change is production ready: the change is GA or otherwise, the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes
 
#### How I validated my change

Checked if the UI works as expected
