### PR TITLE
ROX-26054: expiration timestamp, policy CR validation

### DIFF
--- a/config-controller/api/v1alpha1/policy_types_test.go
+++ b/config-controller/api/v1alpha1/policy_types_test.go
@@ -43,7 +43,6 @@ func TestMarshalJSON(t *testing.T) {
 		Severity:           "LOW_SEVERITY",
 		EventSource:        "DEPLOYMENT_EVENT",
 		EnforcementActions: []EnforcementAction{"SCALE_TO_ZERO_ENFORCEMENT"},
-		PolicyVersion:      "1.1",
 		PolicySections: []PolicySection{{
 			SectionName: "Section name",
 			PolicyGroups: []PolicyGroup{{

--- a/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
+++ b/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
@@ -90,6 +90,8 @@ spec:
                               type: string
                           type: object
                       type: object
+                    expiration:
+                      type: string
                     image:
                       properties:
                         name:
@@ -155,8 +157,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              policyVersion:
-                type: string
               rationale:
                 type: string
               remediation:

--- a/image/templates/helm/stackrox-central/templates/00-securitypolicies-crd.yaml
+++ b/image/templates/helm/stackrox-central/templates/00-securitypolicies-crd.yaml
@@ -92,6 +92,8 @@ spec:
                               type: string
                           type: object
                       type: object
+                    expiration:
+                      type: string
                     image:
                       properties:
                         name:
@@ -157,8 +159,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              policyVersion:
-                type: string
               rationale:
                 type: string
               remediation:


### PR DESCRIPTION
### Description
1. Added expiration timestamp of exclusion to the CRD
2. Removed policyVersion from CRD
3. Validations for default policy in CR which will not be supported in 4.6

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

Manual testing to see policy creation in UI, as well as policy reconcile error in logs because isDefault is true (unsupported in 4.6)
```
2024-09-23T23:03:17Z	INFO	Reconciling	{"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "SecurityPolicy": {"name":"boo-default","namespace":"stackrox"}, "namespace": "stackrox", "name": "boo-default", "reconcileID": "189b73a1-77da-448e-a268-fa344cb6a9b4", "namespace": "stackrox", "name": "boo-default"}
2024-09-23T23:03:17Z	ERROR	Reconciler error	{"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "SecurityPolicy": {"name":"boo-default","namespace":"stackrox"}, "namespace": "stackrox", "name": "boo-default", "reconcileID": "189b73a1-77da-448e-a268-fa344cb6a9b4", "error": "Invalid policy resource: namespace=stackrox, name=boo-default: isDefault must be false"}
```

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manual testing