### PR TITLE
ROX-25990: Add debug logging to flaky test

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -835,9 +835,10 @@ func (m *networkFlowManager) enrichProcessesListening(hostConns *hostConnections
 func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (map[networkConnIndicator]timestamp.MicroTS, map[containerEndpointIndicator]timestamp.MicroTS) {
 	allHostConns := m.getAllHostConnections()
 	for i, conn := range allHostConns {
-		conn.mutex.Lock()
-		log.Infof("currentEnrichedConnsAndEndpoints: allHostConns: [%d]:%+v", i, conn)
-		conn.mutex.Unlock()
+		concurrency.WithLock(&conn.mutex, func() {
+			log.Infof("currentEnrichedConnsAndEndpoints: allHostConns: [%d]:%+v", i, conn)
+
+		})
 	}
 
 	enrichedConnections := make(map[networkConnIndicator]timestamp.MicroTS)

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -91,6 +91,7 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		require.NotEqual(t, "", talkIP)
 
 		if !helper.UseRealCollector.BooleanSetting() {
+			t.Log("Using fake collector messages for the test")
 			nginxPodIDs, nginxContainerIDs := c.GetContainerIdsFromDeployment(nginxObj)
 			require.Len(t, nginxPodIDs, 1)
 			require.Len(t, nginxContainerIDs, 1)

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -152,8 +152,10 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		}, time.Minute)
 		assert.NoError(t, err)
 		assert.NotNil(t, msg)
+		t.Logf("Expecting Network Flow for %s -> %s", talkUID, nginxUID)
 		msg, err = testContext.WaitForMessageWithMatcher(func(event *central.MsgFromSensor) bool {
 			for _, flow := range event.GetNetworkFlowUpdate().GetUpdated() {
+				t.Logf("Processing Flow: %v - %v", flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity())
 				if flow.GetProps().GetSrcEntity().GetId() == talkUID && flow.GetProps().GetDstEntity().GetId() == nginxUID {
 					return true
 				}


### PR DESCRIPTION
### Description

To further debug the flaky `Test_SensorIntermediateRuntimeEvents`, debug logs are added to provide insight into the state of Network Flows at test time.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change
As this is as work in progress to collect additional information, no validation has been conducted at this point in time.
