### PR TITLE
refactor(ui): Clean up reporting related components

### DIFF
--- a/ui/apps/platform/src/Components/ReportJob/MyActiveJobStatusTh.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/MyActiveJobStatusTh.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+
+import HelpIconTh from 'Containers/Vulnerabilities/VulnerablityReporting/VulnReports/HelpIconTh';
+
+function MyActiveJobStatusTh() {
+    return (
+        <HelpIconTh
+            popoverContent={
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+                    <FlexItem>
+                        <p>
+                            The status of your last requested job from the{' '}
+                            <strong>active job queue</strong>. An <strong>active job queue</strong>{' '}
+                            includes any requested job with the status of <strong>preparing</strong>{' '}
+                            or <strong>waiting</strong> until completed.
+                        </p>
+                    </FlexItem>
+                    <FlexItem>
+                        <p>
+                            <strong>Preparing:</strong>
+                        </p>
+                        <p>Your last requested job is still being processed.</p>
+                    </FlexItem>
+                    <FlexItem>
+                        <p>
+                            <strong>Waiting:</strong>
+                        </p>
+                        <p>
+                            Your last requested job is in the queue and waiting to be processed
+                            since other requested jobs are being processed.
+                        </p>
+                    </FlexItem>
+                </Flex>
+            }
+        >
+            My active job status
+        </HelpIconTh>
+    );
+}
+
+export default MyActiveJobStatusTh;

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobsHelpAction.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobsHelpAction.tsx
@@ -4,8 +4,8 @@ import { HelpIcon } from '@patternfly/react-icons';
 
 import { systemConfigPath } from 'routePaths';
 import usePermissions from 'hooks/usePermissions';
