### PR TITLE
ROX-24563: Changing All to NoneSpecified in Collections

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -22,7 +22,7 @@ describe('Create collection', () => {
         cy.get('input[name="name"]').type(collectionName);
         cy.get('input[name="description"]').type('A collection for financial data');
 
-        cy.get('button:contains("All deployments")').click();
+        cy.get('button:contains("No deployments specified")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
             'meta/name=visa-processor'
@@ -32,11 +32,11 @@ describe('Create collection', () => {
             'meta/name=mastercard-processor'
         );
 
-        cy.get('button:contains("All namespaces")').click();
+        cy.get('button:contains("No namespaces specified")').click();
         cy.get('button:contains("Namespaces with names matching")').click();
         cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type('payments');
 
-        cy.get('button:contains("All clusters")').click();
+        cy.get('button:contains("No clusters specified")').click();
         cy.get('button:contains("Clusters with names matching")').click();
         cy.get('input[aria-label="Select value 1 of 1 for the cluster name"]').type('production');
 

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -31,7 +31,7 @@ describe('Collection deployment matching', () => {
         cy.get('input[name="name"]').type(sampleCollectionName);
         cy.get('input[name="description"]').type('Matches some stackrox deployments');
 
-        cy.get('button:contains("All namespaces")').click();
+        cy.get('button:contains("No namespaces specified")').click();
         cy.get('button:contains("Namespaces with names matching")').click();
         cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type('stackrox');
 
@@ -39,7 +39,7 @@ describe('Collection deployment matching', () => {
         assertDeploymentsAreMatched(['central', 'central-db', 'collector', 'scanner', 'sensor']);
 
         // Restrict collection to two specific deployments
-        cy.get('button:contains("All deployments")').click();
+        cy.get('button:contains("No deployments specified")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
             'app=collector'
@@ -68,7 +68,7 @@ describe('Collection deployment matching', () => {
         cy.get('input[name="name"]').type(withEmbeddedCollectionName);
         cy.get('input[name="description"]').type('Embeds another collection');
 
-        cy.get('button:contains("All namespaces")').click();
+        cy.get('button:contains("No namespaces specified")').click();
         cy.get('button:contains("Namespaces with names matching")').click();
         cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type(
             'kube-system'
@@ -91,7 +91,7 @@ describe('Collection deployment matching', () => {
         assertDeploymentsAreMatched(['kube-dns']);
 
         // Restrict collection to two specific deployments
-        cy.get('button:contains("All deployments")').click();
+        cy.get('button:contains("No deployments specified")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
             'k8s-app=calico-node-autoscaler'

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -165,7 +165,7 @@ function yupNameRuleObject({ field }: ByNameResourceSelector) {
 function yupResourceSelectorObject() {
     return yup.lazy((ruleObject: ScopedResourceSelector) => {
         switch (ruleObject.type) {
-            case 'All':
+            case 'NoneSpecified':
                 return yup.object().shape({});
             case 'ByName':
                 return yupNameRuleObject(ruleObject);

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -110,7 +110,7 @@ function ByLabelSelector({
             handleChange(entityType, newSelector);
         } else {
             // This was the last value in the last rule, so drop the selector
-            handleChange(entityType, { type: 'All' });
+            handleChange(entityType, { type: 'NoneSpecified' });
         }
     }
 

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -91,7 +91,7 @@ function ByNameSelector({
             handleChange(entityType, newSelector);
         } else {
             // This was the last value in the rule, so drop the selector
-            handleChange(entityType, { type: 'All' });
+            handleChange(entityType, { type: 'NoneSpecified' });
         }
     }
 

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.cy.jsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.cy.jsx
@@ -27,10 +27,10 @@ function setup(defaultSelector, onChange) {
 }
 
 describe(Cypress.spec.relative, () => {
-    it('should render "All entities" option when selector is null', () => {
-        setup({ type: 'All' }, () => {});
+    it('should render "No deployments specified" option when selector is null', () => {
+        setup({ type: 'NoneSpecified' }, () => {});
 
-        cy.findByText('All deployments');
+        cy.findByText('No deployments specified');
     });
 
     it('should allow users to add name selectors', () => {
@@ -48,7 +48,7 @@ describe(Cypress.spec.relative, () => {
 
         const hasRuleValues = (values) => (s) => isEqual(s.resourceSelector.rule.values, values);
 
-        setup({ type: 'All' }, onChange);
+        setup({ type: 'NoneSpecified' }, onChange);
 
         cy.findByLabelText('Select deployments by name or label').click();
         cy.findByText('Deployments with names matching').click();
@@ -121,7 +121,7 @@ describe(Cypress.spec.relative, () => {
         cy.findByLabelText('Delete visa-processor').click();
         cy.findByLabelText('Delete discover-processor').click();
 
-        cy.wrap(state).should('deep.equal', { resourceSelector: { type: 'All' } });
+        cy.wrap(state).should('deep.equal', { resourceSelector: { type: 'NoneSpecified' } });
     });
 
     it('should allow users to add label key/value selectors', () => {
@@ -140,7 +140,7 @@ describe(Cypress.spec.relative, () => {
         const hasRuleValues = (values) => (s) =>
             isEqual(s.resourceSelector.rules[0].values, values);
 
-        setup({ type: 'All' }, onChange);
+        setup({ type: 'NoneSpecified' }, onChange);
 
         cy.findByLabelText('Select deployments by name or label').click();
         cy.findByText('Deployments with labels matching exactly').click();
@@ -248,6 +248,6 @@ describe(Cypress.spec.relative, () => {
         cy.findByLabelText('Delete kubernetes.io/metadata.name=mastercard-processor').click();
         cy.findByLabelText('Delete kubernetes.io/metadata.name=discover-processor').click();
 
-        cy.wrap(state).should('deep.equal', { resourceSelector: { type: 'All' } });
+        cy.wrap(state).should('deep.equal', { resourceSelector: { type: 'NoneSpecified' } });
     });
 });

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -59,7 +59,7 @@ function RuleSelector({
         }
 
         const selectorMap: Record<RuleSelectorOption, ScopedResourceSelector> = {
-            All: { type: 'All' },
+            NoneSpecified: { type: 'NoneSpecified' },
             ByName: {
                 type: 'ByName',
                 field: entityType,
@@ -77,7 +77,6 @@ function RuleSelector({
     }
 
     const selection = scopedResourceSelector.type;
-
     return (
         <div className="rule-selector">
             <Select
@@ -88,7 +87,9 @@ function RuleSelector({
                 onSelect={onRuleOptionSelect}
                 isDisabled={isDisabled}
             >
-                <SelectOption value="All">All {pluralEntity.toLowerCase()}</SelectOption>
+                <SelectOption value="NoneSpecified">
+                    No specified {pluralEntity.toLowerCase()}
+                </SelectOption>
                 <SelectOption value="ByName">{pluralEntity} with names matching</SelectOption>
                 <SelectOption value="ByLabel">
                     {pluralEntity} with labels matching exactly

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -88,7 +88,7 @@ function RuleSelector({
                 isDisabled={isDisabled}
             >
                 <SelectOption value="NoneSpecified">
-                    No specified {pluralEntity.toLowerCase()}
+                    No {pluralEntity.toLowerCase()} specified
                 </SelectOption>
                 <SelectOption value="ByName">{pluralEntity} with names matching</SelectOption>
                 <SelectOption value="ByLabel">

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -49,7 +49,7 @@ describe('Collection parser', () => {
             name: 'Sample',
             description: 'Sample description',
             resourceSelector: {
-                Deployment: { type: 'All' },
+                Deployment: { type: 'NoneSpecified' },
                 Namespace: {
                     type: 'ByLabel',
                     field: 'Namespace Label',
@@ -188,8 +188,8 @@ describe('Collection response generator', () => {
             name: 'Sample',
             description: 'Sample description',
             resourceSelector: {
-                // "All" should result in no rules
-                Deployment: { type: 'All' },
+                // "NoneSpecified" should result in no rules
+                Deployment: { type: 'NoneSpecified' },
                 // "ByLabel" will create two rules, one with multiple values, and test the joining of keys'values
                 Namespace: {
                     type: 'ByLabel',

--- a/ui/apps/platform/src/Containers/Collections/converter.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.ts
@@ -53,9 +53,9 @@ export function parseCollection(
         description: data.description,
         embeddedCollectionIds: data.embeddedCollections.map(({ id }) => id),
         resourceSelector: {
-            Deployment: { type: 'All' },
-            Namespace: { type: 'All' },
-            Cluster: { type: 'All' },
+            Deployment: { type: 'NoneSpecified' },
+            Namespace: { type: 'NoneSpecified' },
+            Cluster: { type: 'NoneSpecified' },
         },
     };
 
@@ -75,7 +75,8 @@ export function parseCollection(
         }
         const entity = fieldToEntityMap[field];
         const selectorScope = collection.resourceSelector[entity];
-        const existingEntityField = selectorScope.type === 'All' ? undefined : selectorScope.field;
+        const existingEntityField =
+            selectorScope.type === 'NoneSpecified' ? undefined : selectorScope.field;
         const hasMultipleFieldsForEntity = existingEntityField && existingEntityField !== field;
         const isUnsupportedField = !isSupportedSelectorField(field);
         const isUnsupportedRuleOperator = rule.operator !== 'OR';
@@ -100,7 +101,7 @@ export function parseCollection(
             return;
         }
 
-        if (selectorScope.type === 'All') {
+        if (selectorScope.type === 'NoneSpecified') {
             if (isByLabelField(field)) {
                 collection.resourceSelector[entity] = {
                     type: 'ByLabel',
@@ -146,7 +147,7 @@ export function parseCollection(
                 selector.rule.values = nameMatchValues;
                 break;
             }
-            case 'All':
+            case 'NoneSpecified':
                 // Do nothing
                 break;
             default:
@@ -188,7 +189,7 @@ export function generateRequest(collection: ClientCollection): CollectionRequest
                     });
                 });
                 break;
-            case 'All':
+            case 'NoneSpecified':
                 // Append nothing
                 break;
             default:

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
@@ -18,8 +18,9 @@ export function useCollectionFormSubmission(pageAction: CollectionPageAction) {
                 return reject(new Error('A Collection form has been submitted in read-only view'));
             }
             const isEmptyCollection =
-                Object.values(collection.resourceSelector).every(({ type }) => type === 'All') &&
-                collection.embeddedCollectionIds.length === 0;
+                Object.values(collection.resourceSelector).every(
+                    ({ type }) => type === 'NoneSpecified'
+                ) && collection.embeddedCollectionIds.length === 0;
 
             if (isEmptyCollection) {
                 return reject(new Error('Cannot save an empty collection'));

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -70,12 +70,12 @@ export function isSupportedSelectorField(field: SelectorField): field is Support
     return isByNameField(field) || isByLabelField(field);
 }
 
-export const selectorOptions = ['All', 'ByName', 'ByLabel'] as const;
+export const selectorOptions = ['NoneSpecified', 'ByName', 'ByLabel'] as const;
 
 export type RuleSelectorOption = (typeof selectorOptions)[number];
 
-export type AllResourceSelector = {
-    type: 'All';
+export type NoneSpecifiedResourceSelector = {
+    type: 'NoneSpecified';
 };
 export type ByNameResourceSelector = {
     type: 'ByName';
@@ -88,7 +88,7 @@ export type ByLabelResourceSelector = {
     rules: LabelSelectorRule[];
 };
 export type ScopedResourceSelector =
-    | AllResourceSelector
+    | NoneSpecifiedResourceSelector
     | ByNameResourceSelector
     | ByLabelResourceSelector;
 


### PR DESCRIPTION
### Description

As specified, should behave the same as before but `All` should be replaced as `None specified` to be more explicit about what the selection includes.

<img width="671" alt="image" src="https://github.com/user-attachments/assets/f7a11e37-e8ec-498f-85bb-c26fc45a1fce">
<img width="659" alt="image" src="https://github.com/user-attachments/assets/f9381cd2-b6a5-43e5-bd49-594744723203">
<img width="675" alt="image" src="https://github.com/user-attachments/assets/b382956e-a13f-486d-ad45-e43c65cb8e18">


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Creating a new collection and viewing existing collections should result in no errors or awkward wordage.
