### PR TITLE
ROX-26661: Allow revert of auth provider options and do so on error

### DIFF
--- a/central/authprovider/service/service_impl_test.go
+++ b/central/authprovider/service/service_impl_test.go
@@ -1,0 +1,110 @@
+//go:build sql_integration
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	authProviderDatastore "github.com/stackrox/rox/central/authprovider/datastore"
+	groupDatastore "github.com/stackrox/rox/central/group/datastore"
+	roleDatastore "github.com/stackrox/rox/central/role/datastore"
+	roleMapper "github.com/stackrox/rox/central/role/mapper"
+	userDatastore "github.com/stackrox/rox/central/user/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+	openshiftAuth "github.com/stackrox/rox/pkg/auth/authproviders/openshift"
+	authTokenMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAuthProviderService(t *testing.T) {
+	suite.Run(t, new(authProviderServiceTestSuite))
+}
+
+type authProviderServiceTestSuite struct {
+	suite.Suite
+
+	db *pgtest.TestPostgres
+
+	service Service
+
+	mockCtrl *gomock.Controller
+}
+
+func (s *authProviderServiceTestSuite) SetupSuite() {
+	s.db = pgtest.ForT(s.T())
+
+	s.mockCtrl = gomock.NewController(s.T())
+
+	tokenIssuerFactory := authTokenMocks.NewMockIssuerFactory(s.mockCtrl)
+	tokenIssuerFactory.EXPECT().CreateIssuer(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
+
+	roleDS, err := roleDatastore.GetTestPostgresDataStore(s.T(), s.db)
+	require.NoError(s.T(), err)
+	authProviderDS := authProviderDatastore.GetTestPostgresDataStore(s.T(), s.db)
+	groupDS := groupDatastore.GetTestPostgresDataStore(s.T(), s.db, roleDS, authProviderDS)
+	userDS := userDatastore.GetTestDatastore(s.T())
+	mapperFactory := roleMapper.NewStoreBasedMapperFactory(groupDS, roleDS, userDS)
+	providerRegistry := authproviders.NewStoreBackedRegistry(
+		"/sso/",
+		"/auth/response/generic",
+		authProviderDS,
+		tokenIssuerFactory,
+		mapperFactory,
+	)
+
+	ctx := sac.WithAllAccess(context.Background())
+	providerRegistry.RegisterBackendFactory(ctx, openshiftAuth.TypeName, openshiftAuth.NewTestFactoryFunc(s.T()))
+
+	s.service = New(providerRegistry, groupDS)
+}
+
+func (s *authProviderServiceTestSuite) TearDownSuite() {
+	s.db.Teardown(s.T())
+}
+
+func (s *authProviderServiceTestSuite) TestPostDuplicateAuthProvider() {
+	ctx := sac.WithAllAccess(context.Background())
+	svc := s.service
+
+	assert.Zero(s.T(), openshiftAuth.GetRegisteredBackendCount())
+
+	postRequest := &v1.PostAuthProviderRequest{
+		Provider: &storage.AuthProvider{
+			Name:       "OpenShift",
+			Type:       openshiftAuth.TypeName,
+			Config:     map[string]string{},
+			UiEndpoint: "central.svc",
+			Enabled:    true,
+			Traits:     &storage.Traits{MutabilityMode: storage.Traits_ALLOW_MUTATE},
+		},
+	}
+
+	otherPostRequest := postRequest.CloneVT()
+	otherPostRequest.Provider.Name = "OpenShift 2"
+
+	// First call should succeed and register an auth provider backend
+	// in the openshiftAuth certificate watch loop.
+	_, err := svc.PostAuthProvider(ctx, postRequest)
+	s.NoError(err)
+	s.Equal(1, openshiftAuth.GetRegisteredBackendCount())
+
+	// Second call should register a backend, hit an error when storing
+	// the auth provider in DB and deregister its backend.
+	_, err = svc.PostAuthProvider(ctx, postRequest)
+	s.Error(err)
+	s.Equal(1, openshiftAuth.GetRegisteredBackendCount())
+
+	// Call with another provider name should succeed and register another
+	// auth provider backend in the openshiftAuth certificate watch loop.
+	_, err = svc.PostAuthProvider(ctx, otherPostRequest)
+	s.NoError(err)
+	s.Equal(2, openshiftAuth.GetRegisteredBackendCount())
+}

--- a/central/main.go
+++ b/central/main.go
@@ -524,6 +524,7 @@ func startGRPCServer() {
 	// is the case, we can be setting up an auth providers which won't work.
 	if env.EnableOpenShiftAuth.BooleanSetting() {
 		authProviderBackendFactories[openshift.TypeName] = openshift.NewFactory
+		openshift.WatchCertPool()
 	}
 
 	for typeName, factoryCreator := range authProviderBackendFactories {

--- a/central/user/datastore/datastore_test_constructors.go
+++ b/central/user/datastore/datastore_test_constructors.go
@@ -1,0 +1,13 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/central/user/datastore/internal/store"
+)
+
+// GetTestDatastore returns a datastore instance for testing purposes.
+func GetTestDatastore(_ testing.TB) DataStore {
+	testStorage := store.New()
+	return New(testStorage)
+}

--- a/pkg/auth/authproviders/backend_factory.go
+++ b/pkg/auth/authproviders/backend_factory.go
@@ -21,6 +21,9 @@ type BackendFactory interface {
 	// Note: we only support `mappings` for OIDC auth provider.
 	CreateBackend(ctx context.Context, id string, uiEndpoints []string, config map[string]string, mappings map[string]string) (Backend, error)
 
+	// CleanupBackend cleans up the resources allocated at backend creation.
+	CleanupBackend(id string) error
+
 	// ProcessHTTPRequest is the dispatcher for HTTP/1.1 requests to `<sso-prefix>/<provider-type>/...`. The envisioned
 	// workflow consists of extracting the specific auth provider ID and clientState from the request, usually via a
 	// `state` parameter, and returning this provider ID and clientState from the function (with the Registry taking

--- a/pkg/auth/authproviders/basic/backend_factory_impl.go
+++ b/pkg/auth/authproviders/basic/backend_factory_impl.go
@@ -45,6 +45,10 @@ func (f *factory) CreateBackend(ctx context.Context, id string, _ []string, _ ma
 	return be, nil
 }
 
+func (f *factory) CleanupBackend(_ string) error {
+	return nil
+}
+
 func (f *factory) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (string, string, error) {
 	restPath := strings.TrimPrefix(r.URL.Path, f.urlPathPrefix)
 	if len(restPath) == len(r.URL.Path) {

--- a/pkg/auth/authproviders/iap/backend_factory_impl.go
+++ b/pkg/auth/authproviders/iap/backend_factory_impl.go
@@ -33,6 +33,10 @@ func (f *factory) CreateBackend(_ context.Context, id string, _ []string, config
 	return newBackend(audience, loginURL)
 }
 
+func (f *factory) CleanupBackend(_ string) error {
+	return nil
+}
+
 func (f *factory) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (string, string, error) {
 	if r.Method != http.MethodGet {
 		return "", "", httputil.Errorf(http.StatusMethodNotAllowed, "invalid method %q, only GET requests are allowed", r.Method)

--- a/pkg/auth/authproviders/oidc/backend_factory_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_factory_impl.go
@@ -53,6 +53,10 @@ func (f *factory) CreateBackend(ctx context.Context, id string, uiEndpoints []st
 	return newBackend(ctx, id, uiEndpoints, f.callbackURLPath, config, f.providerFactoryFunc, f.oauthExchange, f.noncePool, mappings)
 }
 
+func (f *factory) CleanupBackend(_ string) error {
+	return nil
+}
+
 func (f *factory) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (string, string, error) {
 	if r.URL.Path != f.callbackURLPath {
 		return "", "", httputil.NewError(http.StatusNotFound, "Not Found")

--- a/pkg/auth/authproviders/openshift/backend_factory_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_factory_impl.go
@@ -35,6 +35,11 @@ func (f *factory) CreateBackend(_ context.Context, id string, _ []string, config
 	return newBackend(id, f.callbackURLPath, config)
 }
 
+func (f *factory) CleanupBackend(id string) error {
+	deregisterBackend(id)
+	return nil
+}
+
 func (f *factory) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (providerID string, clientState string, err error) {
 	if r.URL.Path != f.callbackURLPath {
 		return "", "", httputil.NewError(http.StatusNotFound, "Not Found")

--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -80,10 +80,7 @@ func newBackend(id string, callbackURLPath string, _ map[string]string) (authpro
 		openshiftConnector:  openshiftConnector,
 	}
 
-	// Start watching the underlying cert pool injected into the openshift connector.
-	// In case the cert pool changes, we re-create the openshift connector so that newly added trusted CAs
-	// are being added included.
-	watchCertPool(b.recreateOpenshiftConnector)
+	registerBackend(b)
 
 	return b, nil
 }

--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -66,9 +66,12 @@ type openShiftSettings struct {
 	trustedCertPool *x509.CertPool
 }
 
-var _ authproviders.RefreshTokenEnabledBackend = (*backend)(nil)
+var (
+	_ authproviders.Backend                    = (*backend)(nil)
+	_ authproviders.RefreshTokenEnabledBackend = (*backend)(nil)
+)
 
-func newBackend(id string, callbackURLPath string, _ map[string]string) (authproviders.Backend, error) {
+func newBackend(id string, callbackURLPath string, _ map[string]string) (*backend, error) {
 	openshiftConnector, err := createOpenshiftConnector()
 	if err != nil {
 		return nil, err
@@ -79,8 +82,6 @@ func newBackend(id string, callbackURLPath string, _ map[string]string) (authpro
 		baseRedirectURLPath: callbackURLPath,
 		openshiftConnector:  openshiftConnector,
 	}
-
-	registerBackend(b)
 
 	return b, nil
 }

--- a/pkg/auth/authproviders/openshift/testutils.go
+++ b/pkg/auth/authproviders/openshift/testutils.go
@@ -1,0 +1,30 @@
+package openshift
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+)
+
+// NewTestFactoryFunc returns a function that creates a new factory for OpenShift oauth authprovider backends.
+func NewTestFactoryFunc(t testing.TB) func(urlPathPrefix string) authproviders.BackendFactory {
+	return func(urlPathPrefix string) authproviders.BackendFactory {
+		urlPathPrefix = strings.TrimRight(urlPathPrefix, "/") + "/"
+		return &factory{
+			callbackURLPath: urlPathPrefix + callbackRelativePath,
+			newBackendFunc:  newTestBackendFunc(t),
+		}
+	}
+}
+
+func newTestBackendFunc(_ testing.TB) func(id string, callbackURL string, config map[string]string) (*backend, error) {
+	return func(id string, callbackURL string, _ map[string]string) (*backend, error) {
+		b := &backend{
+			id:                  id,
+			baseRedirectURLPath: callbackURL,
+			openshiftConnector:  nil,
+		}
+		return b, nil
+	}
+}

--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -27,7 +27,7 @@ func registerBackend(b *backend) {
 	}
 	backendRegistrationMutex.Lock()
 	defer backendRegistrationMutex.Unlock()
-	registeredBackends[b.ID()] = b
+	registeredBackends[b.id] = b
 }
 
 func deregisterBackend(id string) {
@@ -38,7 +38,7 @@ func deregisterBackend(id string) {
 
 func handleCertPoolUpdate() {
 	backends := make([]*backend, 0)
-	concurrency.WithRLock(backendRegistrationMutex, func() {
+	concurrency.WithRLock(&backendRegistrationMutex, func() {
 		for _, b := range registeredBackends {
 			backends = append(backends, b)
 		}

--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -48,6 +48,14 @@ func handleCertPoolUpdate() {
 	}
 }
 
+// GetRegisteredBackendCount gives the number of backend registered
+// in the certificate watcher update loop.
+func GetRegisteredBackendCount() int {
+	backendRegistrationMutex.RLock()
+	defer backendRegistrationMutex.RUnlock()
+	return len(registeredBackends)
+}
+
 // WatchCertPool starts watching the underlying cert pool injected into the openshift connector.
 // In case the cert pool changes, we re-create the openshift connector so that newly added trusted CAs
 // are being added included.

--- a/pkg/auth/authproviders/provider_commands.go
+++ b/pkg/auth/authproviders/provider_commands.go
@@ -16,39 +16,64 @@ import (
 
 // DefaultAddToStore adds the providers stored data to the input store.
 func DefaultAddToStore(ctx context.Context, store Store) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.doNotStore {
-			return nil
+			return noOpRevert, nil
+		}
+		providerID := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			return store.RemoveAuthProvider(ctx, providerID, true)
 		}
 		if pr.storedInfo.LastUpdated == nil {
 			pr.storedInfo.LastUpdated = protocompat.TimestampNow()
 		}
-		return store.AddAuthProvider(ctx, pr.storedInfo)
+		return revert, store.AddAuthProvider(ctx, pr.storedInfo)
 	}
 }
 
 // UpdateStore updates the stored value for the provider in the input store.
 func UpdateStore(ctx context.Context, store Store) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.doNotStore {
-			return nil
+			return noOpRevert, nil
+		}
+		oldProvider, found, err := store.GetAuthProvider(ctx, pr.storedInfo.Id)
+		if err != nil {
+			return noOpRevert, err
+		}
+		revert := func(pr *providerImpl) error {
+			if !found {
+				return store.RemoveAuthProvider(ctx, pr.storedInfo.Id, true)
+			}
+			return store.UpdateAuthProvider(ctx, oldProvider)
 		}
 		pr.storedInfo.LastUpdated = protocompat.TimestampNow()
-		return store.UpdateAuthProvider(ctx, pr.storedInfo)
+		return revert, store.UpdateAuthProvider(ctx, pr.storedInfo)
 	}
 }
 
 // DeleteFromStore removes the providers stored data from the input store.
 func DeleteFromStore(ctx context.Context, store Store, providerID string, force bool) ProviderOption {
-	return func(pr *providerImpl) error {
-		err := store.RemoveAuthProvider(ctx, providerID, force)
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldProvider, found, err := store.GetAuthProvider(ctx, pr.storedInfo.GetId())
+		if err != nil && !pr.doNotStore {
+			return noOpRevert, err
+		}
+		revert := func(pr *providerImpl) error {
+			if !found {
+				return nil
+			}
+			pr.storedInfo = oldProvider
+			return store.AddAuthProvider(ctx, oldProvider)
+		}
+		err = store.RemoveAuthProvider(ctx, providerID, force)
 		if err != nil {
 			// If it's a type we don't want to store, then we're okay with it not existing.
 			// We do this in case it was stored in the DB in a previous version.
 			if pr.doNotStore && dberrors.IsNotFound(err) {
-				return nil
+				return noOpRevert, nil
 			}
-			return err
+			return revert, err
 		}
 		// a deleted provider should no longer be accessible, but it's still cached as a token source so mark it as
 		// no longer valid
@@ -56,19 +81,19 @@ func DeleteFromStore(ctx context.Context, store Store, providerID string, force 
 			Id:      pr.storedInfo.GetId(),
 			Enabled: false,
 		}
-		return nil
+		return revert, nil
 	}
 }
 
 // UnregisterSource unregisters the token source from the source factory
 func UnregisterSource(factory tokens.IssuerFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		err := factory.UnregisterSource(pr)
 		// both DeleteFromStore and UnregisterSource mutate external stores, so regardless of order the second one
 		// can't return err and fail the change.
 		if err != nil {
 			log.Warnf("Unable to unregister token source: %v", err)
 		}
-		return nil
+		return noOpRevert, nil
 	}
 }

--- a/pkg/auth/authproviders/provider_default_options.go
+++ b/pkg/auth/authproviders/provider_default_options.go
@@ -15,29 +15,45 @@ import (
 
 // DefaultNewID sets the id of the provider to a new value if not already set.
 func DefaultNewID() ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo.GetId() != "" {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo == nil {
-			return errors.New("no storage information for auth provider")
+			return noOpRevert, errors.New("no storage information for auth provider")
+		}
+		oldID := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errors.New("no storage information for auth provider")
+			}
+			pr.storedInfo.Id = oldID
+			return nil
 		}
 		pr.storedInfo.Id = uuid.NewV4().String()
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultLoginURL fills in the login url if not set using a function that creates a url for the provider id.
 func DefaultLoginURL(fn func(authProviderID string) string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo.GetLoginUrl() != "" {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo == nil {
-			return errors.New("no storage information for auth provider")
+			return noOpRevert, errors.New("no storage information for auth provider")
+		}
+		oldLoginURL := pr.storedInfo.GetLoginUrl()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errors.New("no storage information for auth provider")
+			}
+			pr.storedInfo.LoginUrl = oldLoginURL
+			return nil
 		}
 		pr.storedInfo.LoginUrl = fn(pr.storedInfo.Id)
-		return nil
+		return revert, nil
 	}
 }
 
@@ -45,44 +61,66 @@ const tokenTTL = 12 * time.Hour
 
 // DefaultTokenIssuerFromFactory sets the token issuer of the provider from the factory if not already set.
 func DefaultTokenIssuerFromFactory(tf tokens.IssuerFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.issuer != nil {
+			return noOpRevert, nil
+		}
+		oldIssuer := pr.issuer
+		revert := func(pr *providerImpl) error {
+			pr.issuer = oldIssuer
 			return nil
 		}
 		issuer, err := tf.CreateIssuer(pr, tokens.WithTTL(tokenTTL))
 		if err != nil {
-			return errors.Wrap(err, "failed to create issuer for newly created auth provider")
+			return noOpRevert, errors.Wrap(err, "failed to create issuer for newly created auth provider")
 		}
 		pr.issuer = issuer
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultRoleMapperOption loads a role mapper from the factory if one is not set on the provider.
 func DefaultRoleMapperOption(fn func(id string) permissions.RoleMapper) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.roleMapper != nil {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo.GetId() == "" {
+			return noOpRevert, nil
+		}
+		oldRoleMapper := pr.roleMapper
+		revert := func(pr *providerImpl) error {
+			pr.roleMapper = oldRoleMapper
 			return nil
 		}
 		pr.roleMapper = fn(pr.storedInfo.GetId())
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultBackend sets a backend from the pool of backend factories if one is not set.
 func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.backend != nil {
-			return nil
+			return noOpRevert, nil
 		}
 
+		oldBackendFactory := pr.backendFactory
+		oldBackend := pr.backend
+		oldConfig := pr.storedInfo.GetConfig()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo != nil {
+				pr.storedInfo.Config = oldConfig
+			}
+			pr.backend = oldBackend
+			err := pr.backendFactory.CleanupBackend(pr.storedInfo.GetId())
+			pr.backendFactory = oldBackendFactory
+			return err
+		}
 		// Get the backend factory for the type of provider.
 		backendFactory := backendFactoryPool[pr.storedInfo.GetType()]
 		if backendFactory == nil {
-			return errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.GetType())
+			return noOpRevert, errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.GetType())
 		}
 
 		pr.backendFactory = backendFactory
@@ -90,12 +128,12 @@ func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFa
 		// Create the backend for the provider.
 		backend, err := backendFactory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), pr.storedInfo.GetClaimMappings())
 		if err != nil {
-			return errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.GetId())
+			return revert, errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.GetId())
 		}
 		pr.backend = backend
 		// We can assume that pr.storedInfo is non-nil here because pr.storedInfo.GetType() referenced a valid auth provider type.
 		pr.storedInfo.Config = backend.Config()
-		return nil
+		return revert, nil
 	}
 }
 
@@ -129,11 +167,11 @@ func DefaultOptionsForNewProvider(ctx context.Context, store Store, backendFacto
 
 // LogOptionError eats any error from the input option and logs it.
 func LogOptionError(po ProviderOption) ProviderOption {
-	return func(pr *providerImpl) error {
-		err := po(pr)
+	return func(pr *providerImpl) (RevertOption, error) {
+		revert, err := po(pr)
 		if err != nil {
 			log.Errorf("error adding option to provider: %s", err)
 		}
-		return nil
+		return revert, nil
 	}
 }

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -210,25 +210,6 @@ func WithActive(active bool) ProviderOption {
 	}
 }
 
-// WithConfig sets the config for the provider.
-func WithConfig(config map[string]string) ProviderOption {
-	return func(pr *providerImpl) (RevertOption, error) {
-		if pr.storedInfo == nil {
-			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
-		}
-		oldConfig := pr.storedInfo.GetConfig()
-		revert := func(pr *providerImpl) error {
-			if pr.storedInfo == nil {
-				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
-			}
-			pr.storedInfo.Config = oldConfig
-			return nil
-		}
-		pr.storedInfo.Config = config
-		return revert, nil
-	}
-}
-
 // WithAttributeVerifier adds an attribute verifier to the provider based on the list of
 // required attributes from the provided auth provider instance.
 func WithAttributeVerifier(stored *storage.AuthProvider) ProviderOption {
@@ -239,7 +220,7 @@ func WithAttributeVerifier(stored *storage.AuthProvider) ProviderOption {
 			return nil
 		}
 		if stored.GetRequiredAttributes() == nil {
-			return revert, nil
+			return noOpRevert, nil
 		}
 		pr.attributeVerifier = user.NewRequiredAttributesVerifier(stored.GetRequiredAttributes())
 		return revert, nil

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -34,11 +34,11 @@ func WithBackendFromFactory(ctx context.Context, factory BackendFactory) Provide
 		oldBackendFactory := pr.backendFactory
 		oldBackend := pr.backend
 		oldConfig := pr.storedInfo.GetConfig()
-		backendID := pr.storedInfo.GetId()
 		revert := func(pr *providerImpl) error {
 			if pr.storedInfo != nil {
 				pr.storedInfo.Config = oldConfig
 			}
+			backendID := pr.storedInfo.GetId()
 			pr.backend = oldBackend
 			err := pr.backendFactory.CleanupBackend(backendID)
 			pr.backendFactory = oldBackendFactory

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -15,154 +15,263 @@ var (
 	internalUpdateProviderCtx = sac.WithAllAccess(context.Background())
 )
 
+// RevertOption is a function that modifies a providerImpl.
+// Do not use Provider functions in Options, as this will try to RLock inside of a Lock and deadlock.
+// You can assume that the provider is locked for the duration of the option's execution.
+type RevertOption func(*providerImpl) error
+
 // ProviderOption is a function that modifies a providerImpl.
 // Do not use Provider functions in Options, as this will try to RLock inside of a Lock and deadlock.
 // You can assume that the provider is locked for the duration of the option's execution.
-type ProviderOption func(*providerImpl) error
+type ProviderOption func(*providerImpl) (RevertOption, error)
 
 // Options for building and updating.
 /////////////////////////////////////
 
 // WithBackendFromFactory adds a backend from the factory to the provider.
 func WithBackendFromFactory(ctx context.Context, factory BackendFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldBackendFactory := pr.backendFactory
+		oldBackend := pr.backend
+		oldConfig := pr.storedInfo.GetConfig()
+		backendID := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo != nil {
+				pr.storedInfo.Config = oldConfig
+			}
+			pr.backend = oldBackend
+			err := pr.backendFactory.CleanupBackend(backendID)
+			pr.backendFactory = oldBackendFactory
+			return err
+		}
+
 		pr.backendFactory = factory
 
 		backend, err := factory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.GetType())
+			return revert, errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.GetType())
 		}
 
 		pr.backend = backend
 		pr.storedInfo.Config = backend.Config()
-		return nil
+		return revert, nil
 	}
 }
 
 // DoNotStore indicates that this provider should not be stored.
 func DoNotStore() ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldDoNotStore := pr.doNotStore