-import PopoverBodyContent from './PopoverBodyContent';
-import ExternalLink from './PatternFly/IconText/ExternalLink';
+import PopoverBodyContent from '../PopoverBodyContent';
+import ExternalLink from '../PatternFly/IconText/ExternalLink';
 
 type ReportJobsHelpActionProps = {
     reportType: 'Vulnerability' | 'Scan schedule';

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
@@ -18,7 +18,7 @@ import { saveFile } from 'services/DownloadService';
 import { getDateTime } from 'utils/dateUtils';
 import ReportJobStatus from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus';
 import { ComplianceScanSnapshot } from 'services/ComplianceScanConfigurationService';
-import EmptyStateTemplate from './EmptyStateTemplate';
+import EmptyStateTemplate from '../EmptyStateTemplate';
 
 export type ReportJobsTableProps<T> = {
     snapshots: T[];

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -31,10 +31,10 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { JobContextTab } from 'types/reportJob';
 import { ensureJobContextTab } from 'utils/reportJob';
+import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
 import ScanConfigActionDropdown from './ScanConfigActionDropdown';
 import ConfigDetails from './components/ConfigDetails';
 import ReportJobs from './components/ReportJobs';
-import ReportJobsHelpAction from '../../../Components/ReportJobsHelpAction';
 
 type ViewScanConfigDetailProps = {
     hasWriteAccessForCompliance: boolean;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -14,7 +14,7 @@ import {
     ComplianceScanSnapshot,
 } from 'services/ComplianceScanConfigurationService';
 import JobDetails from 'Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails';
-import ReportJobsTable from 'Components/ReportJobsTable';
+import ReportJobsTable from 'Components/ReportJob/ReportJobsTable';
 import { RunState } from 'services/ReportsService.types';
 import useURLPagination from 'hooks/useURLPagination';
 import ConfigDetails from './ConfigDetails';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -45,7 +45,7 @@ import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import usePermissions from 'hooks/usePermissions';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 
-import ReportJobsHelpAction from 'Components/ReportJobsHelpAction';
+import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
 import { JobContextTab } from 'types/reportJob';
 import { ensureJobContextTab } from 'utils/reportJob';
 import EmailTemplatePreview from '../components/EmailTemplatePreview';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
@@ -75,7 +75,7 @@ export function useWatchLastSnapshotForReports(
     const result: FetchLastSnapshotReturn = {
         reportSnapshots: data || {},
         isLoading,
-        error: getAxiosErrorMessage(error),
+        error: error ? getAxiosErrorMessage(error) : null,
         fetchSnapshots: refetch,
     };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
@@ -1,20 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 
 import { fetchReportHistory } from 'services/ReportsService';
 import { ReportConfiguration, ReportSnapshot } from 'services/ReportsService.types';
 import useInterval from 'hooks/useInterval';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useRestQuery from 'hooks/useRestQuery';
 import { getRequestQueryString } from './apiUtils';
-import { getErrorMessage } from '../errorUtils';
-
-type Result = {
-    reportSnapshots: Record<string, ReportSnapshot | null>;
-    isLoading: boolean;
-    error: string | null;
-};
-
-export type FetchLastSnapshotReturn = Result & {
-    fetchSnapshots: () => void;
-};
 
 async function fetchLastReportJobForConfiguration(
     reportConfigurationId: string
@@ -36,64 +27,57 @@ async function fetchLastReportJobForConfiguration(
     return reportSnapshot[0] ?? null;
 }
 
-const defaultResult = {
-    reportSnapshots: {},
-    isLoading: false,
-    error: null,
+type ReportSnapshotLookup = Record<string, ReportSnapshot | null>;
+
+type Result = {
+    reportSnapshots: ReportSnapshotLookup;
+    isLoading: boolean;
+    error: string | null;
+};
+
+export type FetchLastSnapshotReturn = Result & {
+    fetchSnapshots: () => void;
 };
 
 export function useWatchLastSnapshotForReports(
     reportConfigurations: ReportConfiguration | ReportConfiguration[] | null
 ): FetchLastSnapshotReturn {
-    const [result, setResult] = useState<Result>(defaultResult);
-
-    const fetchSnapshots = useCallback(async () => {
+    const fetchSnapshotsCallback = useCallback(async () => {
         if (!reportConfigurations) {
-            return;
+            const result: ReportSnapshotLookup = {};
+            return Promise.resolve(result);
         }
 
-        setResult((prevResult) => ({
-            ...prevResult,
-            isLoading: true,
-            error: null,
-        }));
+        const promise: Promise<ReportSnapshotLookup> = new Promise((resolve, reject) => {
+            const configurations = Array.isArray(reportConfigurations)
+                ? reportConfigurations
+                : [reportConfigurations];
 
-        const configurations = Array.isArray(reportConfigurations)
-            ? reportConfigurations
-            : [reportConfigurations];
+            Promise.all(configurations.map(({ id }) => fetchLastReportJobForConfiguration(id)))
+                .then((snapshotResults) => {
+                    const result: ReportSnapshotLookup = configurations.reduce(
+                        (acc, { id }, index) => ({ ...acc, [id]: snapshotResults[index] }),
+                        {}
+                    );
+                    resolve(result);
+                })
+                .catch((error) => {
+                    reject(error);
+                });
+        });
 
-        try {
-            const snapshots = await Promise.all(
-                configurations.map(({ id }) => fetchLastReportJobForConfiguration(id))
-            );
-            setResult({
-                reportSnapshots: configurations.reduce(
-                    (acc, { id }, index) => ({ ...acc, [id]: snapshots[index] }),
-                    {}
-                ),
-                isLoading: false,
-                error: null,
-            });
-        } catch (error) {
-            setResult({
-                reportSnapshots: {},
-                isLoading: false,
-                error: getErrorMessage(error),
-            });
-        }
+        return promise;
     }, [reportConfigurations]);
+    const { data, isLoading, error, refetch } = useRestQuery(fetchSnapshotsCallback);
 
-    useInterval(fetchSnapshots, 10000);
+    useInterval(refetch, 10000);
 
-    useEffect(() => {
-        // eslint-disable-next-line no-void
-        void fetchSnapshots();
-        // Clear out statuses when report configurations change to avoid stale renders across pages
-        setResult(defaultResult);
-    }, [fetchSnapshots]);
-
-    return {
-        ...result,
-        fetchSnapshots,
+    const result: FetchLastSnapshotReturn = {
+        reportSnapshots: data || {},
+        isLoading,
+        error: getAxiosErrorMessage(error),
+        fetchSnapshots: refetch,
     };
+
+    return result;
 }


### PR DESCRIPTION
### Description

This PR cleans up a few things in regards to the reporting feature:

1. Moving `ReportJobsHelpAction` and `ReportJobsTable` into a `Components/ReportJob` directory
2. Added a new `MyActiveJobStatusTh` component that we can reuse in both VM Reports and Compliance. I just copied over the exact rendered component you see in VM Reports
3. Cleaned up the code within the `useWatchLastSnapshotForReports` hook. This is pre-work for the eventual one we'll need to make for compliance reporting

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no added tests

#### How I validated my change

I manually tested it out to see if it behaves similarly


https://github.com/user-attachments/assets/b326ed8a-52da-4959-9e2f-8b54e926f525

