### PR TITLE
chore(ci): scanner v4 vuln update improvements

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -245,10 +245,6 @@ jobs:
     - name: Create bundle output directory
       run: mkdir -p definitions/${{ github.event.pull_request.number }}
 
-    - name: Run Updater (single bundle)
-      run: |
-        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${{ github.event.pull_request.number }}"
-
     - name: Run updater (multi bundle)
       run: |
         scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -68,7 +68,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 	}
 
 	// Rate limit to ~16 requests/second by default.
-	interval := 62*time.Millisecond
+	interval := 62 * time.Millisecond
 	configuredInterval := os.Getenv("STACKROX_SCANNER_V4_UPDATER_INTERVAL")
 	if configuredInterval != "" {
 		parsedInterval, err := time.ParseDuration(configuredInterval)

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -74,9 +74,9 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 		parsedInterval, err := time.ParseDuration(configuredInterval)
 		switch {
 		case err != nil:
-			log.Println(fmt.Errorf("invalid interval, using default (%v): %w", interval, err))
+			log.Printf("invalid interval, using default (%v): %v", interval, err)
 		case parsedInterval < interval:
-			log.Println(fmt.Errorf("interval is too small (%v): using default (%v)", parsedInterval, interval))
+			log.Printf("interval is too small (%v): using default (%v)", parsedInterval, interval)
 		default:
 			interval = parsedInterval
 		}


### PR DESCRIPTION
### Description

1. Stop running the single-bundle updater for PRs, as it's no longer used.
2. Fix the frequency of reaching out to the vulnerability providers. It was (probably) meant to be 15 requests/second, but it's actually 1 request/second. This change makes it ~16 requests/second.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

This **is** the test

#### How I validated my change

CI
