### PR TITLE
ROX-25643: Remove tabs from postgresql conf

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -21,12 +21,12 @@ log_timezone = 'Etc/UTC'
 datestyle = 'iso, mdy'
 timezone = 'Etc/UTC'
 lc_messages = 'en_US.utf8'
-lc_monetary = 'en_US.utf8'		# locale for monetary formatting
-lc_numeric = 'en_US.utf8'		# locale for number formatting
-lc_time = 'en_US.utf8'			# locale for time formatting
+lc_monetary = 'en_US.utf8'          # locale for monetary formatting
+lc_numeric = 'en_US.utf8'           # locale for number formatting
+lc_time = 'en_US.utf8'              # locale for time formatting
 
 default_text_search_config = 'pg_catalog.english'
-shared_preload_libraries = 'pg_stat_statements'	# StackRox customized
+shared_preload_libraries = 'pg_stat_statements'     # StackRox customized
 
 # Logging. For more details, see
 # https://www.postgresql.org/docs/current/runtime-config-logging.html


### PR DESCRIPTION
### Description

It turns out tabs in the configuration are causing an annoying inconvenience. The yaml renderer output for files with tabs ends up being a mess of all lines merged together with the new line character in between. This makes manual configuration harder, and since the tabs are not essential, get rid of them.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not validated yet.