### PR TITLE
Shorten description of related images mode

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -450,7 +450,7 @@ bundle-post-process: test-bundle-helpers operator-sdk ## Post-process CSV file t
 		--first-version $${first_version} \
 		--operator-image $(IMG) \
 		$${unreleased_opt} \
-		--no-related-images \
+		--related-images-mode=omit \
 		--add-supported-arch amd64 \
 		--add-supported-arch arm64 \
 		--add-supported-arch ppc64le \

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -60,7 +60,7 @@ def patch_csv(csv_doc, version, operator_image, first_version, related_images_mo
 
     csv_doc['spec']['version'] = version
 
-    if related_images_mode in ["downstream", "konflux"]:
+    if related_images_mode != "omit":
         rewrite(csv_doc, related_image_passthrough)
 
     previous_y_stream = get_previous_y_stream(version)

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -6,7 +6,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import textwrap
 from collections import namedtuple
 from datetime import datetime, timezone
 
@@ -168,14 +167,9 @@ def get_previous_y_stream(version):
     return subprocess.check_output([executable, version], encoding='utf-8').strip()
 
 
-# This class configures ArgumentParser help to print default values and preserve linebreaks in argument help.
-class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
-    pass
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file',
-                                     formatter_class=HelpFormatter)
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--use-version", required=True, metavar='version',
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
@@ -183,16 +177,12 @@ def parse_args():
     parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
     parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux"], default="downstream",
-                        help=textwrap.dedent("""
+                        help="""
                         Set mode of operation for handling related image attributes in the output CSV.
-                        Supported modes:
-                            downstream: In this mode the current RELATED_IMAGE_* environment variables are injected into
-                                the output CSV and spec.relatedImages is not added.
-                            omit: In this mode no RELATED_IMAGE_* environment variables are injected into the output CSV
-                                and spec.relatedImages is not added.
-                            konflux: In this mode the current RELATED_IMAGE_* environment variables are injected into the
-                                output CSV and spec.relatedImages is populated based on them.
-                        """).lstrip())
+                        "downstream": add RELATED_IMAGE_* env variables, delete spec.relatedImages.
+                        "omit": ignore RELATED_IMAGE_* env variables, delete spec.relatedImages.
+                        "konflux": add RELATED_IMAGE_* env variables, populate spec.relatedImages.
+                        """)
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -7,7 +7,6 @@ import pathlib
 import subprocess
 import sys
 import yaml
-import textwrap
 from collections import namedtuple
 from datetime import datetime, timezone
 
@@ -164,23 +163,15 @@ def get_previous_y_stream(version):
 
 
 def parse_args():
-    partial_parser = argparse.ArgumentParser(add_help=False)
-    partial_parser.add_argument('--related-images-mode', nargs='?')
-    args, _ = partial_parser.parse_known_args()
-    if args.related_images_mode == 'help':
-        print_related_images_mode_help()
-        sys.exit(0)
-
-    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file')
     parser.add_argument("--use-version", required=True, metavar='version',
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
                         help='The first version of the operator that was published')
     parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
-    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux", "help"], default="downstream",
-                        help="Set mode of operation for handling related image settings; specify 'help' for more information.")
+    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux"], default="downstream",
+                        help="Set mode of operation for handling related image settings.")
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
@@ -189,21 +180,6 @@ def parse_args():
     parser.add_argument("--unreleased", help="Not yet released version of operator, if any.")
     return parser.parse_args()
 
