### PR TITLE
ROX-25642: Make the database monitoring interval configurable

### DIFF
--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -356,7 +356,7 @@ func getMaxConnections(ctx context.Context, db postgres.DB) {
 }
 
 func startMonitoringPostgres(ctx context.Context, db postgres.DB, postgresConfig *postgres.Config) {
-	t := time.NewTicker(1 * time.Minute)
+	t := time.NewTicker(env.PostgresMonitoringInterval.DurationSetting())
 	defer t.Stop()
 	for range t.C {
 		_ = CollectPostgresStats(ctx, db)

--- a/pkg/env/postgres.go
+++ b/pkg/env/postgres.go
@@ -1,0 +1,14 @@
+package env
+
+import "time"
+
+var (
+	// PostgresMonitoringInterval specifies how frequently the database
+	// statistics will be collected. Every time it happens a set of queries are
+	// performed against the database to monitor its internal state: tables
+	// size, number of tuples and open connections. In real environment those
+	// metrics change slowly, and there is no reason to hit the database every
+	// minute or so to get the same numbers over and over. But for testing
+	// environment it might be beneficial to increase monitoring resolution.
+	PostgresMonitoringInterval = registerDurationSetting("ROX_POSTGRES_DEFAULT_MONITORING_INTERVAL", 1*time.Hour)
+)


### PR DESCRIPTION
### Description

It does not make sense to fetch e.g. table sizes every minute, since they usually glow slowly. At the same time for testing environment it makes sense to have high resolution monitoring. To get the best of both worlds, make the monitoring interval configurable.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not validated yet.