### PR TITLE
fix: (konflux) Add spec.relatedImages iff executing in Konflux mode

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -450,7 +450,7 @@ bundle-post-process: test-bundle-helpers operator-sdk ## Post-process CSV file t
 		--first-version $${first_version} \
 		--operator-image $(IMG) \
 		$${unreleased_opt} \
-		--no-related-images \
+		--related-images-mode=omit \
 		--add-supported-arch amd64 \
 		--add-supported-arch arm64 \
 		--add-supported-arch ppc64le \

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -60,7 +60,7 @@ def patch_csv(csv_doc, version, operator_image, first_version, related_images_mo
 
     csv_doc['spec']['version'] = version
 
-    if related_images_mode in ["downstream", "konflux"]:
+    if related_images_mode != "omit":
         rewrite(csv_doc, related_image_passthrough)
 
     previous_y_stream = get_previous_y_stream(version)

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -7,6 +7,7 @@ import pathlib
 import subprocess
 import sys
 import yaml
+import textwrap
 from collections import namedtuple
 from datetime import datetime, timezone
 
@@ -163,15 +164,23 @@ def get_previous_y_stream(version):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file')
+    partial_parser = argparse.ArgumentParser(add_help=False)
+    partial_parser.add_argument('--related-images-mode', nargs='?')
+    args, _ = partial_parser.parse_known_args()
+    if args.related_images_mode == 'help':
+        print_related_images_mode_help()
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--use-version", required=True, metavar='version',
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
                         help='The first version of the operator that was published')
     parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
-    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux"], default="downstream",
-                        help="Set mode of operation for handling related image settings.")
+    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux", "help"], default="downstream",
+                        help="Set mode of operation for handling related image settings; specify 'help' for more information.")
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
@@ -180,6 +189,21 @@ def parse_args():
     parser.add_argument("--unreleased", help="Not yet released version of operator, if any.")
     return parser.parse_args()
 
