### PR TITLE
chore: add image name to vuln request to scanner v2

### DIFF
--- a/pkg/scanners/clairify/clairify.go
+++ b/pkg/scanners/clairify/clairify.go
@@ -412,6 +412,7 @@ func (c *clairify) GetVulnerabilities(image *storage.Image, components *scannerT
 	clairComponents := components.Clairify()
 
 	req := &clairGRPCV1.GetImageVulnerabilitiesRequest{
+		Image:      utils.GetFullyQualifiedFullName(image),
 		Components: clairComponents,
 		Notes:      notes,
 	}


### PR DESCRIPTION
### Description

Scanner v2 logs the image name for which it is retrieving vulnerabilities (gRPC method): https://github.com/stackrox/scanner/blob/2.34.2/api/v1/imagescan/service.go#L205

We are currently not sending the image name over, though we are sending it when fetching the components: https://github.com/stackrox/stackrox/blob/4.5.3/sensor/common/scannerclient/grpc_client.go#L183

This change adds that same line to the vulnerability request

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

none

#### How I validated my change

trivial
