### PR TITLE
chore(ui): Increase cypress requestTimeout to 20 seconds

### DIFF
--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -10,7 +10,7 @@ module.exports = {
     blockHosts: ['*.*'], // Browser options
     chromeWebSecurity: false, // Browser options
     numTestsKeptInMemory: 0, // Global options
-    requestTimeout: 10000, // Timeouts options
+    requestTimeout: 20000, // Timeouts options
     video: true, // Videos options
     videoCompression: 32, // Videos options
 


### PR DESCRIPTION
### Description

As discussed in team meeting, see effect of `requestTimeout` on occasional test failures for generic requests

History: increased from default 5 seconds to 10 seconds about 2 years ago on 2022-10-04 in #3307

https://docs.cypress.io/guides/references/configuration#Timeouts

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] edited configuration of e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI