### PR TITLE
ROX-26434: Adding policyName field to the policy CR spec

### DIFF
--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -36,25 +36,90 @@ type EnforcementAction string
 
 // SecurityPolicySpec defines the desired state of SecurityPolicy
 type SecurityPolicySpec struct {
-	Description string   `json:"description,omitempty"`
-	Rationale   string   `json:"rationale,omitempty"`
-	Remediation string   `json:"remediation,omitempty"`
-	Disabled    bool     `json:"disabled,omitempty"`
-	Categories  []string `json:"categories,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^[^\n\r\$]{5,128}$`
+	PolicyName string `json:"name,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^[^\$]{0,800}$`
+	Description string `json:"description,omitempty"`
+	Rationale   string `json:"rationale,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+	Disabled    bool   `json:"disabled,omitempty"`
+	// +kubebuilder:validation:MinItems=1
+	Categories []string `json:"categories,omitempty"`
 	// +kubebuilder:validation:MinItems=1
 	LifecycleStages []LifecycleStage `json:"lifecycleStages,omitempty"`
 	EventSource     EventSource      `json:"eventSource,omitempty"`
 	Exclusions      []Exclusion      `json:"exclusions,omitempty"`
 	Scope           []Scope          `json:"scope,omitempty"`
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=UNSET_SEVERITY;LOW_SEVERITY;MEDIUM_SEVERITY;HIGH_SEVERITY;CRITICAL_SEVERITY
-	Severity           string               `json:"severity,omitempty"`
-	EnforcementActions []EnforcementAction  `json:"enforcementActions,omitempty"`
-	Notifiers          []string             `json:"notifiers,omitempty"`
+	Severity           string              `json:"severity,omitempty"`
+	EnforcementActions []EnforcementAction `json:"enforcementActions,omitempty"`
+	Notifiers          []string            `json:"notifiers,omitempty"`
+	// +kubebuilder:validation:MinItems=1
 	PolicySections     []PolicySection      `json:"policySections,omitempty"`
 	MitreAttackVectors []MitreAttackVectors `json:"mitreAttackVectors,omitempty"`
 	CriteriaLocked     bool                 `json:"criteriaLocked,omitempty"`
 	MitreVectorsLocked bool                 `json:"mitreVectorsLocked,omitempty"`
 	IsDefault          bool                 `json:"isDefault,omitempty"`
+}
+
+type Exclusion struct {
+	Name       string     `json:"name,omitempty"`
+	Deployment Deployment `json:"deployment,omitempty"`
+	Image      Image      `json:"image,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Format="date-time"
+	Expiration string `json:"expiration,omitempty"`
+}
+
+type Deployment struct {
+	Name  string `json:"name,omitempty"`
+	Scope Scope  `json:"scope,omitempty"`
+}
+
+type Image struct {
+	Name string `json:"name,omitempty"`
+}
+
+type Scope struct {
+	Cluster   string `json:"cluster,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Label     Label  `json:"label,omitempty"`
+}
+
+type Label struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+type PolicySection struct {
+	SectionName  string        `json:"sectionName,omitempty"`
+	PolicyGroups []PolicyGroup `json:"policyGroups,omitempty"`
+}
+
+type PolicyGroup struct {
+	FieldName string `json:"fieldName,omitempty"`
+	// +kubebuilder:validation:Enum=OR;AND
+	BooleanOperator string        `json:"booleanOperator,omitempty"`
+	Negate          bool          `json:"negate,omitempty"`
+	Values          []PolicyValue `json:"values,omitempty"`
+}
+
+type PolicyValue struct {
+	Value string `json:"value,omitempty"`
+}
+
+type MitreAttackVectors struct {
+	Tactic     string   `json:"tactic,omitempty"`
+	Techniques []string `json:"techniques,omitempty"`
+}
+
+// SecurityPolicyStatus defines the observed state of SecurityPolicy
+type SecurityPolicyStatus struct {
+	Accepted bool   `json:"accepted"`
+	Message  string `json:"message"`
 }
 
 // IsValid runs validation checks against the SecurityPolicy spec
@@ -68,6 +133,7 @@ func (p SecurityPolicySpec) IsValid() (bool, error) {
 // ToProtobuf converts the SecurityPolicy spec into policy proto
 func (p SecurityPolicySpec) ToProtobuf() *storage.Policy {
 	proto := storage.Policy{
+		Name:               p.PolicyName,
 		Description:        p.Description,
 		Rationale:          p.Rationale,
 		Remediation:        p.Remediation,
@@ -92,8 +158,13 @@ func (p SecurityPolicySpec) ToProtobuf() *storage.Policy {
 			Name: exclusion.Name,
 		}
 
-		if protoTS, err := protocompat.ParseRFC3339NanoTimestamp(exclusion.Expiration); err == nil {
+		if exclusion.Expiration != "" {
+			protoTS, err := protocompat.ParseRFC3339NanoTimestamp(exclusion.Expiration)
+			if err != nil {
+				return nil
+			}
 			protoExclusion.Expiration = protoTS
+
 		}
 
 		if exclusion.Deployment != (Deployment{}) {
@@ -191,61 +262,6 @@ func (p SecurityPolicySpec) ToProtobuf() *storage.Policy {
 	}
 
 	return &proto
-}
-
-type Exclusion struct {
-	Name       string     `json:"name,omitempty"`
-	Deployment Deployment `json:"deployment,omitempty"`
-	Image      Image      `json:"image,omitempty"`
-	Expiration string     `json:"expiration,omitempty"`
-}
-
-type Deployment struct {
-	Name  string `json:"name,omitempty"`
-	Scope Scope  `json:"scope,omitempty"`
-}
-
-type Image struct {
-	Name string `json:"name,omitempty"`
-}
-
-type Scope struct {
-	Cluster   string `json:"cluster,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Label     Label  `json:"label,omitempty"`
-}
-
-type Label struct {
-	Key   string `json:"key,omitempty"`
-	Value string `json:"value,omitempty"`
-}
-
-type PolicySection struct {
-	SectionName  string        `json:"sectionName,omitempty"`
-	PolicyGroups []PolicyGroup `json:"policyGroups,omitempty"`
-}
-
-type PolicyGroup struct {
-	FieldName string `json:"fieldName,omitempty"`
-	// +kubebuilder:validation:Enum=OR;AND
-	BooleanOperator string        `json:"booleanOperator,omitempty"`
-	Negate          bool          `json:"negate,omitempty"`
-	Values          []PolicyValue `json:"values,omitempty"`
-}
-
-type PolicyValue struct {
-	Value string `json:"value,omitempty"`
-}
-
-type MitreAttackVectors struct {
-	Tactic     string   `json:"tactic,omitempty"`
-	Techniques []string `json:"techniques,omitempty"`
-}
-
-// SecurityPolicyStatus defines the observed state of SecurityPolicy
-type SecurityPolicyStatus struct {
-	Accepted bool   `json:"accepted"`
-	Message  string `json:"message"`
 }
 
 // +kubebuilder:object:root=true

