### PR TITLE
chore(CI): Remove ignore pod restarts for compliance container

### DIFF
--- a/scripts/ci/logcheck/check-restart-logs_test.bats
+++ b/scripts/ci/logcheck/check-restart-logs_test.bats
@@ -41,16 +41,6 @@ TEST_FIXTURES="${BATS_TEST_DIRNAME}/test_fixtures"
     [ "$status" -eq 2 ]
 }
 
-@test "it can depend on CI job" {
-    run "$CMD" "another-job" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
-    [ "$status" -eq 2 ]
-}
-
-@test "it handles the exception for ROX-5861" {
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
-    [ "$status" -eq 0 ]
-}
-
 @test "it handles collector restarts under openshift due to slow sensor start" {
     run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/slow-sensor-collector-previous.log"
     [ "$status" -eq 0 ]
@@ -62,22 +52,22 @@ TEST_FIXTURES="${BATS_TEST_DIRNAME}/test_fixtures"
 }
 
 @test "it handles exceptions in > 1 logs" {
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
+    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/slow-sensor-collector-previous.log"
     [ "$status" -eq 0 ]
 }
 
 @test "it spots a log with no exceptions with other logs that have an exception (by content)" {
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/no-exception-collector-previous.log" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
+    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/no-exception-collector-previous.log" "${TEST_FIXTURES}/exception-collector-previous.log"
     [ "$status" -eq 2 ]
 }
 
 @test "it spots a log with no exceptions with other logs that have an exception (by process)" {
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/other-process-previous.log" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
+    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/other-process-previous.log" "${TEST_FIXTURES}/exception-collector-previous.log"
     [ "$status" -eq 2 ]
 }
 
 @test "ordering is not a problem" {
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log"
+    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log"
     [ "$status" -eq 2 ]
 }
 
@@ -85,9 +75,9 @@ TEST_FIXTURES="${BATS_TEST_DIRNAME}/test_fixtures"
     if [[ -n "${GITHUB_ACTION:-}" ]]; then
         skip "not working on GHA"
     fi
-    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
+    run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log"
     [ "$status" -eq 2 ]
-    [ "${#lines[@]}" -eq 7 ]
+    [ "${#lines[@]}" -eq 5 ]
 }
 
 @test "this kernel flavor restart is OK" {

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -1,11 +1,5 @@
 [
     {
-        "comment": "ROX-5861: compliance restarts with openshift after sensor bounce tests",
-        "job": "^(ocp|openshift)",
-        "logfile": "compliance-previous",
-        "logline": "Fatal: error initializing stream to sensor"
-    },
-    {
         "comment": "collector initialization restart with download failure",
         "job": ".*",
         "logfile": "collector-previous",

--- a/scripts/ci/logcheck/test_fixtures/rox-5861-exception-compliance-previous.log
+++ b/scripts/ci/logcheck/test_fixtures/rox-5861-exception-compliance-previous.log
@@ -1,3 +1,0 @@
-blah blah
-main: 2020/10/30 11:02:15.529350 main.go:74: Fatal: error initializing stream to sensor: Failed to initialize sensor connection: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.109.185:443: connect: no route to host"
-more blah


### PR DESCRIPTION
### Description

This PR removes ignore for compliance container restarts.

After merging of: #12859 - we don't see Pod Restart failures. Because of that PR: #12815 is not relevant anymore.
Still, we should remove existing invalid ignores from our code.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

Run tests locally. This time, with set `ARTIFACT_DIR` env variable.
