### PR TITLE
fix(ui): Add no-anchor-href-docs-string generic lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -132,7 +132,9 @@ const rules = {
         create(context) {
             const isDocs = (href) =>
                 href.startsWith('https://docs.openshift.com/acs/') ||
-                href.startsWith('https://docs.redhat.com/acs/');
+                href.startsWith(
+                    'https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/'
+                );
             return {
                 JSXOpeningElement(node) {
                     if (node.name?.name === 'a') {

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -4,7 +4,7 @@ const rules = {
     // ESLint naming convention for positive rules:
     // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
 
-    'ExternalLink-a': {
+    'ExternalLink-anchor': {
         // Require ExternalLink with anchor element as child for consistent presentation of external links.
         meta: {
             type: 'problem',
@@ -51,16 +51,16 @@ const rules = {
                     if (node.name?.name === 'Link') {
                         if (
                             node.attributes.some(
-                                (nodeAttribute) =>
-                                    nodeAttribute.name?.name === 'target' &&
-                                    nodeAttribute.value?.value === '_blank'
+                                (attribute) =>
+                                    attribute.name?.name === 'target' &&
+                                    attribute.value?.value === '_blank'
                             )
                         ) {
                             if (
                                 !node.attributes.some(
-                                    (nodeAttribute) =>
-                                        nodeAttribute.name?.name === 'rel' &&
-                                        nodeAttribute.value?.value === 'noopener noreferrer'
+                                    (attribute) =>
+                                        attribute.name?.name === 'rel' &&
+                                        attribute.value?.value === 'noopener noreferrer'
                                 )
                             ) {
                                 context.report({
@@ -75,7 +75,7 @@ const rules = {
             };
         },
     },
-    'a-target-rel': {
+    'anchor-target-rel': {
         // Require props for consistent behavior and security of external links.
         meta: {
             type: 'problem',
@@ -91,14 +91,14 @@ const rules = {
                     if (node.name?.name === 'a') {
                         if (
                             !node.attributes.some(
-                                (nodeAttribute) =>
-                                    nodeAttribute.name?.name === 'target' &&
-                                    nodeAttribute.value?.value === '_blank'
+                                (attribute) =>
+                                    attribute.name?.name === 'target' &&
+                                    attribute.value?.value === '_blank'
                             ) ||
                             !node.attributes.some(
-                                (nodeAttribute) =>
-                                    nodeAttribute.name?.name === 'rel' &&
-                                    nodeAttribute.value?.value === 'noopener noreferrer'
+                                (attribute) =>
+                                    attribute.name?.name === 'rel' &&
+                                    attribute.value?.value === 'noopener noreferrer'
                             )
                         ) {
                             context.report({
@@ -116,6 +116,45 @@ const rules = {
     // ESLint naming convention for negative rules.
     // If your rule only disallows something, prefix it with no.
     // However, we can write forbid instead of disallow as the verb in description and message.
+
+    'no-anchor-href-docs-string': {
+        // Full path string lacks what getVersionedDocs function provides:
+        // Include version number so doc page corresponds to product version.
+        // Encapsulate openshift versus redhat in origin of path.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Replace string with getVersionedDocs function call in href prop of anchor element for product docs',
+            },
+            schema: [],
+        },
+        create(context) {
+            const isDocs = (href) =>
+                href.startsWith('https://docs.openshift.com/acs/') ||
+                href.startsWith('https://docs.redhat.com/acs/');
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'a') {
+                        if (
+                            node.attributes.some(
+                                (attribute) =>
+                                    attribute.name?.name === 'href' &&
+                                    typeof attribute.value?.value === 'string' &&
+                                    isDocs(attribute.value.value)
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Replace full path string with getVersionedDocs function call in href prop of anchor element for product docs',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
 };
 
 const pluginKey = 'generic'; // key of pluginGeneric in eslint.config.js file

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -11,14 +11,16 @@ import {
 } from '@patternfly/react-core';
 import * as yup from 'yup';
 
-import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
-
-import usePageState from 'Containers/Integrations/hooks/usePageState';
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import usePageState from 'Containers/Integrations/hooks/usePageState';
+import useMetadata from 'hooks/useMetadata';
+import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
+import { getVersionedDocs } from 'utils/versioning';
+
 import IntegrationHelpIcon from '../Components/IntegrationHelpIcon';
 import useIntegrationForm from '../../useIntegrationForm';
 import { IntegrationFormProps } from '../../integrationFormTypes';
@@ -152,6 +154,7 @@ function GcsIntegrationForm({
         initialValues: formInitialValues,
         validationSchema,
     });
+    const { version } = useMetadata();
     const { isCreating } = usePageState();
 
     function onChange(value, event) {
@@ -324,7 +327,10 @@ function GcsIntegrationForm({
                                             For more information, see{' '}
                                             <ExternalLink>
                                                 <a
-                                                    href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
+                                                    href={getVersionedDocs(
+                                                        version,
+                                                        'integration/integrate-using-short-lived-tokens.html'
+                                                    )}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                 >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -3,14 +3,16 @@ import React, { ReactElement } from 'react';
 import { Checkbox, Form, FormSelect, PageSection, Text, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
 
-import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
-
-import usePageState from 'Containers/Integrations/hooks/usePageState';
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import usePageState from 'Containers/Integrations/hooks/usePageState';
+import useMetadata from 'hooks/useMetadata';
+import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
+import { getVersionedDocs } from 'utils/versioning';
+
 import IntegrationHelpIcon from '../Components/IntegrationHelpIcon';
 import useIntegrationForm from '../../useIntegrationForm';
 import { IntegrationFormProps } from '../../integrationFormTypes';
@@ -154,6 +156,7 @@ function S3IntegrationForm({
         initialValues: formInitialValues,
         validationSchema,
     });
+    const { version } = useMetadata();
     const { isCreating } = usePageState();
 
     function onChange(value, event) {
@@ -409,7 +412,10 @@ function S3IntegrationForm({
                                             For more information, see{' '}
                                             <ExternalLink>
                                                 <a
-                                                    href="https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html"
+                                                    href={getVersionedDocs(
+                                                        version,
+                                                        'integration/integrate-using-short-lived-tokens.html'
+                                                    )}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                 >

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -5,8 +5,8 @@ import NoResultsMessage from 'Components/NoResultsMessage';
 
 const Factor = ({ message, url }) => {
     // TODO is the link external or internal?
-    /* eslint-disable generic/ExternalLink-a */
-    /* eslint-disable generic/a-target-rel */
+    /* eslint-disable generic/ExternalLink-anchor */
+    /* eslint-disable generic/anchor-target-rel */
     const renderedMessage = url ? (
         <a href={url} target="_blank" rel="noopener noreferrer">
             {message}
@@ -14,8 +14,8 @@ const Factor = ({ message, url }) => {
     ) : (
         message
     );
-    /* eslint-enable generic/ExternalLink-a */
-    /* eslint-enable generic/a-target-rel */
+    /* eslint-enable generic/ExternalLink-anchor */
+    /* eslint-enable generic/anchor-target-rel */
 
     return (
         <div className="px-3">


### PR DESCRIPTION
### Description

Prerequisite to change origin of docs site in only one line of code.

```diff
- return `https://docs.openshift.com/acs/${getVersionMajorMinor(completeVersion)}/${subPath}`;
+ return `https://docs.redhat.com/acs/${getVersionMajorMinor(completeVersion)}/${subPath}`;
```

Especially to help contributors from other teams be consistent.

Brad wrote `getVersionedDocs` helper function in #4494
* Include version number so doc page corresponds to product version.
* Encapsulate openshift versus redhat in origin of path.
    Based on information from Kerry, the change is more than just the origin.

### Bonus

Dear reviewer, forgive these additional changes:
1. Replace `a` with `anchor` in rule keys which I forgot when we improved the prose in #12558
2. Replace `nodeAttribute` with `attribute` in 2 existing rules to simplify the pattern.
3. Move `import` statements in forms to usual order.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
    With new line rule, but before changes to `href` props, see errors:

```
src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
  326:49  error  Replace full path string with getVersionedDocs function call in href prop of anchor element for product docs  generic/no-anchor-href-docs-string

src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
  411:49  error  Replace full path string with getVersionedDocs function call in href prop of anchor element for product docs  generic/no-anchor-href-docs-string
```

2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit docs page without version number and see redirect to acs/4.5/…
    Although 4.5 is the most recent version, what if customer has older version?

    * https://docs.openshift.com/acs/integration/integrate-using-short-lived-tokens.html

2. Visit /main/integrations/backups/gcs/create, click ? at the right of **Short-lived tokens**, and then click **RHACS documentation** link.
    Open https://docs.openshift.com/acs/4.6/integration/integrate-using-short-lived-tokens.html which does not exist because this is dev version, but becomes correct link if I edit page address.

3. Visit /main/integrations/backups/s3/create, and ditto.