### PR TITLE
ROX-26287: Missing deployment info in violations deployment tab

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -14,18 +14,13 @@ function ContainerConfiguration({ deployment }: ContainerConfigurationProps): Re
     if (deployment === null) {
         content =
             "Container configurations are unavailable because the alert's deployment no longer exists.";
-    } else {
-        if (Array.isArray(deployment?.containers) && deployment.containers.length !== 0) {
-            content = deployment.containers.map((container, i) => (
-                <React.Fragment key={container.id}>
-                    <Title headingLevel="h4" className="pf-v5-u-mb-md">{`containers[${i}]`}</Title>
-                    <ContainerConfigurationDescriptionList
-                        key={container.id}
-                        container={container}
-                    />
-                </React.Fragment>
-            ));
-        }
+    } else if (deployment.containers.length !== 0) {
+        content = deployment.containers.map((container, i) => (
+            <React.Fragment key={container.id}>
+                <Title headingLevel="h4" className="pf-v5-u-mb-md">{`containers[${i}]`}</Title>
+                <ContainerConfigurationDescriptionList key={container.id} container={container} />
+            </React.Fragment>
+        ));
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -1,92 +1,38 @@
 import React, { ReactElement } from 'react';
-import { DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
-import DescriptionListItem from 'Components/DescriptionListItem';
-import { Container } from 'types/deployment.proto';
+import { Deployment } from 'types/deployment.proto';
+import ContainerConfigurationDescriptionList from './ContainerConfigurationDescriptionList';
 
-import ContainerImage from './ContainerImage';
-import ContainerResourcesDescriptionList from './ContainerResourcesDescriptionList';
-import ContainerSecretDescriptionList from './ContainerSecretDescriptionList';
-import ContainerVolumeDescriptionList from './ContainerVolumeDescriptionList';
-
-function MultilineDescription({ descArr }) {
-    return (
-        <Flex direction={{ default: 'column' }}>
-            {descArr.map((desc, idx) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <div key={idx}>
-                    <FlexItem>{desc}</FlexItem>
-                </div>
-            ))}
-        </Flex>
-    );
-}
-
-type ContainerConfigurationProps = {
-    container: Container;
+export type ContainerConfigurationProps = {
+    deployment: Deployment | null;
 };
 
-function ContainerConfiguration({ container }: ContainerConfigurationProps): ReactElement {
-    const { resources, volumes, secrets, config, image } = container;
-    const { command, args } = config || {};
+function ContainerConfiguration({ deployment }: ContainerConfigurationProps): ReactElement {
+    let content: JSX.Element[] | string = 'None';
+
+    if (deployment === null) {
+        content =
+            "Container configurations are unavailable because the alert's deployment no longer exists.";
+    } else {
+        if (Array.isArray(deployment?.containers) && deployment.containers.length !== 0) {
+            content = deployment.containers.map((container, i) => (
+                <React.Fragment key={container.id}>
+                    <Title headingLevel="h4" className="pf-v5-u-mb-md">{`containers[${i}]`}</Title>
+                    <ContainerConfigurationDescriptionList
+                        key={container.id}
+                        container={container}
+                    />
+                </React.Fragment>
+            ));
+        }
+    }
+
     return (
-        <DescriptionList isCompact isHorizontal>
-            <ContainerImage image={image} />
-            {(command?.length > 0 || args?.length > 0) && (
-                <>
-                    {command.length > 0 && (
-                        <DescriptionListItem
-                            term="Commands"
-                            desc={<MultilineDescription descArr={command} />}
-                            aria-label="Commands"
-                        />
-                    )}
-                    {args?.length > 0 && (
-                        <DescriptionListItem
-                            term="Arguments"
-                            desc={<MultilineDescription descArr={args} />}
-                            aria-label="Arguments"
-                        />
-                    )}
-                </>
-            )}
-            {!!resources && (
-                <DescriptionListItem
-                    term="Resources"
-                    desc={
-                        resources ? (
-                            <ContainerResourcesDescriptionList resources={resources} />
-                        ) : (
-                            'None'
-                        )
-                    }
-                />
-            )}
-            {!!volumes &&
-                (volumes.length === 0 ? (
-                    <DescriptionListItem term="volumes" desc="None" />
-                ) : (
-                    volumes.map((volume, i) => (
-                        <DescriptionListItem
-                            key={volume.name}
-                            term={`volumes[${i}]`}
-                            desc={<ContainerVolumeDescriptionList volume={volume} />}
-                        />
-                    ))
-                ))}
-            {!!secrets &&
-                (secrets.length === 0 ? (
-                    <DescriptionListItem term="secrets" desc="None" />
-                ) : (
-                    secrets.map((secret, i) => (
-                        <DescriptionListItem
-                            key={`${secret.name}_${secret.path}`}
-                            term={`secrets[${i}]`}
-                            desc={<ContainerSecretDescriptionList secret={secret} />}
-                        />
-                    ))
-                ))}
-        </DescriptionList>
+        <Card isFlat>
+            <CardTitle component="h3">Container configuration</CardTitle>
+            <CardBody>{content}</CardBody>
+        </Card>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
@@ -34,60 +34,44 @@ function ContainerConfigurationDescriptionList({
     return (
         <DescriptionList isCompact isHorizontal>
             <ContainerImage image={image} />
-            {(command?.length > 0 || args?.length > 0) && (
-                <>
-                    {command.length > 0 && (
-                        <DescriptionListItem
-                            term="Commands"
-                            desc={<MultilineDescription descArr={command} />}
-                            aria-label="Commands"
-                        />
-                    )}
-                    {args?.length > 0 && (
-                        <DescriptionListItem
-                            term="Arguments"
-                            desc={<MultilineDescription descArr={args} />}
-                            aria-label="Arguments"
-                        />
-                    )}
-                </>
+            <DescriptionListItem
+                term="Commands"
+                desc={command?.length > 0 ? <MultilineDescription descArr={command} /> : 'None'}
+                aria-label="Commands"
+            />
+            <DescriptionListItem
+                term="Arguments"
+                desc={args?.length > 0 ? <MultilineDescription descArr={args} /> : 'None'}
+                aria-label="Arguments"
+            />
+            <DescriptionListItem
+                term="Resources"
+                desc={
+                    resources ? <ContainerResourcesDescriptionList resources={resources} /> : 'None'
+                }
+            />
+            {volumes == null || volumes.length === 0 ? (
+                <DescriptionListItem term="volumes" desc="None" />
+            ) : (
+                volumes.map((volume, i) => (
+                    <DescriptionListItem
+                        key={volume.name}
+                        term={`volumes[${i}]`}
+                        desc={<ContainerVolumeDescriptionList volume={volume} />}
+                    />
+                ))
             )}
-            {!!resources && (
-                <DescriptionListItem
-                    term="Resources"
-                    desc={
-                        resources ? (
-                            <ContainerResourcesDescriptionList resources={resources} />
-                        ) : (
-                            'None'
-                        )
-                    }
-                />
+            {secrets == null || secrets.length === 0 ? (
+                <DescriptionListItem term="secrets" desc="None" />
+            ) : (
+                secrets.map((secret, i) => (
+                    <DescriptionListItem
+                        key={`${secret.name}_${secret.path}`}
+                        term={`secrets[${i}]`}
+                        desc={<ContainerSecretDescriptionList secret={secret} />}
+                    />
+                ))
             )}
-            {!!volumes &&
-                (volumes.length === 0 ? (
-                    <DescriptionListItem term="volumes" desc="None" />
-                ) : (
-                    volumes.map((volume, i) => (
-                        <DescriptionListItem
-                            key={volume.name}
-                            term={`volumes[${i}]`}
-                            desc={<ContainerVolumeDescriptionList volume={volume} />}
-                        />
-                    ))
-                ))}
-            {!!secrets &&
-                (secrets.length === 0 ? (
-                    <DescriptionListItem term="secrets" desc="None" />
-                ) : (
-                    secrets.map((secret, i) => (
-                        <DescriptionListItem
-                            key={`${secret.name}_${secret.path}`}
-                            term={`secrets[${i}]`}
-                            desc={<ContainerSecretDescriptionList secret={secret} />}
-                        />
-                    ))
-                ))}
         </DescriptionList>
     );
 }

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
@@ -1,0 +1,95 @@
+import React, { ReactElement } from 'react';
+import { DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
+
+import DescriptionListItem from 'Components/DescriptionListItem';
+import { Container } from 'types/deployment.proto';
+
+import ContainerImage from './ContainerImage';
+import ContainerResourcesDescriptionList from './ContainerResourcesDescriptionList';
+import ContainerSecretDescriptionList from './ContainerSecretDescriptionList';
+import ContainerVolumeDescriptionList from './ContainerVolumeDescriptionList';
+
+function MultilineDescription({ descArr }) {
+    return (
+        <Flex direction={{ default: 'column' }}>
+            {descArr.map((desc, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={idx}>
+                    <FlexItem>{desc}</FlexItem>
+                </div>
+            ))}
+        </Flex>
+    );
+}
+
+type ContainerConfigurationDescriptionListProps = {
+    container: Container;
+};
+
+function ContainerConfigurationDescriptionList({
+    container,
+}: ContainerConfigurationDescriptionListProps): ReactElement {
+    const { resources, volumes, secrets, config, image } = container;
+    const { command, args } = config || {};
+    return (
+        <DescriptionList isCompact isHorizontal>
+            <ContainerImage image={image} />
+            {(command?.length > 0 || args?.length > 0) && (
+                <>
+                    {command.length > 0 && (
+                        <DescriptionListItem
+                            term="Commands"
+                            desc={<MultilineDescription descArr={command} />}
+                            aria-label="Commands"
+                        />
+                    )}
+                    {args?.length > 0 && (
+                        <DescriptionListItem
+                            term="Arguments"
+                            desc={<MultilineDescription descArr={args} />}
+                            aria-label="Arguments"
+                        />
+                    )}
+                </>
+            )}
+            {!!resources && (
+                <DescriptionListItem
+                    term="Resources"
+                    desc={
+                        resources ? (
+                            <ContainerResourcesDescriptionList resources={resources} />
+                        ) : (
+                            'None'
+                        )
+                    }
+                />
+            )}
+            {!!volumes &&
+                (volumes.length === 0 ? (
+                    <DescriptionListItem term="volumes" desc="None" />
+                ) : (
+                    volumes.map((volume, i) => (
+                        <DescriptionListItem
+                            key={volume.name}
+                            term={`volumes[${i}]`}
+                            desc={<ContainerVolumeDescriptionList volume={volume} />}
+                        />
+                    ))
+                ))}
+            {!!secrets &&
+                (secrets.length === 0 ? (
+                    <DescriptionListItem term="secrets" desc="None" />
+                ) : (
+                    secrets.map((secret, i) => (
+                        <DescriptionListItem
+                            key={`${secret.name}_${secret.path}`}
+                            term={`secrets[${i}]`}
+                            desc={<ContainerSecretDescriptionList secret={secret} />}
+                        />
+                    ))
+                ))}
+        </DescriptionList>
+    );
+}
+
+export default ContainerConfigurationDescriptionList;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -13,7 +13,7 @@ import FlatObjectDescriptionList from './FlatObjectDescriptionList';
 
 export type DeploymentOverviewProps = {
     alertDeployment: AlertDeployment;
-    deployment?: Deployment;
+    deployment: Deployment | null;
 };
 
 function DeploymentOverview({

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -32,7 +32,7 @@ function DeploymentTabWithReadAccessForDeployment({
                 <Alert
                     variant="warning"
                     isInline
-                    title="There was an error fetching the deployment details. This deployment may no longer exist. The information below is based on the last known state at the time the alert was triggered and may be outdated."
+                    title="Unable to fetch deployment details. The deployment may no longer exist. The information below reflects the last known state at the time the alert was triggered and may be outdated."
                     component="p"
                 >
                     {getAxiosErrorMessage(relatedDeploymentFetchError)}

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -1,15 +1,15 @@
 import React, { ReactElement } from 'react';
-import { Alert, Card, CardBody, CardTitle, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Alert, Card, CardBody, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
 import useFetchDeployment from 'hooks/useFetchDeployment';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { AlertDeployment } from 'types/alert.proto';
 
-import ContainerConfiguration from './ContainerConfiguration';
 import DeploymentOverview from './DeploymentOverview';
-import PortDescriptionList from './PortDescriptionList';
 import SecurityContext from './SecurityContext';
+import PortConfiguration from './PortConfiguration';
+import ContainerConfiguration from './ContainerConfiguration';
 
 export type DeploymentTabWithReadAccessForDeploymentProps = {
     alertDeployment: AlertDeployment;
@@ -21,8 +21,6 @@ function DeploymentTabWithReadAccessForDeployment({
     // attempt to fetch related deployment to selected alert
     const { deployment: relatedDeployment, error: relatedDeploymentFetchError } =
         useFetchDeployment(alertDeployment.id);
-
-    const relatedDeploymentPorts = relatedDeployment?.ports || [];
 
     return (
         <Flex
@@ -46,36 +44,15 @@ function DeploymentTabWithReadAccessForDeployment({
                         <Card isFlat>
                             <CardTitle component="h3">Deployment overview</CardTitle>
                             <CardBody>
-                                {relatedDeployment && (
-                                    <DeploymentOverview
-                                        alertDeployment={alertDeployment}
-                                        deployment={relatedDeployment}
-                                    />
-                                )}
+                                <DeploymentOverview
+                                    alertDeployment={alertDeployment}
+                                    deployment={relatedDeployment}
+                                />
                             </CardBody>
                         </Card>
                     </FlexItem>
                     <FlexItem>
-                        <Card isFlat>
-                            <CardTitle component="h3">Port configuration</CardTitle>
-                            <CardBody>
-                                {relatedDeploymentPorts.length === 0
-                                    ? 'None'
-                                    : relatedDeploymentPorts.map((port, i) => {
-                                          /* eslint-disable react/no-array-index-key */
-                                          return (
-                                              <React.Fragment key={i}>
-                                                  <Title
-                                                      headingLevel="h4"
-                                                      className="pf-v5-u-mb-md"
-                                                  >{`ports[${i}]`}</Title>
-                                                  <PortDescriptionList port={port} />
-                                              </React.Fragment>
-                                          );
-                                          /* eslint-enable react/no-array-index-key */
-                                      })}
-                            </CardBody>
-                        </Card>
+                        <PortConfiguration deployment={relatedDeployment} />
                     </FlexItem>
                     <FlexItem>
                         <SecurityContext deployment={relatedDeployment} />
@@ -83,26 +60,7 @@ function DeploymentTabWithReadAccessForDeployment({
                 </Flex>
                 <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }}>
                     <FlexItem>
-                        <Card isFlat>
-                            <CardTitle component="h3">Container configuration</CardTitle>
-                            <CardBody>
-                                {Array.isArray(relatedDeployment?.containers) &&
-                                relatedDeployment?.containers.length !== 0
-                                    ? relatedDeployment?.containers.map((container, i) => (
-                                          <React.Fragment key={container.id}>
-                                              <Title
-                                                  headingLevel="h4"
-                                                  className="pf-v5-u-mb-md"
-                                              >{`containers[${i}]`}</Title>
-                                              <ContainerConfiguration
-                                                  key={container.id}
-                                                  container={container}
-                                              />
-                                          </React.Fragment>
-                                      ))
-                                    : 'None'}
-                            </CardBody>
-                        </Card>
+                        <ContainerConfiguration deployment={relatedDeployment} />
                     </FlexItem>
                 </Flex>
             </Flex>

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -32,7 +32,7 @@ function DeploymentTabWithReadAccessForDeployment({
                 <Alert
                     variant="warning"
                     isInline
-                    title="There was an error fetching the deployment details. This deployment may no longer exist."
+                    title="There was an error fetching the deployment details. This deployment may no longer exist. The information below is based on the last known state at the time the alert was triggered and may be outdated."
                     component="p"
                 >
                     {getAxiosErrorMessage(relatedDeploymentFetchError)}

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
@@ -24,7 +24,10 @@ function DeploymentTabWithoutReadAccessForDeployment({
                         <Card isFlat>
                             <CardTitle component="h3">Deployment overview</CardTitle>
                             <CardBody>
-                                <DeploymentOverview alertDeployment={alertDeployment} />
+                                <DeploymentOverview
+                                    alertDeployment={alertDeployment}
+                                    deployment={null}
+                                />
                             </CardBody>
                         </Card>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
+
+import { Deployment } from 'types/deployment.proto';
+import PortDescriptionList from './PortDescriptionList';
+
+export type PortConfigurationProps = {
+    deployment: Deployment | null;
+};
+
+function PortConfiguration({ deployment }: PortConfigurationProps): ReactElement {
+    let content: JSX.Element[] | string = 'None';
+
+    if (deployment === null) {
+        content =
+            "Port configurations are unavailable because the alert's deployment no longer exists.";
+    } else {
+        if (deployment.ports.length !== 0) {
+            content = deployment.ports.map((port, i) => {
+                /* eslint-disable react/no-array-index-key */
+                return (
+                    <React.Fragment key={i}>
+                        <Title headingLevel="h4" className="pf-v5-u-mb-md">{`ports[${i}]`}</Title>
+                        <PortDescriptionList port={port} />
+                    </React.Fragment>
+                );
+                /* eslint-enable react/no-array-index-key */
+            });
+        }
+    }
+
+    return (
+        <Card isFlat>
+            <CardTitle component="h3">Port configuration</CardTitle>
+            <CardBody>{content}</CardBody>
+        </Card>
+    );
+}
+
+export default PortConfiguration;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
@@ -14,19 +14,17 @@ function PortConfiguration({ deployment }: PortConfigurationProps): ReactElement
     if (deployment === null) {
         content =
             "Port configurations are unavailable because the alert's deployment no longer exists.";
-    } else {
-        if (deployment.ports.length !== 0) {
-            content = deployment.ports.map((port, i) => {
-                /* eslint-disable react/no-array-index-key */
-                return (
-                    <React.Fragment key={i}>
-                        <Title headingLevel="h4" className="pf-v5-u-mb-md">{`ports[${i}]`}</Title>
-                        <PortDescriptionList port={port} />
-                    </React.Fragment>
-                );
-                /* eslint-enable react/no-array-index-key */
-            });
-        }
+    } else if (deployment.ports.length !== 0) {
+        content = deployment.ports.map((port, i) => {
+            /* eslint-disable react/no-array-index-key */
+            return (
+                <React.Fragment key={i}>
+                    <Title headingLevel="h4" className="pf-v5-u-mb-md">{`ports[${i}]`}</Title>
+                    <PortDescriptionList port={port} />
+                </React.Fragment>
+            );
+            /* eslint-enable react/no-array-index-key */
+        });
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -9,46 +9,44 @@ export type SecurityContextProps = {
 };
 
 function SecurityContext({ deployment }: SecurityContextProps): ReactElement {
-    const securityContextContainers =
-        deployment?.containers?.filter(
-            (container) =>
-                !!(
-                    container?.securityContext?.privileged ||
-                    container?.securityContext?.addCapabilities.length > 0 ||
-                    container?.securityContext?.dropCapabilities.length > 0
-                )
-        ) ?? [];
+    let content: JSX.Element[] | string = 'None';
+
+    if (deployment === null) {
+        content =
+            "Security context is unavailable because the alert's deployment no longer exists.";
+    } else {
+        const securityContextContainers =
+            deployment?.containers?.filter(
+                (container) =>
+                    !!(
+                        container?.securityContext?.privileged ||
+                        container?.securityContext?.addCapabilities.length > 0 ||
+                        container?.securityContext?.dropCapabilities.length > 0
+                    )
+            ) ?? [];
+        if (securityContextContainers.length !== 0) {
+            content = securityContextContainers.map((container, idx) => {
+                const { privileged, addCapabilities, dropCapabilities } = container.securityContext;
+                return (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <DescriptionList isHorizontal key={idx}>
+                        {privileged && <DescriptionListItem term="Privileged" desc="true" />}
+                        {addCapabilities.length > 0 && (
+                            <DescriptionListItem term="Add capabilities" desc={addCapabilities} />
+                        )}
+                        {dropCapabilities.length > 0 && (
+                            <DescriptionListItem term="Drop capabilities" desc={dropCapabilities} />
+                        )}
+                    </DescriptionList>
+                );
+            });
+        }
+    }
+
     return (
         <Card isFlat>
             <CardTitle component="h3">Security context</CardTitle>
-            <CardBody>
-                {securityContextContainers?.length > 0
-                    ? securityContextContainers.map((container, idx) => {
-                          const { privileged, addCapabilities, dropCapabilities } =
-                              container.securityContext;
-                          return (
-                              // eslint-disable-next-line react/no-array-index-key
-                              <DescriptionList isHorizontal key={idx}>
-                                  {privileged && (
-                                      <DescriptionListItem term="Privileged" desc="true" />
-                                  )}
-                                  {addCapabilities.length > 0 && (
-                                      <DescriptionListItem
-                                          term="Add capabilities"
-                                          desc={addCapabilities}
-                                      />
-                                  )}
-                                  {dropCapabilities.length > 0 && (
-                                      <DescriptionListItem
-                                          term="Drop capabilities"
-                                          desc={dropCapabilities}
-                                      />
-                                  )}
-                              </DescriptionList>
-                          );
-                      })
-                    : 'None'}
-            </CardBody>
+            <CardBody>{content}</CardBody>
         </Card>
     );
 }


### PR DESCRIPTION
### Description

Bug:

When the deployment no longer exists, we don't display anything in the Deployment tab of the Violations detail page. This is misleading because the alert does keep track of some of the deployment details. 

<img width="1439" alt="Screenshot 2024-09-17 at 9 40 35 AM" src="https://github.com/user-attachments/assets/8bc48353-420c-44c0-8735-da0586287124">

Fix:

This is a partial fix. We can display the available details from the alert's deployment object. However, if the user requires more deployment information, that you would see if the deployment was still available, we would need to store that information in the alert object. 

![Screenshot 2024-09-17 at 2 20 23 PM](https://github.com/user-attachments/assets/efc44080-1648-4bb3-bc14-34a28405cbfd)


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and Quality

- [x] the change is production ready: the change is GA or otherwise, the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no changes
 
#### How I validated my change

Checked if the UI works as expected
