### PR TITLE
ROX-25813: Add compliance coverages page status filtering

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -31,13 +31,18 @@ import { defaultChartHeight } from 'utils/chartUtils';
 
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { clusterSearchFilterConfig } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
+import {
+    CHECK_NAME_QUERY,
+    CHECK_STATUS_QUERY,
+    CLUSTER_QUERY,
+} from './compliance.coverage.constants';
 import {
     coverageProfileChecksPath,
     coverageProfileClustersPath,
 } from './compliance.coverage.routes';
 import { createScanConfigFilter } from './compliance.coverage.utils';
 import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
+import CheckStatusDropdown from './components/CheckStatusDropdown';
 import ProfileDetailsHeader from './components/ProfileDetailsHeader';
 import ProfileStatsWidget from './components/ProfileStatsWidget';
 import ScanConfigurationSelect from './components/ScanConfigurationSelect';
@@ -91,6 +96,17 @@ function CoveragesPage() {
 
     const onSearch = (payload: OnSearchPayload) => {
         onURLSearch(searchFilter, setSearchFilter, payload);
+    };
+
+    const onCheckStatusSelect = (
+        filterType: 'Compliance Check Status',
+        checked: boolean,
+        selection: string
+    ) => {
+        const action = checked ? 'ADD' : 'REMOVE';
+        const category = filterType;
+        const value = selection;
+        onSearch({ action, category, value });
     };
 
     const selectedProfileDetails = scanConfigProfilesResponse?.profiles.find(
@@ -175,6 +191,12 @@ function CoveragesPage() {
                                                 onSearch={onSearch}
                                             />
                                         </ToolbarItem>
+                                        <ToolbarItem>
+                                            <CheckStatusDropdown
+                                                searchFilter={searchFilter}
+                                                onSelect={onCheckStatusSelect}
+                                            />
+                                        </ToolbarItem>
                                     </ToolbarGroup>
                                     <ToolbarGroup className="pf-v5-u-w-100">
                                         <SearchFilterChips
@@ -188,6 +210,10 @@ function CoveragesPage() {
                                                 {
                                                     displayName: 'Cluster',
                                                     searchFilterName: CLUSTER_QUERY,
+                                                },
+                                                {
+                                                    displayName: 'Compliance Status',
+                                                    searchFilterName: CHECK_STATUS_QUERY,
                                                 },
                                             ]}
                                         />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -3,14 +3,11 @@ import { Link } from 'react-router-dom';
 import {
     Divider,
     Pagination,
-    Progress,
-    ProgressMeasureLocation,
     Text,
     TextVariants,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
-    Tooltip,
 } from '@patternfly/react-core';
 import {
     ExpandableRowContent,
@@ -31,9 +28,10 @@ import { ComplianceCheckResultStatusCount } from 'services/ComplianceCommon';
 import { TableUIState } from 'utils/getTableUIState';
 import { getPercentage } from 'utils/mathUtils';
 
-import { CHECK_NAME_QUERY } from './compliance.coverage.constants';
+import { CHECK_NAME_QUERY, CHECK_STATUS_QUERY } from './compliance.coverage.constants';
 import { coverageCheckDetailsPath } from './compliance.coverage.routes';
 import { getStatusCounts } from './compliance.coverage.utils';
+import ComplianceProgressBar from './components/ComplianceProgressBar';
 import ControlLabels from './components/ControlLabels';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
@@ -74,14 +72,15 @@ function ProfileChecksTable({
     }, [page, perPage, tableState]);
 
     function isComplianceStatusFiltered() {
-        return Array.isArray(searchFilter['Compliance Check Status']);
+        return CHECK_STATUS_QUERY in searchFilter;
     }
 
     function shouldDisableIcon(statuses) {
-        const statusFilter = searchFilter['Compliance Check Status'];
-        return (
-            Array.isArray(statusFilter) && !statuses.some((status) => statusFilter.includes(status))
-        );
+        const statusFilter = searchFilter[CHECK_STATUS_QUERY];
+        if (!statusFilter) {
+            return false;
+        }
+        return !statuses.some((status) => statusFilter.includes(status));
     }
 
     return (
@@ -174,10 +173,10 @@ function ProfileChecksTable({
                                                         {checkName}
                                                     </Link>
                                                     {/*
-                                                grid display is required to prevent the cell from
-                                                expanding to the text length. The Truncate PF component
-                                                is not used here because it displays a tooltip on hover
-                                            */}
+                                                        grid display is required to prevent the cell from
+                                                        expanding to the text length. The Truncate PF component
+                                                        is not used here because it displays a tooltip on hover
+                                                    */}
                                                     <div style={{ display: 'grid' }}>
                                                         <Text
                                                             component={TextVariants.small}
@@ -249,32 +248,13 @@ function ProfileChecksTable({
                                                     />
                                                 </Td>
                                                 <Td dataLabel="Compliance">
-                                                    {isComplianceStatusFiltered() ? (
-                                                        <div>—</div>
-                                                    ) : (
-                                                        <>
-                                                            <Progress
-                                                                id={progressBarId}
-                                                                value={passPercentage}
-                                                                measureLocation={
-                                                                    ProgressMeasureLocation.outside
-                                                                }
-                                                                aria-label={`${checkName} compliance percentage`}
-                                                            />
-                                                            <Tooltip
-                                                                content={
-                                                                    <div>
-                                                                        {`${passCount} / ${totalCount} clusters are passing this check`}
-                                                                    </div>
-                                                                }
-                                                                triggerRef={() =>
-                                                                    document.getElementById(
-                                                                        progressBarId
-                                                                    ) as HTMLButtonElement
-                                                                }
-                                                            />
-                                                        </>
-                                                    )}
+                                                    <ComplianceProgressBar
+                                                        ariaLabel={`${checkName} compliance percentage`}
+                                                        isDisabled={isComplianceStatusFiltered()}
+                                                        passPercentage={passPercentage}
+                                                        progressBarId={progressBarId}
+                                                        tooltipText={`${passCount} / ${totalCount} clusters are passing this check`}
+                                                    />
                                                 </Td>
                                             </Tr>
                                             {isRowExpanded && (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-    Divider,
-    Pagination,
-    Progress,
-    ProgressMeasureLocation,
-    Toolbar,
-    ToolbarContent,
-    ToolbarItem,
-    Tooltip,
-} from '@patternfly/react-core';
+import { Divider, Pagination, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
@@ -20,8 +11,10 @@ import { ComplianceClusterOverallStats } from 'services/ComplianceCommon';
 import { TableUIState } from 'utils/getTableUIState';
 import { getPercentage } from 'utils/mathUtils';
 
+import { CHECK_STATUS_QUERY } from './compliance.coverage.constants';
 import { coverageClusterDetailsPath } from './compliance.coverage.routes';
 import { getStatusCounts, getTimeDifferenceAsPhrase } from './compliance.coverage.utils';
+import ComplianceProgressBar from './components/ComplianceProgressBar';
 import ProfilesTableToggleGroup from './components/ProfilesTableToggleGroup';
 import StatusCountIcon from './components/StatusCountIcon';
 import useScanConfigRouter from './hooks/useScanConfigRouter';
@@ -50,14 +43,15 @@ function ProfileClustersTable({
     const { page, perPage, setPage, setPerPage } = pagination;
 
     function isComplianceStatusFiltered() {
-        return Array.isArray(searchFilter['Compliance Check Status']);
+        return CHECK_STATUS_QUERY in searchFilter;
     }
 
     function shouldDisableIcon(statuses) {
-        const statusFilter = searchFilter['Compliance Check Status'];
-        return (
-            Array.isArray(statusFilter) && !statuses.some((status) => statusFilter.includes(status))
-        );
+        const statusFilter = searchFilter[CHECK_STATUS_QUERY];
+        if (!statusFilter) {
+            return false;
+        }
+        return !statuses.some((status) => statusFilter.includes(status));
     }
 
     return (
@@ -193,32 +187,13 @@ function ProfileClustersTable({
                                                 />
                                             </Td>
                                             <Td dataLabel="Compliance">
-                                                {isComplianceStatusFiltered() ? (
-                                                    <div>—</div>
-                                                ) : (
-                                                    <>
-                                                        <Progress
-                                                            id={progressBarId}
-                                                            value={passPercentage}
-                                                            measureLocation={
-                                                                ProgressMeasureLocation.outside
-                                                            }
-                                                            aria-label={`${clusterName} compliance percentage`}
-                                                        />
-                                                        <Tooltip
-                                                            content={
-                                                                <div>
-                                                                    {`${passCount} / ${totalCount} checks are passing for this cluster`}
-                                                                </div>
-                                                            }
-                                                            triggerRef={() =>
-                                                                document.getElementById(
-                                                                    progressBarId
-                                                                ) as HTMLButtonElement
-                                                            }
-                                                        />
-                                                    </>
-                                                )}
+                                                <ComplianceProgressBar
+                                                    ariaLabel={`${clusterName} compliance percentage`}
+                                                    isDisabled={isComplianceStatusFiltered()}
+                                                    passPercentage={passPercentage}
+                                                    progressBarId={progressBarId}
+                                                    tooltipText={`${passCount} / ${totalCount} checks are passing for this cluster`}
+                                                />
                                             </Td>
                                         </Tr>
                                     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ComplianceProgressBar.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ComplianceProgressBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Progress, ProgressMeasureLocation, Tooltip } from '@patternfly/react-core';
+
+export type ComplianceProgressBarProps = {
+    ariaLabel: string;
+    isDisabled: boolean;
+    passPercentage: number;
+    progressBarId: string;
+    tooltipText: string;
+};
+
+function ComplianceProgressBar({
+    ariaLabel,
+    isDisabled,
+    passPercentage,
+    progressBarId,
+    tooltipText,
+}: ComplianceProgressBarProps) {
+    if (isDisabled) {
+        return <div>—</div>;
+    }
+    return (
+        <>
+            <Progress
+                id={progressBarId}
+                value={passPercentage}
+                measureLocation={ProgressMeasureLocation.outside}
+                aria-label={`${ariaLabel} compliance percentage`}
+            />
+            <Tooltip
+                content={<div>{tooltipText}</div>}
+                triggerRef={() => document.getElementById(progressBarId) as HTMLButtonElement}
+            />
+        </>
+    );
+}
+
+export default ComplianceProgressBar;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -18,11 +18,12 @@ type StatusCountIconProps = {
     text: string;
     status: Status;
     count: number;
+    disabled?: boolean;
 };
 
-function getStatusIcon(status: Status, count: number) {
+function getStatusIcon(status: Status, count: number, disabled: boolean) {
     let color = 'var(--pf-v5-global--disabled-color--100)';
-    if (count > 0) {
+    if (!disabled && count > 0) {
         switch (status) {
             case 'fail':
                 color = FAILING_VAR_COLOR;
@@ -62,10 +63,11 @@ function getStatusIcon(status: Status, count: number) {
     }
 }
 
-function StatusCountIcon({ text, status, count }: StatusCountIconProps) {
-    const icon = <Icon>{getStatusIcon(status, count)}</Icon>;
+function StatusCountIcon({ text, status, count, disabled = false }: StatusCountIconProps) {
+    const icon = <Icon>{getStatusIcon(status, count, disabled)}</Icon>;
+    const displayText = disabled ? '—' : `${count} ${pluralize(text, count)}`;
 
-    return <IconText icon={icon} text={`${count} ${pluralize(text, count)}`} />;
+    return <IconText icon={icon} text={displayText} />;
 }
 
 export default StatusCountIcon;


### PR DESCRIPTION
### Description

Add the ability to filter by status on the compliance coverages page tables.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Without filters:
![Screenshot 2024-10-07 at 2 55 59 PM](https://github.com/user-attachments/assets/b023691e-510a-4aab-bef4-0a2e27b008da)

With 'Pass' filter applied:
![Screenshot 2024-10-07 at 2 56 08 PM](https://github.com/user-attachments/assets/2e36155c-167b-471f-8cca-3c2e7228b8dc)


With 'Pass' and 'Manual' filter applied:
![Screenshot 2024-10-07 at 2 56 21 PM](https://github.com/user-attachments/assets/0615f4a0-f7dc-4c75-a871-e58a3c5f7b9a)


Compliance header tooltip:
![Screenshot 2024-10-07 at 2 56 27 PM](https://github.com/user-attachments/assets/4bc104ff-25ad-448d-a341-3e7a02d760d2)

