### PR TITLE
ROX-26661: Introduce and use AuthProvider revert options

### DIFF
--- a/central/authprovider/service/service_impl_test.go
+++ b/central/authprovider/service/service_impl_test.go
@@ -114,5 +114,5 @@ func (s *authProviderServiceTestSuite) TestPostDuplicateAuthProvider() {
 	// in a follow-up PR.
 	_, err = s.service.PostAuthProvider(ctx, postRequest)
 	s.Error(err)
-	s.Equal(3, openshiftAuth.GetRegisteredBackendCount())
+	s.Equal(2, openshiftAuth.GetRegisteredBackendCount())
 }

--- a/pkg/auth/authproviders/oidc/registry_impl_test.go
+++ b/pkg/auth/authproviders/oidc/registry_impl_test.go
@@ -78,6 +78,7 @@ func TestDeleteAuthProvider(t *testing.T) {
 	}
 
 	providerStore.EXPECT().AddAuthProvider(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	providerStore.EXPECT().GetAuthProvider(gomock.Any(), gomock.Any()).Times(1).Return(testProvider, true, nil)
 
 	provider, err := registry.CreateProvider(ctx, authproviders.WithStorageView(testProvider))
 	assert.NoError(t, err)

--- a/pkg/auth/authproviders/provider_commands.go
+++ b/pkg/auth/authproviders/provider_commands.go
@@ -20,15 +20,32 @@ func DefaultAddToStore(ctx context.Context, store Store) ProviderOption {
 		if pr.doNotStore {
 			return noOpRevert, nil
 		}
-		providerID := pr.storedInfo.GetId()
-		revert := func(pr *providerImpl) error {
-			return store.RemoveAuthProvider(ctx, providerID, true)
-		}
+		revert := getRevertLastUpdated(pr)
 		if pr.storedInfo.LastUpdated == nil {
 			pr.storedInfo.LastUpdated = protocompat.TimestampNow()
 		}
+		revert = getRemoveProvider(ctx, pr, store, revert)
 		return revert, store.AddAuthProvider(ctx, pr.storedInfo)
 	}
+}
+
+func getRevertLastUpdated(pr *providerImpl) RevertOption {
+	oldLastUpdated := pr.storedInfo.GetLastUpdated()
+	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return noStoredInfoErrox
+		}
+		pr.storedInfo.LastUpdated = oldLastUpdated
+		return nil
+	}
+}
+
+func getRemoveProvider(ctx context.Context, provider *providerImpl, store Store, revert RevertOption) RevertOption {
+	providerID := provider.storedInfo.GetId()
+	removeProviderAction := func(pr *providerImpl) error {
+		return store.RemoveAuthProvider(ctx, providerID, true)
+	}
+	return composeRevertOptions(removeProviderAction, revert)
 }
 
 // UpdateStore updates the stored value for the provider in the input store.
@@ -37,48 +54,45 @@ func UpdateStore(ctx context.Context, store Store) ProviderOption {
 		if pr.doNotStore {
 			return noOpRevert, nil
 		}
-		providerID := pr.storedInfo.GetId()
-		oldProvider, found, err := store.GetAuthProvider(ctx, providerID)
-		if err != nil {
-			return noOpRevert, err
-		}
-		revert := func(pr *providerImpl) error {
-			if !found {
-				return store.RemoveAuthProvider(ctx, providerID, true)
-			}
-			return store.UpdateAuthProvider(ctx, oldProvider)
-		}
+		revert := getRevertLastUpdated(pr)
 		pr.storedInfo.LastUpdated = protocompat.TimestampNow()
+		revert = getRevertUpdateProvider(ctx, pr, store, revert)
 		return revert, store.UpdateAuthProvider(ctx, pr.storedInfo)
 	}
+}
+
+func getRevertUpdateProvider(ctx context.Context, provider *providerImpl, store Store, revert RevertOption) RevertOption {
+	oldProviderID := provider.storedInfo.GetId()
+	oldProvider, found, err := store.GetAuthProvider(ctx, oldProviderID)
+	if err != nil {
+		return noOpRevert
+	}
+	revertUpdateAction := func(_ *providerImpl) error {
+		if !found {
+			return store.RemoveAuthProvider(ctx, oldProviderID, true)
+		}
+		return store.UpdateAuthProvider(ctx, oldProvider)
+	}
+	return composeRevertOptions(revertUpdateAction, revert)
 }
 
 // DeleteFromStore removes the providers stored data from the input store.
 func DeleteFromStore(ctx context.Context, store Store, providerID string, force bool) ProviderOption {
 	return func(pr *providerImpl) (RevertOption, error) {
-		oldProvider, found, err := store.GetAuthProvider(ctx, providerID)
-		if err != nil && !pr.doNotStore {
-			return noOpRevert, err
-		}
-		revert := func(pr *providerImpl) error {
-			if !found {
-				return nil
-			}
-			if pr.doNotStore {
-				return nil
-			}
-			pr.storedInfo = oldProvider
-			return store.AddAuthProvider(ctx, oldProvider)
-		}
-		err = store.RemoveAuthProvider(ctx, providerID, force)
+		revert := getRevertDeleteProvider(ctx, store, providerID)
+		err := store.RemoveAuthProvider(ctx, providerID, force)
 		if err != nil {
 			// If it's a type we don't want to store, then we're okay with it not existing.
 			// We do this in case it was stored in the DB in a previous version.
+			// The revert action will anyway restore what was in the DB prior to the removal,
+			// if there was anything in DB.
 			if pr.doNotStore && dberrors.IsNotFound(err) {
-				return noOpRevert, nil
+				return revert, nil
 			}
 			return revert, err
 		}
+
+		revert = getRestoreStoredInfo(pr, revert)
 		// a deleted provider should no longer be accessible, but it's still cached as a token source so mark it as
 		// no longer valid
 		pr.storedInfo = &storage.AuthProvider{
@@ -87,6 +101,29 @@ func DeleteFromStore(ctx context.Context, store Store, providerID string, force 
 		}
 		return revert, nil
 	}
+}
+
+func getRevertDeleteProvider(ctx context.Context, store Store, providerID string) RevertOption {
+	oldProvider, found, err := store.GetAuthProvider(ctx, providerID)
+	if err != nil {
+		return noOpRevert
+	}
+	if !found {
+		// No DB data to re-create.
+		return noOpRevert
+	}
+	return func(_ *providerImpl) error {
+		return store.AddAuthProvider(ctx, oldProvider)
+	}
+}
+
+func getRestoreStoredInfo(provider *providerImpl, revert RevertOption) RevertOption {
+	oldStoredInfo := provider.storedInfo
+	restoreStoredInfoAction := func(pr *providerImpl) error {
+		pr.storedInfo = oldStoredInfo
+		return nil
+	}
+	return composeRevertOptions(restoreStoredInfoAction, revert)
 }
 
 // UnregisterSource unregisters the token source from the source factory

--- a/pkg/auth/authproviders/provider_commands_test.go
+++ b/pkg/auth/authproviders/provider_commands_test.go
@@ -1,0 +1,344 @@
+package authproviders
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders/mocks"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/protomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func getPreviousStoredView() *storage.AuthProvider {
+	updateTime := time.Date(2023, time.December, 24, 23, 59, 59, 999999999, time.UTC)
+	return &storage.AuthProvider{
+		Id:          authProviderID,
+		LastUpdated: protocompat.ConvertTimeToTimestampOrNil(&updateTime),
+	}
+}
+
+func TestDefaultAddToStore(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	lastUpdateTime := time.Date(2024, time.July, 4, 13, 30, 30, 123456789, time.UTC)
+	storageView := &storage.AuthProvider{
+		Id:          authProviderID,
+		LastUpdated: protocompat.ConvertTimeToTimestampOrNil(&lastUpdateTime),
+	}
+	provider := &providerImpl{
+		storedInfo: storageView,
+	}
+
+	option := DefaultAddToStore(context.Background(), providerStore)
+
+	providerStore.EXPECT().
+		AddAuthProvider(
+			gomock.Any(),
+			protomock.GoMockMatcherEqualMessage(storageView),
+		).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestDefaultAddToStoreBreakRevert(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	storageView := &storage.AuthProvider{
+		Id: authProviderID,
+	}
+	provider := &providerImpl{
+		storedInfo: storageView,
+	}
+
+	option := DefaultAddToStore(context.Background(), providerStore)
+
+	providerStore.EXPECT().
+		AddAuthProvider(
+			gomock.Any(),
+			gomock.Any(),
+		).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+	assert.NotNil(t, provider.storedInfo.GetLastUpdated())
+
+	provider.storedInfo = nil
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	err = revert(provider)
+	assert.ErrorIs(t, err, noStoredInfoErrox)
+
+}
+
+func TestUpdateStoreWithPreviousStoredValue(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	storedView := getPreviousStoredView()
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(storedView, true, nil)
+
+	lastUpdateTime := time.Date(2024, time.July, 4, 13, 30, 30, 123456789, time.UTC)
+	storageView := &storage.AuthProvider{
+		Id:          authProviderID,
+		LastUpdated: protocompat.ConvertTimeToTimestampOrNil(&lastUpdateTime),
+	}
+	provider := &providerImpl{
+		storedInfo: storageView,
+	}
+
+	option := UpdateStore(context.Background(), providerStore)
+
+	providerStore.EXPECT().
+		UpdateAuthProvider(gomock.Any(), testRecentEnoughAuthProviderWithID(authProviderID)).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	providerStore.EXPECT().
+		UpdateAuthProvider(gomock.Any(), protomock.GoMockMatcherEqualMessage(storedView)).
+		Times(1).
+		Return(nil)
+
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestUpdateStoreWithoutPreviousStoredValue(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(nil, false, nil)
+
+	lastUpdateTime := time.Date(2024, time.July, 4, 13, 30, 30, 123456789, time.UTC)
+	storageView := &storage.AuthProvider{
+		Id:          authProviderID,
+		LastUpdated: protocompat.ConvertTimeToTimestampOrNil(&lastUpdateTime),
+	}
+	provider := &providerImpl{
+		storedInfo: storageView,
+	}
+
+	option := UpdateStore(context.Background(), providerStore)
+
+	providerStore.EXPECT().
+		UpdateAuthProvider(gomock.Any(), testRecentEnoughAuthProviderWithID(authProviderID)).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestUpdateStoreWithLookupError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(nil, false, errors.New("DB Lookup failure"))
+
+	lastUpdateTime := time.Date(2024, time.July, 4, 13, 30, 30, 123456789, time.UTC)
+	storageView := &storage.AuthProvider{
+		Id:          authProviderID,
+		LastUpdated: protocompat.ConvertTimeToTimestampOrNil(&lastUpdateTime),
+	}
+	provider := &providerImpl{
+		storedInfo: storageView,
+	}
+
+	option := UpdateStore(context.Background(), providerStore)
+
+	providerStore.EXPECT().
+		UpdateAuthProvider(gomock.Any(), testRecentEnoughAuthProviderWithID(authProviderID)).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	// On lookup error, the revert action should be a no-op.
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestDeletePreExistingFromStore(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	option := DeleteFromStore(context.Background(), providerStore, authProviderID, true)
+
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+
+	// The option application should fetch the stored state for revert generation,
+	// then call remove on the store.
+	storedView := getPreviousStoredView()
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(storedView, true, nil)
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	// Revert should add back the previous stored state.
+	providerStore.EXPECT().
+		AddAuthProvider(gomock.Any(), protomock.GoMockMatcherEqualMessage(storedView)).
+		Times(1).
+		Return(nil)
+
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestDeleteMissingFromStore(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	option := DeleteFromStore(context.Background(), providerStore, authProviderID, true)
+
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+
+	// The option application should fetch the stored state for revert generation,
+	// then call remove on the store.
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(nil, false, nil)
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	// Revert should do nothing as there is no previously stored state.
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+func TestDeleteFromStoreWithLookupError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	providerStore := mocks.NewMockStore(mockCtrl)
+
+	option := DeleteFromStore(context.Background(), providerStore, authProviderID, true)
+
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+
+	// The option application should fetch the stored state for revert generation,
+	// then call remove on the store.
+	providerStore.EXPECT().
+		GetAuthProvider(gomock.Any(), authProviderID).
+		Times(1).
+		Return(nil, false, errors.New("DB Lookup failure"))
+
+	providerStore.EXPECT().
+		RemoveAuthProvider(gomock.Any(), authProviderID, true).
+		Times(1).
+		Return(nil)
+
+	revert, err := option(provider)
+	assert.NoError(t, err)
+
+	// Revert should be a no-op on DB lookup failure when generating the revert.
+	err = revert(provider)
+	assert.NoError(t, err)
+}
+
+// region test helpers
+
+func testRecentEnoughAuthProviderWithID(id string) gomock.Matcher {
+	testProvider := func(msg any) bool {
+		pr := msg.(*storage.AuthProvider)
+		if pr == nil {
+			return false
+		}
+		if pr.Id != id {
+			return false
+		}
+		now := time.Now()
+		lastUpdated := pr.GetLastUpdated().AsTime()
+		delta := now.Sub(lastUpdated)
+		lowBound := -1 * time.Second
+		upperBound := time.Second
+		return delta >= lowBound && delta <= upperBound
+	}
+	return gomock.Cond(testProvider)
+}
+
+// endregion test helpers

--- a/pkg/auth/authproviders/provider_default_options.go
+++ b/pkg/auth/authproviders/provider_default_options.go
@@ -118,9 +118,9 @@ func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFa
 			}
 			pr.backend = oldBackend
 			backendID := pr.storedInfo.GetId()
-			err := pr.backendFactory.CleanupBackend(backendID)
+			pr.backendFactory.CleanupBackend(backendID)
 			pr.backendFactory = oldBackendFactory
-			return err
+			return nil
 		}
 		// Get the backend factory for the type of provider.
 		backendFactory := backendFactoryPool[pr.storedInfo.GetType()]

--- a/pkg/auth/authproviders/provider_default_options.go
+++ b/pkg/auth/authproviders/provider_default_options.go
@@ -10,34 +10,54 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
+var (
+	noStoredInfoErr = errors.New("no storage information for auth provider")
+)
+
 // Default Options which fill in values only if not already set.
 ////////////////////////////////////////////////////////////////
 
 // DefaultNewID sets the id of the provider to a new value if not already set.
 func DefaultNewID() ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo.GetId() != "" {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo == nil {
-			return errors.New("no storage information for auth provider")
+			return noOpRevert, noStoredInfoErr
+		}
+		oldID := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return noStoredInfoErr
+			}
+			pr.storedInfo.Id = oldID
+			return nil
 		}
 		pr.storedInfo.Id = uuid.NewV4().String()
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultLoginURL fills in the login url if not set using a function that creates a url for the provider id.
 func DefaultLoginURL(fn func(authProviderID string) string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo.GetLoginUrl() != "" {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo == nil {
-			return errors.New("no storage information for auth provider")
+			return noOpRevert, noStoredInfoErr
+		}
+		oldLoginURL := pr.storedInfo.GetLoginUrl()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return noStoredInfoErr
+			}
+			pr.storedInfo.LoginUrl = oldLoginURL
+			return nil
 		}
 		pr.storedInfo.LoginUrl = fn(pr.storedInfo.Id)
-		return nil
+		return revert, nil
 	}
 }
 
