### PR TITLE
ROX-26411: Improve the upgrader nudge texts

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -830,7 +830,7 @@ func (c *sensorConnection) ObjectsDeletedByReconciliation() (map[string]int, boo
 
 func (c *sensorConnection) CheckAutoUpgradeSupport() error {
 	if c.sensorHello.GetHelmManagedConfigInit() != nil && !c.sensorHello.GetHelmManagedConfigInit().GetNotHelmManaged() {
-		return errors.New("cluster is Helm-managed and does not support auto upgrades; use 'helm upgrade' or a Helm-aware CD pipeline for upgrades")
+		return errors.New("secured cluster version is managed by external tools (helm, operator)")
 	}
 	return nil
 }

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -147,7 +147,7 @@ func (c *sensorConnection) Stopped() concurrency.ReadOnlyErrorSignal {
 // multiplexedPush pushes the given message to a dedicated queue for the respective event type.
 // The queues parameter, if non-nil, will be used to look up the queue by event type. If the `queues`
 // map is nil or does not contain an entry for the respective type, a queue is retrieved from the
-// mutex-protected `c.queues` map (and created if exists), and afterwards stored in the `queues` map
+// mutex-protected `c.queues` map (and created if exists), and afterward stored in the `queues` map
 // if non-nil.
 // The envisioned use for this is that a caller invoking `multiplexedPush` repeatedly will maintain
 // an exclusively used (i.e., not requiring protection via a mutex) map, that will automatically be
@@ -830,7 +830,7 @@ func (c *sensorConnection) ObjectsDeletedByReconciliation() (map[string]int, boo
 
 func (c *sensorConnection) CheckAutoUpgradeSupport() error {
 	if c.sensorHello.GetHelmManagedConfigInit() != nil && !c.sensorHello.GetHelmManagedConfigInit().GetNotHelmManaged() {
-		return errors.New("secured cluster version is managed by external tools (helm, operator)")
+		return errors.New("External tools (Helm or Operator) control the secured cluster version.")
 	}
 	return nil
 }

--- a/central/sensor/service/connection/upgradecontroller/trigger.go
+++ b/central/sensor/service/connection/upgradecontroller/trigger.go
@@ -129,11 +129,11 @@ func (u *upgradeController) doTriggerUpgrade() (common.MessageInjector, *central
 	case storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER:
 		// We still allow upgrade triggers in this case.
 	case storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED:
-		return nil, nil, errors.Errorf("manual upgrade required for cluster %s; cannot trigger upgrade", u.clusterID)
+		return nil, nil, errors.Errorf("ACS does not manage version for secured cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
 	case storage.ClusterUpgradeStatus_UP_TO_DATE:
 		return nil, nil, errors.Errorf("sensor for cluster %s is already up-to-date; cannot trigger upgrade", u.clusterID)
 	default:
-		return nil, nil, errors.Errorf("unknown upgradability status of sensor for cluster %s; cannot trigger upgrades", u.clusterID)
+		return nil, nil, errors.Errorf("unknown upgradability status of sensor for cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
 	}
 
 	cluster := u.getCluster()

--- a/central/sensor/service/connection/upgradecontroller/trigger.go
+++ b/central/sensor/service/connection/upgradecontroller/trigger.go
@@ -129,11 +129,11 @@ func (u *upgradeController) doTriggerUpgrade() (common.MessageInjector, *central
 	case storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER:
 		// We still allow upgrade triggers in this case.
 	case storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED:
-		return nil, nil, errors.Errorf("RHACS does not manage version for secured cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
+		return nil, nil, errors.Errorf("RHACS does not control the version for the secured cluster %s; cannot trigger upgrade or downgrade", u.clusterID)
 	case storage.ClusterUpgradeStatus_UP_TO_DATE:
 		return nil, nil, errors.Errorf("sensor for cluster %s is already up-to-date; cannot trigger upgrade", u.clusterID)
 	default:
-		return nil, nil, errors.Errorf("unknown upgradability status of sensor for cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
+		return nil, nil, errors.Errorf("The upgradability status for secured cluster %s is unclear; cannot trigger upgrade or downgrade", u.clusterID)
 	}
 
 	cluster := u.getCluster()

--- a/central/sensor/service/connection/upgradecontroller/trigger.go
+++ b/central/sensor/service/connection/upgradecontroller/trigger.go
@@ -129,7 +129,7 @@ func (u *upgradeController) doTriggerUpgrade() (common.MessageInjector, *central
 	case storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER:
 		// We still allow upgrade triggers in this case.
 	case storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED:
-		return nil, nil, errors.Errorf("ACS does not manage version for secured cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
+		return nil, nil, errors.Errorf("RHACS does not manage version for secured cluster %s; cannot trigger upgrade/downgrade", u.clusterID)
 	case storage.ClusterUpgradeStatus_UP_TO_DATE:
 		return nil, nil, errors.Errorf("sensor for cluster %s is already up-to-date; cannot trigger upgrade", u.clusterID)
 	default:

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -340,7 +340,7 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it(`should return "Secured cluster version is not managed by ${getProductBranding().reportName}." if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
+        it(`should return "Secured cluster version is not managed by ${getProductBranding().shortName}." if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
@@ -348,7 +348,7 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
-                displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}.`,
+                displayValue: `Secured cluster version is not managed by ${getProductBranding().shortName}.`,
                 type: 'intervention',
             };
             expect(received).toEqual(expected);

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -340,7 +340,7 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it(`should return "Version not managed by ${getProductBranding().reportName}" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
+        it(`should return "Secured cluster version is not managed by ${getProductBranding().reportName}" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -338,14 +338,14 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it('should return "Version not managed by ACS" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED', () => {
+        it('should return "Version not managed by RHACS" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED', () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
 
             const received = findUpgradeState(testUpgradeStatus);
 
-            const expected = { displayValue: 'Version not managed by ACS', type: 'intervention' };
+            const expected = { displayValue: 'Version not managed by RHACS', type: 'intervention' };
             expect(received).toEqual(expected);
         });
 

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -8,6 +8,8 @@ import {
     getUpgradeableClusters,
 } from './cluster.helpers';
 
+import { getProductBranding } from 'constants/productBranding';
+
 describe('cluster helpers', () => {
     describe('formatKubernetesVersion', () => {
         it('should return version of Kubernetes from the orchestrator metadata response', () => {
@@ -338,14 +340,31 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it('should return "Version not managed by RHACS" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED', () => {
+        it(`should return "Version not managed by ${getProductBranding().reportName}" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
 
             const received = findUpgradeState(testUpgradeStatus);
 
-            const expected = { displayValue: 'Version not managed by RHACS', type: 'intervention' };
+            const expected = {
+                displayValue: `Version not managed by ${getProductBranding().reportName}`,
+                type: 'intervention',
+            };
+            expect(received).toEqual(expected);
+        });
+
+        it('should return "Downgrade possible" if there is no mostRecentProcess', () => {
+            const testUpgradeStatus = {
+                upgradability: 'SENSOR_VERSION_HIGHER',
+            };
+
+            const received = findUpgradeState(testUpgradeStatus);
+
+            const expected = {
+                type: 'download',
+                actionText: 'Downgrade possible',
+            };
             expect(received).toEqual(expected);
         });
 

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -1,3 +1,5 @@
+import { getProductBranding } from 'constants/productBranding';
+
 import {
     findUpgradeState,
     formatSensorVersion,
@@ -7,8 +9,6 @@ import {
     getCredentialExpirationStatus,
     getUpgradeableClusters,
 } from './cluster.helpers';
-
-import { getProductBranding } from 'constants/productBranding';
 
 describe('cluster helpers', () => {
     describe('formatKubernetesVersion', () => {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -338,14 +338,14 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it('should return "Manual upgrade required" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED', () => {
+        it('should return "Version not managed by ACS" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED', () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
 
             const received = findUpgradeState(testUpgradeStatus);
 
-            const expected = { displayValue: 'Manual upgrade required', type: 'intervention' };
+            const expected = { displayValue: 'Version not managed by ACS', type: 'intervention' };
             expect(received).toEqual(expected);
         });
 

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -348,7 +348,7 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
-                displayValue: `Version not managed by ${getProductBranding().reportName}`,
+                displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}`,
                 type: 'intervention',
             };
             expect(received).toEqual(expected);

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -340,7 +340,7 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it(`should return "Secured cluster version is not managed by ${getProductBranding().reportName}" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
+        it(`should return "Secured cluster version is not managed by ${getProductBranding().reportName}." if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
@@ -348,7 +348,7 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
-                displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}`,
+                displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}.`,
                 type: 'intervention',
             };
             expect(received).toEqual(expected);

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -187,7 +187,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: 'Version not managed by ACS',
+        displayValue: 'Version not managed by RHACS',
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -187,12 +187,16 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: 'Manual upgrade required',
+        displayValue: 'Version not managed by ACS',
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {
         type: 'download',
         actionText: 'Upgrade available',
+    },
+    DOWNGRADE_POSSIBLE: {
+        type: 'download',
+        actionText: 'Downgrade possible',
     },
     UPGRADE_INITIALIZING: {
         displayValue: 'Upgrade initializing',
@@ -468,6 +472,17 @@ export function findUpgradeState(
         // and not really something we ever expect, but eh.) If the backend detects this to be the case, it will not
         // trigger an upgrade unless asked to by the user.
         case 'SENSOR_VERSION_HIGHER':
+          if (!hasRelevantInformationFromMostRecentUpgrade(upgradeStatus)) {
+            return upgradeStates.DOWNGRADE_POSSIBLE;
+          }
+
+          const upgradeState = get(
+            upgradeStatus,
+            'mostRecentProcess.progress.upgradeState',
+            'unknown'
+          );
+
+          return upgradeStates[upgradeState] || upgradeStates.unknown;
         case 'AUTO_UPGRADE_POSSIBLE': {
             if (!hasRelevantInformationFromMostRecentUpgrade(upgradeStatus)) {
                 return upgradeStates.UPGRADE_AVAILABLE;

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -471,18 +471,19 @@ export function findUpgradeState(
         // Auto upgrades are possible even in the case of SENSOR_VERSION_HIGHER (it's not technically an upgrade,
         // and not really something we ever expect, but eh.) If the backend detects this to be the case, it will not
         // trigger an upgrade unless asked to by the user.
-        case 'SENSOR_VERSION_HIGHER':
-          if (!hasRelevantInformationFromMostRecentUpgrade(upgradeStatus)) {
-            return upgradeStates.DOWNGRADE_POSSIBLE;
-          }
+        case 'SENSOR_VERSION_HIGHER': {
+            if (!hasRelevantInformationFromMostRecentUpgrade(upgradeStatus)) {
+                return upgradeStates.DOWNGRADE_POSSIBLE;
+            }
 
-          const upgradeState = get(
-            upgradeStatus,
-            'mostRecentProcess.progress.upgradeState',
-            'unknown'
-          );
+            const upgradeState = get(
+                upgradeStatus,
+                'mostRecentProcess.progress.upgradeState',
+                'unknown'
+            );
 
-          return upgradeStates[upgradeState] || upgradeStates.unknown;
+            return upgradeStates[upgradeState] || upgradeStates.unknown;
+        }
         case 'AUTO_UPGRADE_POSSIBLE': {
             if (!hasRelevantInformationFromMostRecentUpgrade(upgradeStatus)) {
                 return upgradeStates.UPGRADE_AVAILABLE;

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -14,6 +14,7 @@ import {
 
 import { Cluster, ClusterProviderMetadata } from 'types/cluster.proto';
 import { getDate } from 'utils/dateUtils';
+import { getProductBranding } from 'constants/productBranding';
 import { CertExpiryStatus } from './clusterTypes';
 
 export const runtimeOptions = [
@@ -187,7 +188,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: 'Version not managed by RHACS',
+        displayValue: `Version not managed by ${getProductBranding().reportName}`,
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -188,7 +188,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: `Version not managed by ${getProductBranding().reportName}`,
+        displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}`,
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -188,7 +188,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}.`,
+        displayValue: `Secured cluster version is not managed by ${getProductBranding().shortName}.`,
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -188,7 +188,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}`,
+        displayValue: `Secured cluster version is not managed by ${getProductBranding().reportName}.`,
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {

--- a/ui/apps/platform/src/constants/productBranding.ts
+++ b/ui/apps/platform/src/constants/productBranding.ts
@@ -16,6 +16,8 @@ export interface BrandingAssets {
     basePageTitle: string;
     /** Value for default subject of report e-mail */
     reportName: string;
+    /** Shortened version of product name */
+    shortName: string;
     /** Absolute path to the page favicon */
     favicon: string;
 }
@@ -26,6 +28,7 @@ const rhacsBranding: BrandingAssets = {
     logoAltText: 'Red Hat Advanced Cluster Security Logo',
     basePageTitle: 'Red Hat Advanced Cluster Security',
     reportName: 'Red Hat Advanced Cluster Security (RHACS)',
+    shortName: 'RHACS',
     favicon: rhacsFavicon,
 };
 
@@ -35,6 +38,7 @@ const stackroxBranding: BrandingAssets = {
     logoAltText: 'StackRox Logo',
     basePageTitle: 'StackRox',
     reportName: 'StackRox',
+    shortName: 'StackRox',
     favicon: stackroxFavicon,
 };
 


### PR DESCRIPTION
### Description

This PR updates some texts regarding the upgradability of the secured clusters. 

It addresses the following issues:
1. We should not indicate that a version is managed by Helm if it is managed by an operator
2. We should not speak of **upgrade** when in fact we mean **downgrade**
3. We should not use the word **required** when we propose a **downgrade**

in the following manner:
1. Instead we indicate that the version is not managed by ACS but by external tools - for example Helm or an operator
2. We use **upgrade** only if sensor is behind Central. In opposite case, we use word **downgrade**
3. If we discover that sensor can be downgraded, we do not use **required** but **possible** instead. The goal is to not stress the necessity.

What this PR is not addressing:
1. Instead of proposing a Sensor downgrade on **self-managed** cluster, we should recommend an upgrade of Central
2. Instead of proposing a Sensor downgrade on **managed** cluster, we should recommend **waiting** for an upgrade of Central

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

##### Who manages the cluster?

1. Deployed to GKE using Helm
2. Manually changed sensor version to lower
3. Expected the cluster page to report that the cluster version is not managed by ACS
4. Got: The clusters page gave a link to upgrade the cluster. Apparently the discovery of installation method does not work well. I [asked the install team
](https://redhat-internal.slack.com/archives/C073B14UE10/p1727696319624519) and moved on (this is outside of the scope for this PR).
5. I manually edited the secret `helm-cluster-config` and changed the respective values to force this cluster being recognized as managed by helm: `managedBy: MANAGER_TYPE_HELM` and `notHelmManaged: false`. After that, I restarted sensor.

Clusters table view:
![Screenshot 2024-10-08 at 17 30 05](https://github.com/user-attachments/assets/4c981ea2-1f2a-4e2f-bb92-532a5242a6e9)


Cluster details view:
![Screenshot 2024-10-08 at 17 22 16](https://github.com/user-attachments/assets/e528660f-3e38-42e3-acab-4a83040dfd93)


##### Downgrade situation

To validate the downgrade scenario, I would require (1) a sensor that has higher version, and (2) central that is based on this branch. I built two custom images from this branch - one 4.6.99, the other 4.6.98 - and shuffled them to trigger the downgrade scenario. The result is as on the screenshot.

![Screenshot 2024-09-30 at 15 08 30](https://github.com/user-attachments/assets/31d80e86-980f-44ec-94dc-505a7c829d77)

Cluster details view:
![Screenshot 2024-09-30 at 15 10 01](https://github.com/user-attachments/assets/cde34932-a5a4-4763-9713-9a9f564c6f70)