+def print_related_images_mode_help():
+    print(textwrap.dedent('''
+            The '--related-images-mode' parameter allows controlling the mode in which the 'related images'
+            are integrated within the output CSV. The default mode is 'downstream'.
+
+            Description of the supported modes:
+
+                downstream: In this mode the current RELATED_IMAGE_* environment variables are injected into
+                    the output CSV and spec.relatedImages is not added.
+
+                omit: In this mode no RELATED_IMAGE_* environment variables are injected into the output CSV
+                    and spec.relatedImages is not added.
+
+                konflux: In this mode the current RELATED_IMAGE_* environment variables are injected into the
+                    output CSV and spec.relatedImages is populated based on them.'''))
 
 def main():
     logging.basicConfig(stream=sys.stderr, level=logging.INFO,

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p build/ && \
     ./bundle_helpers/patch-csv.py \
       --use-version "${OPERATOR_IMAGE_TAG}" \
       --first-version 3.62.0 \
+      --inject-related-images \
       --operator-image "${OPERATOR_IMAGE_REF}" \
       --add-supported-arch amd64 \
       --add-supported-arch arm64 \

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p build/ && \
     ./bundle_helpers/patch-csv.py \
       --use-version "${OPERATOR_IMAGE_TAG}" \
       --first-version 3.62.0 \
-      --inject-related-images \
+      --related-images-mode=konflux \
       --operator-image "${OPERATOR_IMAGE_REF}" \
       --add-supported-arch amd64 \
       --add-supported-arch arm64 \


### PR DESCRIPTION
### Description

See subject. This PR has been rebased and modified so that it only deals with the problem that `spec.relatedImages` must only be populating if (and only if) we are in "Konflux mode". This has been implemented in the form of a new command-line flag for the patching script, which is used by the konflux Dockerfile.

[ROX-26151](https://issues.redhat.com/browse/ROX-26151)

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

Nothing done here.

#### How I validated my change

Inspected the CSV.

Downstream `spec.relatedImages`:

```
  - name: rhacs-rhel8-operator-9905fb7988a9203b3aaa3295e19149fd2312872c11e3aca2686cb3c4dcee7054-annotation
    image: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:9905fb7988a9203b3aaa3295e19149fd2312872c11e3aca2686cb3c4dcee7054
  - name: manager
    image: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:9905fb7988a9203b3aaa3295e19149fd2312872c11e3aca2686cb3c4dcee7054
  - name: main
    image: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:595c65a6335f33ebc8ee9d012b5cc4945a032ff14a50ac6e24fa2e8e92b583d5
  - name: scanner
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8@sha256:64439c4e1e8e234d0bafe01394b20c79ede42684144838f8a2411523bda5f1c5
  - name: scanner_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8@sha256:d19e6dc268547e7fc2a042b799b977f73aa61600050df4b616ee73bbb51a7c9f
  - name: scanner_db
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:2381e5f5befabc89817b3737461ac8948b0c98e9d8fb04b61cbd6055a469e74b
  - name: scanner_db_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8@sha256:9a110df33c169932b4e8c0a98abb83d97a5215fbf0a8b688a66916454835a8d5
  - name: collector_slim
    image: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8@sha256:6762a626b0342a5d9d106827bfd13a94a087882f8885a2bdfab86fd2fd4de310
  - name: collector_full
    image: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8@sha256:490f2e0170d162ec496588b878dbbef96d66bfc1ee8f3c6dc2f9263458d901cd
  - name: roxctl
    image: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:3a61d781f0d961ab410d88faccff870a356dd15edc3e69e1c1878961db5884c3
  - name: central_db
    image: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:be90e0fcee9dcb015bfac1d4c02c8eedded9141ad38ca632fb0715f679423d6e
  - name: scanner_v4_db
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:8adbe0d91c30aaf847074f62cfb31f415b1bd663f3c0c99b19f57e5e2aac0e6f
  - name: scanner_v4
    image: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:28dea7a1ba2c878b13c598518a572f982ce7a4e176b071b93a2320290cbf91db
```

PR's `spec.relatedImages`:
```
  - image: quay.io/rhacs-eng/scanner-db-slim@sha256:af44e5912b0527bd723450f49a104a2bb1fc37294fdeaa339cc6ea6312c5f78d
    name: scanner_db_slim
  - image: quay.io/rhacs-eng/central-db@sha256:4c6c379dd0ae5a8b4a81773d0e9560df772589dc032da88c63267a0388bf0e24
    name: central_db
  - image: quay.io/rhacs-eng/scanner@sha256:5d010dc4b8714fc82288bc5b77947dfefff670eac8e3edf23e7161e5dcf37033
    name: scanner
  - image: quay.io/rhacs-eng/scanner-v4@sha256:b631f094239383b1ef03a31c2feba329826b4ce1709a71e483ed2046d3e67028
    name: scanner_v4
  - image: quay.io/rhacs-eng/collector@sha256:e609434f801a56bc308509b5b0f311098a6237fca3b8ce8ae11d8b15cc3876d9
    name: collector_full
  - image: quay.io/rhacs-eng/scanner-slim@sha256:1f56334ba9c4c92bec40c8242e46e2c18cc3d800ee9477a6fec7ceefd7a4fd14
    name: scanner_slim
  - image: quay.io/rhacs-eng/main@sha256:5452df8c88e2ce89a7493091f968aa27d5c18a93ee6ff9056d9155d84dc1d5d8
    name: main
  - image: quay.io/rhacs-eng/scanner-db@sha256:73e597e105701315528b3ff865484136805afbb3a7b1f3a58608274d7518c041
    name: scanner_db
  - image: quay.io/rhacs-eng/scanner-v4-db@sha256:d339f637c74e429b90c603e67c1a0fa2d6d16cac73f441aabae3ecdc4f96df6f
    name: scanner_v4_db
  - image: quay.io/rhacs-eng/collector-slim@sha256:e609434f801a56bc308509b5b0f311098a6237fca3b8ce8ae11d8b15cc3876d9
    name: collector_slim
  - image: quay.io/rhacs-eng/roxctl@sha256:146323fcc977c757ca036039f1a036d6ec549f1d5a278a092fb682eb01615478
    name: roxctl
  - image: quay.io/rhacs-eng/stackrox-operator@sha256:b79eab6b09f0bf9e1c5f8f16e2c50afc78c47151a46abdda76161be09040571b
    name: manager
```

Downstream `spec.install.spec.label.spec.template.spec.args.env`:
```
                - name: RELATED_IMAGE_MAIN
                  value: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:595c65a6335f33ebc8ee9d012b5cc4945a032ff14a50ac6e24fa2e8e92b583d5
                - name: RELATED_IMAGE_SCANNER
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8@sha256:64439c4e1e8e234d0bafe01394b20c79ede42684144838f8a2411523bda5f1c5
                - name: RELATED_IMAGE_SCANNER_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8@sha256:d19e6dc268547e7fc2a042b799b977f73aa61600050df4b616ee73bbb51a7c9f
                - name: RELATED_IMAGE_SCANNER_DB
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:2381e5f5befabc89817b3737461ac8948b0c98e9d8fb04b61cbd6055a469e74b
                - name: RELATED_IMAGE_SCANNER_DB_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8@sha256:9a110df33c169932b4e8c0a98abb83d97a5215fbf0a8b688a66916454835a8d5
                - name: RELATED_IMAGE_COLLECTOR_SLIM
                  value: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8@sha256:6762a626b0342a5d9d106827bfd13a94a087882f8885a2bdfab86fd2fd4de310
                - name: RELATED_IMAGE_COLLECTOR_FULL
                  value: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8@sha256:490f2e0170d162ec496588b878dbbef96d66bfc1ee8f3c6dc2f9263458d901cd
                - name: RELATED_IMAGE_ROXCTL
                  value: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:3a61d781f0d961ab410d88faccff870a356dd15edc3e69e1c1878961db5884c3
                - name: RELATED_IMAGE_CENTRAL_DB
                  value: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:be90e0fcee9dcb015bfac1d4c02c8eedded9141ad38ca632fb0715f679423d6e
                - name: RELATED_IMAGE_SCANNER_V4_DB
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:8adbe0d91c30aaf847074f62cfb31f415b1bd663f3c0c99b19f57e5e2aac0e6f
                - name: RELATED_IMAGE_SCANNER_V4
                  value: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:28dea7a1ba2c878b13c598518a572f982ce7a4e176b071b93a2320290cbf91db
```

PR's `spec.install.spec.label.spec.template.spec.args.env`:
```
                - name: RELATED_IMAGE_MAIN
                  value: quay.io/rhacs-eng/main@sha256:5452df8c88e2ce89a7493091f968aa27d5c18a93ee6ff9056d9155d84dc1d5d8
                - name: RELATED_IMAGE_SCANNER
                  value: quay.io/rhacs-eng/scanner@sha256:5d010dc4b8714fc82288bc5b77947dfefff670eac8e3edf23e7161e5dcf37033
                - name: RELATED_IMAGE_SCANNER_SLIM
                  value: quay.io/rhacs-eng/scanner-slim@sha256:1f56334ba9c4c92bec40c8242e46e2c18cc3d800ee9477a6fec7ceefd7a4fd14
                - name: RELATED_IMAGE_SCANNER_DB
                  value: quay.io/rhacs-eng/scanner-db@sha256:73e597e105701315528b3ff865484136805afbb3a7b1f3a58608274d7518c041
                - name: RELATED_IMAGE_SCANNER_DB_SLIM
                  value: quay.io/rhacs-eng/scanner-db-slim@sha256:af44e5912b0527bd723450f49a104a2bb1fc37294fdeaa339cc6ea6312c5f78d
                - name: RELATED_IMAGE_COLLECTOR_SLIM
                  value: quay.io/rhacs-eng/collector-slim@sha256:e609434f801a56bc308509b5b0f311098a6237fca3b8ce8ae11d8b15cc3876d9
                - name: RELATED_IMAGE_COLLECTOR_FULL
                  value: quay.io/rhacs-eng/collector@sha256:e609434f801a56bc308509b5b0f311098a6237fca3b8ce8ae11d8b15cc3876d9
                - name: RELATED_IMAGE_ROXCTL
                  value: quay.io/rhacs-eng/roxctl@sha256:146323fcc977c757ca036039f1a036d6ec549f1d5a278a092fb682eb01615478
                - name: RELATED_IMAGE_CENTRAL_DB
                  value: quay.io/rhacs-eng/central-db@sha256:4c6c379dd0ae5a8b4a81773d0e9560df772589dc032da88c63267a0388bf0e24
                - name: RELATED_IMAGE_SCANNER_V4_DB
                  value: quay.io/rhacs-eng/scanner-v4-db@sha256:d339f637c74e429b90c603e67c1a0fa2d6d16cac73f441aabae3ecdc4f96df6f
                - name: RELATED_IMAGE_SCANNER_V4
                  value: quay.io/rhacs-eng/scanner-v4@sha256:b631f094239383b1ef03a31c2feba329826b4ce1709a71e483ed2046d3e67028
```