@@ -45,44 +65,67 @@ const tokenTTL = 12 * time.Hour
 
 // DefaultTokenIssuerFromFactory sets the token issuer of the provider from the factory if not already set.
 func DefaultTokenIssuerFromFactory(tf tokens.IssuerFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.issuer != nil {
+			return noOpRevert, nil
+		}
+		oldIssuer := pr.issuer
+		revert := func(pr *providerImpl) error {
+			pr.issuer = oldIssuer
 			return nil
 		}
 		issuer, err := tf.CreateIssuer(pr, tokens.WithTTL(tokenTTL))
 		if err != nil {
-			return errors.Wrap(err, "failed to create issuer for newly created auth provider")
+			return noOpRevert, errors.Wrap(err, "failed to create issuer for newly created auth provider")
 		}
 		pr.issuer = issuer
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultRoleMapperOption loads a role mapper from the factory if one is not set on the provider.
 func DefaultRoleMapperOption(fn func(id string) permissions.RoleMapper) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.roleMapper != nil {
-			return nil
+			return noOpRevert, nil
 		}
 		if pr.storedInfo.GetId() == "" {
+			return noOpRevert, nil
+		}
+		oldRoleMapper := pr.roleMapper
+		revert := func(pr *providerImpl) error {
+			pr.roleMapper = oldRoleMapper
 			return nil
 		}
 		pr.roleMapper = fn(pr.storedInfo.GetId())
-		return nil
+		return revert, nil
 	}
 }
 
 // DefaultBackend sets a backend from the pool of backend factories if one is not set.
 func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.backend != nil {
-			return nil
+			return noOpRevert, nil
 		}
 
+		oldBackendFactory := pr.backendFactory
+		oldBackend := pr.backend
+		oldConfig := pr.storedInfo.GetConfig()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo != nil {
+				pr.storedInfo.Config = oldConfig
+			}
+			pr.backend = oldBackend
+			backendID := pr.storedInfo.GetId()
+			err := pr.backendFactory.CleanupBackend(backendID)
+			pr.backendFactory = oldBackendFactory
+			return err
+		}
 		// Get the backend factory for the type of provider.
 		backendFactory := backendFactoryPool[pr.storedInfo.GetType()]
 		if backendFactory == nil {
-			return errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.GetType())
+			return noOpRevert, errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.GetType())
 		}
 
 		pr.backendFactory = backendFactory
@@ -90,12 +133,12 @@ func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFa
 		// Create the backend for the provider.
 		backend, err := backendFactory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), pr.storedInfo.GetClaimMappings())
 		if err != nil {
-			return errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.GetId())
+			return revert, errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.GetId())
 		}
 		pr.backend = backend
 		// We can assume that pr.storedInfo is non-nil here because pr.storedInfo.GetType() referenced a valid auth provider type.
 		pr.storedInfo.Config = backend.Config()
-		return nil
+		return revert, nil
 	}
 }
 
