### PR TITLE
ROX-24859: Add NVD CVSS policy criteria

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
@@ -367,7 +367,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 clearPolicyCriteriaCards();
 
                 clickPolicyKeyGroup('Image contents');
-                dragFieldIntoSection(`${selectors.step3.policyCriteria.key}:contains('CVSS')`);
+                // eq(0) to specify CVSS instead of NVD CVSS
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('CVSS'):eq(0)`
+                );
                 cy.get(selectors.step3.policyCriteria.value.select).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.numberInput).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.select).click();

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -24,9 +24,10 @@ function addPolicyField(fieldName) {
     // cy.log(firstWordOfFieldName);
     cy.get(TREE_VIEW_SEARCH_INPUT).type(firstWordOfFieldName);
 
-    cy.get(
-        `${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-v5-c-tree-view__node-title:contains(${fieldName})`
-    ).click();
+    // Match entire title to distinguish CVSS From NVD CVSS.
+    cy.get(`${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-v5-c-tree-view__node-title`)
+        .contains(new RegExp(`^${fieldName}$`))
+        .click();
 
     cy.get(`${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-v5-c-tree-view__node`).should(
         'have.class',

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
@@ -11,6 +11,7 @@ const allowListForItems = [
     'API',
     'CPU',
     'CVE',
+    'CVSS',
     'Dockerfile',
     'IP',
     'IPC',
@@ -25,7 +26,10 @@ const allowListForItems = [
 ];
 
 // Items that are allowed only in the content of an entire string.
-const allowListForNames = ['Common Vulnerability Scoring System (CVSS) score'];
+const allowListForNames = [
+    'Common Vulnerability Scoring System (CVSS) score',
+    'Common Vulnerability Scoring System (CVSS) score from National Vulnerability Database (NVD)',
+];
 
 function isInitialUpperCase(item: string) {
     return /^[A-Z]/.test(item);

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -492,7 +492,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         subComponents: [
             {
                 type: 'select',
-                options: equalityOptions,
+                options: equalityOptions, // see nonStandardNumberFields
                 subpath: 'key',
             },
             {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -482,6 +482,32 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
+        label: 'NVD CVSS',
+        name: 'NVD CVSS',
+        shortName: 'NVD CVSS',
+        longName:
+            'Common Vulnerability Scoring System (CVSS) score from National Vulnerability Database (NVD)',
+        category: policyCriteriaCategories.IMAGE_CONTENTS,
+        type: 'group',
+        subComponents: [
+            {
+                type: 'select',
+                options: equalityOptions,
+                subpath: 'key',
+            },
+            {
+                type: 'number',
+                placeholder: '0-10',
+                max: 10.0,
+                min: 0.0,
+                step: 0.1,
+                subpath: 'value',
+            },
+        ],
+        canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
+    },
+    {
         label: 'Severity',
         name: 'Severity',
         shortName: 'Severity',

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -506,6 +506,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         ],
         canBooleanLogic: true,
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
+        featureFlagDependency: ['ROX_NVD_CVSS_UI'],
     },
     {
         label: 'Severity',

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -309,6 +309,7 @@ const nonStandardNumberFields = [
     'Container CPU Limit',
     'Container Memory Request',
     'Container Memory Limit',
+    'NVD CVSS',
     'Replicas',
     'Severity',
 ];


### PR DESCRIPTION
### Description

Frontend counterpart to #12896

Feature flag for policy criteria is only to allow frontend to precede backend.

At end of sprint, either:
* Remove `featureFlagDependency` property, because policy criteria is released.
* Comment out policy criteria, if policy criteria cannot be released.

### Changes

1. Copy, paste, and then edit **CVSS** policy criteria.
    * Paste after, because order of criteria is order in `policyCriteriaDescriptors` array.
    * Because the `name` property is the correspondence between frontend and backend, I confirmed the field name with Surabhi in advance.
        https://github.com/stackrox/stackrox/blob/20498cae2fffe60f74e6561c458688411e2b8acd/pkg/booleanpolicy/fieldnames/list.go

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed for this contribution

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] edited unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Prerequisite before `npm run deploy` in ui folder

```sh
export ROX_NVD_CVSS_UI=true
```

I tested in modal interface, although that is not for release in 4.6

```sh
export ROX_POLICY_CRITERIA_MODAL=true
```

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4617088 - 4617088
        total 435 = 11696298 - 11695863
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/policies, click **Create policy**, advance to **Rules**, click **Add policy field** and then expand **Image contents**

    * Before changes, see absence of **NVD CVSS** policy criteria.
        ![without_NVD_CVSS](https://github.com/user-attachments/assets/e1bff882-fdf6-4488-8dd1-cfb134ae7c9e)

    * After changes, see presence of **NVD CVSS** policy criteria.
        With feature flag enabled. I also verified absence (like above) with feature flag disabled.
        ![with_NVD_CVSS](https://github.com/user-attachments/assets/2050cac5-abed-4965-bdb8-cc27a76ac080)

        And see card on **Rules** step
        ![Rules](https://github.com/user-attachments/assets/9f423b93-163a-4bb2-90cb-fd823062efdc)

        And then see expected failure on **Review** step
        Without `nonStandardNumberFields` see presence of extra `=` in payload compared to staging.
        ![Review](https://github.com/user-attachments/assets/0a5e99be-395d-48e0-97b9-66e0628ac8b8)

        With `nonStandardNumberFields` see absence of extra `=` in payload compared to staging.
        ![Review_nonStandardNumberFields](https://github.com/user-attachments/assets/f3e9b869-1a73-4ad8-a667-8e36a0db16c8)

#### Unit testing

1. `npm run test` in ui/apps/platform folder
