### PR TITLE
fix:  Fix image references in operator bundle for the related images

### DIFF
--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -618,17 +618,17 @@ spec:
       - OPERATOR_IMAGE_TAG=$(tasks.determine-operator-image-tag.results.IMAGE_TAG)
       - OPERATOR_IMAGE_DIGEST=$(tasks.determine-operator-image-digest.results.IMAGE_DIGEST)
       - OPERATOR_IMAGE_REPO=$(params.operator-image-repo)
-      - RELATED_IMAGE_MAIN="$(params.main-image-repo):$(tasks.determine-main-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER="$(params.scanner-image-repo):$(tasks.determine-scanner-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER_DB="$(params.scanner-db-image-repo):$(tasks.determine-scanner-db-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER_SLIM="$(params.scanner-slim-image-repo):$(tasks.determine-scanner-slim-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER_DB_SLIM="$(params.scanner-db-slim-image-repo):$(tasks.determine-scanner-db-slim-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER_V4="$(params.scanner-v4-image-repo):$(tasks.determine-scanner-v4-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_SCANNER_V4_DB="$(params.scanner-v4-db-image-repo):$(tasks.determine-scanner-v4-db-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_COLLECTOR_SLIM="$(params.collector-slim-image-repo):$(tasks.determine-collector-slim-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_COLLECTOR_FULL="$(params.collector-full-image-repo):$(tasks.determine-collector-full-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_ROXCTL="$(params.roxctl-image-repo):$(tasks.determine-roxctl-image-digest.results.IMAGE_DIGEST)"
-      - RELATED_IMAGE_CENTRAL_DB="$(params.central-db-image-repo):$(tasks.determine-central-db-image-digest.results.IMAGE_DIGEST)"
+      - RELATED_IMAGE_MAIN=$(params.main-image-repo)@$(tasks.determine-main-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER=$(params.scanner-image-repo)@$(tasks.determine-scanner-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER_DB=$(params.scanner-db-image-repo)@$(tasks.determine-scanner-db-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER_SLIM=$(params.scanner-slim-image-repo)@$(tasks.determine-scanner-slim-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER_DB_SLIM=$(params.scanner-db-slim-image-repo)@$(tasks.determine-scanner-db-slim-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER_V4=$(params.scanner-v4-image-repo)@$(tasks.determine-scanner-v4-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_SCANNER_V4_DB=$(params.scanner-v4-db-image-repo)@$(tasks.determine-scanner-v4-db-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_COLLECTOR_SLIM=$(params.collector-slim-image-repo)@$(tasks.determine-collector-slim-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_COLLECTOR_FULL=$(params.collector-full-image-repo)@$(tasks.determine-collector-full-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_ROXCTL=$(params.roxctl-image-repo)@$(tasks.determine-roxctl-image-digest.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_CENTRAL_DB=$(params.central-db-image-repo)@$(tasks.determine-central-db-image-digest.results.IMAGE_DIGEST)
 
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)


### PR DESCRIPTION
### Description

This is a fix for the injection of the related Images. Before this change the image references looked like this:

```
image: '"quay.io/rhacs-eng/roxctl:sha256:2fed1592ce09139868bda931c6e33d5312924d1a4e25e7d96fd86e8f2f0085aa"'
```

notice the double quotation marks and the double colon between the repo name and the hash.

With this change the references look like this:

```
image: "quay.io/rhacs-eng/roxctl@sha256:2fed1592ce09139868bda931c6e33d5312924d1a4e25e7d96fd86e8f2f0085aa"
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

Extracted the CSV from the image and verified that it looks good now.

- [x] CI results are inspected