@@ -129,11 +172,11 @@ func DefaultOptionsForNewProvider(ctx context.Context, store Store, backendFacto
 
 // LogOptionError eats any error from the input option and logs it.
 func LogOptionError(po ProviderOption) ProviderOption {
-	return func(pr *providerImpl) error {
-		err := po(pr)
+	return func(pr *providerImpl) (RevertOption, error) {
+		revert, err := po(pr)
 		if err != nil {
 			log.Errorf("error adding option to provider: %s", err)
 		}
-		return nil
+		return revert, nil
 	}
 }

--- a/pkg/auth/authproviders/provider_default_options_test.go
+++ b/pkg/auth/authproviders/provider_default_options_test.go
@@ -1,0 +1,282 @@
+package authproviders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/auth/tokens"
+	tokenIssuerMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDefaultNewID(t *testing.T) {
+	option := DefaultNewID()
+
+	// DefaultNewID should fail on a provider object with nil storedInfo field.
+	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractID)
+
+	// DefaultNewID should not overwrite a pre-existing ID,
+	// nor should the associated reveret action.
+	previousIDProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousIDProvider, noIssuer, noMapper, noBackend, noBackendFactory)
+
+	// DefaultNewID should set the ID field in the storedInfo field
+	// with a valid UUID. The revert action should set the ID back
+	// to its previous value (here empty string).
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{},
+	}
+	assert.Empty(t, provider.storedInfo.GetId())
+	t.Run(emptyInfoProviderCaseName, func(it *testing.T) {
+		revert, err := option(provider)
+		assert.NoError(t, err)
+		providerID := provider.storedInfo.GetId()
+		assert.NotEmpty(t, providerID)
+		_, err = uuid.FromString(providerID)
+		assert.NoError(t, err)
+		err = revert(provider)
+		assert.NoError(t, err)
+		assert.Empty(t, provider.storedInfo.GetId())
+	})
+}
+
+func TestDefaultLoginURL(t *testing.T) {
+	called := 0
+	getLoginURL := func(_ string) string {
+		called += 1
+		return testLoginURL
+	}
+	option := DefaultLoginURL(getLoginURL)
+
+	// DefaultLoginURL should fail on a provider object with nil storedInfo field.
+	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractLoginURL)
+	// Ensure the option application did not call getLoginURL.
+	assert.Zero(t, called)
+
+	// DefaultLoginURL should not overwrite a pre-existing login URL,
+	// nor should the revert action.
+	previousLoginURLProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			LoginUrl: baseLoginURL,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousLoginURLProvider, noIssuer, noMapper, noBackend, noBackendFactory)
+	// Ensure the option application did not call getLoginURL.
+	assert.Zero(t, called)
+
+	// DefaultLoginURL on a provider with non-nil stored info but no
+	// previous login URL should set the login URL to the result of the
+	// provided function call, the revert action should reset
+	// the login URL to an empty value.
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{},
+	}
+	assert.Empty(t, extractLoginURL(provider))
+	t.Run(
+		emptyInfoProviderCaseName,
+		testProviderOptionApplication(
+			option,
+			&storage.AuthProvider{},
+			testLoginURL,
+			extractLoginURL,
+		),
+	)
+	// ensure the getLoginURL function was called while applying the option.
+	assert.Equal(t, 1, called)
+}
+
+func TestDefaultTokenIssuerFromFactory(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	baseIssuer := &fakeIssuer{ID: baseIssuerID}
+	testIssuer := &fakeIssuer{ID: testIssuerID}
+
+	mockIssuerFactory := tokenIssuerMocks.NewMockIssuerFactory(mockCtrl)
+	mockIssuerFactory.EXPECT().
+		CreateIssuer(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(testIssuer, nil)
+
+	option := DefaultTokenIssuerFromFactory(mockIssuerFactory)
+
+	// DefaultTokenIssuerFromFactory should not overwrite a pre-existing issuer,
+	// nor should the associated revert action.
+	previousIssuerProvider := &providerImpl{
+		issuer: baseIssuer,
+	}
+	testNoOverwriteOptionApplication(t, option, previousIssuerProvider, baseIssuer, noMapper, noBackend, noBackendFactory)
+
+	// DefaultIssuerFromFactory should set the issuer to the result
+	// of the provider factory creation call, the revert action should
+	// reset the issuer to a nil value.
+	noIssuerProvider := &providerImpl{}
+	assert.Nil(t, noIssuerProvider.issuer)
+	t.Run("Provider with no previous token issuer", func(it *testing.T) {
+		revert, err := option(noIssuerProvider)
+		assert.NoError(it, err)
+		assert.Equal(it, testIssuer, noIssuerProvider.issuer)
+		err = revert(noIssuerProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIssuerProvider.issuer)
+	})
+}
+
+func TestDefaultRoleMapperOption(t *testing.T) {
+	optionBaseRoleMapper := &fakeRoleMapper{ID: baseRoleMapperID}
+	optionTestRoleMapper := &fakeRoleMapper{ID: testRoleMapperID}
+
+	getRoleMapper := func(_ string) permissions.RoleMapper {
+		return optionTestRoleMapper
+	}
+	option := DefaultRoleMapperOption(getRoleMapper)
+
+	// DefaultRoleMapper should not erase any pre-existing role mapper,
+	// nor should the associated revert action.
+	previousRoleMapperProvider := &providerImpl{
+		roleMapper: optionBaseRoleMapper,
+	}
+	testNoOverwriteOptionApplication(t, option, previousRoleMapperProvider, noIssuer, optionBaseRoleMapper, noBackend, noBackendFactory)
+
+	// DefaultRoleMapper should not touch the role mapper if there is
+	// no previous role mapper, but the storage can NOT provide an ID,
+	// the associated revert action should not touch the role mapper either.
+	t.Run("Provider with no previous role mapper nor ID", func(it *testing.T) {
+		noIDNoMapperProvider := &providerImpl{}
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+		assert.Empty(it, extractID(noIDNoMapperProvider))
+		revert, err := option(noIDNoMapperProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+		err = revert(noIDNoMapperProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+	})
+
+	// DefaultRoleMapper should set the role mapper if there is
+	// no previous mapper and the storage view can provide an ID.
+	// The revert action should reset the role mapper to a nil value.
+	t.Run("Provider with ID but no previous role mapper", func(it *testing.T) {
+		provider := &providerImpl{
+			storedInfo: &storage.AuthProvider{
+				Id: authProviderID,
+			},
+		}
+		assert.Nil(it, provider.roleMapper)
+		assert.Equal(it, authProviderID, extractID(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, optionTestRoleMapper, provider.roleMapper)
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, err)
+	})
+}
+
+func TestDefaultBackend(t *testing.T) {
+	backendFactoryPool := map[string]BackendFactory{
+		"test": testAuthProviderBackendFactory,
+	}
+	option := DefaultBackend(context.Background(), backendFactoryPool)
+
+	baseAuthProviderBackendFactory := &tstAuthProviderBackendFactory{
+		ID: baseAuthProviderBackendFactoryID,
+	}
+	baseAuthProviderBackend := &tstAuthProviderBackend{
+		ID: baseAuthProviderBackendID,
+	}
+
+	previousBackendProvider := &providerImpl{
+		backend:        baseAuthProviderBackend,
+		backendFactory: baseAuthProviderBackendFactory,
+		storedInfo: &storage.AuthProvider{
+			Config: baseAuthProviderBackendConfig,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousBackendProvider, noIssuer, noMapper, baseAuthProviderBackend, baseAuthProviderBackendFactory)
+
+	t.Run("Provider with wrong type", func(it *testing.T) {
+		provider := &providerImpl{
+			storedInfo: &storage.AuthProvider{
+				Type: "base",
+			},
+		}
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+		revert, err := option(provider)
+		assert.Error(t, err)
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+	})
+
+	t.Run("Provider without backend", func(it *testing.T) {
+		provider := &providerImpl{
+			backendFactory: baseAuthProviderBackendFactory,
+			storedInfo: &storage.AuthProvider{
+				Type:   "test",
+				Config: baseAuthProviderBackendConfig,
+			},
+		}
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, testAuthProviderBackend, provider.backend)
+		assert.Equal(it, testAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, testAuthProviderBackendConfig, extractConfig(provider))
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+	})
+}
+
+// region test helpers
+
+func testNoOverwriteOptionApplication(
+	t *testing.T,
+	option ProviderOption,
+	provider *providerImpl,
+	oldTokenIssuer tokens.Issuer,
+	oldRoleMapper permissions.RoleMapper,
+	oldBackend Backend,
+	oldBackendFactory BackendFactory,
+) {
+	t.Run(noOverwriteCaseName, func(it *testing.T) {
+		oldStoredInfo := provider.storedInfo.CloneVT()
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
+		assert.Equal(it, oldTokenIssuer, provider.issuer)
+		assert.Equal(it, oldRoleMapper, provider.roleMapper)
+		assert.Equal(it, oldBackend, provider.backend)
+		assert.Equal(it, oldBackendFactory, provider.backendFactory)
+		err = revert(provider)
+		assert.NoError(it, err)
+		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
+		assert.Equal(it, oldTokenIssuer, provider.issuer)
+		assert.Equal(it, oldRoleMapper, provider.roleMapper)
+		assert.Equal(it, oldBackend, provider.backend)
+		assert.Equal(it, oldBackendFactory, provider.backendFactory)
+	})
+}
+
+// endregion test helpers

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -15,154 +15,243 @@ var (
 	internalUpdateProviderCtx = sac.WithAllAccess(context.Background())
 )
 
+// RevertOption is a function that modifies a providerImpl, undoing the work of a ProviderOption.
+// Do not use Provider functions in Options, as this will try to RLock inside of a Lock and deadlock.
+// You can assume that the provider is locked for the duration of the option's execution.
+type RevertOption func(*providerImpl) error
+
 // ProviderOption is a function that modifies a providerImpl.
 // Do not use Provider functions in Options, as this will try to RLock inside of a Lock and deadlock.
 // You can assume that the provider is locked for the duration of the option's execution.
-type ProviderOption func(*providerImpl) error
+type ProviderOption func(*providerImpl) (RevertOption, error)
 
 // Options for building and updating.
 /////////////////////////////////////
 
 // WithBackendFromFactory adds a backend from the factory to the provider.
 func WithBackendFromFactory(ctx context.Context, factory BackendFactory) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldBackendFactory := pr.backendFactory
+		oldBackend := pr.backend
+		oldConfig := pr.storedInfo.GetConfig()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo != nil {
+				pr.storedInfo.Config = oldConfig
+			}
+			pr.backend = oldBackend
+			backendID := pr.storedInfo.GetId()
+			err := pr.backendFactory.CleanupBackend(backendID)
+			pr.backendFactory = oldBackendFactory
+			return err
+		}
 		pr.backendFactory = factory
 
 		backend, err := factory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.GetType())
+			return revert, errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.GetType())
 		}
 
 		pr.backend = backend
 		pr.storedInfo.Config = backend.Config()
-		return nil
+		return revert, nil
 	}
 }
 
 // DoNotStore indicates that this provider should not be stored.
 func DoNotStore() ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldDoNotStore := pr.doNotStore
+		revert := func(pr *providerImpl) error {
+			pr.doNotStore = oldDoNotStore
+			return nil
+		}
 		pr.doNotStore = true
-		return nil
+		return revert, nil
 	}
 }
 
 // WithRoleMapper adds a role mapper to the provider.
 func WithRoleMapper(roleMapper permissions.RoleMapper) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldRoleMapper := pr.roleMapper
+		revert := func(pr *providerImpl) error {
+			pr.roleMapper = oldRoleMapper
+			return nil
+		}
 		pr.roleMapper = roleMapper
-		return nil
+		return revert, nil
 	}
 }
 
 // WithStorageView sets the values in the store auth provider from the input value.
 func WithStorageView(stored *storage.AuthProvider) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldStoredInfo := pr.storedInfo
+		revert := func(pr *providerImpl) error {
+			pr.storedInfo = oldStoredInfo
+			return nil
+		}
 		pr.storedInfo = stored.CloneVT()
-		return nil
+		return revert, nil
 	}
 }
 
 // WithID sets the id for the provider to the input value.
 func WithID(id string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldID := pr.storedInfo.GetId()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Id = oldID
+			return nil
 		}
 		pr.storedInfo.Id = id
