### PR TITLE
fix: config in UI form values

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
@@ -46,11 +46,11 @@ function EmailIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ACSCSEmailIntegration>): ReactElement {
-    const formInitialValues = merge(
+    const formInitialValues: ACSCSEmailIntegrationFormValues = merge(
         {},
         defaultValues,
         initialValues
-    ) as ACSCSEmailIntegrationFormValues;
+    );
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
@@ -2,6 +2,7 @@
 import React, { ReactElement } from 'react';
 import { Form, PageSection, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -45,13 +46,11 @@ function EmailIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ACSCSEmailIntegration>): ReactElement {
-    let formInitialValues = { ...defaultValues, ...initialValues };
-    if (initialValues) {
-        formInitialValues = {
-            ...formInitialValues,
-            ...initialValues,
-        };
-    }
+    const formInitialValues = merge(
+        {},
+        defaultValues,
+        initialValues
+    ) as ACSCSEmailIntegrationFormValues;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactRegistryIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactRegistryIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -101,9 +102,10 @@ function ArtifactRegistryIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ArtifactRegistryIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.google.serviceAccount = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -75,9 +76,10 @@ function ArtifactoryIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ArtifactoryIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AwsSecurityHubIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AwsSecurityHubIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, FormSelect, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -120,12 +121,10 @@ function AwsSecurityHubIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<AwsSecurityHubIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = {
-            ...formInitialValues.notifier,
-            ...initialValues,
-        };
+        merge(formInitialValues.notifier, initialValues);
+
         // We want to clear these values because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.awsSecurityHub.credentials.accessKeyId = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -93,9 +94,10 @@ function ClairifyIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<AzureIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -9,6 +9,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -64,9 +65,7 @@ function ClairIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? ({ ...defaultValues, ...initialValues } as ClairIntegration)
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as ClairIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -65,7 +65,7 @@ function ClairIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as ClairIntegration;
+    const formInitialValues: ClairIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairV4IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairV4IntegrationForm.tsx
@@ -47,7 +47,7 @@ function ClairV4IntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairV4ImageIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as ClairV4ImageIntegration;
+    const formInitialValues: ClairV4ImageIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairV4IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairV4IntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ClairV4ImageIntegration } from 'types/imageIntegration.proto';
 
@@ -46,9 +47,7 @@ function ClairV4IntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairV4ImageIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? ({ ...defaultValues, ...initialValues } as ClairV4ImageIntegration)
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as ClairV4ImageIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
@@ -54,7 +54,7 @@ function ClairifyIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairifyImageIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as ClairifyImageIntegration;
+    const formInitialValues: ClairifyImageIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Form, PageSection, TextInput, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ClairifyImageIntegration } from 'types/imageIntegration.proto';
 
@@ -53,9 +54,7 @@ function ClairifyIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ClairifyImageIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? { ...defaultValues, ...initialValues }
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as ClairifyImageIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/OcmIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/OcmIntegrationForm.tsx
@@ -53,16 +53,14 @@ export const validationSchema = yup.object().shape({
         }),
         skipTestIntegration: yup.bool(),
     }),
