### PR TITLE
fix(ui): Add pagination-function-call generic lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -112,6 +112,33 @@ const rules = {
             };
         },
     },
+    'pagination-function-call': {
+        // Require that pagination property has function call like getPaginationParams.
+        // Some classic pages have queryService.getPagination function call instead.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require that pagination property has function call like getPaginationParams',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                Property(node) {
+                    if (node.key?.name === 'pagination' && !node.shorthand) {
+                        if (node.value?.type !== 'CallExpression') {
+                            context.report({
+                                node,
+                                message:
+                                    'Require that pagination property has function call like getPaginationParams',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
 
     // ESLint naming convention for negative rules.
     // If your rule only disallows something, prefix it with no.

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -89,7 +89,7 @@ function ScanConfigsTablePage({
     });
 
     const listQuery = useCallback(
-        () => listComplianceScanConfigurations(sortOption, page - 1, perPage),
+        () => listComplianceScanConfigurations(sortOption, page, perPage),
         [sortOption, page, perPage]
     );
     const { data: listData, isLoading, error, refetch } = useRestQuery(listQuery);

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -76,7 +76,7 @@ function PolicyScopeForm() {
         // TODO from ROX-14643 and stackrox/stackrox/issues/2725
         // Move request to exclusion card to add restSearch for cluster or namespace if specified in exclusion scope.
         // Search element to support creatable deployment names.
-        const restSort = { field: 'Deployment' }; // ascending by name
+        const restSort = { field: 'Deployment', reversed: false }; // ascending by name
         fetchDeploymentsWithProcessInfo([], restSort, 0, 0)
             .then((response) => {
                 const deploymentList = response

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -3,7 +3,7 @@ import qs from 'qs';
 
 import { ApiSortOption, SearchFilter } from 'types/search';
 import { SlimUser } from 'types/user.proto';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import { ComplianceProfileSummary, complianceV2Url } from './ComplianceCommon';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
@@ -110,15 +110,11 @@ export type ListComplianceScanConfigsClusterProfileResponse = {
  */
 export function listComplianceScanConfigurations(
     sortOption?: ApiSortOption,
-    page?: number,
-    pageSize?: number
+    page = 1, // one-based page for compatibility with PatternFly Pagination element
+    perPage = 0
 ): Promise<ListComplianceScanConfigurationsResponse> {
-    let offset: number | undefined;
-    if (typeof page === 'number' && typeof pageSize === 'number') {
-        offset = page > 0 ? page * pageSize : 0;
-    }
     const query = {
-        pagination: { offset, limit: pageSize, sortOption },
+        pagination: getPaginationParams({ page, perPage, sortOption }),
     };
     const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
     return axios

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -94,25 +94,24 @@ export function fetchDeploymentsWithProcessInfo(
  */
 export function fetchDeploymentsWithProcessInfoLegacy(
     options: RestSearchOption[] = [],
-    sortOption: Record<string, string>,
-    page: number,
-    pageSize: number
+    sortOption: ApiSortOption,
+    page: number, // zero-based page
+    perPage: number
 ): Promise<ListDeploymentWithProcessInfo[]> {
-    const offset = page * pageSize;
     let searchOptions: RestSearchOption[] = options;
     if (shouldHideOrchestratorComponents()) {
         searchOptions = [...options, ...orchestratorComponentsOption];
     }
     const query = searchOptionsToQuery(searchOptions);
-    const queryObject: Record<
-        string,
-        string | Record<string, number | string | Record<string, string>>
-    > = {
-        pagination: {
-            offset,
-            limit: pageSize,
+    const queryObject: {
+        pagination: Pagination;
+        query?: string;
+    } = {
+        pagination: getPaginationParams({
+            page: page + 1, // one-based page for compatibility with PatternFly Pagination element
+            perPage,
             sortOption,
-        },
+        }),
     };
     if (query) {
         queryObject.query = query;

--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -2,6 +2,7 @@ import queryString from 'qs';
 import { saveFile } from 'services/DownloadService';
 import { cveSortFields } from 'constants/sortFields';
 import queryService from 'utils/queryService';
+import { getPaginationParams } from 'utils/searchUtils';
 import entityTypes from 'constants/entityTypes';
 import axios from './instance';
 
@@ -66,15 +67,14 @@ export function getCvesInCsvFormat(
     pageSize = 0
 ) {
     const csvUrl = getCSVExportUrl(cveType);
-    const offset = page * pageSize;
     const params = queryString.stringify(
         {
             query,
-            pagination: {
-                offset,
-                limit: pageSize,
+            pagination: getPaginationParams({
+                page: page + 1, // one-based page for compatibility with PatternFly Pagination element
+                perPage: pageSize,
                 sortOption,
-            },
+            }),
         },
         { arrayFormat: 'repeat', allowDots: true }
     );


### PR DESCRIPTION
### Description

Follow up to contributions by David for consistent pagination as prerequisites for multi sort.

I added `!node.shorthand` to ignore properties without values as in destructuring.

Find in Files for the following:
* `pagination: PropTypes.shape(` has 1 result in 1 file
* `pagination: getPaginationParams(` has 30 results in 28 files
* `pagination: queryService.getPagination(` has 13 results in 13 files
* `pagination: {` has 9 results in 8 files but lint reports only 5 results in 4 files because the others are either in TypeScript type alias or `gql` template literals.

```
src/services/CollectionsService.ts
   56:9   error  Require that pagination property has function call like getPaginationParams  generic/pagination-function-call
  210:17  error  Require that pagination property has function call like getPaginationParams  generic/pagination-function-call

src/services/ComplianceScanConfigurationService.ts
  121:9  error  Require that pagination property has function call like getPaginationParams  generic/pagination-function-call

src/services/DeploymentsService.ts
  111:9  error  Require that pagination property has function call like getPaginationParams  generic/pagination-function-call

src/services/VulnerabilitiesService.js
  73:13  error  Require that pagination property has function call like getPaginationParams  generic/pagination-function-call```
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform

#### Manual testing

1. Visit /main/collections and see request:
    Staging without change: GET /v1/collections?query.query=&query.pagination.offset=0&query.pagination.limit=20&query.pagination.sortOption.field=Collection%20Name&query.pagination.sortOption.reversed=false
    Local with change: GET /v1/collections?query.query=&query.pagination.offset=0&query.pagination.limit=20&query.pagination.sortOption.field=Collection%20Name&query.pagination.sortOption.reversed=false

2. Visit /main/risk and turn on **Show Orchestrator Components** switch to test sorting and pagination.
    Page address: /main/risk?sort[0][id]=Deployment&sort[0][desc]=false&p=1
    GET /v1/deploymentswithprocessinfo?pagination.offset=50&pagination.limit=50&pagination.sortOption.field=Deployment&pagination.sortOption.reversed=false

3. Visit /main/policy-management/policies, clone a policy that have violations, and see request on **Review** step:
    Staging without change: GET /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=0&pagination.sortOption.field=Deployment&query=Orchestrator%20Component%3Afalse
    Local with change and **Show Orchestrator Components** off: GET /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=0&pagination.sortOption.field=Deployment&pagination.sortOption.reversed=false&query=Orchestrator%20Component%3Afalse
    Local with change and **Show Orchestrator Components** on, left over discover from step 1: /v1/deploymentswithprocessinfo?pagination.offset=0&pagination.limit=0&pagination.sortOption.field=Deployment&pagination.sortOption.reversed=false

4. Visit /main/vulnerability-management/image-cves, click **Export**, and then click **Download Evidence as CSV** to see request:
    Staging without change: GET /api/export/csv/image/cve?query=&pagination.offset=0&pagination.limit=0&pagination.sortOption.field=CVSS&pagination.sortOption.reversed=true
    Local with change: GET /api/export/csv/image/cve?query=&pagination.offset=0&pagination.limit=0&pagination.sortOption.field=CVSS&pagination.sortOption.reversed=true