-		return nil
+		return revert, nil
 	}
 }
 
 // WithType sets the type for the provider.
 func WithType(typ string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldType := pr.storedInfo.GetType()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Type = oldType
+			return nil
 		}
 		pr.storedInfo.Type = typ
-		return nil
+		return revert, nil
 	}
 }
 
 // WithName sets the name for the provider.
 func WithName(name string) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldName := pr.storedInfo.GetName()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Name = oldName
+			return nil
 		}
 		pr.storedInfo.Name = name
-		return nil
+		return revert, nil
 	}
 }
 
 // WithEnabled sets the enabled flag for the provider.
 func WithEnabled(enabled bool) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldEnabled := pr.storedInfo.GetEnabled()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Enabled = oldEnabled
+			return nil
 		}
 		pr.storedInfo.Enabled = enabled
-		return nil
+		return revert, nil
 	}
 }
 
 // WithValidateCallback adds a callback to validate the auth provider.
 func WithValidateCallback(store Store) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldValidateCallback := pr.validateCallback
+		revert := func(pr *providerImpl) error {
+			pr.validateCallback = oldValidateCallback
+			return nil
+		}
 		pr.validateCallback = func() error {
 			return pr.ApplyOptions(WithActive(true), UpdateStore(internalUpdateProviderCtx, store))
 		}
-		return nil
+		return revert, nil
 	}
 }
 
 // WithActive sets the active flag for the provider.
 func WithActive(active bool) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldValidated := pr.storedInfo.GetValidated()
+		oldActive := pr.storedInfo.GetActive()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			pr.storedInfo.Active = oldActive
+			pr.storedInfo.Validated = oldValidated
+			return nil
 		}
 		pr.storedInfo.Validated = active
 		pr.storedInfo.Active = active
