### PR TITLE
feat(ui): Update useURLSort to support multi sort

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -88,7 +88,10 @@ function PoliciesTablePage({
             });
     }
 
-    function fetchPolicies(query: string, sortOption: ApiSortOption) {
+    function fetchPolicies(query: string, fetchSortOption: ApiSortOption) {
+        // The policy table does not currently support multi sort, but it must handle the case where the sortOption is an array
+        // due to the hook's API. Although this should not occur, we will handle it here by using the first option.
+        const sortOption = Array.isArray(fetchSortOption) ? fetchSortOption[0] : fetchSortOption;
         setIsLoading(true);
         getPolicies(query)
             .then((data) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -4,10 +4,13 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import sortBy from 'lodash/sortBy';
 
 import useTableSort from 'hooks/patternfly/useTableSort';
-import { ApiSortOption } from 'types/search';
+import { ApiSortOptionSingle } from 'types/search';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 
-function sortTableData(tableData: NodeComponent[], sortOption: ApiSortOption): NodeComponent[] {
+function sortTableData(
+    tableData: NodeComponent[],
+    sortOption: ApiSortOptionSingle
+): NodeComponent[] {
     const sortedRows = sortBy(tableData, (row) => {
         switch (sortOption.field) {
             case 'Component':

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -166,7 +166,7 @@ function CVEsTable({
                         Top CVSS
                     </TooltipTh>
                     <TooltipTh
-                        sort={getSortParams('Image sha', aggregateByDistinctCount)}
+                        sort={getSortParams('Image Sha', aggregateByDistinctCount)}
                         tooltip="Ratio of total images affected by this CVE"
                     >
                         Affected images

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -4,7 +4,7 @@ import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
 import { SourceType } from 'types/image.proto';
-import { ApiSortOption } from 'types/search';
+import { ApiSortOptionSingle } from 'types/search';
 
 import {
     getHighestVulnerabilitySeverity,
@@ -190,7 +190,7 @@ function extractCommonComponentFields(
 
 export function sortTableData<TableRowType extends TableDataRow>(
     tableData: TableRowType[],
-    sortOption: ApiSortOption
+    sortOption: ApiSortOptionSingle
 ): TableRowType[] {
     const sortedRows = sortBy(tableData, (row) => {
         switch (sortOption.field) {

--- a/ui/apps/platform/src/hooks/patternfly/useTableSort.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useTableSort.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ThProps } from '@patternfly/react-table';
 import { SortOption } from 'types/table';
-import { ApiSortOption } from 'types/search';
+import { ApiSortOptionSingle } from 'types/search';
 
 export type GetSortParams = (field: string) => ThProps['sort'];
 
@@ -11,7 +11,7 @@ type UseTableSortProps = {
 };
 
 type UseTableSortResult = {
-    sortOption: ApiSortOption;
+    sortOption: ApiSortOptionSingle;
     getSortParams: GetSortParams;
 };
 

--- a/ui/apps/platform/src/hooks/useTableSort.ts
+++ b/ui/apps/platform/src/hooks/useTableSort.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { SortDirection, TableColumn } from 'types/table';
-import { ApiSortOption } from 'types/search';
+import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
 
 export type UseTableSort = {
     activeSortIndex: number;
@@ -10,7 +10,7 @@ export type UseTableSort = {
     sortOption: ApiSortOption;
 };
 
-function useTableSort(columns: TableColumn[], defaultSort: ApiSortOption): UseTableSort {
+function useTableSort(columns: TableColumn[], defaultSort: ApiSortOptionSingle): UseTableSort {
     const defaultSortIndex = columns.findIndex((column) => column?.sortField === defaultSort.field);
     const defaultSortDirection = defaultSort.reversed ? 'desc' : 'asc';
     // index of the currently active column

--- a/ui/apps/platform/src/hooks/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/useURLSort.test.js
@@ -273,11 +273,11 @@ describe('useURLSort', () => {
                     .getSortParams('Severity', [
                         {
                             field: 'Critical severity count',
-                            aggregateBy: { distinct: true, aggregateFunc: 'max' },
+                            aggregateBy: { distinct: 'true', aggregateFunc: 'max' },
                         },
                         {
                             field: 'Low severity count',
-                            aggregateBy: { distinct: true, aggregateFunc: 'max' },
+                            aggregateBy: { distinct: 'true', aggregateFunc: 'max' },
                         },
                     ])
                     .onSort(null, null, 'asc');

--- a/ui/apps/platform/src/hooks/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/useURLSort.test.js
@@ -109,7 +109,7 @@ describe('useURLSort', () => {
 
         it('should retain the passed `aggregateBy` value when sorting', () => {
             const sortParams = cloneDeep(params);
-            const aggregateBy = { distinct: true, aggregateFunc: 'count' };
+            const aggregateBy = { distinct: 'true', aggregateFunc: 'count' };
             sortParams.defaultSortOption.aggregateBy = aggregateBy;
             const { result } = renderHook(() => useURLSort(sortParams), { wrapper });
 
@@ -125,6 +125,16 @@ describe('useURLSort', () => {
             expect(result.current.sortOption.field).toEqual('Name');
             expect(result.current.sortOption.reversed).toEqual(false);
             expect(result.current.sortOption.aggregateBy.distinct).toEqual(true);
+            expect(result.current.sortOption.aggregateBy.aggregateFunc).toEqual('count');
+
+            actAndRunTicks(() => {
+                result.current
+                    .getSortParams('Name', { distinct: 'false', aggregateFunc: 'count' })
+                    .onSort(null, null, 'asc');
+            });
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(false);
+            expect(result.current.sortOption.aggregateBy.distinct).toEqual(false);
             expect(result.current.sortOption.aggregateBy.aggregateFunc).toEqual('count');
 
             actAndRunTicks(() => {
@@ -203,6 +213,20 @@ describe('useURLSort', () => {
 
         it('should get the sort options from URL by default', () => {
             const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+        });
+
+        it('should return the default sort option when an empty multi field sort option is provided', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Severity', []).onSort(null, null, 'asc');
+            });
 
             expect(result.current.sortOption.field).toEqual('Name');
             expect(result.current.sortOption.reversed).toEqual(true);

--- a/ui/apps/platform/src/hooks/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/useURLSort.test.js
@@ -6,14 +6,6 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import useURLSort from './useURLSort';
 
-const params = {
-    sortFields: ['Name', 'Status'],
-    defaultSortOption: {
-        field: 'Name',
-        direction: 'desc',
-    },
-};
-
 const wrapper = ({ children }) => {
     const history = createMemoryHistory();
 
@@ -33,6 +25,14 @@ function actAndRunTicks(callback) {
 
 describe('useURLSort', () => {
     describe('when using URL sort with single sort options', () => {
+        const params = {
+            sortFields: ['Name', 'Status'],
+            defaultSortOption: {
+                field: 'Name',
+                direction: 'desc',
+            },
+        };
+
         it('should get the sort options from URL by default', () => {
             const { result } = renderHook(() => useURLSort(params), { wrapper });
 
@@ -149,7 +149,7 @@ describe('useURLSort', () => {
             expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
             expect(result.current.getSortParams('Status').sortBy.index).toEqual(0);
             expect(result.current.getSortParams('Status').sortBy.direction).toEqual('desc');
-            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
             expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(0);
             expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('desc');
 
@@ -165,7 +165,7 @@ describe('useURLSort', () => {
             expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
             expect(result.current.getSortParams('Status').sortBy.index).toEqual(1);
             expect(result.current.getSortParams('Status').sortBy.direction).toEqual('desc');
-            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
             expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(1);
             expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('desc');
 
@@ -176,14 +176,190 @@ describe('useURLSort', () => {
             expect(result.current.sortOption.field).toEqual('Bogus');
             expect(result.current.sortOption.reversed).toEqual(false);
             expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
-            expect(result.current.getSortParams('Name').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(-1);
             expect(result.current.getSortParams('Name').sortBy.direction).toEqual('asc');
             expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
-            expect(result.current.getSortParams('Status').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(-1);
             expect(result.current.getSortParams('Status').sortBy.direction).toEqual('asc');
-            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
-            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(-1);
             expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('asc');
+        });
+    });
+
+    describe('when using URL sort with multiple sort options', () => {
+        const params = {
+            sortFields: [
+                'Name',
+                'Status',
+                ['Critical severity count', 'Low severity count'],
+                'Created date',
+            ],
+            defaultSortOption: {
+                field: 'Name',
+                direction: 'desc',
+            },
+        };
+
+        it('should get the sort options from URL by default', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+        });
+
+        it('should change sorting fields and directions', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            // Change to single field sort
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'desc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            // Change to subset of multi field sort
+            actAndRunTicks(() => {
+                result.current
+                    .getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.length).toEqual(1);
+            expect(result.current.sortOption[0].field).toEqual('Critical severity count');
+            expect(result.current.sortOption[0].reversed).toEqual(false);
+
+            // A multi field sort option that matches a single field sort field will match
+            // and return the sort option in array form
+            actAndRunTicks(() => {
+                result.current.getSortParams('Name', [{ field: 'Name' }]).onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.length).toEqual(1);
+            expect(result.current.sortOption[0].field).toEqual('Name');
+            expect(result.current.sortOption[0].reversed).toEqual(false);
+
+            // Change to multi field sort with aggregateBy using multi sort function parameters
+            actAndRunTicks(() => {
+                result.current
+                    .getSortParams('Severity', [
+                        {
+                            field: 'Critical severity count',
+                            aggregateBy: { distinct: true, aggregateFunc: 'max' },
+                        },
+                        {
+                            field: 'Low severity count',
+                            aggregateBy: { distinct: true, aggregateFunc: 'max' },
+                        },
+                    ])
+                    .onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.length).toEqual(2);
+            expect(result.current.sortOption[0].field).toEqual('Critical severity count');
+            expect(result.current.sortOption[0].reversed).toEqual(false);
+            expect(result.current.sortOption[0].aggregateBy.distinct).toEqual(true);
+            expect(result.current.sortOption[0].aggregateBy.aggregateFunc).toEqual('max');
+            expect(result.current.sortOption[1].field).toEqual('Low severity count');
+            expect(result.current.sortOption[1].reversed).toEqual(false);
+            expect(result.current.sortOption[1].aggregateBy.distinct).toEqual(true);
+            expect(result.current.sortOption[1].aggregateBy.aggregateFunc).toEqual('max');
+        });
+
+        it('should return the correct PatternFly sort parameters via the `getSortParams` function', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            // Test handling of both provided fields, and a bogus fields that do not exist in the sortFields array
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('desc');
+            const criticalSeveritySortParams = result.current.getSortParams('Severity', [
+                { field: 'Critical severity count' },
+            ]);
+            expect(criticalSeveritySortParams.columnIndex).toEqual(2);
+            expect(criticalSeveritySortParams.sortBy.index).toEqual(0);
+            expect(criticalSeveritySortParams.sortBy.direction).toEqual('desc');
+            const bogusSeveritySortParams = result.current.getSortParams('Severity', [
+                { field: 'Bogus severity count' },
+            ]);
+            expect(bogusSeveritySortParams.columnIndex).toEqual(-1);
+            expect(bogusSeveritySortParams.sortBy.index).toEqual(0);
+            expect(bogusSeveritySortParams.sortBy.direction).toEqual('desc');
+
+            actAndRunTicks(() => {
+                result.current
+                    .getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.length).toEqual(1);
+            expect(result.current.sortOption[0].field).toEqual('Critical severity count');
+            expect(result.current.sortOption[0].reversed).toEqual(false);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(2);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(2);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(2);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('asc');
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .columnIndex
+            ).toEqual(2);
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .sortBy.index
+            ).toEqual(2);
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .sortBy.direction
+            ).toEqual('asc');
+
+            actAndRunTicks(() => {
+                result.current
+                    .getSortParams('Bogus', [{ field: 'Bogus severity count' }])
+                    .onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.length).toEqual(1);
+            expect(result.current.sortOption[0].field).toEqual('Bogus severity count');
+            expect(result.current.sortOption[0].reversed).toEqual(false);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(-1);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(-1);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(-1);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(-1);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('asc');
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .columnIndex
+            ).toEqual(2);
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .sortBy.index
+            ).toEqual(-1);
+            expect(
+                result.current.getSortParams('Severity', [{ field: 'Critical severity count' }])
+                    .sortBy.direction
+            ).toEqual('asc');
         });
     });
 });

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -1,33 +1,22 @@
-import { useRef, useState } from 'react';
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import { useRef } from 'react';
+import findIndex from 'lodash/findIndex';
+import intersection from 'lodash/intersection';
+import isEqual from 'lodash/isEqual';
 
-import useURLParameter, { HistoryAction } from 'hooks/useURLParameter';
-import { SortAggregate, SortDirection, SortOption, ThProps } from 'types/table';
-import { ApiSortOption } from 'types/search';
-import { isParsedQs } from 'utils/queryStringUtils';
+import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+import { SortAggregate, SortOption, ThProps, isSortOption } from 'types/table';
+import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
 
 export type GetSortParams = (
-    field: string,
-    aggregateBy?: SortAggregate
+    columnName: string,
+    fieldOptions?: SortAggregate | { field: string; aggregateBy?: SortAggregate }[]
 ) => ThProps['sort'] | undefined;
 
-export type UseURLSortProps = {
-    sortFields: string[];
-    defaultSortOption: SortOption;
-    onSort?: (newSortOption: SortOption) => void;
-};
-
-export type UseURLSortResult = {
-    sortOption: ApiSortOption;
-    setSortOption: (newSortOption: SortOption, historyAction?: HistoryAction | undefined) => void;
-    getSortParams: GetSortParams;
-};
-
-function tableSortOption(
-    field: string,
-    direction: SortDirection,
-    aggregateBy?: SortAggregate
-): ApiSortOption {
+function sortOptionToApiSortOption({
+    field,
+    direction,
+    aggregateBy,
+}: SortOption): ApiSortOptionSingle {
     const sortOption = {
         field,
         reversed: direction === 'desc',
@@ -45,65 +34,161 @@ function tableSortOption(
     return sortOption;
 }
 
-function isDirection(val: unknown): val is 'asc' | 'desc' {
-    return val === 'asc' || val === 'desc';
+function getValidSortOption(activeSortOption: SortOption | SortOption[]): ApiSortOption {
+    return Array.isArray(activeSortOption)
+        ? activeSortOption.map(sortOptionToApiSortOption)
+        : sortOptionToApiSortOption(activeSortOption);
 }
 
+function getActiveSortOption(
+    sortOption: QueryValue,
+    defaultSortOption: SortOption
+): SortOption | SortOption[] {
+    if (Array.isArray(sortOption)) {
+        return sortOption.filter(isSortOption);
+    }
+
+    return isSortOption(sortOption) ? sortOption : defaultSortOption;
+}
+
+export type UseURLSortProps = {
+    sortFields: (string | string[])[];
+    defaultSortOption: SortOption;
+    onSort?: (newSortOption: SortOption | SortOption[]) => void;
+};
+
+export type UseURLSortResult = {
+    sortOption: ApiSortOption;
+    setSortOption: (newSortOption: SortOption, historyAction?: HistoryAction | undefined) => void;
+    getSortParams: GetSortParams;
+};
+
+/**
+ * A hook that manages the sort option for a table in the URL.
+ *
+ * @param options.sortFields
+ *      An array of (string | string[]) that represent the sort fields that will
+ *      sent over the API for a given table column. A `string` value represents a
+ *      single field, while a `string[]` value represents multiple fields that may
+ *      have a subset of values sent over the API.
+ * @param options.defaultSortOption
+ *      The default sort option to use when the sort option is not present in the URL.
+ * @param options.onSort
+ *      A callback function that is called when the sort option is changed.
+ * @returns UseURLSortResult.sortOption
+ *      The current sort option. This may be a single
+ *      sort option or an array of sort options.
+ * @returns UseURLSortResult.setSortOption
+ *     A function that can be used to directly set the sort option.
+ * @returns UseURLSortResult.getSortParams
+ *     A function that can be used to get the sort parameters for a given column in a PatternFly table.
+ *     This function has two main signatures for the singular and multi sort use cases:
+ *
+ *     1. getSortParams(columnName: string, fieldOptions?: SortAggregate)
+ *     - This signature is used when the column has a single sort field. The `columnName` parameter
+ *     is used to find the correct column index in the PatternFly table, and is also used as the default
+ *     field name when sending the sort option to the API. The `fieldOptions` parameter is optional and
+ *     is used to specify the aggregate function to use when sorting the column.
+ *
+ *     2. getSortParams(columnName: string, fieldOptions: { field: string; aggregateBy?: SortAggregate }[])
+ *     - This signature is used when the column has multiple sort fields. In this form, the fields sent to
+ *     the API will be the `field` values in the `fieldOptions` array, each of which can optionally
+ *     include an aggregate. The correct column index in the PatternFly table is found by finding any array
+ *     provided in the `sortFields` option that contains one of the `field` values in the `fieldOptions` array.
+ *
+ * @example
+ * // A use case where a table only has single sort columns
+ * const { sortOption, setSortOption, getSortParams } = useURLSort({
+ *    sortFields: ['name', 'age', 'date'],
+ *    defaultSortOption: { field: 'name', direction: 'asc' },
+ * });
+ *
+ * return (
+ *   <Thead>
+ *     <Th sort={getSortParams('name')}>Name</Th>
+ *     <Th sort={getSortParams('age')}>Age</Th>
+ *     <Th sort={getSortParams('date')}>Date</Th>
+ *   </Thead>
+ * );
+ *
+ * @example
+ * // A use case where a table has both single and multi sort columns
+ * const { sortOption, setSortOption, getSortParams } = useURLSort({
+ *   sortFields: ['name', 'age', 'date', ['critical count', 'important count']],
+ *  defaultSortOption: { field: 'name', direction: 'asc' },
+ * });
+ *
+ * return (
+ *   <Thead>
+ *     <Th sort={getSortParams('name')}>Name</Th>
+ *     <Th sort={getSortParams('age')}>Age</Th>
+ *     <Th sort={getSortParams('date')}>Date</Th>
+ *    <Th sort={getSortParams('critical count', [
+ *       { field: 'critical count' },
+ *       { field: 'important count' },
+ *    ])}>Critical Count</Th>
+ *   </Thead>
+ * );
+ *
+ *
+ */
 function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps): UseURLSortResult {
     const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
 
     // get the parsed sort option values from the URL, if available
     // otherwise, use the default sort option values
-    const activeSortField =
-        isParsedQs(sortOption) && typeof sortOption?.field === 'string'
-            ? sortOption.field
-            : defaultSortOption.field;
-    const activeSortDirection =
-        isParsedQs(sortOption) && isDirection(sortOption?.direction)
-            ? sortOption.direction
-            : defaultSortOption.direction;
-    const activeAggregateBy =
-        isParsedQs(sortOption) && sortOption?.aggregateBy
-            ? (sortOption?.aggregateBy as SortAggregate)
-            : undefined;
+    const activeSortOption = getActiveSortOption(sortOption, defaultSortOption);
 
-    const internalSortResultOption = useRef<ApiSortOption>(
-        tableSortOption(activeSortField, activeSortDirection, activeAggregateBy)
-    );
+    const internalSortResultOption = useRef<ApiSortOption>(getValidSortOption(activeSortOption));
 
-    // we'll use this to map the sort fields to an index PatternFly can use internally
-    const [fieldToIndexMap, setFieldToIndexMap] = useState<Record<string, number>>({});
-
-    // we'll construct a map of sort fields to indices that will make it easier to work with
-    // PatternFly
-    useDeepCompareEffect(() => {
-        const newFieldToIndexMap = sortFields.reduce(
-            (acc, curr, index) => {
-                acc[curr] = index;
-                return acc;
-            },
-            {} as Record<string, number>
+    function getSortParams(
+        columnName: string,
+        fieldOptions?: SortAggregate | { field: string; aggregateBy?: SortAggregate }[]
+    ): ThProps['sort'] {
+        // Convert the caller provided sort fields of type (string | string[]) to an
+        // array of string[].
+        const declaredSortFields: string[][] = sortFields.map((field) =>
+            Array.isArray(field) ? field : [field]
         );
-        setFieldToIndexMap(newFieldToIndexMap);
-    }, [sortFields]);
 
-    function getSortParams(field: string, aggregateBy?: SortAggregate): ThProps['sort'] {
-        const index = fieldToIndexMap[field];
-        const activeSortIndex = activeSortField ? fieldToIndexMap[activeSortField] : undefined;
+        // Find the index of the field passed to `getSortParams` in the sortFields provided
+        // to the hook.
+        const targetSortFields: string[] = Array.isArray(fieldOptions)
+            ? fieldOptions.map(({ field }) => field)
+            : [columnName];
+
+        const index = findIndex(
+            declaredSortFields,
+            (field) => intersection(field, targetSortFields).length > 0
+        );
+
+        // Find the index of the active sort field in the declared sort fields.
+        const activeSortOptionFields: string[] = Array.isArray(activeSortOption)
+            ? activeSortOption.map(({ field }) => field)
+            : [activeSortOption.field];
+
+        const activeSortIndex = findIndex(
+            declaredSortFields,
+            (field) => intersection(field, activeSortOptionFields).length > 0
+        );
+
+        // We can't support multiple sort fields with different directions at this time, so
+        // we'll just use the first sort field's direction.
+        const direction = Array.isArray(activeSortOption)
+            ? activeSortOption[0].direction
+            : activeSortOption.direction;
 
         return {
             sortBy: {
                 index: activeSortIndex,
-                direction: activeSortDirection,
+                direction,
                 defaultDirection: 'desc',
             },
             onSort: (_event, _index, direction) => {
-                // modify the URL based on the new sort
-                const newSortOption: SortOption = {
-                    field,
-                    aggregateBy,
-                    direction,
-                };
+                const newSortOption = Array.isArray(fieldOptions)
+                    ? fieldOptions.map((o) => ({ ...o, direction }))
+                    : { field: columnName, aggregateBy: fieldOptions, direction };
+
                 if (onSort) {
                     onSort(newSortOption);
                 }
@@ -113,15 +198,8 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         };
     }
 
-    if (
-        internalSortResultOption.current.field !== activeSortField ||
-        internalSortResultOption.current.reversed !== (activeSortDirection === 'desc')
-    ) {
-        internalSortResultOption.current = tableSortOption(
-            activeSortField,
-            activeSortDirection,
-            activeAggregateBy
-        );
+    if (!isEqual(internalSortResultOption.current, getValidSortOption(activeSortOption))) {
+        internalSortResultOption.current = getValidSortOption(activeSortOption);
     }
 
     return {

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -99,34 +99,34 @@ export type UseURLSortResult = {
  * @example
  * // A use case where a table only has single sort columns
  * const { sortOption, setSortOption, getSortParams } = useURLSort({
- *    sortFields: ['name', 'age', 'date'],
- *    defaultSortOption: { field: 'name', direction: 'asc' },
+ *    sortFields: ['CVE', 'Top CVSS', 'First Discovered'],
+ *    defaultSortOption: { field: 'CVE', direction: 'asc' },
  * });
  *
  * return (
  *   <Thead>
- *     <Th sort={getSortParams('name')}>Name</Th>
- *     <Th sort={getSortParams('age')}>Age</Th>
- *     <Th sort={getSortParams('date')}>Date</Th>
+ *     <Th sort={getSortParams('CVE')}>CVE</Th>
+ *     <Th sort={getSortParams('Top CVSS')}>Top CVSS</Th>
+ *     <Th sort={getSortParams('First Discovered')}>First discovered</Th>
  *   </Thead>
  * );
  *
  * @example
  * // A use case where a table has both single and multi sort columns
  * const { sortOption, setSortOption, getSortParams } = useURLSort({
- *   sortFields: ['name', 'age', 'date', ['critical count', 'important count']],
- *  defaultSortOption: { field: 'name', direction: 'asc' },
+ *   sortFields: ['CVE', 'Top CVSS', 'First Discovered', ['Critical Severity Count', 'Important Severity Count']],
+ *  defaultSortOption: { field: 'CVE', direction: 'asc' },
  * });
  *
  * return (
  *   <Thead>
- *     <Th sort={getSortParams('name')}>Name</Th>
- *     <Th sort={getSortParams('age')}>Age</Th>
- *     <Th sort={getSortParams('date')}>Date</Th>
- *    <Th sort={getSortParams('severity count', [
- *       { field: 'critical count' },
- *       { field: 'important count' },
- *    ])}>Critical Count</Th>
+ *     <Th sort={getSortParams('CVE')}>CVE</Th>
+ *     <Th sort={getSortParams('Top CVSS')}>Top CVSS</Th>
+ *     <Th sort={getSortParams('First Discovered')}>First discovered</Th>
+ *    <Th sort={getSortParams('Images by severity', [
+ *       { field: 'Critical Severity Count' },
+ *       { field: 'Important Severity Count' },
+ *    ])}>Images by severity</Th>
  *   </Thead>
  * );
  *

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -27,7 +27,7 @@ function sortOptionToApiSortOption({
             ...sortOption,
             aggregateBy: {
                 aggregateFunc,
-                distinct: !!distinct,
+                distinct: distinct === 'true',
             },
         };
     }
@@ -45,7 +45,8 @@ function getActiveSortOption(
     defaultSortOption: SortOption
 ): SortOption | SortOption[] {
     if (Array.isArray(sortOption)) {
-        return sortOption.filter(isSortOption);
+        const validOptions = sortOption.filter(isSortOption);
+        return validOptions.length > 0 ? validOptions : defaultSortOption;
     }
 
     return isSortOption(sortOption) ? sortOption : defaultSortOption;
@@ -175,7 +176,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         // We can't support multiple sort fields with different directions at this time, so
         // we'll just use the first sort field's direction.
         const direction = Array.isArray(activeSortOption)
-            ? activeSortOption[0].direction
+            ? activeSortOption[0].direction ?? 'desc'
             : activeSortOption.direction;
 
         return {

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -123,7 +123,7 @@ export type UseURLSortResult = {
  *     <Th sort={getSortParams('name')}>Name</Th>
  *     <Th sort={getSortParams('age')}>Age</Th>
  *     <Th sort={getSortParams('date')}>Date</Th>
- *    <Th sort={getSortParams('critical count', [
+ *    <Th sort={getSortParams('severity count', [
  *       { field: 'critical count' },
  *       { field: 'important count' },
  *    ])}>Critical Count</Th>

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -6,10 +6,13 @@ import isEqual from 'lodash/isEqual';
 import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
 import { SortAggregate, SortOption, ThProps, isSortOption } from 'types/table';
 import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
+import { isNonEmptyArray, NonEmptyArray } from 'utils/type.utils';
+
+export type FieldOption = { field: string; aggregateBy?: SortAggregate };
 
 export type GetSortParams = (
     columnName: string,
-    fieldOptions?: SortAggregate | { field: string; aggregateBy?: SortAggregate }[]
+    fieldOptions?: SortAggregate | NonEmptyArray<FieldOption>
 ) => ThProps['sort'] | undefined;
 
 function sortOptionToApiSortOption({
@@ -43,10 +46,10 @@ function getValidSortOption(activeSortOption: SortOption | SortOption[]): ApiSor
 function getActiveSortOption(
     sortOption: QueryValue,
     defaultSortOption: SortOption
-): SortOption | SortOption[] {
+): SortOption | NonEmptyArray<SortOption> {
     if (Array.isArray(sortOption)) {
         const validOptions = sortOption.filter(isSortOption);
-        return validOptions.length > 0 ? validOptions : defaultSortOption;
+        return isNonEmptyArray(validOptions) ? validOptions : defaultSortOption;
     }
 
     return isSortOption(sortOption) ? sortOption : defaultSortOption;
@@ -144,7 +147,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
 
     function getSortParams(
         columnName: string,
-        fieldOptions?: SortAggregate | { field: string; aggregateBy?: SortAggregate }[]
+        fieldOptions?: SortAggregate | NonEmptyArray<FieldOption>
     ): ThProps['sort'] {
         // Convert the caller provided sort fields of type (string | string[]) to an
         // array of string[].
@@ -176,7 +179,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         // We can't support multiple sort fields with different directions at this time, so
         // we'll just use the first sort field's direction.
         const direction = Array.isArray(activeSortOption)
-            ? activeSortOption[0].direction ?? 'desc'
+            ? activeSortOption[0].direction
             : activeSortOption.direction;
 
         return {

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -1,4 +1,4 @@
-import { ApiSortOption } from 'types/search';
+import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
 
 /* The type for pagination data stored and generated client side */
 export type ClientPagination = {
@@ -7,12 +7,16 @@ export type ClientPagination = {
     sortOption?: ApiSortOption;
 };
 
-/* The type for pagination data passed to the server side APIs */
-export type Pagination = {
+type PaginationBase = {
     offset: number;
     limit: number;
-    sortOption?: ApiSortOption;
 };
+
+/* The type for pagination data passed to the server side APIs */
+export type Pagination =
+    | PaginationBase
+    | (PaginationBase & { sortOption: ApiSortOptionSingle })
+    | (PaginationBase & { sortOptions: ApiSortOptionSingle[] });
 
 export type FilterQuery = {
     query: string;

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -20,7 +20,7 @@ export type SearchEntry = {
     label: string; // an option ends with a colon
 };
 
-export type ApiSortOption = {
+export type ApiSortOptionSingle = {
     field: string;
     aggregateBy?: {
         aggregateFunc: AggregateFunc;
@@ -28,6 +28,8 @@ export type ApiSortOption = {
     };
     reversed: boolean;
 };
+
+export type ApiSortOption = ApiSortOptionSingle | ApiSortOptionSingle[];
 
 export type GraphQLSortOption = {
     id: string;

--- a/ui/apps/platform/src/types/table.ts
+++ b/ui/apps/platform/src/types/table.ts
@@ -1,20 +1,35 @@
 import { ReactElement } from 'react';
+import * as yup from 'yup';
 
 export type { ThProps } from '@patternfly/react-table';
 
-export type SortDirection = 'asc' | 'desc';
-export type AggregateFunc = 'max' | 'count' | 'min';
+export const SortDirectionSchema = yup.string().oneOf(['asc', 'desc']).defined();
+export const AggregateFuncSchema = yup.string().oneOf(['max', 'count', 'min']).defined();
+export const SortAggregateSchema = yup.object({
+    aggregateFunc: AggregateFuncSchema.required(),
+    distinct: yup.string().oneOf(['true', 'false']).optional(),
+});
+export const SortOptionSchema = yup.object({
+    field: yup.string().required(),
+    // The .default(undefined) is necessary to allow for the aggregateBy field to be
+    // omitted and pass validation.
+    aggregateBy: SortAggregateSchema.optional().default(undefined),
+    direction: SortDirectionSchema.required(),
+});
 
-export type SortAggregate = {
-    aggregateFunc: AggregateFunc;
-    distinct?: 'true' | 'false';
-};
+export type SortDirection = yup.InferType<typeof SortDirectionSchema>;
+export type AggregateFunc = yup.InferType<typeof AggregateFuncSchema>;
+export type SortAggregate = yup.InferType<typeof SortAggregateSchema>;
+export type SortOption = yup.InferType<typeof SortOptionSchema>;
 
-export type SortOption = {
-    field: string;
-    aggregateBy?: SortAggregate;
-    direction: SortDirection;
-};
+export function isSortOption(val: unknown): val is SortOption {
+    try {
+        SortOptionSchema.validateSync(val);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
 
 export type TableColumn = {
     Header: string;

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,6 +1,12 @@
 import qs from 'qs';
 
-import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
+import {
+    SearchEntry,
+    ApiSortOption,
+    GraphQLSortOption,
+    SearchFilter,
+    ApiSortOptionSingle,
+} from 'types/search';
 import { Pagination } from 'services/types';
 import { ValueOf } from './type.utils';
 import { safeGeneratePath } from './urlUtils';
@@ -70,14 +76,19 @@ export function convertToRestSearch(workflowSearch: Record<string, string>): Sea
     return restSearch;
 }
 
-export function convertSortToGraphQLFormat({ field, reversed }: ApiSortOption): GraphQLSortOption {
+export function convertSortToGraphQLFormat({
+    field,
+    reversed,
+}: ApiSortOptionSingle): GraphQLSortOption {
     return {
         id: field,
         desc: reversed,
     };
 }
 
-export function convertSortToRestFormat(graphqlSort: GraphQLSortOption[]): Partial<ApiSortOption> {
+export function convertSortToRestFormat(
+    graphqlSort: GraphQLSortOption[]
+): Partial<ApiSortOptionSingle> {
     return {
         field: graphqlSort[0]?.id,
         reversed: graphqlSort[0]?.desc,
@@ -240,6 +251,12 @@ export function getPaginationParams({
 
     if (typeof sortOption === 'undefined') {
         return paginationBase;
+    }
+
+    // When using multiple sort options, the API expects an array of sort options and the
+    // plural form of `sortOption` is used.
+    if (Array.isArray(sortOption)) {
+        return { ...paginationBase, sortOptions: sortOption };
     }
 
     return { ...paginationBase, sortOption };


### PR DESCRIPTION
### Description

Reworks the `useURLSort()` hook to add the ability to sort by multiple fields in a single sort operation.

> Reviewing the `useURLSort.ts` file will likely be easier in "Split" mode due to the extent of the changes

This is nearly a rewrite of the hook, but was done in place instead of creating a separate hook for the following reasons:
1. Most importantly, customers may have saved links using _singular_ sort fields, and switching to an API that enforced an array of sort fields would break these links.
2. Since most tables will have a mix of columns that use single and multi sort, and the backend API requires `sortOption` and `sortOptions` fields respectively, we want to be able to easily distinguish when a sort operation is intended to span multiple options and when it should be sent as a single option.

The implementation process followed the following steps:
1. [Update the global `ApiSortOption` type](https://github.com/stackrox/stackrox/pull/12725/files#diff-567137c8bf241186d665d25bb945cb6cbf528b541a71aa28038ab61b0d14073a) so that it refers to both the singular sort option as well as multiple sort options
2. [Update the `Pagination` type](https://github.com/stackrox/stackrox/pull/12725/files#diff-225d1d3f34456ffd1dd6dfcd00d49805cf0a1e21ccbeb524df3fea38b2802753) that represents the type the server accepts so that it accounts for either the singular `{ sortOption: ApiSortOptionSingle }` xor plural `{ sortOptions: ApiSortOptionSingle[] }` sort options types.
3. Update any location using the old `ApiSortOption` type in a singular way only to rely on the `ApiSortOptionSingle` type instead (multiple locations)
4. Update the implementation of `useURLSort()` so that it returns a `{ sortOption }` that can be either singular or an array, and accepts input parameters that can be singular or arrays. Determining how to handle the singular or array type is up to the caller of the hook. In almost all cases this is handled internally in the `getPaginationParams` function, which doesn't require code changes or new patterns when using the hook in the typical way and sending the parameters to the API.

### Caveats

1. If the hook or `getSortParams` function are called with array types and the values are sent to an API that does not support multiple sort options (i.e. all REST endpoints currently), the sorting will be silently ignored. This is similar to what happens when unknown API parameters are sent to the BE, and is up to the developer to test that sorting is having the intended effect.




### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Existing unit tests.
- New unit tests.
- Existing e2e tests.
- Manual smoke tests of various sections of the UI that use sorting.
