### PR TITLE
ROX-26448: add scheduler watcher

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	profileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
 	reportGen "github.com/stackrox/rox/central/complianceoperator/v2/report/manager/complianceReportgenerator/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/watcher"
 	scanConfigurationDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore/mocks"
@@ -26,6 +27,7 @@ type ManagerTestSuite struct {
 	ctx                 context.Context
 	scanConfigDataStore *scanConfigurationDS.MockDataStore
 	scanDataStore       *scanMocks.MockDataStore
+	profileDataStore    *profileMocks.MockDataStore
 	reportGen           *reportGen.MockComplianceReportGenerator
 }
 
@@ -38,6 +40,7 @@ func (m *ManagerTestSuite) SetupTest() {
 	m.mockCtrl = gomock.NewController(m.T())
 	m.scanConfigDataStore = scanConfigurationDS.NewMockDataStore(m.mockCtrl)
 	m.scanDataStore = scanMocks.NewMockDataStore(m.mockCtrl)
+	m.profileDataStore = profileMocks.NewMockDataStore(m.mockCtrl)
 	m.reportGen = reportGen.NewMockComplianceReportGenerator(m.mockCtrl)
 }
 
@@ -46,7 +49,7 @@ func TestComplianceReportManager(t *testing.T) {
 }
 
 func (m *ManagerTestSuite) TestSubmitReportRequest() {
-	manager := New(m.scanConfigDataStore, m.scanDataStore, m.reportGen)
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.reportGen)
 	reportRequest := &storage.ComplianceOperatorScanConfigurationV2{
 		ScanConfigName: "test_scan_config",
 		Id:             "test_scan_config",
@@ -62,7 +65,7 @@ func (m *ManagerTestSuite) TearDownTest() {
 }
 
 func (m *ManagerTestSuite) TestHandleScan() {
-	manager := New(m.scanConfigDataStore, m.scanDataStore, m.reportGen)
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.reportGen)
 	managerImplementation, ok := manager.(*managerImpl)
 	require.True(m.T(), ok)
 	scan := &storage.ComplianceOperatorScanV2{
@@ -91,7 +94,7 @@ func (m *ManagerTestSuite) TestHandleScan() {
 }
 
 func (m *ManagerTestSuite) TestHandleResult() {
-	manager := New(m.scanConfigDataStore, m.scanDataStore, m.reportGen)
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.reportGen)
 	managerImplementation, ok := manager.(*managerImpl)
 	require.True(m.T(), ok)
 	timeNow := time.Now()

--- a/central/complianceoperator/v2/report/manager/singleton.go
+++ b/central/complianceoperator/v2/report/manager/singleton.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	reportGen "github.com/stackrox/rox/central/complianceoperator/v2/report/manager/complianceReportgenerator"
 	scanConfigurationDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
 	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
@@ -19,5 +20,5 @@ func Singleton() Manager {
 }
 
 func initialize() {
-	instance = New(scanConfigurationDS.Singleton(), scanDS.Singleton(), reportGen.Singleton())
+	instance = New(scanConfigurationDS.Singleton(), scanDS.Singleton(), profileDatastore.Singleton(), reportGen.Singleton())
 }

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -1,0 +1,196 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
+	scanConfigurationDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
+	scan "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	ScanConfigTimeoutError   = errors.New("scan config watcher timed out")
+	defaultScanConfigTimeout = defaultTimeout * 2
+)
+
+// GetScanConfigFromScan returns the ScanConfiguration associated with the given scan
+func GetScanConfigFromScan(ctx context.Context, scan *storage.ComplianceOperatorScanV2, scanConfigDS scanConfigurationDS.DataStore) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+	return scanConfigDS.GetScanConfigurationByName(ctx, scan.GetScanConfigName())
+}
+
+// ScanConfigWatcher determines if a ScanConfiguration has running scans or has completed
+type ScanConfigWatcher interface {
+	PushScanResults(results *ScanWatcherResults) error
+	Subscribe(snapshotID string)
+	Stop()
+	Finished() concurrency.ReadOnlySignal
+}
+
+// ScanConfigWatcherResults is returned when the watcher detects all the scans are completed
+type ScanConfigWatcherResults struct {
+	Ctx               context.Context
+	WatcherID         string
+	ReportSnapshotIDs []string
+	ScanConfig        *storage.ComplianceOperatorScanConfigurationV2
+	ScanResults       map[string]*ScanWatcherResults
+	Error             error
+}
+
+type scanConfigWatcherImpl struct {
+	ctx     context.Context
+	cancel  func()
+	scanC   chan *ScanWatcherResults
+	stopped *concurrency.Signal
+
+	scanDS    scan.DataStore
+	profileDS profileDatastore.DataStore
+
+	snapshotsLock     sync.Mutex
+	readyQueue        readyQueue[*ScanConfigWatcherResults]
+	scanConfigResults *ScanConfigWatcherResults
+	scansToWait       set.StringSet
+	totalResults      int
+}
+
+// NewScanConfigWatcher creates a new ScanConfigWatcher
+func NewScanConfigWatcher(ctx context.Context, watcherID string, sc *storage.ComplianceOperatorScanConfigurationV2, scanDS scan.DataStore, profileDS profileDatastore.DataStore, queue readyQueue[*ScanConfigWatcherResults], snapshotIDs ...string) *scanConfigWatcherImpl {
+	watcherCtx, cancel := context.WithCancel(ctx)
+	finishedSignal := concurrency.NewSignal()
+	ret := &scanConfigWatcherImpl{
+		ctx:        watcherCtx,
+		cancel:     cancel,
+		stopped:    &finishedSignal,
+		scanDS:     scanDS,
+		profileDS:  profileDS,
+		scanC:      make(chan *ScanWatcherResults),
+		readyQueue: queue,
+		scanConfigResults: &ScanConfigWatcherResults{
+			Ctx:               ctx,
+			WatcherID:         watcherID,
+			ScanConfig:        sc,
+			ReportSnapshotIDs: snapshotIDs,
+			ScanResults:       make(map[string]*ScanWatcherResults),
+		},
+		scansToWait: set.NewStringSet(),
+	}
+	timeout := time.NewTicker(defaultScanConfigTimeout)
+	go ret.run(timeout.C)
+	return ret
+}
+
+// PushScanResults queues a ScanWatcherResults to be handled
+func (w *scanConfigWatcherImpl) PushScanResults(results *ScanWatcherResults) error {
+	select {
+	case <-w.ctx.Done():
+		return errors.New("The watcher is stopped")
+	case w.scanC <- results:
+		return nil
+	}
+}
+
+// Subscribe a new readyQueue to the watcher
+func (w *scanConfigWatcherImpl) Subscribe(id string) {
+	concurrency.WithLock(&w.snapshotsLock, func() {
+		w.scanConfigResults.ReportSnapshotIDs = append(w.scanConfigResults.ReportSnapshotIDs, id)
+	})
+}
+
+// Stop the watcher
+func (w *scanConfigWatcherImpl) Stop() {
+	w.cancel()
+}
+
+// Finished indicates whether the watcher is finished or not
+func (w *scanConfigWatcherImpl) Finished() concurrency.ReadOnlySignal {
+	return w.stopped
+}
+
+func (w *scanConfigWatcherImpl) run(timerC <-chan time.Time) {
+	defer func() {
+		w.stopped.Signal()
+		<-w.stopped.Done()
+	}()
+	for {
+		select {
+		case <-w.ctx.Done():
+			log.Infof("Stopping scan config watcher")
+			return
+		case <-timerC:
+			log.Warnf("Timeout waiting for the ScanConfiguration %s's scans to finish", w.scanConfigResults.ScanConfig.GetScanConfigName())
+			concurrency.WithLock(&w.snapshotsLock, func() {
+				w.scanConfigResults.Error = ScanConfigTimeoutError
+				w.readyQueue.Push(w.scanConfigResults)
+			})
+			return
+		case result := <-w.scanC:
+			if err := w.handleScanResults(result); err != nil {
+				log.Errorf("Unable to handle scan results %s: %v", result.Scan.GetScanName(), err)
+			}
+		}
+		if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
+			concurrency.WithLock(&w.snapshotsLock, func() {
+				w.readyQueue.Push(w.scanConfigResults)
+			})
+			return
+		}
+	}
+}
+
+func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) error {
+	// Here we have the scan config id and the scan
+	if w.totalResults == 0 {
+		var profileNames []string
+		for _, p := range w.scanConfigResults.ScanConfig.GetProfiles() {
+			profileNames = append(profileNames, p.GetProfileName())
+		}
+		log.Debugf("Profiles %v", profileNames)
+		var clusters []string
+		for _, c := range w.scanConfigResults.ScanConfig.GetClusters() {
+			clusters = append(clusters, c.GetClusterId())
+		}
+		profileQuery := search.NewQueryBuilder().
+			AddExactMatches(
+				search.ComplianceOperatorProfileName,
+				profileNames...,
+			).
+			AddExactMatches(
+				search.ClusterID,
+				clusters...,
+			).ProtoQuery()
+		profiles, err := w.profileDS.SearchProfiles(result.Ctx, profileQuery)
+		if err != nil {
+			return err
+		}
+		for _, p := range profiles {
+			scanRefQuery := search.NewQueryBuilder().AddExactMatches(
+				search.ComplianceOperatorProfileRef,
+				p.GetProfileRefId(),
+			).ProtoQuery()
+			scans, err := w.scanDS.SearchScans(result.Ctx, scanRefQuery)
+			if err != nil {
+				log.Errorf("Unable to retrieve scans: %v", err)
+				continue
+			}
+			for _, s := range scans {
+				log.Debugf("Adding scan to wait %s", s.GetScanName())
+				w.scansToWait.Add(fmt.Sprintf("%s:%s", s.GetClusterId(), s.GetId()))
+			}
+		}
+		w.totalResults = len(w.scansToWait)
+		log.Infof("Scan config %s needs to wait for %d scans", w.scanConfigResults.ScanConfig.GetScanConfigName(), w.totalResults)
+	}
+	log.Infof("Scan to handle %s with id %s", result.Scan.GetScanName(), result.Scan.GetId())
+	if found := w.scansToWait.Remove(fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetId())); !found {
+		return errors.Errorf("The scan %s should be handle by this watcher", result.Scan.GetId())
+	}
+	w.scanConfigResults.ScanResults[fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetId())] = result
+	return nil
+}

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -1,0 +1,263 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
+	scanMocks "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/queue"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type scanConfigTestEvent func(*testing.T, ScanConfigWatcher)
+
+func handleInitialScanResults(id string, scanDS *scanMocks.MockDataStore, profileDS *profileDatastore.MockDataStore, numOfScans int) scanConfigTestEvent {
+	return func(t *testing.T, watcher ScanConfigWatcher) {
+		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).
+			DoAndReturn(func(_, _ any) ([]*storage.ComplianceOperatorProfileV2, error) {
+				return []*storage.ComplianceOperatorProfileV2{
+					{
+						Id: fmt.Sprintf("profile-%s", id),
+					},
+				}, nil
+			})
+		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).
+			DoAndReturn(func(_, _ any) ([]*storage.ComplianceOperatorScanV2, error) {
+				ret := make([]*storage.ComplianceOperatorScanV2, numOfScans)
+				for i := 0; i < numOfScans; i++ {
+					ret[i] = &storage.ComplianceOperatorScanV2{
+						Id: fmt.Sprintf("scan-%d", i),
+					}
+				}
+				return ret, nil
+			})
+		err := watcher.PushScanResults(&ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				Id: id,
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
+func handleScanResults(id string) scanConfigTestEvent {
+	return func(t *testing.T, watcher ScanConfigWatcher) {
+		err := watcher.PushScanResults(&ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				Id: id,
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
+func handleScanResultsWithError(id string) scanConfigTestEvent {
+	return func(t *testing.T, watcher ScanConfigWatcher) {
+		err := watcher.PushScanResults(&ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				Id: id,
+			},
+			Error: errors.New("some error in the scan"),
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestScanConfigWatcher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	scanDS := scanMocks.NewMockDataStore(ctrl)
+	profileDS := profileDatastore.NewMockDataStore(ctrl)
+	cases := map[string]struct {
+		events           []scanConfigTestEvent
+		snapshotIDs      []string
+		assertScanIDs    []string
+		assertScanErrors []string
+	}{
+		"one successful scan": {
+			events: []scanConfigTestEvent{
+				handleInitialScanResults("scan-0", scanDS, profileDS, 1),
+			},
+			snapshotIDs:   []string{"snapshot-0"},
+			assertScanIDs: []string{"scan-0"},
+		},
+		"two successful scans": {
+			events: []scanConfigTestEvent{
+				handleInitialScanResults("scan-0", scanDS, profileDS, 2),
+				handleScanResults("scan-1"),
+			},
+			snapshotIDs:   []string{"snapshot-0"},
+			assertScanIDs: []string{"scan-0", "scan-1"},
+		},
+		"two successful scans with two snapshots": {
+			events: []scanConfigTestEvent{
+				handleInitialScanResults("scan-0", scanDS, profileDS, 2),
+				handleScanResults("scan-1"),
+			},
+			snapshotIDs:   []string{"snapshot-0", "snapshot-1"},
+			assertScanIDs: []string{"scan-0", "scan-1"},
+		},
+		"one successful scan and one failed scan": {
+			events: []scanConfigTestEvent{
+				handleInitialScanResults("scan-0", scanDS, profileDS, 2),
+				handleScanResultsWithError("scan-1"),
+			},
+			snapshotIDs:      []string{"snapshot-0"},
+			assertScanErrors: []string{"scan-1"},
+			assertScanIDs:    []string{"scan-0", "scan-1"},
+		},
+	}
+	for tName, tCase := range cases {
+		t.Run(tName, func(t *testing.T) {
+			watcherID := "sc-id"
+			scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
+				Id: watcherID,
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			resultsQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+			scanConfigWatcher := NewScanConfigWatcher(ctx, watcherID, scanConfig, scanDS, profileDS, resultsQueue, tCase.snapshotIDs...)
+			for _, event := range tCase.events {
+				event(t, scanConfigWatcher)
+			}
+			require.Eventually(t, func() bool {
+				return resultsQueue.Len() != 0
+			}, 200*time.Millisecond, 10*time.Millisecond)
+			result := resultsQueue.Pull()
+			require.NotNil(t, result)
+			require.Len(t, result.ScanResults, len(tCase.assertScanIDs))
+			for _, scanResult := range result.ScanResults {
+				assert.Contains(t, tCase.assertScanIDs, scanResult.Scan.GetId())
+				if scanResult.Error != nil {
+					assert.Contains(t, tCase.assertScanErrors, scanResult.Scan.GetId())
+				}
+			}
+			require.Len(t, result.ReportSnapshotIDs, len(tCase.snapshotIDs))
+			for _, id := range tCase.snapshotIDs {
+				assert.Contains(t, result.ReportSnapshotIDs, id)
+			}
+		})
+	}
+}
+
+func TestScanConfigWatcherCancel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	scanDS := scanMocks.NewMockDataStore(ctrl)
+	profileDS := profileDatastore.NewMockDataStore(ctrl)
+	watcherID := "sc-id"
+	scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
+		Id: watcherID,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	scanConfigWatcher := NewScanConfigWatcher(ctx, watcherID, scanConfig, scanDS, profileDS, resultQueue)
+	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	cancel()
+	select {
+	case <-scanConfigWatcher.Finished().Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout waiting for the watcher to stop")
+	}
+	assert.Equal(t, 0, resultQueue.Len())
+}
+
+func TestScanConfigWatcherStop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	scanDS := scanMocks.NewMockDataStore(ctrl)
+	profileDS := profileDatastore.NewMockDataStore(ctrl)
+	watcherID := "sc-id"
+	scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
+		Id: watcherID,
+	}
+	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	scanConfigWatcher := NewScanConfigWatcher(context.Background(), watcherID, scanConfig, scanDS, profileDS, resultQueue)
+	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	scanConfigWatcher.Stop()
+	select {
+	case <-scanConfigWatcher.Finished().Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout waiting for the watcher to stop")
+	}
+	assert.Equal(t, 0, resultQueue.Len())
+}
+
+func TestScanConfigWatcherTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	scanDS := scanMocks.NewMockDataStore(ctrl)
+	profileDS := profileDatastore.NewMockDataStore(ctrl)
+	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	ctx, cancel := context.WithCancel(context.Background())
+	finishedSignal := concurrency.NewSignal()
+	scanConfigWatcher := &scanConfigWatcherImpl{
+		ctx:       ctx,
+		cancel:    cancel,
+		stopped:   &finishedSignal,
+		scanDS:    scanDS,
+		profileDS: profileDS,
+		scanC:     make(chan *ScanWatcherResults),
+		scanConfigResults: &ScanConfigWatcherResults{
+			WatcherID: "id",
+			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{
+				Id: "id",
+			},
+			ScanResults: make(map[string]*ScanWatcherResults),
+		},
+		readyQueue:  resultQueue,
+		scansToWait: set.NewStringSet(),
+	}
+	timeoutC := make(chan time.Time)
+	go scanConfigWatcher.run(timeoutC)
+	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	timeoutC <- time.Now()
+	select {
+	case <-scanConfigWatcher.Finished().Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout waiting for the watcher to stop")
+	}
+	// We should have a result in the queue with an error
+	require.Equal(t, 1, resultQueue.Len())
+	result := resultQueue.Pull()
+	assert.Error(t, result.Error)
+}
+
+func TestScanConfigWatcherSubscribe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	scanDS := scanMocks.NewMockDataStore(ctrl)
+	profileDS := profileDatastore.NewMockDataStore(ctrl)
+	watcherID := "sc-id"
+	scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
+		Id: watcherID,
+	}
+	resultsQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	scanIDs := []string{"scan-0", "scan-1", "scan-2"}
+	snapshotIDS := []string{"snapshot-0", "snapshot-1"}
+	scanConfigWatcher := NewScanConfigWatcher(context.Background(), watcherID, scanConfig, scanDS, profileDS, resultsQueue, snapshotIDS[0])
+	handleInitialScanResults(scanIDs[0], scanDS, profileDS, len(scanIDs))(t, scanConfigWatcher)
+	handleScanResults(scanIDs[1])(t, scanConfigWatcher)
+	scanConfigWatcher.Subscribe(snapshotIDS[1])
+	handleScanResults(scanIDs[2])(t, scanConfigWatcher)
+
+	require.Eventually(t, func() bool {
+		return resultsQueue.Len() != 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	require.Equal(t, 1, resultsQueue.Len())
+	result := resultsQueue.Pull()
+	require.NotNil(t, result)
+	require.Len(t, result.ScanResults, len(scanIDs))
+	for _, scanResult := range result.ScanResults {
+		assert.Contains(t, scanIDs, scanResult.Scan.GetId())
+	}
+	require.Len(t, result.ReportSnapshotIDs, len(snapshotIDS))
+	for _, id := range snapshotIDS {
+		assert.Contains(t, result.ReportSnapshotIDs, id)
+	}
+}

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -212,6 +212,7 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 		},
 		readyQueue:  resultQueue,
 		scansToWait: set.NewStringSet(),