-		return nil
-	}
-}
-
-// WithConfig sets the config for the provider.
-func WithConfig(config map[string]string) ProviderOption {
-	return func(pr *providerImpl) error {
-		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
-		}
-		pr.storedInfo.Config = config
-		return nil
+		return revert, nil
 	}
 }
 
 // WithAttributeVerifier adds an attribute verifier to the provider based on the list of
 // required attributes from the provided auth provider instance.
 func WithAttributeVerifier(stored *storage.AuthProvider) ProviderOption {
-	return func(pr *providerImpl) error {
-		if stored.GetRequiredAttributes() == nil {
+	return func(pr *providerImpl) (RevertOption, error) {
+		oldAttributeVerifier := pr.attributeVerifier
+		revert := func(pr *providerImpl) error {
+			pr.attributeVerifier = oldAttributeVerifier
 			return nil
 		}
+		if stored.GetRequiredAttributes() == nil {
+			return noOpRevert, nil
+		}
 		pr.attributeVerifier = user.NewRequiredAttributesVerifier(stored.GetRequiredAttributes())
-		return nil
+		return revert, nil
 	}
 }
 
 // WithVisibility sets the visibility for the auth provider.
 func WithVisibility(visibility storage.Traits_Visibility) ProviderOption {
-	return func(pr *providerImpl) error {
+	return func(pr *providerImpl) (RevertOption, error) {
 		if pr.storedInfo == nil {
-			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			return noOpRevert, errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		oldTraits := pr.storedInfo.GetTraits()
+		oldVisibility := oldTraits.GetVisibility()
+		revert := func(pr *providerImpl) error {
+			if pr.storedInfo == nil {
+				return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+			}
+			if oldTraits == nil {
+				pr.storedInfo.Traits = nil
+			} else {
+				pr.storedInfo.Traits.Visibility = oldVisibility
+			}
+			return nil
 		}
 		if pr.storedInfo.GetTraits() != nil {
 			pr.storedInfo.Traits.Visibility = visibility
 		} else {
 			pr.storedInfo.Traits = &storage.Traits{Visibility: visibility}
 		}
-		return nil
+		return revert, nil
 	}
 }
+
+func noOpRevert(_ *providerImpl) error { return nil }

--- a/pkg/auth/authproviders/provider_options_test.go
+++ b/pkg/auth/authproviders/provider_options_test.go
@@ -1,0 +1,818 @@
+package authproviders
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/auth/tokens"
+	tokenIssuerMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	authProviderID = "41757468-5072-6f76-6964-657200111111"
+	testProviderID = "41757468-5072-6f76-6964-657200222222"
+
+	baseLoginURL = "/base/login/url"
+	testLoginURL = "/test/login/url"
+
+	baseIssuerID = "546f6b64-6e49-7373-7565-721111111111"
+	testIssuerID = "546f6b64-6e49-7373-7565-722222222222"
+
+	baseRoleMapperID = "526f6c65-4d61-7171-6572-111111111111"
+	testRoleMapperID = "526f6c65-4d61-7171-6572-222222222222"
+
+	baseAuthProviderBackendID = "4261636b-656e-6478-7878-111111111111"
+	testAuthProviderBackendID = "4261636b-656e-6478-7878-222222222222"
+
+	baseAuthProviderBackendFactoryID = "4261636b-656e-6446-6163-746f72791111"
+	testAuthProviderBackendFactoryID = "4261636b-656e-6446-6163-746f72792222"
+
+	baseAuthProviderType = "base"
+	testAuthProviderType = "test"
+
+	baseAuthProviderName = "Auth Provider"
+	testAuthProviderName = "Test Auth Provider"
+
+	noInfoProviderCaseName    = "Provider without storedInfo"
+	noOverwriteCaseName       = "Provider with previous option data"
+	emptyInfoProviderCaseName = "Provider with empty storedInfo"
+)
+
+var (
+	baseAuthProviderBackendConfig = map[string]string{
+		"baseKey": "baseValue",
+	}
+
+	testAuthProviderBackendConfig = map[string]string{
+		"testKey": "testValue",
+	}
+
+	noIssuer         tokens.Issuer          = nil
+	noMapper         permissions.RoleMapper = nil
+	noBackend        Backend                = nil
+	noBackendFactory BackendFactory         = nil
+)
+
+func TestDefaultNewID(t *testing.T) {
+	option := DefaultNewID()
+
+	// DefaultNewID should fail on a provider object with nil storedInfo field.
+	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractID)
+
+	// DefaultNewID should not overwrite a pre-existing ID,
+	// nor should the associated reveret action.
+	previousIDProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			Id: authProviderID,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousIDProvider, noIssuer, noMapper, noBackend, noBackendFactory)
+
+	// DefaultNewID should set the ID field in the storedInfo field
+	// with a valid UUID. The revert action should set the ID back
+	// to its previous value (here empty string).
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{},
+	}
+	assert.Empty(t, provider.storedInfo.GetId())
+	t.Run(emptyInfoProviderCaseName, func(it *testing.T) {
+		revert, err := option(provider)
+		assert.NoError(t, err)
+		providerID := provider.storedInfo.GetId()
+		assert.NotEmpty(t, providerID)
+		_, err = uuid.FromString(providerID)
+		assert.NoError(t, err)
+		err = revert(provider)
+		assert.NoError(t, err)
+		assert.Empty(t, provider.storedInfo.GetId())
+	})
+}
+
+func TestDefaultLoginURL(t *testing.T) {
+	called := 0
+	getLoginURL := func(_ string) string {
+		called += 1
+		return testLoginURL
+	}
+	option := DefaultLoginURL(getLoginURL)
+
+	// DefaultLoginURL should fail on a provider object with nil storedInfo field.
+	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractLoginURL)
+	// Ensure the option application did not call getLoginURL.
+	assert.Zero(t, called)
+
+	// DefaultLoginURL should not overwrite a pre-existing login URL,
+	// nor should the revert action.
+	previousLoginURLProvider := &providerImpl{
+		storedInfo: &storage.AuthProvider{
+			LoginUrl: baseLoginURL,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousLoginURLProvider, noIssuer, noMapper, noBackend, noBackendFactory)
+	// Ensure the option application did not call getLoginURL.
+	assert.Zero(t, called)
+
+	// DefaultLoginURL on a provider with non-nil stored info but no
+	// previous login URL should set the login URL to the result of the
+	// provided function call, the revert action should reset
+	// the login URL to an empty value.
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{},
+	}
+	assert.Empty(t, extractLoginURL(provider))
+	t.Run(
+		emptyInfoProviderCaseName,
+		testProviderOptionApplication(
+			option,
+			&storage.AuthProvider{},
+			testLoginURL,
+			extractLoginURL,
+		),
+	)
+	// ensure the getLoginURL function was called while applying the option.
+	assert.Equal(t, 1, called)
+}
+
+func TestDefaultTokenIssuerFromFactory(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	baseIssuer := &fakeIssuer{ID: baseIssuerID}
+	testIssuer := &fakeIssuer{ID: testIssuerID}
+
+	mockIssuerFactory := tokenIssuerMocks.NewMockIssuerFactory(mockCtrl)
+	mockIssuerFactory.EXPECT().
+		CreateIssuer(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(testIssuer, nil)
+
+	option := DefaultTokenIssuerFromFactory(mockIssuerFactory)
+
+	// DefaultTokenIssuerFromFactory should not overwrite a pre-existing issuer,
+	// nor should the associated revert action.
+	previousIssuerProvider := &providerImpl{
+		issuer: baseIssuer,
+	}
+	testNoOverwriteOptionApplication(t, option, previousIssuerProvider, baseIssuer, noMapper, noBackend, noBackendFactory)
+
+	// DefaultIssuerFromFactory should set the issuer to the result
+	// of the provider factory creation call, the revert action should
+	// reset the issuer to a nil value.
+	noIssuerProvider := &providerImpl{}
+	assert.Nil(t, noIssuerProvider.issuer)
+	t.Run("Provider with no previous token issuer", func(it *testing.T) {
+		revert, err := option(noIssuerProvider)
+		assert.NoError(it, err)
+		assert.Equal(it, testIssuer, noIssuerProvider.issuer)
+		err = revert(noIssuerProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIssuerProvider.issuer)
+	})
+}
+
+func TestDefaultRoleMapperOption(t *testing.T) {
+	optionBaseRoleMapper := &fakeRoleMapper{ID: baseRoleMapperID}
+	optionTestRoleMapper := &fakeRoleMapper{ID: testRoleMapperID}
+
+	getRoleMapper := func(_ string) permissions.RoleMapper {
+		return optionTestRoleMapper
+	}
+	option := DefaultRoleMapperOption(getRoleMapper)
+
+	// DefaultRoleMapper should not erase any pre-existing role mapper,
+	// nor should the associated revert action.
+	previousRoleMapperProvider := &providerImpl{
+		roleMapper: optionBaseRoleMapper,
+	}
+	testNoOverwriteOptionApplication(t, option, previousRoleMapperProvider, noIssuer, optionBaseRoleMapper, noBackend, noBackendFactory)
+
+	// DefaultRoleMapper should not touch the role mapper if there is
+	// no previous role mapper, but the storage can NOT provide an ID,
+	// the associated revert action should not touch the role mapper either.
+	t.Run("Provider with no previous role mapper nor ID", func(it *testing.T) {
+		noIDNoMapperProvider := &providerImpl{}
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+		assert.Empty(it, extractID(noIDNoMapperProvider))
+		revert, err := option(noIDNoMapperProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+		err = revert(noIDNoMapperProvider)
+		assert.NoError(it, err)
+		assert.Nil(it, noIDNoMapperProvider.roleMapper)
+	})
+
+	// DefaultRoleMapper should set the role mapper if there is
+	// no previous mapper and the storage view can provide an ID.
+	// The revert action should reset the role mapper to a nil value.
+	t.Run("Provider with ID but no previous role mapper", func(it *testing.T) {
+		provider := &providerImpl{
+			storedInfo: &storage.AuthProvider{
+				Id: authProviderID,
+			},
+		}
+		assert.Nil(it, provider.roleMapper)
+		assert.Equal(it, authProviderID, extractID(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, optionTestRoleMapper, provider.roleMapper)
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, err)
+	})
+}
+
+func TestDefaultBackend(t *testing.T) {
+	backendFactoryPool := map[string]BackendFactory{
+		"test": testAuthProviderBackendFactory,
+	}
+	option := DefaultBackend(context.Background(), backendFactoryPool)
+
+	baseAuthProviderBackendFactory := &tstAuthProviderBackendFactory{
+		ID: baseAuthProviderBackendFactoryID,
+	}
+	baseAuthProviderBackend := &tstAuthProviderBackend{
+		ID: baseAuthProviderBackendID,
+	}
+
+	previousBackendProvider := &providerImpl{
+		backend:        baseAuthProviderBackend,
+		backendFactory: baseAuthProviderBackendFactory,
+		storedInfo: &storage.AuthProvider{
+			Config: baseAuthProviderBackendConfig,
+		},
+	}
+	testNoOverwriteOptionApplication(t, option, previousBackendProvider, noIssuer, noMapper, baseAuthProviderBackend, baseAuthProviderBackendFactory)
+
+	t.Run("Provider with wrong type", func(it *testing.T) {
+		provider := &providerImpl{
+			storedInfo: &storage.AuthProvider{
+				Type: "base",
+			},
+		}
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+		revert, err := option(provider)
+		assert.Error(t, err)
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.backend)
+		assert.Nil(it, provider.backendFactory)
+		assert.Empty(it, provider.storedInfo.GetConfig())
+	})
+
+	t.Run("Provider without backend", func(it *testing.T) {
+		provider := &providerImpl{
+			backendFactory: baseAuthProviderBackendFactory,
+			storedInfo: &storage.AuthProvider{
+				Type:   "test",
+				Config: baseAuthProviderBackendConfig,
+			},
+		}
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, testAuthProviderBackend, provider.backend)
+		assert.Equal(it, testAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, testAuthProviderBackendConfig, extractConfig(provider))
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+	})
+}
+
+func TestWithBackendFromFactory(t *testing.T) {
+	option := WithBackendFromFactory(context.Background(), testAuthProviderBackendFactory)
+
+	baseAuthProviderBackendFactory := &tstAuthProviderBackendFactory{
+		ID: baseAuthProviderBackendFactoryID,
+	}
+	baseAuthProviderBackend := &tstAuthProviderBackend{
+		ID: baseAuthProviderBackendID,
+	}
+
+	t.Run("Provider with previous backend", func(it *testing.T) {
+		provider := &providerImpl{
+			backend:        baseAuthProviderBackend,
+			backendFactory: baseAuthProviderBackendFactory,
+			storedInfo: &storage.AuthProvider{
+				Config: baseAuthProviderBackendConfig,
+			},
+		}
+		assert.Equal(it, baseAuthProviderBackend, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, testAuthProviderBackend, provider.backend)
+		assert.Equal(it, testAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, testAuthProviderBackendConfig, extractConfig(provider))
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, baseAuthProviderBackend, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+	})
+
+	t.Run("Provider without previous backend", func(it *testing.T) {
+		provider := &providerImpl{
+			backendFactory: baseAuthProviderBackendFactory,
+			storedInfo: &storage.AuthProvider{
+				Type:   "test",
+				Config: baseAuthProviderBackendConfig,
+			},
+		}
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		assert.Equal(it, testAuthProviderBackend, provider.backend)
+		assert.Equal(it, testAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, testAuthProviderBackendConfig, extractConfig(provider))
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.backend)
+		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
+		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
+	})
+}
+
+func TestDoNotStore(t *testing.T) {
+	option := DoNotStore()
+
+	testCases := map[string]struct {
+		provider     *providerImpl
+		initialState bool
+	}{
+		"Base provider": {
+			provider:     &providerImpl{},
+			initialState: false,
+		},
+		"Do not store provider": {
+			provider: &providerImpl{
+				doNotStore: true,
+			},
+			initialState: true,
+		},
+		"Do store provider": {
+			provider: &providerImpl{
+				doNotStore: false,
+			},
+			initialState: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(it *testing.T) {
+			provider := tc.provider
+			assert.Equal(it, tc.initialState, provider.doNotStore)
+			revert, err := option(provider)
+			assert.NoError(it, err)
+			assert.True(it, provider.doNotStore)
+			err = revert(provider)
+			assert.NoError(it, err)
+			assert.Equal(it, tc.initialState, provider.doNotStore)
+		})
+	}
+}
+
+func TestWithRoleMapper(t *testing.T) {
+	baseRoleMapper := &fakeRoleMapper{ID: baseRoleMapperID}
+	optionTestRoleMapper := &fakeRoleMapper{ID: testRoleMapperID}
+
+	option := WithRoleMapper(optionTestRoleMapper)
+
+	testCases := map[string]struct {
+		provider          *providerImpl
+		providerID        string
+		initialRoleMapper permissions.RoleMapper
+	}{
+		"Provider with previous role mapper": {
+			provider: &providerImpl{
+				roleMapper: baseRoleMapper,
+			},
+			initialRoleMapper: baseRoleMapper,
+		},
+		"Provider with no stored ID and no role mapper": {
+			provider: &providerImpl{},
+		},
+		"Provider with stored ID but no role mapper": {
+			provider: &providerImpl{
+				storedInfo: &storage.AuthProvider{
+					Id: authProviderID,
+				},
+			},
+			providerID: authProviderID,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(it *testing.T) {
+			provider := tc.provider
+			if tc.initialRoleMapper == nil {
+				assert.Nil(it, provider.roleMapper)
+			} else {
+				assert.Equal(it, tc.initialRoleMapper, provider.roleMapper)
+			}
+			assert.Equal(it, tc.providerID, provider.storedInfo.GetId())
+			revert, err := option(provider)
+			assert.NoError(it, err)
+			assert.Equal(it, optionTestRoleMapper, provider.roleMapper)
+			err = revert(provider)
+			assert.NoError(it, err)
+			if tc.initialRoleMapper == nil {
+				assert.Nil(it, provider.roleMapper)
+			} else {
+				assert.Equal(it, tc.initialRoleMapper, provider.roleMapper)
+			}
+		})
+	}
+}
+
+func TestWithStorageView(t *testing.T) {
+	baseStorageView := &storage.AuthProvider{
+		Id: authProviderID,
+	}
+	testStorageView := &storage.AuthProvider{
+		Id: testProviderID,
+	}
+	option := WithStorageView(testStorageView)
+
+	noStorageViewProvider := &providerImpl{}
+	assert.Nil(t, noStorageViewProvider.storedInfo)
+	revert1, err := option(noStorageViewProvider)
+	assert.NoError(t, err)
+	protoassert.Equal(t, testStorageView, noStorageViewProvider.storedInfo)
+	err = revert1(noStorageViewProvider)
+	assert.NoError(t, err)
+	assert.Nil(t, noStorageViewProvider.storedInfo)
+
+	previousStorageViewProvider := &providerImpl{
+		storedInfo: baseStorageView,
+	}
+	protoassert.Equal(t, baseStorageView, previousStorageViewProvider.storedInfo)
+	revert2, err := option(previousStorageViewProvider)
+	assert.NoError(t, err)
+	protoassert.Equal(t, testStorageView, previousStorageViewProvider.storedInfo)
+	// validate that the provider stored info is a copy of the input object
+	testStorageView.Type = "changed"
+	protoassert.NotEqual(t, testStorageView, previousStorageViewProvider.storedInfo)
+	err = revert2(previousStorageViewProvider)
+	assert.NoError(t, err)
+	protoassert.Equal(t, baseStorageView, previousStorageViewProvider.storedInfo)
+}
+
+func TestWithID(t *testing.T) {
+	option := WithID(testProviderID)
+
+	extractID := func(provider *providerImpl) interface{} {
+		return provider.storedInfo.GetId()
+	}
+	testNoStoredInfoProvider(t, option, errox.InvariantViolation, extractID)
+
+	testCases := map[string]*storage.AuthProvider{
+		"Provider with storedInfo but no ID": {},
+		"Provider with storedInfo and previous ID": {
+			Id: authProviderID,
+		},
+	}
+
+	for name, storedInfo := range testCases {
+		t.Run(name, testProviderOptionApplication(option, storedInfo, testProviderID, extractID))
+		t.Run(
+			name+" - breaking revert",
+			testProviderOptionApplicationBreakingRevert(option, storedInfo, testProviderID, extractID),
+		)
+	}
+}
+
+func TestWithType(t *testing.T) {
+	option := WithType(testAuthProviderType)
+
+	testNoStoredInfoProvider(t, option, errox.InvariantViolation, extractType)
+
+	testCases := map[string]*storage.AuthProvider{
+		"Provider with storedInfo but no type": {},
+		"Provider with storedInfo and previous type": {
+			Type: baseAuthProviderType,
+		},
+	}
+
+	for name, storedInfo := range testCases {
+		t.Run(name, testProviderOptionApplication(option, storedInfo, testAuthProviderType, extractType))
+		t.Run(
+			name+" - breaking revert",
+			testProviderOptionApplicationBreakingRevert(option, storedInfo, testAuthProviderType, extractType),
+		)
+	}
+}
+
+func TestWithName(t *testing.T) {
+	option := WithName(testAuthProviderName)
+
+	testNoStoredInfoProvider(t, option, errox.InvariantViolation, extractName)
+
+	testCases := map[string]*storage.AuthProvider{
+		"Provider with storedInfo but no name": {},
+		"Provider with storedInfo and previous name": {
+			Name: baseAuthProviderName,
+		},
+	}
+
+	for name, providerStoredInfo := range testCases {
+		t.Run(name, testProviderOptionApplication(option, providerStoredInfo, testAuthProviderName, extractName))
+		t.Run(
+			name+" - breaking revert",
+			testProviderOptionApplicationBreakingRevert(option, providerStoredInfo, testAuthProviderName, extractName),
+		)
+	}
+}
+
+func TestWithEnabled(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		option := WithEnabled(enabled)
+		extractEnabled := func(provider *providerImpl) interface{} {
+			return provider.storedInfo.GetEnabled()
+		}
+		t.Run(fmt.Sprintf("New Enabled %t", enabled), func(it *testing.T) {
+			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractEnabled)
+			testCases := map[string]*storage.AuthProvider{
+				"Provider with storedInfo but enable not set": {},
+				"Provider with storedInfo and enabled": {
+					Enabled: true,
+				},
+				"Provider with storedInfo and disabled": {
+					Enabled: false,
+				},
+			}
+			for name, providerStoredInfo := range testCases {
+				it.Run(name, testProviderOptionApplication(option, providerStoredInfo, enabled, extractEnabled))
+				it.Run(
+					name+" - breaking revert",
+					testProviderOptionApplicationBreakingRevert(option, providerStoredInfo, enabled, extractEnabled),
+				)
+			}
+		})
+	}
+}
+
+func TestWithActive(t *testing.T) {
+	for _, activate := range []bool{true, false} {
+		option := WithActive(activate)
+		extractActive := func(provider *providerImpl) interface{} {
+			return provider.storedInfo.GetActive()
+		}
+		extractValidated := func(provider *providerImpl) interface{} {
+			return provider.storedInfo.GetValidated()
+		}
+		t.Run(fmt.Sprintf("New Active %t", activate), func(it *testing.T) {
+			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractActive, extractValidated)
+			testCases := map[string]*storage.AuthProvider{
+				"Provider with storedInfo, but no active nor validated data": {},
+				"Provider with storedInfo, active, but no validated data": {
+					Active: true,
+				},
+				"Provider with storedInfo, inactive, but no validated data": {
+					Active: false,
+				},
+				"Provider with storedInfo, validated, but no active data": {
+					Validated: true,
+				},
+				"Provider with storedInfo, not validated, no active data": {
+					Validated: false,
+				},
+				"Provider with storedInfo, active, validated": {
+					Active:    true,
+					Validated: true,
+				},
+				"Provider with storedInfo, active, not validated": {
+					Active:    true,
+					Validated: false,
+				},
+				"Provider with storedInfo, inactive, validated": {
+					Active:    false,
+					Validated: true,
+				},
+				"Provider with storedInfo, inactive, not validated": {
+					Active:    false,
+					Validated: false,
+				},
+			}
+			for name, providerStoredInfo := range testCases {
+				it.Run(name, testProviderOptionApplication(option, providerStoredInfo, activate, extractActive, extractValidated))
+				it.Run(
+					name+" - breaking revert",
+					testProviderOptionApplicationBreakingRevert(option, providerStoredInfo, activate, extractActive, extractValidated),
+				)
+			}
+		})
+	}
+}
+
+func TestWithVisibility(t *testing.T) {
+	for _, visibility := range []storage.Traits_Visibility{
+		storage.Traits_VISIBLE, storage.Traits_HIDDEN,
+	} {
+		option := WithVisibility(visibility)
+		extractVisibility := func(provider *providerImpl) interface{} {
+			return provider.storedInfo.GetTraits().GetVisibility()
+		}
+		t.Run(fmt.Sprintf("New Visibility %s", visibility.String()), func(it *testing.T) {
+			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractVisibility)
+			testCases := map[string]*storage.AuthProvider{
+				"Provider with storedInfo, no traits": {},
+				"Provider with storedInfo, nil traits": {
+					Traits: nil,
+				},
+				"Provider with storedInfo, traits with no visibility info": {
+					Traits: &storage.Traits{},
+				},
+				"Provider with storedInfo, traits with visible": {
+					Traits: &storage.Traits{
+						Visibility: storage.Traits_VISIBLE,
+					},
+				},
+				"Provider with storedInfo, traits with hidden": {
+					Traits: &storage.Traits{
+						Visibility: storage.Traits_HIDDEN,
+					},
+				},
+			}
+			for name, providerStoredInfo := range testCases {
+				it.Run(name, testProviderOptionApplication(option, providerStoredInfo, visibility, extractVisibility))
+				it.Run(
+					name+" - breaking revert",
+					testProviderOptionApplicationBreakingRevert(option, providerStoredInfo, visibility, extractVisibility),
+				)
+			}
+		})
+	}
+}
+
+// region test helpers
+
+func testNoStoredInfoProvider(
+	t *testing.T,
+	option ProviderOption,
+	expectedError error,
+	extractors ...func(*providerImpl) interface{},
+) {
+	t.Run(noInfoProviderCaseName, func(it *testing.T) {
+		provider := &providerImpl{}
+		assert.Nil(it, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Empty(it, extractor(provider))
+		}
+		revert, err := option(provider)
+		assert.ErrorIs(it, err, expectedError)
+		assert.Nil(it, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Empty(it, extractor(provider))
+		}
+		err = revert(provider)
+		assert.NoError(it, err)
+		assert.Nil(it, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Empty(it, extractor(provider))
+		}
+	})
+}
+
+func testNoOverwriteOptionApplication(
+	t *testing.T,
+	option ProviderOption,
+	provider *providerImpl,
+	oldTokenIssuer tokens.Issuer,
+	oldRoleMapper permissions.RoleMapper,
+	oldBackend Backend,
+	oldBackendFactory BackendFactory,
+) {
+	t.Run(noOverwriteCaseName, func(it *testing.T) {
+		oldStoredInfo := provider.storedInfo.CloneVT()
+		revert, err := option(provider)
+		assert.NoError(it, err)
+		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
+		assert.Equal(it, oldTokenIssuer, provider.issuer)
+		assert.Equal(it, oldRoleMapper, provider.roleMapper)
+		assert.Equal(it, oldBackend, provider.backend)
+		assert.Equal(it, oldBackendFactory, provider.backendFactory)
+		err = revert(provider)
+		assert.NoError(it, err)
+		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
+		assert.Equal(it, oldTokenIssuer, provider.issuer)
+		assert.Equal(it, oldRoleMapper, provider.roleMapper)
+		assert.Equal(it, oldBackend, provider.backend)
+		assert.Equal(it, oldBackendFactory, provider.backendFactory)
+	})
+}
+
+func testProviderOptionApplication(
+	option ProviderOption,
+	originalStoredInfo *storage.AuthProvider,
+	targetValue interface{},
+	extractors ...func(*providerImpl) interface{},
+) func(*testing.T) {
+	return func(t *testing.T) {
+		provider := &providerImpl{storedInfo: originalStoredInfo.CloneVT()}
+		assert.NotNil(t, provider.storedInfo)
+		protoassert.Equal(t, originalStoredInfo, provider.storedInfo)
+		fmt.Println("calling option")
+		revert, err := option(provider)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Equal(t, targetValue, extractor(provider))
+		}
+		err = revert(provider)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider.storedInfo)
+		protoassert.Equal(t, originalStoredInfo, provider.storedInfo)
+	}
+}
+
+func testProviderOptionApplicationBreakingRevert(
+	option ProviderOption,
+	originalStoredInfo *storage.AuthProvider,
+	targetValue interface{},
+	extractors ...func(*providerImpl) interface{},
+) func(*testing.T) {
+	return func(t *testing.T) {
+		provider := &providerImpl{storedInfo: originalStoredInfo.CloneVT()}
+		assert.NotNil(t, provider.storedInfo)
+		protoassert.Equal(t, originalStoredInfo, provider.storedInfo)
+		revert, err := option(provider)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Equal(t, targetValue, extractor(provider))
+		}
+		provider.storedInfo = nil
+		assert.Nil(t, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Empty(t, extractor(provider))
+		}
+		err = revert(provider)
+		assert.ErrorIs(t, err, errox.InvariantViolation)
+		assert.Nil(t, provider.storedInfo)
+		for _, extractor := range extractors {
+			assert.Empty(t, extractor(provider))
+		}
+	}
+}
+
+// region field extractors
+
+func extractID(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetId()
+}
+
+func extractLoginURL(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetLoginUrl()
+}
+
+func extractConfig(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetConfig()
+}
+
+func extractType(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetType()
+}
+
+func extractName(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetName()
+}
+
+// endregion field extractors
+
+type fakeIssuer struct {
+	ID string
+}
+
+func (i *fakeIssuer) Issue(_ context.Context, _ tokens.RoxClaims, _ ...tokens.Option) (*tokens.TokenInfo, error) {
+	return nil, nil
+}
+
+type fakeRoleMapper struct {
+	ID string
+}
+
+func (m *fakeRoleMapper) FromUserDescriptor(_ context.Context, _ *permissions.UserDescriptor) ([]permissions.ResolvedRole, error) {
+	return nil, nil
+}
+
+// endregion test helpers

