### PR TITLE
ROX-25828: Make Pruner more configurable

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	orphanedTimeout = 5 * time.Minute
-
 	pruneActiveComponentsStmt = `DELETE FROM active_components child WHERE NOT EXISTS
 		(SELECT 1 from deployments parent WHERE child.deploymentid = parent.id)`
 
@@ -86,6 +84,8 @@ const (
 )
 
 var (
+	orphanedTimeout = env.PruneOrphanedTimeout.DurationSetting()
+
 	pruningTimeout = env.PostgresDefaultPruningStatementTimeout.DurationSetting()
 
 	log = logging.LoggerForModule()

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -84,7 +84,7 @@ const (
 )
 
 var (
-	orphanedTimeout = env.PruneOrphanedTimeout.DurationSetting()
+	orphanedQueryTimeout = env.PruneOrphanedQueryTimeout.DurationSetting()
 
 	pruningTimeout = env.PostgresDefaultPruningStatementTimeout.DurationSetting()
 
@@ -133,7 +133,7 @@ func getOrphanedIDs(ctx context.Context, pool postgres.DB, query string) ([]stri
 // GetOrphanedAlertIDs returns the alert IDs for alerts that are orphaned, so they can be resolved.
 func GetOrphanedAlertIDs(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
 	return pgutils.Retry2(ctx, func() ([]string, error) {
-		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
+		ctx, cancel := context.WithTimeout(ctx, orphanedQueryTimeout)
 		defer cancel()
 
 		query := fmt.Sprintf(getAllOrphanedAlerts, int(orphanWindow.Minutes()))
@@ -144,7 +144,7 @@ func GetOrphanedAlertIDs(ctx context.Context, pool postgres.DB, orphanWindow tim
 // GetOrphanedPodIDs returns the pod IDs for pods that are orphaned, so they can be removed.
 func GetOrphanedPodIDs(ctx context.Context, pool postgres.DB) ([]string, error) {
 	return pgutils.Retry2(ctx, func() ([]string, error) {
-		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
+		ctx, cancel := context.WithTimeout(ctx, orphanedQueryTimeout)
 		defer cancel()
 
 		return getOrphanedIDs(ctx, pool, getAllOrphanedPods)
@@ -154,7 +154,7 @@ func GetOrphanedPodIDs(ctx context.Context, pool postgres.DB) ([]string, error) 
 // GetOrphanedNodeIDs returns the node ids that have a cluster that has been removed.
 func GetOrphanedNodeIDs(ctx context.Context, pool postgres.DB) ([]string, error) {
 	return pgutils.Retry2(ctx, func() ([]string, error) {
-		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
+		ctx, cancel := context.WithTimeout(ctx, orphanedQueryTimeout)
 		defer cancel()
 
 		return getOrphanedIDs(ctx, pool, getAllOrphanedNodes)
@@ -164,7 +164,7 @@ func GetOrphanedNodeIDs(ctx context.Context, pool postgres.DB) ([]string, error)
 // GetOrphanedProcessIDsByDeployment returns the process ids that have a deployment that has been removed.
 func GetOrphanedProcessIDsByDeployment(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
 	return pgutils.Retry2(ctx, func() ([]string, error) {
-		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
+		ctx, cancel := context.WithTimeout(ctx, orphanedQueryTimeout)
 		defer cancel()
 
 		query := fmt.Sprintf(getOrphanedProcessesByDeployment, int(orphanWindow.Minutes()))
@@ -175,7 +175,7 @@ func GetOrphanedProcessIDsByDeployment(ctx context.Context, pool postgres.DB, or
 // GetOrphanedProcessIDsByPod returns the process ids that have a pod that has been removed.
 func GetOrphanedProcessIDsByPod(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) ([]string, error) {
 	return pgutils.Retry2(ctx, func() ([]string, error) {
-		ctx, cancel := context.WithTimeout(ctx, orphanedTimeout)
+		ctx, cancel := context.WithTimeout(ctx, orphanedQueryTimeout)
 		defer cancel()
 
 		query := fmt.Sprintf(getOrphanedProcessesByPod, int(orphanWindow.Minutes()))

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -50,8 +50,6 @@ import (
 )
 
 const (
-	pruneInterval      = 1 * time.Hour
-	orphanWindow       = 30 * time.Minute
 	baselineBatchLimit = 10000
 	clusterGCFreq      = 24 * time.Hour
 	logImbueGCFreq     = 24 * time.Hour
@@ -75,6 +73,9 @@ var (
 	lastClusterPruneTime  time.Time
 	lastLogImbuePruneTime time.Time
 	pruningTimeout        = env.PostgresDefaultPruningStatementTimeout.DurationSetting()
+
+	pruneInterval = env.PruneInterval.DurationSetting()
+	orphanWindow  = env.PruneOrphanedWindow.DurationSetting()
 )
 
 // GarbageCollector implements a generic garbage collection mechanism.

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -22,4 +22,29 @@ var (
 
 	// PostgresDefaultPruningStatementTimeout sets the default timeout for pruning operations
 	PostgresDefaultPruningStatementTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_PRUNING_TIMEOUT", 3*time.Minute)
+
+	// How often to perform pruning
+	PruneInterval = registerDurationSetting("ROX_PRUNE_INTERVAL", 1*time.Hour)
+
+	// Timeout for reading part of pruning query
+	PruneOrphanedQueryTimeout = registerDurationSetting("ROX_PRUNE_ORPHANED_QUERY_TIMEOUT", 5*time.Minute)
+
+	// Pruning is necessary due to the asynchronous nature of some events. E.g.
+	// a process indicator may arrive before a corresponding deployment was
+	// received, which will prevent us from making any hard constraints and
+	// make data cleanup more complicated. Pruner helps to address that by
+	// defining an arbitrary threshold, after which an event is concidered to
+	// be orphaned and could be deleted.
+	//
+	// Currently the default timeout is 5 minutes, which is a plausible looking
+	// arbitrary value. This cut off line may significantly affect the
+	// underlying query performance, if it doesn't match the actual lifetime:
+	//   * if it's too short and the actual events live longer, the pruner
+	//     would have to read lots of non-orphaned data only to skip it.
+	//   * if it's too long, orphaned records will stay longer, clogging the
+	//     table.
+	//
+	// Thus it has to be configured if needed, when pruner performance issues
+	// are observed.
+	PruneOrphanedWindow = registerDurationSetting("ROX_PRUNE_ORPHANED_WINDOW", 30*time.Minute)
 )

--- a/pkg/env/process_pruning.go
+++ b/pkg/env/process_pruning.go
@@ -1,35 +1,8 @@
 package env
 
-import "time"
-
 var (
 	// ProcessPruningEnabled toggles whether process pruning should be done periodically using heuristics
 	// This may be useful in certain large environments, but is fairly expensive as it requires a full
 	// sweep over the database
 	ProcessPruningEnabled = RegisterBooleanSetting("ROX_PROCESS_PRUNING", false)
-
-	// How often to perform pruning
-	PruneInterval = registerDurationSetting("ROX_PRUNE_INTERVAL", 1*time.Hour)
-
-	// Timeout for reading part of pruning query
-	PruneOrphanedTimeout = registerDurationSetting("ROX_PRUNE_ORPHANED_TIMEOUT", 5*time.Minute)
-
-	// Pruning is necessary due to the asynchronous nature of some events. E.g.
-	// a process indicator may arrive before a corresponding deployment was
-	// received, which will prevent us from making any hard constraints and
-	// make data cleanup more complicated. Pruner helps to address that by
-	// defining an arbitrary threshold, after which an event is concidered to
-	// be orphaned and could be deleted.
-	//
-	// Currently the default timeout is 5 minutes, which is a plausible looking
-	// arbitrary value. This cut off line may significantly affect the
-	// underlying query performance, if it doesn't match the actual lifetime:
-	//   * if it's too short and the actual events live longer, the pruner
-	//     would have to read lots of non-orphaned data only to skip it.
-	//   * if it's too long, orphaned records will stay longer, clogging the
-	//     table.
-	//
-	// Thus it has to be configured if needed, when pruner performance issues
-	// are observed.
-	PruneOrphanedWindow = registerDurationSetting("ROX_PRUNE_ORPHANED_WINDOW", 30*time.Minute)
 )

--- a/pkg/env/process_pruning.go
+++ b/pkg/env/process_pruning.go
@@ -1,8 +1,35 @@
 package env
 
+import "time"
+
 var (
 	// ProcessPruningEnabled toggles whether process pruning should be done periodically using heuristics
 	// This may be useful in certain large environments, but is fairly expensive as it requires a full
 	// sweep over the database
 	ProcessPruningEnabled = RegisterBooleanSetting("ROX_PROCESS_PRUNING", false)
+
+	// How often to perform pruning
+	PruneInterval = registerDurationSetting("ROX_PRUNE_INTERVAL", 1*time.Hour)
+
+	// Timeout for reading part of pruning query
+	PruneOrphanedTimeout = registerDurationSetting("ROX_PRUNE_ORPHANED_TIMEOUT", 5*time.Minute)
+
+	// Pruning is necessary due to the asynchronous nature of some events. E.g.
+	// a process indicator may arrive before a corresponding deployment was
+	// received, which will prevent us from making any hard constraints and
+	// make data cleanup more complicated. Pruner helps to address that by
+	// defining an arbitrary threshold, after which an event is concidered to
+	// be orphaned and could be deleted.
+	//
+	// Currently the default timeout is 5 minutes, which is a plausible looking
+	// arbitrary value. This cut off line may significantly affect the
+	// underlying query performance, if it doesn't match the actual lifetime:
+	//   * if it's too short and the actual events live longer, the pruner
+	//     would have to read lots of non-orphaned data only to skip it.
+	//   * if it's too long, orphaned records will stay longer, clogging the
+	//     table.
+	//
+	// Thus it has to be configured if needed, when pruner performance issues
+	// are observed.
+	PruneOrphanedWindow = registerDurationSetting("ROX_PRUNE_ORPHANED_WINDOW", 30*time.Minute)
 )


### PR DESCRIPTION
### Description

Currently the only thing that could be tuned for the pruning process is whether it's enabled. The way how pruner works right now might be causing high memory utilization, due to queries doing large amount of reads. This could be adjusted via frequency and the orphan cut-off line. Introduce those two configurations to help with troubleshooting.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manually verified that it's possible to get expected pruning configuration:

* Deploy the modified image
* Configure pruning interval, timeout and orphan window so that pruning will happen frequently, the timeout will be low to prevent any other pruning activity (e.g. alerts cleanup) to stuck for a long time, and the orphan window long enough to essentially skip all the processes.

```
queryid             | 3727384489359643919
query               | SELECT id FROM process_indicators pi WHERE NOT EXISTS                                                             +
                    |                 (SELECT $1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND                           +
                    |                 (signal_time < now() AT time zone $2 - INTERVAL $3 OR signal_time IS NULL)
calls               | 18
total_exec_time     | 0.44726699999999997
min_exec_time       | 0.0073100000000000005
max_exec_time       | 0.09509999999999999
mean_exec_time      | 0.024848166666666664
stddev_exec_time    | 0.02014491902096186
rows                | 0
```