### PR TITLE
ROX-25897: Add logging to display found violations in test

### DIFF
--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -229,7 +229,11 @@ class Services extends BaseService {
 
     static checkForNoViolations(String deploymentName, String policyName, int checkSeconds = 5) {
         def violations = getViolationsWithTimeout(deploymentName, policyName, checkSeconds)
-        return violations == null || violations.size() == 0
+        boolean noViolations = (violations == null || violations.size() == 0)
+        if (!noViolations) {
+            LOG.info "Deployment '${deploymentName}' has violation(s): ${violations}"
+        }
+        return noViolations
     }
 
     static boolean expectNoViolations(String deploymentName, String policyName, int timeoutSeconds = 60) {


### PR DESCRIPTION
### Description

This PR is adding logging to the flaky test.

It is not visible from the provided logs and dumps what violations we get during a test. The image and signatures verified for it are the same for successful and failed tests.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

Will let CI do that