+		revert := func(pr *providerImpl) error {
+			pr.doNotStore = oldDoNotStore
+			return nil
+		}
 		pr.doNotStore = true
-		return nil
+		return revert, nil
 	}
 }
 
 // WithRoleMapper adds a role mapper to the provider.
 func WithRoleMapper(roleMapper permissions.RoleMapper) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldRoleMapper := pr.roleMapper
+		revert := func(pr *providerImpl) error {
+			pr.roleMapper = oldRoleMapper
+			return nil
+		}
 		pr.roleMapper = roleMapper
-		return nil
+		return revert, nil
 	}
 }
 
 // WithStorageView sets the values in the store auth provider from the input value.
 func WithStorageView(stored *storage.AuthProvider) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldStoredInfo := pr.storedInfo
+		revert := func(pr *providerImpl) error {
+			pr.storedInfo = oldStoredInfo
+			return nil
+		}
 		pr.storedInfo = stored.CloneVT()
-		return nil
+		return revert, nil
 	}
 }
 
 // WithID sets the id for the provider to the input value.
 func WithID(id string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldId := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Id = oldId
+			return nil
 		}
 		pr.storedInfo.Id = id
-		return nil
+		return revert, nil
 	}
 }
 
 // WithType sets the type for the provider.
 func WithType(typ string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldType := pr.storedInfo.GetType()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Type = oldType
+			return nil
 		}
 		pr.storedInfo.Type = typ
