### PR TITLE
ROX-26274: Improve the UI text for upgradability of clusters 

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -56,9 +56,10 @@ function ClusterDeployment({
                     >
                         <Title headingLevel="h3">1. Configure possibility of future upgrades</Title>
                         <Text>
-                            Configuring clusters for future upgrades creates a powerful service account in your secured
-                            cluster that will be used to perform the upgrades. This is a prerequisite
-                            for automated or on-click upgrades of legacy-installed Secured Clusters to work.
+                            Configuring clusters for future upgrades creates a powerful service
+                            account in your secured cluster that will be used to perform the
+                            upgrades. This is a prerequisite for automated or on-click upgrades of
+                            legacy-installed Secured Clusters to work.
                         </Text>
                         <Switch
                             label="Configured for upgrades: Secured Clusters can be upgraded to match Central's version."
@@ -67,9 +68,7 @@ function ClusterDeployment({
                             isChecked={createUpgraderSA}
                         />
                         <Title headingLevel="h3">2. Download files</Title>
-                        <Text>
-                            Download the required configuration files, keys, and scripts.
-                        </Text>
+                        <Text>Download the required configuration files, keys, and scripts.</Text>
                         <Flex
                             direction={{ default: 'column' }}
                             spaceItems={{ default: 'spaceItemsSm' }}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -54,18 +54,22 @@ function ClusterDeployment({
                         direction={{ default: 'column' }}
                         spaceItems={{ default: 'spaceItemsMd' }}
                     >
-                        <Title headingLevel="h3">1. Download files</Title>
+                        <Title headingLevel="h3">1. Configure possibility of future upgrades</Title>
                         <Text>
-                            Download the required configuration files, keys, and scripts. Enabling
-                            automatic upgrades creates a powerful service account in your secured
-                            cluster that will be used to perform the upgrades.
+                            Configuring clusters for future upgrades creates a powerful service account in your secured
+                            cluster that will be used to perform the upgrades. This is a prerequisite
+                            for automated or on-click upgrades of legacy-installed Secured Clusters to work.
                         </Text>
                         <Switch
-                            label="Automatic upgrades ON: Secured Clusters are upgraded automatically to match Central's version."
-                            labelOff="Automatic upgrades OFF: Secured clusters are not upgraded automatically."
+                            label="Configured for upgrades: Secured Clusters can be upgraded to match Central's version."
+                            labelOff="Not configured for upgrades: Attempts to upgrade Secured Clusters will fail."
                             onChange={toggleSA}
                             isChecked={createUpgraderSA}
                         />
+                        <Title headingLevel="h3">2. Download files</Title>
+                        <Text>
+                            Download the required configuration files, keys, and scripts.
+                        </Text>
                         <Flex
                             direction={{ default: 'column' }}
                             spaceItems={{ default: 'spaceItemsSm' }}
@@ -89,7 +93,7 @@ function ClusterDeployment({
                         </Flex>
                     </Flex>
                     <Flex direction={{ default: 'column' }}>
-                        <Title headingLevel="h3">2. Deploy</Title>
+                        <Title headingLevel="h3">3. Deploy</Title>
                         <Text>Use the deploy script inside the bundle to set up your cluster.</Text>
                     </Flex>
                 </>


### PR DESCRIPTION
### Description

Follow-up to: https://github.com/stackrox/stackrox/pull/12460

This applies only to legacy-installation method of secured cluster. The previously used text could suggest that the toggle was for switching between manual or automated upgrades. That was not correct, as the toggle does not do this. Instead it configures the cluster to *enable* automated or on-click upgrades of the clusters. Switching this toggle off would cause all upgrade attempts to fail no matter how they were triggered. Whether the upgrade is triggered automatically or manually is set in a different place (on the clusters page).

Additionally, I separated optically the step of the configuration (with the toggle) from the download step, to make it more prominent and visible. This should help users read the text about the configuration and make an informed choice about the option.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Deployed a GKE cluster and inspected the changes visually


![Screenshot 2024-09-17 at 13 21 28](https://github.com/user-attachments/assets/774b654b-3ffe-4a13-b98e-8f23d5723720)

![Screenshot 2024-09-17 at 13 21 32](https://github.com/user-attachments/assets/85f4b78b-4297-44eb-81f3-955e531f1e94)

The state before this change is depicted in the PR description of #12460.