### PR TITLE
fix: Disallow CRS name duplicates

### DIFF
--- a/central/clusterinit/store/store.go
+++ b/central/clusterinit/store/store.go
@@ -114,6 +114,11 @@ func (w *storeImpl) checkDuplicateName(ctx context.Context, meta *storage.InitBu
 	if err != nil {
 		return err
 	}
+	crsMetas, err := w.GetAllCRS(ctx)
+	if err != nil {
+		return err
+	}
+	metas = append(metas, crsMetas...)
 	for _, m := range metas {
 		if m.GetName() == meta.GetName() && !m.GetIsRevoked() {
 			return ErrInitBundleDuplicateName


### PR DESCRIPTION
### Description

Fix: Forbid multiple CRSs with the same name.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

Attempted to create multiple CRSs with the same name using `roxctl central crs generate`.
+ new unit test.
