### PR TITLE
chore(ownership): Make IBM Research team codeowners of NP-Guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,9 +33,12 @@ tests/performance           @stackrox/merlin
 
 /ui/**/* @stackrox/ui
 
-pkg/images/defaults/**/*    @stackrox/maple
-roxctl/netpol/**/*          @stackrox/maple
-sensor/**/*                 @stackrox/maple
+pkg/images/defaults/**/*                       @stackrox/maple
+roxctl/netpol/**/*                             @stackrox/ibm-research @stackrox/maple
+tests/roxctl/bats-tests/local/roxctl-netpol-*  @stackrox/ibm-research @stackrox/maple
+tests/roxctl/bats-tests/test-data/np-guard/    @stackrox/ibm-research @stackrox/maple
+
+sensor/**/*                                    @stackrox/maple
 
 operator/**/* @stackrox/draco
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@ tests/roxctl/bats-tests/test-data/np-guard/    @stackrox/ibm-research @stackrox/
 
 sensor/**/*                                    @stackrox/maple
 
-operator/**/* @stackrox/draco
+operator/**/* @stackrox/install
 
 # Scanner team's responsibilities include anything related to the scanner itself and scanning utilities
 # such as vulnerability uploading and image integrations.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,12 +33,13 @@ tests/performance           @stackrox/merlin
 
 /ui/**/* @stackrox/ui
 
-pkg/images/defaults/**/*                       @stackrox/maple
-roxctl/netpol/**/*                             @stackrox/ibm-research @stackrox/maple
-tests/roxctl/bats-tests/local/roxctl-netpol-*  @stackrox/ibm-research @stackrox/maple
-tests/roxctl/bats-tests/test-data/np-guard/    @stackrox/ibm-research @stackrox/maple
+# Listing all users as "Outside collaborators cannot be added to a team"
+roxctl/netpol/**/*                             @zivnevo @adisos @shireenf-ibm @stackrox/maple
+tests/roxctl/bats-tests/local/roxctl-netpol-*  @zivnevo @adisos @shireenf-ibm @stackrox/maple
+tests/roxctl/bats-tests/test-data/np-guard/    @zivnevo @adisos @shireenf-ibm @stackrox/maple
 
-sensor/**/*                                    @stackrox/maple
+pkg/images/defaults/**/* @stackrox/maple
+sensor/**/*              @stackrox/maple
 
 operator/**/* @stackrox/install
 


### PR DESCRIPTION
### Description

This PR marks the roxctl code that integrates with NP-Guard and the respective tests as owned by IBM-Research team.
The goal is to make clear who are the goto people in case some functionality changes in the NP-Guard dependencies and the tests start failing.

Unfortunately "outside collaborators cannot be added to a team, team membership is restricted to members of the organization", so I needed to list all three involved users from the IBM Research team.

I also renamed `draco` to `install` team as otherwise Github claimed that the codeowners file contains errors.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

None
