### PR TITLE
ROX-26305: use NVD published time as a fallback

### DIFF
--- a/pkg/protoconv/time.go
+++ b/pkg/protoconv/time.go
@@ -12,7 +12,7 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	// timeLayouts lists each known time format returned by vulnerability scanners.
+	// timeLayouts lists each known time format used throughout StackRox.
 	timeLayouts = []string{
 		// NVD API v2 time layout.
 		"2006-01-02T15:04:05.999",

--- a/pkg/protoconv/time.go
+++ b/pkg/protoconv/time.go
@@ -12,15 +12,14 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	// vulnTimeLayouts lists each known time format
-	// returned by vulnerability scanners.
-	vulnTimeLayouts = []string{
+	// timeLayouts lists each known time format returned by vulnerability scanners.
+	timeLayouts = []string{
 		// NVD API v2 time layout.
 		"2006-01-02T15:04:05.999",
 		// NVD JSON feed time layout.
 		"2006-01-02T15:04Z",
-		// Red Hat Security API time layout.
-		"2006-01-02T15:04:03Z",
+		// Red Hat Security API time layout and catchall.
+		time.RFC3339,
 	}
 )
 
@@ -77,7 +76,7 @@ func ConvertTimeString(str string) *timestamppb.Timestamp {
 	if str == "" {
 		return nil
 	}
-	for _, layout := range vulnTimeLayouts {
+	for _, layout := range timeLayouts {
 		t, err := time.Parse(layout, str)
 		if err != nil {
 			continue

--- a/pkg/protoconv/time_test.go
+++ b/pkg/protoconv/time_test.go
@@ -24,6 +24,10 @@ func TestConvertTimeString(t *testing.T) {
 			output: nil,
 		},
 		{
+			input:  "2018-02-07T23:29:00.000",
+			output: protocompat.GetProtoTimestampFromSeconds(1518046140),
+		},
+		{
 			input:  "2018-02-07T23:29Z",
 			output: protocompat.GetProtoTimestampFromSeconds(1518046140),
 		},

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/scanners/scannerv4"
 	"github.com/stackrox/rox/pkg/scannerv4/constants"
 )
@@ -301,6 +302,7 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 		if v == nil {
 			continue
 		}
+		// Do this up here to fail early, if needed.
 		issued, err := protocompat.ConvertTimeToTimestampOrError(v.Issued)
 		if err != nil {
 			return nil, err
@@ -368,6 +370,9 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 			if len(nvdVuln.Descriptions) > 0 {
 				description = nvdVuln.Descriptions[0].Value
 			}
+		}
+		if v.Issued.IsZero() {
+			issued = protoconv.ConvertTimeString(nvdVuln.Published)
 		}
 		if vulnerabilities == nil {
 			vulnerabilities = make(map[string]*v4.VulnerabilityReport_Vulnerability, len(vulns))

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -371,10 +371,13 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 		issued := issuedTime(v.Issued, nvdVuln.Published)
 		if issued == nil {
 			zlog.Warn(ctx).
-				Err(err).
 				Str("vuln_id", v.ID).
 				Str("vuln_name", v.Name).
 				Str("vuln_updater", v.Updater).
+				// Use Str instead of Time because the latter will format the time into
+				// RFC3339 form, which may not be valid for this.
+				Str("claircore_issued", v.Issued.String()).
+				Str("nvd_published", nvdVuln.Published).
 				Msg("issued time invalid: leaving empty")
 		}
 		if vulnerabilities == nil {

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -66,7 +66,7 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 			arg:  &claircore.VulnerabilityReport{},
 			want: &v4.VulnerabilityReport{Contents: &v4.Contents{}},
 		},
-		"when invalid time in vulnerability map then error": {
+		"when invalid time in vulnerability map then nil issued": {
 			arg: &claircore.VulnerabilityReport{
 				Vulnerabilities: map[string]*claircore.Vulnerability{
 					"sample CVE": {
@@ -76,7 +76,13 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "internal error",
+			want: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"sample CVE": {
+						Id: "sample CVE",
+					},
+				}},
 		},
 		"when sample fields are set then conversion is successful": {
 			arg: &claircore.VulnerabilityReport{
@@ -1260,7 +1266,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
 				"foo": {
 					"CVE-2021-44228": {
-						ID: "CVE-2021-44228",
+						ID:        "CVE-2021-44228",
 						Published: "2021-12-10T10:15:09.143",
 					},
 				},

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -903,7 +903,8 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 	now := time.Now()
 	protoNow, err := protocompat.ConvertTimeToTimestampOrError(now)
 	assert.NoError(t, err)
-	proto2021 := protoconv.ConvertTimeString("2021-12-10T10:15:09.143")
+	published2021 := "2021-12-10T10:15:09.143"
+	proto2021 := protoconv.ConvertTimeString(published2021)
 	tests := map[string]struct {
 		ccVulnerabilities map[string]*claircore.Vulnerability
 		nvdVulns          map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem
@@ -1267,7 +1268,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				"foo": {
 					"CVE-2021-44228": {
 						ID:        "CVE-2021-44228",
-						Published: "2021-12-10T10:15:09.143",
+						Published: published2021,
 					},
 				},
 			},

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -896,6 +897,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 	now := time.Now()
 	protoNow, err := protocompat.ConvertTimeToTimestampOrError(now)
 	assert.NoError(t, err)
+	proto2021 := protoconv.ConvertTimeString("2021-12-10T10:15:09.143")
 	tests := map[string]struct {
 		ccVulnerabilities map[string]*claircore.Vulnerability
 		nvdVulns          map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem
@@ -1244,6 +1246,30 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 						},
 					},
+				},
+			},
+		},
+		"when issued time is empty, use NVD published time": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:      "foo",
+					Name:    "CVE-2021-44228",
+					Updater: "unknown updater",
+				},
+			},
+			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
+				"foo": {
+					"CVE-2021-44228": {
+						ID: "CVE-2021-44228",
+						Published: "2021-12-10T10:15:09.143",
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Name:   "CVE-2021-44228",
+					Issued: proto2021,
 				},
 			},
 		},


### PR DESCRIPTION
### Description

While reading through this file, I noticed we never used the published times we retrieved from NVD. This change uses the NVD time when the main datasource does not have it. This is relevant for Alpine and Debian vulnerabilities, for example.

### User-facing documentation

- [x] CHANGELOG updated is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

Scanned alpine:3.17.0 with current staging and saw this for `busybox`:

```
{
        "name": "busybox",
        "version": "1.35.0-r29",
        "vulns": [
          {
            "cve": "CVE-2023-42364",
            "cvss": 5.5,
            "summary": "A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a denial of service via a crafted awk pattern in the awk.c evaluate function.",
            "link": "https://www.cve.org/CVERecord?id=CVE-2023-42364",
            "fixedBy": "1.35.0-r31",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
              "exploitabilityScore": 1.8,
              "impactScore": 3.6,
              "userInteraction": "UI_REQUIRED",
              "availability": "IMPACT_HIGH",
              "score": 5.5,
              "severity": "MEDIUM"
            },
            "publishedOn": "0001-01-01T00:00:00Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY",
            "severity": "MODERATE_VULNERABILITY_SEVERITY"
          },
          {
            "cve": "CVE-2023-42363",
            "cvss": 5.5,
            "summary": "A use-after-free vulnerability was discovered in xasprintf function in xfuncs_printf.c:344 in BusyBox v.1.36.1.",
            "link": "https://www.cve.org/CVERecord?id=CVE-2023-42363",
            "fixedBy": "1.35.0-r31",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
              "exploitabilityScore": 1.8,
              "impactScore": 3.6,
              "userInteraction": "UI_REQUIRED",
              "availability": "IMPACT_HIGH",
              "score": 5.5,
              "severity": "MEDIUM"
            },
            "publishedOn": "0001-01-01T00:00:00Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY",
            "severity": "MODERATE_VULNERABILITY_SEVERITY"
          },
          ...
```

Scanned it again but with this PR and got this:

```
 {
        "name": "busybox",
        "version": "1.35.0-r29",
        "vulns": [
          {
            "cve": "CVE-2023-42365",
            "cvss": 5.5,
            "summary": "A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted awk pattern in the awk.c copyvar function.",
            "link": "https://www.cve.org/CVERecord?id=CVE-2023-42365",
            "fixedBy": "1.35.0-r31",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
              "exploitabilityScore": 1.8,
              "impactScore": 3.6,
              "userInteraction": "UI_REQUIRED",
              "availability": "IMPACT_HIGH",
              "score": 5.5,
              "severity": "MEDIUM"
            },
            "publishedOn": "2023-11-27T23:15:07.373Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY",
            "severity": "MODERATE_VULNERABILITY_SEVERITY"
          },
          {
            "cve": "CVE-2023-42364",
            "cvss": 5.5,
            "summary": "A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a denial of service via a crafted awk pattern in the awk.c evaluate function.",
            "link": "https://www.cve.org/CVERecord?id=CVE-2023-42364",
            "fixedBy": "1.35.0-r31",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
              "exploitabilityScore": 1.8,
              "impactScore": 3.6,
              "userInteraction": "UI_REQUIRED",
              "availability": "IMPACT_HIGH",
              "score": 5.5,
              "severity": "MEDIUM"
            },
            "publishedOn": "2023-11-27T23:15:07.313Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY",
            "severity": "MODERATE_VULNERABILITY_SEVERITY"
          },
          ...
```

(ignore the fact the vulns are different, the ordering of the vulns seems to differ, but the results are the same otherwise. Just focus on the `publishedOn`)