### PR TITLE
ci: Enable config-controller unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SILENT ?= @
 # the pattern is passed to: grep -Ev
 #  usage: "path/to/ignored|another/path"
 # TODO: [ROX-19070] Update postgres store test generation to work for foreign keys
-UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests|stackrox/rox/operator/tests|stackrox/rox/config-controller|stackrox/rox/central/reports/config/store/postgres|stackrox/rox/central/complianceoperator/v2/scanconfigurations/store/postgres|stackrox/rox/central/auth/store/postgres|stackrox/rox/scanner/e2etests"
+UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests|stackrox/rox/operator/tests|stackrox/rox/central/reports/config/store/postgres|stackrox/rox/central/complianceoperator/v2/scanconfigurations/store/postgres|stackrox/rox/central/auth/store/postgres|stackrox/rox/scanner/e2etests"
 
 ifeq ($(TAG),)
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')$(MAIN_TAG_SUFFIX)

--- a/config-controller/internal/controller/suite_test.go
+++ b/config-controller/internal/controller/suite_test.go
@@ -42,9 +42,10 @@ var k8sClient ctrlClient.Client
 var testEnv *envtest.Environment
 
 func TestControllers(t *testing.T) {
-	RegisterFailHandler(Fail)
+	// TODO(ROX-25485): Re-enable these tests
+	// RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Controller Suite")
+	// RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/config-controller/pkg/client/client_test.go
+++ b/config-controller/pkg/client/client_test.go
@@ -103,7 +103,7 @@ func TestCachedClientList(t *testing.T) {
 
 	assert.NoError(t, err, "Unexpected error listing policies")
 	assert.Equal(t, 2, len(returnedPolicies), "Wrong size of returned policy list")
-	protoassert.SlicesEqual(t, clientTest.policies, returnedPolicies)
+	protoassert.ElementsMatch(t, clientTest.policies, returnedPolicies)
 }
 
 // TestCachedClientGet validates that the cached client fetches policies as expected

--- a/config-controller/test/e2e/e2e_suite_test.go
+++ b/config-controller/test/e2e/e2e_suite_test.go
@@ -17,16 +17,16 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
+	// "fmt"
 	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	// . "github.com/onsi/ginkgo/v2"
+	// . "github.com/onsi/gomega"
 )
 
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
-	RegisterFailHandler(Fail)
-	fmt.Fprint(GinkgoWriter, "Starting config-controller suite\n")
-	RunSpecs(t, "e2e suite")
+	// TODO(ROX-25485): Re-enable these tests
+	// RegisterFailHandler(Fail)
+	// fmt.Fprint(GinkgoWriter, "Starting config-controller suite\n")
+	// RunSpecs(t, "e2e suite")
 }


### PR DESCRIPTION
I had originally excluded all config-controller unit tests, but now that we have a few that need to be run in CI, I am including the `config-controller` directory and am commenting out the tests that still don't work.  The commented tests have a TODO to ensure we follow up on this.

### How I validated my change

Check results of unit tests. Of course they should pass, but the results should include passing tests from `config-controller/pkg/client` and `config-controller/api`