-		return nil
+		return revert, nil
 	}
 }
 
 // WithName sets the name for the provider.
 func WithName(name string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldName := pr.storedInfo.GetName()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Name = oldName
+			return nil
 		}
 		pr.storedInfo.Name = name
-		return nil
+		return revert, nil
 	}
 }
 
 // WithEnabled sets the enabled flag for the provider.
 func WithEnabled(enabled bool) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldEnabled := pr.storedInfo.GetEnabled()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Enabled = oldEnabled
+			return nil
 		}
 		pr.storedInfo.Enabled = enabled
-		return nil
+		return revert, nil
 	}
 }
 
 // WithValidateCallback adds a callback to validate the auth provider.
 func WithValidateCallback(store Store) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldValidateCallback := pr.validateCallback
+		revert := func(pr *providerImpl) error {
+			pr.validateCallback = oldValidateCallback
+			return nil
+		}
 		pr.validateCallback = func() error {
 			return pr.ApplyOptions(WithActive(true), UpdateStore(internalUpdateProviderCtx, store))
 		}
-		return nil
+		return revert, nil
 	}
 }
 
 // WithActive sets the active flag for the provider.
 func WithActive(active bool) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldValidated := pr.storedInfo.GetValidated()
+		oldActive := pr.storedInfo.GetActive()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Active = oldActive
+			pr.storedInfo.Validated = oldValidated
+			return nil
 		}
 		pr.storedInfo.Validated = active
 		pr.storedInfo.Active = active
