### PR TITLE
refactor(scanner): Use separate v4 prefix for new bundles

### DIFF
--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Generate offline bundle
       run: |
-        .github/workflows/scripts/scanner-update-offline-bundle.sh \
+        .github/workflows/scripts/scanner-offline-bundle-generate.sh \
             bundle \
             "$VULNERABILITY_VERSION" \
             "$SUPPORTED_RELEASES"
@@ -81,7 +81,7 @@ jobs:
         credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Authenticate with Google Cloud (pull request)
-      if: github.event_name != 'schedule'
+      if: github.event_name == 'pull_request'
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
@@ -89,27 +89,31 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
 
-    - name: Upload bundles (release)
+    - name: Set GCS bucket (release)
       if: github.event_name == 'schedule'
       run: |
-        cd bundles
-        gsutil cp scanner-v4-defs-*.zip "gs://definitions.stackrox.io/v4/offline-bundles/"
+        bucket="gs://definitions.stackrox.io/v4/offline-bundles/"
+        echo "BUCKET=$bucket" >> "$GITHUB_ENV"
 
-    - name: Upload bundles (pull request)
-      if: github.event_name != 'schedule'
+    - name: Set GCS bucket (pull request)
+      if: github.event_name == 'pull_request'
       run: |
-        branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-        # Replace / with -, so the branch name isn't truncated when pushed to GCS.
-        dir=${branch////-}
+        branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+        dir="${branch////-}"
         case $dir in
         dev|1.0.0)
           echo "Branch $dir is disallowed"
           exit 1
         esac
+        bucket="gs://scanner-v4-test/offline-bundles/$dir"
+        echo "BUCKET=$bucket" >> "$GITHUB_ENV"
 
+    - name: Upload bundles
+      run: |
         cd bundles
-        ls -lh
-        gsutil cp -r . "gs://scanner-v4-test/offline-bundles/$dir"
+        echo "uploading files to $BUCKET"
+        ls -lh .
+        gsutil cp -r . "$BUCKET"
 
   offline-bundle-notification:
     needs:

--- a/.github/workflows/scripts/scanner-offline-bundle-generate.sh
+++ b/.github/workflows/scripts/scanner-offline-bundle-generate.sh
@@ -12,16 +12,20 @@ mkdir -p "$output_dir"
 
 filename=vulnerabilities.zip
 filename_version="$vulnerability_version"
+bundle_prefix=v4-definitions-
 
 # Backward compatibility with previous releases where vulnerability version is a
-# release number, and in 4.4 the file is the single bundle.
+# release number, in 4.4 the file is the single bundle, and bundle prefix is
+# different.
 case "$vulnerability_version" in
     4.4.*)
         filename=vulns.json.zst
         filename_version="v1"
+        bundle_prefix=scanner-v4-defs-
         ;;
     4.5.*)
         filename_version="v1"
+        bundle_prefix=scanner-v4-defs-
         ;;
 esac
 
@@ -61,4 +65,4 @@ for f in "$tmpdir"/*.json; do
 done
 
 # Bundle creation.
-zip -j "$output_dir/scanner-v4-defs-$version.zip" "$tmpdir"/*
+zip -j "$output_dir/$bundle_prefix$version.zip" "$tmpdir"/*


### PR DESCRIPTION
### Description

This changes the offline definition bundles prefix to ensure 4.5 remains compatible with the latest offline bundle. By using a new prefix, 4.5 will accept its specific bundle (`scanner-defs-4.5.zip`) and ignore the newer definitions. This prevents 4.5 to reject the bundle, since today 4.5 rejects multiple definitions in a single zip. The goal is for the latest bundle to contain all definitions, even though size will increase, but it allows backward compatibility, and customers can use `roxctl scanner download-db` if needed.

The follow changes to adopt the new prefix will be performed at https://github.com/stackrox/scanner/pull/1643 

There are some short/small refactoring and style-related changed as well.

### User-facing documentation

- [X] CHANGELOG is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I've added `pr-update-scanner-vulns`, and checked upload step:

```
uploading files to gs://scanner-v4-test/offline-bundles/jvdm-versioned-offline-prefix
total 604M
-rw-r--r-- 1 runner docker [20](https://github.com/stackrox/stackrox/actions/runs/11133829413/job/30940804791?pr=12872#step:8:21)2M Oct  1 21:35 scanner-v4-defs-4.4.zip
-rw-r--r-- 1 runner docker 202M Oct  1 [21](https://github.com/stackrox/stackrox/actions/runs/11133829413/job/30940804791?pr=12872#step:8:22):35 scanner-v4-defs-4.5.zip
-rw-r--r-- 1 runner docker 202M Oct  1 21:35 v4-definitions-v1.zip
```

Bucket seems OK:

![image](https://github.com/user-attachments/assets/e5c87e6c-17fb-4e7f-92a9-3eb39698eaa2)

Checked the 4.5 files:

```
unzip -l ~/tmp/download/offline-bundles_jvdm-versioned-offline-prefix_v4-definitions-v1.zip
Archive:  /home/jvdm/tmp/download/offline-bundles_jvdm-versioned-offline-prefix_v4-definitions-v1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    82240  2024-09-30 17:25   container-name-repos-map.json
      149  2024-10-01 14:35   manifest.json
  2295358  2024-09-30 17:25   repository-to-cpe.json
210722293  2024-10-01 14:35   vulnerabilities.zip
---------                     -------
213100040                     4 files
⮩  unzip -l ~/tmp/download/offline-bundles_jvdm-versioned-offline-prefix_v4-definitions-v1.zip manifest.json
Archive:  /home/jvdm/tmp/download/offline-bundles_jvdm-versioned-offline-prefix_v4-definitions-v1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      149  2024-10-01 14:35   manifest.json
---------                     -------
      149                     1 file
⮩  cat manifest.json
{
  "version": "4.5",
  "created": "2024-09-28T18:02:32+00:00",
  "release_versions": "4.5.0 4.5.1 4.5.2 4.5.3"
}
⮩
```

Other files are also healthy.

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->