### PR TITLE
chore: better protoassert accuracy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dave/jennifer v1.7.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/facebookincubator/nvdtools v0.1.5
@@ -254,7 +255,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f // indirect
 	github.com/cyphar/filepath-securejoin v0.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/vtprotobuf v0.6.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.20.2
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.57.0
@@ -397,7 +398,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/quay/claircore/updater/driver v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/pkg/protoassert/assert.go
+++ b/pkg/protoassert/assert.go
@@ -1,130 +1,194 @@
+// Package protoassert provides utility functions for comparing protobuf-generated objects in tests.
+//
+// These functions are based on related ones found in https://github.com/stretchr/testify.
 package protoassert
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
 type message[V any] interface {
 	*V
 	proto.Message
-	String() string
-	EqualVT(other *V) bool
+	fmt.Stringer
+	EqualVT(that *V) bool
 }
 
-func Equal[V any, T message[V]](t testing.TB, expected, actual T, msgAndArgs ...interface{}) bool {
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+// Equal mimics [assert.Equal].
+func Equal[T message[V], V any](t testing.TB, expected, actual T, msgAndArgs ...any) bool {
 	t.Helper()
-	if expected.EqualVT(actual) {
-		return true
+	if !actual.EqualVT(expected) {
+		return assert.Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %s\n"+
+			"actual  : %s", expected, actual), msgAndArgs...)
 	}
-	e, err := toJson(expected)
-	require.NoError(t, err)
-	a, err := toJson(actual)
-	require.NoError(t, err)
-	return assert.JSONEq(t, e, a, msgAndArgs)
+	return true
 }
 