--- a/pkg/auth/authproviders/provider_options_test.go
+++ b/pkg/auth/authproviders/provider_options_test.go
@@ -480,9 +480,6 @@ func TestWithStorageView(t *testing.T) {
 func TestWithID(t *testing.T) {
 	option := WithID(testProviderID)
 
-	extractID := func(provider *providerImpl) interface{} {
-		return provider.storedInfo.GetId()
-	}
 	testNoStoredInfoProvider(t, option, errox.InvariantViolation, extractID)
 
 	testCases := map[string]*storage.AuthProvider{
@@ -546,9 +543,6 @@ func TestWithName(t *testing.T) {
 func TestWithEnabled(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
 		option := WithEnabled(enabled)
-		extractEnabled := func(provider *providerImpl) interface{} {
-			return provider.storedInfo.GetEnabled()
-		}
 		t.Run(fmt.Sprintf("New Enabled %t", enabled), func(it *testing.T) {
 			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractEnabled)
 			testCases := map[string]*storage.AuthProvider{
@@ -574,12 +568,6 @@ func TestWithEnabled(t *testing.T) {
 func TestWithActive(t *testing.T) {
 	for _, activate := range []bool{true, false} {
 		option := WithActive(activate)
-		extractActive := func(provider *providerImpl) interface{} {
-			return provider.storedInfo.GetActive()
-		}
-		extractValidated := func(provider *providerImpl) interface{} {
-			return provider.storedInfo.GetValidated()
-		}
 		t.Run(fmt.Sprintf("New Active %t", activate), func(it *testing.T) {
 			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractActive, extractValidated)
 			testCases := map[string]*storage.AuthProvider{
@@ -629,9 +617,6 @@ func TestWithVisibility(t *testing.T) {
 		storage.Traits_VISIBLE, storage.Traits_HIDDEN,
 	} {
 		option := WithVisibility(visibility)
-		extractVisibility := func(provider *providerImpl) interface{} {
-			return provider.storedInfo.GetTraits().GetVisibility()
-		}
 		t.Run(fmt.Sprintf("New Visibility %s", visibility.String()), func(it *testing.T) {
 			testNoStoredInfoProvider(it, option, errox.InvariantViolation, extractVisibility)
 			testCases := map[string]*storage.AuthProvider{
@@ -795,6 +780,22 @@ func extractType(provider *providerImpl) interface{} {
 
 func extractName(provider *providerImpl) interface{} {
 	return provider.storedInfo.GetName()
+}
+
+func extractEnabled(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetEnabled()
+}
+
+func extractActive(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetActive()
+}
+
+func extractValidated(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetValidated()
+}
+
+func extractVisibility(provider *providerImpl) interface{} {
+	return provider.storedInfo.GetTraits().GetVisibility()
 }
 
 // endregion field extractors

--- a/pkg/auth/authproviders/provider_options_test.go
+++ b/pkg/auth/authproviders/provider_options_test.go
@@ -8,12 +8,9 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/auth/tokens"
-	tokenIssuerMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/protoassert"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 const (
@@ -60,241 +57,6 @@ var (
 	noBackend        Backend                = nil
 	noBackendFactory BackendFactory         = nil
 )
-
-func TestDefaultNewID(t *testing.T) {
-	option := DefaultNewID()
-
-	// DefaultNewID should fail on a provider object with nil storedInfo field.
-	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractID)
-
-	// DefaultNewID should not overwrite a pre-existing ID,
-	// nor should the associated reveret action.
-	previousIDProvider := &providerImpl{
-		storedInfo: &storage.AuthProvider{
-			Id: authProviderID,
-		},
-	}
-	testNoOverwriteOptionApplication(t, option, previousIDProvider, noIssuer, noMapper, noBackend, noBackendFactory)
-
-	// DefaultNewID should set the ID field in the storedInfo field
-	// with a valid UUID. The revert action should set the ID back
-	// to its previous value (here empty string).
-	provider := &providerImpl{
-		storedInfo: &storage.AuthProvider{},
-	}
-	assert.Empty(t, provider.storedInfo.GetId())
-	t.Run(emptyInfoProviderCaseName, func(it *testing.T) {
-		revert, err := option(provider)
-		assert.NoError(t, err)
-		providerID := provider.storedInfo.GetId()
-		assert.NotEmpty(t, providerID)
-		_, err = uuid.FromString(providerID)
-		assert.NoError(t, err)
-		err = revert(provider)
-		assert.NoError(t, err)
-		assert.Empty(t, provider.storedInfo.GetId())
-	})
-}
-
-func TestDefaultLoginURL(t *testing.T) {
-	called := 0
-	getLoginURL := func(_ string) string {
-		called += 1
-		return testLoginURL
-	}
-	option := DefaultLoginURL(getLoginURL)
-
-	// DefaultLoginURL should fail on a provider object with nil storedInfo field.
-	testNoStoredInfoProvider(t, option, noStoredInfoErr, extractLoginURL)
-	// Ensure the option application did not call getLoginURL.
-	assert.Zero(t, called)
-
-	// DefaultLoginURL should not overwrite a pre-existing login URL,
-	// nor should the revert action.
-	previousLoginURLProvider := &providerImpl{
-		storedInfo: &storage.AuthProvider{
-			LoginUrl: baseLoginURL,
-		},
-	}
-	testNoOverwriteOptionApplication(t, option, previousLoginURLProvider, noIssuer, noMapper, noBackend, noBackendFactory)
-	// Ensure the option application did not call getLoginURL.
-	assert.Zero(t, called)
-
-	// DefaultLoginURL on a provider with non-nil stored info but no
-	// previous login URL should set the login URL to the result of the
-	// provided function call, the revert action should reset
-	// the login URL to an empty value.
-	provider := &providerImpl{
-		storedInfo: &storage.AuthProvider{},
-	}
-	assert.Empty(t, extractLoginURL(provider))
-	t.Run(
-		emptyInfoProviderCaseName,
-		testProviderOptionApplication(
-			option,
-			&storage.AuthProvider{},
-			testLoginURL,
-			extractLoginURL,
-		),
-	)
-	// ensure the getLoginURL function was called while applying the option.
-	assert.Equal(t, 1, called)
-}
-
-func TestDefaultTokenIssuerFromFactory(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	baseIssuer := &fakeIssuer{ID: baseIssuerID}
-	testIssuer := &fakeIssuer{ID: testIssuerID}
-
-	mockIssuerFactory := tokenIssuerMocks.NewMockIssuerFactory(mockCtrl)
-	mockIssuerFactory.EXPECT().
-		CreateIssuer(gomock.Any(), gomock.Any()).
-		Times(1).
-		Return(testIssuer, nil)
-
-	option := DefaultTokenIssuerFromFactory(mockIssuerFactory)
-
-	// DefaultTokenIssuerFromFactory should not overwrite a pre-existing issuer,
-	// nor should the associated revert action.
-	previousIssuerProvider := &providerImpl{
-		issuer: baseIssuer,
-	}
-	testNoOverwriteOptionApplication(t, option, previousIssuerProvider, baseIssuer, noMapper, noBackend, noBackendFactory)
-
-	// DefaultIssuerFromFactory should set the issuer to the result
-	// of the provider factory creation call, the revert action should
-	// reset the issuer to a nil value.
-	noIssuerProvider := &providerImpl{}
-	assert.Nil(t, noIssuerProvider.issuer)
-	t.Run("Provider with no previous token issuer", func(it *testing.T) {
-		revert, err := option(noIssuerProvider)
-		assert.NoError(it, err)
-		assert.Equal(it, testIssuer, noIssuerProvider.issuer)
-		err = revert(noIssuerProvider)
-		assert.NoError(it, err)
-		assert.Nil(it, noIssuerProvider.issuer)
-	})
-}
-
-func TestDefaultRoleMapperOption(t *testing.T) {
-	optionBaseRoleMapper := &fakeRoleMapper{ID: baseRoleMapperID}
-	optionTestRoleMapper := &fakeRoleMapper{ID: testRoleMapperID}
-
-	getRoleMapper := func(_ string) permissions.RoleMapper {
-		return optionTestRoleMapper
-	}
-	option := DefaultRoleMapperOption(getRoleMapper)
-
-	// DefaultRoleMapper should not erase any pre-existing role mapper,
-	// nor should the associated revert action.
-	previousRoleMapperProvider := &providerImpl{
-		roleMapper: optionBaseRoleMapper,
-	}
-	testNoOverwriteOptionApplication(t, option, previousRoleMapperProvider, noIssuer, optionBaseRoleMapper, noBackend, noBackendFactory)
-
-	// DefaultRoleMapper should not touch the role mapper if there is
-	// no previous role mapper, but the storage can NOT provide an ID,
-	// the associated revert action should not touch the role mapper either.
-	t.Run("Provider with no previous role mapper nor ID", func(it *testing.T) {
-		noIDNoMapperProvider := &providerImpl{}
-		assert.Nil(it, noIDNoMapperProvider.roleMapper)
-		assert.Empty(it, extractID(noIDNoMapperProvider))
-		revert, err := option(noIDNoMapperProvider)
-		assert.NoError(it, err)
-		assert.Nil(it, noIDNoMapperProvider.roleMapper)
-		err = revert(noIDNoMapperProvider)
-		assert.NoError(it, err)
-		assert.Nil(it, noIDNoMapperProvider.roleMapper)
-	})
-
-	// DefaultRoleMapper should set the role mapper if there is
-	// no previous mapper and the storage view can provide an ID.
-	// The revert action should reset the role mapper to a nil value.
-	t.Run("Provider with ID but no previous role mapper", func(it *testing.T) {
-		provider := &providerImpl{
-			storedInfo: &storage.AuthProvider{
-				Id: authProviderID,
-			},
-		}
-		assert.Nil(it, provider.roleMapper)
-		assert.Equal(it, authProviderID, extractID(provider))
-		revert, err := option(provider)
-		assert.NoError(it, err)
-		assert.Equal(it, optionTestRoleMapper, provider.roleMapper)
-		err = revert(provider)
-		assert.NoError(it, err)
-		assert.Nil(it, err)
-	})
-}
-
-func TestDefaultBackend(t *testing.T) {
-	backendFactoryPool := map[string]BackendFactory{
-		"test": testAuthProviderBackendFactory,
-	}
-	option := DefaultBackend(context.Background(), backendFactoryPool)
-
-	baseAuthProviderBackendFactory := &tstAuthProviderBackendFactory{
-		ID: baseAuthProviderBackendFactoryID,
-	}
-	baseAuthProviderBackend := &tstAuthProviderBackend{
-		ID: baseAuthProviderBackendID,
-	}
-
-	previousBackendProvider := &providerImpl{
-		backend:        baseAuthProviderBackend,
-		backendFactory: baseAuthProviderBackendFactory,
-		storedInfo: &storage.AuthProvider{
-			Config: baseAuthProviderBackendConfig,
-		},
-	}
-	testNoOverwriteOptionApplication(t, option, previousBackendProvider, noIssuer, noMapper, baseAuthProviderBackend, baseAuthProviderBackendFactory)
-
-	t.Run("Provider with wrong type", func(it *testing.T) {
-		provider := &providerImpl{
-			storedInfo: &storage.AuthProvider{
-				Type: "base",
-			},
-		}
-		assert.Nil(it, provider.backend)
-		assert.Nil(it, provider.backendFactory)
-		assert.Empty(it, provider.storedInfo.GetConfig())
-		revert, err := option(provider)
-		assert.Error(t, err)
-		assert.Nil(it, provider.backend)
-		assert.Nil(it, provider.backendFactory)
-		assert.Empty(it, provider.storedInfo.GetConfig())
-		err = revert(provider)
-		assert.NoError(it, err)
-		assert.Nil(it, provider.backend)
-		assert.Nil(it, provider.backendFactory)
-		assert.Empty(it, provider.storedInfo.GetConfig())
-	})
-
-	t.Run("Provider without backend", func(it *testing.T) {
-		provider := &providerImpl{
-			backendFactory: baseAuthProviderBackendFactory,
-			storedInfo: &storage.AuthProvider{
-				Type:   "test",
-				Config: baseAuthProviderBackendConfig,
-			},
-		}
-		assert.Nil(it, provider.backend)
-		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
-		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
-		revert, err := option(provider)
-		assert.NoError(it, err)
-		assert.Equal(it, testAuthProviderBackend, provider.backend)
-		assert.Equal(it, testAuthProviderBackendFactory, provider.backendFactory)
-		assert.Equal(it, testAuthProviderBackendConfig, extractConfig(provider))
-		err = revert(provider)
-		assert.NoError(it, err)
-		assert.Nil(it, provider.backend)
-		assert.Equal(it, baseAuthProviderBackendFactory, provider.backendFactory)
-		assert.Equal(it, baseAuthProviderBackendConfig, extractConfig(provider))
-	})
-}
 
 func TestWithBackendFromFactory(t *testing.T) {
 	option := WithBackendFromFactory(context.Background(), testAuthProviderBackendFactory)
@@ -678,34 +440,6 @@ func testNoStoredInfoProvider(
 	})
 }
 
-func testNoOverwriteOptionApplication(
-	t *testing.T,
-	option ProviderOption,
-	provider *providerImpl,
-	oldTokenIssuer tokens.Issuer,
-	oldRoleMapper permissions.RoleMapper,
-	oldBackend Backend,
-	oldBackendFactory BackendFactory,
-) {
-	t.Run(noOverwriteCaseName, func(it *testing.T) {
-		oldStoredInfo := provider.storedInfo.CloneVT()
-		revert, err := option(provider)
-		assert.NoError(it, err)
-		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
-		assert.Equal(it, oldTokenIssuer, provider.issuer)
-		assert.Equal(it, oldRoleMapper, provider.roleMapper)
-		assert.Equal(it, oldBackend, provider.backend)
-		assert.Equal(it, oldBackendFactory, provider.backendFactory)
-		err = revert(provider)
-		assert.NoError(it, err)
-		protoassert.Equal(it, oldStoredInfo, provider.storedInfo)
-		assert.Equal(it, oldTokenIssuer, provider.issuer)
-		assert.Equal(it, oldRoleMapper, provider.roleMapper)
-		assert.Equal(it, oldBackend, provider.backend)
-		assert.Equal(it, oldBackendFactory, provider.backendFactory)
-	})
-}
-
 func testProviderOptionApplication(
 	option ProviderOption,
 	originalStoredInfo *storage.AuthProvider,
@@ -716,7 +450,6 @@ func testProviderOptionApplication(
 		provider := &providerImpl{storedInfo: originalStoredInfo.CloneVT()}
 		assert.NotNil(t, provider.storedInfo)
 		protoassert.Equal(t, originalStoredInfo, provider.storedInfo)
-		fmt.Println("calling option")
 		revert, err := option(provider)
 		assert.NoError(t, err)
 		assert.NotNil(t, provider.storedInfo)

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -600,6 +600,7 @@ func (*tstRoleMapperFactory) GetRoleMapper(_ string) perm.RoleMapper {
 
 // Authentication backend factory (needed by registry.RegisterBackendFactory)
 type tstAuthProviderBackend struct {
+	ID       string
 	authRsp  *AuthResponse
 	err      error
 	loginURL string
@@ -616,7 +617,7 @@ func (b *tstAuthProviderBackend) registerLoginURL(loginURL string, err error) {
 }
 
 func (*tstAuthProviderBackend) Config() map[string]string {
-	return nil
+	return testAuthProviderBackendConfig
 }
 
 func (b *tstAuthProviderBackend) LoginURL(_ string, _ *requestinfo.RequestInfo) (string, error) {
@@ -645,9 +646,12 @@ func (*tstAuthProviderBackend) Validate(_ context.Context, _ *tokens.Claims) err
 	return nil
 }
 
-var testAuthProviderBackend = &tstAuthProviderBackend{}
+var testAuthProviderBackend = &tstAuthProviderBackend{
+	ID: testAuthProviderBackendID,
+}
 
 type tstAuthProviderBackendFactory struct {
+	ID          string
 	providerID  string
 	clientState string
 	err         error
@@ -693,7 +697,9 @@ func (*tstAuthProviderBackendFactory) MergeConfig(newCfg, oldCfg map[string]stri
 	return mergedCfg
 }
 
-var testAuthProviderBackendFactory = &tstAuthProviderBackendFactory{}
+var testAuthProviderBackendFactory = &tstAuthProviderBackendFactory{
+	ID: testAuthProviderBackendFactoryID,
+}
 
 func newTestAuthProviderBackendFactory(_ string) BackendFactory {
 	return testAuthProviderBackendFactory

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -577,6 +577,8 @@ func (*tstTokenIssuerFactory) UnregisterSource(_ tokens.Source) error {
 	return nil
 }
 
+func (*tstTokenIssuerFactory) RegisterSource(_ tokens.Source) error { return nil }
+
 // RoleMapper factory (needed for NewStoreBackedRegistry)
 type tstRoleMapper struct {
 	roleMapping map[string][]perm.ResolvedRole

--- a/pkg/auth/authproviders/saml/registry_impl_test.go
+++ b/pkg/auth/authproviders/saml/registry_impl_test.go
@@ -68,6 +68,7 @@ func TestDeleteAuthProvider(t *testing.T) {
 	}
 
 	providerStore.EXPECT().AddAuthProvider(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	providerStore.EXPECT().GetAuthProvider(gomock.Any(), gomock.Any()).Times(1).Return(testProvider, true, nil)
 
 	provider, err := registry.CreateProvider(ctx, authproviders.WithStorageView(testProvider))
 	assert.NoError(t, err)

--- a/pkg/auth/tokens/issuer_factory.go
+++ b/pkg/auth/tokens/issuer_factory.go
@@ -16,6 +16,7 @@ type IssuerFactory interface {
 	// CreateIssuer creates an issuer for the given source. This must only be invoked once per source (ID).
 	CreateIssuer(source Source, options ...Option) (Issuer, error)
 	UnregisterSource(source Source) error
+	RegisterSource(source Source) error
 }
 
 func newIssuerFactory(id string, signer jose.Signer, sources *sourceStore, globalOptions ...Option) IssuerFactory {
@@ -35,7 +36,7 @@ type issuerFactory struct {
 }
 
 func (f *issuerFactory) CreateIssuer(source Source, options ...Option) (Issuer, error) {
-	if err := f.sources.Register(source); err != nil {
+	if err := f.RegisterSource(source); err != nil {
 		return nil, err
 	}
 
@@ -85,4 +86,8 @@ func translateExtra(extra map[string]json.RawMessage) map[string]interface{} {
 
 func (f *issuerFactory) UnregisterSource(source Source) error {
 	return f.sources.Unregister(source)
+}
+
+func (f *issuerFactory) RegisterSource(source Source) error {
+	return f.sources.Register(source)
 }

--- a/pkg/auth/tokens/mocks/issuer_factory.go
+++ b/pkg/auth/tokens/mocks/issuer_factory.go
@@ -59,6 +59,20 @@ func (mr *MockIssuerFactoryMockRecorder) CreateIssuer(source any, options ...any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIssuer", reflect.TypeOf((*MockIssuerFactory)(nil).CreateIssuer), varargs...)
 }
 
+// RegisterSource mocks base method.
+func (m *MockIssuerFactory) RegisterSource(source tokens.Source) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterSource", source)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterSource indicates an expected call of RegisterSource.
+func (mr *MockIssuerFactoryMockRecorder) RegisterSource(source any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSource", reflect.TypeOf((*MockIssuerFactory)(nil).RegisterSource), source)
+}
+
 // UnregisterSource mocks base method.
 func (m *MockIssuerFactory) UnregisterSource(source tokens.Source) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The OpenShift AuthProvider leaks backend loop registrations in case an AuthProvider creation request re-uses the name of an existing AuthProvider.

This change is a pre-factor part of a PR stack in order to be able to revert actions done during the creation of an AuthProvider in case of error.
- #12846
  - #12847
    - #12848

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ _update is not needed_
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ _is not needed_

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
<!--
- [ ] added e2e tests
-->
- [x] added regression tests
<!--
- [ ] added compatibility tests
- [ ] modified existing tests
-->

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests
