### PR TITLE
ROX-25439: Remove ROX_DEPLOYMENT_ENVVAR_SEARCH feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
+- The environment variable `ROX_DEPLOYMENT_ENVVAR_SEARCH` has been removed.
 - The environment variable `ROX_DEPLOYMENT_SECRET_SEARCH` has been removed.
 - The environment variable `ROX_DEPLOYMENT_VOLUME_SEARCH` has been removed.
 - The environment variable `ROX_SECRET_FILE_SEARCH` has been removed.

--- a/generated/storage/deployment.pb.go
+++ b/generated/storage/deployment.pb.go
@@ -1415,7 +1415,7 @@ type ContainerConfig struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Env             []*ContainerConfig_EnvironmentConfig `protobuf:"bytes,1,rep,name=env,proto3" json:"env,omitempty" sql:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH" search:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH"` // @gotags: sql:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH" search:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH"
+	Env             []*ContainerConfig_EnvironmentConfig `protobuf:"bytes,1,rep,name=env,proto3" json:"env,omitempty"`
 	Command         []string                             `protobuf:"bytes,2,rep,name=command,proto3" json:"command,omitempty"`
 	Args            []string                             `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`
 	Directory       string                               `protobuf:"bytes,4,opt,name=directory,proto3" json:"directory,omitempty"`

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -46,9 +46,6 @@ var (
 	// SensorDeploymentBuildOptimization enables a performance improvement by skipping deployments processing when no dependency or spec changed
 	SensorDeploymentBuildOptimization = registerFeature("Enables a performance improvement by skipping deployments processing when no dependency or spec changed", "ROX_DEPLOYMENT_BUILD_OPTIMIZATION", enabled)
 
-	// DeploymentEnvvarSearch enables search on the environment variable fields of deployments
-	_ = registerFeature("Enables search on the environment variable fields of deployments", "ROX_DEPLOYMENT_ENVVAR_SEARCH", enabled)
-
 	// SensorCapturesIntermediateEvents enables sensor to capture intermediate events when it is disconnected from central
 	SensorCapturesIntermediateEvents = registerFeature("Enables sensor to capture intermediate events when it is disconnected from central", "ROX_CAPTURE_INTERMEDIATE_EVENTS", enabled)
 

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -230,7 +230,7 @@ message ContainerConfig {
       UNKNOWN = 6;
     }
   }
-  repeated EnvironmentConfig env = 1; // @gotags: sql:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH" search:"flag=ROX_DEPLOYMENT_ENVVAR_SEARCH"
+  repeated EnvironmentConfig env = 1;
   repeated string command = 2;
   repeated string args = 3;
   string directory = 4;


### PR DESCRIPTION
### Description

This PR "rolls back" feature flag `ROX_DEPLOYMENT_ENVVAR_SEARCH` that was added in 4.4.

This branch is based on `mtodor/ROX-25439-remove-features-part3` - used in PR #12792 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] Information about flags is only documented as part of release notes (no need to update docs)

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] didn't change any tests. We want to be sure that everything works as expected after the removal

#### How I validated my change

I'll let CI run.