-    updatePassword: yup.bool(),
+    updateCredentials: yup.bool(),
 });
 
 export type CloudSourceIntegrationFormValues = {
-    id: string;
     cloudSource: CloudSourceIntegration;
     updateCredentials: boolean;
 };
 export const defaultValues: CloudSourceIntegrationFormValues = {
-    id: '',
     cloudSource: {
         id: '',
         name: '',
@@ -87,7 +85,6 @@ function OcmIntegrationForm({
     const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
         merge(formInitialValues.cloudSource, initialValues);
-        formInitialValues.id = formInitialValues.cloudSource.id;
         formInitialValues.cloudSource.credentials.secret = '';
         formInitialValues.cloudSource.credentials.clientId = '';
         formInitialValues.cloudSource.credentials.clientSecret = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/PaladinCloudIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/PaladinCloudIntegrationForm.tsx
@@ -43,12 +43,10 @@ export const validationSchema = yup.object().shape({
 });
 
 export type CloudSourceIntegrationFormValues = {
-    id: string;
     cloudSource: CloudSourceIntegration;
     updateCredentials: boolean;
 };
 export const defaultValues: CloudSourceIntegrationFormValues = {
-    id: '',
     cloudSource: {
         id: '',
         name: '',
@@ -73,7 +71,6 @@ function PaladinCloudIntegrationForm({
     const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
         merge(formInitialValues.cloudSource, initialValues);
-        formInitialValues.id = formInitialValues.cloudSource.id;
         formInitialValues.cloudSource.credentials.secret = '';
         formInitialValues.updateCredentials = false;
     }

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/PaladinCloudIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/CloudSourceIntegrations/PaladinCloudIntegrationForm.tsx
@@ -39,7 +39,7 @@ export const validationSchema = yup.object().shape({
         }),
         skipTestIntegration: yup.bool(),
     }),
-    updatePassword: yup.bool(),
+    updateCredentials: yup.bool(),
 });
 
 export type CloudSourceIntegrationFormValues = {

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/DockerIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/DockerIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -75,9 +76,10 @@ function DockerIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<DockerIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -138,15 +139,15 @@ function EcrIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<EcrIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
-
     const { isCentralCapabilityAvailable } = useCentralCapabilities();
     const canUseContainerIamRoleForEcr = isCentralCapabilityAvailable(
         'centralScanningCanUseContainerIamRoleForEcr'
     );
 
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.ecr.accessKeyId = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
@@ -12,6 +12,7 @@ import {
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import { HelpIcon } from '@patternfly/react-icons';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -143,13 +144,12 @@ function EmailIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<EmailIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
     const [storedUsername, setStoredUsername] = useState('');
+
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = {
-            ...formInitialValues.notifier,
-            ...initialValues,
-        };
+        merge(formInitialValues.notifier, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.email.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -10,6 +10,7 @@ import {
     TextArea,
 } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
@@ -123,12 +124,10 @@ function GcsIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<GcsIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.externalBackup = {
-            ...formInitialValues.externalBackup,
-            ...initialValues,
-        };
+        merge(formInitialValues.externalBackup, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.externalBackup.gcs.serviceAccount = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { BackupIntegrationBase } from 'services/BackupIntegrationsService';
 
@@ -142,13 +143,10 @@ function S3CompatibleIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<S3CompatibleIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
-
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.externalBackup = {
-            ...formInitialValues.externalBackup,
-            ...initialValues,
-        };
+        merge(formInitialValues.externalBackup, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.externalBackup.s3compatible.accessKeyId = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -2,6 +2,7 @@
 import React, { ReactElement } from 'react';
 import { Checkbox, Form, FormSelect, PageSection, Text, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
@@ -123,13 +124,10 @@ function S3IntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<S3Integration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
-
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.externalBackup = {
-            ...formInitialValues.externalBackup,
-            ...initialValues,
-        };
+        merge(formInitialValues.externalBackup, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.externalBackup.s3.accessKeyId = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
@@ -14,6 +14,7 @@ import {
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import * as yup from 'yup';
 import { FieldArray, FormikProvider } from 'formik';
+import merge from 'lodash/merge';
 
 import usePageState from 'Containers/Integrations/hooks/usePageState';
 import FormMessage from 'Components/PatternFly/FormMessage';
@@ -104,12 +105,10 @@ function GenericWebhookIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<GenericWebhookIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = {
-            ...formInitialValues.notifier,
-            ...initialValues,
-        };
+        merge(formInitialValues.notifier, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.generic.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleCloudSccIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleCloudSccIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Checkbox, Form, PageSection, TextInput, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -97,12 +98,10 @@ function GoogleCloudSccIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<GoogleCloudSccIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = {
-            ...formInitialValues.notifier,
-            ...initialValues,
-        };
+        merge(formInitialValues.notifier, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.cscc.serviceAccount = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
@@ -9,6 +9,7 @@ import {
     ToggleGroupItem,
 } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { GoogleImageIntegration } from 'types/imageIntegration.proto';
 
@@ -103,9 +104,10 @@ function GoogleIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<GoogleImageIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.google.serviceAccount = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/IbmIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/IbmIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -86,9 +87,10 @@ function IbmIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<IbmIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.ibm.apiKey = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/JiraIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/JiraIntegrationForm.tsx
@@ -127,9 +127,9 @@ function JiraIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<JiraIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = merge({}, defaultValues.notifier, initialValues); // in case properties are missing from initialValues
+        merge(formInitialValues.notifier, initialValues);
 
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -76,7 +76,7 @@ function MachineAccessIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<MachineAccessConfig>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues);
+    const formInitialValues: MachineAccessConfig = merge({}, defaultValues, initialValues);
     const formik = useIntegrationForm<MachineAccessConfig>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -19,6 +19,7 @@ import {
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import { FieldArray, FormikProvider } from 'formik';
 import { ArrowRightIcon, HelpIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import merge from 'lodash/merge';
 
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
@@ -75,7 +76,7 @@ function MachineAccessIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<MachineAccessConfig>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = merge({}, defaultValues, initialValues);
     const formik = useIntegrationForm<MachineAccessConfig>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/NexusIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/NexusIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -107,9 +108,10 @@ function NexusIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<NexusIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/PagerDutyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/PagerDutyIntegrationForm.tsx
@@ -62,6 +62,12 @@ function PagerDutyIntegrationForm({
     const [isUpdatingStoredCredential, setIsUpdatingCredential] = useState(false);
     const isStoredCredentialInputEnabled = isCreating || isUpdatingStoredCredential;
 
+    let formInitialValues = structuredClone(defaultValues);
+    if (initialValues) {
+        merge(formInitialValues, initialValues);
+        formInitialValues = clearStoredCredentials(formInitialValues, storedCredentialKeyPaths);
+    }
+
     const {
         values,
         touched,
@@ -77,12 +83,7 @@ function PagerDutyIntegrationForm({
         onCancel,
         message,
     } = useIntegrationForm<PagerDutyIntegration>({
-        initialValues: initialValues
-            ? clearStoredCredentials(
-                  merge({}, defaultValues, initialValues),
-                  storedCredentialKeyPaths
-              )
-            : defaultValues,
+        initialValues: formInitialValues,
         validationSchema: () =>
             isStoredCredentialInputEnabled
                 ? validationSchemaStoredCredentialRequired

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/RhelIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/RhelIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
 
@@ -106,9 +107,10 @@ function RhelIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<RhelIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.config = { ...formInitialValues.config, ...initialValues };
+        merge(formInitialValues.config, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ScannerV4IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ScannerV4IntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { ScannerV4ImageIntegration } from 'types/imageIntegration.proto';
 
@@ -54,9 +55,7 @@ function ScannerV4IntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ScannerV4ImageIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? ({ ...defaultValues, ...initialValues } as ScannerV4ImageIntegration)
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as ScannerV4ImageIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ScannerV4IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ScannerV4IntegrationForm.tsx
@@ -55,7 +55,7 @@ function ScannerV4IntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<ScannerV4ImageIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as ScannerV4ImageIntegration;
+    const formInitialValues: ScannerV4ImageIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
@@ -133,7 +133,7 @@ function SignatureIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SignatureIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues);
+    const formInitialValues: SignatureIntegration = merge({}, defaultValues, initialValues);
     const formik = useIntegrationForm<SignatureIntegration>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
@@ -13,6 +13,7 @@ import {
 import * as yup from 'yup';
 import { FieldArray, FormikProvider } from 'formik';
 import { HelpIcon, TrashIcon } from '@patternfly/react-icons';
+import merge from 'lodash/merge';
 
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
@@ -132,9 +133,7 @@ function SignatureIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SignatureIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? ({ ...defaultValues, ...initialValues } as SignatureIntegration)
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues);
     const formik = useIntegrationForm<SignatureIntegration>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
@@ -49,7 +49,7 @@ function SlackIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SlackIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as SlackIntegration;
+    const formInitialValues: SlackIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Form, PageSection, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -48,9 +49,7 @@ function SlackIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SlackIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? ({ ...defaultValues, ...initialValues } as SlackIntegration)
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as SlackIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SplunkIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SplunkIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Checkbox, Form, PageSection, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -104,12 +105,10 @@ function SplunkIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SplunkIntegration>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formInitialValues = structuredClone(defaultValues);
     if (initialValues) {
-        formInitialValues.notifier = {
-            ...formInitialValues.notifier,
-            ...initialValues,
-        };
+        merge(formInitialValues.notifier, initialValues);
+
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.splunk.httpToken = '';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SyslogIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SyslogIntegrationForm.tsx
@@ -82,7 +82,7 @@ function SyslogIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SyslogIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as SyslogIntegration;
+    const formInitialValues: SyslogIntegration = merge({}, defaultValues, initialValues);
     const formik = useIntegrationForm<SyslogIntegration>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SyslogIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SyslogIntegrationForm.tsx
@@ -18,6 +18,7 @@ import {
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import * as yup from 'yup';
 import { FieldArray, FormikProvider } from 'formik';
+import merge from 'lodash/merge';
 
 import { SyslogNotifierIntegration as SyslogIntegration } from 'types/notifier.proto';
 
@@ -81,10 +82,7 @@ function SyslogIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<SyslogIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? { ...defaultValues, ...initialValues }
-        : defaultValues;
-
+    const formInitialValues = merge({}, defaultValues, initialValues) as SyslogIntegration;
     const formik = useIntegrationForm<SyslogIntegration>({
         initialValues: formInitialValues,
         validationSchema,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/TeamsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/TeamsIntegrationForm.tsx
@@ -42,7 +42,7 @@ function TeamsIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<TeamsIntegration>): ReactElement {
-    const formInitialValues = merge({}, defaultValues, initialValues) as TeamsIntegration;
+    const formInitialValues: TeamsIntegration = merge({}, defaultValues, initialValues);
     const {
         values,
         touched,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/TeamsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/TeamsIntegrationForm.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { TextInput, PageSection, Form } from '@patternfly/react-core';
 import * as yup from 'yup';
+import merge from 'lodash/merge';
 
 import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
@@ -41,9 +42,7 @@ function TeamsIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<TeamsIntegration>): ReactElement {
-    const formInitialValues = initialValues
-        ? { ...defaultValues, ...initialValues }
-        : defaultValues;
+    const formInitialValues = merge({}, defaultValues, initialValues) as TeamsIntegration;
     const {
         values,
         touched,

--- a/ui/apps/platform/src/services/CloudSourceService.ts
+++ b/ui/apps/platform/src/services/CloudSourceService.ts
@@ -26,6 +26,11 @@ export type CloudSourceIntegration = {
     ocm?: OcmConfig;
 };
 
+export type UpdateCloudSourceRequest = {
+    cloudSource: CloudSourceIntegration;
+    updateCredentials: boolean;
+};
+
 const cloudSourcesURL = `/v1/cloud-sources`;
 
 export function fetchCloudSources(): Promise<{
@@ -34,6 +39,10 @@ export function fetchCloudSources(): Promise<{
     return axios.get(cloudSourcesURL).then((response) => ({
         response: response.data,
     }));
+}
+
+export function updateCloudSource(request: UpdateCloudSourceRequest): Promise<Empty> {
+    return axios.put(`${cloudSourcesURL}/${request.cloudSource.id}`, request);
 }
 
 export function deleteCloudSource(id: string): Promise<Empty> {

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -1,6 +1,7 @@
 import axios from './instance';
 import { Empty } from './types';
 import { AuthMachineToMachineConfig, updateMachineAccessConfig } from './MachineAccessService';
+import { UpdateCloudSourceRequest, updateCloudSource } from './CloudSourceService';
 
 export type IntegrationSource =
     | 'authProviders'
@@ -35,6 +36,8 @@ function getJsonFieldBySource(source: IntegrationSource): string {
             return 'notifier';
         case 'backups':
             return 'externalBackup';
+        case 'cloudSources':
+            return 'cloudSource';
         default:
             return 'config';
     }
@@ -103,11 +106,20 @@ export function saveIntegrationV2(
         const config = data[getJsonFieldBySource(source)] as IntegrationBase;
         return axios.patch(`${getPath(source)}/${config.id}`, data);
     }
-    // Machine access configs should be wrapped.
-    if (source === 'authProviders') {
-        return updateMachineAccessConfig(data as AuthMachineToMachineConfig);
+    // Some services expect requests to be wrapped in dedicated proto messages.
+    // In these cases, the top level request payload does not contain the integration id.
+    // Taking cloud source requests as an example, the integration id is accessed as
+    // `data.cloudSource.id` rather than `data.id`.
+    // Additionally, services may differ in whether `put` or `patch` is used to update
+    // existing integrations.
+    switch (source) {
+        case 'authProviders':
+            return updateMachineAccessConfig(data as AuthMachineToMachineConfig);
+        case 'cloudSources':
+            return updateCloudSource(data as UpdateCloudSourceRequest);
+        default:
+            return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, data);
     }
-    return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, data);
 }
 
 /*


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR attempts to clean up some tech debt related to the UI integration forms. It is a follow up to issues uncovered during #12277.

1. Removal of the spread operator when assigning the default form values. The current merge of default and passed through initial values doesn't make sense for integrations with a nested structure (the nested structure arises for integrations with credentials from an additional `updatePassword` field next to the integration payload). Also, the spread operator performs shallow copies, which may corrupt the original default values after subsequent assignments.
2. The current UI makes a couple of assumptions about the HTTP verb and the request structure which are not part of the API contract and no longer valid for all integrations. Some of the newer integration APIs (cloud sources, machine-to-machine auth) follow the new [StackRox API guidelines](https://github.com/stackrox/stackrox/blob/master/.github/api_guidelines.md), which recommend introducing a separate request proto message for all request types. Additionally, there is a mix between `patch` and `put` operations for integration edits. This PR leaves the old heuristic via the `updatePassword` field in place where it works, and makes the cases where it doesn't work more clear. I don't think this is perfect and the API assumptions should be removed completely, but it is already an improvement.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI and tested that creation and edit of integration works.