-func NotEqual[V any, T message[V]](t testing.TB, expected, actual T, msgAndArgs ...interface{}) bool {
+// NotEqual mimics [assert.NotEqual].
+func NotEqual[T message[V], V any](t testing.TB, expected, actual T, msgAndArgs ...any) bool {
 	t.Helper()
-	return assert.False(t, expected.EqualVT(actual), msgAndArgs)
-}
-
-func SlicesEqual[V any, T message[V]](t testing.TB, expected, actual []T, msgAndArgs ...interface{}) bool {
-	t.Helper()
-	areEqual := assert.Len(t, actual, len(expected))
-	for i, e := range expected {
-		a := actual[i]
-		areEqual = Equal(t, a, e) && areEqual
+	if actual.EqualVT(expected) {
+		return assert.Fail(t, fmt.Sprintf("Should not be: %#v\n", actual), msgAndArgs...)
 	}
-	if !areEqual {
-		t.Log(msgAndArgs...)
-	}
-	return areEqual
+	return true
 }
 
-func SliceContains[V any, T message[V]](t testing.TB, slice []T, element T, msgAndArgs ...interface{}) bool {
+// SlicesEqual determines if the expected and actual slices are equal.
+func SlicesEqual[S ~[]T, T message[V], V any](t testing.TB, expected, actual S, msgAndArgs ...any) bool {
 	t.Helper()
-	for _, e := range slice {
-		if proto.Equal(e, element) {
-			return true
-		}
+	if !assert.Len(t, actual, len(expected), msgAndArgs...) {
+		return false
 	}
-	return assert.Failf(t, "Slice does not contain element", "%q %v", element.String(), msgAndArgs)
-}
-
-func SliceNotContains[V any, T message[V]](t testing.TB, slice []T, element T, msgAndArgs ...interface{}) bool {
-	t.Helper()
-	for _, e := range slice {
-		if proto.Equal(e, element) {
-			return assert.Failf(t, "Slice contain element", "%q %v", element.String(), msgAndArgs)
+	for i := range expected {
+		if !Equal(t, expected[i], actual[i], msgAndArgs...) {
+			return false
 		}
 	}
 	return true
 }
 
-func ElementsMatch[V any, T message[V]](t testing.TB, expected, actual []T, msgAndArgs ...interface{}) bool {
+// SliceContains mimics [assert.Contains].
+func SliceContains[S ~[]T, T message[V], V any](t testing.TB, s S, contains T, msgAndArgs ...any) bool {
 	t.Helper()
-	areEqual := assert.Len(t, actual, len(expected))
-	for _, e := range expected {
-		areEqual = SliceContains(t, actual, e) && areEqual
+	for _, e := range s {
+		// Do not use [Equal] here, as it will unnecessarily log unequal elements.
+		if e.EqualVT(contains) {
+			return true
+		}
 	}
-	for _, a := range actual {
-		areEqual = SliceContains(t, expected, a) && areEqual
-	}
-	if !areEqual {
-		t.Log(msgAndArgs...)
-	}
-	return areEqual
+	return assert.Fail(t, fmt.Sprintf("%#v does not contain %#v", s, contains), msgAndArgs...)
 }
 
-func MapSliceEqual[K comparable, V any, T message[V]](t testing.TB, expected, actual map[K][]T, msgAndArgs ...interface{}) bool {
+// SliceNotContains mimics [assert.NotContains].
+func SliceNotContains[S ~[]T, T message[V], V any](t testing.TB, s S, contains T, msgAndArgs ...any) bool {
+	t.Helper()
+	for _, e := range s {
+		// Do not use [Equal] here, as it will unnecessarily log unequal elements.
+		if e.EqualVT(contains) {
+			return assert.Fail(t, fmt.Sprintf("%#v should not contain %#v", s, contains), msgAndArgs...)
+		}
+	}
+	return true
+}
+
+// ElementsMatch mimics [assert.ElementsMatch].
+func ElementsMatch[S ~[]T, T message[V], V any](t testing.TB, expected, actual S, msgAndArgs ...any) bool {
+	t.Helper()
+	if len(expected) == 0 && len(actual) == 0 {
+		return true
+	}
+	extraExpected, extraActual := diffSlices(expected, actual)
+	if len(extraExpected) == 0 && len(extraActual) == 0 {
+		return true
+	}
+	return assert.Fail(t, formatSliceDiff(expected, actual, extraExpected, extraActual), msgAndArgs...)
+}
+
+// MapSliceEqual determines if the expected and actual maps (from key to slice) are equal.
+func MapSliceEqual[M ~map[K][]T, K comparable, T message[V], V any](t testing.TB, expected, actual M, msgAndArgs ...any) bool {
 	t.Helper()
 	expectedKeys := maps.Keys(expected)
 	actualKeys := maps.Keys(actual)
-	areEqual := !assert.ElementsMatch(t, expectedKeys, actualKeys)
-	for expectedKey, expectedValue := range expected {
-		a := actual[expectedKey]
-		areEqual = SlicesEqual(t, expectedValue, a, expectedKey) && areEqual
+	if !assert.ElementsMatch(t, expectedKeys, actualKeys, msgAndArgs...) {
+		return false
 	}
-	if !areEqual {
-		t.Log(msgAndArgs...)
+	for key, expectedV := range expected {
+		actualV := actual[key]
+		if !SlicesEqual(t, expectedV, actualV, msgAndArgs...) {
+			return false
+		}
 	}
-	return areEqual
+	return true
 }
 
-func MapEqual[K comparable, V any, T message[V]](t testing.TB, expected, actual map[K]T, msgAndArgs ...interface{}) bool {
+// MapEqual determines if the expected and actual maps are equal.
+func MapEqual[M ~map[K]T, K comparable, T message[V], V any](t testing.TB, expected, actual M, msgAndArgs ...any) bool {
 	t.Helper()
 	expectedKeys := maps.Keys(expected)
 	actualKeys := maps.Keys(actual)
-	areEqual := !assert.ElementsMatch(t, expectedKeys, actualKeys)
-	for expectedKey, expectedValue := range expected {
-		actualValue := actual[expectedKey]
-		areEqual = Equal(t, expectedValue, actualValue, expectedKey) && areEqual
+	if !assert.ElementsMatch(t, expectedKeys, actualKeys, msgAndArgs...) {
+		return false
 	}
-	if !areEqual {
-		t.Log(msgAndArgs...)
+	for key, expectedV := range expected {
+		actualV := actual[key]
+		if !Equal(t, expectedV, actualV, msgAndArgs...) {
+			return false
+		}
 	}
-	return areEqual
+	return true
 }
 
-func toJson(m proto.Message) (string, error) {
-	if m == nil {
-		return "", nil
+// diffSlices is based on [assert.diffLists]. The doc for it is copied below:
+//
+// diffLists diffs two arrays/slices and returns slices of elements that are only in A and only in B.
+// If some element is present multiple times, each instance is counted separately (e.g. if something is 2x in A and
+// 5x in B, it will be 0x in extraA and 3x in extraB). The order of items in both lists is ignored.
+func diffSlices[V any, T message[V]](a, b []T) (extraA, extraB []T) {
+	aLen, bLen := len(a), len(b)
+
+	visited := make([]bool, bLen)
+	for i := 0; i < aLen; i++ {
+		element := a[i]
+		found := false
+		for j := 0; j < bLen; j++ {
+			if visited[j] {
+				continue
+			}
+			if b[j].EqualVT(element) {
+				visited[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			extraA = append(extraA, element)
+		}
 	}
 
-	marshaller := &protojson.MarshalOptions{
-		Indent: "  ",
+	for j := 0; j < bLen; j++ {
+		if visited[j] {
+			continue
+		}
+		extraB = append(extraB, b[j])
 	}
 
-	s, err := marshaller.Marshal(m)
-	if err != nil {
-		return "", err
-	}
+	return
+}
 
-	return string(s), nil
+// formatSliceDiff is based on [assert.formatListDiff].
+func formatSliceDiff[V any, T message[V]](sliceA, sliceB, extraA, extraB []T) string {
+	var msg bytes.Buffer
+
+	msg.WriteString("elements differ")
+	if len(extraA) > 0 {
+		msg.WriteString("\n\nextra elements in expected slice:\n")
+		msg.WriteString(spewConfig.Sdump(extraA))
+	}
+	if len(extraB) > 0 {
+		msg.WriteString("\n\nextra elements in actual slice:\n")
+		msg.WriteString(spewConfig.Sdump(extraB))
+	}
+	msg.WriteString("\n\nexpected slice:\n")
+	msg.WriteString(spewConfig.Sdump(sliceA))
+	msg.WriteString("\n\nactual slice:\n")
+	msg.WriteString(spewConfig.Sdump(sliceB))
+
+	return msg.String()
 }

--- a/pkg/protoassert/assert.go
+++ b/pkg/protoassert/assert.go
@@ -60,12 +60,11 @@ func SlicesEqual[S ~[]T, T message[V], V any](t testing.TB, expected, actual S, 
 	if !assert.Len(t, actual, len(expected), msgAndArgs...) {
 		return false
 	}
+	pass := true
 	for i := range expected {
-		if !Equal(t, expected[i], actual[i], append([]any{fmt.Sprintf("index: %d", i)}, msgAndArgs...)...) {
-			return false
-		}
+		pass = Equal(t, expected[i], actual[i], append([]any{fmt.Sprintf("index: %d\n", i)}, msgAndArgs...)...) && pass
 	}
-	return true
+	return pass
 }
 
 // SliceContains mimics [assert.Contains].
@@ -110,16 +109,15 @@ func MapSliceEqual[M ~map[K][]T, K comparable, T message[V], V any](t testing.TB
 	t.Helper()
 	expectedKeys := maps.Keys(expected)
 	actualKeys := maps.Keys(actual)
-	if !assert.ElementsMatch(t, expectedKeys, actualKeys, msgAndArgs...) {
+	if !assert.ElementsMatch(t, expectedKeys, actualKeys, append([]any{"keys differ:\n"}, msgAndArgs...)...) {
 		return false
 	}
+	pass := true
 	for key, expectedV := range expected {
 		actualV := actual[key]
-		if !SlicesEqual(t, expectedV, actualV, msgAndArgs...) {
-			return false
-		}
+		pass = SlicesEqual(t, expectedV, actualV, append([]any{fmt.Sprintf("key: %v\n", key)}, msgAndArgs...)...) && pass
 	}
-	return true
+	return pass
 }
 
 // MapEqual determines if the expected and actual maps are equal.
@@ -127,16 +125,15 @@ func MapEqual[M ~map[K]T, K comparable, T message[V], V any](t testing.TB, expec
 	t.Helper()
 	expectedKeys := maps.Keys(expected)
 	actualKeys := maps.Keys(actual)
-	if !assert.ElementsMatch(t, expectedKeys, actualKeys, msgAndArgs...) {
+	if !assert.ElementsMatch(t, expectedKeys, actualKeys, append([]any{"keys differ:\n"}, msgAndArgs...)...) {
 		return false
 	}
+	pass := true
 	for key, expectedV := range expected {
 		actualV := actual[key]
-		if !Equal(t, expectedV, actualV, msgAndArgs...) {
-			return false
-		}
+		pass = Equal(t, expectedV, actualV, append([]any{fmt.Sprintf("key: %v\n", key)}, msgAndArgs...)...) && pass
 	}
-	return true
+	return pass
 }
 
 // diff is based on [assert.diff]. The doc for it is copied below:


### PR DESCRIPTION
### Description

The current version of `protoassert` has a few issues:

* When two protos are not equal, they are given a second chance to be equal if their JSONs match. This can cause a bug when `nil != nil` (see https://github.com/stackrox/stackrox/pull/12820 where the current implementation would not have caught this bug)
* ElementsMatch does not consider a scenario like the following: [a, a, b] [a, b, b]. These would be seen as equal, when they should not be

This change aims to mimic https://github.com/stretchr/testify more closely.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

This IS the test