### PR TITLE
fix(ci): make scanner v4 test backwards compatible

### DIFF
--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -1,6 +1,7 @@
 package scannerv4
 
 import (
+	"fmt"
 	"testing"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -288,11 +289,8 @@ func TestComponents(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			cs := components(tc.metadata, tc.report)
-			assert.Len(t, cs, len(tc.expected))
-			for i, got := range cs {
-				assert.Truef(t, tc.expected[i].EqualVT(got), "expected: %+#v\ngot: %+#v", tc.expected[i], got)
-			}
+			got := components(tc.metadata, tc.report)
+			protoassert.SlicesEqual(t, tc.expected, got, fmt.Sprintf("expected: %+#v\ngot: %+#v", tc.expected, got))
 		})
 	}
 }


### PR DESCRIPTION
### Description

Makes this test compatible with 4.5. It is **not** compatible with 4.4, though

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

This IS the test