### PR TITLE
ROX-26428: Ensure image ID is not lost when evaluating mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
     - Previously when reading Red Hat's OVAL data, the vulnerabilities dated back to pre-2000, but ClairCore only reads back to 2014.
   - Scanner V4 DB requires less space for vulnerability data, and its initialization time has improved from about 1 hour on SSD to about 10 minutes.
 - ROX-26372: `ROX_POSTGRES_VM_STATEMENT_TIMEOUT` env var defaulting to 3 minutes to allow customers to extend the timeout for queries backing VM pages only
+- ROX-26428: Fixed a bug when using delegated scanning where newer image metadata and layers were pulled incorrectly for an older image referenced by tag when the image registry contents have changed since deployment.
+  - Now the metadata and layers pulled will be based on the digest of the image provided by the container runtime (when available) instead of just the tag.
 
 ## [4.5.0]
 

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -206,7 +206,7 @@ func (s *FileStore) PullSources(srcImage string) ([]string, error) {
 	}
 
 	if reg == nil {
-		return []string{srcImage}, nil
+		return nil, os.ErrNotExist
 	}
 
 	// ParseNamed assumes srcImage is a fully qualified references (contains a hostname), will produce error

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -2,6 +2,7 @@ package registrymirror
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -199,14 +200,12 @@ func (s *FileStore) updateConfigNow() error {
 func (s *FileStore) PullSources(srcImage string) ([]string, error) {
 	// FindRegistry will parse the registries config file and cache it for future usage.
 	reg, err := sysregistriesv2.FindRegistry(s.systemContext, srcImage)
-	// Using errors.Is instead of os.IsNotExist because the return from FindRegistry
-	// wraps the error in a type that os.IsNotExist ignores.
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.Wrap(err, "failed finding registry")
+	if err != nil {
+		return nil, err
 	}
 
 	if reg == nil {
-		return nil, os.ErrNotExist
+		return nil, fs.ErrNotExist
 	}
 
 	// ParseNamed assumes srcImage is a fully qualified references (contains a hostname), will produce error

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -2,7 +2,6 @@ package registrymirror
 
 import (
 	"bytes"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -205,7 +204,7 @@ func (s *FileStore) PullSources(srcImage string) ([]string, error) {
 	}
 
 	if reg == nil {
-		return nil, fs.ErrNotExist
+		return nil, nil
 	}
 
 	// ParseNamed assumes srcImage is a fully qualified references (contains a hostname), will produce error

--- a/pkg/registrymirror/store_test.go
+++ b/pkg/registrymirror/store_test.go
@@ -2,6 +2,7 @@ package registrymirror
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -219,7 +220,7 @@ func TestPullSources(t *testing.T) {
 		s := NewFileStore(WithConfigPath(path))
 
 		srcs, err := s.PullSources(icspImageWithDigest)
-		require.ErrorIs(t, err, os.ErrNotExist)
+		require.ErrorIs(t, err, fs.ErrNotExist)
 		assert.Zero(t, srcs)
 	})
 
@@ -232,7 +233,7 @@ func TestPullSources(t *testing.T) {
 		s := NewFileStore(WithConfigPath(path))
 
 		srcs, err := s.PullSources(icspImageWithDigest)
-		require.ErrorIs(t, err, os.ErrNotExist)
+		require.ErrorIs(t, err, fs.ErrNotExist)
 		assert.Zero(t, srcs)
 	})
 
@@ -355,7 +356,7 @@ func TestPullSources(t *testing.T) {
 
 		src := "nginx:latest"
 		srcs, err := s.PullSources(src)
-		require.ErrorIs(t, err, os.ErrNotExist)
+		require.ErrorIs(t, err, fs.ErrNotExist)
 		assert.Zero(t, srcs)
 	})
 }

--- a/pkg/registrymirror/store_test.go
+++ b/pkg/registrymirror/store_test.go
@@ -224,7 +224,7 @@ func TestPullSources(t *testing.T) {
 		assert.Zero(t, srcs)
 	})
 
