### PR TITLE
ROX-26047: Switch to prod subscription-manager activation key

### DIFF
--- a/.konflux/scripts/subscription-manager/subscription-manager-bro.sh
+++ b/.konflux/scripts/subscription-manager/subscription-manager-bro.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-SECRET_NAME_IN_KONFLUX="subscription-manager-activation-key"
+SECRET_NAME_IN_KONFLUX="subscription-manager-activation-key-prod"
 # The mount is provided by the buildah task when the ACTIVATION_KEY parameter is set to a valid secret name.
 SECRET_MOUNT_PATH="/activation-key"
 SECRET_KEY="activation-key"

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -246,7 +246,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name
@@ -288,7 +288,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name
@@ -331,7 +331,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name
@@ -374,7 +374,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
### Description

See the ticket's description. The key is already set up.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No change to automated testing.

#### How I validated my change

- Put the key in `.konflux/scripts/subscription-manager/activation-key` locally and ran `subscription-manager-bro.sh self-test`.
- CI.
