### PR TITLE
test(ui): Add more coverage to `useURLSort` unit tests

### DIFF
--- a/ui/apps/platform/src/hooks/useURLSort.test.js
+++ b/ui/apps/platform/src/hooks/useURLSort.test.js
@@ -2,10 +2,9 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
+import cloneDeep from 'lodash/cloneDeep';
 
 import useURLSort from './useURLSort';
-
-const history = createMemoryHistory();
 
 const params = {
     sortFields: ['Name', 'Status'],
@@ -16,6 +15,8 @@ const params = {
 };
 
 const wrapper = ({ children }) => {
+    const history = createMemoryHistory();
+
     return <Router history={history}>{children}</Router>;
 };
 
@@ -31,53 +32,158 @@ function actAndRunTicks(callback) {
 }
 
 describe('useURLSort', () => {
-    it('should get the sort options from URL by default', () => {
-        const { result } = renderHook(
-            () => {
-                return useURLSort(params);
-            },
-            {
-                wrapper,
-            }
-        );
+    describe('when using URL sort with single sort options', () => {
+        it('should get the sort options from URL by default', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
 
-        expect(result.current.sortOption.field).toEqual('Name');
-        expect(result.current.sortOption.reversed).toEqual(true);
-    });
-
-    it('should keep sorting to the "Status" field and change direction to "asc"', () => {
-        const { result } = renderHook(
-            () => {
-                return useURLSort(params);
-            },
-            {
-                wrapper,
-            }
-        );
-
-        actAndRunTicks(() => {
-            result.current.getSortParams('Name').onSort(null, null, 'asc');
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
         });
 
-        expect(result.current.sortOption.field).toEqual('Name');
-        expect(result.current.sortOption.reversed).toEqual(false);
-    });
+        it('should change sorting directions on a single field', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
 
-    it('should change sorting to the "Status" field and direction to "desc"', () => {
-        const { result } = renderHook(
-            () => {
-                return useURLSort(params);
-            },
-            {
-                wrapper,
-            }
-        );
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
 
-        actAndRunTicks(() => {
-            result.current.getSortParams('Status').onSort(null, null, 'desc');
+            actAndRunTicks(() => {
+                result.current.getSortParams('Name').onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(false);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Name').onSort(null, null, 'desc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
         });
 
-        expect(result.current.sortOption.field).toEqual('Status');
-        expect(result.current.sortOption.reversed).toEqual(true);
+        it('should change sorting fields and directions', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'desc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(false);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Name').onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(false);
+        });
+
+        it('should trigger the `onSort` callback when the sort option changes', () => {
+            const onSort = jest.fn();
+
+            const { result } = renderHook(() => useURLSort({ ...params, onSort }), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'desc');
+            });
+
+            expect(onSort).toHaveBeenCalledTimes(1);
+            expect(onSort).toHaveBeenCalledWith({ field: 'Status', direction: 'desc' });
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(true);
+        });
+
+        it('should retain the passed `aggregateBy` value when sorting', () => {
+            const sortParams = cloneDeep(params);
+            const aggregateBy = { distinct: true, aggregateFunc: 'count' };
+            sortParams.defaultSortOption.aggregateBy = aggregateBy;
+            const { result } = renderHook(() => useURLSort(sortParams), { wrapper });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+            expect(result.current.sortOption.aggregateBy.distinct).toEqual(true);
+            expect(result.current.sortOption.aggregateBy.aggregateFunc).toEqual('count');
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Name', aggregateBy).onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(false);
+            expect(result.current.sortOption.aggregateBy.distinct).toEqual(true);
+            expect(result.current.sortOption.aggregateBy.aggregateFunc).toEqual('count');
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'desc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(true);
+            expect(result.current.sortOption.aggregateBy).toEqual(undefined);
+        });
+
+        it('should return the correct PatternFly sort parameters via the `getSortParams` function', () => {
+            const { result } = renderHook(() => useURLSort(params), { wrapper });
+
+            // Test handling of both provided fields, and a bogus field that doesn't exist in the sortFields array
+
+            expect(result.current.sortOption.field).toEqual('Name');
+            expect(result.current.sortOption.reversed).toEqual(true);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(0);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('desc');
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Status').onSort(null, null, 'desc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Status');
+            expect(result.current.sortOption.reversed).toEqual(true);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(1);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('desc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(1);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('desc');
+
+            actAndRunTicks(() => {
+                result.current.getSortParams('Bogus').onSort(null, null, 'asc');
+            });
+
+            expect(result.current.sortOption.field).toEqual('Bogus');
+            expect(result.current.sortOption.reversed).toEqual(false);
+            expect(result.current.getSortParams('Name').columnIndex).toEqual(0);
+            expect(result.current.getSortParams('Name').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Name').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Status').columnIndex).toEqual(1);
+            expect(result.current.getSortParams('Status').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Status').sortBy.direction).toEqual('asc');
+            expect(result.current.getSortParams('Bogus').columnIndex).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').sortBy.index).toEqual(undefined);
+            expect(result.current.getSortParams('Bogus').sortBy.direction).toEqual('asc');
+        });
     });
 });


### PR DESCRIPTION
### Description

The `useURLSort` hook will require a very large refactor/rewrite in order to support multiple sort options. This PR adds many more test cases to ensure the existing functionality is well tested before implementing a change.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

`npm run test`
