### PR TITLE
fix: install gcloud CLI in job-preamble

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -20,6 +20,9 @@ runs:
         git config --global --add safe.directory "$(pwd)"
       shell: bash
 
+    - name: Set up gcloud CLI
+      uses: 'google-github-actions/setup-gcloud@v2'
+
     - name: Record job info
       uses: gacts/run-and-post-run@674528335da98a7afc80915ff2b4b860a0b3553a # v1.4.0
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -686,7 +686,7 @@ jobs:
         directory: 'junit-reports'
 
   scan-images-with-roxctl:
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     needs:
       - build-and-push-main
       - build-and-push-operator

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -686,7 +686,7 @@ jobs:
         directory: 'junit-reports'
 
   scan-images-with-roxctl:
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     needs:
       - build-and-push-main
       - build-and-push-operator


### PR DESCRIPTION
### Description

Fixes errors like: https://github.com/stackrox/stackrox/actions/runs/11275363888/job/31358119043

Investigation showed that `gcloud` was removed from the ubuntu-latest image:

Compare:
- new runner: https://github.com/actions/runner-images/blob/ubuntu24/20241006.1/images/ubuntu/Ubuntu2404-Readme.md
- older runner: https://github.com/actions/runner-images/blob/ubuntu22/20240922.1/images/ubuntu/Ubuntu2204-Readme.md (has Google Cloud CLI )

### User-facing documentation

- [x] update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~[ ] added unit tests~
- ~[ ] added e2e tests~
- ~[ ] added regression tests~
- ~[ ] added compatibility tests~
- ~[ ] modified existing tests~

#### How I validated my change

Forcing previously failing image vuln check job to run by removing gating for PRs.
Proof build: https://github.com/stackrox/stackrox/actions/runs/11276418382/job/31361542063?pr=12982.  