### PR TITLE
ROX-25822: Query nvd cvss for vuln report

### DIFF
--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -121,10 +121,11 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 							discoveredTs,
 							v.Link,
 						}
-						if includeNvd == true {
-							row = append(row, strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64))
-						}
 						csvWriter.AddValue(row)
+						if includeNvd == true {
+							csvWriter.AppendValue(row, strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64))
+						}
+
 					}
 				}
 			}

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -92,7 +92,7 @@ type ZippedCSVResult struct {
 // a flag if the report is empty or not. For v1 config pass an empty string.
 func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults []WatchedImagesResult, configName string, includeNvd bool) (*ZippedCSVResult, error) {
 	csvHeaderRep := csvHeader
-	if includeNvd == true {
+	if includeNvd {
 		csvHeaderRep = append(csvHeader, "NVDCVSS")
 	}
 	csvWriter := csv.NewGenericWriter(csvHeaderRep, true)
@@ -121,11 +121,10 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 							discoveredTs,
 							v.Link,
 						}
-						csvWriter.AddValue(row)
-						if includeNvd == true {
-							csvWriter.AppendValue(row, strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64))
+						if includeNvd {
+							csvWriter.AppendToValue(&row, strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64))
 						}
-
+						csvWriter.AddValue(row)
 					}
 				}
 			}
@@ -142,7 +141,7 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 					if v.DiscoveredAtImage != nil {
 						discoveredTs = v.DiscoveredAtImage.Time.Format("January 02, 2006")
 					}
-					csvWriter.AddValue(csv.Value{
+					row := csv.Value{
 						"",
 						"",
 						"",
@@ -153,10 +152,13 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 						v.FixedByVersion,
 						strings.ToTitle(stringutils.GetUpTo(v.Severity, "_")),
 						strconv.FormatFloat(v.Cvss, 'f', 2, 64),
-						strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64),
 						discoveredTs,
 						v.Link,
-					})
+					}
+					if includeNvd {
+						csvWriter.AppendToValue(&row, strconv.FormatFloat(v.Nvdcvss, 'f', 2, 64))
+					}
+					csvWriter.AddValue(row)
 				}
 			}
 		}

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -278,7 +278,10 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVResult, err := common.Format(reportData, nil, "", false)
+	watchedImagesReportData := []common.WatchedImagesResult{}
+	configName := ""
+	includedNvd := false
+	zippedCSVResult, err := common.Format(reportData, watchedImagesReportData, configName, includedNvd)
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -278,8 +278,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	includeNvd := rc.GetVulnReportFilters().GetIncludeNvdCvss()
-	zippedCSVResult, err := common.Format(reportData, nil, "", includeNvd)
+	zippedCSVResult, err := common.Format(reportData, nil, "", false)
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -278,7 +278,8 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVResult, err := common.Format(reportData, nil, "")
+	includeNvd := rc.GetVulnReportFilters().GetIncludeNvdCvss()
+	zippedCSVResult, err := common.Format(reportData, nil, "", includeNvd)
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}

--- a/central/reports/scheduler/v2/reportgenerator/consts.go
+++ b/central/reports/scheduler/v2/reportgenerator/consts.go
@@ -11,6 +11,7 @@ const (
                              discoveredAtImage
 		                     link
                              cvss
+                             nvdCvss
                          }`
 
 	deployedImagesReportQuery = `query getDeployedImagesReportData($scopequery: String, 

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -107,7 +107,8 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	}
 
 	// Format results into CSV
-	zippedSCVResult, err := common.Format(deployedImgData, watchedImgData, req.ReportSnapshot.Name)
+	includeNvd := req.ReportSnapshot.GetVulnReportFilters().GetIncludeNvdCvss()
+	zippedSCVResult, err := common.Format(deployedImgData, watchedImgData, req.ReportSnapshot.Name, includeNvd)
 	if err != nil {
 		return err
 	}

--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -39,6 +39,11 @@ func (c *GenericWriter) AddValue(value Value) {
 	c.values = append(c.values, value)
 }
 
+// Append to value
+func (c *GenericWriter) AppendValue(value Value, field string) {
+	value = append(value, field)
+}
+
 // IsEmpty returns true if there are no values.
 func (c *GenericWriter) IsEmpty() bool {
 	return len(c.values) == 0

--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -40,8 +40,8 @@ func (c *GenericWriter) AddValue(value Value) {
 }
 
 // Append to value
-func (c *GenericWriter) AppendValue(value Value, field string) {
-	value = append(value, field)
+func (c *GenericWriter) AppendToValue(value *Value, field string) {
+	*value = append(*value, field)
 }
 
 // IsEmpty returns true if there are no values.


### PR DESCRIPTION
This PR adds nvd cvss field to vuln report
Tested these changes by manually dwnloading report when nvdcvss filter is set to truwe and when filter is set to false
[RHACS_Vulnerability_Report_Test_09_October_2024_false.csv](https://github.com/user-attachments/files/17318839/RHACS_Vulnerability_Report_Test_09_October_2024_false.csv)
[RHACS_Vulnerability_Report_Test_08_October_2024 2_true.csv](https://github.com/user-attachments/files/17318840/RHACS_Vulnerability_Report_Test_08_October_2024.2_true.csv)


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
