### PR TITLE
build: Drop clamav-scan resource requests

### DIFF
--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -121,11 +121,3 @@ spec:
           memory: 3Gi
         requests:
           memory: 3Gi
-  - pipelineTaskName: clamav-scan
-    stepSpecs:
-    # Provision more CPU to speed up ClamAV scan compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
-    - name: extract-and-scan-image
-      computeResources:
-        requests:
-          cpu: 1


### PR DESCRIPTION
### Description

Let the Konflux team manage these resources as they seem to be on track of doing that
https://github.com/konflux-ci/build-definitions/pull/1247

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No changes to automated testing.

#### How I validated my change

Only CI.
