### PR TITLE
ROX-26013: Fix image cve count when unknown severities are present

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -12,7 +12,6 @@ import {
 } from '@patternfly/react-core';
 import { DropdownItem } from '@patternfly/react-core/deprecated';
 import { gql, useQuery } from '@apollo/client';
-import sum from 'lodash/sum';
 
 import useURLSearch from 'hooks/useURLSearch';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
@@ -83,6 +82,7 @@ export const imageVulnerabilitiesQuery = gql`
     ) {
         image(id: $id) {
             ...ImageMetadataContext
+            imageVulnerabilityCount(query: $query)
             imageCVECountBySeverity(query: $query) {
                 ...ResourceCountsByCVESeverityAndStatus
             }
@@ -146,6 +146,7 @@ function ImagePageVulnerabilities({
         {
             image: ImageMetadataContext & {
                 imageCVECountBySeverity: ResourceCountByCveSeverityAndStatus;
+                imageVulnerabilityCount: number;
                 imageVulnerabilities: ImageVulnerability[];
             };
         },
@@ -189,13 +190,7 @@ function ImagePageVulnerabilities({
 
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
-    const severityCounts = data?.image.imageCVECountBySeverity;
-    const totalVulnerabilityCount = sum([
-        severityCounts?.critical.total ?? 0,
-        severityCounts?.important.total ?? 0,
-        severityCounts?.moderate.total ?? 0,
-        severityCounts?.low.total ?? 0,
-    ]);
+    const totalVulnerabilityCount = data?.image?.imageVulnerabilityCount ?? 0;
 
     return (
         <>


### PR DESCRIPTION
### Description

Fixes an issue where the total results count and pagination counts are derived from the `imageCVECountBySeverity` field, which breaks down CVEs by severity and fixability, but **does not** include counts for CVEs with `Unknown` severity.

This resulted in incorrect counts in the table on the Workload CVE image page, as well as inaccessible data when paginating to the last page.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit an image that contains CVEs of "Unknown" severity. This data is transient, but at the time of this PR `registry.redhat.io/redhat/redhat-operator-index:v4.14` is one such image.

Before:
View the image page and notice the CVE count above the table matches the sum of the counts in the summary cards. Also notice that there are 2 critical CVEs and 1 important, and that the data spans 9 table pages.
![image](https://github.com/user-attachments/assets/51c4f5d8-861d-4d69-b266-bbf86f152b39)

Sort by severity ascending to see the Unknown severity CVEs:
![image](https://github.com/user-attachments/assets/3ede56f9-f390-47b9-a781-facd64a9bc15)

Page through to the last page and see that both of the critical CVEs, the imporant CVE, and a single moderate CVE are inaccessible due to the incorrect count resulting in too few table pages:
![image](https://github.com/user-attachments/assets/b512b9fe-c776-434e-a619-ba62790e9848)
![image](https://github.com/user-attachments/assets/9880586f-a767-45bb-9306-f51b7e1ce274)



After:
See that the data count includes the Unknown severity CVEs, and view the CVEs sorted by most severe first.
![image](https://github.com/user-attachments/assets/9ed83efb-ace7-4a7e-b70b-036f08f9c2fb)

Sort by _least_ severe and page to the final page. All of the top severity CVEs should be present.
![image](https://github.com/user-attachments/assets/0da81264-e4e0-479a-ab91-5df1646ef02e)
