### PR TITLE
ROX-26041: Add required Date header to email messages

### DIFF
--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -240,6 +240,7 @@ func (m Message) Bytes() []byte {
 	buf := bytes.NewBuffer(nil)
 	buf.WriteString(fmt.Sprintf("From: %s\r\n", m.From))
 	buf.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(m.To, ",")))
+	buf.WriteString(fmt.Sprintf("Date: %s\r\n", time.Now().Format(time.RFC3339)))
 
 	m.writeContentBytes(buf)
 	return buf.Bytes()

--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	dateEmailHeaderValidator = regexp.MustCompile(`Date: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`)
+)
+
 func TestBuildReportMessage(t *testing.T) {
 	recipients := []string{"scooby@stackrox.com", "shaggy@stackrox.com"}
 	from := "velma@stackrox.com"
@@ -42,14 +46,13 @@ func TestBuildReportMessage(t *testing.T) {
 
 	assert.Contains(t, msgStr, "From: velma@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "To: scooby@stackrox.com,shaggy@stackrox.com\r\n")
+	assert.Regexp(t, dateEmailHeaderValidator, msgStr, "must have a valid Date header in RFC3339 format")
 	assert.Contains(t, msgStr, expectedSubjectHeader)
-	// assert.Contains(t, msgStr, expectedSubjectHeader)
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
 	assert.Contains(t, msgStr, "Content-Type: application/zip\r\n")
 	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
 	assert.Contains(t, msgStr, expectedReportAttachmentHeader)
-	// assert.Contains(t, msgStr, expectedReportAttachmentHeader)
 
 	assert.Contains(t, msgStr, "Content-Type: image/png; name=logo.png\r\n")
 	assert.Contains(t, msgStr, "Content-Transfer-Encoding: base64\r\n")
@@ -153,6 +156,7 @@ func TestEmailMsgWithMultipleAttachments(t *testing.T) {
 
 	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
+	assert.Regexp(t, dateEmailHeaderValidator, msgStr, "must have a valid Date header in RFC3339 format")
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: multipart/mixed;")
@@ -189,6 +193,7 @@ func TestEmailMsgNoAttachmentsWithLogo(t *testing.T) {
 
 	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
+	assert.Regexp(t, dateEmailHeaderValidator, msgStr, "must have a valid Date header in RFC3339 format")
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: text/html; charset=\"utf-8\"\r\n\r\n")
@@ -218,6 +223,7 @@ func TestEmailMsgNoAttachments(t *testing.T) {
 
 	assert.Contains(t, msgStr, "From: xyz@stackrox.com\r\n")
 	assert.Contains(t, msgStr, "To: foo@stackrox.com,bar@stackrox.com\r\n")
+	assert.Regexp(t, dateEmailHeaderValidator, msgStr, "must have a valid Date header in RFC3339 format")
 	assert.Contains(t, msgStr, "Subject: Test Email\r\n")
 	assert.Contains(t, msgStr, "MIME-Version: 1.0\r\n")
 	assert.Contains(t, msgStr, "Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")


### PR DESCRIPTION
### Description

This changes adds the required Date header to all emails send by the ACS system.

(from the Jira ticket description)
> In ACS the emails that are sent from the "Vulnerability Management (2.0)" > Vulnerability Reporting function are missing the Date header in the email.
> 
>This header is mandatory in emails as specified by the RFC 5322
> 
> https://datatracker.ietf.org/doc/html/rfc5322#section-3.6
> 
> Mails without a date header are still processed but gather a higher than normal spam score due to RFC non-compliance. Additionally the mails are not properly ordered in the email client (eg. Thunderbird) because of the missing date. This can create confusion on the time a vulnerability report has actually been generated.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

### Testing and quality


- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

* Added additional checks for this new header to this function's unit tests
* Verified CI
* Manually, by:
* * Deploying the PR build image
* * Creating a email integration, a collection, and a VM report that uses those
* * Selecting "Send now" for that VM report
* * Inspecting the raw headers on the email I received (I saved the email as a .eml file, which I opened in a text editor.)

Relevant section of email headers:
```
From: ACS <scooby@vanwilson.info>
To: vwilson@redhat.com
Date: 2024-10-01T23:57:11Z
Subject: StackRox Workload CVE Report for Van3; Scope: Scooby
MIME-Version: 1.0
```

Note: I had opened the headers of a previous test email, without this change, and there was no date header.