### PR TITLE
ROX-25786: Create FilteredWorkflowSelector component

### DIFF
--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/FilteredWorkflowSelector.tsx
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/FilteredWorkflowSelector.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {
+    Flex,
+    Icon,
+    MenuToggleElement,
+    MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+
+import { FilteredWorkflowState, SetFilteredWorkflowState } from './types';
+
+const width = '330px';
+
+export type FilteredWorkflowSelectorProps = {
+    filteredWorkflowState: FilteredWorkflowState;
+    setFilteredWorkflowState: SetFilteredWorkflowState;
+};
+
+function FilteredWorkflowSelector({
+    filteredWorkflowState,
+    setFilteredWorkflowState,
+}: FilteredWorkflowSelectorProps) {
+    const [isSelectOpen, setIsSelectOpen] = useState(false);
+
+    return (
+        <Select
+            isOpen={isSelectOpen}
+            selected={filteredWorkflowState}
+            onSelect={(_, value) => {
+                setFilteredWorkflowState(value);
+                setIsSelectOpen(false);
+            }}
+            onOpenChange={(isOpen) => setIsSelectOpen(isOpen)}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                    style={{ width }}
+                    aria-label="Filtered workflow select"
+                    ref={toggleRef}
+                    onClick={() => setIsSelectOpen(!isSelectOpen)}
+                    isExpanded={isSelectOpen}
+                >
+                    <Flex
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                    >
+                        <Icon>{<CubesIcon />}</Icon>
+                        <span>{filteredWorkflowState}</span>
+                    </Flex>
+                </MenuToggle>
+            )}
+            shouldFocusToggleOnSelect
+        >
+            <SelectList style={{ width }}>
+                <SelectOption
+                    value="Application view"
+                    description="Display findings for application workloads."
+                    isDisabled
+                >
+                    Application view
+                </SelectOption>
+                <SelectOption
+                    value="Platform view"
+                    description="Display findings for platform components in OpenShift and layered services."
+                    isDisabled
+                >
+                    Platform view
+                </SelectOption>
+                <SelectOption
+                    value="Full view"
+                    description="Display findings for application workloads and platform components simultaneously."
+                >
+                    Full view
+                </SelectOption>
+            </SelectList>
+        </Select>
+    );
+}
+
+export default FilteredWorkflowSelector;

--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/types.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/types.ts
@@ -1,0 +1,7 @@
+import { HistoryAction } from 'hooks/useURLParameter';
+
+export const filteredWorkflowStates = ['Application view', 'Platform view', 'Full view'] as const;
+
+export type FilteredWorkflowState = (typeof filteredWorkflowStates)[number];
+
+export type SetFilteredWorkflowState = (nextValue: unknown, historyAction?: HistoryAction) => void;

--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowState.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowState.ts
@@ -1,0 +1,19 @@
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import { FilteredWorkflowState, filteredWorkflowStates, SetFilteredWorkflowState } from './types';
+
+export type FilteredWorkflowStateResult = {
+    filteredWorkflowState: FilteredWorkflowState;
+    setFilteredWorkflowState: SetFilteredWorkflowState;
+};
+
+function useFilteredWorkflowState(): FilteredWorkflowStateResult {
+    const [filteredWorkflowState, setFilteredWorkflowState] = useURLStringUnion(
+        'filteredWorkflowState',
+        filteredWorkflowStates,
+        filteredWorkflowStates[2] // @TODO: Remove this once we can show the Application and Platform views
+    );
+
+    return { filteredWorkflowState, setFilteredWorkflowState };
+}
+
+export default useFilteredWorkflowState;

--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowURLState.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowURLState.ts
@@ -1,12 +1,12 @@
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import { FilteredWorkflowState, filteredWorkflowStates, SetFilteredWorkflowState } from './types';
 
