### PR TITLE
Jv poc collector cluster config helm charts

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl
@@ -29,5 +29,8 @@ clusterConfig:
       disableBypass: {{ ._rox.admissionControl.dynamic.disableBypass }}
       enforceOnUpdates: {{ ._rox.admissionControl.dynamic.enforceOnUpdates }}
     registryOverride: {{ ._rox.registryOverride }}
+    collectorConfig:
+      networkEndpointConfig:
+        enableExternalIps: {{ ._rox.networkConnectionConfig.enableExternalIps }}
   configFingerprint: {{ ._rox._configFP }}
   clusterLabels: {{- toYaml ._rox.clusterLabels | nindent 4 }}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -145,8 +145,12 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	} else {
 		processSignals = signalService.New(processPipeline, indicators, signalService.WithTraceWriter(cfg.processIndicatorWriter))
 	}
+
+	collectorRuntimeConfigHandler := collectorruntimeconfig.StoreInstance()
+	collectorRuntimeConfigHandler.SetCollectorConfigFromHelmConfig(helmManagedConfig)
+
 	networkFlowManager :=
-		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), collectorruntimeconfig.StoreInstance(), policyDetector, pubSub)
+		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), collectorRuntimeConfigHandler, policyDetector, pubSub)
 	enhancer := deploymentenhancer.CreateEnhancer(storeProvider)
 	components := []common.SensorComponent{
 		admCtrlMsgForwarder,


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Makes it so that if a helm chart is used to set the cluster config the collector config will be sent to collector.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Built locally and pushed to quay.io/jvirtane and used those images. Used a version of collector capable of communicating with this version of sensor and a version of this PR without the actual helm chart change, but with the go code changes.

Set the following environment variables.

```
export SENSOR_HELM_MANAGED=true
export CI=false
export SENSOR_HELM_DEPLOY=true
export ROX_COLLECTOR_RUNTIME_CONFIG
```

Deployed on a GKE cluster using
```
./deploy/k8s/deploy-local.sh
```

Checked the sensor logs. Saw the following

```
kubernetes/sensor: 2024/10/04 16:22:56.155377 sensor.go:83: Info: Loaded Helm cluster configuration with fingerprint "7d01860c74ddb471d90b35ab33e564481f7182213d584ee1ccc2c2e72ec02210"
kubernetes/sensor: 2024/10/04 16:22:56.155460 sensor.go:99: Info: Cluster name from Helm configuration: "remote"
kubernetes/sensor: 2024/10/04 16:22:56.155481 sensor.go:102: Info: Install method: "MANAGER_TYPE_HELM_CHART"

...

kubernetes/sensor: 2024/10/04 16:22:56.180872 sensor.go:150: Info: helmManagedConfig= cluster_config:{dynamic_config:{admission_controller_config:{timeout_seconds:10}  disable_audit_logs:true}  static_config:{type:KUBERNETES_CLUSTER  main_image:"quay.io/rhacs-eng/main"  central_api_endpoint:"central.stackrox:443"  collection_method:CORE_BPF  collector_image:"quay.io/rhacs-eng/collector"  admission_controller:true  tolerations_config:{}  slim_collector:true  admission_controller_events:true}  config_fingerprint:"7d01860c74ddb471d90b35ab33e564481f7182213d584ee1ccc2c2e72ec02210"}  cluster_name:"remote"  managed_by:MANAGER_TYPE_HELM_CHART
common/collectorruntimeconfig: 2024/10/04 16:22:56.180926 handler.go:129: Info: In SetCollectorConfigFromHelmConfig
common/collectorruntimeconfig: 2024/10/04 16:22:56.180959 handler.go:131: Info: helmManagedConfig not nil
common/collectorruntimeconfig: 2024/10/04 16:22:56.181100 handler.go:137: Info: h.collectorConfg= network_connection_config:{enable_external_ips:true}

...

common/networkflow/service: 2024/10/04 16:41:49.839776 service_impl.go:108: Info: In recevieMessage hostname= gke-jv-10-03-default-pool-96b94da2-g71f
common/networkflow/service: 2024/10/04 16:41:49.840008 service_impl.go:149: Info: CollectorRuntimeConfig.Enabled()= true
common/networkflow/service: 2024/10/04 16:41:49.840058 service_impl.go:151: Info: CollectorRuntimeConfig is enabled
common/networkflow/service: 2024/10/04 16:41:49.840390 service_impl.go:291: Info: Sending collector config collector_config:{network_connection_config:{enable_external_ips:true}}
common/networkflow/service: 2024/10/04 16:41:51.268047 service_impl.go:108: Info: In recevieMessage hostname= gke-jv-10-03-default-pool-96b94da2-53ln
common/networkflow/service: 2024/10/04 16:41:51.268147 service_impl.go:149: Info: CollectorRuntimeConfig.Enabled()= true
common/networkflow/service: 2024/10/04 16:41:51.268171 service_impl.go:151: Info: CollectorRuntimeConfig is enabled
common/networkflow/service: 2024/10/04 16:41:51.268307 service_impl.go:291: Info: Sending collector config collector_config:{network_connection_config:{enable_external_ips:true}}
common/networkflow/service: 2024/10/04 16:41:52.740460 service_impl.go:108: Info: In recevieMessage hostname= gke-jv-10-03-default-pool-96b94da2-c6s0
common/networkflow/service: 2024/10/04 16:41:52.740575 service_impl.go:149: Info: CollectorRuntimeConfig.Enabled()= true
common/networkflow/service: 2024/10/04 16:41:52.740602 service_impl.go:151: Info: CollectorRuntimeConfig is enabled
common/networkflow/service: 2024/10/04 16:41:52.740724 service_impl.go:291: Info: Sending collector config collector_config:{network_connection_config:{enable_external_ips:true}}

```

Hence when the cluster config is set using helm, a collector config is sent to collector. A test was run with SENSOR_HELM_MANAGED, CI, and SENSOR_HELM_DEPLOY unset. In that case the collector config was not sent to collector.