### PR TITLE
ROX-25787: Filter Policy Violations using Filtered Workflow Selector

### DIFF
--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/FilteredWorkflowSelector.tsx
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/FilteredWorkflowSelector.tsx
@@ -57,14 +57,12 @@ function FilteredWorkflowSelector({
                 <SelectOption
                     value="Application view"
                     description="Display findings for application workloads."
-                    isDisabled
                 >
                     Application view
                 </SelectOption>
                 <SelectOption
                     value="Platform view"
                     description="Display findings for platform components in OpenShift and layered services."
-                    isDisabled
                 >
                     Platform view
                 </SelectOption>

--- a/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowURLState.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowSelector/useFilteredWorkflowURLState.ts
@@ -9,8 +9,7 @@ export type FilteredWorkflowURLStateResult = {
 function useFilteredWorkflowURLState(): FilteredWorkflowURLStateResult {
     const [filteredWorkflowState, setFilteredWorkflowState] = useURLStringUnion(
         'filteredWorkflowState',
-        filteredWorkflowStates,
-        filteredWorkflowStates[2] // @TODO: Remove this once we can show the Application and Platform views
+        filteredWorkflowStates
     );
 
     return { filteredWorkflowState, setFilteredWorkflowState };

--- a/ui/apps/platform/src/services/AlertsService.ts
+++ b/ui/apps/platform/src/services/AlertsService.ts
@@ -47,16 +47,28 @@ export function fetchSummaryAlertCounts(
     );
 }
 
+type FetchAlertsArguments = {
+    alertSearchFilter: SearchFilter;
+    sortOption: ApiSortOption;
+    page: number;
+    perPage: number;
+};
+
 /*
  * Fetch a page of list alert objects.
  */
-export function fetchAlerts(
-    searchFilter: SearchFilter,
-    sortOption: ApiSortOption,
-    page: number,
-    perPage: number
-): CancellableRequest<ListAlert[]> {
-    const params = getListQueryParams({ searchFilter, sortOption, page, perPage });
+export function fetchAlerts({
+    alertSearchFilter,
+    sortOption,
+    page,
+    perPage,
+}: FetchAlertsArguments): CancellableRequest<ListAlert[]> {
+    const params = getListQueryParams({
+        searchFilter: alertSearchFilter,
+        sortOption,
+        page,
+        perPage,
+    });
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<{ alerts: ListAlert[] }>(`${baseUrl}?${params}`, { signal })
@@ -67,9 +79,9 @@ export function fetchAlerts(
 /*
  * Fetch count of alerts.
  */
-export function fetchAlertCount(searchFilter: SearchFilter): CancellableRequest<number> {
+export function fetchAlertCount(alertSearchFilter: SearchFilter): CancellableRequest<number> {
     const params = queryString.stringify(
-        { query: getRequestQueryStringForSearchFilter(searchFilter) },
+        { query: getRequestQueryStringForSearchFilter(alertSearchFilter) },
         { arrayFormat: 'repeat' }
     );
     return makeCancellableAxiosRequest((signal) =>


### PR DESCRIPTION
### Description

This PR takes the `filteredWorkflowState` in the URL and determines what search filters to pass to the API using the query parameter. The logic goes like this:

- Application view - `Platform Component: false` and `Entity Type: DEPLOYMENT`
- Platform view - `Platform Component: true` and `Entity Type: DEPLOYMENT`
- Full view - No query

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [] no added tests

#### How I validated my change

### Screenshots

#### Policy Violations page
<img width="722" alt="Screenshot 2024-10-03 at 3 52 03 PM" src="https://github.com/user-attachments/assets/af845a96-f03e-4854-bd10-96f40b459354">

#### Filtered Workflow Selector
<img width="364" alt="Screenshot 2024-10-03 at 3 52 19 PM" src="https://github.com/user-attachments/assets/4d1e1f91-f642-4333-b73d-fb0c45cbea80">

#### Application view
![Screenshot 2024-10-03 at 3 52 50 PM](https://github.com/user-attachments/assets/15a2a465-32fb-4778-ad39-588a8048eb94)
#### Platform view
![Screenshot 2024-10-03 at 3 53 11 PM](https://github.com/user-attachments/assets/4dca4e9e-3f51-4d3e-8050-7046257cbe8d)
#### Full view
![Screenshot 2024-10-03 at 3 53 21 PM](https://github.com/user-attachments/assets/5fc411d3-e734-4b90-8b71-320697fc3fc1)
