### PR TITLE
ROX-26526: fix migrator min sequence comparison

### DIFF
--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -297,7 +297,7 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 			withPrevious:         false,
 			forceRollback:        "",
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.seqNum, futureVerDifferentMin.minSeqNum),
 		},
 		{
 			// Any rollbacks to 4.1 or later will only use central_active
@@ -305,7 +305,7 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 			withPrevious:         false,
 			forceRollback:        currVer.version,
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.seqNum, futureVerDifferentMin.minSeqNum),
 		},
 		{
 			description:          "force rollback with previous",
@@ -319,14 +319,14 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 			withPrevious:         true,
 			forceRollback:        "",
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.seqNum, futureVerDifferentMin.minSeqNum),
 		},
 		{
 			description:          "with force rollback code does not support min sequence in DB",
 			withPrevious:         true,
 			forceRollback:        currVer.version,
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.seqNum, futureVerDifferentMin.minSeqNum),
 			wrongVersion:         true,
 		},
 	}

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -215,8 +215,6 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string) error
 	}
 
 	pgClone, err := dbm.GetCloneToMigrate()
-	log.Infof("SHREWS -- %v", pgClone)
-	log.Infof("SHREWS -- %v", err)
 	if err != nil {
 		return err
 	}
@@ -224,7 +222,6 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string) error
 
 	// If we are running rocks too, we need to either have just a pgClone OR both.
 	if m.runBoth {
-		log.Infof("SHREWS run both -- %v", pgClone)
 		require.True(m.t, pgClone != "")
 	}
 	if breakPoint == breakAfterGetClone {

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -54,9 +54,8 @@ func (d *dbCloneManagerImpl) getVersion() (*migrations.MigrationVersion, error) 
 
 func (d *dbCloneManagerImpl) ensureVersionCompatible(ver *migrations.MigrationVersion) error {
 	if d.versionExists(ver) {
-		// current sequence number == database sequence number -- All good
-		// current sequence number != database sequence number BUT database min >= current min -- ALL Good
-		// version min < current database min -- DO NOT ROLLBACK
+		// minimum sequence number from the database > current software sequence number -- DO NOT ROLLBACK
+		// This implies an unsupported rollback where structure and data may have changed
 		if ver.MinimumSeqNum > migrations.CurrentDBVersionSeqNum() {
 			return errors.Errorf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.CurrentDBVersionSeqNum(), ver.MinimumSeqNum)
 		}

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -57,8 +57,8 @@ func (d *dbCloneManagerImpl) ensureVersionCompatible(ver *migrations.MigrationVe
 		// current sequence number == database sequence number -- All good
 		// current sequence number != database sequence number BUT database min >= current min -- ALL Good
 		// version min < current database min -- DO NOT ROLLBACK
-		if ver.MinimumSeqNum > migrations.MinimumSupportedDBVersionSeqNum() {
-			return errors.Errorf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.MinimumSupportedDBVersionSeqNum(), ver.MinimumSeqNum)
+		if ver.MinimumSeqNum > migrations.CurrentDBVersionSeqNum() {
+			return errors.Errorf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.CurrentDBVersionSeqNum(), ver.MinimumSeqNum)
 		}
 	}
 

--- a/migrator/clone/postgres/db_clone_manager_impl_external_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_external_test.go
@@ -135,7 +135,7 @@ func (s *PostgresExternalManagerSuite) TestScanIncompatibleExternal() {
 		SeqNum:        int32(migrations.CurrentDBVersionSeqNum() + 2),
 		Version:       futureVer.version,
 		LastPersisted: protoconv.ConvertMicroTSToProtobufTS(timestamp.Now()),
-		MinSeqNum:     int32(migrations.MinimumSupportedDBVersionSeqNum() + 2),
+		MinSeqNum:     int32(migrations.CurrentDBVersionSeqNum() + 2),
 	}
 	migVer.SetVersionPostgres(s.ctx, externalDB, futureVersion)
 
@@ -143,7 +143,7 @@ func (s *PostgresExternalManagerSuite) TestScanIncompatibleExternal() {
 	pgtest.DropDatabase(s.T(), migrations.PreviousDatabase)
 
 	// Scan the clones
-	errorMessage := fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.MinimumSupportedDBVersionSeqNum(), futureVersion.MinSeqNum)
+	errorMessage := fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.CurrentDBVersionSeqNum(), futureVersion.MinSeqNum)
 	s.EqualError(dbm.Scan(), errorMessage)
 }
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When the minimum supported sequence number was implemented the check was in correct.  The check should have been to compare the minimum sequence number with the sequence number the software supports.  Previously it was comparing minimum to minimum which would never allow us to move the minimum sequence number to reduce rollback support.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Updated the unit tests.  and lots of manual tests.

Tested the following scenarios.
- 4.5.2 -> this PR -> 4.5.2 -- ensured upgrade and rollback were both successful.
- 4.5.2 -> this PR -> test PR #12980 -> this PR -- ensured upgrade and rollback were both successful.
- 4.5.2 -> this PR -> test PR #12981 -> this PR -- ensured upgrades succeeded, but unable to rollback from test PR back to this PR or earlier.
```
Migrator: 2024/10/10 15:10:15.536264 log.go:18: Info: Migrator failed: Software downgrade is not supported.  The software supports database version of 207 but the database requires the software support a database version to be at least least 386
```
