### PR TITLE
ROX-25183: Dummy compatibility target

### DIFF
--- a/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
@@ -4,5 +4,11 @@
 Run version compatibility tests
 """
 import logging
+from runners import ClusterTestRunner
+from clusters import GKECluster
 
 logging.info("Dummy test target gke-nongroovy-comatibility-tests has been called successfully.")
+
+ClusterTestRunner(
+    cluster=GKECluster("upgrade-test", machine_type="e2-standard-8")
+).run()

--- a/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run version compatibility tests
+"""
+import logging
+
+logging.info("Dummy test target gke-nongroovy-comatibility-tests has been called successfully.")


### PR DESCRIPTION
### Description

Adds a dummy target `gke-nongroovy-compatibility-tests` so that I can add it to the openshift CI

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

None