### PR TITLE
chore(scanner): refactor CVSS score mapping

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -669,6 +669,7 @@ func cvssMetrics(ctx context.Context, vuln *claircore.Vulnerability, nvdVuln *nv
 	case strings.HasPrefix(vuln.Updater, osvUpdaterPrefix) && !isOSVDBSpecificSeverity(vuln.Severity):
 		preferredCVSS, preferredErr = vulnCVSS(vuln, v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV)
 	case strings.EqualFold(vuln.Updater, constants.ManualUpdaterName):
+		// It is expected manually added vulnerabilities only have a single link.
 		preferredCVSS, preferredErr = vulnCVSS(vuln, sourceFromLinks(vuln.Links))
 	}
 	if preferredCVSS != nil {

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -650,14 +650,7 @@ func pkgFixedBy(enrichments map[string][]json.RawMessage) (map[string]string, er
 // An error is returned when there is a failure to collect CVSS metrics from all sources;
 // however, the returned slice of metrics will still be populated with any successfully gathered metrics.
 // It is up to the caller to ensure the returned slice is populated prior to using it.
-func cvssMetrics(ctx context.Context, vuln *claircore.Vulnerability, nvdVuln *nvdschema.CVEAPIJSON20CVEItem) ([]*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
-	// Add context values for consistent logging
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "mappers/cvssMetrics",
-		"updater", vuln.Updater,
-		"vuln_id", vuln.ID,
-		"vuln_name", vuln.Name,
-	)
+func cvssMetrics(_ context.Context, vuln *claircore.Vulnerability, nvdVuln *nvdschema.CVEAPIJSON20CVEItem) ([]*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
 
 	var metrics []*v4.VulnerabilityReport_Vulnerability_CVSS
 

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -682,7 +682,7 @@ func cvssMetrics(ctx context.Context, vuln *claircore.Vulnerability, nvdVuln *nv
 	// especially since there is a reason the manual entry exists in the first place.
 	if preferredCVSS.GetSource() != v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD {
 		var cvss *v4.VulnerabilityReport_Vulnerability_CVSS
-		cvss, nvdErr = nvdCVSS(vuln, nvdVuln)
+		cvss, nvdErr = nvdCVSS(nvdVuln)
 		if cvss != nil {
 			metrics = append(metrics, cvss)
 		}
@@ -848,7 +848,7 @@ func sourceFromLinks(links string) v4.VulnerabilityReport_Vulnerability_CVSS_Sou
 }
 
 // nvdCVSS returns cvssValues based on the given vulnerability and the associated NVD item.
-func nvdCVSS(vuln *claircore.Vulnerability, v *nvdschema.CVEAPIJSON20CVEItem) (*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
+func nvdCVSS(v *nvdschema.CVEAPIJSON20CVEItem) (*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
 	// Sanity check the NVD data.
 	if v.Metrics == nil || (v.Metrics.CvssMetricV31 == nil && v.Metrics.CvssMetricV30 == nil && v.Metrics.CvssMetricV2 == nil) {
 		return nil, errors.New("no NVD CVSS metrics")

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/scannerv4/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -995,7 +996,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:   protoNow,
-					Severity: "sample severity",
+					Severity: "cve=CVE-1234-567&cvss3_score=9.9&cvss3_vector=CVSS%3A3.0%2FAV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AH&severity=sample+severity",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
 							BaseScore: 9.9,
@@ -1033,7 +1034,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:   protoNow,
-					Severity: "sample severity",
+					Severity: "cve=CVE-1234-567&cvss2_score=1.1&cvss2_vector=AV%3AN%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP&severity=sample+severity",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
 							BaseScore: 1.1,
@@ -1072,7 +1073,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:   protoNow,
-					Severity: "sample severity",
+					Severity: "cvss2_score=1.1&cvss2_vector=AV%3AN%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP&cvss3_score=9.9&cvss3_vector=CVSS%3A3.0%2FAV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AH&severity=sample+severity",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
 							BaseScore: 9.9,
@@ -1114,7 +1115,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:   protoNow,
-					Severity: "sample severity",
+					Severity: "cvss2_vector=invalid+cvss2+vector&severity=sample+severity",
 				},
 			},
 		},
@@ -1132,13 +1133,14 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:   protoNow,
-					Severity: "sample severity",
+					Severity: "cvss3_vector=invalid+cvss3+vector&severity=sample+severity",
 				},
 			},
 		},
 		"when OSV and severity with CVSSv3 then return": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
+					Name:     "CVE-2024-1234",
 					Issued:   now,
 					Severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 					Updater:  "osv/sample-updater",
@@ -1146,20 +1148,25 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			},
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
+					Name:     "CVE-2024-1234",
 					Issued:   protoNow,
 					Severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+							Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+							BaseScore: 10,
 						},
 						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV,
