### PR TITLE
chore(CI): Add collector DaemonSet state check before checking pods

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -554,6 +554,10 @@ wait_for_collectors_to_be_operational() {
         return
     fi
 
+    # Ensure collector DaemonSet state is stable
+    kubectl rollout status daemonset collector --namespace "${sensor_namespace}" --timeout=5m --watch=true
+
+    # Check each collector pod readiness.
     local start_time
     start_time="$(date '+%s')"
     local all_ready="false"


### PR DESCRIPTION
### Description

This PR is adding an additional check on the collector DaemonSet state before checking pod states. This will ensure that all pods are re-scheduled and ready after any change on DaemonSet. Collector rollout usually takes longer because of the update strategy:
```
        "updateStrategy": {
            "rollingUpdate": {
                "maxSurge": 0,
                "maxUnavailable": 1
            },
            "type": "RollingUpdate"
        }
```
also, we have always had a few pods deployed by collector daemonset.

Here are some test logs that indicate this problem:
```
Sensor is running
NAME        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
collector   3         3         3       0            3           <none>          22s
Waiting for collectors to start
Collectors are running
INFO: Mon Sep  9 16:05:42 UTC 2024: Will wait for collectors to reach a ready state in namespace stackrox
Checking readiness of collector-cgplg
INFO: Mon Sep  9 16:05:43 UTC 2024: collector-cgplg is not ready
..
INFO: Mon Sep  9 16:05:43 UTC 2024: Found at least one unready collector pod, will check again in 10 seconds
Checking readiness of collector-cgplg
collector-cgplg is deemed ready
Checking readiness of collector-dn6bw
..
INFO: Mon Sep  9 16:05:55 UTC 2024: Found at least one unready collector pod, will check again in 10 seconds
Checking readiness of collector-7fhct
collector-7fhct is deemed ready
Checking readiness of collector-cgplg
Error from server (NotFound): pods "collector-cgplg" not found
INFO: Mon Sep  9 16:06:06 UTC 2024: collector-cgplg is not ready
Error from server (NotFound): pods "collector-cgplg" not found
****
**** 16:06:06: ERROR: test failed [Test failed: exit 1]
****
****
**** 16:06:06: About to run post test
****
16:06:06: Running post command: ['scripts/ci/collect-collector-metrics.sh', 'stackrox', '/tmp/collector-metrics']
.
set up port-forwarding from collector-7fhct:9090 to localhost:9090
finished download collector-7fhct.txt
finished tear down of port-forwarding from collector-7fhct:9090 to localhost:9090
.Error from server (NotFound): pods "collector-dn6bw" not found
....scripts/ci/collect-collector-metrics.sh: line 65: kill: (8446) - No such process
failed to collect metrics from collector-dn6bw after 5 retries
16:06:32: Exception raised in ['scripts/ci/collect-collector-metrics.sh', 'stackrox', '/tmp/collector-metrics'], Command '['scripts/ci/collect-collector-metrics.sh', 'stackrox', '/tmp/collector-metrics']' returned non-zero exit status 1.
16:06:32: Running post command: ['tests/e2e/lib.sh', 'wait_for_api']
INFO: Mon Sep  9 16:06:32 UTC 2024: Waiting for Central to be ready in namespace stackrox

..

INFO: Mon Sep  9 16:08:08 UTC 2024: >>> Collecting from namespace stackrox <<<
INFO: Mon Sep  9 16:08:08 UTC 2024: >>> Collecting daemonsets from namespace stackrox <<<
NAME        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE     CONTAINERS             IMAGES                                                                                                SELECTOR
collector   3         3         3       3            3           <none>          2m48s   collector,compliance   quay.io/rhacs-eng/collector:3.19.x-70-gf3a66fa3a5-slim,quay.io/rhacs-eng/main:4.6.x-470-g4a33a24e92   service=collector
...
INFO: Mon Sep  9 16:08:34 UTC 2024: >>> Collecting pods from namespace stackrox <<<
NAME                                 READY   STATUS    RESTARTS   AGE     IP             NODE                                                  NOMINATED NODE   READINESS GATES
admission-control-5844dbfcf5-76sw7   1/1     Running   0          3m17s   10.28.160.17   gke-rox-ci-upgrade-test--default-pool-26c0bb21-9408   <none>           <none>
admission-control-5844dbfcf5-lfwps   1/1     Running   0          3m17s   10.28.161.8    gke-rox-ci-upgrade-test--default-pool-26c0bb21-gdhn   <none>           <none>
admission-control-5844dbfcf5-zlzks   1/1     Running   0          3m17s   10.28.162.6    gke-rox-ci-upgrade-test--default-pool-26c0bb21-bxxs   <none>           <none>
central-5795dc5d84-n6wb5             1/1     Running   0          7m1s    10.28.162.5    gke-rox-ci-upgrade-test--default-pool-26c0bb21-bxxs   <none>           <none>
central-db-58c5dbd577-w4lnx          1/1     Running   0          6m59s   10.28.161.7    gke-rox-ci-upgrade-test--default-pool-26c0bb21-gdhn   <none>           <none>
collector-7fhct                      2/2     Running   0          2m37s   10.28.162.10   gke-rox-ci-upgrade-test--default-pool-26c0bb21-bxxs   <none>           <none>
collector-ptmjb                      2/2     Running   0          2m29s   10.28.160.19   gke-rox-ci-upgrade-test--default-pool-26c0bb21-9408   <none>           <none>
collector-vckt9                      2/2     Running   0          2m24s   10.28.161.10   gke-rox-ci-upgrade-test--default-pool-26c0bb21-gdhn   <none>           <none>
scanner-5494699cb7-7d258             1/1     Running   0          6m56s   10.28.161.6    gke-rox-ci-upgrade-test--default-pool-26c0bb21-gdhn   <none>           <none>
scanner-db-6dc5cc9f7b-brwh2          1/1     Running   0          6m56s   10.28.161.5    gke-rox-ci-upgrade-test--default-pool-26c0bb21-gdhn   <none>           <none>
sensor-69fb5c5dfc-5q8h9              1/1     Running   0          3m8s    10.28.162.9    gke-rox-ci-upgrade-test--default-pool-26c0bb21-bxxs   <none>           <none>
```

As we can see daemonset state is not correct before pod checking (0 - updated). The pods checked are mostly terminating, and they are gone after some time.
```
Error from server (NotFound): pods "collector-cgplg" not found
```

Link to full log: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-upgrade-tests/1833165755667976192/artifacts/merge-gke-upgrade-tests/stackrox-stackrox-e2e-test/build-log.txt

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

The changed script is part of CI. Only manual testing is done.

#### How I validated my change

I copied the section added to the script and executed it independently with the command above to trigger rollout.
```
kubectl --namespace "${sensor_namespace}" set env daemonset/collector TEST_ENV=$RANDOM
```
Result was:
```
Waiting for daemon set "collector" rollout to finish: 0 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 0 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 of 2 updated pods are available...
daemon set "collector" successfully rolled out
```

I also tested if daemonset does not exist. Modified first `kubectl` to:
```
kubectl rollout status daemonset collector-a --namespace "${sensor_namespace}" --timeout=300s --watch=true
```
Result was:
```
Error from server (NotFound): daemonsets.apps "collector-a" not found
```

Tested also `timeout` - I get:
```
Waiting for daemon set "collector" rollout to finish: 0 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 out of 2 new pods have been updated...
Waiting for daemon set "collector" rollout to finish: 1 of 2 updated pods are available...
error: timed out waiting for the condition
```