### PR TITLE
feat(auto-retest): Add list of exceptions for PR checks

### DIFF
--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -14,6 +14,11 @@ import (
 	"github.com/google/go-github/v60/github"
 )
 
+// allowedCheckFailures defines a set of PR checks that should not prevent the retest job starting
+var allowedCheckFailures = map[string]struct{}{
+	"codecov/patch": {},
+}
+
 const s = "stackrox"
 
 func main() {
@@ -62,7 +67,7 @@ issues:
 		log.Printf("#%d has %d completed checks", prNumber, len(checks))
 
 		for name, status := range checks {
-			if !status {
+			if _, allowedFailure := allowedCheckFailures[name]; !status && !allowedFailure {
 				log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
 				continue issues
 			}


### PR DESCRIPTION
### Description

The auto-retest feature is very useful for retriggering rarely occurring flakes. Unfortunately, it requires a PR to have all checks passed or it would not start. This limits the usability of it, so I propose to add a list of checks that are allowed to fail for the retest to start.

I tried to query GH API for the "required" checks, but that is not trivial, thus I propose a manually curated list of checks.
I added the code coverage check as the first example.

PR inspired by trying to test this flake on CI: https://github.com/stackrox/stackrox/pull/11027

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I ran it locally with my token against #11027 and observed the output.
