### PR TITLE
ROX-26311: Compliance connecting to Sensor shall retry longer

### DIFF
--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -284,7 +284,7 @@ func (c *Compliance) manageSendToSensor(ctx context.Context, cli sensor.Complian
 func (c *Compliance) initializeStream(ctx context.Context, cli sensor.ComplianceServiceClient) (sensor.ComplianceService_CommunicateClient, *sensor.MsgToCompliance_ScrapeConfig, error) {
 	eb := backoff.NewExponentialBackOff()
 	eb.MaxInterval = 30 * time.Second
-	eb.MaxElapsedTime = 3 * time.Minute
+	eb.MaxElapsedTime = 15 * time.Minute
 
 	var client sensor.ComplianceService_CommunicateClient
 	var config *sensor.MsgToCompliance_ScrapeConfig


### PR DESCRIPTION
### Description

In some test cases in the CI Sensor was unavailable for over 10 minutes. Compliance tries to reconnect to Sensor for maximally 3 minutes. Compliance starts retrying immediately after the connection is down. There are many cases where compliance misses Sensor by few seconds.

See comments in: https://issues.redhat.com/browse/ROX-26311

If https://github.com/stackrox/stackrox/pull/12815 is merged, then this PR must include a revert of the part that disables checking for compliance restarts.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

I did nothing so far - this is pretty difficult to test the way it was caught by the CI.

#### How I validated my change

The error condition difficult to reproduce the way it was seen in CI, but I did the following:
- Confirmed that if Sensor is down for over 3 mins, then Compliance container fails with error as from the ticket.
- Confirmed that if Sensor is down for less than 3 minutes, then Compliance reconnects successfully.
- The change from 3 to 15 mins is trivial and I have not tested the change of the number itself.