### PR TITLE
chore: upper case AS in Dockerfiles

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /
 COPY download.sh /download.sh
 RUN /download.sh
 
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as stackrox_data
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS stackrox_data
 
 RUN mkdir /stackrox-data
 RUN microdnf upgrade --nobest -y  && microdnf install -y zip

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -6,7 +6,7 @@
 #
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.22 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,7 +1,7 @@
 # We have to emulate directory layout as in the repo so that imports in go files work fine.
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 
-FROM quay.io/stackrox-io/apollo-ci:${BUILD_IMAGE_VERSION} as builder
+FROM quay.io/stackrox-io/apollo-ci:${BUILD_IMAGE_VERSION} AS builder
 
 # Build the manager binary
 ARG roxpath

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -1,6 +1,6 @@
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 # We're targeting a floating tag here which should be reasonably safe to do as both RHEL major 8 and Go major.minor 1.20 should provide enough stability.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=ubi8-minimal
 ARG BASE_TAG=latest
 
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
 
 ENV GOFLAGS=""
 # TODO(ROX-24276): re-enable release builds for fast stream.


### PR DESCRIPTION
Fixing the warning:
```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)
```

See [PR run](https://github.com/stackrox/stackrox/actions/runs/11250698536/job/31281104596?pr=12405) for example.