### PR TITLE
ROX-26555: Manual helm installation fails due to missing flag

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -347,7 +347,7 @@ function launch_central {
       central_scripts_dir="$unzip_dir/scripts"
 
       # New helm setup flavor
-      local helm_args=( )
+      local helm_args=(--set central.persistence.none="true")
 
       if [[ "${central_namespace}" != "stackrox" ]]; then
         helm_args+=(--set "allowNonstandardNamespace=true")
@@ -392,12 +392,6 @@ function launch_central {
       if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
         helm_args+=(
           --set env.managedServices=true
-        )
-      fi
-
-      if [[ -n "$CENTRAL_PERSISTENCE_NONE" ]]; then
-        helm_args+=(
-          --set central.persistence.none="true"
         )
       fi
 

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -48,7 +48,6 @@ _compatibility_test() {
     local short_sensor_tag="$4"
 
     export_test_environment
-    ci_export CENTRAL_PERSISTENCE_NONE "true"
 
     if [[ "${SKIP_DEPLOY:-false}" = "false" ]]; then
         if [[ "${CI:-false}" = "true" ]]; then


### PR DESCRIPTION
### Description

Always set `--set central.persistence.none="true"` during central helm install instead of only in compatibility tests, since it looks like it has become necessary to make manual installs work after 4.1.

See issue: https://github.com/stackrox/stackrox/issues/12721 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

TODO: Manually install using Helm following our instructions and see that it works
