### PR TITLE
fix(be): Fix alert search not working for new fields

### DIFF
--- a/central/alert/mappings/options.go
+++ b/central/alert/mappings/options.go
@@ -14,7 +14,7 @@ var OptionsMap search.OptionsMap
 
 func init() {
 	OptionsMap = search.Walk(v1.SearchCategory_ALERTS, "list_alert", (*storage.ListAlert)(nil))
-	alertOptions := schema.AlertsSchema.OptionsMap
+	alertOptions := schema.AlertsSchema.OptionsMap.Clone()
 
 	// There are more search terms in the alert proto due to the embeddings of policies.
 	// This pruning of options ensures that the search options are stable between RocksDB and Postgres

--- a/pkg/search/mocks/options_map.go
+++ b/pkg/search/mocks/options_map.go
@@ -54,6 +54,20 @@ func (mr *MockOptionsMapMockRecorder) Add(label, field any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockOptionsMap)(nil).Add), label, field)
 }
 
+// Clone mocks base method.
+func (m *MockOptionsMap) Clone() search.OptionsMap {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone")
+	ret0, _ := ret[0].(search.OptionsMap)
+	return ret0
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockOptionsMapMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockOptionsMap)(nil).Clone))
+}
+
 // Get mocks base method.
 func (m *MockOptionsMap) Get(field string) (*search.Field, bool) {
 	m.ctrl.T.Helper()

--- a/pkg/search/options_map.go
+++ b/pkg/search/options_map.go
@@ -38,6 +38,8 @@ type OptionsMap interface {
 	// PrimaryCategory is the category of the object this options map describes. Note that some of the fields might
 	// be linked fields and hence refer to a different category.
 	PrimaryCategory() v1.SearchCategory
+	// Clone creates copy of the OptionsMap
+	Clone() OptionsMap
 }
 
 type optionsMapImpl struct {
@@ -96,6 +98,14 @@ func (o *optionsMapImpl) Merge(o1 OptionsMap) OptionsMap {
 		o.Add(k, v)
 	}
 	return o
+}
+
+func (o *optionsMapImpl) Clone() OptionsMap {
+	clone := NewOptionsMap(o.PrimaryCategory())
+	for k, v := range o.Original() {
+		clone.Add(k, v)
+	}
+	return clone
 }
 
 // Difference returns a new option map with all elements of first not in second.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Alerts are stored in the db with type `Alert` but the v1/alerts/ APIs respond with `ListAlert` type objects. `ListAlert` has its own search fields that are exposed in the API. However, since db stores objects of type `Alert` , `ListAlert`'s search fields are updated to contain the search paths (`table_name.field_name`) as  `Alert`'s fields to ensure that search works. This implementation also ends up removing fields from the `OptionsMap` of the `AlertsSchema`. Because of this, it is not possible to add any new internal fields to `Alert` and use them for internal searches. This PR fixes this by cloning the `Alert` OptionsMap before reconciling with `ListAlert` OptionsMap. This way the search fields supported by schema will not change and can be used for internal searches.
 
### User-facing documentation

- [X] CHANGELOG update is not needed
- [X] documentation is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Will test manually in PR #12887 that adds new internal use fields to the Alerts schema
