### PR TITLE
fix(ci): Scanner job broken due to `gcloud` CLI missing

### DIFF
--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -46,6 +46,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}


### PR DESCRIPTION
### Description

Fix for CI errors `ERROR: missing "gcloud" executable`

Ex: https://github.com/stackrox/stackrox/actions/runs/11262989448

Not 100% sure on root cause on how this was working previously - the current `ubuntu-latest` (`24.04`) runner does NOT include the `Google Cloud CLI`, previous versions (`22.04`) do however.


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A no automated tests for this job

#### How I validated my change

Created this PR and added label to trigger CI, workflow `Scanner release offline vulnerability bundle update` ran successfully: https://github.com/stackrox/stackrox/actions/runs/11263430502?pr=12968
