### PR TITLE
ROX-26218: Adds multi sort by image severity count to Workload CVEs

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -167,10 +167,11 @@ export function interceptAndWatchRequests(routeMatcherMap, staticResponseMap) {
 
 export function expectRequestedSort(expectedSort) {
     return (variables) => {
-        const { sortOption } = variables.pagination;
-        expect(sortOption).to.deep.equal(
+        const { sortOption, sortOptions } = variables.pagination;
+        const targetSortOption = typeof sortOptions === 'undefined' ? sortOption : sortOptions;
+        expect(targetSortOption).to.deep.equal(
             expectedSort,
-            `Expected sort option ${JSON.stringify(expectedSort)} but received ${JSON.stringify(sortOption)}`
+            `Expected sort option ${JSON.stringify(expectedSort)} but received ${JSON.stringify(targetSortOption)}`
         );
     };
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
@@ -51,8 +51,53 @@ describe('Exception Management Request Details Page', () => {
         cy.get(selectors.tableSortColumn('CVE')).should('have.attr', 'aria-sort', 'ascending');
     });
 
+    it('should be able to sort on the "Images by severity" column', () => {
+        deferAndVisitRequestDetails(deferralProps);
+        cy.get(selectors.tableSortColumn('Images by severity')).should(
+            'have.attr',
+            'aria-sort',
+            'descending'
+        );
+        const severityFields = [
+            'Critical Severity Count',
+            'Important Severity Count',
+            'Moderate Severity Count',
+            'Low Severity Count',
+        ].map((field) => encodeURIComponent(field));
+        cy.get(selectors.tableColumnSortButton('Images by severity')).click();
+        severityFields.forEach((field, index) => {
+            cy.location('search').should(
+                'contain',
+                `sortOption[${index}][field]=${field}&sortOption[${index}][direction]=asc`
+            );
+        });
+        cy.get(selectors.tableSortColumn('Images by severity')).should(
+            'have.attr',
+            'aria-sort',
+            'ascending'
+        );
+        cy.get(selectors.tableColumnSortButton('Images by severity')).click();
+        severityFields.forEach((field, index) => {
+            cy.location('search').should(
+                'contain',
+                `sortOption[${index}][field]=${field}&sortOption[${index}][direction]=desc`
+            );
+        });
+        cy.get(selectors.tableSortColumn('Images by severity')).should(
+            'have.attr',
+            'aria-sort',
+            'descending'
+        );
+    });
+
     it('should be able to sort on the "CVSS" column', () => {
         deferAndVisitRequestDetails(deferralProps);
+        cy.get(selectors.tableSortColumn('CVSS')).should('have.attr', 'aria-sort', 'none');
+        cy.get(selectors.tableColumnSortButton('CVSS')).click();
+        cy.location('search').should(
+            'contain',
+            'sortOption[field]=CVSS&sortOption[aggregateBy][aggregateFunc]=max&sortOption[direction]=desc'
+        );
         cy.get(selectors.tableSortColumn('CVSS')).should('have.attr', 'aria-sort', 'descending');
         cy.get(selectors.tableColumnSortButton('CVSS')).click();
         cy.location('search').should(
@@ -60,12 +105,6 @@ describe('Exception Management Request Details Page', () => {
             'sortOption[field]=CVSS&sortOption[aggregateBy][aggregateFunc]=max&sortOption[direction]=asc'
         );
         cy.get(selectors.tableSortColumn('CVSS')).should('have.attr', 'aria-sort', 'ascending');
-        cy.get(selectors.tableColumnSortButton('CVSS')).click();
-        cy.location('search').should(
-            'contain',
-            'sortOption[field]=CVSS&sortOption[aggregateBy][aggregateFunc]=max&sortOption[direction]=desc'
-        );
-        cy.get(selectors.tableSortColumn('CVSS')).should('have.attr', 'aria-sort', 'descending');
     });
 
     it('should be able to sort on the "Affected images" column', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
@@ -117,7 +117,7 @@ describe('Exception Management Request Details Page', () => {
         cy.get(selectors.tableColumnSortButton('Affected images')).click();
         cy.location('search').should(
             'contain',
-            'sortOption[field]=Image%20sha&sortOption[aggregateBy][aggregateFunc]=count&sortOption[aggregateBy][distinct]=true&sortOption[direction]=desc'
+            'sortOption[field]=Image%20Sha&sortOption[aggregateBy][aggregateFunc]=count&sortOption[aggregateBy][distinct]=true&sortOption[direction]=desc'
         );
         cy.get(selectors.tableSortColumn('Affected images')).should(
             'have.attr',
@@ -127,7 +127,7 @@ describe('Exception Management Request Details Page', () => {
         cy.get(selectors.tableColumnSortButton('Affected images')).click();
         cy.location('search').should(
             'contain',
-            'sortOption[field]=Image%20sha&sortOption[aggregateBy][aggregateFunc]=count&sortOption[aggregateBy][distinct]=true&sortOption[direction]=asc'
+            'sortOption[field]=Image%20Sha&sortOption[aggregateBy][aggregateFunc]=count&sortOption[aggregateBy][distinct]=true&sortOption[direction]=asc'
         );
         cy.get(selectors.tableSortColumn('Affected images')).should(
             'have.attr',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -24,8 +24,8 @@ export function getFutureDateByDays(days) {
     return addDays(new Date(), days);
 }
 
-export function visitWorkloadCveOverview({ clearFiltersOnVisit = true } = {}) {
-    visit(basePath);
+export function visitWorkloadCveOverview({ clearFiltersOnVisit = true, urlSearch = '' } = {}) {
+    visit(basePath + urlSearch);
 
     cy.get('h1:contains("Workload CVEs")');
     cy.location('pathname').should('eq', basePath);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -296,6 +296,16 @@ describe('Workload CVE overview page tests', () => {
                     waitAndYieldRequestBodyVariables().then(
                         expectRequestedSort({ field: 'CVE', reversed: true })
                     );
+
+                    // Check that visiting via a direct link that includes a severity filter maintains
+                    // the correct sort
+                    visitWorkloadCveOverview({
+                        clearFiltersOnVisit: false,
+                        urlSearch: '?s[SEVERITY][0]=Important',
+                    });
+                    waitAndYieldRequestBodyVariables().then(
+                        expectRequestedSort([{ field: 'Important Severity Count', reversed: true }])
+                    );
                 }
             );
         });

--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Button, ChipGroup, Chip, Flex, FlexItem, ToolbarChip } from '@patternfly/react-core';
-import noop from 'lodash/noop';
 import { Globe } from 'react-feather';
 
-import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import { searchValueAsArray } from 'utils/searchUtils';
 
@@ -38,8 +36,10 @@ export type FilterChipGroupDescriptor = {
 export type SearchFilterChipsProps = {
     /** The search filter categories to display */
     filterChipGroupDescriptors: FilterChipGroupDescriptor[];
+    /** The current search filter */
+    searchFilter: SearchFilter;
     /** Callback for when the search filter changes */
-    onFilterChange?: (searchFilter: SearchFilter) => void;
+    onFilterChange: (searchFilter: SearchFilter) => void;
 };
 
 /**
@@ -48,12 +48,10 @@ export type SearchFilterChipsProps = {
  */
 function SearchFilterChips({
     filterChipGroupDescriptors,
-    onFilterChange = noop,
+    searchFilter,
+    onFilterChange,
 }: SearchFilterChipsProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
-
     function onChangeSearchFilter(newFilter: SearchFilter) {
-        setSearchFilter(newFilter);
         onFilterChange(newFilter);
     }
 

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -213,6 +213,8 @@ function ListeningEndpointsPage() {
 
                         <ToolbarGroup className="pf-v5-u-w-100">
                             <SearchFilterChips
+                                searchFilter={searchFilter}
+                                onFilterChange={setSearchFilter}
                                 filterChipGroupDescriptors={[
                                     { displayName: 'Deployment', searchFilterName: 'Deployment' },
                                     { displayName: 'Namespace', searchFilterName: 'Namespace' },

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -134,7 +134,11 @@ function DiscoveredClustersToolbar({
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-v5-u-w-100">
-                    <SearchFilterChips filterChipGroupDescriptors={searchFilterChipDescriptors} />
+                    <SearchFilterChips
+                        searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
+                        filterChipGroupDescriptors={searchFilterChipDescriptors}
+                    />
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -215,6 +215,7 @@ function CheckDetails() {
                         getSortParams={getSortParams}
                         searchFilterConfig={searchFilterConfig}
                         searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
                         onSearch={onSearch}
                         onCheckStatusSelect={onCheckStatusSelect}
                         onClearFilters={onClearFilters}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -41,6 +41,7 @@ export type CheckDetailsTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilterConfig: CompoundSearchFilterConfig;
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: (payload: OnSearchPayload) => void;
     onCheckStatusSelect: (
         filterType: 'Compliance Check Status',
@@ -59,6 +60,7 @@ function CheckDetailsTable({
     getSortParams,
     searchFilterConfig,
     searchFilter,
+    onFilterChange,
     onSearch,
     onCheckStatusSelect,
     onClearFilters,
@@ -96,6 +98,8 @@ function CheckDetailsTable({
                     </ToolbarGroup>
                     <ToolbarGroup className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={[
                                 {
                                     displayName: 'Cluster',

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -229,6 +229,7 @@ function ClusterDetailsPage() {
                             getSortParams={getSortParams}
                             searchFilterConfig={searchFilterConfig}
                             searchFilter={searchFilter}
+                            onFilterChange={setSearchFilter}
                             onSearch={onSearch}
                             onCheckStatusSelect={onCheckStatusSelect}
                             onClearFilters={onClearFilters}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -38,6 +38,7 @@ export type ClusterDetailsTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilterConfig: CompoundSearchFilterConfig;
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: (payload: OnSearchPayload) => void;
     onCheckStatusSelect: (
         filterType: 'Compliance Check Status',
@@ -55,6 +56,7 @@ function ClusterDetailsTable({
     getSortParams,
     searchFilterConfig,
     searchFilter,
+    onFilterChange,
     onSearch,
     onCheckStatusSelect,
     onClearFilters,
@@ -105,6 +107,8 @@ function ClusterDetailsTable({
                     </ToolbarGroup>
                     <ToolbarGroup className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={[
                                 {
                                     displayName: 'Profile Check',

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -178,6 +178,8 @@ function CoveragesPage() {
                                     </ToolbarGroup>
                                     <ToolbarGroup className="pf-v5-u-w-100">
                                         <SearchFilterChips
+                                            searchFilter={searchFilter}
+                                            onFilterChange={setSearchFilter}
                                             filterChipGroupDescriptors={[
                                                 {
                                                     displayName: 'Profile Check',

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -230,6 +230,7 @@ function ViolationsTablePage(): ReactElement {
                             getSortParams={getSortParams}
                             columns={columns}
                             searchFilter={searchFilter}
+                            onFilterChange={setSearchFilter}
                             onSearch={onSearch}
                         />
                     </PageSection>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -56,6 +56,7 @@ type ViolationsTablePanelProps = {
     getSortParams: GetSortParams;
     columns: TableColumn[];
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: OnSearchCallback;
 };
 
@@ -71,6 +72,7 @@ function ViolationsTablePanel({
     getSortParams,
     columns,
     searchFilter,
+    onFilterChange,
     onSearch,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
@@ -194,7 +196,11 @@ function ViolationsTablePanel({
                     </Alert>
                 ))}
             </AlertGroup>
-            <ViolationsTableSearchFilter searchFilter={searchFilter} onSearch={onSearch} />
+            <ViolationsTableSearchFilter
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                onSearch={onSearch}
+            />
             <Divider component="div" />
             <Toolbar>
                 <ToolbarContent>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -76,10 +76,15 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
 
 export type ViolationsTableSearchFilterProps = {
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: OnSearchCallback;
 };
 
-function ViolationsTableSearchFilter({ searchFilter, onSearch }: ViolationsTableSearchFilterProps) {
+function ViolationsTableSearchFilter({
+    searchFilter,
+    onFilterChange,
+    onSearch,
+}: ViolationsTableSearchFilterProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
     return (
@@ -95,7 +100,11 @@ function ViolationsTableSearchFilter({ searchFilter, onSearch }: ViolationsTable
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-v5-u-w-100">
-                    <SearchFilterChips filterChipGroupDescriptors={filterChipGroupDescriptors} />
+                    <SearchFilterChips
+                        searchFilter={searchFilter}
+                        onFilterChange={onFilterChange}
+                        filterChipGroupDescriptors={filterChipGroupDescriptors}
+                    />
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -19,6 +19,7 @@ import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -93,7 +94,8 @@ function ApprovedDeferrals() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -142,6 +144,7 @@ function ApprovedDeferrals() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -20,6 +20,7 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestIDLink,
     RequestedAction,
@@ -86,7 +87,8 @@ function ApprovedFalsePositives() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -135,6 +137,7 @@ function ApprovedFalsePositives() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -19,6 +19,7 @@ import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -90,7 +91,8 @@ function DeniedRequests() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -139,6 +141,7 @@ function DeniedRequests() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -19,6 +19,7 @@ import useURLSort from 'hooks/useURLSort';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -91,7 +92,8 @@ function PendingApprovals() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -140,6 +142,7 @@ function PendingApprovals() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -26,6 +26,7 @@ import {
     sortCveDistroList,
     getWorkloadSortFields,
     getDefaultWorkloadSortOption,
+    getSeveritySortOptions,
 } from '../../utils/sortUtils';
 import { CVEListQueryResult, cveListQuery } from '../../WorkloadCves/Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
@@ -93,7 +94,14 @@ function RequestCVEsTable({
                                 <span className="pf-v5-screen-reader">Row expansion</span>
                             </Th>
                             <Th sort={getSortParams('CVE')}>CVE</Th>
-                            <Th>Images by severity</Th>
+                            <Th
+                                sort={getSortParams(
+                                    'Images By Severity',
+                                    getSeveritySortOptions([])
+                                )}
+                            >
+                                Images by severity
+                            </Th>
                             <Th sort={getSortParams('CVSS', aggregateByCVSS)}>CVSS</Th>
                             <Th sort={getSortParams('Image sha', aggregateByDistinctCount)}>
                                 Affected images

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -103,7 +103,7 @@ function RequestCVEsTable({
                                 Images by severity
                             </Th>
                             <Th sort={getSortParams('CVSS', aggregateByCVSS)}>CVSS</Th>
-                            <Th sort={getSortParams('Image sha', aggregateByDistinctCount)}>
+                            <Th sort={getSortParams('Image Sha', aggregateByDistinctCount)}>
                                 Affected images
                             </Th>
                             <Th sort={getSortParams('CVE Created Time', aggregateByCreatedTime)}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -38,6 +38,7 @@ import {
     clusterSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
+import { SearchFilter } from 'types/search';
 import { getRegexScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import DeploymentFilterLink from './DeploymentFilterLink';
@@ -149,12 +150,12 @@ function NamespaceViewPage() {
                     : selectedSearchFilter.filter((oldValue) => value !== oldValue),
         };
 
-        setSearchFilter(newFilter);
-        onFilterChange();
+        onFilterChange(newFilter);
         trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
     }
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -209,6 +210,7 @@ function NamespaceViewPage() {
                         </ToolbarItem>
                         <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                             <SearchFilterChips
+                                searchFilter={searchFilter}
                                 onFilterChange={onFilterChange}
                                 filterChipGroupDescriptors={filterChipGroupDescriptors}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -6,13 +6,13 @@ import { DropdownItem } from '@patternfly/react-core/deprecated';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 import useMap from 'hooks/useMap';
 import { VulnerabilityState } from 'types/cve.proto';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import CVEsTable, { ImageCVE, cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
@@ -25,6 +25,8 @@ import CompletedExceptionRequestModal from '../../components/ExceptionRequestMod
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 
 export type CVEsTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -36,6 +38,8 @@ export type CVEsTableContainerProps = {
 };
 
 function CVEsTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -45,7 +49,6 @@ function CVEsTableContainer({
     workloadCvesScopedQueryString,
     isFiltered,
 }: CVEsTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -164,7 +167,7 @@ function CVEsTableContainer({
                     vulnerabilityState={vulnerabilityState}
                     createTableActions={createTableActions}
                     onClearFilters={() => {
-                        setSearchFilter({});
+                        onFilterChange({});
                         pagination.setPage(1);
                     }}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -4,15 +4,17 @@ import { Divider } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import { VulnerabilitySeverityLabel } from '../../types';
 
 type DeploymentsTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -24,6 +26,8 @@ type DeploymentsTableContainerProps = {
 };
 
 function DeploymentsTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -33,7 +37,6 @@ function DeploymentsTableContainer({
     isFiltered,
     showCveDetailFields,
 }: DeploymentsTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -75,7 +78,7 @@ function DeploymentsTableContainer({
                     filteredSeverities={searchFilter.SEVERITY as VulnerabilitySeverityLabel[]}
                     showCveDetailFields={showCveDetailFields}
                     onClearFilters={() => {
-                        setSearchFilter({});
+                        onFilterChange({});
                         pagination.setPage(1);
                     }}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -4,10 +4,10 @@ import { Divider } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import ImagesTable, { Image, ImagesTableProps, imageListQuery } from '../Tables/ImagesTable';
 import { VulnerabilitySeverityLabel } from '../../types';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
@@ -15,6 +15,8 @@ import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/Ta
 export { imageListQuery } from '../Tables/ImagesTable';
 
 type ImagesTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -29,6 +31,8 @@ type ImagesTableContainerProps = {
 };
 
 function ImagesTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -41,7 +45,6 @@ function ImagesTableContainer({
     onUnwatchImage,
     showCveDetailFields,
 }: ImagesTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -85,7 +88,10 @@ function ImagesTableContainer({
                     onWatchImage={onWatchImage}
                     onUnwatchImage={onUnwatchImage}
                     showCveDetailFields={showCveDetailFields}
-                    onClearFilters={() => setSearchFilter({})}
+                    onClearFilters={() => {
+                        onFilterChange({});
+                        pagination.setPage(1);
+                    }}
                 />
             </div>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -469,6 +469,8 @@ function WorkloadCvesOverviewPage() {
                             </Flex>
                             {activeEntityTabKey === 'CVE' && (
                                 <CVEsTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.CVE}
@@ -481,6 +483,8 @@ function WorkloadCvesOverviewPage() {
                             )}
                             {activeEntityTabKey === 'Image' && (
                                 <ImagesTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.Image}
@@ -503,6 +507,8 @@ function WorkloadCvesOverviewPage() {
                             )}
                             {activeEntityTabKey === 'Deployment' && (
                                 <DeploymentsTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.Deployment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -33,6 +33,7 @@ import {
     getDefaultWorkloadSortOption,
     getDefaultZeroCveSortOption,
     getWorkloadSortFields,
+    syncSeveritySortOption,
 } from 'Containers/Vulnerabilities/utils/sortUtils';
 import useURLSort from 'hooks/useURLSort';
 import {
@@ -173,7 +174,7 @@ function WorkloadCvesOverviewPage() {
 
     const currentVulnerabilityState = useVulnerabilityState();
 
-    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const [activeEntityTabKey, setActiveEntityTabKey] = useURLStringUnion(
         'entityTab',
@@ -242,6 +243,11 @@ function WorkloadCvesOverviewPage() {
         onSort: () => pagination.setPage(1),
     });
 
+    function setSearchFilter(searchFilter: SearchFilter) {
+        setURLSearchFilter(searchFilter);
+        syncSeveritySortOption(searchFilter, sort.sortOption, sort.setSortOption);
+    }
+
     function updateDefaultFilters(values: DefaultFilters) {
         pagination.setPage(1);
         setStoredValue({ preferences: { defaultFilters: values } });
@@ -288,7 +294,7 @@ function WorkloadCvesOverviewPage() {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
         setSearchFilter({});
-        sort.setSortOption(getDefaultWorkloadSortOption('CVE'));
+        sort.setSortOption(getDefaultWorkloadSortOption('CVE', searchFilter));
         pagination.setPage(1);
         setObservedCveMode('WITH_CVES');
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -239,7 +239,7 @@ function WorkloadCvesOverviewPage() {
 
     const sort = useURLSort({
         sortFields: getWorkloadSortFields(activeEntityTabKey),
-        defaultSortOption: getDefaultSortOption(activeEntityTabKey),
+        defaultSortOption: getDefaultSortOption(activeEntityTabKey, searchFilter),
         onSort: () => pagination.setPage(1),
     });
 
@@ -262,7 +262,7 @@ function WorkloadCvesOverviewPage() {
 
     function onEntityTabChange(entityTab: WorkloadEntityTab) {
         pagination.setPage(1);
-        sort.setSortOption(getDefaultSortOption(entityTab));
+        sort.setSortOption(getDefaultSortOption(entityTab, searchFilter));
 
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -294,7 +294,7 @@ function WorkloadCvesOverviewPage() {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
         setSearchFilter({});
-        sort.setSortOption(getDefaultWorkloadSortOption('CVE', searchFilter));
+        sort.setSortOption(getDefaultWorkloadSortOption('CVE'));
         pagination.setPage(1);
         setObservedCveMode('WITH_CVES');
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -35,6 +35,7 @@ import {
     aggregateByCVSS,
     aggregateByCreatedTime,
     aggregateByDistinctCount,
+    getSeveritySortOptions,
 } from '../../utils/sortUtils';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
@@ -155,7 +156,13 @@ function CVEsTable({
                     <ExpandRowTh />
                     {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
-                    <TooltipTh tooltip="Severity of this CVE across images">
+                    <TooltipTh
+                        sort={getSortParams(
+                            'Images By Severity',
+                            getSeveritySortOptions(filteredSeverities)
+                        )}
+                        tooltip="Severity of this CVE across images"
+                    >
                         Images by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -170,7 +170,8 @@ function WorkloadCveFilterToolbar({
                 )}
                 <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                     <SearchFilterChips
-                        onFilterChange={onFilterChange}
+                        searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
                         filterChipGroupDescriptors={filterChipGroupDescriptors}
                     />
                 </ToolbarGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -42,7 +42,7 @@ const emptyDefaultFilters = {
 type AdvancedFiltersToolbarProps = {
     searchFilterConfig: CompoundSearchFilterProps['config'];
     searchFilter: SearchFilter;
-    onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
+    onFilterChange: (searchFilter: SearchFilter, payload?: OnSearchPayload) => void;
     cveStatusFilterField?: 'FIXABLE' | 'CLUSTER CVE FIXABLE';
     className?: string;
     defaultFilters?: DefaultFilters;
@@ -160,6 +160,8 @@ function AdvancedFiltersToolbar({
                 {getHasSearchApplied(searchFilter) && (
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={filterChipGroupDescriptors}
                         />
                     </ToolbarGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 
-const vulnerabilitySeverityLabels = ['Critical', 'Important', 'Moderate', 'Low'] as const;
+export const vulnerabilitySeverityLabels = ['Critical', 'Important', 'Moderate', 'Low'] as const;
 export type VulnerabilitySeverityLabel = (typeof vulnerabilitySeverityLabels)[number];
 export function isVulnerabilitySeverityLabel(value: unknown): value is VulnerabilitySeverityLabel {
     return vulnerabilitySeverityLabels.some((severity) => severity === value);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -16,6 +16,7 @@ import { getQueryString } from 'utils/queryStringUtils';
 import { searchValueAsArray, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 
+import { ensureStringArray } from 'Components/CompoundSearchFilter/utils/utils';
 import {
     FixableStatus,
     NodeEntityTab,
@@ -157,6 +158,10 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
     }
 
     return cleanSearchFilter;
+}
+
+export function getAppliedSeverities(searchFilter: SearchFilter): VulnerabilitySeverityLabel[] {
+    return ensureStringArray(searchFilter.SEVERITY).filter(isVulnerabilitySeverityLabel);
 }
 
 // Given a search filter, determine which severities should be hidden from the user

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -16,7 +16,7 @@ import { getQueryString } from 'utils/queryStringUtils';
 import { searchValueAsArray, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 
-import { ensureStringArray } from 'Components/CompoundSearchFilter/utils/utils';
+import { ensureStringArray } from 'utils/ensure';
 import {
     FixableStatus,
     NodeEntityTab,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
@@ -1,4 +1,9 @@
-import { getScoreVersionsForTopCVSS, sortCveDistroList } from './sortUtils';
+import {
+    getScoreVersionsForTopCVSS,
+    getSeveritySortOptions,
+    sortCveDistroList,
+    syncSeveritySortOption,
+} from './sortUtils';
 
 describe('sortCveDistroList', () => {
     it('should return an array of objects sorted by operating system priority', () => {
@@ -111,5 +116,61 @@ describe('getScoreVersionsForTopCVSS', () => {
                 { cvss: 9.4, scoreVersion: 'V2' },
             ])
         ).toEqual(['V1', 'V2', 'V3']);
+    });
+});
+
+describe('getSeveritySortOptions', () => {
+    it('should return all severity sort options when no severity filters are applied', () => {
+        expect(getSeveritySortOptions(undefined)).toEqual([
+            { field: 'Critical Severity Count' },
+            { field: 'Important Severity Count' },
+            { field: 'Moderate Severity Count' },
+            { field: 'Low Severity Count' },
+        ]);
+    });
+
+    it('should return only the visible severity sort options when some severities filters are applied', () => {
+        expect(getSeveritySortOptions(['Critical'])).toEqual([
+            { field: 'Critical Severity Count' },
+        ]);
+
+        expect(getSeveritySortOptions(['Critical', 'Low'])).toEqual([
+            { field: 'Critical Severity Count' },
+            { field: 'Low Severity Count' },
+        ]);
+    });
+
+    it('should return all severity sort options when all severity filters are applied', () => {
+        expect(getSeveritySortOptions(['Critical', 'Important', 'Moderate', 'Low'])).toEqual([
+            { field: 'Critical Severity Count' },
+            { field: 'Important Severity Count' },
+            { field: 'Moderate Severity Count' },
+            { field: 'Low Severity Count' },
+        ]);
+    });
+});
+
+describe('syncSeveritySortOption', () => {
+    it('should not update the sort option if the current sort option is not sorting by severity', () => {
+        const searchFilter = {};
+        const currentSortOption = { field: 'Image', reversed: false };
+        const applySort = jest.fn();
+
+        syncSeveritySortOption(searchFilter, currentSortOption, applySort);
+
+        expect(applySort).not.toHaveBeenCalled();
+    });
+
+    it('should update the sort option if the current sort option is sorting by severity and a new severity filter is applied', () => {
+        const searchFilter = { SEVERITY: ['Critical', 'Important'] };
+        const currentSortOption = [{ field: 'Critical Severity Count', reversed: false }];
+        const applySort = jest.fn();
+
+        syncSeveritySortOption(searchFilter, currentSortOption, applySort);
+
+        expect(applySort).toHaveBeenCalledWith([
+            { field: 'Critical Severity Count', direction: 'asc' },
+            { field: 'Important Severity Count', direction: 'asc' },
+        ]);
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -60,14 +60,15 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | s
  * @returns The default sort option
  */
 export function getDefaultWorkloadSortOption(
-    entityTab: WorkloadEntityTab
+    entityTab: WorkloadEntityTab,
+    searchFilter?: SearchFilter
 ): SortOption | NonEmptyArray<SortOption> {
     switch (entityTab) {
         case 'CVE':
             // Array.prototype.map does not currently retain the arity of an input tuple, so
             // we need to cast the return value to a NonEmptyArray<SortOption>. This may be fixed
             // soon in a future version of TypeScript https://github.com/microsoft/TypeScript/issues/29841
-            return getSeveritySortOptions(getAppliedSeverities({})).map((o) => ({
+            return getSeveritySortOptions(getAppliedSeverities(searchFilter ?? {})).map((o) => ({
                 ...o,
                 direction: 'desc',
             })) as NonEmptyArray<SortOption>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -60,15 +60,14 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | s
  * @returns The default sort option
  */
 export function getDefaultWorkloadSortOption(
-    entityTab: WorkloadEntityTab,
-    searchFilter?: SearchFilter
+    entityTab: WorkloadEntityTab
 ): SortOption | NonEmptyArray<SortOption> {
     switch (entityTab) {
         case 'CVE':
             // Array.prototype.map does not currently retain the arity of an input tuple, so
             // we need to cast the return value to a NonEmptyArray<SortOption>. This may be fixed
             // soon in a future version of TypeScript https://github.com/microsoft/TypeScript/issues/29841
-            return getSeveritySortOptions(getAppliedSeverities(searchFilter ?? {})).map((o) => ({
+            return getSeveritySortOptions(getAppliedSeverities({})).map((o) => ({
                 ...o,
                 direction: 'desc',
             })) as NonEmptyArray<SortOption>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -1,8 +1,8 @@
+import intersection from 'lodash/intersection';
 import sortBy from 'lodash/sortBy';
 import { ensureExhaustive, isNonEmptyArray, NonEmptyArray } from 'utils/type.utils';
 import { SortAggregate, SortOption } from 'types/table';
 import { FieldOption } from 'hooks/useURLSort';
-import intersection from 'lodash/intersection';
 import { ApiSortOption, SearchFilter } from 'types/search';
 import {
     vulnerabilitySeverityLabels,
@@ -45,7 +45,7 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | s
                 'CVE Created Time',
             ];
         case 'Image':
-            return ['Image', 'Image OS', 'Image created time', 'Image scan time'];
+            return ['Image', 'Image OS', 'Image Created Time', 'Image Scan Time'];
         case 'Deployment':
             return ['Deployment', 'Cluster', 'Namespace', 'Created'];
         default:

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -1,7 +1,15 @@
 import sortBy from 'lodash/sortBy';
-import { ensureExhaustive } from 'utils/type.utils';
+import { ensureExhaustive, isNonEmptyArray, NonEmptyArray } from 'utils/type.utils';
 import { SortAggregate, SortOption } from 'types/table';
-import { WorkloadEntityTab } from '../types';
+import { FieldOption } from 'hooks/useURLSort';
+import intersection from 'lodash/intersection';
+import { ApiSortOption, SearchFilter } from 'types/search';
+import {
+    vulnerabilitySeverityLabels,
+    VulnerabilitySeverityLabel,
+    WorkloadEntityTab,
+} from '../types';
+import { getAppliedSeverities } from './searchUtils';
 
 export const aggregateByCVSS: SortAggregate = {
     aggregateFunc: 'max',
@@ -21,10 +29,21 @@ export const aggregateByCreatedTime: SortAggregate = {
  * @param entityTab The chosen entity
  * @returns The available sort fields
  */
-export function getWorkloadSortFields(entityTab: WorkloadEntityTab): string[] {
+export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | string[])[] {
     switch (entityTab) {
         case 'CVE':
-            return ['CVE', 'CVSS', 'Image Sha', 'CVE Created Time'];
+            return [
+                'CVE',
+                [
+                    'Critical Severity Count',
+                    'Important Severity Count',
+                    'Moderate Severity Count',
+                    'Low Severity Count',
+                ],
+                'CVSS',
+                'Image Sha',
+                'CVE Created Time',
+            ];
         case 'Image':
             return ['Image', 'Image OS', 'Image created time', 'Image scan time'];
         case 'Deployment':
@@ -40,10 +59,19 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): string[] {
  * @param entityTab The chosen entity
  * @returns The default sort option
  */
-export function getDefaultWorkloadSortOption(entityTab: WorkloadEntityTab): SortOption {
+export function getDefaultWorkloadSortOption(
+    entityTab: WorkloadEntityTab,
+    searchFilter?: SearchFilter
+): SortOption | NonEmptyArray<SortOption> {
     switch (entityTab) {
         case 'CVE':
-            return { field: 'CVSS', aggregateBy: aggregateByCVSS, direction: 'desc' };
+            // Array.prototype.map does not currently retain the arity of an input tuple, so
+            // we need to cast the return value to a NonEmptyArray<SortOption>. This may be fixed
+            // soon in a future version of TypeScript https://github.com/microsoft/TypeScript/issues/29841
+            return getSeveritySortOptions(getAppliedSeverities(searchFilter ?? {})).map((o) => ({
+                ...o,
+                direction: 'desc',
+            })) as NonEmptyArray<SortOption>;
         case 'Deployment':
             return { field: 'Deployment', direction: 'asc' };
         case 'Image':
@@ -109,4 +137,74 @@ export function getScoreVersionsForTopCVSS(
         .filter(({ cvss }) => cvss.toFixed(1) === topCvss.toFixed(1))
         .map(({ scoreVersion }) => scoreVersion);
     return Array.from(new Set(scoreVersions)).sort();
+}
+
+export const severitySortMap = {
+    Critical: 'Critical Severity Count',
+    Important: 'Important Severity Count',
+    Moderate: 'Moderate Severity Count',
+    Low: 'Low Severity Count',
+} as const;
+
+/**
+ * Given the selected severity filters, return the sort options for the severity column. Severities
+ * that are hidden will not be included in the sort options.
+ *
+ * @param selectedSeverities Severities that have been enabled by the user
+ * @returns A non-empty array of sort options for the severity columns
+ */
+export function getSeveritySortOptions(
+    selectedSeverities: VulnerabilitySeverityLabel[] | undefined
+): NonEmptyArray<FieldOption> {
+    const options = vulnerabilitySeverityLabels
+        .filter((severity) => selectedSeverities?.includes(severity))
+        .map((severity) => ({ field: severitySortMap[severity] }));
+
+    if (isNonEmptyArray(options)) {
+        return options;
+    }
+
+    return [
+        { field: 'Critical Severity Count' },
+        { field: 'Important Severity Count' },
+        { field: 'Moderate Severity Count' },
+        { field: 'Low Severity Count' },
+    ];
+}
+
+/**
+ * If the current sort option is sorting by severity, update the sort option
+ * to match the applied severity filters when the filters change. This is necessary because
+ * the severity multi sort is dynamic and changes based on the applied severity filters, but
+ * does not update the sort fields automatically when the filters change.
+ *
+ * @param searchFilter The updated search filter
+ * @param currentSortOption The current sort option
+ * @param applySort A callback function to apply the new sort option, usually from the useURLSort hook
+ */
+export function syncSeveritySortOption(
+    searchFilter: SearchFilter,
+    currentSortOption: ApiSortOption,
+    applySort: (sort: SortOption | SortOption[]) => void
+) {
+    // Only sync the sort option if the current sort option is sorting by severity. This
+    // is determined by detecting that the current sort option is an array and that it
+    // contains a field that matches a severity.
+    if (
+        !Array.isArray(currentSortOption) ||
+        intersection(
+            currentSortOption.map((s) => s.field),
+            Object.values(severitySortMap)
+        ).length === 0
+    ) {
+        return;
+    }
+
+    const appliedSeverities = getAppliedSeverities(searchFilter);
+    const { reversed } = currentSortOption[0];
+    const direction = reversed ? 'desc' : 'asc';
+    const sortOptions = getSeveritySortOptions(appliedSeverities).map(
+        (option) => ({ ...option, direction }) as const
+    );
+    applySort(sortOptions);
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
@@ -13,13 +13,12 @@ type FilterAppliedEvent =
     | typeof PLATFORM_CVE_FILTER_APPLIED;
 
 export function createFilterTracker(analyticsTrack: (analyticsEvent: AnalyticsEvent) => void) {
-    return function trackAppliedFilter(event: FilterAppliedEvent, payload: OnSearchPayload) {
-        const { action, category, value: filter } = payload;
-
-        if (action !== 'ADD') {
+    return function trackAppliedFilter(event: FilterAppliedEvent, payload?: OnSearchPayload) {
+        if (!payload || payload.action !== 'ADD') {
             // Only track when a filter is applied, not removed
             return;
         }
+        const { category, value: filter } = payload;
 
         const telemetryEvent = isSearchCategoryWithFilter(category)
             ? { event, properties: { category, filter } }

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -130,7 +130,7 @@ export type UseURLSortResult = {
  *     <Th sort={getSortParams('CVE')}>CVE</Th>
  *     <Th sort={getSortParams('Top CVSS')}>Top CVSS</Th>
  *     <Th sort={getSortParams('First Discovered')}>First discovered</Th>
- *    <Th sort={getSortParams('Images by severity', [
+ *    <Th sort={getSortParams('Images By Severity', [
  *       { field: 'Critical Severity Count' },
  *       { field: 'Important Severity Count' },
  *    ])}>Images by severity</Th>

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -45,7 +45,7 @@ function getValidSortOption(activeSortOption: SortOption | SortOption[]): ApiSor
 
 function getActiveSortOption(
     sortOption: QueryValue,
-    defaultSortOption: SortOption
+    defaultSortOption: SortOption | NonEmptyArray<SortOption>
 ): SortOption | NonEmptyArray<SortOption> {
     if (Array.isArray(sortOption)) {
         const validOptions = sortOption.filter(isSortOption);
@@ -57,13 +57,16 @@ function getActiveSortOption(
 
 export type UseURLSortProps = {
     sortFields: (string | string[])[];
-    defaultSortOption: SortOption;
+    defaultSortOption: SortOption | NonEmptyArray<SortOption>;
     onSort?: (newSortOption: SortOption | SortOption[]) => void;
 };
 
 export type UseURLSortResult = {
     sortOption: ApiSortOption;
-    setSortOption: (newSortOption: SortOption, historyAction?: HistoryAction | undefined) => void;
+    setSortOption: (
+        newSortOption: SortOption | SortOption[],
+        historyAction?: HistoryAction | undefined
+    ) => void;
     getSortParams: GetSortParams;
 };
 


### PR DESCRIPTION
### Description

Adds the ability to sort Workload CVEs by on the Images by severity column. This uses [Olympic Medal Table](https://en.wikipedia.org/wiki/Olympic_medal_table) sorting to rank the CVEs by the number of affected images with a given severity.

CVEs are sorted by images affected by the CVE at a critical severity level, descending to important, moderate, and low severity to break ties at each level.

If a given severity is hidden via the filter, it is _not_ used in the sorting calculation.

**Must be merged after** https://github.com/stackrox/stackrox/pull/12821 in order to work correctly when filter chips are removed.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Visit Workload CVEs and see the new default sort by severity:
![image](https://github.com/user-attachments/assets/4ed63479-e9be-45fb-8eaf-fbfbb82618f7)
![image](https://github.com/user-attachments/assets/7fcca286-1f5b-46c9-9acb-3778098e5254)

Hide some severities and ensure those severities are not calculated in the sort:
![image](https://github.com/user-attachments/assets/ad94944c-8cd8-4568-9f83-6a98d7564e6d)
![image](https://github.com/user-attachments/assets/eb124d13-2eb3-4fc2-b5aa-288d2637105a)
