### PR TITLE
ROX-25990: Send both flows in a single message

### DIFF
--- a/sensor/tests/helper/collector.go
+++ b/sensor/tests/helper/collector.go
@@ -132,14 +132,6 @@ func SendFlowMessage(fakeCollector *collector.FakeCollector,
 							Port:        port,
 						},
 					},
-				},
-			},
-		},
-	})
-	fakeCollector.SendFakeNetworkFlow(&sensor.NetworkConnectionInfoMessage{
-		Msg: &sensor.NetworkConnectionInfoMessage_Info{
-			Info: &sensor.NetworkConnectionInfo{
-				UpdatedConnections: []*sensor.NetworkConnection{
 					{
 						SocketFamily: socketFamily,
 						Protocol:     protocol,


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The network flows are processed every 30s. This means we need between 30s and a minute (exactly the timeout in the assertion) to process the two flows that collector sends in the runtime test.

The test sends a message for each flow so if we are lucky they could be processed in one tick (30s) or two ticks (1 minute) if we are unlucky. If the second scenario occurs the 1 minute timeout might not be enough to process both network flows.

This PR fixes this issue by having the collector in the test send one message with both flows instead of two messages.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Run multiple times manually
- [x] CI should be happy