+		timeout:     time.NewTimer(defaultScanConfigTimeout),
 	}
 	timeoutC := make(chan time.Time)
 	go scanConfigWatcher.run(timeoutC)

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -212,7 +212,10 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 		},
 		readyQueue:  resultQueue,
 		scansToWait: set.NewStringSet(),
-		timeout:     time.NewTimer(defaultScanConfigTimeout),
+		stopFn: func() {
+			finishedSignal.Signal()
+			<-finishedSignal.Done()
+		},
 	}
 	timeoutC := make(chan time.Time)
 	go scanConfigWatcher.run(timeoutC)

--- a/central/complianceoperator/v2/report/manager/watcher/utils.go
+++ b/central/complianceoperator/v2/report/manager/watcher/utils.go
@@ -1,0 +1,30 @@
+package watcher
+
+import "time"
+
+// Timer interface to wrap a timer, so it can be injected in tests
+type Timer interface {
+	Stop() bool
+	C() <-chan time.Time
+}
+
+type timerWrapper struct {
+	timer *time.Timer
+}
+
+// NewTimer creates a new timerWrapper
+func NewTimer(duration time.Duration) *timerWrapper {
+	return &timerWrapper{
+		timer: time.NewTimer(duration),
+	}
+}
+
+// Stop the timer
+func (t *timerWrapper) Stop() bool {
+	return t.timer.Stop()
+}
+
+// C returns the timer channel
+func (t *timerWrapper) C() <-chan time.Time {
+	return t.timer.C
+}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds the logic to identify when a ScanConfiguration has started and completed. This is necessary for the accurate reporting of compliance 2.0

- Depends on #12890

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit test
- [x] Deployed ACS and CO and observe in the logs that the ScanConfiguration start and completion are detected