-	t.Run("return error when config is empty", func(t *testing.T) {
+	t.Run("return nil when config is empty", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), fileName)
 
 		_, err := os.Create(path)
@@ -233,7 +233,7 @@ func TestPullSources(t *testing.T) {
 		s := NewFileStore(WithConfigPath(path))
 
 		srcs, err := s.PullSources(icspImageWithDigest)
-		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.NoError(t, err)
 		assert.Zero(t, srcs)
 	})
 
@@ -346,7 +346,7 @@ func TestPullSources(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("unqualified hostname returns error", func(t *testing.T) {
+	t.Run("unqualified hostname returns nil", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), fileName)
 
 		s := NewFileStore(WithConfigPath(path), WithDelay(0))
@@ -356,7 +356,7 @@ func TestPullSources(t *testing.T) {
 
 		src := "nginx:latest"
 		srcs, err := s.PullSources(src)
-		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.NoError(t, err)
 		assert.Zero(t, srcs)
 	})
 }

--- a/pkg/registrymirror/store_test.go
+++ b/pkg/registrymirror/store_test.go
@@ -213,18 +213,17 @@ func TestPullSources(t *testing.T) {
 	itmsImageWithDigest := fmt.Sprintf(itmsfmtStr, digest)
 	itmsImageWithTag := fmt.Sprintf(itmsfmtStr, tag)
 
-	t.Run("return source image when config does not exist", func(t *testing.T) {
+	t.Run("return error when config does not exist", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), fileName)
 
 		s := NewFileStore(WithConfigPath(path))
 
 		srcs, err := s.PullSources(icspImageWithDigest)
-		assert.NoError(t, err)
-		require.Len(t, srcs, 1)
-		assert.Equal(t, icspImageWithDigest, srcs[0])
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.Zero(t, srcs)
 	})
 
