### PR TITLE
chore: Add notifier import test

### DIFF
--- a/central/notifiers/all/all_test.go
+++ b/central/notifiers/all/all_test.go
@@ -1,0 +1,56 @@
+package all
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var blacklist = []string{"all", "utils", "validation", "metadatagetter"}
+
+func TestAllPackagesAreImported(t *testing.T) {
+	migrationDirEntries, err := os.ReadDir("..")
+	require.NoError(t, err, "failed to read migrations directory")
+
+	existingNotifiers := set.NewStringSet()
+	for _, entry := range migrationDirEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		baseName := filepath.Base(entry.Name())
+
+		if slices.Contains(blacklist, baseName) {
+			continue
+		}
+		existingNotifiers.Add(baseName)
+	}
+
+	var allImports []*ast.ImportSpec
+	f, err := parser.ParseFile(token.NewFileSet(), "all.go", nil, parser.ImportsOnly)
+	require.NoError(t, err, "failed to parse all.go")
+
+	allImports = append(allImports, f.Imports...)
+
+	importedNotifiers := set.NewStringSet()
+	for _, imp := range allImports {
+		pkgName := strings.TrimSuffix(strings.TrimPrefix(imp.Path.Value, `"`), `"`)
+		pkgBaseName := path.Base(pkgName)
+		importedNotifiers.Add(pkgBaseName)
+	}
+
+	existingButNotImported := existingNotifiers.Difference(importedNotifiers)
+	importedButNotExisting := importedNotifiers.Difference(existingNotifiers)
+
+	assert.Emptyf(t, existingButNotImported, "some existing notifiers aren't imported")
+	assert.Empty(t, importedButNotExisting, "some imported notifiers don't exist")
+}

--- a/central/notifiers/all/all_test.go
+++ b/central/notifiers/all/all_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var blacklist = []string{"all", "utils", "validation", "metadatagetter"}
+var whitelist = []string{"all", "utils", "validation", "metadatagetter"}
 
 func TestAllPackagesAreImported(t *testing.T) {
 	notifiersDirEntry, err := os.ReadDir("..")
@@ -29,7 +29,7 @@ func TestAllPackagesAreImported(t *testing.T) {
 		}
 		baseName := filepath.Base(entry.Name())
 
-		if slices.Contains(blacklist, baseName) {
+		if slices.Contains(whitelist, baseName) {
 			continue
 		}
 		existingNotifiers.Add(baseName)

--- a/central/notifiers/all/all_test.go
+++ b/central/notifiers/all/all_test.go
@@ -19,11 +19,11 @@ import (
 var blacklist = []string{"all", "utils", "validation", "metadatagetter"}
 
 func TestAllPackagesAreImported(t *testing.T) {
-	migrationDirEntries, err := os.ReadDir("..")
-	require.NoError(t, err, "failed to read migrations directory")
+	notifiersDirEntry, err := os.ReadDir("..")
+	require.NoError(t, err, "failed to read notifiers directory")
 
 	existingNotifiers := set.NewStringSet()
-	for _, entry := range migrationDirEntries {
+	for _, entry := range notifiersDirEntry {
 		if !entry.IsDir() {
 			continue
 		}


### PR DESCRIPTION
### Description

Add notifier import test to notify engineers their notifier must be added to the `all.go` file.