### PR TITLE
ROX-26372:  VM query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - Scanner V4 now only considers vulnerabilities affecting Red Hat products dated back to 2014.
     - Previously when reading Red Hat's OVAL data, the vulnerabilities dated back to pre-2000, but ClairCore only reads back to 2014.
   - Scanner V4 DB requires less space for vulnerability data, and its initialization time has improved from about 1 hour on SSD to about 10 minutes.
+- ROX-26372: `ROX_POSTGRES_VM_STATEMENT_TIMEOUT` env var defaulting to 3 minutes to allow customers to extend the timeout for queries backing VM pages only
 
 ## [4.5.0]
 

--- a/central/graphql/resolvers/loaders/image_cves.go
+++ b/central/graphql/resolvers/loaders/image_cves.go
@@ -9,11 +9,15 @@ import (
 	ImageCVEDataStore "github.com/stackrox/rox/central/cve/image/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-var imageCveLoaderType = reflect.TypeOf(storage.ImageCVE{})
+var (
+	imageCveLoaderType = reflect.TypeOf(storage.ImageCVE{})
+	log                = logging.LoggerForModule()
+)
 
 func init() {
 	RegisterTypeFactory(reflect.TypeOf(storage.ImageCVE{}), func() interface{} {
@@ -92,6 +96,7 @@ func (idl *imageCveLoaderImpl) GetIDs(ctx context.Context, query *v1.Query) ([]s
 }
 
 func (idl *imageCveLoaderImpl) CountFromQuery(ctx context.Context, query *v1.Query) (int32, error) {
+	log.Infof("SHREWS -- image_cves.go.CountFromQuery")
 	count, err := idl.ds.Count(ctx, query)
 	if err != nil {
 		return 0, err

--- a/central/graphql/resolvers/loaders/image_cves.go
+++ b/central/graphql/resolvers/loaders/image_cves.go
@@ -9,15 +9,11 @@ import (
 	ImageCVEDataStore "github.com/stackrox/rox/central/cve/image/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-var (
-	imageCveLoaderType = reflect.TypeOf(storage.ImageCVE{})
-	log                = logging.LoggerForModule()
-)
+var imageCveLoaderType = reflect.TypeOf(storage.ImageCVE{})
 
 func init() {
 	RegisterTypeFactory(reflect.TypeOf(storage.ImageCVE{}), func() interface{} {
@@ -96,7 +92,6 @@ func (idl *imageCveLoaderImpl) GetIDs(ctx context.Context, query *v1.Query) ([]s
 }
 
 func (idl *imageCveLoaderImpl) CountFromQuery(ctx context.Context, query *v1.Query) (int32, error) {
-	log.Infof("SHREWS -- image_cves.go.CountFromQuery")
 	count, err := idl.ds.Count(ctx, query)
 	if err != nil {
 		return 0, err

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -286,16 +286,13 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 }
 
 func (v *imageCVECoreViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
-	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
-	defer cancel()
-
 	var cveIDsToFilter []string
 
 	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
 	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
 	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
 	var identifiersList []*imageCVECoreResponse
-	identifiersList, err := pgSearch.RunSelectRequestForSchema[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q))
+	identifiersList, err := pgSearch.RunSelectRequestForSchema[imageCVECoreResponse](ctx, v.db, v.schema, withSelectCVEIdentifiersQuery(q))
 	if err != nil {
 		return nil, err
 	}

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/views"
@@ -107,8 +106,6 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err
 	}
-
-	time.Sleep(2 * time.Minute)
 
 	var err error
 	// Avoid changing the passed query
@@ -288,11 +285,14 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 func (v *imageCVECoreViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
 	var cveIDsToFilter []string
 
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
 	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
 	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
 	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
 	var identifiersList []*imageCVECoreResponse
-	identifiersList, err := pgSearch.RunSelectRequestForSchema[imageCVECoreResponse](ctx, v.db, v.schema, withSelectCVEIdentifiersQuery(q))
+	identifiersList, err := pgSearch.RunSelectRequestForSchema[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q))
 	if err != nil {
 		return nil, err
 	}

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/views"
@@ -106,6 +107,8 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err
 	}
+
+	time.Sleep(2 * time.Minute)
 
 	var err error
 	// Avoid changing the passed query

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -47,4 +47,7 @@ var (
 	// Thus it has to be configured if needed, when pruner performance issues
 	// are observed.
 	PruneOrphanedWindow = registerDurationSetting("ROX_PRUNE_ORPHANED_WINDOW", 30*time.Minute)
+
+	// PostgresVMStatementTimeout sets the statement timeout for VM
+	PostgresVMStatementTimeout = registerDurationSetting("ROX_POSTGRES_VM_STATEMENT_TIMEOUT", 3*time.Minute)
 )


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

We found in a customer case some issues with the VM2.0 queries timing out.  After making some adjustments in Postgres we could get them to run, but we don't have enough resources to make those settings permanent.  What we can do is extend the timeout for these queries.  The default of 1 minute is too short.  So this PR seeks to make a configurable timeout that is narrow in focus to VM and defaults to 3 minutes.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual testing.  Artificially set the VM query timeout to 1 ms.  Went to VM page and verified an error was received.

```
{
    "errors": [
        {
            "message": "context deadline exceeded",
            "path": [
                "imageCVEs"
            ]
        }
    ],
    "data": null
}
```

Set the timeout back to a normal value and verified that the query completed.