### PR TITLE
ROX-26555: Add central persistence helm flag to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ From here, you can install stackrox-central-services to get Central and Scanner 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
   stackrox/stackrox-central-services \
-  --set central.adminPassword.value="${STACKROX_ADMIN_PASSWORD}"
+  --set central.adminPassword.value="${STACKROX_ADMIN_PASSWORD}" \
+  --set central.persistence.none="true"
 ```
 
 #### Install Central in Clusters With Limited Resources
@@ -130,7 +131,8 @@ helm upgrade -n stackrox stackrox-central-services stackrox/stackrox-central-ser
   --set scanner.resources.requests.memory=500Mi \
   --set scanner.resources.requests.cpu=500m \
   --set scanner.resources.limits.memory=2500Mi \
-  --set scanner.resources.limits.cpu=2000m
+  --set scanner.resources.limits.cpu=2000m \
+  --set central.persistence.none="true"
 ```
 
 </details>

--- a/scripts/quick-helm-install.sh
+++ b/scripts/quick-helm-install.sh
@@ -52,7 +52,7 @@ STACKROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 
 echo "Installing stackrox-central-services"
 
-installflags=()
+installflags=('--set' 'central.persistence.none=true')
 if [[ "$SMALL_INSTALL" == "true" ]]; then
     installflags+=('--set' 'central.resources.requests.memory=1Gi')
     installflags+=('--set' 'central.resources.requests.cpu=1')
@@ -68,7 +68,6 @@ if [[ "$SMALL_INSTALL" == "true" ]]; then
     installflags+=('--set' 'scanner.resources.requests.cpu=500m')
     installflags+=('--set' 'scanner.resources.limits.memory=2500Mi')
     installflags+=('--set' 'scanner.resources.limits.cpu=2000m')
-    installflags+=('--set' 'central.persistence.none=true')
 fi
 
 helm install -n stackrox --create-namespace stackrox-central-services stackrox/stackrox-central-services \

--- a/scripts/quick-helm-install.sh
+++ b/scripts/quick-helm-install.sh
@@ -68,6 +68,7 @@ if [[ "$SMALL_INSTALL" == "true" ]]; then
     installflags+=('--set' 'scanner.resources.requests.cpu=500m')
     installflags+=('--set' 'scanner.resources.limits.memory=2500Mi')
     installflags+=('--set' 'scanner.resources.limits.cpu=2000m')
+    installflags+=('--set' 'central.persistence.none=true')
 fi
 
 helm install -n stackrox --create-namespace stackrox-central-services stackrox/stackrox-central-services \


### PR DESCRIPTION
### Description

Added `--set central.persistence.none=true` to the central helm install commands in the readme as well as the `quick-helm-install.sh` scripts.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Just ran the quick-helm-install.sh script locally and it works, no more pvc error
