### PR TITLE
ROX-26308: Fix First discovered time for affected images

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -182,7 +182,7 @@ function AffectedImagesTable({
                                                 date={getEarliestDiscoveredAtTime(vulnerabilities)}
                                             />
                                         ) : (
-                                            'N/A'
+                                            'Not available'
                                         )}
                                     </Td>
                                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
@@ -1,7 +1,9 @@
+import { NonEmptyArray } from 'utils/type.utils';
 import {
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,
     getHighestCvssScore,
+    getEarliestDiscoveredAtTime,
 } from './vulnerabilityUtils';
 
 const CRITICAL = 'CRITICAL_VULNERABILITY_SEVERITY';
@@ -85,6 +87,17 @@ describe('vulnerability utils', () => {
                 cvss: 6.0,
                 scoreVersion: '2.0',
             });
+        });
+    });
+
+    describe('getEarliestDiscoveredAtTime', () => {
+        it('returns the earliest discoveredAt time from the vulnerabilities', () => {
+            const vulnerabilities: NonEmptyArray<{ discoveredAtImage: string }> = [
+                { discoveredAtImage: '2021-01-01T00:00:00Z' },
+                { discoveredAtImage: '2021-01-02T00:00:00Z' },
+                { discoveredAtImage: '2021-01-03T00:00:00Z' },
+            ];
+            expect(getEarliestDiscoveredAtTime(vulnerabilities)).toEqual('2021-01-01T00:00:00Z');
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
@@ -1,5 +1,6 @@
 import { severityRankings } from 'constants/vulnerabilities';
 import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
+import { NonEmptyArray } from 'utils/type.utils';
 
 /**
  * Get the highest severity of any vulnerability in the component array.
@@ -44,4 +45,16 @@ export function getHighestCvssScore(vulnerabilities: { cvss: number; scoreVersio
         }
     });
     return { cvss: topCvss, scoreVersion: topScoreVersion };
+}
+
+export function getEarliestDiscoveredAtTime(
+    vulnerabilities: NonEmptyArray<{ discoveredAtImage: string }>
+): string {
+    let earliestDiscoveredAt = vulnerabilities[0].discoveredAtImage;
+    vulnerabilities.forEach(({ discoveredAtImage }) => {
+        if (discoveredAtImage.localeCompare(earliestDiscoveredAt) < 0) {
+            earliestDiscoveredAt = discoveredAtImage;
+        }
+    });
+    return earliestDiscoveredAt;
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
@@ -52,7 +52,7 @@ export function getEarliestDiscoveredAtTime(
 ): string {
     let earliestDiscoveredAt = vulnerabilities[0].discoveredAtImage;
     vulnerabilities.forEach(({ discoveredAtImage }) => {
-        if (discoveredAtImage.localeCompare(earliestDiscoveredAt) < 0) {
+        if (discoveredAtImage < earliestDiscoveredAt) {
             earliestDiscoveredAt = discoveredAtImage;
         }
     });


### PR DESCRIPTION
### Description

Fixes the "First discovered" data on the affected images page by using `image->imageComponents->imageVulnerabilities->discoveredAtImage` instead of `image->scanTime`.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Note the time displayed in the header label versus the time displayed in the individual table rows.

Before:
![image](https://github.com/user-attachments/assets/8a134c6b-d36a-4cea-80bc-06350a5b67c3)

After:
![image](https://github.com/user-attachments/assets/253b91b3-d0df-43d3-9c98-b98266bb160b)
