### PR TITLE
ROX-26320: Putting report job filter state into URL

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -9,7 +9,7 @@ import {
 
 import { SearchFilter } from 'types/search';
 import CheckboxSelect from 'Components/CheckboxSelect';
-import { ensureString } from 'utils/ensure';
+import { ensureString, ensureStringArray } from 'utils/ensure';
 import { SelectedEntity } from './EntitySelector';
 import { SelectedAttribute } from './AttributeSelector';
 import { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
@@ -18,7 +18,6 @@ import {
     dateConditionMap,
     ensureConditionDate,
     ensureConditionNumber,
-    ensureStringArray,
     getAttribute,
     getEntity,
     hasGroupedSelectOptions,

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -80,16 +80,6 @@ export function getDefaultAttributeName(
     return attributes?.[0]?.displayName;
 }
 
-export function ensureStringArray(value: unknown): string[] {
-    if (Array.isArray(value) && value.every((element) => typeof element === 'string')) {
-        return value;
-    }
-    if (value === 'string') {
-        return [value];
-    }
-    return [];
-}
-
 export function ensureConditionNumber(value: unknown): { condition: string; number: number } {
     if (
         typeof value === 'object' &&

--- a/ui/apps/platform/src/Components/ReportJob/types.ts
+++ b/ui/apps/platform/src/Components/ReportJob/types.ts
@@ -1,2 +1,3 @@
 export const jobContextTabs = ['CONFIGURATION_DETAILS', 'ALL_REPORT_JOBS'] as const;
+
 export type JobContextTab = (typeof jobContextTabs)[number];

--- a/ui/apps/platform/src/Components/ReportJob/utils.ts
+++ b/ui/apps/platform/src/Components/ReportJob/utils.ts
@@ -1,4 +1,4 @@
-import { JobContextTab, jobContextTabs } from 'types/reportJob';
+import { JobContextTab, jobContextTabs } from './types';
 
 export function ensureJobContextTab(value: unknown): JobContextTab {
     if (typeof value === 'string' && jobContextTabs.includes(value as JobContextTab)) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -18,21 +18,19 @@ import {
 } from '@patternfly/react-core';
 
 import { complianceEnhancedSchedulesPath } from 'routePaths';
-import PageTitle from 'Components/PageTitle';
-import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useAlert from 'hooks/useAlert';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import {
     ComplianceScanConfigurationStatus,
     runComplianceReport,
     runComplianceScanConfiguration,
 } from 'services/ComplianceScanConfigurationService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-
-import useFeatureFlags from 'hooks/useFeatureFlags';
-import { jobContextTabs } from 'types/reportJob';
-import { ensureJobContextTab } from 'utils/reportJob';
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
-import useURLStringUnion from 'hooks/useURLStringUnion';
+import { jobContextTabs } from 'Components/ReportJob/types';
 import ScanConfigActionDropdown from './ScanConfigActionDropdown';
 import ConfigDetails from './components/ConfigDetails';
 import ReportJobs from './components/ReportJobs';
@@ -182,7 +180,7 @@ function ViewScanConfigDetail({
                     <Tabs
                         activeKey={activeScanConfigTab}
                         onSelect={(_e, tab) => {
-                            setActiveScanConfigTab(ensureJobContextTab(tab));
+                            setActiveScanConfigTab(tab);
                         }}
                         aria-label="Scan schedule details tabs"
                     >

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -29,9 +29,10 @@ import {
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { JobContextTab } from 'types/reportJob';
+import { jobContextTabs } from 'types/reportJob';
 import { ensureJobContextTab } from 'utils/reportJob';
 import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import ScanConfigActionDropdown from './ScanConfigActionDropdown';
 import ConfigDetails from './components/ConfigDetails';
 import ReportJobs from './components/ReportJobs';
@@ -55,7 +56,10 @@ function ViewScanConfigDetail({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isReportJobsEnabled = isFeatureFlagEnabled('ROX_SCAN_SCHEDULE_REPORT_JOBS');
 
-    const [selectedTab, setSelectedTab] = useState<JobContextTab>('CONFIGURATION_DETAILS');
+    const [activeScanConfigTab, setActiveScanConfigTab] = useURLStringUnion(
+        'scanConfigTab',
+        jobContextTabs
+    );
     const [isTriggeringRescan, setIsTriggeringRescan] = useState(false);
 
     const { alertObj, setAlertObj, clearAlertObj } = useAlert();
@@ -176,9 +180,9 @@ function ViewScanConfigDetail({
             {isReportJobsEnabled && (
                 <PageSection variant="light" className="pf-v5-u-py-0">
                     <Tabs
-                        activeKey={selectedTab}
+                        activeKey={activeScanConfigTab}
                         onSelect={(_e, tab) => {
-                            setSelectedTab(ensureJobContextTab(tab));
+                            setActiveScanConfigTab(ensureJobContextTab(tab));
                         }}
                         aria-label="Scan schedule details tabs"
                     >
@@ -196,7 +200,7 @@ function ViewScanConfigDetail({
                     </Tabs>
                 </PageSection>
             )}
-            {selectedTab === 'CONFIGURATION_DETAILS' && (
+            {activeScanConfigTab === 'CONFIGURATION_DETAILS' && (
                 <PageSection isCenterAligned id={configDetailsTabId}>
                     <Card isFlat>
                         <CardBody>
@@ -209,7 +213,7 @@ function ViewScanConfigDetail({
                     </Card>
                 </PageSection>
             )}
-            {selectedTab === 'ALL_REPORT_JOBS' && (
+            {activeScanConfigTab === 'ALL_REPORT_JOBS' && (
                 <PageSection isCenterAligned id={allReportJobsTabId}>
                     <ReportJobs scanConfig={scanConfig} />
                 </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Switch } from '@patternfly/react-core';
 
 export type MyJobsFilterProps = {
-    showOnlyMyJobs: boolean;
+    viewOnlyMyJobs: boolean;
     onMyJobsFilterChange: (checked: boolean) => void;
 };
 
-function MyJobsFilter({ showOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProps) {
+function MyJobsFilter({ viewOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProps) {
     // We're using the same label for both "label" and "labelOff" because changing the label between "on" and "off" states was causing confusion.
     // When the label changes (e.g., from "View only my jobs" to "View all jobs"), users found it unclear what state the switch was in and what they were actually viewing.
     // By keeping the label consistent, it avoids this confusion and maintains clarity on what the switch controls.
@@ -15,7 +15,7 @@ function MyJobsFilter({ showOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProp
             id="view-only-my-jobs"
             label="View only my jobs"
             labelOff="View only my jobs"
-            isChecked={showOnlyMyJobs}
+            isChecked={viewOnlyMyJobs}
             onChange={(_event, checked: boolean) => onMyJobsFilterChange(checked)}
         />
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/MyJobsFilter.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Switch } from '@patternfly/react-core';
 
 export type MyJobsFilterProps = {
-    viewOnlyMyJobs: boolean;
+    isViewingOnlyMyJobs: boolean;
     onMyJobsFilterChange: (checked: boolean) => void;
 };
 
-function MyJobsFilter({ viewOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProps) {
+function MyJobsFilter({ isViewingOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProps) {
     // We're using the same label for both "label" and "labelOff" because changing the label between "on" and "off" states was causing confusion.
     // When the label changes (e.g., from "View only my jobs" to "View all jobs"), users found it unclear what state the switch was in and what they were actually viewing.
     // By keeping the label consistent, it avoids this confusion and maintains clarity on what the switch controls.
@@ -15,7 +15,7 @@ function MyJobsFilter({ viewOnlyMyJobs, onMyJobsFilterChange }: MyJobsFilterProp
             id="view-only-my-jobs"
             label="View only my jobs"
             labelOff="View only my jobs"
-            isChecked={viewOnlyMyJobs}
+            isChecked={isViewingOnlyMyJobs}
             onChange={(_event, checked: boolean) => onMyJobsFilterChange(checked)}
         />
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -19,8 +19,9 @@ import { RunState } from 'services/ReportsService.types';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { ensureBoolean, ensureStringArray } from 'utils/ensure';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import ConfigDetails from './ConfigDetails';
-import ReportStatesFilter, { ensureReportStates } from './ReportStatusFilter';
+import ReportRunStatesFilter, { ensureReportRunStates } from './ReportRunStatesFilter';
 import MyJobsFilter from './MyJobsFilter';
 
 function createMockData(scanConfig: ComplianceScanConfigurationStatus) {
@@ -61,31 +62,33 @@ type ReportJobsProps = {
 function ReportJobs({ scanConfig }: ReportJobsProps) {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { searchFilter, setSearchFilter } = useURLSearch();
+    const [isViewingOnlyMyJobs, setIsViewingOnlyMyJobs] = useURLStringUnion('viewOnlyMyJobs', [
+        'false',
+        'true',
+    ]);
 
-    const filteredReportStates = ensureStringArray(searchFilter['Report state']);
-    const viewOnlyMyJobs = ensureBoolean(searchFilter['View only my jobs']);
+    const filteredReportRunStates = ensureStringArray(searchFilter['Report State']);
 
     const onReportStatesFilterChange = (_checked: boolean, selectedStatus: RunState) => {
-        const isStatusIncluded = filteredReportStates.includes(selectedStatus);
+        const isStatusIncluded = filteredReportRunStates.includes(selectedStatus);
         if (isStatusIncluded) {
             setSearchFilter({
                 ...searchFilter,
-                'Report state': filteredReportStates.filter((status) => status !== selectedStatus),
+                'Report State': filteredReportRunStates.filter(
+                    (status) => status !== selectedStatus
+                ),
             });
         } else {
             setSearchFilter({
                 ...searchFilter,
-                'Report state': [...filteredReportStates, selectedStatus],
+                'Report State': [...filteredReportRunStates, selectedStatus],
             });
         }
         setPage(1);
     };
 
     const onMyJobsFilterChange = (checked: boolean) => {
-        setSearchFilter({
-            ...searchFilter,
-            'View only my jobs': String(checked),
-        });
+        setIsViewingOnlyMyJobs(String(checked));
         setPage(1);
     };
 
@@ -97,14 +100,14 @@ function ReportJobs({ scanConfig }: ReportJobsProps) {
             <Toolbar>
                 <ToolbarContent>
                     <ToolbarItem alignItems="center">
-                        <ReportStatesFilter
-                            reportStates={ensureReportStates(filteredReportStates)}
+                        <ReportRunStatesFilter
+                            reportRunStates={ensureReportRunStates(filteredReportRunStates)}
                             onChange={onReportStatesFilterChange}
                         />
                     </ToolbarItem>
                     <ToolbarItem className="pf-v5-u-flex-grow-1" alignSelf="center">
                         <MyJobsFilter
-                            viewOnlyMyJobs={viewOnlyMyJobs}
+                            isViewingOnlyMyJobs={ensureBoolean(isViewingOnlyMyJobs)}
                             onMyJobsFilterChange={onMyJobsFilterChange}
                         />
                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportRunStatesFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportRunStatesFilter.tsx
@@ -18,30 +18,32 @@ import CheckboxSelect from 'Components/CheckboxSelect';
  *                         and returns them as an array.
  *                         If the input is not an array or undefined, it returns an empty array.
  */
-export function ensureReportStates(searchFilterValue: string | string[] | undefined): RunState[] {
+export function ensureReportRunStates(
+    searchFilterValue: string | string[] | undefined
+): RunState[] {
     if (Array.isArray(searchFilterValue)) {
-        const reportStates = searchFilterValue.filter((value) => runStates[value]) as RunState[];
-        return reportStates;
+        const reportRunStates = searchFilterValue.filter((value) => runStates[value]) as RunState[];
+        return reportRunStates;
     }
     return [];
 }
 
-export type ReportStatesFilterProps = {
-    reportStates: RunState[];
+export type ReportRunStatesFilterProps = {
+    reportRunStates: RunState[];
     onChange: (checked: boolean, value: RunState) => void;
 };
 
-function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps) {
+function ReportRunStatesFilter({ reportRunStates, onChange }: ReportRunStatesFilterProps) {
     function onChangeHandler(checked: boolean, value: string) {
         onChange(checked, value as RunState);
     }
 
     return (
         <CheckboxSelect
-            ariaLabelMenu="Filter by report states select menu"
-            toggleLabel="Filter by report states"
+            ariaLabelMenu="Filter by report run states select menu"
+            toggleLabel="Filter by report run states"
             toggleIcon={<FilterIcon />}
-            selection={reportStates}
+            selection={reportRunStates}
             onChange={onChangeHandler}
         >
             <SelectList>
@@ -49,7 +51,7 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
                     key={runStates.PREPARING}
                     value={runStates.PREPARING}
                     hasCheckbox
-                    isSelected={reportStates.includes(runStates.PREPARING)}
+                    isSelected={reportRunStates.includes(runStates.PREPARING)}
                 >
                     Preparing
                 </SelectOption>
@@ -57,7 +59,7 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
                     key={runStates.WAITING}
                     value={runStates.WAITING}
                     hasCheckbox
-                    isSelected={reportStates.includes(runStates.WAITING)}
+                    isSelected={reportRunStates.includes(runStates.WAITING)}
                 >
                     Waiting
                 </SelectOption>
@@ -65,7 +67,7 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
                     key={runStates.GENERATED}
                     value={runStates.GENERATED}
                     hasCheckbox
-                    isSelected={reportStates.includes(runStates.GENERATED)}
+                    isSelected={reportRunStates.includes(runStates.GENERATED)}
                 >
                     Download generated
                 </SelectOption>
@@ -73,7 +75,7 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
                     key={runStates.DELIVERED}
                     value={runStates.DELIVERED}
                     hasCheckbox
-                    isSelected={reportStates.includes(runStates.DELIVERED)}
+                    isSelected={reportRunStates.includes(runStates.DELIVERED)}
                 >
                     Email delivered
                 </SelectOption>
@@ -81,7 +83,7 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
                     key={runStates.FAILURE}
                     value={runStates.FAILURE}
                     hasCheckbox
-                    isSelected={reportStates.includes(runStates.FAILURE)}
+                    isSelected={reportRunStates.includes(runStates.FAILURE)}
                 >
                     Error
                 </SelectOption>
@@ -90,4 +92,4 @@ function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps)
     );
 }
 
-export default ReportStatesFilter;
+export default ReportRunStatesFilter;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportStatusFilter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportStatusFilter.tsx
@@ -5,22 +5,43 @@ import { FilterIcon } from '@patternfly/react-icons';
 import { RunState, runStates } from 'services/ReportsService.types';
 import CheckboxSelect from 'Components/CheckboxSelect';
 
-export type ReportStatusFilterProps = {
-    selection: RunState[];
+/**
+ * Ensures that the given search filter value is converted to an array of valid "RunState" values.
+ *
+ * Example:
+ * ensureReportStates(["WAITING", "PREPARING"]);  // returns ["WAITING", "PREPARING"]
+ * ensureReportStates("WAITING");                 // returns [] (since input is not an array)
+ * ensureReportStates(undefined);                 // returns []
+ *
+ * @param searchFilterValue - The input value, which can be a string, an array of strings, or undefined.
+ * @returns {RunState[]} - If the input is an array of strings, it filters the values that match valid "RunState"s
+ *                         and returns them as an array.
+ *                         If the input is not an array or undefined, it returns an empty array.
+ */
+export function ensureReportStates(searchFilterValue: string | string[] | undefined): RunState[] {
+    if (Array.isArray(searchFilterValue)) {
+        const reportStates = searchFilterValue.filter((value) => runStates[value]) as RunState[];
+        return reportStates;
+    }
+    return [];
+}
+
+export type ReportStatesFilterProps = {
+    reportStates: RunState[];
     onChange: (checked: boolean, value: RunState) => void;
 };
 
-function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
+function ReportStatesFilter({ reportStates, onChange }: ReportStatesFilterProps) {
     function onChangeHandler(checked: boolean, value: string) {
         onChange(checked, value as RunState);
     }
 
     return (
         <CheckboxSelect
-            ariaLabelMenu="Filter by report status select menu"
-            toggleLabel="Filter by report status"
+            ariaLabelMenu="Filter by report states select menu"
+            toggleLabel="Filter by report states"
             toggleIcon={<FilterIcon />}
-            selection={selection}
+            selection={reportStates}
             onChange={onChangeHandler}
         >
             <SelectList>
@@ -28,7 +49,7 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
                     key={runStates.PREPARING}
                     value={runStates.PREPARING}
                     hasCheckbox
-                    isSelected={selection.includes(runStates.PREPARING)}
+                    isSelected={reportStates.includes(runStates.PREPARING)}
                 >
                     Preparing
                 </SelectOption>
@@ -36,7 +57,7 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
                     key={runStates.WAITING}
                     value={runStates.WAITING}
                     hasCheckbox
-                    isSelected={selection.includes(runStates.WAITING)}
+                    isSelected={reportStates.includes(runStates.WAITING)}
                 >
                     Waiting
                 </SelectOption>
@@ -44,7 +65,7 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
                     key={runStates.GENERATED}
                     value={runStates.GENERATED}
                     hasCheckbox
-                    isSelected={selection.includes(runStates.GENERATED)}
+                    isSelected={reportStates.includes(runStates.GENERATED)}
                 >
                     Download generated
                 </SelectOption>
@@ -52,7 +73,7 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
                     key={runStates.DELIVERED}
                     value={runStates.DELIVERED}
                     hasCheckbox
-                    isSelected={selection.includes(runStates.DELIVERED)}
+                    isSelected={reportStates.includes(runStates.DELIVERED)}
                 >
                     Email delivered
                 </SelectOption>
@@ -60,7 +81,7 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
                     key={runStates.FAILURE}
                     value={runStates.FAILURE}
                     hasCheckbox
-                    isSelected={selection.includes(runStates.FAILURE)}
+                    isSelected={reportStates.includes(runStates.FAILURE)}
                 >
                     Error
                 </SelectOption>
@@ -69,4 +90,4 @@ function ReportStatusFilter({ selection, onChange }: ReportStatusFilterProps) {
     );
 }
 
-export default ReportStatusFilter;
+export default ReportStatesFilter;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -46,8 +46,8 @@ import usePermissions from 'hooks/usePermissions';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 
 import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
-import { JobContextTab } from 'types/reportJob';
-import { ensureJobContextTab } from 'utils/reportJob';
+import { JobContextTab } from 'Components/ReportJob/types';
+import { ensureJobContextTab } from 'Components/ReportJob/utils';
 import EmailTemplatePreview from '../components/EmailTemplatePreview';
 import ReportParametersDetails from '../components/ReportParametersDetails';
 import ScheduleDetails from '../components/ScheduleDetails';

--- a/ui/apps/platform/src/utils/ensure.ts
+++ b/ui/apps/platform/src/utils/ensure.ts
@@ -1,5 +1,6 @@
 /**
  * Helper function to ensure that the provided value is a string.
+ *
  * If the value is a string, it returns the value as is.
  * If the value is not a string, it returns an empty string.
  *
@@ -11,4 +12,56 @@ export function ensureString(value: unknown): string {
         return value;
     }
     return '';
+}
+
+/**
+ * Helper function to ensure that the provided value is converted to an array of strings.
+ *
+ * Example:
+ * ensureStringArray(['a', 'b', 'c']);   // returns ['a', 'b', 'c']
+ * ensureStringArray('hello');           // returns ['hello']
+ * ensureStringArray([1, 'b', {}]);      // returns ['b'] (filters out non-string elements)
+ * ensureStringArray(123);               // returns []
+ *
+ * @param value - The input value, which could be of any type.
+ * @returns {string[]} - If the value is an array, it filters and returns only the string elements.
+ *                       If the value is a single string, it wraps it in an array and returns it.
+ *                       For all other values, it returns an empty array.
+ */
+export function ensureStringArray(value: unknown): string[] {
+    if (Array.isArray(value)) {
+        const result: string[] = value.filter((element) => typeof element === 'string');
+        return result;
+    }
+    if (typeof value === 'string') {
+        return [value];
+    }
+    return [];
+}
+
+/**
+ * Helper function to ensure that the provided value is converted to a boolean.
+ *
+ * Example:
+ * ensureBoolean(true);        // returns true
+ * ensureBoolean('true');      // returns true
+ * ensureBoolean('false');     // returns false
+ * ensureBoolean(123);         // returns false (non-boolean values default to false)
+ *
+ * @param value - The input value, which could be of any type.
+ * @returns {boolean} - Returns the value as a boolean if it's already a boolean,
+ *                      or converts string values 'true'/'false' (case-insensitive) to booleans.
+ *                      Returns `false` for all other values.
+ */
+export function ensureBoolean(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string' && value.toLowerCase() === 'true') {
+        return true;
+    }
+    if (typeof value === 'string' && value.toLowerCase() === 'false') {
+        return false;
+    }
+    return false;
 }


### PR DESCRIPTION
### Description

This PR changes the behavior in the scan config details page to keep the state in the URL vs. in the component. 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no added tests

#### How I validated my change