-export type FilteredWorkflowStateResult = {
+export type FilteredWorkflowURLStateResult = {
     filteredWorkflowState: FilteredWorkflowState;
     setFilteredWorkflowState: SetFilteredWorkflowState;
 };
 
-function useFilteredWorkflowState(): FilteredWorkflowStateResult {
+function useFilteredWorkflowURLState(): FilteredWorkflowURLStateResult {
     const [filteredWorkflowState, setFilteredWorkflowState] = useURLStringUnion(
         'filteredWorkflowState',
         filteredWorkflowStates,
@@ -16,4 +16,4 @@ function useFilteredWorkflowState(): FilteredWorkflowStateResult {
     return { filteredWorkflowState, setFilteredWorkflowState };
 }
 
-export default useFilteredWorkflowState;
+export default useFilteredWorkflowURLState;

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -30,7 +30,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import useInterval from 'hooks/useInterval';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import FilteredWorkflowSelector from 'Components/FilteredWorkflowSelector/FilteredWorkflowSelector';
-import useFilteredWorkflowState from 'Components/FilteredWorkflowSelector/useFilteredWorkflowState';
+import useFilteredWorkflowURLState from 'Components/FilteredWorkflowSelector/useFilteredWorkflowURLState';
 import ViolationsTablePanel from './ViolationsTablePanel';
 import tableColumnDescriptor from './violationTableColumnDescriptors';
 import { violationStateTabs } from './types';
@@ -48,7 +48,7 @@ function ViolationsTablePage(): ReactElement {
         'violationState',
         violationStateTabs
     );
-    const { filteredWorkflowState, setFilteredWorkflowState } = useFilteredWorkflowState();
+    const { filteredWorkflowState, setFilteredWorkflowState } = useFilteredWorkflowURLState();
 
     const hasExecutableFilter =
         Object.keys(searchFilter).length &&

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -20,6 +20,7 @@ import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
 import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useEffectAfterFirstRender from 'hooks/useEffectAfterFirstRender';
 import useURLSort from 'hooks/useURLSort';
@@ -28,6 +29,8 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useInterval from 'hooks/useInterval';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import FilteredWorkflowSelector from 'Components/FilteredWorkflowSelector/FilteredWorkflowSelector';
+import useFilteredWorkflowState from 'Components/FilteredWorkflowSelector/useFilteredWorkflowState';
 import ViolationsTablePanel from './ViolationsTablePanel';
 import tableColumnDescriptor from './violationTableColumnDescriptors';
 import { violationStateTabs } from './types';
@@ -38,11 +41,14 @@ const tabContentId = 'ViolationsTable';
 
 function ViolationsTablePage(): ReactElement {
     const { searchFilter, setSearchFilter } = useURLSearch();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isPlatformComponentsEnabled = isFeatureFlagEnabled('ROX_PLATFORM_COMPONENTS');
 
     const [activeViolationStateTab, setActiveViolationStateTab] = useURLStringUnion(
         'violationState',
         violationStateTabs
     );
+    const { filteredWorkflowState, setFilteredWorkflowState } = useFilteredWorkflowState();
 
     const hasExecutableFilter =
         Object.keys(searchFilter).length &&
@@ -201,6 +207,14 @@ function ViolationsTablePage(): ReactElement {
                     />
                 </Tabs>
             </PageSection>
+            {isPlatformComponentsEnabled && (
+                <PageSection className="pf-v5-u-py-md" component="div" variant="light">
+                    <FilteredWorkflowSelector
+                        filteredWorkflowState={filteredWorkflowState}
+                        setFilteredWorkflowState={setFilteredWorkflowState}
+                    />
+                </PageSection>
+            )}
             <PageSection variant="default" id={tabContentId}>
                 {isLoadingAlerts && (
                     <Bullseye>


### PR DESCRIPTION
### Description

This PR adds a new selector to the Policy Violations to choose a filtered workflow (`Application view`, `Platform view`, `Full view`). The state for the filtered workflow will be kept in the URL as `filteredWorkflowState`. The value will be used to filter the table in Policy Violations. That functionality will come in the following PR once the backend adds the capability. We will disable the `Application view` and `Platform view` for now.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [] no added tests

#### How I validated my change

<img width="1437" alt="Screenshot 2024-10-01 at 9 29 04 PM" src="https://github.com/user-attachments/assets/f0c02609-6c68-40d4-b548-0ef1fc45b9a2">
<img width="1439" alt="Screenshot 2024-10-01 at 9 29 10 PM" src="https://github.com/user-attachments/assets/b9036a3d-d168-4a99-a679-67707dfc8eed">
<img width="332" alt="Screenshot 2024-10-01 at 9 29 19 PM" src="https://github.com/user-attachments/assets/cd5242f3-8fd4-4999-b0d6-cad8e5ecce2c">
