### PR TITLE
ROX-23835, ROX-26239: Mask graph deployment IDs for baseline compare 

### DIFF
--- a/central/deployment/utils/utils.go
+++ b/central/deployment/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+// GetMaskedDeploymentID returns a deterministic ID value different
+// from the input ID in order to hide deployment IDs for deployments
+// out of the requester access scope.
+func GetMaskedDeploymentID(id string, name string) string {
+	return uuid.NewV5FromNonUUIDs(id, name).String()
+}

--- a/central/deployment/utils/utils_test.go
+++ b/central/deployment/utils/utils_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMaskedDeploymentID(t *testing.T) {
+	expected := "b289f32e-1a05-5efe-b3dd-24760f09c58b"
+	originalID := fixtureconsts.Deployment1
+	maskedID := GetMaskedDeploymentID(originalID, "test deployment")
+	assert.Equal(t, expected, maskedID)
+	assert.NotEqual(t, originalID, maskedID)
+}

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
+	deploymentUtils "github.com/stackrox/rox/central/deployment/utils"
 	"github.com/stackrox/rox/central/networkbaseline/datastore"
 	"github.com/stackrox/rox/central/networkbaseline/manager"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -184,7 +185,7 @@ func (s *serviceImpl) getBaselinePeerByEntityID(
 			deploymentName := peer.GetEntity().GetInfo().GetDeployment().GetName()
 			maskedKey := networkgraph.Entity{
 				Type: peerType,
-				ID:   getMaskedDeploymentID(peerId, deploymentName),
+				ID:   deploymentUtils.GetMaskedDeploymentID(peerId, deploymentName),
 			}
 			result[maskedKey] = peer
 		}

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/sac/resources"
-	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc"
 )
 
@@ -192,10 +191,6 @@ func (s *serviceImpl) getBaselinePeerByEntityID(
 	}
 
 	return result
-}
-
-func getMaskedDeploymentID(id string, name string) string {
-	return uuid.NewV5FromNonUUIDs(id, name).String()
 }
 
 func (s *serviceImpl) ModifyBaselineStatusForPeers(ctx context.Context, request *v1.ModifyBaselineStatusForPeersRequest) (*v1.Empty, error) {

--- a/central/networkbaseline/service/service_impl_test.go
+++ b/central/networkbaseline/service/service_impl_test.go
@@ -16,6 +16,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const (
+	testPeerDeploymentName = "testPeerDeployment"
+)
+
 var (
 	allAllowedCtx = sac.WithAllAccess(context.Background())
 )
@@ -59,7 +63,11 @@ func (s *NetworkBaselineServiceTestSuite) getBaselineWithCustomFlow(
 				Info: &storage.NetworkEntityInfo{
 					Type: entityType,
 					Id:   entityID,
-					Desc: nil,
+					Desc: &storage.NetworkEntityInfo_Deployment_{
+						Deployment: &storage.NetworkEntityInfo_Deployment{
+							Name: testPeerDeploymentName,
+						},
+					},
 				},
 				Scope: &storage.NetworkEntity_Scope{ClusterId: entityClusterID},
 			},
@@ -103,6 +111,9 @@ func (s *NetworkBaselineServiceTestSuite) TestGetNetworkBaselineStatusForFlows()
 			},
 		},
 	}
+	otherRequest := request.CloneVT()
+	s.Require().NotEmpty(otherRequest.Peers)
+	otherRequest.Peers[0].Entity.Id = getMaskedDeploymentID(entityID, testPeerDeploymentName)
 
 	// If we don't have any baseline, then it is in observation and not created yet, so we will create
 	// one
@@ -115,11 +126,19 @@ func (s *NetworkBaselineServiceTestSuite) TestGetNetworkBaselineStatusForFlows()
 	s.Nil(err)
 	s.NotNil(testBase)
 
+	// Check the request with the original deployment ID of the baseline peer flags the flow as baseline
 	s.baselines.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).Return(baseline, true, nil)
 	rsp, err := s.service.GetNetworkBaselineStatusForFlows(allAllowedCtx, request)
 	s.Nil(err)
 	s.Equal(1, len(rsp.Statuses))