-	t.Run("return source image when config is empty", func(t *testing.T) {
+	t.Run("return error when config is empty", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), fileName)
 
 		_, err := os.Create(path)
@@ -233,9 +232,8 @@ func TestPullSources(t *testing.T) {
 		s := NewFileStore(WithConfigPath(path))
 
 		srcs, err := s.PullSources(icspImageWithDigest)
-		assert.NoError(t, err)
-		require.Len(t, srcs, 1)
-		assert.Equal(t, icspImageWithDigest, srcs[0])
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.Zero(t, srcs)
 	})
 
 	t.Run("return mirrors from ICSP", func(t *testing.T) {
@@ -347,7 +345,7 @@ func TestPullSources(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("unqualified hostname returns source image", func(t *testing.T) {
+	t.Run("unqualified hostname returns error", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), fileName)
 
 		s := NewFileStore(WithConfigPath(path), WithDelay(0))
@@ -357,8 +355,7 @@ func TestPullSources(t *testing.T) {
 
 		src := "nginx:latest"
 		srcs, err := s.PullSources(src)
-		require.NoError(t, err)
-		require.Len(t, srcs, 1)
-		assert.Equal(t, src, srcs[0])
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.Zero(t, srcs)
 	})
 }

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"time"
 
 	pkgErrors "github.com/pkg/errors"
@@ -290,7 +290,7 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 func (s *LocalScan) getPullSources(srcImage *storage.ContainerImage) []*storage.ContainerImage {
 	pullSources, err := s.mirrorStore.PullSources(srcImage.GetName().GetFullName())
 	// A not exist error is expected when mirroring is not setup, therefore we do not log it.
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		log.Warnf("Error obtaining pull sources: %v", err)
 	}
 

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	pkgErrors "github.com/pkg/errors"
@@ -288,14 +289,15 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 
 func (s *LocalScan) getPullSources(srcImage *storage.ContainerImage) []*storage.ContainerImage {
 	pullSources, err := s.mirrorStore.PullSources(srcImage.GetName().GetFullName())
-	if err != nil {
+	// A not exist error is expected when mirroring is not setup, therefore we do not log it.
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Warnf("Error obtaining pull sources: %v", err)
 	}
 
 	if len(pullSources) == 0 {
 		// If no pull source was found due to an error or some other reason, we
 		// default to the source image.
-		log.Debugf("Using source image only for enriching %q", srcImage.GetName().GetFullName())
+		log.Debugf("Using source image only for enriching %q (id: %q)", srcImage.GetName().GetFullName(), srcImage.GetId())
 		return []*storage.ContainerImage{srcImage}
 	}
 
@@ -308,10 +310,23 @@ func (s *LocalScan) getPullSources(srcImage *storage.ContainerImage) []*storage.
 			continue
 		}
 
+		// This ID assignment addresses an edge case where a podspec references an image
+		// by tag (e.g. latest) and the registry contents for that tag change after the pod was
+		// created. We want to ensure that we pull metadata and layers based on the
+		// ID (digest) of the running image instead of what the tag currently represents.
+		// This condition will only be true for mirrors setup via the ImageTagMirrorSet (ITMS) CR,
+		// the other supported CRs, ImageContentSourcePolicy (ICSP) and ImageDigestMirrorSet (IDMS),
+		// will only match IF the podspec references the image by digest, in which case ID
+		// would be populated and this condition never true.
+		if img.GetId() == "" && srcImage.GetId() != "" {
+			log.Debugf("Adding id from source image %q (id: %q) to pull source %q", srcImage.GetName().GetFullName(), srcImage.GetId(), img.GetName().GetFullName())
+			img.Id = srcImage.GetId()
+		}
+
 		cImages = append(cImages, img)
 	}
 
-	log.Debugf("Using %d pull sources for enriching %q: %+v", len(cImages), srcImage.GetName().GetFullName(), cImages)
+	log.Debugf("Using %d pull sources for enriching %q (id: %q): %+v", len(cImages), srcImage.GetName().GetFullName(), srcImage.GetId(), cImages)
 	return cImages
 }
 

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -314,8 +314,8 @@ func (s *LocalScan) getPullSources(srcImage *storage.ContainerImage) []*storage.
 		// by tag (e.g. latest) and the registry contents for that tag change after the pod was
 		// created. We want to ensure that we pull metadata and layers based on the
 		// ID (digest) of the running image instead of what the tag currently represents.