--- a/config-controller/api/v1alpha1/policy_types_test.go
+++ b/config-controller/api/v1alpha1/policy_types_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 //go:embed test.json
-
 var files embed.FS
+
+const (
+	expirationTS = "2006-01-02T15:04:05Z"
+)
 
 func TestMarshalJSON(t *testing.T) {
 
@@ -25,33 +28,41 @@ func TestMarshalJSON(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(bytes, &policyCRSpec), "Failed to unmarshal policy spec CR JSON")
 
 	expected := SecurityPolicySpec{
+		PolicyName:      "This is a test policy",
 		Description:     "This is a test description",
 		Rationale:       "This is a test rationale",
 		Remediation:     "This is a test remediation",
 		Categories:      []string{"Security Best Practices"},
 		LifecycleStages: []LifecycleStage{"BUILD", "DEPLOY"},
-		Exclusions: []Exclusion{{
-			Name: "Don't alert on deployment collector in namespace stackrox",
-			Deployment: Deployment{
-				Name: "collector",
-				Scope: Scope{
-					Namespace: "stackrox",
-					Cluster:   "test",
+		Exclusions: []Exclusion{
+			{
+				Name: "Don't alert on deployment collector in namespace stackrox",
+				Deployment: Deployment{
+					Name: "collector",
+					Scope: Scope{
+						Namespace: "stackrox",
+						Cluster:   "test",
+					},
 				},
-			}},
+				Expiration: expirationTS,
+			},
 		},
 		Severity:           "LOW_SEVERITY",
 		EventSource:        "DEPLOYMENT_EVENT",
 		EnforcementActions: []EnforcementAction{"SCALE_TO_ZERO_ENFORCEMENT"},
-		PolicySections: []PolicySection{{
-			SectionName: "Section name",
-			PolicyGroups: []PolicyGroup{{
-				FieldName: "Image Component",
-				Values: []PolicyValue{{
-					Value: "rpm|microdnf|dnf|yum=",
-				}},
-			}},
-		}},
+		PolicySections: []PolicySection{
+			{
+				SectionName: "Section name",
+				PolicyGroups: []PolicyGroup{
+					{
+						FieldName: "Image Component",
+						Values: []PolicyValue{{
+							Value: "rpm|microdnf|dnf|yum=",
+						}},
+					},
+				},
+			},
+		},
 		CriteriaLocked:     true,
 		MitreVectorsLocked: true,
 		IsDefault:          false,
@@ -66,6 +77,5 @@ func TestMarshalJSON(t *testing.T) {
 	}.Marshal(protoPolicy)
 
 	assert.NoError(t, err, "Failed to marshal protobuf")
-
 	assert.Equal(t, string(bytes), strings.ReplaceAll(string(protoBytes), ":  ", ": ")+"\n")
 }

--- a/config-controller/api/v1alpha1/test.json
+++ b/config-controller/api/v1alpha1/test.json
@@ -1,4 +1,5 @@
 {
+  "name": "This is a test policy",
   "description": "This is a test description",
   "rationale": "This is a test rationale",
   "remediation": "This is a test remediation",
@@ -19,7 +20,8 @@
           "cluster": "test",
           "namespace": "stackrox"
         }
-      }
+      },
+      "expiration": "2006-01-02T15:04:05Z"
     }
   ],
   "severity": "LOW_SEVERITY",

