### PR TITLE
ROX-26532: Fixing policy violations search filter bugs

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -46,34 +46,6 @@ export const LifecycleStage: CompoundSearchFilterAttribute = {
     },
 };
 
-export const EnforcementAction: CompoundSearchFilterAttribute = {
-    displayName: 'Enforcement action',
-    filterChipLabel: 'Enforcement action',
-    searchTerm: 'Enforcement',
-    inputType: 'select',
-    inputProps: {
-        options: [
-            { value: 'FAIL_BUILD_ENFORCEMENT', label: 'Fail build' },
-            {
-                value: 'FAIL_DEPLOYMENT_CREATE_ENFORCEMENT',
-                label: 'Fail deployment create',
-            },
-            {
-                value: 'FAIL_DEPLOYMENT_UPDATE_ENFORCEMENT',
-                label: 'Fail deployment update',
-            },
-            { value: 'FAIL_KUBE_REQUEST_ENFORCEMENT', label: 'Fail kube request' },
-            { value: 'KILL_POD_ENFORCEMENT', label: 'Kill pod' },
-            { value: 'SCALE_TO_ZERO_ENFORCEMENT', label: 'Scale to zero' },
-            {
-                value: 'UNSATISFIABLE_NODE_CONSTRAINT_ENFORCEMENT',
-                label: 'Unsatisfiable node constraint',
-            },
-            { value: 'UNSET_ENFORCEMENT', label: 'Unset' },
-        ],
-    },
-};
-
 export const InactiveDeployment: CompoundSearchFilterAttribute = {
     displayName: 'Deployment status',
     filterChipLabel: 'Deployment status',
@@ -134,7 +106,6 @@ export const policyAttributes = [
     Category,
     Severity,
     LifecycleStage,
-    EnforcementAction,
     InactiveDeployment,
     ViolationTime,
     EntityType,

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
@@ -64,6 +64,7 @@ function ConditionDate({ value, onChange, onSearch }: ConditionDateProps) {
                 dateFormat={getDate}
                 dateParse={dateParse}
                 placeholder="MM/DD/YYYY"
+                invalidFormatText="Enter valid date: MM/DD/YYYY"
             />
             <Button
                 variant="control"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -66,6 +66,16 @@ function getSelectOptions(
         return options;
     }
 
+    if (filterValue === '') {
+        return [
+            {
+                isDisabled: true,
+                value: filterValue,
+                children: 'No options',
+            },
+        ];
+    }
+
     return [
         {
             value: filterValue,
@@ -123,7 +133,7 @@ function SearchFilterAutocomplete({
             ? [autocompleteContextString, autocompleteSearchString].join('+')
             : autocompleteSearchString;
 
-    const { data, loading: isLoading } = useQuery<SearchAutocompleteQueryResponse>(
+    const { data: rawData, loading: isLoading } = useQuery<SearchAutocompleteQueryResponse>(
         SEARCH_AUTOCOMPLETE_QUERY,
         {
             variables: {
@@ -132,6 +142,10 @@ function SearchFilterAutocomplete({
             },
         }
     );
+    // Filter out empty strings
+    const data: SearchAutocompleteQueryResponse = {
+        searchAutocomplete: rawData?.searchAutocomplete?.filter((item) => item !== '') ?? [],
+    };
 
     const selectOptions: SelectOptionProps[] = getSelectOptions(
         data,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -31,7 +31,6 @@ import { ListAlert } from 'types/alert.proto';
 import { TableColumn } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { SearchFilter } from 'types/search';
-
 import { OnSearchCallback } from 'Components/CompoundSearchFilter/types';
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -14,7 +14,6 @@ import {
     Name as PolicyName,
     LifecycleStage as PolicyLifecycleStage,
     Severity as PolicySeverity,
-    EnforcementAction as PolicyEnforcementAction,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import {
     ViolationTime as AlertViolationTime,
@@ -23,15 +22,20 @@ import {
 import {
     Name as ClusterName,
     ID as ClusterID,
+    Label as ClusterLabel,
 } from 'Components/CompoundSearchFilter/attributes/cluster';
 import {
     ID as NamespaceID,
     Name as NamespaceName,
+    Label as NamespaceLabel,
+    Annotation as NamespaceAnnotation,
 } from 'Components/CompoundSearchFilter/attributes/namespace';
 import {
     ID as DeploymentID,
     Name as DeploymentName,
     Inactive as DeploymentInactive,
+    Label as DeploymentLabel,
+    Annotation as DeploymentAnnotation,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
 import { Name as ResourceName } from 'Components/CompoundSearchFilter/attributes/resource';
 
@@ -39,13 +43,7 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Policy',
         searchCategory: 'ALERTS',
-        attributes: [
-            PolicyName,
-            PolicyCategory,
-            PolicySeverity,
-            PolicyLifecycleStage,
-            PolicyEnforcementAction,
-        ],
+        attributes: [PolicyName, PolicyCategory, PolicySeverity, PolicyLifecycleStage],
     },
     {
         displayName: 'Policy violation',
@@ -55,17 +53,23 @@ const searchFilterConfig: CompoundSearchFilterConfig = [
     {
         displayName: 'Cluster',
         searchCategory: 'ALERTS',
-        attributes: [ClusterName, ClusterID],
+        attributes: [ClusterName, ClusterID, ClusterLabel],
     },
     {
         displayName: 'Namespace',
         searchCategory: 'ALERTS',
-        attributes: [NamespaceName, NamespaceID],
+        attributes: [NamespaceName, NamespaceID, NamespaceLabel, NamespaceAnnotation],
     },
     {
         displayName: 'Deployment',
         searchCategory: 'ALERTS',
-        attributes: [DeploymentName, DeploymentID, DeploymentInactive],
+        attributes: [
+            DeploymentName,
+            DeploymentID,
+            DeploymentLabel,
+            DeploymentAnnotation,
+            DeploymentInactive,
+        ],
     },
     {
         displayName: 'Resource',


### PR DESCRIPTION
### Description

This PR fixes a few issues from the bug bash:

1. Filtering out empty string options in the autocomplete component.
2. Removing the Entity Type filter.
3. Adding labels and annotations for namespaces and deployments and labels for clusters.
4. Giving a better error text when using an invalid date format.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests
- [] no added tests

#### How I validated my change

<img width="1440" alt="Screenshot 2024-10-10 at 8 24 21 AM" src="https://github.com/user-attachments/assets/b437e2c7-0e5e-4dc6-8480-38730691a50e">
<img width="1439" alt="Screenshot 2024-10-10 at 8 23 07 AM" src="https://github.com/user-attachments/assets/2338fabe-dc26-4f75-9a29-6ec65cde7848">
<img width="1437" alt="Screenshot 2024-10-10 at 8 23 18 AM" src="https://github.com/user-attachments/assets/f0fb05b3-a953-412d-b1d9-8e688e7a77b0">
<img width="1439" alt="Screenshot 2024-10-10 at 8 23 28 AM" src="https://github.com/user-attachments/assets/3d2072cc-7bf3-438c-8aa4-403ed1bfef50">
<img width="1439" alt="Screenshot 2024-10-10 at 8 23 50 AM" src="https://github.com/user-attachments/assets/9c5af65c-7bdd-45c0-a850-54395bbf7732">
<img width="1440" alt="Screenshot 2024-10-10 at 8 24 10 AM" src="https://github.com/user-attachments/assets/230b8b82-bdcb-4827-9e8e-1ceaa5da30cc">