-		return nil
+		return revert, nil
 	}
 }
 
 // WithConfig sets the config for the provider.
 func WithConfig(config map[string]string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldConfig := pr.storedInfo.GetConfig()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Config = oldConfig
+			return nil
 		}
 		pr.storedInfo.Config = config
-		return nil
+		return revert, nil
 	}
 }
 
 // WithAttributeVerifier adds an attribute verifier to the provider based on the list of
 // required attributes from the provided auth provider instance.
 func WithAttributeVerifier(stored *storage.AuthProvider) ProviderOption {
-	return func(pr *providerImpl) error {
-		if stored.GetRequiredAttributes() == nil {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldAttributeVerifier := pr.attributeVerifier
+		revert := func(pr *providerImpl) error {
+			pr.attributeVerifier = oldAttributeVerifier
 			return nil
 		}
+		if stored.GetRequiredAttributes() == nil {
+			return revert, nil
+		}
 		pr.attributeVerifier = user.NewRequiredAttributesVerifier(stored.GetRequiredAttributes())
-		return nil
+		return revert, nil
 	}
 }
 
 // WithVisibility sets the visibility for the auth provider.
 func WithVisibility(visibility storage.Traits_Visibility) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldTraits := pr.storedInfo.GetTraits()
+		oldVisibility := oldTraits.GetVisibility()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			if oldTraits == nil {
+				pr.storedInfo.Traits = nil
+			} else {
+				pr.storedInfo.Traits.Visibility = oldVisibility
+			}
+			return nil
 		}
 		if pr.storedInfo.GetTraits() != nil {
 			pr.storedInfo.Traits.Visibility = visibility
 		} else {
 			pr.storedInfo.Traits = &storage.Traits{Visibility: visibility}
 		}
-		return nil
+		return revert, nil
 	}
 }
+
+func noOpRevert(_ *providerImpl) error { return nil }