-	s.Equal(v1.NetworkBaselinePeerStatus_BASELINE, rsp.Statuses[0].Status)
+	s.Equal(v1.NetworkBaselinePeerStatus_BASELINE, rsp.Statuses[0].GetStatus())
+
+	// Check the request with the masked ID for the baseline peer deployment flags the flow as baseline
+	s.baselines.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).Return(baseline, true, nil)
+	rsp2, err := s.service.GetNetworkBaselineStatusForFlows(allAllowedCtx, otherRequest)
+	s.Nil(err)
+	s.Equal(1, len(rsp2.Statuses))
+	s.Equal(v1.NetworkBaselinePeerStatus_BASELINE, rsp2.Statuses[0].GetStatus())
 
 	// If we change some baseline details, then the flow should be marked as anomaly
 	baseline =

--- a/central/networkbaseline/service/service_impl_test.go
+++ b/central/networkbaseline/service/service_impl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	deploymentUtils "github.com/stackrox/rox/central/deployment/utils"
 	networkBaselineDSMocks "github.com/stackrox/rox/central/networkbaseline/datastore/mocks"
 	networkBaselineMocks "github.com/stackrox/rox/central/networkbaseline/manager/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -113,7 +114,7 @@ func (s *NetworkBaselineServiceTestSuite) TestGetNetworkBaselineStatusForFlows()
 	}
 	otherRequest := request.CloneVT()
 	s.Require().NotEmpty(otherRequest.Peers)
-	otherRequest.Peers[0].Entity.Id = getMaskedDeploymentID(entityID, testPeerDeploymentName)
+	otherRequest.Peers[0].Entity.Id = deploymentUtils.GetMaskedDeploymentID(entityID, testPeerDeploymentName)
 
 	// If we don't have any baseline, then it is in observation and not created yet, so we will create
 	// one