-		// This condition will only be true for mirrors setup via the ImageTagMirrorSet (ITMS) CR,
-		// the other supported CRs, ImageContentSourcePolicy (ICSP) and ImageDigestMirrorSet (IDMS),
+		// This condition will only be true for mirrors setup via the ImageTagMirrorSet (ITMS) CR.
+		// The other supported CRs, ImageContentSourcePolicy (ICSP) and ImageDigestMirrorSet (IDMS),
 		// will only match IF the podspec references the image by digest, in which case ID
 		// would be populated and this condition never true.
 		if img.GetId() == "" && srcImage.GetId() != "" {

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -3,7 +3,7 @@ package scan
 import (
 	"context"
 	"errors"
-	"os"
+	"io/fs"
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -560,7 +560,7 @@ func (suite *scanTestSuite) TestGetPullSourceIDKeep() {
 		mirrorStore := mirrorStoreMocks.NewMockStore(gomock.NewController(suite.T()))
 		scan := LocalScan{mirrorStore: mirrorStore}
 
-		mirrorStore.EXPECT().PullSources(gomock.Any()).Return(nil, os.ErrNotExist)
+		mirrorStore.EXPECT().PullSources(gomock.Any()).Return(nil, fs.ErrNotExist)
 
 		pullSrcs := scan.getPullSources(srcImg)
 		suite.Require().Len(pullSrcs, 1)


### PR DESCRIPTION
### Description

Addresses an edge case when a podspec's image is referenced by tag, and the registry contents for that tag change after the image has been deployed. To ensure the correct metadata and layers are pulled, we add the image ID from the runtime (if provided) to the 'pull sources' used in delegated scanning - this way the correct metadata and layers are pulled.

Prior to this change the current/latest tag contents were used, which may not have matched the previously deployed image.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Setup: Enabled delegated scanning, created an image, pushed it to quay, created a deployment, then updated the image, pushed it to quay, and created a second deployment. 

<details>
<summary>Creating Deployments</summary>

Creating Deployment dave-1:
```
$ cat Dockerfile 
FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194

RUN echo "$(date)" > /curdate.txt

ENTRYPOINT [ "/bin/sh", "-c"]
CMD [ "trap : TERM INT; sleep 9999999999d & wait" ]

$ docker built -t quay.io/dcaravel/temp:tag

$ docker push quay.io/dcaravel/temp:tag
```
```
$ k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dave-1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dave-1
  template:
    metadata:
      labels:
        app: dave-1
    spec:
      containers:
      - name: main
        imagePullPolicy: Always
        image: quay.io/dcaravel/temp:tag
EOF
```
---

Creating deployment dave-2:
```
$ cat Dockerfile 
FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227

RUN echo "$(date)" > /curdate.txt

ENTRYPOINT [ "/bin/sh", "-c"]
CMD [ "trap : TERM INT; sleep 9999999999d & wait" ]

$ docker built -t quay.io/dcaravel/temp:tag

$ docker push quay.io/dcaravel/temp:tag
```
```
$ k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dave-2
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dave-2
  template:
    metadata:
      labels:
        app: dave-2
    spec:
      containers:
      - name: main
        imagePullPolicy: Always
        image: quay.io/dcaravel/temp:tag
EOF
```
</details>

Confirm the deployments are referencing different images:

```
$ k get pod -lapp=dave-1 -o yaml | yq '.items[].status.containerStatuses[].imageID'
quay.io/dcaravel/temp@sha256:7a501891439dc0b992b073259a31ba513fc7b0021243989e79eaed7f0334d99e

$ k get pod -lapp=dave-2 -o yaml | yq '.items[].status.containerStatuses[].imageID'
quay.io/dcaravel/temp@sha256:778fc952c0aa022e9098c9595734cc7131d702b11a3bbc05d9eb26fa65b1b98c
```

Before the fix notice both images returned from Central API have different IDs but same metadata (only layersShas shown):

```
$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:7a501891439dc0b992b073259a31ba513fc7b0021243989e79eaed7f0334d99e | jq -r '.id, .name, .metadata.layerShas'
sha256:7a501891439dc0b992b073259a31ba513fc7b0021243989e79eaed7f0334d99e
{
  "registry": "quay.io",
  "remote": "dcaravel/temp",
  "tag": "tag",
  "fullName": "quay.io/dcaravel/temp:tag"
}
[
  "sha256:0fa3315a0cca1299566b56c9efd78f83279c1fc50fa6e5b7297565ba6f007253",
  "sha256:ab2c030720eca147fb64ad223cd34e141305f5a495da5d3bcebf2f193bc8a2f0"
]

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:778fc952c0aa022e9098c9595734cc7131d702b11a3bbc05d9eb26fa65b1b98c | jq -r '.id, .name, .metadata.layerShas'
sha256:778fc952c0aa022e9098c9595734cc7131d702b11a3bbc05d9eb26fa65b1b98c
{
  "registry": "quay.io",
  "remote": "dcaravel/temp",
  "tag": "tag",
  "fullName": "quay.io/dcaravel/temp:tag"
}
[
  "sha256:0fa3315a0cca1299566b56c9efd78f83279c1fc50fa6e5b7297565ba6f007253",
  "sha256:ab2c030720eca147fb64ad223cd34e141305f5a495da5d3bcebf2f193bc8a2f0"
]

```
After this change notice both images have different / correct metadata:

```
$ k set image deploy/sensor *=quay.io/rhacs-eng/main:4.6.x-588-gef8bb6e20b

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:7a501891439dc0b992b073259a31ba513fc7b0021243989e79eaed7f0334d99e | jq -r '.id, .name, .metadata.layerShas'
sha256:7a501891439dc0b992b073259a31ba513fc7b0021243989e79eaed7f0334d99e
{
  "registry": "quay.io",
  "remote": "dcaravel/temp",
  "tag": "tag",
  "fullName": "quay.io/dcaravel/temp:tag"
}
[
  "sha256:423c986e97ebd515f172eb484f176107e279ad0ac1db8ead5b21a60a208a8b3c",
  "sha256:32c48a5a9e6c127261e4594922b5dd2bee248e9e57d08819fe66a7a37b8a9abf"
]

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:778fc952c0aa022e9098c9595734cc7131d702b11a3bbc05d9eb26fa65b1b98c | jq -r '.id, .name, .metadata.layerShas'
sha256:778fc952c0aa022e9098c9595734cc7131d702b11a3bbc05d9eb26fa65b1b98c
{
  "registry": "quay.io",
  "remote": "dcaravel/temp",
  "tag": "tag",
  "fullName": "quay.io/dcaravel/temp:tag"
}
[
  "sha256:0fa3315a0cca1299566b56c9efd78f83279c1fc50fa6e5b7297565ba6f007253",
  "sha256:ab2c030720eca147fb64ad223cd34e141305f5a495da5d3bcebf2f193bc8a2f0"
]
```
---
Also tested with mirroring (created two new images and deployments following the same procedure as above):

<details>
<summary>Setup</summary>

```
$ k apply -f - <<EOF
apiVersion: config.openshift.io/v1 
kind: ImageTagMirrorSet 
metadata:
  name: itms-invalid
spec:
  imageTagMirrors: 
  - mirrors:
    - quay.io
    source: itms.invalid
    mirrorSourcePolicy: NeverContactSource 
EOF

$ ### WAIT for changes to propagate to all nodes via machine config operator
$ watch k get machineconfigpools
```
Deploys:

```
$ k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dave-mirror-1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dave-mirror-1
  template:
    metadata:
      labels:
        app: dave-mirror-1
    spec:
      containers:
      - name: main
        imagePullPolicy: Always
        image: itms.invalid/dcaravel/temp:mirror
EOF
```
```
$ k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dave-mirror-2
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dave-mirror-2
  template:
    metadata:
      labels:
        app: dave-mirror-2
    spec:
      containers:
      - name: main
        imagePullPolicy: Always
        image: itms.invalid/dcaravel/temp:mirror
EOF
```
</details>

Confirm the deployments are referencing different images:

```
$ k get pod -lapp=dave-mirror-1 -o yaml | yq '.items[].status.containerStatuses[].imageID'
itms.invalid/dcaravel/temp@sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93

$ k get pod -lapp=dave-mirror-2 -o yaml | yq '.items[].status.containerStatuses[].imageID'
itms.invalid/dcaravel/temp@sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791
```

Before the fix notice both images returned from Central API have different IDs but same metadata (only layersShas shown):

```
$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93 | jq -r '.id, .name, .metadata.layerShas'
sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93
{
  "registry": "itms.invalid",
  "remote": "dcaravel/temp",
  "tag": "mirror",
  "fullName": "itms.invalid/dcaravel/temp:mirror"
}
[
  "sha256:326471b26cd6ab8ee60fd200bcb3334694cdd3ebccd00f547b8b8cc57d4385b7",
  "sha256:79b40feb9783a53aa7f3d37b48863ae7c933f9c1fc5807db0edb91ed63b52cfe"
]

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791 | jq -r '.id, .name, .metadata.layerShas'
sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791
{
  "registry": "itms.invalid",
  "remote": "dcaravel/temp",
  "tag": "mirror",
  "fullName": "itms.invalid/dcaravel/temp:mirror"
}
[
  "sha256:326471b26cd6ab8ee60fd200bcb3334694cdd3ebccd00f547b8b8cc57d4385b7",
  "sha256:79b40feb9783a53aa7f3d37b48863ae7c933f9c1fc5807db0edb91ed63b52cfe"
]
```

After this change notice both images have different / correct metadata:

```
$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93 | jq -r '.id, .name, .metadata.layerShas'
sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93
{
  "registry": "itms.invalid",
  "remote": "dcaravel/temp",
  "tag": "mirror",
  "fullName": "itms.invalid/dcaravel/temp:mirror"
}
[
  "sha256:fde3ad1312f50f2db257eccb0d703c851e5234f26ef15c95c404990228bb014d",
  "sha256:b549e992c486bd405f5b227134df1192a0f6e05e9133232cd77395172d54eda0"
]

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791 | jq -r '.id, .name, .metadata.layerShas'
sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791
{
  "registry": "itms.invalid",
  "remote": "dcaravel/temp",
  "tag": "mirror",
  "fullName": "itms.invalid/dcaravel/temp:mirror"
}
[
  "sha256:326471b26cd6ab8ee60fd200bcb3334694cdd3ebccd00f547b8b8cc57d4385b7",
  "sha256:79b40feb9783a53aa7f3d37b48863ae7c933f9c1fc5807db0edb91ed63b52cfe"
]


```

And the logs from sensor indicate the swap happened:
```
$ da tail sensor | grep -i "Adding id from source image"
common/scan: 2024/09/27 19:39:27.409796 scan.go:311: Debug: Adding id from source image "itms.invalid/dcaravel/temp:mirror" (id: "sha256:1b867adfff1b2e6410b06010f436e0ff474f3e9c6a52083e6e663a209b2c8f93") to pull source "quay.io/dcaravel/temp:mirror"
common/scan: 2024/09/27 19:39:27.410411 scan.go:311: Debug: Adding id from source image "itms.invalid/dcaravel/temp:mirror" (id: "sha256:7194fd0f6dc0e589181dfcfd288cb80e08c921c1dd93416011b9ac6c1bf93791") to pull source "quay.io/dcaravel/temp:mirror"
```

And for good measure, here is the output from `docker inspect` for each image:

<details>

```
$ docker manifest inspect quay.io/dcaravel/temp:tag-1
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 6885,
		"digest": "sha256:857e76696c0d63c462ed7940fe27f66597e146aef965a0442c495e8a18c50292"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 37532117,
			"digest": "sha256:423c986e97ebd515f172eb484f176107e279ad0ac1db8ead5b21a60a208a8b3c"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 137,
			"digest": "sha256:32c48a5a9e6c127261e4594922b5dd2bee248e9e57d08819fe66a7a37b8a9abf"
		}
	]
}

$ docker manifest inspect quay.io/dcaravel/temp:tag-2
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 6883,
		"digest": "sha256:e2515841938dfda052b5b23b9ff73e3b4f3ca6f6ad896c3db121df382eb32eea"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 37787103,
			"digest": "sha256:0fa3315a0cca1299566b56c9efd78f83279c1fc50fa6e5b7297565ba6f007253"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 135,
			"digest": "sha256:ab2c030720eca147fb64ad223cd34e141305f5a495da5d3bcebf2f193bc8a2f0"
		}
	]
}

$ docker manifest inspect quay.io/dcaravel/temp:mirror-1
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 6883,
		"digest": "sha256:f7e9773cbbab2f619d1727dcc942b0b983ee37f835e397588296c1f1b4fb2d4d"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 37531673,
			"digest": "sha256:fde3ad1312f50f2db257eccb0d703c851e5234f26ef15c95c404990228bb014d"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 135,
			"digest": "sha256:b549e992c486bd405f5b227134df1192a0f6e05e9133232cd77395172d54eda0"
		}
	]
}

$ docker manifest inspect quay.io/dcaravel/temp:mirror-2
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 6881,
		"digest": "sha256:35939ddbe28db45ee4de5937af2fbced04d1ac6196bf2cb83bbb5b790cb707cb"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 37545452,
			"digest": "sha256:326471b26cd6ab8ee60fd200bcb3334694cdd3ebccd00f547b8b8cc57d4385b7"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 135,
			"digest": "sha256:79b40feb9783a53aa7f3d37b48863ae7c933f9c1fc5807db0edb91ed63b52cfe"
		}
	]
}
```

</details>