-def print_related_images_mode_help():
-    print(textwrap.dedent('''
-            The '--related-images-mode' parameter allows controlling the mode in which the 'related images'
-            are integrated within the output CSV. The default mode is 'downstream'.
-
-            Description of the supported modes:
-
-                downstream: In this mode the current RELATED_IMAGE_* environment variables are injected into
-                    the output CSV and spec.relatedImages is not added.
-
-                omit: In this mode no RELATED_IMAGE_* environment variables are injected into the output CSV
-                    and spec.relatedImages is not added.
-
-                konflux: In this mode the current RELATED_IMAGE_* environment variables are injected into the
-                    output CSV and spec.relatedImages is populated based on them.'''))
 
 def main():
     logging.basicConfig(stream=sys.stderr, level=logging.INFO,

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -7,6 +7,7 @@ import pathlib
 import subprocess
 import sys
 import yaml
+import textwrap
 from collections import namedtuple
 from datetime import datetime, timezone
 
@@ -163,15 +164,23 @@ def get_previous_y_stream(version):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file')
+    partial_parser = argparse.ArgumentParser(add_help=False)
+    partial_parser.add_argument('--related-images-mode', nargs='?')
+    args, _ = partial_parser.parse_known_args()
+    if args.related_images_mode == 'help':
+        print_related_images_mode_help()
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--use-version", required=True, metavar='version',
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
                         help='The first version of the operator that was published')
     parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
-    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux"], default="downstream",
-                        help="Set mode of operation for handling related image settings.")
+    parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux", "help"], default="downstream",
+                        help="Set mode of operation for handling related image settings; specify 'help' for more information.")
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
@@ -180,6 +189,21 @@ def parse_args():
     parser.add_argument("--unreleased", help="Not yet released version of operator, if any.")
     return parser.parse_args()
 
