### PR TITLE
ROX-24990:  alert time index to help pruning

### DIFF
--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -277,7 +277,7 @@ type Alert struct {
 	Violations       []*Alert_Violation      `protobuf:"bytes,5,rep,name=violations,proto3" json:"violations,omitempty" search:"-"`                                      // @gotags: search:"-"
 	ProcessViolation *Alert_ProcessViolation `protobuf:"bytes,13,opt,name=process_violation,json=processViolation,proto3" json:"process_violation,omitempty" search:"-"` // @gotags: search:"-"
 	Enforcement      *Alert_Enforcement      `protobuf:"bytes,6,opt,name=enforcement,proto3" json:"enforcement,omitempty"`
-	Time             *timestamppb.Timestamp  `protobuf:"bytes,7,opt,name=time,proto3" json:"time,omitempty" sensorhash:"ignore" search:"Violation Time"`                                         // @gotags: sensorhash:"ignore" search:"Violation Time"
+	Time             *timestamppb.Timestamp  `protobuf:"bytes,7,opt,name=time,proto3" json:"time,omitempty" sensorhash:"ignore" search:"Violation Time" sql:"index=btree"`                                         // @gotags: sensorhash:"ignore" search:"Violation Time" sql:"index=btree"
 	FirstOccurred    *timestamppb.Timestamp  `protobuf:"bytes,10,opt,name=first_occurred,json=firstOccurred,proto3" json:"first_occurred,omitempty" sensorhash:"ignore"` // @gotags: sensorhash:"ignore"
 	// The time at which the alert was resolved. Only set if ViolationState is RESOLVED.
 	ResolvedAt *timestamppb.Timestamp `protobuf:"bytes,17,opt,name=resolved_at,json=resolvedAt,proto3" json:"resolved_at,omitempty" sensorhash:"ignore"`  // @gotags: sensorhash:"ignore"

--- a/pkg/postgres/schema/alerts.go
+++ b/pkg/postgres/schema/alerts.go
@@ -73,7 +73,7 @@ type Alerts struct {
 	ResourceResourceType     storage.Alert_Resource_ResourceType `gorm:"column:resource_resourcetype;type:integer"`
 	ResourceName             string                              `gorm:"column:resource_name;type:varchar"`
 	EnforcementAction        storage.EnforcementAction           `gorm:"column:enforcement_action;type:integer"`
-	Time                     *time.Time                          `gorm:"column:time;type:timestamp"`
+	Time                     *time.Time                          `gorm:"column:time;type:timestamp;index:alerts_time,type:btree"`
 	State                    storage.ViolationState              `gorm:"column:state;type:integer;index:alerts_state,type:btree"`
 	Serialized               []byte                              `gorm:"column:serialized;type:bytea"`
 }

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -132,7 +132,7 @@ message Alert {
 
   Enforcement enforcement = 6;
 
-  google.protobuf.Timestamp time = 7; // @gotags: sensorhash:"ignore" search:"Violation Time"
+  google.protobuf.Timestamp time = 7; // @gotags: sensorhash:"ignore" search:"Violation Time" sql:"index=btree"
   google.protobuf.Timestamp first_occurred = 10; // @gotags: sensorhash:"ignore"
 
   // The time at which the alert was resolved. Only set if ViolationState is RESOLVED.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

As the size of the `alert` table grows, pruning becomes slower and slower.  We've improved that over time by batching, it, but there are more gains to be had.  This PR adds an index onto the time field in the alert.  This provides an extra nugget of information for Postgres to use as it determines what rows we are looking for.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Migration on 12K alerts took milliseconds to add the index.

Added the index on a local database of 1M records.  That took 2 seconds.

Verified queries will now use the index if Postgres finds it prudent to use it.

```
explain analyze select alerts.Id::text as Alert_ID 
from alerts 
where ((alerts.Time <= now() at time zone 'utc' - INTERVAL '4 DAYS'));
                                                     QUERY PLAN                                         
             
--------------------------------------------------------------------------------------------------------
-------------
 Index Scan using alerts_time on alerts  (cost=0.29..6.60 rows=1 width=32) (actual time=0.007..0.008 row
s=0 loops=1)
   Index Cond: ("time" <= (timezone('utc'::text, now()) - '4 days'::interval))
 Planning Time: 0.252 ms
 Execution Time: 0.028 ms
(4 rows)
```