### PR TITLE
ROX-25439: Remove ROX_SECRET_FILE_SEARCH feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
+- The environment variable `ROX_SECRET_FILE_SEARCH` has been removed.
 - The Central PVC stackrox-db will be removed. Existing volumes will be released. Flags for configuring Central attached persistent storage have been removed from roxctl:
   - `roxctl central generate k8s pvc` and `roxctl central generate openshift pvc` no longer have the flags `--name`, `--size`, and `--storage-class`.
   - `roxctl central generate k8s hostpath` and `roxctl central generate openshift hostpath` no longer have the flags `--hostpath`, `--node-selector-key`, and `--node-selector-value`.
@@ -197,7 +198,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Secret terms that can be removed by setting ROX_DEPLOYMENT_SECRET_SEARCH=false:
     - Secret, Secret Path
 - The following search terms will be disabled in the next release and removed from the secret context in 2 releases. They can be removed in the current release by setting ROX_SECRET_FILE_SEARCH=false:
-  - Secret Type, Cert Expiration,Image Pull Secret Registry
+  - Secret Type, Cert Expiration, Image Pull Secret Registry
 - The `/v1/availableAuthProviders` endpoint will in a future release require authentication and at least READ permission on the `Access` resource.
   Ensure that any flow interacting with it is authenticated and has the proper permissions going forward.
 - The `/v1/tls-challenge` will  require authentication, ensure that all interactions with these endpoints include proper authentication going forward.

--- a/generated/api/v1/secret_service.swagger.json
+++ b/generated/api/v1/secret_service.swagger.json
@@ -389,7 +389,8 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/storageSecretDataFile"
-          }
+          },
+          "description": "Metadata about the secrets.\nThe secret need not be a file, but rather may be an arbitrary value."
         },
         "relationship": {
           "$ref": "#/definitions/storageSecretRelationship"

--- a/generated/storage/secret.pb.go
+++ b/generated/storage/secret.pb.go
@@ -117,7 +117,7 @@ type Secret struct {
 	CreatedAt   *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty" search:"Created Time"` // @gotags: search:"Created Time"
 	// Metadata about the secrets.
 	// The secret need not be a file, but rather may be an arbitrary value.
-	Files        []*SecretDataFile   `protobuf:"bytes,10,rep,name=files,proto3" json:"files,omitempty" sql:"flag=ROX_SECRET_FILE_SEARCH" search:"flag=ROX_SECRET_FILE_SEARCH"` // @gotags: sql:"flag=ROX_SECRET_FILE_SEARCH" search:"flag=ROX_SECRET_FILE_SEARCH"
+	Files        []*SecretDataFile   `protobuf:"bytes,10,rep,name=files,proto3" json:"files,omitempty"`
 	Relationship *SecretRelationship `protobuf:"bytes,11,opt,name=relationship,proto3" json:"relationship,omitempty"`
 }
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -55,9 +55,6 @@ var (
 	// DeploymentEnvvarSearch enables search on the environment variable fields of deployments
 	_ = registerFeature("Enables search on the environment variable fields of deployments", "ROX_DEPLOYMENT_ENVVAR_SEARCH", enabled)
 
-	// SecretFileSearch enables search on the file fields of secrets
-	_ = registerFeature("Enables search on the file fields of secrets", "ROX_SECRET_FILE_SEARCH", enabled)
-
 	// SensorCapturesIntermediateEvents enables sensor to capture intermediate events when it is disconnected from central
 	SensorCapturesIntermediateEvents = registerFeature("Enables sensor to capture intermediate events when it is disconnected from central", "ROX_CAPTURE_INTERMEDIATE_EVENTS", enabled)
 

--- a/proto/storage/secret.proto
+++ b/proto/storage/secret.proto
@@ -31,7 +31,7 @@ message Secret {
 
   // Metadata about the secrets.
   // The secret need not be a file, but rather may be an arbitrary value.
-  repeated SecretDataFile files = 10; // @gotags: sql:"flag=ROX_SECRET_FILE_SEARCH" search:"flag=ROX_SECRET_FILE_SEARCH"
+  repeated SecretDataFile files = 10;
   SecretRelationship relationship = 11;
 }
 


### PR DESCRIPTION
### Description

This PR "rolls back" feature flag `ROX_SECRET_FILE_SEARCH` that was added in 4.4.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] Information about flags is only documented as part of release notes (no need to update docs)

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] didn't change any tests. We want to be sure that everything works as expected after the removal

#### How I validated my change

I'll let CI run.
