### PR TITLE
chore(ui): Move application of search filter out of filter chips

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Button, ChipGroup, Chip, Flex, FlexItem, ToolbarChip } from '@patternfly/react-core';
-import noop from 'lodash/noop';
 import { Globe } from 'react-feather';
 
-import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import { searchValueAsArray } from 'utils/searchUtils';
 
@@ -38,8 +36,10 @@ export type FilterChipGroupDescriptor = {
 export type SearchFilterChipsProps = {
     /** The search filter categories to display */
     filterChipGroupDescriptors: FilterChipGroupDescriptor[];
+    /** The current search filter */
+    searchFilter: SearchFilter;
     /** Callback for when the search filter changes */
-    onFilterChange?: (searchFilter: SearchFilter) => void;
+    onFilterChange: (searchFilter: SearchFilter) => void;
 };
 
 /**
@@ -48,12 +48,10 @@ export type SearchFilterChipsProps = {
  */
 function SearchFilterChips({
     filterChipGroupDescriptors,
-    onFilterChange = noop,
+    searchFilter,
+    onFilterChange,
 }: SearchFilterChipsProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
-
     function onChangeSearchFilter(newFilter: SearchFilter) {
-        setSearchFilter(newFilter);
         onFilterChange(newFilter);
     }
 

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -213,6 +213,8 @@ function ListeningEndpointsPage() {
 
                         <ToolbarGroup className="pf-v5-u-w-100">
                             <SearchFilterChips
+                                searchFilter={searchFilter}
+                                onFilterChange={setSearchFilter}
                                 filterChipGroupDescriptors={[
                                     { displayName: 'Deployment', searchFilterName: 'Deployment' },
                                     { displayName: 'Namespace', searchFilterName: 'Namespace' },

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -134,7 +134,11 @@ function DiscoveredClustersToolbar({
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-v5-u-w-100">
-                    <SearchFilterChips filterChipGroupDescriptors={searchFilterChipDescriptors} />
+                    <SearchFilterChips
+                        searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
+                        filterChipGroupDescriptors={searchFilterChipDescriptors}
+                    />
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -215,6 +215,7 @@ function CheckDetails() {
                         getSortParams={getSortParams}
                         searchFilterConfig={searchFilterConfig}
                         searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
                         onSearch={onSearch}
                         onCheckStatusSelect={onCheckStatusSelect}
                         onClearFilters={onClearFilters}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -41,6 +41,7 @@ export type CheckDetailsTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilterConfig: CompoundSearchFilterConfig;
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: (payload: OnSearchPayload) => void;
     onCheckStatusSelect: (
         filterType: 'Compliance Check Status',
@@ -59,6 +60,7 @@ function CheckDetailsTable({
     getSortParams,
     searchFilterConfig,
     searchFilter,
+    onFilterChange,
     onSearch,
     onCheckStatusSelect,
     onClearFilters,
@@ -96,6 +98,8 @@ function CheckDetailsTable({
                     </ToolbarGroup>
                     <ToolbarGroup className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={[
                                 {
                                     displayName: 'Cluster',

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -229,6 +229,7 @@ function ClusterDetailsPage() {
                             getSortParams={getSortParams}
                             searchFilterConfig={searchFilterConfig}
                             searchFilter={searchFilter}
+                            onFilterChange={setSearchFilter}
                             onSearch={onSearch}
                             onCheckStatusSelect={onCheckStatusSelect}
                             onClearFilters={onClearFilters}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -38,6 +38,7 @@ export type ClusterDetailsTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilterConfig: CompoundSearchFilterConfig;
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: (payload: OnSearchPayload) => void;
     onCheckStatusSelect: (
         filterType: 'Compliance Check Status',
@@ -55,6 +56,7 @@ function ClusterDetailsTable({
     getSortParams,
     searchFilterConfig,
     searchFilter,
+    onFilterChange,
     onSearch,
     onCheckStatusSelect,
     onClearFilters,
@@ -105,6 +107,8 @@ function ClusterDetailsTable({
                     </ToolbarGroup>
                     <ToolbarGroup className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={[
                                 {
                                     displayName: 'Profile Check',

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -178,6 +178,8 @@ function CoveragesPage() {
                                     </ToolbarGroup>
                                     <ToolbarGroup className="pf-v5-u-w-100">
                                         <SearchFilterChips
+                                            searchFilter={searchFilter}
+                                            onFilterChange={setSearchFilter}
                                             filterChipGroupDescriptors={[
                                                 {
                                                     displayName: 'Profile Check',

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -230,6 +230,7 @@ function ViolationsTablePage(): ReactElement {
                             getSortParams={getSortParams}
                             columns={columns}
                             searchFilter={searchFilter}
+                            onFilterChange={setSearchFilter}
                             onSearch={onSearch}
                         />
                     </PageSection>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -56,6 +56,7 @@ type ViolationsTablePanelProps = {
     getSortParams: GetSortParams;
     columns: TableColumn[];
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: OnSearchCallback;
 };
 
@@ -71,6 +72,7 @@ function ViolationsTablePanel({
     getSortParams,
     columns,
     searchFilter,
+    onFilterChange,
     onSearch,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
@@ -194,7 +196,11 @@ function ViolationsTablePanel({
                     </Alert>
                 ))}
             </AlertGroup>
-            <ViolationsTableSearchFilter searchFilter={searchFilter} onSearch={onSearch} />
+            <ViolationsTableSearchFilter
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                onSearch={onSearch}
+            />
             <Divider component="div" />
             <Toolbar>
                 <ToolbarContent>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -76,10 +76,15 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
 
 export type ViolationsTableSearchFilterProps = {
     searchFilter: SearchFilter;
+    onFilterChange: (newFilter: SearchFilter) => void;
     onSearch: OnSearchCallback;
 };
 
-function ViolationsTableSearchFilter({ searchFilter, onSearch }: ViolationsTableSearchFilterProps) {
+function ViolationsTableSearchFilter({
+    searchFilter,
+    onFilterChange,
+    onSearch,
+}: ViolationsTableSearchFilterProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
     return (
@@ -95,7 +100,11 @@ function ViolationsTableSearchFilter({ searchFilter, onSearch }: ViolationsTable
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-v5-u-w-100">
-                    <SearchFilterChips filterChipGroupDescriptors={filterChipGroupDescriptors} />
+                    <SearchFilterChips
+                        searchFilter={searchFilter}
+                        onFilterChange={onFilterChange}
+                        filterChipGroupDescriptors={filterChipGroupDescriptors}
+                    />
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -19,6 +19,7 @@ import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -93,7 +94,8 @@ function ApprovedDeferrals() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -142,6 +144,7 @@ function ApprovedDeferrals() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -20,6 +20,7 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestIDLink,
     RequestedAction,
@@ -86,7 +87,8 @@ function ApprovedFalsePositives() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -135,6 +137,7 @@ function ApprovedFalsePositives() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -19,6 +19,7 @@ import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -90,7 +91,8 @@ function DeniedRequests() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -139,6 +141,7 @@ function DeniedRequests() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -19,6 +19,7 @@ import useURLSort from 'hooks/useURLSort';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { SearchFilter } from 'types/search';
 import {
     RequestExpires,
     RequestIDLink,
@@ -91,7 +92,8 @@ function PendingApprovals() {
         searchFilter,
     });
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -140,6 +142,7 @@ function PendingApprovals() {
                     </ToolbarItem>
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
                             onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
                                 return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -38,6 +38,7 @@ import {
     clusterSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
+import { SearchFilter } from 'types/search';
 import { getRegexScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import DeploymentFilterLink from './DeploymentFilterLink';
@@ -149,12 +150,12 @@ function NamespaceViewPage() {
                     : selectedSearchFilter.filter((oldValue) => value !== oldValue),
         };
 
-        setSearchFilter(newFilter);
-        onFilterChange();
+        onFilterChange(newFilter);
         trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
     }
 
-    function onFilterChange() {
+    function onFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
         setPage(1);
     }
 
@@ -209,6 +210,7 @@ function NamespaceViewPage() {
                         </ToolbarItem>
                         <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                             <SearchFilterChips
+                                searchFilter={searchFilter}
                                 onFilterChange={onFilterChange}
                                 filterChipGroupDescriptors={filterChipGroupDescriptors}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -6,13 +6,13 @@ import { DropdownItem } from '@patternfly/react-core/deprecated';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 import useMap from 'hooks/useMap';
 import { VulnerabilityState } from 'types/cve.proto';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import CVEsTable, { ImageCVE, cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import { VulnerabilitySeverityLabel } from '../../types';
@@ -25,6 +25,8 @@ import CompletedExceptionRequestModal from '../../components/ExceptionRequestMod
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 
 export type CVEsTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -36,6 +38,8 @@ export type CVEsTableContainerProps = {
 };
 
 function CVEsTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -45,7 +49,6 @@ function CVEsTableContainer({
     workloadCvesScopedQueryString,
     isFiltered,
 }: CVEsTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -164,7 +167,7 @@ function CVEsTableContainer({
                     vulnerabilityState={vulnerabilityState}
                     createTableActions={createTableActions}
                     onClearFilters={() => {
-                        setSearchFilter({});
+                        onFilterChange({});
                         pagination.setPage(1);
                     }}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -4,15 +4,17 @@ import { Divider } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import { VulnerabilitySeverityLabel } from '../../types';
 
 type DeploymentsTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -24,6 +26,8 @@ type DeploymentsTableContainerProps = {
 };
 
 function DeploymentsTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -33,7 +37,6 @@ function DeploymentsTableContainer({
     isFiltered,
     showCveDetailFields,
 }: DeploymentsTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -75,7 +78,7 @@ function DeploymentsTableContainer({
                     filteredSeverities={searchFilter.SEVERITY as VulnerabilitySeverityLabel[]}
                     showCveDetailFields={showCveDetailFields}
                     onClearFilters={() => {
-                        setSearchFilter({});
+                        onFilterChange({});
                         pagination.setPage(1);
                     }}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -4,10 +4,10 @@ import { Divider } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSearch from 'hooks/useURLSearch';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
+import { SearchFilter } from 'types/search';
 import ImagesTable, { Image, ImagesTableProps, imageListQuery } from '../Tables/ImagesTable';
 import { VulnerabilitySeverityLabel } from '../../types';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
@@ -15,6 +15,8 @@ import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/Ta
 export { imageListQuery } from '../Tables/ImagesTable';
 
 type ImagesTableContainerProps = {
+    searchFilter: SearchFilter;
+    onFilterChange: (searchFilter: SearchFilter) => void;
     filterToolbar: TableEntityToolbarProps['filterToolbar'];
     entityToggleGroup: TableEntityToolbarProps['entityToggleGroup'];
     rowCount: number;
@@ -29,6 +31,8 @@ type ImagesTableContainerProps = {
 };
 
 function ImagesTableContainer({
+    searchFilter,
+    onFilterChange,
     filterToolbar,
     entityToggleGroup,
     rowCount,
@@ -41,7 +45,6 @@ function ImagesTableContainer({
     onUnwatchImage,
     showCveDetailFields,
 }: ImagesTableContainerProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage } = pagination;
     const { sortOption, getSortParams } = sort;
 
@@ -85,7 +88,10 @@ function ImagesTableContainer({
                     onWatchImage={onWatchImage}
                     onUnwatchImage={onUnwatchImage}
                     showCveDetailFields={showCveDetailFields}
-                    onClearFilters={() => setSearchFilter({})}
+                    onClearFilters={() => {
+                        onFilterChange({});
+                        pagination.setPage(1);
+                    }}
                 />
             </div>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -469,6 +469,8 @@ function WorkloadCvesOverviewPage() {
                             </Flex>
                             {activeEntityTabKey === 'CVE' && (
                                 <CVEsTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.CVE}
@@ -481,6 +483,8 @@ function WorkloadCvesOverviewPage() {
                             )}
                             {activeEntityTabKey === 'Image' && (
                                 <ImagesTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.Image}
@@ -503,6 +507,8 @@ function WorkloadCvesOverviewPage() {
                             )}
                             {activeEntityTabKey === 'Deployment' && (
                                 <DeploymentsTableContainer
+                                    searchFilter={searchFilter}
+                                    onFilterChange={setSearchFilter}
                                     filterToolbar={filterToolbar}
                                     entityToggleGroup={entityToggleGroup}
                                     rowCount={entityCounts.Deployment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadCveFilterToolbar.tsx
@@ -170,7 +170,8 @@ function WorkloadCveFilterToolbar({
                 )}
                 <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                     <SearchFilterChips
-                        onFilterChange={onFilterChange}
+                        searchFilter={searchFilter}
+                        onFilterChange={setSearchFilter}
                         filterChipGroupDescriptors={filterChipGroupDescriptors}
                     />
                 </ToolbarGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -42,7 +42,7 @@ const emptyDefaultFilters = {
 type AdvancedFiltersToolbarProps = {
     searchFilterConfig: CompoundSearchFilterProps['config'];
     searchFilter: SearchFilter;
-    onFilterChange: (searchFilter: SearchFilter, payload: OnSearchPayload) => void;
+    onFilterChange: (searchFilter: SearchFilter, payload?: OnSearchPayload) => void;
     cveStatusFilterField?: 'FIXABLE' | 'CLUSTER CVE FIXABLE';
     className?: string;
     defaultFilters?: DefaultFilters;
@@ -160,6 +160,8 @@ function AdvancedFiltersToolbar({
                 {getHasSearchApplied(searchFilter) && (
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips
+                            searchFilter={searchFilter}
+                            onFilterChange={onFilterChange}
                             filterChipGroupDescriptors={filterChipGroupDescriptors}
                         />
                     </ToolbarGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/telemetry.ts
@@ -13,13 +13,12 @@ type FilterAppliedEvent =
     | typeof PLATFORM_CVE_FILTER_APPLIED;
 
 export function createFilterTracker(analyticsTrack: (analyticsEvent: AnalyticsEvent) => void) {
-    return function trackAppliedFilter(event: FilterAppliedEvent, payload: OnSearchPayload) {
-        const { action, category, value: filter } = payload;
-
-        if (action !== 'ADD') {
+    return function trackAppliedFilter(event: FilterAppliedEvent, payload?: OnSearchPayload) {
+        if (!payload || payload.action !== 'ADD') {
             // Only track when a filter is applied, not removed
             return;
         }
+        const { category, value: filter } = payload;
 
         const telemetryEvent = isSearchCategoryWithFilter(category)
             ? { event, properties: { category, filter } }


### PR DESCRIPTION
### Description

Prerequisite refactor to allow multi-sort-by-severity in https://github.com/stackrox/stackrox/pull/12764. This removes the usage of `useURLSearch()` from the `<SearchFilterChips>` component and relies on the parent component to pass the state and setter down.

Why?

Due to the new sort functionality needing to update sort parameters each time the filter changes, we need to hook into the `setSearchFilter()` function that sets the search in the URL. However, the widely used `SearchFilterChips` component calls its own version of `useURLSearch()` internally, regardless of other calls up the component tree, and uses this hook to clear the filters.

This results in incorrect sorting when the user removes a severity sort via the filter chips.

The fix is to pass the `setSearchFilter()` function down to this component instead of it handling updates to global state itself.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manual testing of the following locations to verify search functionality works correctly:
- Listening Endpoints page
- Discovered clusters page
- Compliance coverage pages
- Violations page
- All VM Workload CVE related pages