--- a/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
+++ b/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
@@ -42,10 +42,12 @@ spec:
               categories:
                 items:
                   type: string
+                minItems: 1
                 type: array
               criteriaLocked:
                 type: boolean
               description:
+                pattern: ^[^\$]{0,800}$
                 type: string
               disabled:
                 type: boolean
@@ -91,6 +93,7 @@ spec:
                           type: object
                       type: object
                     expiration:
+                      format: date-time
                       type: string
                     image:
                       properties:
@@ -125,6 +128,9 @@ spec:
                 type: array
               mitreVectorsLocked:
                 type: boolean
+              name:
+                pattern: ^[^\n\r\$]{5,128}$
+                type: string
               notifiers:
                 items:
                   type: string
@@ -156,6 +162,7 @@ spec:
                     sectionName:
                       type: string
                   type: object
+                minItems: 1
                 type: array
               rationale:
                 type: string

--- a/image/templates/helm/stackrox-central/templates/00-securitypolicies-crd.yaml
+++ b/image/templates/helm/stackrox-central/templates/00-securitypolicies-crd.yaml
@@ -44,10 +44,12 @@ spec:
               categories:
                 items:
                   type: string
+                minItems: 1
                 type: array
               criteriaLocked:
                 type: boolean
               description:
+                pattern: ^[^\$]{0,800}$
                 type: string
               disabled:
                 type: boolean
@@ -93,6 +95,7 @@ spec:
                           type: object
                       type: object
                     expiration:
+                      format: date-time
                       type: string
                     image:
                       properties:
@@ -127,6 +130,9 @@ spec:
                 type: array
               mitreVectorsLocked:
                 type: boolean
+              name:
+                pattern: ^[^\n\r\$]{5,128}$
+                type: string
               notifiers:
                 items:
                   type: string
@@ -158,6 +164,7 @@ spec:
                     sectionName:
                       type: string
                   type: object
+                minItems: 1
                 type: array
               rationale:
                 type: string


### PR DESCRIPTION
### Description
Added the new policy name field to the CR spec, updated tests.  Added more kubebuilder validation checks for existing CR fields.

@kylape @c-du I think this PR will need to merge before Cong's or atleast right after each other to ensure demoable master.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change
Unit tests
