### PR TITLE
chore(CI): Fix mention author only when new JIRA is created

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1903,7 +1903,8 @@ slack_workflow_failure() {
     repo=$(jq -r <<<"${github_context}" '.repository')
     run_id=$(jq -r <<<"${github_context}" '.run_id')
 
-    local mention_author="true"
+    # If global "mention_author" is set use that value.
+    local mention_author="${mention_author:-true}"
     local slack_mention=""
     _make_slack_mention
 


### PR DESCRIPTION
### Description

Adding change that will respect global `mention_author`. This should fix the issue with tagging the author only if a new JIRA is created.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

I tested only changed bits of code with set/unset global var.
