### PR TITLE
refactor(ui): Wording changes for compliance and reporting

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -32,7 +32,7 @@ describe('Compliance Schedules', () => {
 
         cy.get('th[scope="col"]:contains("Name")');
         cy.get('th[scope="col"]:contains("Schedule")');
-        cy.get('th[scope="col"]:contains("Last run")');
+        cy.get('th[scope="col"]:contains("Last scanned")');
         cy.get('th[scope="col"]:contains("Clusters")');
         cy.get('th[scope="col"]:contains("Profiles")');
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -205,7 +205,7 @@ function ScanConfigsTablePage({
                         <Link to={scanConfigUrl}>{scanName}</Link>
                     </Td>
                     <Td dataLabel="Schedule">{formatScanSchedule(scanConfig.scanSchedule)}</Td>
-                    <Td dataLabel="Last run">
+                    <Td dataLabel="Last scanned">
                         {lastExecutedTime
                             ? getTimeWithHourMinuteFromISO8601(lastExecutedTime)
                             : 'Scanning now'}
@@ -340,7 +340,7 @@ function ScanConfigsTablePage({
                             <Tr>
                                 <Th sort={getSortParams('Compliance Scan Config Name')}>Name</Th>
                                 <Th>Schedule</Th>
-                                <Th>Last run</Th>
+                                <Th>Last scanned</Th>
                                 <Th>Clusters</Th>
                                 <Th>Profiles</Th>
                                 {hasWriteAccessForCompliance && <Td />}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -60,7 +60,7 @@ function ConfigDetails({ isLoading, error, scanConfig }: ConfigDetailsProps) {
                     scanSchedule={scanConfig.scanConfig.scanSchedule}
                 >
                     <DescriptionListGroup>
-                        <DescriptionListTerm>Last run</DescriptionListTerm>
+                        <DescriptionListTerm>Last scanned</DescriptionListTerm>
                         <DescriptionListDescription>
                             {scanConfig.lastExecutedTime
                                 ? getTimeWithHourMinuteFromISO8601(scanConfig.lastExecutedTime)

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -215,7 +215,7 @@ function ViewVulnReportPage() {
                                     </DropdownItem>,
                                     <DropdownSeparator key="separator" />,
                                     <DropdownItem
-                                        key="Send report now"
+                                        key="Send report"
                                         component="button"
                                         onClick={() => runReport(reportId, 'EMAIL')}
                                         isDisabled={
@@ -229,7 +229,7 @@ function ViewVulnReportPage() {
                                                 : ''
                                         }
                                     >
-                                        Send report now
+                                        Send report
                                     </DropdownItem>,
                                     <DropdownItem
                                         key="Generate download"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -463,7 +463,7 @@ function VulnReportsPage() {
                                                 isSeparator: true,
                                             },
                                             {
-                                                title: 'Send report now',
+                                                title: 'Send report',
                                                 description:
                                                     report.notifiers.length === 0
                                                         ? 'No delivery destinations set'


### PR DESCRIPTION
### Description

This PR adds changes some text:
1. We will use `Send report` instead of `Send report now` in VM Reports to align with the wording used in Compliance.
2. We will changed `Last run` to `Last scanned` in the Scan Schedules table to be more specific and correct about the terminology.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [] no added tests

#### How I validated my change

<img width="1440" alt="Screenshot 2024-09-29 at 12 40 13 PM" src="https://github.com/user-attachments/assets/c989ce13-1009-47c6-958a-cd99d9ee2e4d">
<img width="1440" alt="Screenshot 2024-09-29 at 12 40 19 PM" src="https://github.com/user-attachments/assets/b3c49aac-c9db-4cc4-8bca-63578a6d87e5">


