### PR TITLE
ROX-26151: Pin operator image in operator-bundle (3rd)

### DIFF
--- a/.tekton/determine-image-digest-task.yaml
+++ b/.tekton/determine-image-digest-task.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: determine-image-digest
+  namespace: rh-acs-tenant
+spec:
+  description: Determines image digests.
+  params:
+  - name: IMAGE_REPOSITORY
+    description: Image repository.
+    type: string
+  - name: IMAGE_TAG
+    description: Image tag.
+    type: string
+  results:
+  - name: IMAGE_DIGEST
+    description: Image digest in the format `sha256:abcdef0123`.
+  workspaces:
+  - name: pull-secret
+    readOnly: true
+  steps:
+  - name: determine-image-digest
+    image: registry.access.redhat.com/ubi9/skopeo@sha256:a096332b3a6665b1f1e0b34980406649920cf4babba80aff24a715b76f3f62f3
+    env:
+    - name: REGISTRY_AUTH_FILE
+      value: "$(workspaces.pull-secret.path)/.dockerconfigjson"
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      image_ref="docker://$(params.IMAGE_REPOSITORY):$(params.IMAGE_TAG)"
+      digest=$(skopeo inspect \
+        --override-os linux \
+        --override-arch amd64 \
+        --format '{{.Digest}}' \
+        --no-tags \
+        "${image_ref}")
+      echo -n "$digest" | tee "$(results.IMAGE_DIGEST.path)"

--- a/.tekton/determine-image-digest-task.yaml
+++ b/.tekton/determine-image-digest-task.yaml
@@ -29,6 +29,7 @@ spec:
       set -euo pipefail
       image_ref="docker://$(params.IMAGE_REPOSITORY):$(params.IMAGE_TAG)"
       digest=$(skopeo inspect \
+        --retry-times 10 \
         --override-os linux \
         --override-arch amd64 \
         --format '{{.Digest}}' \

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -31,6 +31,8 @@ spec:
     value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/stackrox-operator-bundle
+  - name: operator-image-repo
+    value: quay.io/rhacs-eng/stackrox-operator
   - name: revision
     value: '{{revision}}'
   - name: rebuild
@@ -51,13 +53,17 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: quay-auth
+    secret:
+      secretName: quay-io-rhacs-eng-rw
 
   pipelineRef:
     name: operator-bundle-pipeline
 
   timeouts:
-    # The tasks regularly takes 1h to finish.
-    tasks: 1h
+    # The tasks regularly takes 1h to finish. Due to recently hit timeouts,
+    # let's try with 30m more.
+    tasks: 1h30m
     # Reserve time for final tasks to run.
     finally: 10m
-    pipeline: 1h10m
+    pipeline: 1h40m

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -110,6 +110,9 @@ spec:
     description: Directory in which to run "make tag" command.
     default: "operator"
     type: string
+  - name: operator-image-repo
+    description: Image repository for the StackRox Operator.
+    type: string
 
   results:
   - description: ""
@@ -130,6 +133,7 @@ spec:
 
   workspaces:
   - name: git-auth
+  - name: quay-auth
 
   tasks:
 
@@ -216,6 +220,30 @@ spec:
         value: task
       resolver: bundles
 
+  - name: wait-for-operator-image
+    workspaces:
+    - name: pull-secret
+      workspace: quay-auth
+    params:
+    - name: IMAGE
+      value: "$(params.operator-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
+    taskRef:
+      name: wait-for-image
+
+  - name: determine-operator-image-digest
+    workspaces:
+    - name: pull-secret
+      workspace: quay-auth
+    params:
+    - name: IMAGE_REPOSITORY
+      value: "$(params.operator-image-repo)"
+    - name: IMAGE_TAG
+      value: "$(tasks.determine-image-tag.results.IMAGE_TAG)"
+    taskRef:
+      name: determine-image-digest
+    runAfter:
+      - wait-for-operator-image
+
   - name: build-container
     params:
     - name: IMAGE
@@ -236,6 +264,8 @@ spec:
     - name: BUILD_ARGS
       value:
       - MAIN_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
+      - OPERATOR_IMAGE_DIGEST=$(tasks.determine-operator-image-digest.results.IMAGE_DIGEST)
+      - OPERATOR_IMAGE_REPO=$(params.operator-image-repo)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/.tekton/wait-for-image-task.yaml
+++ b/.tekton/wait-for-image-task.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-for-image
+  namespace: rh-acs-tenant
+spec:
+  description: Waits until the specified image is found.
+  params:
+  - name: IMAGE
+    description: Image reference.
+    type: string
+  workspaces:
+  - name: pull-secret
+    readOnly: true
+  steps:
+  - name: wait-for-image
+    image: registry.access.redhat.com/ubi9/skopeo@sha256:a096332b3a6665b1f1e0b34980406649920cf4babba80aff24a715b76f3f62f3
+    env:
+    - name: REGISTRY_AUTH_FILE
+      value: "$(workspaces.pull-secret.path)/.dockerconfigjson"
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "Waiting for image $(params.IMAGE) to become available..."
+      while true; do
+        if skopeo inspect --raw "docker://$(params.IMAGE)"; then
+          break
+        fi
+        sleep 1m
+      done
+      echo "Image $(params.IMAGE) found."

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -155,7 +155,7 @@ def parse_args():
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
                         help='The first version of the operator that was published')
