### PR TITLE
ROX-25439: Remove ROX_DEPLOYMENT_VOLUME_SEARCH feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
+- The environment variable `ROX_DEPLOYMENT_VOLUME_SEARCH` has been removed.
 - The environment variable `ROX_SECRET_FILE_SEARCH` has been removed.
 - The Central PVC stackrox-db will be removed. Existing volumes will be released. Flags for configuring Central attached persistent storage have been removed from roxctl:
   - `roxctl central generate k8s pvc` and `roxctl central generate openshift pvc` no longer have the flags `--name`, `--size`, and `--storage-class`.

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -208,16 +208,14 @@ func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.Container, d
 		batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetConfig().GetEnv()))
 	}
 
-	if features.Flags["ROX_DEPLOYMENT_VOLUME_SEARCH"].Enabled() {
-		for childIndex, child := range obj.GetVolumes() {
-			if err := insertIntoDeploymentsContainersVolumes(batch, child, deploymentID, idx, childIndex); err != nil {
-				return err
-			}
+	for childIndex, child := range obj.GetVolumes() {
+		if err := insertIntoDeploymentsContainersVolumes(batch, child, deploymentID, idx, childIndex); err != nil {
+			return err
 		}
-
-		query = "delete from deployments_containers_volumes where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-		batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetVolumes()))
 	}
+
+	query = "delete from deployments_containers_volumes where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
+	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetVolumes()))
 
 	if features.Flags["ROX_DEPLOYMENT_SECRET_SEARCH"].Enabled() {
 		for childIndex, child := range obj.GetSecrets() {

--- a/generated/storage/deployment.pb.go
+++ b/generated/storage/deployment.pb.go
@@ -600,7 +600,7 @@ type Container struct {
 	Config          *ContainerConfig  `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
 	Image           *ContainerImage   `protobuf:"bytes,3,opt,name=image,proto3" json:"image,omitempty"`
 	SecurityContext *SecurityContext  `protobuf:"bytes,4,opt,name=security_context,json=securityContext,proto3" json:"security_context,omitempty"`
-	Volumes         []*Volume         `protobuf:"bytes,5,rep,name=volumes,proto3" json:"volumes,omitempty" sql:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH" search:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH"` // @gotags: sql:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH" search:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH"
+	Volumes         []*Volume         `protobuf:"bytes,5,rep,name=volumes,proto3" json:"volumes,omitempty"`
 	Ports           []*PortConfig     `protobuf:"bytes,6,rep,name=ports,proto3" json:"ports,omitempty" policy:",ignore" search:"-"`     // Policies use the port config on the top-level deployment. // @gotags: policy:",ignore" search:"-"
 	Secrets         []*EmbeddedSecret `protobuf:"bytes,7,rep,name=secrets,proto3" json:"secrets,omitempty" sql:"flag=ROX_DEPLOYMENT_SECRET_SEARCH" search:"flag=ROX_DEPLOYMENT_SECRET_SEARCH"` // @gotags: sql:"flag=ROX_DEPLOYMENT_SECRET_SEARCH" search:"flag=ROX_DEPLOYMENT_SECRET_SEARCH"
 	Resources       *Resources        `protobuf:"bytes,8,opt,name=resources,proto3" json:"resources,omitempty"`

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -46,9 +46,6 @@ var (
 	// SensorDeploymentBuildOptimization enables a performance improvement by skipping deployments processing when no dependency or spec changed
 	SensorDeploymentBuildOptimization = registerFeature("Enables a performance improvement by skipping deployments processing when no dependency or spec changed", "ROX_DEPLOYMENT_BUILD_OPTIMIZATION", enabled)
 
-	// DeploymentVolumeSearch enables search on the volume fields of deployments
-	_ = registerFeature("Enables search on the volume fields of deployments", "ROX_DEPLOYMENT_VOLUME_SEARCH", enabled)
-
 	// DeploymentSecretSearch enables search on the secret fields of deployments
 	_ = registerFeature("Enables search on the secret fields of deployments", "ROX_DEPLOYMENT_SECRET_SEARCH", enabled)
 

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -69,7 +69,7 @@ message Container {
 
   ContainerImage image = 3;
   SecurityContext security_context = 4;
-  repeated Volume volumes = 5; // @gotags: sql:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH" search:"flag=ROX_DEPLOYMENT_VOLUME_SEARCH"
+  repeated Volume volumes = 5;
   repeated PortConfig ports = 6; // Policies use the port config on the top-level deployment. // @gotags: policy:",ignore" search:"-"
   repeated EmbeddedSecret secrets = 7; // @gotags: sql:"flag=ROX_DEPLOYMENT_SECRET_SEARCH" search:"flag=ROX_DEPLOYMENT_SECRET_SEARCH"
   Resources resources = 8;


### PR DESCRIPTION
### Description

This PR "rolls back" feature flag `ROX_DEPLOYMENT_VOLUME_SEARCH` that was added in 4.4.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] didn't change any tests. We want to be sure that everything works as expected after the removal

#### How I validated my change

I'll let CI run.
