### PR TITLE
ROX-25828: Add index on process_indicators.signal_time

### DIFF
--- a/generated/storage/process_indicator.pb.go
+++ b/generated/storage/process_indicator.pb.go
@@ -303,7 +303,7 @@ type ProcessSignal struct {
 	// ID of container associated with this process
 	ContainerId string `protobuf:"bytes,2,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty" search:"Container ID,hidden"` // @gotags: search:"Container ID,hidden"
 	// Process creation time
-	Time *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=time,proto3" json:"time,omitempty" search:"Process Creation Time,hidden"` // @gotags: search:"Process Creation Time,hidden"
+	Time *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=time,proto3" json:"time,omitempty" search:"Process Creation Time,hidden" sql:"index=btree"` // @gotags: search:"Process Creation Time,hidden" sql:"index=btree"
 	// Process name
 	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty" search:"Process Name"` // @gotags: search:"Process Name"
 	// Process arguments

--- a/pkg/postgres/schema/process_indicators.go
+++ b/pkg/postgres/schema/process_indicators.go
@@ -58,7 +58,7 @@ type ProcessIndicators struct {
 	PodID              string     `gorm:"column:podid;type:varchar"`
 	PodUID             string     `gorm:"column:poduid;type:uuid;index:processindicators_poduid,type:hash"`
 	SignalContainerID  string     `gorm:"column:signal_containerid;type:varchar"`
-	SignalTime         *time.Time `gorm:"column:signal_time;type:timestamp"`
+	SignalTime         *time.Time `gorm:"column:signal_time;type:timestamp;index:processindicators_signal_time,type:btree"`
 	SignalName         string     `gorm:"column:signal_name;type:varchar"`
 	SignalArgs         string     `gorm:"column:signal_args;type:varchar"`
 	SignalExecFilePath string     `gorm:"column:signal_execfilepath;type:varchar"`

--- a/proto/storage/process_indicator.proto
+++ b/proto/storage/process_indicator.proto
@@ -64,7 +64,7 @@ message ProcessSignal {
   string container_id = 2; // @gotags: search:"Container ID,hidden"
 
   // Process creation time
-  google.protobuf.Timestamp time = 3; // @gotags: search:"Process Creation Time,hidden"
+  google.protobuf.Timestamp time = 3; // @gotags: search:"Process Creation Time,hidden" sql:"index=btree"
 
   // Process name
   string name = 4; // @gotags: search:"Process Name"


### PR DESCRIPTION
### Description

Process indicator pruning worker struggles if the table grows too large. One of the reasons is that limiting query results only to the old records is not supported by any index:

    signal_time < now() AT time zone 'utc' - INTERVAL '$1 MINUTES'

Add the index process_indicators_signal_time_idx, which together with the configuration option for orphan window allow us to specify how much data to prune for process indicators.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

CI is enough.

#### How I validated my change

* Generated large `process_indicators` table (35 Gb)
* Applied the new image to start the migration (parallel index creation took about 3min on the out-of-the box cluster)
* Verified the index is created
* Tested the pruning query, the index is used when needed:

```
-- a query with larger orphan window, 3 hours and less data, bitmap scan with the new index is in use
EXPLAIN SELECT id FROM process_indicators pi WHERE NOT EXISTS
                (SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND
                (signal_time < now() AT time zone 'utc' - INTERVAL '3 hour' OR signal_time IS NULL);
                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------
 Hash Anti Join  (cost=2893.78..474305.98 rows=129797 width=16)
   Hash Cond: (pi.poduid = pods.id)
   ->  Bitmap Heap Scan on process_indicators pi  (cost=2646.90..472384.95 rows=139251 width=32)
         Recheck Cond: ((signal_time < (timezone('utc'::text, now()) - '03:00:00'::interval)) OR (signal_time IS NULL))
         ->  BitmapOr  (cost=2646.90..2646.90 rows=139251 width=0)
               ->  Bitmap Index Scan on processindicators_signal_time  (cost=0.00..2572.83 rows=139251 width=0)
                     Index Cond: (signal_time < (timezone('utc'::text, now()) - '03:00:00'::interval))
               ->  Bitmap Index Scan on processindicators_signal_time  (cost=0.00..4.45 rows=1 width=0)
                     Index Cond: (signal_time IS NULL)
   ->  Hash  (cost=240.24..240.24 rows=532 width=16)
         ->  Index Only Scan using pods_pkey on pods  (cost=0.28..240.24 rows=532 width=16)

-- a query with smaller orphan window, 2 hours and more data, fallback to seq scan
EXPLAIN SELECT id FROM process_indicators pi WHERE NOT EXISTS
                (SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND
                (signal_time < now() AT time zone 'utc' - INTERVAL '2 hour' OR signal_time IS NULL);
                                                    QUERY PLAN
------------------------------------------------------------------------------------------------------------------
 Hash Anti Join  (cost=246.89..4262749.34 rows=13048232 width=16)
   Hash Cond: (pi.poduid = pods.id)
   ->  Seq Scan on process_indicators pi  (cost=0.00..4094204.56 rows=13998623 width=32)
         Filter: ((signal_time < (timezone('utc'::text, now()) - '02:00:00'::interval)) OR (signal_time IS NULL))
   ->  Hash  (cost=240.24..240.24 rows=532 width=16)
         ->  Index Only Scan using pods_pkey on pods  (cost=0.28..240.24 rows=532 width=16)
```