### PR TITLE
chore(ui): Move more UI code to common page util

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -113,7 +113,6 @@ function AdministrationEventsToolbar({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                setPage(1);
                                 setPerPage(newPerPage);
                             }}
                         />

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -205,9 +205,6 @@ function ListeningEndpointsPage() {
                                     perPage={perPage}
                                     onSetPage={(_, newPage) => setPage(newPage)}
                                     onPerPageSelect={(_, newPerPage) => {
-                                        if ((countQuery.data ?? 0) < (page - 1) * newPerPage) {
-                                            setPage(1);
-                                        }
                                         setPerPage(newPerPage);
                                     }}
                                 />

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -128,7 +128,6 @@ function DiscoveredClustersToolbar({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                setPage(1);
                                 setPerPage(newPerPage);
                             }}
                         />

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -127,9 +127,6 @@ function CollectionsTable({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                if (collectionsCount < (page - 1) * newPerPage) {
-                                    setPage(1);
-                                }
                                 setPerPage(newPerPage);
                             }}
                         />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
@@ -29,11 +29,9 @@ function ScanConfigClustersTable({
 
     const onPerPageSelect = (
         _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-        newPerPage: number,
-        newPage: number
+        newPerPage: number
     ) => {
         setPerPage(newPerPage);
-        setPage(newPage);
     };
 
     // Index of the currently sorted column

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -16,7 +16,7 @@ import { gql, useQuery } from '@apollo/client';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useTableSort from 'hooks/patternfly/useTableSort';
 import { SearchFilter } from 'types/search';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 const deploymentQuery = gql`
     query getDeploymentsForPolicyGeneration($query: String!, $pagination: Pagination!) {
@@ -52,11 +52,7 @@ function DeploymentScopeModal({
         skip: !isOpen,
         variables: {
             query: getRequestQueryStringForSearchFilter(searchFilter),
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-                sortOption,
-            },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     };
     const { data, previousData, loading, error } = useQuery<
@@ -94,9 +90,6 @@ function DeploymentScopeModal({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                if (scopeDeploymentCount < (page - 1) * newPerPage) {
-                                    setPage(1);
-                                }
                                 setPerPage(newPerPage);
                             }}
                         />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
@@ -3,7 +3,7 @@ import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
-import { getHasSearchApplied } from 'utils/searchUtils';
+import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
@@ -28,14 +28,14 @@ function ApprovedDeferrals(): ReactElement {
     const { isLoading, data, refetchQuery } = useVulnerabilityRequests({
         query,
         requestID,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
+        pagination: getPaginationParams({
+            page,
+            perPage,
             sortOption: {
                 field: 'Last Updated',
                 reversed: false,
             },
-        },
+        }),
     });
 
     const rows = data?.vulnerabilityRequests || [];

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
@@ -3,7 +3,7 @@ import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
-import { getHasSearchApplied } from 'utils/searchUtils';
+import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
@@ -27,14 +27,14 @@ function ApprovedFalsePositives(): ReactElement {
     const { isLoading, data, refetchQuery } = useVulnerabilityRequests({
         query,
         requestID,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
+        pagination: getPaginationParams({
+            page,
+            perPage,
             sortOption: {
                 field: 'Last Updated',
                 reversed: false,
             },
-        },
+        }),
     });
 
     const rows = data?.vulnerabilityRequests || [];

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEs.tsx
@@ -7,6 +7,7 @@ import { SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
 import queryService from 'utils/queryService';
 import useTableSort from 'hooks/patternfly/useTableSort';
+import { getPaginationParams } from 'utils/searchUtils';
 import DeferredCVEsTable from './DeferredCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
@@ -38,11 +39,7 @@ function DeferredCVEs({ imageId, showComponentDetails }: DeferredCVEsProps): Rea
     const { isLoading, data, refetchQuery } = useImageVulnerabilities({
         imageId,
         vulnsQuery,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
-            sortOption,
-        },
+        pagination: getPaginationParams({ page, perPage, sortOption }),
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEs.tsx
@@ -7,6 +7,7 @@ import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
 import useTableSort from 'hooks/patternfly/useTableSort';
 import { SortOption } from 'types/table';
+import { getPaginationParams } from 'utils/searchUtils';
 import FalsePositiveCVEsTable from './FalsePositiveCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
@@ -41,11 +42,7 @@ function FalsePositiveCVEs({
     const { isLoading, data, refetchQuery } = useImageVulnerabilities({
         imageId,
         vulnsQuery,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
-            sortOption,
-        },
+        pagination: getPaginationParams({ page, perPage, sortOption }),
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEs.tsx
@@ -7,6 +7,7 @@ import { SearchFilter } from 'types/search';
 import queryService from 'utils/queryService';
 import useTableSort from 'hooks/patternfly/useTableSort';
 import { SortOption } from 'types/table';
+import { getPaginationParams } from 'utils/searchUtils';
 import ObservedCVEsTable from './ObservedCVEsTable';
 import useImageVulnerabilities from '../useImageVulnerabilities';
 import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
@@ -38,11 +39,7 @@ function ObservedCVEs({ imageId, showComponentDetails }: ObservedCVEsProps): Rea
     const { isLoading, data, refetchQuery } = useImageVulnerabilities({
         imageId,
         vulnsQuery,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
-            sortOption,
-        },
+        pagination: getPaginationParams({ page, perPage, sortOption }),
     });
 
     const itemCount = data?.image?.vulnCount || 0;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
@@ -3,7 +3,7 @@ import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
-import { getHasSearchApplied } from 'utils/searchUtils';
+import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
@@ -37,14 +37,14 @@ function PendingApprovals(): ReactElement {
     const { isLoading, data, refetchQuery } = useVulnerabilityRequests({
         query,
         requestID,
-        pagination: {
-            limit: perPage,
-            offset: (page - 1) * perPage,
+        pagination: getPaginationParams({
+            page,
+            perPage,
             sortOption: {
                 field: 'Last Updated',
                 reversed: false,
             },
-        },
+        }),
     });
 
     const rows = data?.vulnerabilityRequests || [];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -12,7 +12,7 @@ import {
     VulnerabilityExceptionScope,
     VulnerabilityState,
 } from 'services/VulnerabilityExceptionService';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
@@ -69,11 +69,7 @@ function RequestCVEsTable({
     } = useQuery<CVEListQueryResult>(cveListQuery, {
         variables: {
             query,
-            pagination: {
-                offset: (page - 1) * perPage,
-                limit: perPage,
-                sortOption,
-            },
+            pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });
 

--- a/ui/apps/platform/src/services/DiscoveredClusterService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClusterService.ts
@@ -3,6 +3,7 @@ import qs from 'qs';
 import { SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
 
+import { getPaginationParams } from 'utils/searchUtils';
 import axios from './instance';
 
 import { Pagination } from './types';
@@ -113,8 +114,7 @@ export function getListDiscoveredClustersArg({
     sortOption,
 }): ListDiscoveredClustersRequest {
     const filter = getDiscoveredClustersFilter(searchFilter);
-    const offset = (page - 1) * perPage;
-    const pagination: Pagination = { limit: perPage, offset, sortOption };
+    const pagination = getPaginationParams({ page, perPage, sortOption });
     return { filter, pagination };
 }
 


### PR DESCRIPTION
### Description

A handful more refactoring changes related to UI pagination.

The previous PR with a change to `getPaginationParams()` only covered sections that were strictly necessary in order to implement multiple sort parameters in `useURLSort()`. As a quick check, I searched for `page - 1` and found more sections that were trivial to refactor to use the helper function.

This additionally removes all instances where `setPage(1);` is called when changing the current `perPage` value. The `useURLPagination()` hook was updated a while back to do this automatically internally, so the additional call is redundant.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI

Manual testing of:

- Admin Events page
- Listening endpoints page
- Discovered clusters page
- Collections page
- Compliance schedules page
- Net Graph deployment scope
- VM Exception management
- VM Risk Acceptance is not accessible, so really the change is useless...