### PR TITLE
ROX-25619: External policy edit warnings

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -31,6 +31,7 @@ import { ClientPolicy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import PolicyDetailContent from './PolicyDetailContent';
+import { isExternalPolicy } from '../policies.utils';
 
 function formatUpdateDisabledStateAction(disabled: boolean) {
     return disabled ? 'Enable policy' : 'Disable policy';
@@ -275,6 +276,7 @@ function PolicyDetail({
                 </AlertGroup>
             </PageSection>
             <ConfirmationModal
+                title={isExternalPolicy(policy) ? 'Delete policy?' : 'Permanently delete policy?'}
                 ariaLabel="Confirm delete"
                 confirmText="Delete"
                 isLoading={isRequesting}
@@ -282,7 +284,17 @@ function PolicyDetail({
                 onConfirm={onConfirmDeletePolicy}
                 onCancel={onCancelDeletePolicy}
             >
-                Are you sure you want to delete this policy?
+                {isExternalPolicy(policy) ? (
+                    <>
+                        This policy is managed externally and will only be removed from the system
+                        temporarily. The policy will not trigger violations until the next sync.
+                    </>
+                ) : (
+                    <>
+                        This policy will be permanently removed from the system and will no longer
+                        trigger violations.
+                    </>
+                )}
             </ConfirmationModal>
         </>
     );

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -276,7 +276,7 @@ function PolicyDetail({
                 </AlertGroup>
             </PageSection>
             <ConfirmationModal
-                title={isExternalPolicy(policy) ? 'Delete policy?' : 'Permanently delete policy?'}
+                title={'Delete policy?'}
                 ariaLabel="Confirm delete"
                 confirmText="Delete"
                 isLoading={isRequesting}
@@ -287,7 +287,7 @@ function PolicyDetail({
                 {isExternalPolicy(policy) ? (
                     <>
                         This policy is managed externally and will only be removed from the system
-                        temporarily. The policy will not trigger violations until the next sync.
+                        temporarily. The policy will not trigger violations until the next resync.
                     </>
                 ) : (
                     <>

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -43,9 +43,14 @@ import {
     formatNotifierCountsWithLabelStrings,
     getLabelAndNotifierIdsForTypes,
     getPolicyOriginLabel,
+    isExternalPolicy,
 } from '../policies.utils';
 
 import './PoliciesTable.css';
+
+function isExternalPolicySelected(policies: ListPolicy[], selectedIds: string[]): boolean {
+    return policies.filter(({ id }) => selectedIds.includes(id)).some(isExternalPolicy);
+}
 
 type PoliciesTableProps = {
     notifiers: NotifierIntegration[];
@@ -465,6 +470,11 @@ function PoliciesTable({
                 </Table>
             </PageSection>
             <ConfirmationModal
+                title={`${
+                    isExternalPolicySelected(policies, deletingIds)
+                        ? 'Delete policies?'
+                        : 'Permanently delete policies?'
+                } (${deletingIds.length})`}
                 ariaLabel="Confirm delete"
                 confirmText="Delete"
                 isLoading={isDeleting}
@@ -472,8 +482,21 @@ function PoliciesTable({
                 onConfirm={onConfirmDeletePolicy}
                 onCancel={onCancelDeletePolicy}
             >
-                Are you sure you want to delete {deletingIds.length}&nbsp;
-                {pluralize('policy', deletingIds.length)}?
+                {isExternalPolicySelected(policies, deletingIds) ? (
+                    <>
+                        Deleted policies will be removed from the system and will no longer trigger
+                        violations.{' '}
+                        <em>
+                            The current selection includes at least one externally managed policy
+                            that will be restored automatically during the next resync.
+                        </em>
+                    </>
+                ) : (
+                    <>
+                        Deleted policies will be permanently removed from the system and will no
+                        longer trigger violations.
+                    </>
+                )}
             </ConfirmationModal>
             <EnableDisableNotificationModal
                 enableDisableType={enableDisableType}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import {
     Button,
+    Flex,
+    FlexItem,
     PageSection,
     Pagination,
     Toolbar,
@@ -483,14 +485,18 @@ function PoliciesTable({
                 onCancel={onCancelDeletePolicy}
             >
                 {isExternalPolicySelected(policies, deletingIds) ? (
-                    <>
-                        Deleted policies will be removed from the system and will no longer trigger
-                        violations.{' '}
-                        <em>
-                            The current selection includes at least one externally managed policy
-                            that will be restored automatically during the next resync.
-                        </em>
-                    </>
+                    <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                            Deleted policies will be removed from the system and will no longer
+                            trigger violations.{' '}
+                        </FlexItem>
+                        <FlexItem>
+                            <em>
+                                The current selection includes at least one externally managed
+                                policy that will be restored automatically during the next resync.
+                            </em>
+                        </FlexItem>
+                    </Flex>
                 ) : (
                     <>
                         Deleted policies will be permanently removed from the system and will no

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -20,7 +20,6 @@ import {
 } from '@patternfly/react-core/deprecated';
 import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { CaretDownIcon } from '@patternfly/react-icons';
-import pluralize from 'pluralize';
 
 import { ListPolicy } from 'types/policy.proto';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
@@ -488,7 +487,7 @@ function PoliciesTable({
                     <Flex direction={{ default: 'column' }}>
                         <FlexItem>
                             Deleted policies will be removed from the system and will no longer
-                            trigger violations.{' '}
+                            trigger violations.
                         </FlexItem>
                         <FlexItem>
                             <em>

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -471,11 +471,7 @@ function PoliciesTable({
                 </Table>
             </PageSection>
             <ConfirmationModal
-                title={`${
-                    isExternalPolicySelected(policies, deletingIds)
-                        ? 'Delete policies?'
-                        : 'Permanently delete policies?'
-                } (${deletingIds.length})`}
+                title={`Delete policies? (${deletingIds.length})`}
                 ariaLabel="Confirm delete"
                 confirmText="Delete"
                 isLoading={isDeleting}
@@ -491,8 +487,10 @@ function PoliciesTable({
                         </FlexItem>
                         <FlexItem>
                             <em>
-                                The current selection includes at least one externally managed
-                                policy that will be restored automatically during the next resync.
+                                The current selection includes one or more externally managed
+                                policies that will only be removed from the system temporarily until
+                                the next resync. Locally managed policies will be removed
+                                permanently.
                             </em>
                         </FlexItem>
                     </Flex>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -138,7 +138,7 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
             {isExternalPolicy(policy) && (
                 <Alert isInline title="Externally managed policy" component="p" variant="warning">
                     You are editing a policy that is managed externally. Any local changes to this
-                    policy will be automatically overwritten during the next sync.
+                    policy will be automatically overwritten during the next resync.
                 </Alert>
             )}
             <PageSection variant="light" isFilled id="policy-page" className="pf-v5-u-pb-0">

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -32,7 +32,7 @@ import {
     POLICY_DEFINITION_RULES_ID,
     POLICY_REVIEW_ID,
 } from '../policies.constants';
-import { getServerPolicy } from '../policies.utils';
+import { getServerPolicy, isExternalPolicy } from '../policies.utils';
 import { getValidationSchema } from './policyValidationSchemas';
 import PolicyDetailsForm from './Step1/PolicyDetailsForm';
 import PolicyBehaviorForm from './Step2/PolicyBehaviorForm';
@@ -135,7 +135,7 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
 
     return (
         <>
-            {policy.id && policy.source === 'DECLARATIVE' && (
+            {isExternalPolicy(policy) && (
                 <Alert isInline title="Externally managed policy" component="p" variant="warning">
                     You are editing a policy that is managed externally. Any local changes to this
                     policy will be automatically overwritten during the next sync.

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FormikProvider, useFormik } from 'formik';
 import {
+    Alert,
     Breadcrumb,
     Title,
     BreadcrumbItem,
@@ -134,6 +135,12 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
 
     return (
         <>
+            {policy.id && policy.source === 'DECLARATIVE' && (
+                <Alert isInline title="Externally managed policy" component="p" variant="warning">
+                    You are editing a policy that is managed externally. Any local changes to this
+                    policy will be automatically overwritten during the next sync.
+                </Alert>
+            )}
             <PageSection variant="light" isFilled id="policy-page" className="pf-v5-u-pb-0">
                 <Breadcrumb className="pf-v5-u-mb-md">
                     <BreadcrumbItemLink to={policiesBasePath}>Policies</BreadcrumbItemLink>

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -27,6 +27,7 @@ import {
     PolicyDeploymentExclusion,
     PolicyImageExclusion,
     ListPolicy,
+    BasePolicy,
 } from 'types/policy.proto';
 import { SearchFilter } from 'types/search';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
@@ -716,4 +717,8 @@ export function getPolicyOriginLabel({
         return 'System';
     }
     return source === 'IMPERATIVE' ? 'Locally managed' : 'Externally managed';
+}
+
+export function isExternalPolicy(policy: ListPolicy) {
+    return policy.source === 'DECLARATIVE';
 }

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -27,7 +27,6 @@ import {
     PolicyDeploymentExclusion,
     PolicyImageExclusion,
     ListPolicy,
-    BasePolicy,
 } from 'types/policy.proto';
 import { SearchFilter } from 'types/search';
 import { ExtendedPageAction } from 'utils/queryStringUtils';


### PR DESCRIPTION
### Description

Updates the Policy List page and Policy Detail page to better warn user when editing or deleting an **external** policy. The resync behavior will be noted in the confirmation modal when deleting a policy, as well as at the top of the page in an alert when editing a policy. As part of this change, the modals for deleting policies have been updated to reflect the recommendations in the [PatternFly docs](https://www.patternfly.org/components/modal/design-guidelines#confirmation-dialogs).

### Follow ups

- The Disable/Enable functionality needs to be updated to correctly communicate when a policy is managed externally.
- Would be nice to add full e2e tests for policy create/edit/delete if time.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

From the Policy List page, select one or more **Locally managed** policies and choose the bulk delete option:
![image](https://github.com/user-attachments/assets/bc9a9ae1-621c-45b9-8aa3-e33f8e6529a3)

Repeat, but instead select at least one **externally managed** policy:
![image](https://github.com/user-attachments/assets/9345d264-29e9-405d-907a-0b3509a0bd02)

Visit a **Locally managed** policy and select the delete option:
![image](https://github.com/user-attachments/assets/509f52db-d13f-4476-be37-23b40232c9c8)


Visit an **externally managed** policy and select the edit option:
![image](https://github.com/user-attachments/assets/7f8b826f-db76-40cd-8235-5a5048e921d7)

Visit an **externally managed** policy and select the delete option:
![image](https://github.com/user-attachments/assets/eb6cc4fe-8353-45d2-bb75-1ec006ab6c92)

