### PR TITLE
chore(ui): Change postgres path in listening endpt test

### DIFF
--- a/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsTable.test.js
+++ b/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsTable.test.js
@@ -30,7 +30,7 @@ describe('Listening endpoints page table', () => {
         cy.get(
             `${centralDbProcessTableSelector} ${selectors.tableRowWithValueForColumn(
                 'Exec file path',
-                '/usr/pgsql-13/bin/postgres'
+                '/usr/bin/postgres'
             )}`
         );
         cy.get(


### PR DESCRIPTION
### Description

Fixes a test failure in UI e2e tests due to an assumption made on the postgres path that has changed after an [upstream+downstream convergence on postgres](https://github.com/stackrox/stackrox/pull/12498).

See the new expected path in this test failure video: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-ui-e2e-tests/1840755940098314240/artifacts/merge-gke-ui-e2e-tests/stackrox-stackrox-e2e-test/artifacts/videos/listeningEndpoints/listeningEndpointsTable.test.js.mp4

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

The proof is in the pudding (CI).