--- a/central/networkgraph/service/masker.go
+++ b/central/networkgraph/service/masker.go
@@ -58,9 +58,11 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 	slices.Sort(orderedDeploymentIDsToMask)
 	for ix, deploymentID := range orderedDeploymentIDsToMask {
 		origDeployment := m.deploymentsToMask[deploymentID]
+		origDeploymentId := origDeployment.GetId()
+		origDeploymentName := origDeployment.GetName()
 		maskedDeploymentName := fmt.Sprintf("%s #%d", MaskedDeploymentName, ix+1)
 		maskedDeployment := &storage.ListDeployment{
-			Id:        uuid.NewV4().String(),
+			Id:        uuid.NewV5FromNonUUIDs(origDeploymentId, origDeploymentName).String(),
 			Name:      maskedDeploymentName,
 			Cluster:   origDeployment.GetCluster(),
 			ClusterId: origDeployment.GetClusterId(),

--- a/central/networkgraph/service/masker.go
+++ b/central/networkgraph/service/masker.go
@@ -58,11 +58,9 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 	slices.Sort(orderedDeploymentIDsToMask)
 	for ix, deploymentID := range orderedDeploymentIDsToMask {
 		origDeployment := m.deploymentsToMask[deploymentID]
-		origDeploymentId := origDeployment.GetId()
-		origDeploymentName := origDeployment.GetName()
 		maskedDeploymentName := fmt.Sprintf("%s #%d", MaskedDeploymentName, ix+1)
 		maskedDeployment := &storage.ListDeployment{
-			Id:        uuid.NewV5FromNonUUIDs(origDeploymentId, origDeploymentName).String(),
+			Id:        getMaskedDeploymentID(origDeployment.GetId(), origDeployment.GetName()),
 			Name:      maskedDeploymentName,
 			Cluster:   origDeployment.GetCluster(),
 			ClusterId: origDeployment.GetClusterId(),
@@ -72,6 +70,10 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 		m.maskedDeployments = append(m.maskedDeployments, maskedDeployment)
 		delete(m.deploymentsToMask, deploymentID)
 	}
+}
+
+func getMaskedDeploymentID(id string, name string) string {
+	return uuid.NewV5FromNonUUIDs(id, name).String()
 }
 
 func (m *flowGraphMasker) GetMaskedDeployment(origDeployment *storage.ListDeployment) *storage.ListDeployment {

--- a/central/networkgraph/service/masker.go
+++ b/central/networkgraph/service/masker.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"slices"
 
+	deploymentUtils "github.com/stackrox/rox/central/deployment/utils"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/uuid"
 )
 
 const (
@@ -60,7 +60,7 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 		origDeployment := m.deploymentsToMask[deploymentID]
 		maskedDeploymentName := fmt.Sprintf("%s #%d", MaskedDeploymentName, ix+1)
 		maskedDeployment := &storage.ListDeployment{
-			Id:        getMaskedDeploymentID(origDeployment.GetId(), origDeployment.GetName()),
+			Id:        deploymentUtils.GetMaskedDeploymentID(origDeployment.GetId(), origDeployment.GetName()),
 			Name:      maskedDeploymentName,
 			Cluster:   origDeployment.GetCluster(),
 			ClusterId: origDeployment.GetClusterId(),
@@ -70,10 +70,6 @@ func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
 		m.maskedDeployments = append(m.maskedDeployments, maskedDeployment)
 		delete(m.deploymentsToMask, deploymentID)
 	}
-}
-
-func getMaskedDeploymentID(id string, name string) string {
-	return uuid.NewV5FromNonUUIDs(id, name).String()
 }
 
 func (m *flowGraphMasker) GetMaskedDeployment(origDeployment *storage.ListDeployment) *storage.ListDeployment {

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -9,6 +9,7 @@ import (
 
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	dDSMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	deploymentUtils "github.com/stackrox/rox/central/deployment/utils"
 	graphConfigDSMocks "github.com/stackrox/rox/central/networkgraph/config/datastore/mocks"
 	entityMocks "github.com/stackrox/rox/central/networkgraph/entity/datastore/mocks"
 	networkTreeMocks "github.com/stackrox/rox/central/networkgraph/entity/networktree/mocks"
@@ -761,9 +762,9 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 		"depD",
 		"depE",
 		"depF",
-		getMaskedDeploymentID("depW", "depW"),
-		getMaskedDeploymentID("depX", "depX"),
-		getMaskedDeploymentID("depZ", "depZ"),
+		deploymentUtils.GetMaskedDeploymentID("depW", "depW"),
+		deploymentUtils.GetMaskedDeploymentID("depX", "depX"),
+		deploymentUtils.GetMaskedDeploymentID("depZ", "depZ"),
 		"mycluster__net1",
 		es2ID.String(),
 		es3ID.String(),


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Network graph masking alters the entities in network flows when these (entities) are not allowed access to by the requester roles (more precisely their access scope).

This becomes problematic when flows should be compared to the network baseline, as the entity IDs are masked as well.

This PR aims at relaxing the masking rules in order to allow flow comparison to the network baseline (deterministically computed masked ID so rules can be applied on baseline comparison as well).

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ _update is not needed_
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ _is not needed_

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->
<!--
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
The existing test coverage should be enough.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deploy

- create a restricted scope (e.g. stackrox namespace only), an admin role with this restricted scope, and an API token for that role
- check the network graph for the stackrox namespace on the deployed cluster
- capture the deployment name and IDs in the stackrox namespace
- capture the entity IDs in the network graph, as well as the entities communicating with the kube-dns deployment
- capture the request for network baseline for one of the deployments communicating with kube-dns
- ensure the flow between the deployment of the previous step and kube-dns is part of the network baseline
- capture the network graph rendered for the API token with restricted scope
- replay the request for network baseline using the entity IDs that were exposed in the network graph with restricted scope
- ensure the flow to the masked kube-dns deployment is flagged as BASELINE despite its target being masked
