### PR TITLE
ROX-26422: Include alert ID in API responses and alert notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - To revert back to synchronous TLS checks set `ROX_SENSOR_LAZY_TLS_CHECKS` to `false` on Sensor.
 - ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
 - ROX-22701: Prevent deleting default policies through the API
-- ROX-26422: Central will now include the `id` field in alert notifications. API responses from the violations endpoint include the `id` field too.
+- ROX-26422: Central will now include the `id` field in alert notifications and API responses.
 
 - ROX-20723: Remove monorepo substructure under `ui/` directory and switch from yarn v1 to npm for package management. Use `npm run` in place of `yarn` commands.
 - ROX-26306: Increase minimum Node.js version from `">=18.0.0"` to `"^18.18.0 || >=20.0.0"` for open source community to run `make lint` command in the ui directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - To revert back to synchronous TLS checks set `ROX_SENSOR_LAZY_TLS_CHECKS` to `false` on Sensor.
 - ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
 - ROX-22701: Prevent deleting default policies through the API
-- ROX-26422: Central will now include the `id` field in alert notifications.
+- ROX-26422: Central will now include the `id` field in alert notifications. API responses from the violations endpoint include the `id` field too.
 
 - ROX-20723: Remove monorepo substructure under `ui/` directory and switch from yarn v1 to npm for package management. Use `npm run` in place of `yarn` commands.
 - ROX-26306: Increase minimum Node.js version from `">=18.0.0"` to `"^18.18.0 || >=20.0.0"` for open source community to run `make lint` command in the ui directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - To revert back to synchronous TLS checks set `ROX_SENSOR_LAZY_TLS_CHECKS` to `false` on Sensor.
 - ROX-23343: The auto-sensing within the Helm charts for detecting OpenShift clusters has been changed to depend on the `project.openshift.io/v1` APIVersion.
 - ROX-22701: Prevent deleting default policies through the API
+- ROX-26422: Central will now include the `id` field in alert notifications.
 
 - ROX-20723: Remove monorepo substructure under `ui/` directory and switch from yarn v1 to npm for package management. Use `npm run` in place of `yarn` commands.
 - ROX-26306: Increase minimum Node.js version from `">=18.0.0"` to `"^18.18.0 || >=20.0.0"` for open source community to run `make lint` command in the ui directory.

--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -260,7 +260,7 @@ type Alert struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id             string         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Alert ID,hidden" sensorhash:"ignore" sql:"pk,type(uuid)"`                                                                            // Internal use only // @gotags: search:"Alert ID,hidden" sensorhash:"ignore" sql:"pk,type(uuid)"
+	Id             string         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Alert ID" sensorhash:"ignore" sql:"pk,type(uuid)"`                                                                            // @gotags: search:"Alert ID" sensorhash:"ignore" sql:"pk,type(uuid)"
 	Policy         *Policy        `protobuf:"bytes,2,opt,name=policy,proto3" json:"policy,omitempty" sql:"ignore_pk,ignore_unique,ignore_labels(Lifecycle Stage)"`                                                                    // @gotags: sql:"ignore_pk,ignore_unique,ignore_labels(Lifecycle Stage)"
 	LifecycleStage LifecycleStage `protobuf:"varint,3,opt,name=lifecycle_stage,json=lifecycleStage,proto3,enum=storage.LifecycleStage" json:"lifecycle_stage,omitempty" search:"Lifecycle Stage" sql:"index=btree"` // @gotags: search:"Lifecycle Stage" sql:"index=btree"
 	ClusterId      string         `protobuf:"bytes,18,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,store" sql:"type(uuid)"`                                            // @gotags: search:"Cluster ID,store" sql:"type(uuid)"

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -103,7 +103,7 @@ message Alert {
     string message = 2;
   }
 
-  string id = 1; // Internal use only // @gotags: search:"Alert ID,hidden" sensorhash:"ignore" sql:"pk,type(uuid)"
+  string id = 1; // @gotags: search:"Alert ID" sensorhash:"ignore" sql:"pk,type(uuid)"
   Policy policy = 2; // @gotags: sql:"ignore_pk,ignore_unique,ignore_labels(Lifecycle Stage)"
   LifecycleStage lifecycle_stage = 3; // @gotags: search:"Lifecycle Stage" sql:"index=btree"
 


### PR DESCRIPTION
### Description

To investigate alerts easier and being able to call them in the UI the alert notification now adds the alert ID. See the `id` field in the screeshot attached.

![Screenshot from 2024-09-27 15-01-41](https://github.com/user-attachments/assets/32e825e1-08a1-4f53-9143-712d835ecfd1)

## Testing

Trigger an alert and inspect the log.
