### PR TITLE
chore: Add CGO_ENABLED for konflux operator bundle

### DIFF
--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -70,6 +70,7 @@ RUN echo "Checking required RELATED_IMAGE_CENTRAL_DB"; [[ "${RELATED_IMAGE_CENTR
 #  go: inconsistent vendoring in /stackrox/operator/tools/operator-sdk:
 #      github.com/operator-framework/operator-lifecycle-manager@v0.27.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
 ENV GOFLAGS=''
+ENV CGO_ENABLED=1
 
 RUN mkdir -p build/ && \
     rm -rf build/bundle && \


### PR DESCRIPTION
If some go is compiled in this image, then do we also need to set CGO_ENABLED to ensure a fips compliant build?

It looks like we do not compile go in this builder stage, and only modify text. But I am not familiar with the operator bundle or why it is using the golang image for the builder stage.