### PR TITLE
ROX-26301: Allow 'is null' and 'is not null' queries for bool, enum and numeric fields

### DIFF
--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -1,11 +1,10 @@
-//go:build sql_integration
-
 package service
 
 import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	alertDatastore "github.com/stackrox/rox/central/alert/datastore"
 	alertMocks "github.com/stackrox/rox/central/alert/datastore/mocks"
@@ -33,6 +32,7 @@ import (
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
@@ -117,21 +117,31 @@ func (s *SearchOperationsTestSuite) TestAutocomplete() {
 	deploymentDS, err = deploymentDatastore.New(s.pool, nil, nil, nil, mockRiskDatastore, nil, nil, ranking.NewRanker(), ranking.NewRanker(), deploymentRanker)
 	s.Require().NoError(err)
 
+	timeNow := time.Now()
 	allAccessCtx := sac.WithAllAccess(context.Background())
 
 	deploymentNameOneOff := fixtures.GetDeployment()
+	deploymentNameOneOff.ServiceAccountPermissionLevel = storage.PermissionLevel_DEFAULT
+	deploymentNameOneOff.Created = protocompat.ConvertTimeToTimestampOrNil(&timeNow)
 	deploymentRanker.Add(deploymentNameOneOff.GetId(), 50)
 	s.NoError(deploymentDS.UpsertDeployment(allAccessCtx, deploymentNameOneOff))
 
+	timeNowMinusOne := timeNow.Add(-1 * time.Hour)
 	deploymentName1 := fixtures.GetDeployment()
 	deploymentName1.Id = fixtureconsts.Deployment2
 	deploymentName1.Name = "name1"
+	deploymentName1.OrchestratorComponent = true
+	deploymentName1.ServiceAccountPermissionLevel = storage.PermissionLevel_ELEVATED_CLUSTER_WIDE
+	deploymentName1.Created = protocompat.ConvertTimeToTimestampOrNil(&timeNowMinusOne)
 	deploymentRanker.Add(fixtureconsts.Deployment2, 25)
 	s.NoError(deploymentDS.UpsertDeployment(allAccessCtx, deploymentName1))
 
+	timeNowMinusTwo := timeNow.Add(-2 * time.Hour)
 	deploymentName1Duplicate := fixtures.GetDeployment()
 	deploymentName1Duplicate.Id = fixtureconsts.Deployment3
 	deploymentName1Duplicate.Name = "name1"
+	deploymentName1Duplicate.ServiceAccountPermissionLevel = storage.PermissionLevel_ELEVATED_IN_NAMESPACE
+	deploymentName1Duplicate.Created = protocompat.ConvertTimeToTimestampOrNil(&timeNowMinusTwo)
 	deploymentRanker.Add(fixtureconsts.Deployment3, 25)
 	s.NoError(deploymentDS.UpsertDeployment(allAccessCtx, deploymentName1Duplicate))
 
@@ -197,6 +207,30 @@ func (s *SearchOperationsTestSuite) TestAutocomplete() {
 			query:           fmt.Sprintf("%s:%s+%s:", search.DeploymentName, deploymentName2.Name, search.DeploymentLabel),
 			expectedResults: []string{"hello=hi", "hey=ho"},
 			ignoreOrder:     true,
+		},
+		{
+			query:           fmt.Sprintf("%s:", search.OrchestratorComponent),
+			expectedResults: []string{"false", "true"},
+			ignoreOrder:     true,
+		},
+		{
+			query:           fmt.Sprintf("%s:", search.ServiceAccountPermissionLevel),
+			expectedResults: []string{"UNSET", "DEFAULT", "ELEVATED_CLUSTER_WIDE", "ELEVATED_IN_NAMESPACE"},
+			ignoreOrder:     true,
+		},
+		{
+			query:           fmt.Sprintf("%s:", search.DeploymentRiskScore),
+			expectedResults: []string{"100", "50", "25"},
+			ignoreOrder:     true,
+		},
+		{
+			query: fmt.Sprintf("%s:", search.Created),
+			expectedResults: []string{
+				timeNow.UTC().Format("2006-01-02 15:04:05"),
+				timeNowMinusOne.UTC().Format("2006-01-02 15:04:05"),
+				timeNowMinusTwo.UTC().Format("2006-01-02 15:04:05"),
+			},
+			ignoreOrder: true,
 		},
 	} {
 		s.Run(fmt.Sprintf("Test case %q", testCase.query), func() {

--- a/pkg/search/postgres/query/bool_query.go
+++ b/pkg/search/postgres/query/bool_query.go
@@ -12,12 +12,15 @@ func newBoolQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 	if len(ctx.queryModifiers) > 0 {
 		return nil, fmt.Errorf("modifiers for bool query not allowed: %+v", ctx.queryModifiers)
 	}
-	res, err := parse.FriendlyParseBool(ctx.value)
-	if err != nil {
-		return nil, err
+
+	if !isWildCardOrNullStringQuery(ctx.value) {
+		res, err := parse.FriendlyParseBool(ctx.value)
+		if err != nil {
+			return nil, err
+		}
+		// explicitly apply equality check
+		ctx.value = strconv.FormatBool(res)
+		ctx.queryModifiers = []pkgSearch.QueryModifier{pkgSearch.Equality}
 	}
-	// explicitly apply equality check
-	ctx.value = strconv.FormatBool(res)
-	ctx.queryModifiers = []pkgSearch.QueryModifier{pkgSearch.Equality}
 	return newStringQuery(ctx)
 }

--- a/pkg/search/postgres/query/common.go
+++ b/pkg/search/postgres/query/common.go
@@ -139,3 +139,7 @@ func MatchFieldQuery(dbField *walker.Field, derivedMetadata *walker.DerivedSearc
 	}
 	return qe, nil
 }
+
+func isWildCardOrNullStringQuery(value string) bool {
+	return value == search.WildcardString || value == search.NullString
+}

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -55,6 +55,17 @@ func newEnumQueryWhereClause(columnName string, field *pkgSearch.Field, value st
 	if len(queryModifiers) > 2 {
 		return WhereClause{}, fmt.Errorf("unsupported: more than 2 query modifiers for enum query: %+v", queryModifiers)
 	}
+	if isWildCardOrNullStringQuery(value) {
+		existenceStr := ""
+		if value == pkgSearch.WildcardString {
+			existenceStr = "not"
+		}
+		return WhereClause{
+			Query:  fmt.Sprintf("%s is %s null", columnName, existenceStr),
+			Values: []interface{}{},
+		}, nil
+	}
+	
 	var equality bool
 	switch len(queryModifiers) {
 	case 2:

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -65,7 +65,7 @@ func newEnumQueryWhereClause(columnName string, field *pkgSearch.Field, value st
 			Values: []interface{}{},
 		}, nil
 	}
-	
+
 	var equality bool
 	switch len(queryModifiers) {
 	case 2:

--- a/pkg/search/postgres/query/numeric_query.go
+++ b/pkg/search/postgres/query/numeric_query.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/readable"
+	pkgSearch "github.com/stackrox/rox/pkg/search"
 )
 
 type prefixAndInversion struct {
@@ -176,6 +177,18 @@ func newNumericQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 	if len(ctx.queryModifiers) > 0 {
 		return nil, errors.Errorf("modifiers not supported for numeric query: %+v", ctx.queryModifiers)
 	}
+
+	if isWildCardOrNullStringQuery(ctx.value) {
+		existenceStr := ""
+		if ctx.value == pkgSearch.WildcardString {
+			existenceStr = "not"
+		}
+		return qeWithSelectFieldIfNeeded(ctx, &WhereClause{
+			Query:  fmt.Sprintf("%s is %s null", ctx.qualifiedColumnName, existenceStr),
+			Values: []interface{}{},
+		}, nil), nil
+	}
+
 	prefix, trimmedValue := parseNumericPrefix(ctx.value)
 
 	var whereClause WhereClause

--- a/pkg/search/postgres/query/time_query.go
+++ b/pkg/search/postgres/query/time_query.go
@@ -21,6 +21,17 @@ func newTimeQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 	if len(ctx.queryModifiers) > 0 {
 		return nil, errors.New("modifiers not supported for time query")
 	}
+	if isWildCardOrNullStringQuery(ctx.value) {
+		existenceStr := ""
+		if ctx.value == search.WildcardString {
+			existenceStr = "not"
+		}
+		return qeWithSelectFieldIfNeeded(ctx, &WhereClause{
+			Query:  fmt.Sprintf("%s is %s null", ctx.qualifiedColumnName, existenceStr),
+			Values: []interface{}{},
+		}, nil), nil
+	}
+
 	from, to, ok, err := parseTimeRange(ctx.value)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing time range")


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Wildcard strings already work for string, map, and string array type fields. They did not work for bool, time and numeric fields. This PR adds the ability to do wildcard searches for bool, time and numeric fields. The null values for numeric and bool types might be stored as 0 and false in the db respectively, but there is no way for the framework to know whether that 0 value is a real 0 or a default value. So we just consider 0s as non null values for now.

#### Example SQL queries
##### Bool field
```
select deployments.Id::text as Deployment_ID, deployments.OrchestratorComponent from deployments where deployments.OrchestratorComponent is not null order by deployments.RiskScore desc LIMIT 10
```

##### Enum field
```
select deployments.Id::text as Deployment_ID, deployments.ServiceAccountPermissionLevel from deployments where deployments.ServiceAccountPermissionLevel is not null order by deployments.RiskScore desc LIMIT 10
```

##### Numeric field
```
select deployments.Id::text as Deployment_ID, deployments.RiskScore from deployments where deployments.RiskScore is not null order by deployments.RiskScore desc LIMIT 10
```

##### Timestamp field
```
select deployments.Id::text as Deployment_ID, deployments.Created from deployments where deployments.Created is not null order by deployments.RiskScore desc LIMIT 10
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests
Manual tests