+						Url:    "https://osv.dev/vulnerability/CVE-2024-1234",
 					},
 					CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
 						{
 							V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-								Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+								Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+								BaseScore: 10,
 							},
 							Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV,
+							Url:    "https://osv.dev/vulnerability/CVE-2024-1234",
 						},
 					},
 				},
@@ -1292,7 +1299,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					ID:      "foo",
-					Name:    "NOT-A-CVE",
+					Name:    "CVE-1234-567",
 					Issued:  now,
 					Updater: "unknown updater",
 				},
@@ -1317,7 +1324,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Id:     "foo",
-					Name:   "NOT-A-CVE",
+					Name:   "CVE-1234-567",
 					Issued: protoNow,
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
@@ -1359,6 +1366,62 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 					Id:     "foo",
 					Name:   "CVE-2021-44228",
 					Issued: proto2021,
+				},
+			},
+		},
+		"when manual vulnerability with NVD link, do not get NVD data again": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:       "foo",
+					Name:     "CVE-2021-44228",
+					Links:    "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+					Updater:  constants.ManualUpdaterName,
+					Severity: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					Issued:   now,
+				},
+			},
+			nvdVulns: map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem{
+				"foo": {
+					"CVE-2021-44228": {
+						ID: "CVE-2021-44228",
+						Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
+							CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
+								{
+									CvssData: &nvdschema.CVSSV31{
+										Version:      "3.1",
+										VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:       "foo",
+					Name:     "CVE-2021-44228",
+					Link:     "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+					Issued:   protoNow,
+					Severity: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							BaseScore: 9.3,
+							Vector:    "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+						},
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+					},
+					CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+						{
+							V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+								BaseScore: 9.3,
+								Vector:    "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+							},
+							Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+							Url:    "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+						},
+					},
 				},
 			},
 		},

--- a/scanner/decisions/0013-manual-cvss-source.md
+++ b/scanner/decisions/0013-manual-cvss-source.md
@@ -1,0 +1,63 @@
+# 0013 - Manual CVSS Source
+
+- **Author(s):** Ross Tannenbaum
+- **Created:** [2024-10-03 Thurs]
+
+## Status
+
+Status: Accepted
+
+Updates: [#0010](0010-nvd-cvss-scores.md)
+
+## Context
+
+It was decided to support the following sources of CVSS scores:
+
+* Red Hat
+* OSV
+* NVD
+
+However, this neglects the vulnerabilities we manually curate. The scores we create do not just come out of nowhere,
+and the source does not necessarily need to be UNKNOWN.
+
+## Decision
+
+It is never truly defined where the vulnerability data may originate. Sometimes, it is lifted directly from NVD.
+Other times, it is from another source which scores the vulnerability before NVD has the chance.
+
+The [`claircore.Vulnerability`](https://github.com/quay/claircore/blob/main/vulnerability.go) struct does not
+give us room to add our own metadata, aside from the updater name. We do not want to change the updater name,
+as keeping the name consistent simplifies debugging (easy to search for vulnerabilities we manually added).
+
+Instead, we opt to consider the `Links` field. The manually added vulnerabilities must set a link,
+and we may use this link as the source of the CVSS score.
+
+For example, one entry is copied below:
+
+```yaml
+# Vuln: CVE-2022-22963/GHSA-6v73-fgf6-w5j7
+# Reason: The vuln table has an entry for GHSA-6v73-fgf6-w5j7, but Scanner V4
+# may have trouble determining the groupID when pom.properties is missing.
+# Source: https://osv-vulnerabilities.storage.googleapis.com/Maven/GHSA-6v73-fgf6-w5j7.json
+- Name: CVE-2022-22963
+  Description: Spring Cloud Function Code Injection with a specially crafted SpEL as a routing expression
+  Issued: '2022-04-03T00:00:59Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2022-22963
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: spring-cloud-function-context
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=0&fixed=3.1.7
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2
+```
+
+The `Links` field is a single NVD link. We will recognize this link and identify the CVSS source as NVD.
+
+## Consequences
+
+* We would need to ensure future entries to the manual entries are consistent and follow a set of rules.
+  * There is now a [README.md](../updater/manual/README.md) file to ensure we maintain consistency.

--- a/scanner/updater/manual/README.md
+++ b/scanner/updater/manual/README.md
@@ -13,14 +13,17 @@ Be sure to do the following:
 
 * Leave a comment directly above the vulnerability following the following format,
   so readers understand what this is and why it's here:
-  * Vuln: <name or names>
-  * Reason: <why are you adding this?>
-  * Source: <what are the sources of this data?>
-* Fill out each field in the `Vulnerability` struct defined in [manual.go](manual.go)
+  * Vuln: (name or names)
+  * Reason: (why are you adding this?)
+  * Source: (what are the sources of this data?)
+* Fill out each field in the `Vulnerability` struct defined in [manual.go](manual.go).
+  * See current entries for examples
 * It is **required** to set the link to the source of the CVSS score unless a convincing argument may be made, otherwise.
   * It is very likely the main source of the data is the same as the source of the CVSS score, anyway.
   * Note: OSV may be the main source of the data, but many times the data is from or at least matches NVD's data.
     In this case, NVD is the preferred link.
+  * In the case NVD does not have a native score, but they show a different CNA's score, **do not use NVD's link**.
+    * Otherwise, we may incorrectly attribute the score to NVD, which is not technically true, so it should be avoided.
 
 ## Testing
 

--- a/scanner/updater/manual/README.md
+++ b/scanner/updater/manual/README.md
@@ -1,0 +1,31 @@
+# Scanner V4 "manual" vulnerabilities
+
+This directory contains [vulns.yaml](vulns.yaml) which lists vulnerabilities which Scanner V4 currently misses.
+This may be for various reasons, such as:
+
+* The vulnerability is brand new, and not all Linux vendors track it yet
+* Scanner V4 is unable to match an affected package with the associated vulnerability in its normal capacity
+* The typical sources of data only have partial data (for example: the vulnerability has a severity but no CVSS score)
+
+## Adding a vulnerability
+
+This is not typically required (typically only for the reasons listed above), but when adding a vulnerability,
+be sure to do the following:
+
+* Leave a comment directly above the vulnerability following the following format:
+  * Vuln: <name or names>
+  * Reason: <why are you adding this?>
+  * Source: <what are the sources of this data?>
+* Fill out each field in the `Vulnerability` struct defined in [manual.go](manual.go)
+* It is **required** to set the link to the source of the CVSS score unless a convincing argument may be made, otherwise.
+  * It is very likely the main source of the data is the same as the source of the CVSS score, anyway.
+  * Note: OSV may be the main source of the data, but many times the data is from or at least matches NVD's data.
+    In this case, NVD is the preferred link.
+
+## Testing
+
+The easiest way to test is to do the following:
+
+1. Create a pull request with the `pr-update-scanner-vulns` label
+2. Install StackRox somewhere and be sure to change the `vulnerabilities_url` in the matcher-confg.yaml file (or update it in the related `ConfigMap`)
+3. Scan an image which should be affected by the added vulnerability.

--- a/scanner/updater/manual/README.md
+++ b/scanner/updater/manual/README.md
@@ -9,10 +9,10 @@ This may be for various reasons, such as:
 
 ## Adding a vulnerability
 
-This is not typically required (typically only for the reasons listed above), but when adding a vulnerability,
-be sure to do the following:
+Be sure to do the following:
 
-* Leave a comment directly above the vulnerability following the following format:
+* Leave a comment directly above the vulnerability following the following format,
+  so readers understand what this is and why it's here:
   * Vuln: <name or names>
   * Reason: <why are you adding this?>
   * Source: <what are the sources of this data?>

--- a/scanner/updater/manual/manual.go
+++ b/scanner/updater/manual/manual.go
@@ -20,6 +20,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+// Vulnerability represents a manually entered vulnerability found int vulns.yaml.
 type Vulnerability struct {
 	Name               string `yaml:"Name"`
 	Description        string `yaml:"Description"`


### PR DESCRIPTION
### Description

This makes changes to the CVSS score mapping in Scanner. This originally started when dealing with merge conflicts in https://github.com/stackrox/stackrox/pull/12452, but as I tried to resolve them, the changes became too much for that PR. So, I created this one.

This PR:

* refactors the CVSS score processing by only attempting to compute the one related to the updater as well as NVD
* Accounts for manual vulnerabilities getting CVSS scores from NVD (or other sources)
* Simply uses the Severity we get from ClairCore. There is no real reason to change it (actually, the client currently never uses it, so we really don't need it at all)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

CI