### PR TITLE
ROX-25616: aggregate discovered entities using feature flag

### DIFF
--- a/central/networkgraph/aggregator/aggregator_test.go
+++ b/central/networkgraph/aggregator/aggregator_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/externalsrcs"
 	"github.com/stackrox/rox/pkg/networkgraph/testutils"
@@ -291,6 +292,27 @@ func TestAggregateExtConnsByName(t *testing.T) {
 	f8x := testutils.GetNetworkFlow(e5x, d2, 8080, storage.L4Protocol_L4_PROTOCOL_UNKNOWN, nil)
 
 	expected := []*storage.NetworkFlow{f2x, f3x, f4, f5, f6x, f8x, f9, f10}
+
+	actual := NewDuplicateNameExtSrcConnAggregator().Aggregate(flows)
+
+	assert.Len(t, actual, len(expected))
+	protoassert.ElementsMatch(t, expected, actual)
+}
+
+func TestAnonymizeDiscoveredExtEntities(t *testing.T) {
+	ts1 := time.Now()
+
+	d1 := testutils.GetDeploymentNetworkEntity("d1", "d1")
+
+	discovered_entity := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{35, 187, 144, 4, 32})).ToProto()
+	internet := networkgraph.InternetEntity().ToProto()
+
+	detailed_flow := testutils.GetNetworkFlow(d1, discovered_entity, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
+	anonymized_flow := testutils.GetNetworkFlow(d1, internet, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
+
+	flows := []*storage.NetworkFlow{detailed_flow}
+
+	expected := []*storage.NetworkFlow{anonymized_flow}
 
 	actual := NewDuplicateNameExtSrcConnAggregator().Aggregate(flows)
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -125,4 +125,7 @@ var (
 
 	// ExternalIPs enables storing detailed discovered external IPs
 	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS")
+
+	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
+	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
 )

--- a/pkg/networkgraph/utils.go
+++ b/pkg/networkgraph/utils.go
@@ -20,6 +20,12 @@ func IsExternal(entity *storage.NetworkEntityInfo) bool {
 	return IsKnownExternalSrc(entity) || entity.GetType() == storage.NetworkEntityInfo_INTERNET
 }
 
+// IsExternalDiscovered returns true if the network entity is external to the cluster
+// and discovered
+func IsExternalDiscovered(entity *storage.NetworkEntityInfo) bool {
+	return IsExternal(entity) && entity.GetExternalSource().GetDiscovered()
+}
+
 // IsKnownDefaultExternal returns true if the network entity is known system-generated network source.
 // Note: INTERNET is not treated as system-generated but rather a fallback when exact data is unavailable.
 func IsKnownDefaultExternal(entity *storage.NetworkEntityInfo) bool {

--- a/pkg/networkgraph/utils_test.go
+++ b/pkg/networkgraph/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
@@ -51,5 +52,49 @@ func TestGetQueries(t *testing.T) {
 			protoassert.Equal(t, tc.depQ, actualDepQ)
 			protoassert.Equal(t, tc.scopeQ, actualScopeQ)
 		})
+	}
+}
+
+func TestIsExternalDiscovered(t *testing.T) {
+	for _, tc := range []struct {
+		info     *storage.NetworkEntityInfo
+		expected bool
+	}{
+		// is external and discovered
+		{
+			info: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+				Desc: &storage.NetworkEntityInfo_ExternalSource_{
+					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+						Discovered: true,
+					},
+				},
+			},
+			expected: true,
+		},
+
+		// is external but not discovered
+		{
+			info: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+				Desc: &storage.NetworkEntityInfo_ExternalSource_{
+					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+						Discovered: false,
+					},
+				},
+			},
+			expected: false,
+		},
+
+		// neither external or discovered
+		{
+			info: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_DEPLOYMENT,
+				Desc: &storage.NetworkEntityInfo_Deployment_{},
+			},
+			expected: false,
+		},
+	} {
+		assert.Equal(t, tc.expected, IsExternalDiscovered(tc.info))
 	}
 }


### PR DESCRIPTION
### Description

With the new external IPs feature, this feature flag enables/disables displaying raw IP information in the network graph.

If the flag is not enabled, external discovered entities are aggregated into the Internet entity bucket.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests


#### How I validated my change

So far validated locally, enabling / disabling the feature flag and observing a change to the display in the network graph. 