-    parser.add_argument("--operator-image", metavar='image',
+    parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
     parser.add_argument("--no-related-images", action='store_true',
                         help='Disable passthrough of related images')

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -155,7 +155,7 @@ def parse_args():
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
                         help='The first version of the operator that was published')
-    parser.add_argument("--operator-image", required=True, metavar='image',
+    parser.add_argument("--operator-image", metavar='image',
                         help='Which operator image to use in the patched CSV')
     parser.add_argument("--no-related-images", action='store_true',
                         help='Disable passthrough of related images')

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -5,7 +5,10 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS bui
 # For some reason, openshift-golang-builder 9 comes without any RPM repos in /etc/yum.repos.d/
 # We, however, need to install some packages and so we need to configure RPM repos. The ones for UBI are sufficient.
 COPY --from=ubi-repo-donor /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
-RUN dnf -y upgrade --nobest && dnf -y install --nodocs --noplugins jq
+RUN dnf -y upgrade --nobest && dnf -y install --nodocs --noplugins jq python3-pip
+
+COPY ./operator/bundle_helpers/requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner AS builder
@@ -14,7 +17,11 @@ COPY . /stackrox
 WORKDIR /stackrox/operator
 
 ARG MAIN_IMAGE_TAG
+ARG OPERATOR_IMAGE_DIGEST
+ARG OPERATOR_IMAGE_REPO
+
 RUN if [[ "$MAIN_IMAGE_TAG" == "" ]]; then >&2 echo "error: required MAIN_IMAGE_TAG arg is unset"; exit 6; fi
+
 ENV VERSION=$MAIN_IMAGE_TAG
 ENV ROX_PRODUCT_BRANDING=RHACS_BRANDING
 
@@ -23,7 +30,20 @@ ENV ROX_PRODUCT_BRANDING=RHACS_BRANDING
 #      github.com/operator-framework/operator-lifecycle-manager@v0.27.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
 ENV GOFLAGS=''
 
-RUN make bundle-post-process
+RUN mkdir -p build/ && \
+    rm -rf build/bundle && \
+    cp -a bundle build/ && \
+    ./bundle_helpers/patch-csv.py \
+      --use-version "${VERSION}" \
+      --first-version 3.62.0 \
+      --operator-image "${OPERATOR_IMAGE_REPO}:${OPERATOR_IMAGE_DIGEST}" \
+      --no-related-images \
+      --add-supported-arch amd64 \
+      --add-supported-arch arm64 \
+      --add-supported-arch ppc64le \
+      --add-supported-arch s390x \
+      < bundle/manifests/rhacs-operator.clusterserviceversion.yaml \
+      > build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
 
 FROM scratch
 


### PR DESCRIPTION
### Description

This PR changes the existing pipeline for the operator-bundle so that instead of injecting the operator-image tag into the CSV file we resolve this tag to an image digest and then inject that into the CSV.

**Note:** This is a simplified PR: there are no checks about the actual availability of the "replaced" version (think: "previous") of the operator.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

I have not added any new tests.

#### How I validated my change