--- a/pkg/auth/authproviders/provider_options_test.go
+++ b/pkg/auth/authproviders/provider_options_test.go
@@ -40,6 +40,8 @@ const (
 
 	baseAuthProviderName = "Auth Provider"
 	testAuthProviderName = "Test Auth Provider"
+
+	noInfoProviderCaseName = "Provider without storedInfo"
 )
 
 var (
@@ -500,7 +502,7 @@ func TestWithStorageView(t *testing.T) {
 func TestWithID(t *testing.T) {
 	option := WithID(testProviderID)
 
-	t.Run("Provider without storedInfo", func(it *testing.T) {
+	t.Run(noInfoProviderCaseName, func(it *testing.T) {
 		noStorageProvider := &providerImpl{}
 		assert.Nil(it, noStorageProvider.storedInfo)
 		assert.Empty(it, noStorageProvider.storedInfo.GetId())
@@ -565,7 +567,7 @@ func TestWithID(t *testing.T) {
 func TestWithType(t *testing.T) {
 	option := WithType(testAuthProviderType)
 
-	t.Run("Provider without storedInfo", func(it *testing.T) {
+	t.Run(noInfoProviderCaseName, func(it *testing.T) {
 		noStorageProvider := &providerImpl{}
 		assert.Nil(it, noStorageProvider.storedInfo)
 		assert.Empty(it, noStorageProvider.storedInfo.GetType())
@@ -583,11 +585,11 @@ func TestWithType(t *testing.T) {
 		storedInfo   *storage.AuthProvider
 		providerType string
 	}{
-		"Provider with stored info but no type": {
+		"Provider with storedInfo but no type": {
 			storedInfo:   &storage.AuthProvider{},
 			providerType: "",
 		},
-		"Provider with stored info and previous type": {
+		"Provider with storedInfo and previous type": {
 			storedInfo: &storage.AuthProvider{
 				Type: baseAuthProviderType,
 			},
@@ -631,7 +633,7 @@ func TestWithType(t *testing.T) {
 func TestWithName(t *testing.T) {
 	option := WithName(testAuthProviderName)
 
-	t.Run("Provider without storedInfo", func(it *testing.T) {
+	t.Run(noInfoProviderCaseName, func(it *testing.T) {
 		noStorageProvider := &providerImpl{}
 		assert.Nil(it, noStorageProvider.storedInfo)
 		assert.Empty(it, noStorageProvider.storedInfo.GetName())
@@ -649,11 +651,11 @@ func TestWithName(t *testing.T) {
 		storedInfo   *storage.AuthProvider
 		providerName string
 	}{
-		"Provider with stored info but no name": {
+		"Provider with storedInfo but no name": {
 			storedInfo:   &storage.AuthProvider{},
 			providerName: "",
 		},
-		"Provider with stored info and previous name": {
+		"Provider with storedInfo and previous name": {
 			storedInfo: &storage.AuthProvider{
 				Name: baseAuthProviderName,
 			},
@@ -696,7 +698,12 @@ func TestWithName(t *testing.T) {
 
 func TestWithEnabled(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Provider with no stored info, setting enabled to %t", enabled), func(it *testing.T) {
+		testName := fmt.Sprintf(
+			"%s, setting enabled to %t",
+			noInfoProviderCaseName,
+			enabled,
+		)
+		t.Run(testName, func(it *testing.T) {
 			provider := &providerImpl{}
 			option := WithEnabled(enabled)
 			assert.Nil(it, provider.storedInfo)
@@ -717,38 +724,38 @@ func TestWithEnabled(t *testing.T) {
 		initialEnabled bool
 		targetEnabled  bool
 	}{
-		"Provider with stored information but enable not set - enabling": {
+		"Provider with storedInfo but enable not set - enabling": {
 			storedInfo:     &storage.AuthProvider{},
 			initialEnabled: false,
 			targetEnabled:  true,
 		},
-		"Provider with stored information but enable not set - disabling": {
+		"Provider with storedInfo but enable not set - disabling": {
 			storedInfo:     &storage.AuthProvider{},
 			initialEnabled: false,
 			targetEnabled:  false,
 		},
-		"Provider with stored information and enabled - enabling": {
+		"Provider with storedInfo and enabled - enabling": {
 			storedInfo: &storage.AuthProvider{
 				Enabled: true,
 			},
 			initialEnabled: true,
 			targetEnabled:  true,
 		},
-		"Provider with stored information and enabled - disabling": {
+		"Provider with storedInfo and enabled - disabling": {
 			storedInfo: &storage.AuthProvider{
 				Enabled: true,
 			},
 			initialEnabled: true,
 			targetEnabled:  false,
 		},
-		"Provider with stored information and disabled - enabling": {
+		"Provider with storedInfo and disabled - enabling": {
 			storedInfo: &storage.AuthProvider{
 				Enabled: false,
 			},
 			initialEnabled: false,
 			targetEnabled:  true,
 		},
-		"Provider with stored information and disabled - disabling": {
+		"Provider with storedInfo and disabled - disabling": {
 			storedInfo: &storage.AuthProvider{
 				Enabled: false,
 			},
@@ -795,7 +802,12 @@ func TestWithEnabled(t *testing.T) {
 
 func TestWithActive(t *testing.T) {
 	for _, activate := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Provider with no stored info - activate to %t", activate), func(it *testing.T) {
+		testName := fmt.Sprintf(
+			"%s - activate to %t",
+			noInfoProviderCaseName,
+			activate,
+		)
+		t.Run(testName, func(it *testing.T) {
 			option := WithActive(activate)
 			provider := &providerImpl{}
 			assert.Nil(it, provider.storedInfo)
@@ -817,19 +829,19 @@ func TestWithActive(t *testing.T) {
 		initialActive    bool
 		targetActive     bool
 	}{
-		"Provider with stored info, but no active nor validated data, activating": {
+		"Provider with storedInfo, but no active nor validated data, activating": {
 			storedInfo:       &storage.AuthProvider{},
 			initialActive:    false,
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, but no active nor validated data, deactivating": {
+		"Provider with storedInfo, but no active nor validated data, deactivating": {
 			storedInfo:       &storage.AuthProvider{},
 			initialActive:    false,
 			initialValidated: false,
 			targetActive:     false,
 		},
-		"Provider with stored info, active, but no validated data, activating": {
+		"Provider with storedInfo, active, but no validated data, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active: true,
 			},
@@ -837,7 +849,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, active, but no validated data, deactivating": {
+		"Provider with storedInfo, active, but no validated data, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active: true,
 			},
@@ -845,7 +857,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     false,
 		},
-		"Provider with stored info, inactive, but no validated data, activating": {
+		"Provider with storedInfo, inactive, but no validated data, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active: false,
 			},
@@ -853,7 +865,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, inactive, but no validated data, deactivating": {
+		"Provider with storedInfo, inactive, but no validated data, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active: false,
 			},
@@ -861,7 +873,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     false,
 		},
-		"Provider with stored info, validated, but no active data, activating": {
+		"Provider with storedInfo, validated, but no active data, activating": {
 			storedInfo: &storage.AuthProvider{
 				Validated: true,
 			},
@@ -869,7 +881,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     true,
 		},
-		"Provider with stored info, validated, but no active data, deactivating": {
+		"Provider with storedInfo, validated, but no active data, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Validated: true,
 			},
@@ -877,7 +889,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     false,
 		},
-		"Provider with stored info, not validated, no active data, activating": {
+		"Provider with storedInfo, not validated, no active data, activating": {
 			storedInfo: &storage.AuthProvider{
 				Validated: false,
 			},
@@ -885,7 +897,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, not validated, no active data, deactivating": {
+		"Provider with storedInfo, not validated, no active data, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Validated: false,
 			},
@@ -893,7 +905,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     false,
 		},
-		"Provider with stored info, active, validated, activating": {
+		"Provider with storedInfo, active, validated, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    true,
 				Validated: true,
@@ -902,7 +914,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     true,
 		},
-		"Provider with stored info, active, validated, deactivating": {
+		"Provider with storedInfo, active, validated, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    true,
 				Validated: true,
@@ -911,7 +923,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     false,
 		},
-		"Provider with stored info, not active, validated, activating": {
+		"Provider with storedInfo, not active, validated, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    false,
 				Validated: true,
@@ -920,7 +932,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     true,
 		},
-		"Provider with stored info, not active, validated, deactivating": {
+		"Provider with storedInfo, not active, validated, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    false,
 				Validated: true,
@@ -929,7 +941,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: true,
 			targetActive:     false,
 		},
-		"Provider with stored info, active, not validated, activating": {
+		"Provider with storedInfo, active, not validated, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    true,
 				Validated: false,
@@ -938,7 +950,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, active, not validated, deactivating": {
+		"Provider with storedInfo, active, not validated, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    true,
 				Validated: false,
@@ -947,7 +959,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     false,
 		},
-		"Provider with stored info, not active, not validated, activating": {
+		"Provider with storedInfo, not active, not validated, activating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    false,
 				Validated: false,
@@ -956,7 +968,7 @@ func TestWithActive(t *testing.T) {
 			initialValidated: false,
 			targetActive:     true,
 		},
-		"Provider with stored info, not active, not validated, deactivating": {
+		"Provider with storedInfo, not active, not validated, deactivating": {
 			storedInfo: &storage.AuthProvider{
 				Active:    false,
 				Validated: false,
@@ -1005,6 +1017,158 @@ func TestWithActive(t *testing.T) {
 			assert.Nil(it, provider.storedInfo)
 			assert.False(it, provider.storedInfo.GetActive())
 			assert.False(it, provider.storedInfo.GetValidated())
+		})
+	}
+}
+
+func TestWithVisibility(t *testing.T) {
+	for _, visibility := range []storage.Traits_Visibility{
+		storage.Traits_VISIBLE, storage.Traits_HIDDEN,
+	} {
+		testName := fmt.Sprintf(
+			"%s - setting visibility to %s",
+			noInfoProviderCaseName,
+			visibility.String(),
+		)
+		t.Run(testName, func(it *testing.T) {
+			option := WithVisibility(visibility)
+			provider := &providerImpl{}
+			assert.Nil(it, provider.storedInfo)
+			assert.Equal(it, storage.Traits_VISIBLE, provider.storedInfo.GetTraits().GetVisibility())
+			revert, err := option(provider)
+			assert.ErrorIs(it, err, errox.InvariantViolation)
+			assert.Nil(it, provider.storedInfo)
+			assert.Equal(it, storage.Traits_VISIBLE, provider.storedInfo.GetTraits().GetVisibility())
+			err = revert(provider)
+			assert.NoError(it, err)
+			assert.Nil(it, provider.storedInfo)
+			assert.Equal(it, storage.Traits_VISIBLE, provider.storedInfo.GetTraits().GetVisibility())
+		})
+	}
+
+	testCases := map[string]struct {
+		storedInfo        *storage.AuthProvider
+		hasTraits         bool
+		initialVisibility storage.Traits_Visibility
+		targetVisibility  storage.Traits_Visibility
+	}{
+		"Provider with storedInfo, no traits, setting visible": {
+			storedInfo:        &storage.AuthProvider{},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_VISIBLE,
+		},
+		"Provider with storedInfo, no traits, setting hidden": {
+			storedInfo:        &storage.AuthProvider{},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_HIDDEN,
+		},
+		"Provider with storedInfo, nil traits, setting visible": {
+			storedInfo: &storage.AuthProvider{
+				Traits: nil,
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_VISIBLE,
+		},
+		"Provider with storedInfo, nil traits, setting hidden": {
+			storedInfo: &storage.AuthProvider{
+				Traits: nil,
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_HIDDEN,
+		},
+		"Provider with storedInfo, traits with no visibiity info, setting visible": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_VISIBLE,
+		},
+		"Provider with storedInfo, traits with no visibility info, setting hidden": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_HIDDEN,
+		},
+		"Provider with storedInfo, traits with visible, setting visible": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{
+					Visibility: storage.Traits_VISIBLE,
+				},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_VISIBLE,
+		},
+		"Provider with storedInfo, traits with visible, setting hidden": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{
+					Visibility: storage.Traits_VISIBLE,
+				},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_VISIBLE,
+			targetVisibility:  storage.Traits_HIDDEN,
+		},
+		"Provider with storedInfo, traits with hidden, setting visible": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{
+					Visibility: storage.Traits_HIDDEN,
+				},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_HIDDEN,
+			targetVisibility:  storage.Traits_VISIBLE,
+		},
+		"Provider with storedInfo, traits with hidden, setting hidden": {
+			storedInfo: &storage.AuthProvider{
+				Traits: &storage.Traits{
+					Visibility: storage.Traits_HIDDEN,
+				},
+			},
+			hasTraits:         false,
+			initialVisibility: storage.Traits_HIDDEN,
+			targetVisibility:  storage.Traits_HIDDEN,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(it *testing.T) {
+			option := WithVisibility(tc.targetVisibility)
+			provider := &providerImpl{storedInfo: tc.storedInfo}
+			assert.NotNil(it, provider.storedInfo)
+			assert.Equal(it, tc.initialVisibility, provider.storedInfo.GetTraits().GetVisibility())
+			revert, err := option(provider)
+			assert.NoError(it, err)
+			assert.NotNil(it, provider.storedInfo)
+			assert.Equal(it, tc.targetVisibility, provider.storedInfo.GetTraits().GetVisibility())
+			err = revert(provider)
+			assert.NoError(it, err)
+			assert.NotNil(it, provider.storedInfo)
+			assert.Equal(it, tc.initialVisibility, provider.storedInfo.GetTraits().GetVisibility())
+		})
+		t.Run(name+" - breaking revert", func(it *testing.T) {
+			option := WithVisibility(tc.targetVisibility)
+			provider := &providerImpl{storedInfo: tc.storedInfo}
+			assert.NotNil(it, provider.storedInfo)
+			assert.Equal(it, tc.initialVisibility, provider.storedInfo.GetTraits().GetVisibility())
+			revert, err := option(provider)
+			assert.NoError(it, err)
+			assert.NotNil(it, provider.storedInfo)
+			assert.Equal(it, tc.targetVisibility, provider.storedInfo.GetTraits().GetVisibility())
+			provider.storedInfo = nil
+			assert.Nil(it, provider.storedInfo)
+			assert.Equal(it, storage.Traits_VISIBLE, provider.storedInfo.GetTraits().GetVisibility())
+			err = revert(provider)
+			assert.ErrorIs(it, err, errox.InvariantViolation)
+			assert.Nil(it, provider.storedInfo)
+			assert.Equal(it, storage.Traits_VISIBLE, provider.storedInfo.GetTraits().GetVisibility())
 		})
 	}
 }

--- a/pkg/auth/authproviders/provider_options_test.go
+++ b/pkg/auth/authproviders/provider_options_test.go
@@ -1,0 +1,331 @@
+package authproviders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/auth/tokens"
+	tokenIssuerMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	authProviderID = "41757468-5072-6f76-6964-657211111111"
+
+	baseLoginURL = "/base/login/url"
+	testLoginURL = "/test/login/url"
+
+	baseIssuerID = "546f6b64-6e49-7373-7565-721111111111"
+	testIssuerID = "546f6b64-6e49-7373-7565-722222222222"
+
+	baseRoleMapperID = "526f6c65-4d61-7171-6572-111111111111"
+	testRoleMapperID = "526f6c65-4d61-7171-6572-222222222222"
+
+	baseAuthProviderBackendID = "4261636b-656e-6478-7878-111111111111"
+	testAuthProviderBackendID = "4261636b-656e-6478-7878-222222222222"
+
+	baseAuthProviderBackendFactoryID = "4261636b-656e-6446-6163-746f72791111"
+	testAuthProviderBackendFactoryID = "4261636b-656e-6446-6163-746f72792222"
+)
+
+var (
+	baseAuthProviderBackendConfig = map[string]string{
+		"baseKey": "baseValue",
+	}
+
+	testAuthProviderBackendConfig = map[string]string{
+		"testKey": "testValue",
+	}
+)
+
+func TestDefaultNewID(t *testing.T) {
+	option := DefaultNewID()
+
+	// DefaultNewID should fail on a provider object with nil storedInfo field.
+	noStoredInfoProvider := &providerImpl{}
+	assert.Nil(t, noStoredInfoProvider.storedInfo)
+	_, err := option(noStoredInfoProvider)
+	assert.Error(t, err)
+	assert.Nil(t, noStoredInfoProvider.storedInfo)
+
+	// DefaultNewID should not overwrite a pre-existing ID,
+	// nor should the associated revert action.
+	previousIDProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+	assert.Equal(t, authProviderID, previousIDProvider.storedInfo.GetId())
+	// apply option
+	altRevert, err := option(previousIDProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, authProviderID, previousIDProvider.storedInfo.GetId())
+	_, err = uuid.FromString(previousIDProvider.storedInfo.GetId())
+	assert.NoError(t, err)
+	// revert option
+	err = altRevert(previousIDProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, authProviderID, previousIDProvider.storedInfo.GetId())
+
+	// DefaultNewID should set the ID field in the storedInfo field with
+	// a valid UUID. The returned RevertOption should set the ID
+	// back to its previous value (here empty string).
+	provider := &providerImpl{}
+	provider.storedInfo = &storage.AuthProvider{}
+	assert.Empty(t, provider.storedInfo.GetId())
+	// apply option
+	revert, err := option(provider)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, provider.storedInfo.GetId())
+	_, err = uuid.FromString(provider.storedInfo.GetId())
+	assert.NoError(t, err)
+	// revert option
+	err = revert(provider)
+	assert.NoError(t, err)
+	assert.Empty(t, provider.storedInfo.GetId())
+}
+
+func TestDefaultLoginURL(t *testing.T) {
+	called := 0
+	getLoginURL := func(_ string) string {
+		called += 1
+		return testLoginURL
+	}
+	option := DefaultLoginURL(getLoginURL)
+
+	// DefaultLoginURL should fail on a provider object with nil storedInfo field.
+	noStoredInfoProvider := &providerImpl{}
+	assert.Nil(t, noStoredInfoProvider.storedInfo)
+	_, err := option(noStoredInfoProvider)
+	assert.Error(t, err)
+	assert.Nil(t, noStoredInfoProvider.storedInfo)
+	assert.Zero(t, called)
+
+	// DefaultLoginURL should not overwrite a pre-existing login URL,
+	// nor should the associated revert action.
+	prevLoginURLProvider := &providerImpl{}
+	prevLoginURLProvider.storedInfo = &storage.AuthProvider{
+		LoginUrl: baseLoginURL,
+	}
+	assert.Equal(t, baseLoginURL, prevLoginURLProvider.storedInfo.GetLoginUrl())
+	// apply option
+	altRevert, err := option(prevLoginURLProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseLoginURL, prevLoginURLProvider.storedInfo.GetLoginUrl())
+	assert.Zero(t, called)
+	// revert option
+	err = altRevert(prevLoginURLProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseLoginURL, prevLoginURLProvider.storedInfo.GetLoginUrl())
+	assert.Zero(t, called)
+
+	// DefaultLoginURL should set the login URL to the result
+	// of the provided function call, the revert action should reset
+	// the login URL to an empty value.
+	provider := &providerImpl{}
+	provider.storedInfo = &storage.AuthProvider{}
+	assert.Empty(t, provider.storedInfo.GetLoginUrl())
+	// apply option
+	revert, err := option(provider)
+	assert.NoError(t, err)
+	assert.Equal(t, testLoginURL, provider.storedInfo.GetLoginUrl())
+	assert.Equal(t, 1, called)
+	// revert option
+	err = revert(provider)
+	assert.NoError(t, err)
+	assert.Empty(t, provider.storedInfo.GetLoginUrl())
+	assert.Equal(t, 1, called)
+}
+
+func TestDefaultTokenIssuerFromFactory(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	baseIssuer := &fakeIssuer{ID: baseIssuerID}
+	testIssuer := &fakeIssuer{ID: testIssuerID}
+
+	mockIssuerFactory := tokenIssuerMocks.NewMockIssuerFactory(mockCtrl)
+	mockIssuerFactory.EXPECT().
+		CreateIssuer(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(testIssuer, nil)
+
+	option := DefaultTokenIssuerFromFactory(mockIssuerFactory)
+
+	// DefaultTokenIssuerFromFactory should not overwrite a pre-existing issuer,
+	// nor should the associated revert action.
+	previousIssuerProvider := &providerImpl{
+		issuer: baseIssuer,
+	}
+	assert.Equal(t, baseIssuer, previousIssuerProvider.issuer)
+	revert2, err := option(previousIssuerProvider)
+	assert.Nil(t, err)
+	assert.Equal(t, baseIssuer, previousIssuerProvider.issuer)
+	err = revert2(previousIssuerProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseIssuer, previousIssuerProvider.issuer)
+
+	// DefaultTokenIssuerFromFactory should set the issuer to the result
+	// of the provided factory creation call, the revert action should
+	// reset the issuer to a nil value.
+	noIssuerProvider := &providerImpl{}
+	assert.Nil(t, noIssuerProvider.issuer)
+	revert, err := option(noIssuerProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, testIssuer, noIssuerProvider.issuer)
+	err = revert(noIssuerProvider)
+	assert.NoError(t, err)
+	assert.Nil(t, noIssuerProvider.issuer)
+}
+
+func TestDefaultRoleMapperOption(t *testing.T) {
+	baseRoleMapper := &fakeRoleMapper{ID: baseRoleMapperID}
+	optionTestRoleMapper := &fakeRoleMapper{ID: testRoleMapperID}
+
+	getRoleMapper := func(_ string) permissions.RoleMapper {
+		return optionTestRoleMapper
+	}
+	option := DefaultRoleMapperOption(getRoleMapper)
+
+	// DefaultRoleMapperOption should not erase any pre-existing role mapper,
+	// nor should the associated revert action.
+	previousMapperProvider := &providerImpl{
+		roleMapper: baseRoleMapper,
+	}
+	assert.Equal(t, baseRoleMapper, previousMapperProvider.roleMapper)
+	revert1, err := option(previousMapperProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseRoleMapper, previousMapperProvider.roleMapper)
+	err = revert1(previousMapperProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseRoleMapper, previousMapperProvider.roleMapper)
+
+	// DefaultRoleMapperOption should not touch the role mapper if there is
+	// no previous mapper but the storage view can NOT provide an ID,
+	// nor should the associated revert action.
+	noIDProvider := &providerImpl{}
+	assert.Nil(t, noIDProvider.roleMapper)
+	assert.Empty(t, noIDProvider.storedInfo.GetId())
+	revert2, err := option(noIDProvider)
+	assert.NoError(t, err)
+	assert.Nil(t, noIDProvider.roleMapper)
+	err = revert2(noIDProvider)
+	assert.NoError(t, err)
+	assert.Nil(t, noIDProvider.roleMapper)
+
+	// DefaultRoleMapperOption should set the role mapper if there is
+	// no previous mapper and the storage view can provide an ID,
+	// the revert action should reset the provider to a nil value.
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+	assert.Nil(t, provider.roleMapper)
+	assert.Equal(t, authProviderID, provider.storedInfo.GetId())
+	revert3, err := option(provider)
+	assert.NoError(t, err)
+	assert.Equal(t, optionTestRoleMapper, provider.roleMapper)
+	err = revert3(provider)
+	assert.NoError(t, err)
+	assert.Nil(t, provider.roleMapper)
+}
+
+func TestDefaultBackend(t *testing.T) {
+	backendFactoryPool := map[string]BackendFactory{
+		"test": testAuthProviderBackendFactory,
+	}
+	option := DefaultBackend(context.Background(), backendFactoryPool)
+
+	baseAuthProviderBackendFactory := &tstAuthProviderBackendFactory{
+		ID: baseAuthProviderBackendFactoryID,
+	}
+	baseAuthProviderBackend := &tstAuthProviderBackend{
+		ID: baseAuthProviderBackendID,
+	}
+
+	previousBackendProvider := &providerImpl{
+		backend:        baseAuthProviderBackend,
+		backendFactory: baseAuthProviderBackendFactory,
+		storedInfo: &storage.AuthProvider{
+			Config: baseAuthProviderBackendConfig,
+		},
+	}
+	assert.Equal(t, baseAuthProviderBackend, previousBackendProvider.backend)
+	assert.Equal(t, baseAuthProviderBackendFactory, previousBackendProvider.backendFactory)
+	assert.Equal(t, baseAuthProviderBackendConfig, previousBackendProvider.storedInfo.GetConfig())
+	revert1, err := option(previousBackendProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseAuthProviderBackend, previousBackendProvider.backend)
+	assert.Equal(t, baseAuthProviderBackendFactory, previousBackendProvider.backendFactory)
+	assert.Equal(t, baseAuthProviderBackendConfig, previousBackendProvider.storedInfo.GetConfig())
+	err = revert1(previousBackendProvider)
+	assert.NoError(t, err)
+	assert.Equal(t, baseAuthProviderBackend, previousBackendProvider.backend)
+	assert.Equal(t, baseAuthProviderBackendFactory, previousBackendProvider.backendFactory)
+	assert.Equal(t, baseAuthProviderBackendConfig, previousBackendProvider.storedInfo.GetConfig())
+
+	wrongTypeProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Type: "base",
+		},
+	}
+	assert.Nil(t, wrongTypeProvider.backend)
+	assert.Nil(t, wrongTypeProvider.backendFactory)
+	assert.Empty(t, wrongTypeProvider.storedInfo.GetConfig())
+	revert2, err := option(wrongTypeProvider)
+	assert.Error(t, err)
+	assert.Nil(t, wrongTypeProvider.backend)
+	assert.Nil(t, wrongTypeProvider.backendFactory)
+	assert.Empty(t, wrongTypeProvider.storedInfo.GetConfig())
+	err = revert2(wrongTypeProvider)
+	assert.NoError(t, err)
+	assert.Nil(t, wrongTypeProvider.backend)
+	assert.Nil(t, wrongTypeProvider.backendFactory)
+	assert.Empty(t, wrongTypeProvider.storedInfo.GetConfig())
+
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Type:   "test",
+			Config: baseAuthProviderBackendConfig,
+		},
+		backendFactory: baseAuthProviderBackendFactory,
+	}
+	assert.Nil(t, provider.backend)
+	assert.Equal(t, baseAuthProviderBackendConfig, provider.storedInfo.GetConfig())
+	assert.Equal(t, baseAuthProviderBackendFactory, provider.backendFactory)
+	revert3, err := option(provider)
+	assert.NoError(t, err)
+	assert.Equal(t, testAuthProviderBackend, provider.backend)
+	assert.Equal(t, testAuthProviderBackendFactory, provider.backendFactory)
+	assert.Equal(t, testAuthProviderBackendConfig, provider.storedInfo.GetConfig())
+	err = revert3(provider)
+	assert.NoError(t, err)
+	assert.Nil(t, provider.backend)
+	assert.Equal(t, baseAuthProviderBackendConfig, provider.storedInfo.GetConfig())
+	assert.Equal(t, baseAuthProviderBackendFactory, provider.backendFactory)
+}
+
+// region test utilities
+
+type fakeIssuer struct {
+	ID string
+}
+
+func (i *fakeIssuer) Issue(_ context.Context, _ tokens.RoxClaims, _ ...tokens.Option) (*tokens.TokenInfo, error) {
+	return nil, nil
+}
+
+type fakeRoleMapper struct {
+	ID string
+}
+
+func (m *fakeRoleMapper) FromUserDescriptor(_ context.Context, _ *permissions.UserDescriptor) ([]permissions.ResolvedRole, error) {
+	return nil, nil
+}
+
+// endregion test utilities

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -600,6 +600,7 @@ func (*tstRoleMapperFactory) GetRoleMapper(_ string) perm.RoleMapper {
 
 // Authentication backend factory (needed by registry.RegisterBackendFactory)
 type tstAuthProviderBackend struct {
+	ID       string
 	authRsp  *AuthResponse
 	err      error
 	loginURL string
@@ -616,7 +617,7 @@ func (b *tstAuthProviderBackend) registerLoginURL(loginURL string, err error) {
 }
 
 func (*tstAuthProviderBackend) Config() map[string]string {
-	return nil
+	return testAuthProviderBackendConfig
 }
 
 func (b *tstAuthProviderBackend) LoginURL(_ string, _ *requestinfo.RequestInfo) (string, error) {
@@ -645,9 +646,12 @@ func (*tstAuthProviderBackend) Validate(_ context.Context, _ *tokens.Claims) err
 	return nil
 }
 
-var testAuthProviderBackend = &tstAuthProviderBackend{}
+var testAuthProviderBackend = &tstAuthProviderBackend{
+	ID: testAuthProviderBackendID,
+}
 
 type tstAuthProviderBackendFactory struct {
+	ID          string
 	providerID  string
 	clientState string
 	err         error
@@ -693,7 +697,9 @@ func (*tstAuthProviderBackendFactory) MergeConfig(newCfg, oldCfg map[string]stri
 	return mergedCfg
 }
 
-var testAuthProviderBackendFactory = &tstAuthProviderBackendFactory{}
+var testAuthProviderBackendFactory = &tstAuthProviderBackendFactory{
+	ID: testAuthProviderBackendFactoryID,
+}
 
 func newTestAuthProviderBackendFactory(_ string) BackendFactory {
 	return testAuthProviderBackendFactory

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -667,6 +667,8 @@ func (*tstAuthProviderBackendFactory) CreateBackend(_ context.Context, _ string,
 	return testAuthProviderBackend, nil
 }
 
+func (*tstAuthProviderBackendFactory) CleanupBackend(_ string) error { return nil }
+
 func (f *tstAuthProviderBackendFactory) ProcessHTTPRequest(_ http.ResponseWriter,
 	_ *http.Request) (string, string, error) {
 	return f.providerID, f.clientState, f.err

--- a/pkg/auth/authproviders/saml/backend_factory_impl.go
+++ b/pkg/auth/authproviders/saml/backend_factory_impl.go
@@ -51,6 +51,10 @@ func (f *factory) CreateBackend(ctx context.Context, id string, uiEndpoints []st
 	return be, nil
 }
 
+func (f *factory) CleanupBackend(_ string) error {
+	return nil
+}
+
 func (f *factory) processACSRequest(r *http.Request) (string, error) {
 	if r.Method != http.MethodPost {
 		return "", httputil.NewError(http.StatusMethodNotAllowed, "only POST requests are allowed to this URL")

--- a/pkg/auth/authproviders/userpki/backend_factory_impl.go
+++ b/pkg/auth/authproviders/userpki/backend_factory_impl.go
@@ -40,6 +40,10 @@ func (f *factory) CreateBackend(ctx context.Context, id string, _ []string, conf
 	return be, nil
 }
 
+func (f *factory) CleanupBackend(_ string) error {
+	return nil
+}
+
 func (f *factory) ProcessHTTPRequest(_ http.ResponseWriter, r *http.Request) (providerID string, clientState string, err error) {
 	if r.Method != http.MethodGet {
 		return "", "", httputil.Errorf(http.StatusMethodNotAllowed, "invalid method %q, only GET requests are allowed", r.Method)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Authprovider objects can be instantiated through the API or through declarative configuration.
As a consequence, the configuration and instantiation of provider objects relies heavily on the concept of options (these include changing configuration options, instantiation of token issuer objects or interactions with the data storage layer).
So far options are applied, but not reverted in case the application of a specific option fails.

One option for OpenShift authproviders instantiates a kubernetes watch loop for each created provider instance. In case the instantiated provider cannot be stored (addition loop without error handling), all watch loops remain active, leading to log flooding (that is how the issue was discovered).

This change introduces the concept of option revert action, and applies the option revert actions in the reverse order of the option application one.
On top of this, the openshift provider watcher loop is refactored in order to have a single loop running, and possibly multiple providers registered for update in that loop.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ _is not needed_

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
<!--
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The reproducer case was multiple calls to the PostAuthProvider authprovider service (POST /v1/authProviders).