### PR TITLE
ROX-24283: enable strictfipsruntime in Konflux builds

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -42,7 +42,9 @@ ENV BUILD_TAG="$BUILD_TAG"
 ENV GOFLAGS=""
 ENV CGO_ENABLED=1
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
+ENV GOTAGS="release,strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
 ENV CI=1
 
 RUN # TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy. \

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -20,7 +20,9 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV CI=1 GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
+ENV GOTAGS="release,strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
 
 RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build.sh ./roxctl && \
     cp bin/linux_$(go env GOARCH)/roxctl image/bin/roxctl

--- a/make/env.mk
+++ b/make/env.mk
@@ -3,6 +3,7 @@
 SHELL := /bin/bash
 
 colon := :
+comma := ,
 
 # GOPATH might actually be a colon-separated list of paths. For the purposes of this makefile,
 # work with the first element only.
@@ -40,10 +41,11 @@ endif
 TAG := # make sure tag is never injectable as an env var
 RELEASE_GOTAGS := release
 
-# Use a release go -tag when CI is targetting a tag
+# Use a release go -tag when CI is targeting a tag
 ifdef CI
 ifneq ($(BUILD_TAG),)
-GOTAGS := $(RELEASE_GOTAGS)
+# Preserve existing GOTAGS and append release tags
+GOTAGS := $(if $(GOTAGS),$(GOTAGS)$(comma))$(RELEASE_GOTAGS)
 endif
 endif
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -11,7 +11,9 @@ RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is
 ENV BUILD_TAG="$BUILD_TAG"
 
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
+ENV GOTAGS="release,strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
 ENV CI=1 GOFLAGS="" CGO_ENABLED=1
 
 RUN GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build-file.sh operator/cmd/main.go image/bin/operator

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -14,7 +14,9 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
+ENV GOTAGS="release,strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
 ENV CI=1
 
 COPY . /src


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Enables the `strictfipsruntime` build flag for Konflux builds.

For more info about the `strictfipsruntime` flag, see [this doc](https://docs.google.com/document/d/1CTpSwITQfOgoOTlPITZNJZy0ltYz60hxkmWsLemCqw0/edit?tab=t.0) (there might be a better resource but this is the one David and I found), and for our general research regarding the linked ticket, see [this doc](https://docs.google.com/document/d/1KcjlevcMF4DLi-KROru7tuUUIb4wSk5e6bnXpU8HZxA/edit?tab=t.0).

Related scanner v2 PR: https://github.com/stackrox/scanner/pull/1709

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### How I validated my change

Verified the build works via Konflux CI and verified the `check-payload` results of the following images:
- [x] `quay.io/rhacs-eng/main:4.7.x-121-gfd7fbe926b-fast`
- [x] `quay.io/rhacs-eng/scanner-v4:4.7.x-121-gfd7fbe926b-fast`
- [x] `quay.io/rhacs-eng/roxctl:4.7.x-121-gfd7fbe926b-fast`
- [x] `quay.io/rhacs-eng/stackrox-operator:4.7.0-121-gfd7fbe926b-fast`