### PR TITLE
fix(scannerv4): check if layer index is nil

### DIFF
--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -50,13 +50,20 @@ func components(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport)
 		}
 
 		component := &storage.EmbeddedImageScanComponent{
-			Name:          pkg.GetName(),
-			Version:       pkg.GetVersion(),
-			Vulns:         vulnerabilities(report.GetVulnerabilities(), vulnIDs),
-			FixedBy:       pkg.GetFixedInVersion(),
-			Source:        source,
-			Location:      location,
-			HasLayerIndex: layerIdx,
+			Name:     pkg.GetName(),
+			Version:  pkg.GetVersion(),
+			Vulns:    vulnerabilities(report.GetVulnerabilities(), vulnIDs),
+			FixedBy:  pkg.GetFixedInVersion(),
+			Source:   source,
+			Location: location,
+		}
+		// DO NOT BLINDLY SET THIS INSIDE THE STRUCT DECLARATION DIRECTLY ABOVE.
+		// IF layerIdx IS nil, IT DOES NOT MEAN HasLayerIndex WILL BE THE SAME nil.
+		// GO CAN SOMETIMES BE ANNOYING AND nil DOES NOT ALWAYS EQUAL nil.
+		// IT IS MUCH SAFER TO ONLY SET HasLayerIndex TO layerIdx WHEN WE KNOW FOR
+		// SURE layerIdx != nil!!!
+		if layerIdx != nil {
+			component.HasLayerIndex = layerIdx
 		}
 
 		components = append(components, component)

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -62,6 +62,16 @@ func components(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport)
 		// GO CAN SOMETIMES BE ANNOYING AND nil DOES NOT ALWAYS EQUAL nil.
 		// IT IS MUCH SAFER TO ONLY SET HasLayerIndex TO layerIdx WHEN WE KNOW FOR
 		// SURE layerIdx != nil!!!
+		//
+		// See https://go.dev/doc/faq#nil_error for an explanation about this.
+		// For this particular use-case, layerIdx is a pointer to a struct
+		// which implements the interface. Therefore,
+		// even if layerIdx is set to nil, it still of type
+		// *storage.EmbeddedImageScanComponent_LayerIndex.
+		// HasLayerIndex is an interface type, and, according to the docs,
+		// this will only be nil if both the type and value are unset.
+		// If we always set HasLayerIndex to layerIdx, then
+		// it will never be nil, as layerIdx always has a type.
 		if layerIdx != nil {
 			component.HasLayerIndex = layerIdx
 		}

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -131,7 +131,7 @@ func TestComponents(t *testing.T) {
 			name: "basic no vulns",
 			metadata: &storage.ImageMetadata{
 				V1: &storage.V1Metadata{
-					Digest: "sha256:809a91adbd71a06ab4513434ec04c8f496f042614a8d12033933e9e433c4c179",
+					Digest: "some V1 digest",
 					Layers: []*storage.ImageLayer{
 						{
 							Empty: true,
@@ -156,12 +156,9 @@ func TestComponents(t *testing.T) {
 					},
 				},
 				V2: &storage.V2Metadata{
-					Digest: "sha256:ac9f0defc3f00ff1459e77b930bbd82870570560b3437b88010514fea79b1808",
+					Digest: "some V2 digest",
 				},
-				LayerShas: []string{
-					"sha256:423c986e97ebd515f172eb484f176107e279ad0ac1db8ead5b21a60a208a8b3c",
-					"sha256:c7212d1c19435c5a25bf5ac9ee9de2bfa66e97684bdc383822b72a934f795545",
-				},
+				LayerShas: []string{"layer1", "layer2"},
 				DataSource: &storage.DataSource{
 					Id:   "dataSourceID",
 					Name: "dataSourceName",
@@ -189,7 +186,7 @@ func TestComponents(t *testing.T) {
 							Environments: []*v4.Environment{
 								{
 									PackageDb:      "sqlite:var/lib/rpm",
-									IntroducedIn:   "sha256:423c986e97ebd515f172eb484f176107e279ad0ac1db8ead5b21a60a208a8b3c",
+									IntroducedIn:   "layer1",
 									DistributionId: "1",
 									RepositoryIds:  []string{"0"},
 								},
@@ -214,7 +211,7 @@ func TestComponents(t *testing.T) {
 			name: "layer mismatch, no layer indexes",
 			metadata: &storage.ImageMetadata{
 				V1: &storage.V1Metadata{
-					Digest: "sha256:809a91adbd71a06ab4513434ec04c8f496f042614a8d12033933e9e433c4c179",
+					Digest: "some V1 digest",
 					Layers: []*storage.ImageLayer{
 						{
 							Empty: true,
@@ -239,12 +236,9 @@ func TestComponents(t *testing.T) {
 					},
 				},
 				V2: &storage.V2Metadata{
-					Digest: "sha256:ac9f0defc3f00ff1459e77b930bbd82870570560b3437b88010514fea79b1808",
+					Digest: "some V2 digest",
 				},
-				LayerShas: []string{
-					"sha256:423c986e97ebd515f172eb484f176107e279ad0ac1db8ead5b21a60a208a8b3c",
-					"sha256:c7212d1c19435c5a25bf5ac9ee9de2bfa66e97684bdc383822b72a934f795545",
-				},
+				LayerShas: []string{"layer1", "layer2"},
 				DataSource: &storage.DataSource{
 					Id:   "dataSourceID",
 					Name: "dataSourceName",
@@ -272,7 +266,7 @@ func TestComponents(t *testing.T) {
 							Environments: []*v4.Environment{
 								{
 									PackageDb:      "sqlite:var/lib/rpm",
-									IntroducedIn:   "sha256:0fa3315a0cca1299566b56c9efd78f83279c1fc50fa6e5b7297565ba6f007253",
+									IntroducedIn:   "some layer which does not exist in the image",
 									DistributionId: "1",
 									RepositoryIds:  []string{"0"},
 								},

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -115,6 +115,13 @@ func (s *scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {
 		return nil, err
 	}
 
+	log.Debugf("Scanning %q for digest %q with image ID %q, manifest v2 digest %q, and manifest v1 digest %q",
+		image.GetName().GetFullName(),
+		digest.String(),
+		image.GetId(),
+		image.GetMetadata().GetV2().GetDigest(),
+		image.GetMetadata().GetV1().GetDigest(),
+	)
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 	opt := client.ImageRegistryOpt{InsecureSkipTLSVerify: rc.GetInsecure()}


### PR DESCRIPTION
### Description

In Go, `nil` does not always equal `nil`. As much as I love calling methods with `nil` receivers, this is a case when `nil != nil` is a huge pain. This mimics https://github.com/stackrox/stackrox/blob/4.5.2/pkg/scanners/clairify/convert.go#L248 which only sets `HasLayerIndex` when we know the value we are setting `HasLayerIndex` to is not `nil`.

This also adds a Debug log, which may be helpful in the future to identify differences between the version of the image whose metadata we have and the version of the image which is scanned.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

CI
