### PR TITLE
ROX-27212: Add a "version" identifier for CRS for future proofness

### DIFF
--- a/central/clusterinit/backend/backend.go
+++ b/central/clusterinit/backend/backend.go
@@ -25,9 +25,10 @@ type InitBundleWithMeta struct {
 
 // CRS contains a Cluster Registration Secret.
 type CRS struct {
-	CAs  []string `json:"CAs"`
-	Cert string   `json:"cert"`
-	Key  string   `json:"key"`
+	Version int      `json:"version"`
+	CAs     []string `json:"CAs"`
+	Cert    string   `json:"cert"`
+	Key     string   `json:"key"`
 }
 
 // CRSWithMeta contains a CRS alongside its meta data.

--- a/central/clusterinit/backend/backend_impl.go
+++ b/central/clusterinit/backend/backend_impl.go
@@ -17,6 +17,10 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 )
 
+const (
+	currentCrsVersion = 1
+)
+
 var _ authn.ValidateCertChain = (*backendImpl)(nil)
 
 type backendImpl struct {
@@ -193,9 +197,10 @@ func (b *backendImpl) IssueCRS(ctx context.Context, name string) (*CRSWithMeta, 
 
 	return &CRSWithMeta{
 		CRS: &CRS{
-			CAs:  []string{caCert},
-			Cert: string(cert.CertPEM),
-			Key:  string(cert.KeyPEM),
+			Version: currentCrsVersion,
+			CAs:     []string{caCert},
+			Cert:    string(cert.CertPEM),
+			Key:     string(cert.KeyPEM),
 		},
 		Meta: meta,
 	}, nil

--- a/central/clusterinit/backend/backend_test.go
+++ b/central/clusterinit/backend/backend_test.go
@@ -320,6 +320,7 @@ func (s *clusterInitBackendTestSuite) TestCRSLifecycle() {
 	s.Require().NoError(err)
 	id := crsWithMeta.Meta.Id
 
+	s.Require().Equal(crsWithMeta.CRS.Version, currentCrsVersion)
 	err = s.backend.CheckRevoked(ctx, id)
 	s.Require().NoErrorf(err, "newly generated CRS %q is revoked", id)
 


### PR DESCRIPTION
### Description

See ROX-27212 for details.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Unit tests.