+def print_related_images_mode_help():
+    print(textwrap.dedent('''
+            The '--related-images-mode' parameter allows controlling the mode in which the 'related images'
+            are integrated within the output CSV. The default mode is 'downstream'.
+
+            Description of the supported modes:
+
+                downstream: In this mode the current RELATED_IMAGE_* environment variables are injected into
+                    the output CSV and spec.relatedImages is not added.
+
+                omit: In this mode no RELATED_IMAGE_* environment variables are injected into the output CSV
+                    and spec.relatedImages is not added.
+
+                konflux: In this mode the current RELATED_IMAGE_* environment variables are injected into the
+                    output CSV and spec.relatedImages is populated based on them.'''))
 
 def main():
     logging.basicConfig(stream=sys.stderr, level=logging.INFO,

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -6,9 +6,11 @@ import os
 import pathlib
 import subprocess
 import sys
-import yaml
+import textwrap
 from collections import namedtuple
 from datetime import datetime, timezone
+
+import yaml
 
 from rewrite import rewrite, string_replacer
 
@@ -49,7 +51,8 @@ def must_replace_suffix(str, suffix, replacement):
     return splits[0] + replacement
 
 
-def patch_csv(csv_doc, version, operator_image, first_version, related_images_mode, extra_supported_arches, unreleased=None):
+def patch_csv(csv_doc, version, operator_image, first_version, related_images_mode, extra_supported_arches,
+              unreleased=None):
     csv_doc['metadata']['annotations']['createdAt'] = datetime.now(timezone.utc).isoformat()
 
     placeholder_image = csv_doc['metadata']['annotations']['containerImage']
@@ -76,7 +79,8 @@ def patch_csv(csv_doc, version, operator_image, first_version, related_images_mo
 
     skips = parse_skips(csv_doc["spec"], raw_name)
     replaced_xyz = calculate_replaced_version(
-        version=version, first_version=first_version, previous_y_stream=previous_y_stream, skips=skips, unreleased=unreleased)
+        version=version, first_version=first_version, previous_y_stream=previous_y_stream, skips=skips,
+        unreleased=unreleased)
     if replaced_xyz is not None:
         csv_doc["spec"]["replaces"] = f"{raw_name}.v{replaced_xyz}"
 
@@ -86,6 +90,7 @@ def patch_csv(csv_doc, version, operator_image, first_version, related_images_mo
         # OSBS fills relatedImages therefore we must not provide that ourselves.
         # Ref https://osbs.readthedocs.io/en/latest/users.html?highlight=relatedImages#creating-the-relatedimages-section
         del csv_doc['spec']['relatedImages']
+
 
 def construct_related_images(manager_image):
     related_images = []
@@ -98,6 +103,7 @@ def construct_related_images(manager_image):
     # air-gapped installation, but has no reason to appear in operator manager's environment.
     related_images.append({'name': 'manager', 'image': manager_image})
     return related_images
+
 
 def parse_skips(spec, raw_name):
     raw_skips = spec.get("skips", [])
@@ -162,8 +168,14 @@ def get_previous_y_stream(version):
     return subprocess.check_output([executable, version], encoding='utf-8').strip()
 
 
+# This class configures ArgumentParser help to print default values and preserve linebreaks in argument help.
+class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    pass
+
+
 def parse_args():
-    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file')
+    parser = argparse.ArgumentParser(description='Patch StackRox Operator ClusterServiceVersion file',
+                                     formatter_class=HelpFormatter)
     parser.add_argument("--use-version", required=True, metavar='version',
                         help='Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0')
     parser.add_argument("--first-version", required=True, metavar='version',
@@ -171,7 +183,16 @@ def parse_args():
     parser.add_argument("--operator-image", required=True, metavar='image',
                         help='Which operator image to use in the patched CSV')
     parser.add_argument("--related-images-mode", choices=["downstream", "omit", "konflux"], default="downstream",
-                        help="Set mode of operation for handling related image settings.")
+                        help=textwrap.dedent("""
+                        Set mode of operation for handling related image attributes in the output CSV.
+                        Supported modes:
+                            downstream: In this mode the current RELATED_IMAGE_* environment variables are injected into
+                                the output CSV and spec.relatedImages is not added.
+                            omit: In this mode no RELATED_IMAGE_* environment variables are injected into the output CSV
+                                and spec.relatedImages is not added.
+                            konflux: In this mode the current RELATED_IMAGE_* environment variables are injected into the
+                                output CSV and spec.relatedImages is populated based on them.
+                        """).lstrip())
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p build/ && \
     ./bundle_helpers/patch-csv.py \
       --use-version "${OPERATOR_IMAGE_TAG}" \
       --first-version 3.62.0 \
+      --inject-related-images \
       --operator-image "${OPERATOR_IMAGE_REF}" \
       --add-supported-arch amd64 \
       --add-supported-arch arm64 \

--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p build/ && \
     ./bundle_helpers/patch-csv.py \
       --use-version "${OPERATOR_IMAGE_TAG}" \
       --first-version 3.62.0 \
-      --inject-related-images \
+      --related-images-mode=konflux \
       --operator-image "${OPERATOR_IMAGE_REF}" \
       --add-supported-arch amd64 \
       --add-supported-arch arm64 \


### PR DESCRIPTION
Goes on top of https://github.com/stackrox/stackrox/pull/12918, see https://github.com/stackrox/stackrox/pull/12918#discussion_r1793830904

Example:
```
$ operator/bundle_helpers/patch-csv.py --help         
usage: patch-csv.py [-h] --use-version version --first-version version --operator-image image
                    [--related-images-mode {downstream,omit,konflux}] [--add-supported-arch ADD_SUPPORTED_ARCH]
                    [--echo-replaced-version-only] [--unreleased UNRELEASED]

Patch StackRox Operator ClusterServiceVersion file

options:
  -h, --help            show this help message and exit
  --use-version version
                        Which SemVer version of the operator to set in the patched CSV, e.g. 3.62.0 (default: None)
  --first-version version
                        The first version of the operator that was published (default: None)
  --operator-image image
                        Which operator image to use in the patched CSV (default: None)
  --related-images-mode {downstream,omit,konflux}
                        Set mode of operation for handling related image attributes in the output CSV. "downstream": add
                        RELATED_IMAGE_* env variables, delete spec.relatedImages. "omit": ignore RELATED_IMAGE_* env variables,
                        delete spec.relatedImages. "konflux": add RELATED_IMAGE_* env variables, populate spec.relatedImages.
                        (default: downstream)
  --add-supported-arch ADD_SUPPORTED_ARCH
                        Enable specified operator architecture via CSV labels (may be passed multiple times) (default: [])
  --echo-replaced-version-only
                        Do not modify any files, just compute and echo the replaced operator version. (default: False)
  --unreleased UNRELEASED
                        Not yet released version of operator, if any. (default: None)
```