### PR TITLE
feat(auto-retest): Logs explaining why a job won't be retested

### DIFF
--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -108,10 +108,19 @@ func checksForCommit(ctx context.Context, client *github.Client, lastCommit stri
 }
 
 func checkToState(check *github.CheckRun) jobState {
-	if check.GetConclusion() == "failure" {
+	// "timed_out" means the check never reached a verdict, same as a
+	// Statuses API "error". "error" is folded into jobFailure alongside
+	// "failure" so retestable checks (e.g. "e2e-...") still trigger a retry.
+	//
+	// "cancelled" is mapped to jobOK: because `retest_comment.yml` only
+	// reruns GitHub Actions runs with status=failure, so issuing "/retest"
+	// for a cancelled run wouldn't trigger anything anyway.
+	switch check.GetConclusion() {
+	case "failure", "timed_out":
 		return jobFailure
+	default:
+		return jobOK
 	}
-	return jobOK
 }
 
 type Status struct {

--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -69,14 +69,17 @@ func splitMultilineComment(comment string) []string {
 
 // jobState normalizes a job's outcome regardless of which GitHub API it
 // came from: the Statuses API (Prow jobs, reported as free-form strings
-// such as "success"/"failure"/"pending") and the Checks API (GitHub Actions,
-// reported as a pass/fail conclusion) each have their own raw
-// representation. Decision logic in main.go only ever needs to ask "is this
-// job failing?" or "is this job still pending?", so both sources are
+// such as "success"/"failure"/"pending"/"error") and the Checks API
+// (GitHub Actions, reported as a pass/fail conclusion) each have their own
+// raw representation. Decision logic in main.go only ever needs to ask "is
+// this job failing?" or "is this job still pending?", so both sources are
 // translated into this one type at the point they're fetched, instead of
 // letting two different truthiness conventions leak into the rest of the
-// file. The zero value, jobOK, covers every other raw state (success,
-// error, cancelled, or simply "no news") since none of those get special
+// file. A status of "error" (the job didn't reach a verdict, e.g. due to
+// infra trouble) is folded into jobFailure alongside "failure" (the job
+// reached a verdict and it was negative), since both warrant a retest the
+// same way. The zero value, jobOK, covers every other raw state (success,
+// cancelled, or simply "no news") since none of those get special
 // treatment today.
 type jobState int
 
@@ -143,7 +146,7 @@ func statusesForPR(ctx context.Context, client *github.Client, url string) (map[
 
 func parseJobState(raw string) jobState {
 	switch raw {
-	case "failure":
+	case "failure", "error":
 		return jobFailure
 	case "pending":
 		return jobPending

--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -99,13 +99,16 @@ func checksForCommit(ctx context.Context, client *github.Client, lastCommit stri
 
 	result := map[string]jobState{}
 	for _, check := range checks.CheckRuns {
-		state := jobOK
-		if check.GetConclusion() == "failure" {
-			state = jobFailure
-		}
-		result[check.GetName()] = state
+		result[check.GetName()] = checkToState(check)
 	}
 	return result, nil
+}
+
+func checkToState(check *github.CheckRun) jobState {
+	if check.GetConclusion() == "failure" {
+		return jobFailure
+	}
+	return jobOK
 }
 
 type Status struct {

--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -67,7 +67,26 @@ func splitMultilineComment(comment string) []string {
 	return result
 }
 
-func checksForCommit(ctx context.Context, client *github.Client, lastCommit string) (map[string]bool, error) {
+// jobState normalizes a job's outcome regardless of which GitHub API it
+// came from: the Statuses API (Prow jobs, reported as free-form strings
+// such as "success"/"failure"/"pending") and the Checks API (GitHub Actions,
+// reported as a pass/fail conclusion) each have their own raw
+// representation. Decision logic in main.go only ever needs to ask "is this
+// job failing?" or "is this job still pending?", so both sources are
+// translated into this one type at the point they're fetched, instead of
+// letting two different truthiness conventions leak into the rest of the
+// file. The zero value, jobOK, covers every other raw state (success,
+// error, cancelled, or simply "no news") since none of those get special
+// treatment today.
+type jobState int
+
+const (
+	jobOK jobState = iota
+	jobPending
+	jobFailure
+)
+
+func checksForCommit(ctx context.Context, client *github.Client, lastCommit string) (map[string]jobState, error) {
 	completed := "completed"
 	latest := "latest"
 	checks, _, err := client.Checks.ListCheckRunsForRef(ctx, s, s, lastCommit, &github.ListCheckRunsOptions{
@@ -78,9 +97,13 @@ func checksForCommit(ctx context.Context, client *github.Client, lastCommit stri
 		return nil, err
 	}
 
-	result := map[string]bool{}
+	result := map[string]jobState{}
 	for _, check := range checks.CheckRuns {
-		result[check.GetName()] = check.GetConclusion() != "failure"
+		state := jobOK
+		if check.GetConclusion() == "failure" {
+			state = jobFailure
+		}
+		result[check.GetName()] = state
 	}
 	return result, nil
 }
@@ -91,7 +114,7 @@ type Status struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-func statusesForPR(ctx context.Context, client *github.Client, url string) (map[string]string, error) {
+func statusesForPR(ctx context.Context, client *github.Client, url string) (map[string]jobState, error) {
 	var statuses []Status
 	statusRequest, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -106,11 +129,22 @@ func statusesForPR(ctx context.Context, client *github.Client, url string) (map[
 		return a.UpdatedAt.Compare(b.UpdatedAt)
 	})
 
-	result := map[string]string{}
+	result := map[string]jobState{}
 	for _, status := range statuses {
 		job := strings.TrimPrefix(status.Context, "ci/prow/")
-		result[job] = status.State
+		result[job] = parseJobState(status.State)
 	}
 
 	return result, nil
+}
+
+func parseJobState(raw string) jobState {
+	switch raw {
+	case "failure":
+		return jobFailure
+	case "pending":
+		return jobPending
+	default:
+		return jobOK
+	}
 }

--- a/tools/retest/github_test.go
+++ b/tools/retest/github_test.go
@@ -3,44 +3,76 @@ package main
 import (
 	"testing"
 
+	"github.com/google/go-github/v60/github"
 	"github.com/stretchr/testify/assert"
 )
 
-// Test_parseJobState checks how parseJobState maps the Statuses API's raw
-// state strings (success/pending/failure/error, plus any other value it
-// might report) onto jobState.
-func Test_parseJobState(t *testing.T) {
+// Test_jobStateMapping checks how parseJobState and checkToState each map
+// their own API's raw value — a Statuses API state, or a Checks API
+// conclusion — onto the shared jobState type.
+func Test_jobStateMapping(t *testing.T) {
 	tests := map[string]struct {
 		raw       string
+		fromCheck bool
 		wantState jobState
 	}{
-		"success maps to ok": {
+		"status: success maps to ok": {
 			raw:       "success",
 			wantState: jobOK,
 		},
-		"pending maps to pending": {
+		"status: pending maps to pending": {
 			raw:       "pending",
 			wantState: jobPending,
 		},
-		"failure maps to failure": {
+		"status: failure maps to failure": {
 			raw:       "failure",
 			wantState: jobFailure,
 		},
-		"error maps to failure, since it also warrants a retest": {
+		"status: error maps to failure, since it also warrants a retest": {
 			raw:       "error",
 			wantState: jobFailure,
 		},
-		"unknown state falls back to ok": {
+		"status: unknown state falls back to ok": {
 			raw:       "something-unexpected",
 			wantState: jobOK,
 		},
-		"empty string falls back to ok": {
+		"status: empty string falls back to ok": {
 			raw:       "",
+			wantState: jobOK,
+		},
+		"check: success maps to ok": {
+			raw:       "success",
+			fromCheck: true,
+			wantState: jobOK,
+		},
+		"check: failure maps to failure": {
+			raw:       "failure",
+			fromCheck: true,
+			wantState: jobFailure,
+		},
+		"check: timed_out maps to failure, since it also warrants a retest": {
+			raw:       "timed_out",
+			fromCheck: true,
+			wantState: jobFailure,
+		},
+		"check: neutral falls back to ok": {
+			raw:       "neutral",
+			fromCheck: true,
+			wantState: jobOK,
+		},
+		"check: cancelled falls back to ok": {
+			raw:       "cancelled",
+			fromCheck: true,
 			wantState: jobOK,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			if tt.fromCheck {
+				check := &github.CheckRun{Conclusion: github.String(tt.raw)}
+				assert.Equal(t, tt.wantState, checkToState(check))
+				return
+			}
 			assert.Equal(t, tt.wantState, parseJobState(tt.raw))
 		})
 	}

--- a/tools/retest/github_test.go
+++ b/tools/retest/github_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_parseJobState checks how parseJobState maps the Statuses API's raw
+// state strings (success/pending/failure/error, plus any other value it
+// might report) onto jobState.
+func Test_parseJobState(t *testing.T) {
+	tests := map[string]struct {
+		raw       string
+		wantState jobState
+	}{
+		"success maps to ok": {
+			raw:       "success",
+			wantState: jobOK,
+		},
+		"pending maps to pending": {
+			raw:       "pending",
+			wantState: jobPending,
+		},
+		"failure maps to failure": {
+			raw:       "failure",
+			wantState: jobFailure,
+		},
+		"error maps to failure, since it also warrants a retest": {
+			raw:       "error",
+			wantState: jobFailure,
+		},
+		"unknown state falls back to ok": {
+			raw:       "something-unexpected",
+			wantState: jobOK,
+		},
+		"empty string falls back to ok": {
+			raw:       "",
+			wantState: jobOK,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.wantState, parseJobState(tt.raw))
+		})
+	}
+}

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -104,7 +105,11 @@ issues:
 			continue
 		}
 		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
-		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatusesAndChecks(statuses, userComments, checks))
+		reason := skipRetestReason(statuses, userComments, checks)
+		if reason != nil {
+			log.Printf("#%d not issuing /retest: %v", prNumber, reason)
+		}
+		newComments := commentsToCreate(statuses, jobsToRetest, reason == nil)
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
 	}
 	return nil
@@ -120,6 +125,7 @@ func commentsToCreate(statuses map[string]string, jobsToRetest []string, shouldR
 	for _, job := range jobsToRetest {
 		state := statuses[job]
 		if state == "pending" {
+			log.Printf("Not issuing /test %q because it is already %s", job, state)
 			continue
 		}
 		comments = append(comments, "/test "+job)
@@ -174,6 +180,7 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 	for job, times := range jobsToRetest {
 		toTest := times - testedJobs[job]
 		if toTest < 1 {
+			log.Printf("Exceeded max number (%d) of retests for %q: already tested %d times", times, job, testedJobs[job])
 			continue
 		}
 		missingTests = append(missingTests, job)
@@ -185,7 +192,9 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 
 const retestComment = "/retest"
 
-func shouldRetestFailedStatusesAndChecks(statuses map[string]string, comments []string, checks map[string]bool) bool {
+// skipRetestReason reports why a "/retest" comment should not be issued.
+// It returns nil when a retest is warranted, and a human-readable reason otherwise.
+func skipRetestReason(statuses map[string]string, comments []string, checks map[string]bool) error {
 	retested := 0
 	for _, c := range comments {
 		if c == retestComment {
@@ -193,19 +202,19 @@ func shouldRetestFailedStatusesAndChecks(statuses map[string]string, comments []
 		}
 	}
 	if retested > 3 {
-		return false
+		return fmt.Errorf("PR has already been retested %d times", retested)
 	}
 
 	for name, passed := range checks {
 		if !passed && hasAnyPrefix(name, retestableCheckPrefixes) {
-			return true
+			return nil
 		}
 	}
 
 	for _, status := range statuses {
 		if status == "failure" {
-			return true
+			return nil
 		}
 	}
-	return false
+	return errors.New("no failing status or retestable check found")
 }

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -29,6 +29,24 @@ func hasAnyPrefix(name string, prefixes []string) bool {
 	})
 }
 
+// skipReason explains why a job (or, when job is empty, the PR's overall
+// "/retest") was not retested. Decision functions return skipReasons instead
+// of logging directly, so that they stay pure and unit-testable, and so that
+// every "why won't this be retested" message is formatted consistently by a
+// single call site that has the PR number in scope.
+type skipReason struct {
+	job     string
+	message string
+}
+
+func logSkipReason(prNumber int, reason skipReason) {
+	if reason.job == "" {
+		log.Printf("#%d not issuing /retest: %s", prNumber, reason.message)
+		return
+	}
+	log.Printf("#%d not issuing /test %q: %s", prNumber, reason.job, reason.message)
+}
+
 const s = "stackrox"
 
 func main() {
@@ -91,7 +109,7 @@ issues:
 			continue
 		}
 		log.Printf("#%d has %d statuses", prNumber, len(statuses))
-		jobsToRetest, err := jobsToRetestFromComments(userComments, allComments)
+		jobsToRetest, jobSkips, err := jobsToRetestFromComments(userComments, allComments)
 		if err != nil {
 			log.Printf("#%d could not get jobs to retest: %v", prNumber, err)
 			for _, c := range userComments {
@@ -104,12 +122,18 @@ issues:
 			createComment(ctx, client, prNumber, errorComment)
 			continue
 		}
-		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
-		reason := skipRetestReason(statuses, userComments, checks)
-		if reason != nil {
-			log.Printf("#%d not issuing /retest: %v", prNumber, reason)
+		for _, skip := range jobSkips {
+			logSkipReason(prNumber, skip)
 		}
-		newComments := commentsToCreate(statuses, jobsToRetest, reason == nil)
+		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
+		retestReason := skipRetestReason(statuses, userComments, checks)
+		if retestReason != nil {
+			logSkipReason(prNumber, skipReason{message: retestReason.Error()})
+		}
+		newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestReason == nil)
+		for _, skip := range testSkips {
+			logSkipReason(prNumber, skip)
+		}
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
 	}
 	return nil
@@ -120,29 +144,24 @@ var (
 	testJob       = regexp.MustCompile(`/test\s+(.*)`)
 )
 
-func commentsToCreate(statuses map[string]string, jobsToRetest []string, shouldRetest bool) []string {
-	var comments []string
+func commentsToCreate(statuses map[string]string, jobsToRetest []string, shouldRetest bool) (comments []string, skipped []skipReason) {
 	for _, job := range jobsToRetest {
 		state := statuses[job]
 		if state == "pending" {
-			log.Printf("Not issuing /test %q because it is already %s", job, state)
+			skipped = append(skipped, skipReason{job: job, message: fmt.Sprintf("already %s", state)})
 			continue
 		}
 		comments = append(comments, "/test "+job)
 	}
 
-	if len(jobsToRetest) != 0 {
-		return comments
-	}
-
-	if !shouldRetest {
-		return comments
+	if len(jobsToRetest) != 0 || !shouldRetest {
+		return comments, skipped
 	}
 	comments = append(comments, retestComment)
-	return comments
+	return comments, skipped
 }
 
-func jobsToRetestFromComments(userComments, allComments []string) ([]string, error) {
+func jobsToRetestFromComments(userComments, allComments []string) ([]string, []skipReason, error) {
 	testedJobs := map[string]int{}
 	for _, c := range userComments {
 		testJobMatch := testJob.FindStringSubmatch(c)
@@ -156,7 +175,7 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 		}
 	}
 
-	jobsToRetest := map[string]int{}
+	requestedRetests := map[string]int{}
 	for _, c := range allComments {
 		matched := restestNTimes.FindStringSubmatch(c)
 		if len(matched) != 3 {
@@ -165,29 +184,34 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 		job := strings.TrimSpace(matched[2])
 		t, err := strconv.Atoi(matched[1])
 		if err != nil {
-			return nil, fmt.Errorf("got an error in a comment %q: %w", c, err)
+			return nil, nil, fmt.Errorf("got an error in a comment %q: %w", c, err)
 		}
 		if t < 1 || t > 100 {
-			return nil, fmt.Errorf("invalid retest number requested: %q", c)
+			return nil, nil, fmt.Errorf("invalid retest number requested: %q", c)
 		}
-		if _, ok := jobsToRetest[job]; !ok {
-			jobsToRetest[job] = 0
+		if _, ok := requestedRetests[job]; !ok {
+			requestedRetests[job] = 0
 		}
-		jobsToRetest[job] += t
+		requestedRetests[job] += t
 	}
 
-	missingTests := make([]string, 0, len(jobsToRetest))
-	for job, times := range jobsToRetest {
-		toTest := times - testedJobs[job]
-		if toTest < 1 {
-			log.Printf("Exceeded max number (%d) of retests for %q: already tested %d times", times, job, testedJobs[job])
+	jobsToRetest := make([]string, 0, len(requestedRetests))
+	var skipped []skipReason
+	for job, requested := range requestedRetests {
+		remaining := requested - testedJobs[job]
+		if remaining < 1 {
+			skipped = append(skipped, skipReason{
+				job:     job,
+				message: fmt.Sprintf("exceeded retest budget of %d, already tested %d times", requested, testedJobs[job]),
+			})
 			continue
 		}
-		missingTests = append(missingTests, job)
+		jobsToRetest = append(jobsToRetest, job)
 	}
-	slices.Sort(missingTests)
+	slices.Sort(jobsToRetest)
+	slices.SortFunc(skipped, func(a, b skipReason) int { return strings.Compare(a.job, b.job) })
 
-	return missingTests, nil
+	return jobsToRetest, skipped, nil
 }
 
 const retestComment = "/retest"

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -176,6 +176,8 @@ type retestDecision struct {
 // Keeping it pure (no GitHub I/O, no logging) means the whole per-PR
 // decision pipeline can be unit tested with plain data.
 func decideRetest(userComments, allComments []string, checks, statuses map[string]jobState) retestDecision {
+	var allSkipReasons []skipReason
+
 	jobsToRetest, jobSkips, err := jobsToRetestFromComments(userComments, allComments)
 	if err != nil {
 		return retestDecision{
@@ -183,18 +185,19 @@ func decideRetest(userComments, allComments []string, checks, statuses map[strin
 			alreadyReported: slices.Contains(userComments, err.Error()),
 		}
 	}
+	allSkipReasons = append(allSkipReasons, jobSkips...)
 
-	retestReason := skipRetestReason(statuses, userComments, checks)
-	skipped := jobSkips
-	if retestReason != nil {
-		skipped = append(skipped, skipReason{message: retestReason.Error()})
+	retestSkipReason := skipRetestReason(statuses, userComments, checks)
+	if retestSkipReason != nil {
+		allSkipReasons = append(allSkipReasons, skipReason{message: retestSkipReason.Error()})
 	}
-	newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestReason == nil)
-	skipped = append(skipped, testSkips...)
+
+	newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestSkipReason == nil)
+	allSkipReasons = append(allSkipReasons, testSkips...)
 
 	return retestDecision{
 		jobsToRetest: jobsToRetest,
-		skipped:      skipped,
+		skipped:      allSkipReasons,
 		comment:      strings.Join(newComments, "\n"),
 	}
 }

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"maps"
@@ -187,12 +186,10 @@ func decideRetest(userComments, allComments []string, checks, statuses map[strin
 	}
 	allSkipReasons = append(allSkipReasons, jobSkips...)
 
-	retestSkipReason := skipRetestReason(statuses, userComments, checks)
-	if retestSkipReason != nil {
-		allSkipReasons = append(allSkipReasons, skipReason{message: retestSkipReason.Error()})
-	}
+	retestSkipReasons := skipRetestReason(statuses, userComments, checks)
+	allSkipReasons = append(allSkipReasons, retestSkipReasons...)
 
-	newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestSkipReason == nil)
+	newComments, testSkips := commentsToCreate(statuses, jobsToRetest, len(retestSkipReasons) == 0)
 	allSkipReasons = append(allSkipReasons, testSkips...)
 
 	return retestDecision{
@@ -278,9 +275,11 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, []s
 
 const retestComment = "/retest"
 
-// skipRetestReason reports why a "/retest" comment should not be issued.
-// It returns nil when a retest is warranted, and a human-readable reason otherwise.
-func skipRetestReason(statuses map[string]jobState, comments []string, checks map[string]jobState) error {
+// skipRetestReason reports why a PR-level "/retest" comment should not be
+// issued. It returns nil when a retest is warranted, and a single-element
+// skipReason otherwise — a slice, rather than an error, so callers can fold
+// it straight into a skipReason accumulator via append.
+func skipRetestReason(statuses map[string]jobState, comments []string, checks map[string]jobState) []skipReason {
 	retested := 0
 	for _, c := range comments {
 		if c == retestComment {
@@ -288,7 +287,7 @@ func skipRetestReason(statuses map[string]jobState, comments []string, checks ma
 		}
 	}
 	if retested > 3 {
-		return fmt.Errorf("PR has already been retested %d times", retested)
+		return []skipReason{{message: fmt.Sprintf("PR has already been retested %d times", retested)}}
 	}
 
 	for name, state := range checks {
@@ -302,5 +301,5 @@ func skipRetestReason(statuses map[string]jobState, comments []string, checks ma
 			return nil
 		}
 	}
-	return errors.New("no failing status or retestable check found")
+	return []skipReason{{message: "no failing status or retestable check found"}}
 }

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -72,71 +72,135 @@ func run(ctx context.Context, client *github.Client) error {
 	}
 	log.Printf("Found %d PRs", search.GetTotal())
 
-issues:
 	for _, pr := range search.Issues {
-		prNumber := pr.GetNumber()
-		log.Printf("#%d retrieving...: %s", prNumber, pr.GetHTMLURL())
-		prDetails, _, err := client.PullRequests.Get(ctx, s, s, prNumber)
-		if err != nil {
-			log.Printf("#%d could not get PR details: %v", prNumber, err)
-			continue
-		}
-		userComments, allComments, err := commentsForPrByUser(ctx, client, prNumber, user.GetID())
-		if err != nil {
-			log.Printf("#%d could not get allComments: %v", prNumber, err)
-			continue
-		}
-		log.Printf("#%d has %d allComments by %s and %d in total", prNumber, len(userComments), user.GetLogin(), len(allComments))
-		checks, err := checksForCommit(ctx, client, prDetails.GetHead().GetSHA())
-		if err != nil {
-			log.Printf("#%d could not get checks: %v", prNumber, err)
-			continue
-		}
-		log.Printf("#%d has %d completed checks", prNumber, len(checks))
-
-		skippableCheckPrefixes := slices.Concat(allowedCheckFailurePrefixes, retestableCheckPrefixes)
-		for name, state := range checks {
-			if state != jobFailure || hasAnyPrefix(name, skippableCheckPrefixes) {
-				continue
-			}
-			log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
-			continue issues
-		}
-
-		statuses, err := statusesForPR(ctx, client, prDetails.GetStatusesURL())
-		if err != nil {
-			log.Printf("#%d could not get statuses: %v", prNumber, err)
-			continue
-		}
-		log.Printf("#%d has %d statuses", prNumber, len(statuses))
-		jobsToRetest, jobSkips, err := jobsToRetestFromComments(userComments, allComments)
-		if err != nil {
-			log.Printf("#%d could not get jobs to retest: %v", prNumber, err)
-			for _, c := range userComments {
-				if c == err.Error() {
-					continue issues
-				}
-			}
-			errorComment := fmt.Sprintf(":x: There was an error with a comment. "+
-				"Please edit or remove it and issue a proper command\n%s", err.Error())
-			createComment(ctx, client, prNumber, errorComment)
-			continue
-		}
-		for _, skip := range jobSkips {
-			logSkipReason(prNumber, skip)
-		}
-		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
-		retestReason := skipRetestReason(statuses, userComments, checks)
-		if retestReason != nil {
-			logSkipReason(prNumber, skipReason{message: retestReason.Error()})
-		}
-		newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestReason == nil)
-		for _, skip := range testSkips {
-			logSkipReason(prNumber, skip)
-		}
-		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
+		processPR(ctx, client, user, pr)
 	}
 	return nil
+}
+
+// processPR fetches everything needed to decide what to do about a single
+// PR, delegates the actual decision to the pure functions below, and
+// carries out whatever they decided (post a comment, or do nothing). It
+// deliberately contains no branching logic of its own beyond "did this
+// GitHub call fail" and "what did the decision say to do" — every
+// interesting decision lives in failingCheck/decideRetest, which are
+// unit-tested directly instead of only through this function's GitHub I/O.
+func processPR(ctx context.Context, client *github.Client, user *github.User, pr *github.Issue) {
+	prNumber := pr.GetNumber()
+	log.Printf("#%d retrieving...: %s", prNumber, pr.GetHTMLURL())
+	prDetails, _, err := client.PullRequests.Get(ctx, s, s, prNumber)
+	if err != nil {
+		log.Printf("#%d could not get PR details: %v", prNumber, err)
+		return
+	}
+	userComments, allComments, err := commentsForPrByUser(ctx, client, prNumber, user.GetID())
+	if err != nil {
+		log.Printf("#%d could not get allComments: %v", prNumber, err)
+		return
+	}
+	log.Printf("#%d has %d allComments by %s and %d in total", prNumber, len(userComments), user.GetLogin(), len(allComments))
+
+	checks, err := checksForCommit(ctx, client, prDetails.GetHead().GetSHA())
+	if err != nil {
+		log.Printf("#%d could not get checks: %v", prNumber, err)
+		return
+	}
+	log.Printf("#%d has %d completed checks", prNumber, len(checks))
+
+	if name := failingCheck(checks); name != "" {
+		log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
+		return
+	}
+
+	statuses, err := statusesForPR(ctx, client, prDetails.GetStatusesURL())
+	if err != nil {
+		log.Printf("#%d could not get statuses: %v", prNumber, err)
+		return
+	}
+	log.Printf("#%d has %d statuses", prNumber, len(statuses))
+
+	decision := decideRetest(userComments, allComments, checks, statuses)
+	if decision.commentParseErr != "" {
+		log.Printf("#%d could not get jobs to retest: %s", prNumber, decision.commentParseErr)
+		if decision.alreadyReported {
+			return
+		}
+		createComment(ctx, client, prNumber, fmt.Sprintf(":x: There was an error with a comment. "+
+			"Please edit or remove it and issue a proper command\n%s", decision.commentParseErr))
+		return
+	}
+
+	log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(decision.jobsToRetest, ", "))
+	for _, skip := range decision.skipped {
+		logSkipReason(prNumber, skip)
+	}
+	createComment(ctx, client, prNumber, decision.comment)
+}
+
+// failingCheck returns the name of a failing check that isn't covered by
+// allowedCheckFailurePrefixes/retestableCheckPrefixes, or "" if none is
+// found. Such a check means the whole PR is skipped, as opposed to the
+// skipReason vocabulary below which is about withholding one job/action
+// within a PR that otherwise gets processed.
+func failingCheck(checks map[string]jobState) string {
+	skippableCheckPrefixes := slices.Concat(allowedCheckFailurePrefixes, retestableCheckPrefixes)
+	names := make([]string, 0, len(checks))
+	for name := range checks {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		if checks[name] != jobFailure || hasAnyPrefix(name, skippableCheckPrefixes) {
+			continue
+		}
+		return name
+	}
+	return ""
+}
+
+// retestDecision is the outcome of evaluating a PR's comments together
+// with its checks/statuses: which comment (if any) to post, and every
+// skipReason explaining why some other action was withheld.
+type retestDecision struct {
+	// commentParseErr is set when a "/retest-times" comment could not be
+	// parsed. When set, jobsToRetest/skipped/comment below are unused.
+	commentParseErr string
+	// alreadyReported is true when commentParseErr was already posted as a
+	// comment in an earlier run, so nothing new needs to be said now.
+	alreadyReported bool
+
+	jobsToRetest []string
+	skipped      []skipReason
+	comment      string
+}
+
+// decideRetest is a pure function of already-fetched PR data: it composes
+// jobsToRetestFromComments, skipRetestReason and commentsToCreate, plus the
+// "was this malformed comment already reported" check, into one decision.
+// Keeping it pure (no GitHub I/O, no logging) means the whole per-PR
+// decision pipeline can be unit tested with plain data.
+func decideRetest(userComments, allComments []string, checks, statuses map[string]jobState) retestDecision {
+	jobsToRetest, jobSkips, err := jobsToRetestFromComments(userComments, allComments)
+	if err != nil {
+		return retestDecision{
+			commentParseErr: err.Error(),
+			alreadyReported: slices.Contains(userComments, err.Error()),
+		}
+	}
+
+	retestReason := skipRetestReason(statuses, userComments, checks)
+	skipped := jobSkips
+	if retestReason != nil {
+		skipped = append(skipped, skipReason{message: retestReason.Error()})
+	}
+	newComments, testSkips := commentsToCreate(statuses, jobsToRetest, retestReason == nil)
+	skipped = append(skipped, testSkips...)
+
+	return retestDecision{
+		jobsToRetest: jobsToRetest,
+		skipped:      skipped,
+		comment:      strings.Join(newComments, "\n"),
+	}
 }
 
 var (

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -95,8 +95,8 @@ issues:
 		log.Printf("#%d has %d completed checks", prNumber, len(checks))
 
 		skippableCheckPrefixes := slices.Concat(allowedCheckFailurePrefixes, retestableCheckPrefixes)
-		for name, passed := range checks {
-			if passed || hasAnyPrefix(name, skippableCheckPrefixes) {
+		for name, state := range checks {
+			if state != jobFailure || hasAnyPrefix(name, skippableCheckPrefixes) {
 				continue
 			}
 			log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
@@ -144,11 +144,10 @@ var (
 	testJob       = regexp.MustCompile(`/test\s+(.*)`)
 )
 
-func commentsToCreate(statuses map[string]string, jobsToRetest []string, shouldRetest bool) (comments []string, skipped []skipReason) {
+func commentsToCreate(statuses map[string]jobState, jobsToRetest []string, shouldRetest bool) (comments []string, skipped []skipReason) {
 	for _, job := range jobsToRetest {
-		state := statuses[job]
-		if state == "pending" {
-			skipped = append(skipped, skipReason{job: job, message: fmt.Sprintf("already %s", state)})
+		if statuses[job] == jobPending {
+			skipped = append(skipped, skipReason{job: job, message: "already pending"})
 			continue
 		}
 		comments = append(comments, "/test "+job)
@@ -218,7 +217,7 @@ const retestComment = "/retest"
 
 // skipRetestReason reports why a "/retest" comment should not be issued.
 // It returns nil when a retest is warranted, and a human-readable reason otherwise.
-func skipRetestReason(statuses map[string]string, comments []string, checks map[string]bool) error {
+func skipRetestReason(statuses map[string]jobState, comments []string, checks map[string]jobState) error {
 	retested := 0
 	for _, c := range comments {
 		if c == retestComment {
@@ -229,14 +228,14 @@ func skipRetestReason(statuses map[string]string, comments []string, checks map[
 		return fmt.Errorf("PR has already been retested %d times", retested)
 	}
 
-	for name, passed := range checks {
-		if !passed && hasAnyPrefix(name, retestableCheckPrefixes) {
+	for name, state := range checks {
+		if state == jobFailure && hasAnyPrefix(name, retestableCheckPrefixes) {
 			return nil
 		}
 	}
 
-	for _, status := range statuses {
-		if status == "failure" {
+	for _, state := range statuses {
+		if state == jobFailure {
 			return nil
 		}
 	}

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -144,12 +145,7 @@ func processPR(ctx context.Context, client *github.Client, user *github.User, pr
 // within a PR that otherwise gets processed.
 func failingCheck(checks map[string]jobState) string {
 	skippableCheckPrefixes := slices.Concat(allowedCheckFailurePrefixes, retestableCheckPrefixes)
-	names := make([]string, 0, len(checks))
-	for name := range checks {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-	for _, name := range names {
+	for _, name := range slices.Sorted(maps.Keys(checks)) {
 		if checks[name] != jobFailure || hasAnyPrefix(name, skippableCheckPrefixes) {
 			continue
 		}

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -211,7 +211,7 @@ var (
 func commentsToCreate(statuses map[string]jobState, jobsToRetest []string, shouldRetest bool) (comments []string, skipped []skipReason) {
 	for _, job := range jobsToRetest {
 		if statuses[job] == jobPending {
-			skipped = append(skipped, skipReason{job: job, message: "already pending"})
+			skipped = append(skipped, skipReason{job: job, message: "job is pending"})
 			continue
 		}
 		comments = append(comments, "/test "+job)

--- a/tools/retest/main_integration_test.go
+++ b/tools/retest/main_integration_test.go
@@ -228,5 +228,5 @@ func TestGetStatuses(t *testing.T) {
 
 	statuses, err := statusesForPR(context.Background(), client, baseUrl.String())
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"gke-upgrade-tests": "success"}, statuses)
+	assert.Equal(t, map[string]jobState{"gke-upgrade-tests": jobOK}, statuses)
 }

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -361,9 +361,9 @@ func Test_skipRetestReason(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gotReason := skipRetestReason(tt.statuses, tt.comments, tt.checks)
 			if tt.wantSkipReasonMsg == "" {
-				assert.NoError(t, gotReason)
+				assert.Nil(t, gotReason)
 			} else {
-				assert.EqualError(t, gotReason, tt.wantSkipReasonMsg)
+				assert.Equal(t, []skipReason{{message: tt.wantSkipReasonMsg}}, gotReason)
 			}
 		})
 	}

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -6,68 +6,73 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_retestNTimes(t *testing.T) {
+// Test_jobsToRetestFromComments checks which jobs jobsToRetestFromComments
+// decides still need a fresh "/test <job>" comment, given how many retests a
+// "/retest-times N <job>" comment requested and how many "/test <job>"
+// comments the bot has already posted for that job (userComments).
+func Test_jobsToRetestFromComments(t *testing.T) {
 	tests := []struct {
-		name         string
-		userComments []string
-		allComments  []string
-		want         []string
-		error        string
+		name             string
+		userComments     []string
+		allComments      []string
+		wantJobsToRetest []string
+		wantSkipped      []skipReason
+		error            string
 	}{
 		{
-			name:        "nil",
-			allComments: nil,
-			want:        []string{},
+			name:             "nil",
+			allComments:      nil,
+			wantJobsToRetest: []string{},
 		},
 		{
-			name:        "empty",
-			allComments: nil,
-			want:        []string{},
+			name:             "empty",
+			allComments:      nil,
+			wantJobsToRetest: []string{},
 		},
 		{
-			name:        "not matching regexp",
-			allComments: []string{"lorem ipsum"},
-			want:        []string{},
+			name:             "not matching regexp",
+			allComments:      []string{"lorem ipsum"},
+			wantJobsToRetest: []string{},
 		},
 		{
 			name:        "request test 10 times",
 			allComments: []string{"/retest-times 10 job-name-1"},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
 		{
 			name:        "extra whitespace between count and job name",
 			allComments: []string{"/retest-times 10  job-name-1"},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
 		{
 			name:        "extra whitespace before count",
 			allComments: []string{"/retest-times    3 job-name-1"},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
 		{
 			name:        "extra whitespace in all positions",
 			allComments: []string{"/retest-times   10   job-name-1"},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
 		{
 			name:        "tab between count and job name",
 			allComments: []string{"/retest-times 5\tjob-name-1"},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
 		{
 			name:        "trailing whitespace in job name",
 			allComments: []string{"/retest-times 3 job-name-1   "},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -82,7 +87,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/test  job-name-1",
 				"/test  job-name-1",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -97,7 +102,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/test job-name-1",
 				"/test  job-name-1",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -128,7 +133,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/test job-name-1",
 				"/test job-name-1",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -149,7 +154,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/test job-name-1",
 				"/test job-name-1",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -172,7 +177,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/test job-name-3",
 				"/test job-name-3",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 				"job-name-2",
 			},
@@ -192,7 +197,11 @@ func Test_retestNTimes(t *testing.T) {
 				"/retest-times 1 job-name-1",
 				"/retest-times 1 job-name-2",
 			},
-			want: []string{},
+			wantJobsToRetest: []string{},
+			wantSkipped: []skipReason{
+				{job: "job-name-1", message: "exceeded retest budget of 2, already tested 2 times"},
+				{job: "job-name-2", message: "exceeded retest budget of 1, already tested 1 times"},
+			},
 		},
 		{
 			name:         "request test 1 and one retested by another user",
@@ -201,7 +210,7 @@ func Test_retestNTimes(t *testing.T) {
 				"/retest-times 1 job-name-1",
 				"/test job-name-1",
 			},
-			want: []string{
+			wantJobsToRetest: []string{
 				"job-name-1",
 			},
 		},
@@ -214,22 +223,30 @@ func Test_retestNTimes(t *testing.T) {
 				"/retest-times 1 job-name-1",
 				"/test job-name-1",
 			},
-			want: []string{},
+			wantJobsToRetest: []string{},
+			wantSkipped: []skipReason{
+				{job: "job-name-1", message: "exceeded retest budget of 1, already tested 1 times"},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := jobsToRetestFromComments(tt.userComments, tt.allComments)
+			gotJobsToRetest, gotSkipped, err := jobsToRetestFromComments(tt.userComments, tt.allComments)
 			if tt.error == "" {
 				assert.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tt.error)
 			}
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantJobsToRetest, gotJobsToRetest)
+			assert.Equal(t, tt.wantSkipped, gotSkipped)
 		})
 	}
 }
 
+// Test_skipRetestReason checks whether skipRetestReason decides a PR's
+// "/retest" should be issued (nil) or withheld (a reason), given its
+// statuses, its retestable check results, and how many times it has already
+// been retested.
 func Test_skipRetestReason(t *testing.T) {
 	tests := map[string]struct {
 		statuses          map[string]string
@@ -308,111 +325,122 @@ func Test_skipRetestReason(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := skipRetestReason(tt.statuses, tt.comments, tt.checks)
+			gotReason := skipRetestReason(tt.statuses, tt.comments, tt.checks)
 			if tt.wantSkipReasonMsg == "" {
-				assert.NoError(t, got)
+				assert.NoError(t, gotReason)
 			} else {
-				assert.EqualError(t, got, tt.wantSkipReasonMsg)
+				assert.EqualError(t, gotReason, tt.wantSkipReasonMsg)
 			}
 		})
 	}
 }
 
+// Test_commentsToCreate checks which "/test <job>" and "/retest" comments
+// commentsToCreate decides to post, given the jobs that need retesting and
+// whether the PR as a whole warrants a "/retest".
 func Test_commentsToCreate(t *testing.T) {
 	tests := []struct {
 		name         string
 		statuses     map[string]string
 		jobsToRetest []string
 		shouldRetest bool
-		want         []string
+		wantComments []string
+		wantSkipped  []skipReason
 	}{
 		{
 			name:         "nil",
 			statuses:     nil,
 			jobsToRetest: nil,
-			want:         nil,
+			wantComments: nil,
 		},
 		{
 			name:         "empty",
 			statuses:     map[string]string{},
 			jobsToRetest: []string{},
-			want:         nil,
+			wantComments: nil,
 		},
 		{
 			name:         "competed",
 			statuses:     map[string]string{"job-1": "succeeded"},
 			jobsToRetest: []string{"job-1"},
-			want:         []string{"/test job-1"},
+			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "competed",
 			statuses:     map[string]string{"job-1": "pending"},
 			jobsToRetest: []string{"job-1"},
-			want:         nil,
+			wantComments: nil,
+			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
 		},
 		{
 			name:         "competed",
 			statuses:     map[string]string{"job-1": "succeeded"},
 			jobsToRetest: []string{"job-1"},
-			want:         []string{"/test job-1"},
+			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "retest",
 			statuses:     map[string]string{"job-1": "failure"},
 			jobsToRetest: []string{},
 			shouldRetest: true,
-			want:         []string{"/retest"},
+			wantComments: []string{"/retest"},
 		},
 		{
 			name:         "retest",
 			statuses:     map[string]string{"job-1": "failure"},
 			jobsToRetest: []string{},
-			want:         nil,
+			wantComments: nil,
 		},
 		{
 			name:         "just test no retest",
 			statuses:     map[string]string{"job-1": "failure"},
 			jobsToRetest: []string{"job-1"},
 			shouldRetest: true,
-			want:         []string{"/test job-1"},
+			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "pending job is skipped even with trimmed name",
 			statuses:     map[string]string{"job-1": "pending"},
 			jobsToRetest: []string{"job-1"},
-			want:         nil,
+			wantComments: nil,
+			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
 		},
 		{
 			name:         "multiple jobs — pending skipped, completed retested",
 			statuses:     map[string]string{"job-1": "pending", "job-2": "failure"},
 			jobsToRetest: []string{"job-1", "job-2"},
-			want:         []string{"/test job-2"},
+			wantComments: []string{"/test job-2"},
+			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := commentsToCreate(tt.statuses, tt.jobsToRetest, tt.shouldRetest)
-			assert.Equal(t, tt.want, got)
+			gotComments, gotSkipped := commentsToCreate(tt.statuses, tt.jobsToRetest, tt.shouldRetest)
+			assert.Equal(t, tt.wantComments, gotComments)
+			assert.Equal(t, tt.wantSkipped, gotSkipped)
 		})
 	}
 }
 
+// Test_splitMultilineComment checks that splitMultilineComment breaks a
+// (possibly multi-line, possibly indented) GitHub comment body into a list
+// of trimmed, non-empty lines.
 func Test_splitMultilineComment(t *testing.T) {
 	tests := []struct {
-		comment string
-		want    []string
+		comment   string
+		wantLines []string
 	}{
 		{
-			comment: "",
-			want:    []string{},
+			comment:   "",
+			wantLines: []string{},
 		},
 		{
-			comment: "a\nb\nc",
-			want:    []string{"a", "b", "c"},
+			comment:   "a\nb\nc",
+			wantLines: []string{"a", "b", "c"},
 		},
 		{
-			comment: "a \nb \t \n c \t \n \t",
-			want:    []string{"a", "b", "c"},
+			comment:   "a \nb \t \n c \t \n \t",
+			wantLines: []string{"a", "b", "c"},
 		},
 		{
 			comment: `
@@ -423,7 +451,7 @@ func Test_splitMultilineComment(t *testing.T) {
 				/retest-times 1 job-name-1
 				/retest-times 1 job-name-2
 			`,
-			want: []string{
+			wantLines: []string{
 				"/retest-times 1 job-name-1",
 				"/test job-name-1",
 				"/test job-name-2",
@@ -435,7 +463,8 @@ func Test_splitMultilineComment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			assert.Equal(t, tt.want, splitMultilineComment(tt.comment))
+			gotLines := splitMultilineComment(tt.comment)
+			assert.Equal(t, tt.wantLines, gotLines)
 		})
 	}
 }

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -249,9 +249,9 @@ func Test_jobsToRetestFromComments(t *testing.T) {
 // been retested.
 func Test_skipRetestReason(t *testing.T) {
 	tests := map[string]struct {
-		statuses          map[string]string
+		statuses          map[string]jobState
 		comments          []string
-		checks            map[string]bool
+		checks            map[string]jobState
 		wantSkipReasonMsg string
 	}{
 		"nil": {
@@ -260,66 +260,66 @@ func Test_skipRetestReason(t *testing.T) {
 			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"empty": {
-			statuses:          map[string]string{},
+			statuses:          map[string]jobState{},
 			comments:          []string{},
 			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"all success": {
-			statuses: map[string]string{
-				"a": "success",
-				"b": "success",
-				"c": "success",
+			statuses: map[string]jobState{
+				"a": jobOK,
+				"b": jobOK,
+				"c": jobOK,
 			},
 			comments:          []string{},
 			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"one failure": {
-			statuses: map[string]string{
-				"a": "success",
-				"b": "failure",
-				"c": "success",
+			statuses: map[string]jobState{
+				"a": jobOK,
+				"b": jobFailure,
+				"c": jobOK,
 			},
 			comments: []string{},
 		},
 		"one failure but already retested once": {
-			statuses: map[string]string{
-				"a": "success",
-				"b": "failure",
-				"c": "success",
+			statuses: map[string]jobState{
+				"a": jobOK,
+				"b": jobFailure,
+				"c": jobOK,
 			},
 			comments: []string{"/retest"},
 		},
 		"one failure but already retested too many times": {
-			statuses: map[string]string{
-				"a": "success",
-				"b": "failure",
-				"c": "success",
+			statuses: map[string]jobState{
+				"a": jobOK,
+				"b": jobFailure,
+				"c": jobOK,
 			},
 			comments:          []string{"/retest", "/retest", "/retest", "/retest"},
 			wantSkipReasonMsg: "PR has already been retested 4 times",
 		},
 		"failed e2e check triggers retest": {
-			statuses: map[string]string{},
+			statuses: map[string]jobState{},
 			comments: []string{},
-			checks:   map[string]bool{"e2e-gke-tests": false},
+			checks:   map[string]jobState{"e2e-gke-tests": jobFailure},
 		},
 		"failed e2e check but already retested too many times": {
-			statuses:          map[string]string{},
+			statuses:          map[string]jobState{},
 			comments:          []string{"/retest", "/retest", "/retest", "/retest"},
-			checks:            map[string]bool{"e2e-gke-tests": false},
+			checks:            map[string]jobState{"e2e-gke-tests": jobFailure},
 			wantSkipReasonMsg: "PR has already been retested 4 times",
 		},
 		"failed e2e check with prow success": {
-			statuses: map[string]string{
-				"a": "success",
+			statuses: map[string]jobState{
+				"a": jobOK,
 			},
 			comments: []string{},
-			checks:   map[string]bool{"e2e-gke-tests": false},
+			checks:   map[string]jobState{"e2e-gke-tests": jobFailure},
 		},
 		"passing e2e check does not trigger retest": {
-			statuses:          map[string]string{},
+			statuses:          map[string]jobState{},
 			comments:          []string{},
-			checks:            map[string]bool{"e2e-gke-tests": true},
+			checks:            map[string]jobState{"e2e-gke-tests": jobOK},
 			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 	}
@@ -341,7 +341,7 @@ func Test_skipRetestReason(t *testing.T) {
 func Test_commentsToCreate(t *testing.T) {
 	tests := []struct {
 		name         string
-		statuses     map[string]string
+		statuses     map[string]jobState
 		jobsToRetest []string
 		shouldRetest bool
 		wantComments []string
@@ -355,59 +355,59 @@ func Test_commentsToCreate(t *testing.T) {
 		},
 		{
 			name:         "empty",
-			statuses:     map[string]string{},
+			statuses:     map[string]jobState{},
 			jobsToRetest: []string{},
 			wantComments: nil,
 		},
 		{
 			name:         "competed",
-			statuses:     map[string]string{"job-1": "succeeded"},
+			statuses:     map[string]jobState{"job-1": jobOK},
 			jobsToRetest: []string{"job-1"},
 			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "competed",
-			statuses:     map[string]string{"job-1": "pending"},
+			statuses:     map[string]jobState{"job-1": jobPending},
 			jobsToRetest: []string{"job-1"},
 			wantComments: nil,
 			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
 		},
 		{
 			name:         "competed",
-			statuses:     map[string]string{"job-1": "succeeded"},
+			statuses:     map[string]jobState{"job-1": jobOK},
 			jobsToRetest: []string{"job-1"},
 			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "retest",
-			statuses:     map[string]string{"job-1": "failure"},
+			statuses:     map[string]jobState{"job-1": jobFailure},
 			jobsToRetest: []string{},
 			shouldRetest: true,
 			wantComments: []string{"/retest"},
 		},
 		{
 			name:         "retest",
-			statuses:     map[string]string{"job-1": "failure"},
+			statuses:     map[string]jobState{"job-1": jobFailure},
 			jobsToRetest: []string{},
 			wantComments: nil,
 		},
 		{
 			name:         "just test no retest",
-			statuses:     map[string]string{"job-1": "failure"},
+			statuses:     map[string]jobState{"job-1": jobFailure},
 			jobsToRetest: []string{"job-1"},
 			shouldRetest: true,
 			wantComments: []string{"/test job-1"},
 		},
 		{
 			name:         "pending job is skipped even with trimmed name",
-			statuses:     map[string]string{"job-1": "pending"},
+			statuses:     map[string]jobState{"job-1": jobPending},
 			jobsToRetest: []string{"job-1"},
 			wantComments: nil,
 			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
 		},
 		{
 			name:         "multiple jobs — pending skipped, completed retested",
-			statuses:     map[string]string{"job-1": "pending", "job-2": "failure"},
+			statuses:     map[string]jobState{"job-1": jobPending, "job-2": jobFailure},
 			jobsToRetest: []string{"job-1", "job-2"},
 			wantComments: []string{"/test job-2"},
 			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -230,22 +230,22 @@ func Test_retestNTimes(t *testing.T) {
 	}
 }
 
-func Test_shouldRetest(t *testing.T) {
+func Test_skipRetestReason(t *testing.T) {
 	tests := map[string]struct {
-		statuses map[string]string
-		comments []string
-		checks   map[string]bool
-		want     bool
+		statuses          map[string]string
+		comments          []string
+		checks            map[string]bool
+		wantSkipReasonMsg string
 	}{
 		"nil": {
-			statuses: nil,
-			comments: nil,
-			want:     false,
+			statuses:          nil,
+			comments:          nil,
+			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"empty": {
-			statuses: map[string]string{},
-			comments: []string{},
-			want:     false,
+			statuses:          map[string]string{},
+			comments:          []string{},
+			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"all success": {
 			statuses: map[string]string{
@@ -253,8 +253,8 @@ func Test_shouldRetest(t *testing.T) {
 				"b": "success",
 				"c": "success",
 			},
-			comments: []string{},
-			want:     false,
+			comments:          []string{},
+			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 		"one failure": {
 			statuses: map[string]string{
@@ -263,7 +263,6 @@ func Test_shouldRetest(t *testing.T) {
 				"c": "success",
 			},
 			comments: []string{},
-			want:     true,
 		},
 		"one failure but already retested once": {
 			statuses: map[string]string{
@@ -272,7 +271,6 @@ func Test_shouldRetest(t *testing.T) {
 				"c": "success",
 			},
 			comments: []string{"/retest"},
-			want:     true,
 		},
 		"one failure but already retested too many times": {
 			statuses: map[string]string{
@@ -280,20 +278,19 @@ func Test_shouldRetest(t *testing.T) {
 				"b": "failure",
 				"c": "success",
 			},
-			comments: []string{"/retest", "/retest", "/retest", "/retest"},
-			want:     false,
+			comments:          []string{"/retest", "/retest", "/retest", "/retest"},
+			wantSkipReasonMsg: "PR has already been retested 4 times",
 		},
 		"failed e2e check triggers retest": {
 			statuses: map[string]string{},
 			comments: []string{},
 			checks:   map[string]bool{"e2e-gke-tests": false},
-			want:     true,
 		},
 		"failed e2e check but already retested too many times": {
-			statuses: map[string]string{},
-			comments: []string{"/retest", "/retest", "/retest", "/retest"},
-			checks:   map[string]bool{"e2e-gke-tests": false},
-			want:     false,
+			statuses:          map[string]string{},
+			comments:          []string{"/retest", "/retest", "/retest", "/retest"},
+			checks:            map[string]bool{"e2e-gke-tests": false},
+			wantSkipReasonMsg: "PR has already been retested 4 times",
 		},
 		"failed e2e check with prow success": {
 			statuses: map[string]string{
@@ -301,19 +298,22 @@ func Test_shouldRetest(t *testing.T) {
 			},
 			comments: []string{},
 			checks:   map[string]bool{"e2e-gke-tests": false},
-			want:     true,
 		},
 		"passing e2e check does not trigger retest": {
-			statuses: map[string]string{},
-			comments: []string{},
-			checks:   map[string]bool{"e2e-gke-tests": true},
-			want:     false,
+			statuses:          map[string]string{},
+			comments:          []string{},
+			checks:            map[string]bool{"e2e-gke-tests": true},
+			wantSkipReasonMsg: "no failing status or retestable check found",
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := shouldRetestFailedStatusesAndChecks(tt.statuses, tt.comments, tt.checks)
-			assert.Equal(t, tt.want, got)
+			got := skipRetestReason(tt.statuses, tt.comments, tt.checks)
+			if tt.wantSkipReasonMsg == "" {
+				assert.NoError(t, got)
+			} else {
+				assert.EqualError(t, got, tt.wantSkipReasonMsg)
+			}
 		})
 	}
 }

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -22,8 +22,8 @@ func Test_logSkipReason(t *testing.T) {
 			wantLog: fmt.Sprintf(`#%d not issuing /retest: no failing status or retestable check found`, testPRNumber),
 		},
 		"job-level reason": {
-			reason:  skipReason{job: "job-name-1", message: "already pending"},
-			wantLog: fmt.Sprintf(`#%d not issuing /test "job-name-1": already pending`, testPRNumber),
+			reason:  skipReason{job: "job-name-1", message: "job is pending"},
+			wantLog: fmt.Sprintf(`#%d not issuing /test "job-name-1": job is pending`, testPRNumber),
 		},
 	}
 	for name, tt := range tests {
@@ -404,7 +404,7 @@ func Test_commentsToCreate(t *testing.T) {
 			statuses:     map[string]jobState{"job-1": jobPending},
 			jobsToRetest: []string{"job-1"},
 			wantComments: nil,
-			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
+			wantSkipped:  []skipReason{{job: "job-1", message: "job is pending"}},
 		},
 		{
 			name:         "competed",
@@ -437,14 +437,14 @@ func Test_commentsToCreate(t *testing.T) {
 			statuses:     map[string]jobState{"job-1": jobPending},
 			jobsToRetest: []string{"job-1"},
 			wantComments: nil,
-			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
+			wantSkipped:  []skipReason{{job: "job-1", message: "job is pending"}},
 		},
 		{
 			name:         "multiple jobs — pending skipped, completed retested",
 			statuses:     map[string]jobState{"job-1": jobPending, "job-2": jobFailure},
 			jobsToRetest: []string{"job-1", "job-2"},
 			wantComments: []string{"/test job-2"},
-			wantSkipped:  []skipReason{{job: "job-1", message: "already pending"}},
+			wantSkipped:  []skipReason{{job: "job-1", message: "job is pending"}},
 		},
 	}
 	for _, tt := range tests {
@@ -574,7 +574,7 @@ func Test_decideRetest(t *testing.T) {
 				jobsToRetest: []string{"job-name-1"},
 				skipped: []skipReason{
 					{message: "no failing status or retestable check found"},
-					{job: "job-name-1", message: "already pending"},
+					{job: "job-name-1", message: "job is pending"},
 				},
 				comment: "",
 			},

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -1,10 +1,44 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// Test_logSkipReason checks the exact log line logSkipReason produces for a
+// PR-level reason (job == "") versus a job-level reason.
+func Test_logSkipReason(t *testing.T) {
+	const testPRNumber = 7
+	tests := map[string]struct {
+		reason  skipReason
+		wantLog string
+	}{
+		"PR-level reason": {
+			reason:  skipReason{message: "no failing status or retestable check found"},
+			wantLog: fmt.Sprintf(`#%d not issuing /retest: no failing status or retestable check found`, testPRNumber),
+		},
+		"job-level reason": {
+			reason:  skipReason{job: "job-name-1", message: "already pending"},
+			wantLog: fmt.Sprintf(`#%d not issuing /test "job-name-1": already pending`, testPRNumber),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			original := log.Writer()
+			log.SetOutput(&buf)
+			t.Cleanup(func() { log.SetOutput(original) })
+
+			logSkipReason(testPRNumber, tt.reason)
+
+			assert.Contains(t, buf.String(), tt.wantLog)
+		})
+	}
+}
 
 // Test_jobsToRetestFromComments checks which jobs jobsToRetestFromComments
 // decides still need a fresh "/test <job>" comment, given how many retests a
@@ -418,6 +452,138 @@ func Test_commentsToCreate(t *testing.T) {
 			gotComments, gotSkipped := commentsToCreate(tt.statuses, tt.jobsToRetest, tt.shouldRetest)
 			assert.Equal(t, tt.wantComments, gotComments)
 			assert.Equal(t, tt.wantSkipped, gotSkipped)
+		})
+	}
+}
+
+// Test_failingCheck checks which check (if any) failingCheck reports as
+// grounds for skipping a PR entirely, given its completed checks.
+func Test_failingCheck(t *testing.T) {
+	tests := map[string]struct {
+		checks   map[string]jobState
+		wantName string
+	}{
+		"nil": {
+			checks:   nil,
+			wantName: "",
+		},
+		"all ok": {
+			checks: map[string]jobState{
+				"lint":         jobOK,
+				"codecov/repo": jobOK,
+			},
+			wantName: "",
+		},
+		"failing but allowed prefix": {
+			checks: map[string]jobState{
+				"codecov/repo": jobFailure,
+			},
+			wantName: "",
+		},
+		"failing but retestable prefix": {
+			checks: map[string]jobState{
+				"e2e-gke-tests": jobFailure,
+			},
+			wantName: "",
+		},
+		"failing non-skippable check": {
+			checks: map[string]jobState{
+				"lint": jobFailure,
+			},
+			wantName: "lint",
+		},
+		"multiple failing non-skippable checks — lowest name wins deterministically": {
+			checks: map[string]jobState{
+				"unit-tests": jobFailure,
+				"lint":       jobFailure,
+			},
+			wantName: "lint",
+		},
+		"one failing non-skippable among otherwise-ok and skippable checks": {
+			checks: map[string]jobState{
+				"codecov/repo":  jobFailure,
+				"e2e-gke-tests": jobFailure,
+				"lint":          jobOK,
+				"unit-tests":    jobFailure,
+			},
+			wantName: "unit-tests",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotName := failingCheck(tt.checks)
+			assert.Equal(t, tt.wantName, gotName)
+		})
+	}
+}
+
+// Test_decideRetest checks the end-to-end per-PR decision (comment to post,
+// skip reasons, and the malformed-comment special case) that decideRetest
+// derives from already-fetched comments/checks/statuses, without any
+// GitHub I/O.
+func Test_decideRetest(t *testing.T) {
+	tests := map[string]struct {
+		userComments []string
+		allComments  []string
+		checks       map[string]jobState
+		statuses     map[string]jobState
+		want         retestDecision
+	}{
+		"malformed retest-times comment, not previously reported": {
+			allComments: []string{"/retest-times 101 job-name-1"},
+			want: retestDecision{
+				commentParseErr: `invalid retest number requested: "/retest-times 101 job-name-1"`,
+				alreadyReported: false,
+			},
+		},
+		"malformed retest-times comment, already reported by the bot": {
+			userComments: []string{`invalid retest number requested: "/retest-times 101 job-name-1"`},
+			allComments:  []string{"/retest-times 101 job-name-1"},
+			want: retestDecision{
+				commentParseErr: `invalid retest number requested: "/retest-times 101 job-name-1"`,
+				alreadyReported: true,
+			},
+		},
+		"nothing to do": {
+			statuses: map[string]jobState{"a": jobOK},
+			want: retestDecision{
+				jobsToRetest: []string{},
+				skipped:      []skipReason{{message: "no failing status or retestable check found"}},
+				comment:      "",
+			},
+		},
+		"failing status triggers /retest": {
+			statuses: map[string]jobState{"a": jobFailure},
+			want: retestDecision{
+				jobsToRetest: []string{},
+				comment:      "/retest",
+			},
+		},
+		"requested job is tested; a specific job request never also triggers a blanket /retest": {
+			allComments: []string{"/retest-times 1 job-name-1"},
+			statuses:    map[string]jobState{"job-name-2": jobFailure},
+			want: retestDecision{
+				jobsToRetest: []string{"job-name-1"},
+				comment:      "/test job-name-1",
+			},
+		},
+		"requested job is pending, so only skipped — no failing status means no /retest either": {
+			allComments: []string{"/retest-times 1 job-name-1"},
+			statuses:    map[string]jobState{"job-name-1": jobPending},
+			want: retestDecision{
+				jobsToRetest: []string{"job-name-1"},
+				skipped: []skipReason{
+					{message: "no failing status or retestable check found"},
+					{job: "job-name-1", message: "already pending"},
+				},
+				comment: "",
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := decideRetest(tt.userComments, tt.allComments, tt.checks, tt.statuses)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

I was unable to fully understand why some retests are skipped. Adding logs with
explanation for those reasons should help.

This PR was originally opened in Oct 2024 and went stale. It's now rebased onto
current `master` (whose retest logic had evolved in the meantime to also
consider GitHub Actions checks, not just Prow statuses) and reworked to
actually address the review feedback it got back then, which pointed at a
real architectural issue, not just wording nits.

<details>
<summary><strong>📋 Reviewer guide (click to expand)</strong> — the diff is bigger than the original ask, here's how to review it painlessly</summary>

The diff is organized as 5 small, atomic, independently-reviewable commits.
**Reviewing them in commit order is much easier than reviewing the full diff
at once.**

1. **`feat: log why a /retest is skipped`** — the actual feature this PR is
   about. Small, mostly additive: renames the old bool-returning decision
   function to return an `error` (per @porridge's original comment), and adds
   the log lines the PR was originally for.
2. **`refactor: centralize skip-reason decisions, clarify naming`** —
   introduces a `skipReason{job, message}` struct and a single
   `logSkipReason` call site, so every "why won't this be retested" message
   is logged in one consistent format instead of scattered `log.Printf`s
   (the deeper issue behind @porridge's "different places" comments). Also a
   batch of variable/test renames for self-documentation — pure naming, no
   logic change, safe to skim quickly.
3. **`refactor: normalize job outcomes into one jobState type`** — mechanical
   type change: `map[string]bool` (checks) and `map[string]string`
   (statuses) both become `map[string]jobState`. No behavior change, just
   removes two different truthiness conventions from the decision
   functions' signatures.
4. **`refactor: decompose run() into testable pieces`** — the biggest diff.
   Extracts `processPR` (I/O shell) and two pure functions, `failingCheck`
   and `decideRetest`, out of the previous ~80-line `run()`. Despite the
   size, this is zero-behavior-change: `TestIntegration` (the existing
   end-to-end httptest-based test) passes completely unmodified — that's the
   safety net proving it.
5. **`fix: drop leftover "already"-judgment wording`** — one-line wording fix
   (`"already pending"` → `"job is pending"`) found during a final
   full-branch re-check against every original review comment; both
   @porridge and CodeRabbit had flagged this exact phrasing on the original
   2024 PR and it never actually got fixed.

**What did *not* change:** `TestIntegration` is untouched and still green —
the GitHub API call sequence, ordering, and every posted comment body are
identical to before commits 2-4. No new external dependencies (still no
`github.com/pkg/errors`).

**Anticipated questions:**
- *Why not merge `checks` and `statuses` into one map?* They're different job
  namespaces (Prow job names vs. GitHub Actions check names) — merging risked
  silently colliding two unrelated jobs that happen to share a name. Only the
  *value* type (`jobState`) is unified, not the maps themselves.
- *Why keep the failing-check gate in `processPR` instead of folding it into
  `decideRetest`?* It's a qualitatively different action (abort the whole PR
  vs. skip one job/action within it), and folding it in would mean fetching
  statuses uselessly for PRs that get aborted anyway.

</details>

This is the log output that originally prompted this PR, explaining why a PR
wasn't being retested anymore (from the 2024 branch, kept here for context):

```
2024/10/09 09:23:53 #12781 retrieving...: https://github.com/stackrox/stackrox/pull/12781
2024/10/09 09:23:54 #12781 has 49 allComments by rhacs-bot and 161 in total
2024/10/09 09:23:55 #12781 has 27 completed checks
2024/10/09 09:23:55 #12781 has 6 statuses
2024/10/09 09:23:55 Job "gke-sensor-integration-tests" has been tested already 42 out of 30 times
2024/10/09 09:23:55 Exceeded number of retests for "gke-sensor-integration-tests"
2024/10/09 09:23:55 #12781 jobs to retest: 
2024/10/09 09:23:55 PR 12781 retest status due to failures: job has not failed
2024/10/09 09:23:55 #12781 not commented
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Ran this action from this branch. [Logs](https://github.com/stackrox/stackrox/actions/runs/29244344712/job/86797556899)
