### PR TITLE
ROX-25990: Fix flake in SensorIntermediate events

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -181,15 +181,6 @@ func (c *sensorConnection) multiplexedPush(ctx context.Context, msg *central.Msg
 	queue.Push(msg)
 }
 
-func getSensorMessageTypeString(msg *central.MsgFromSensor) string {
-	messageType := reflectutils.Type(msg.GetMsg())
-	var eventType string
-	if msg.GetEvent() != nil {
-		eventType = event.GetEventTypeWithoutPrefix(msg.GetEvent().GetResource())
-	}
-	return fmt.Sprintf("%s_%s", messageType, eventType)
-}
-
 func (c *sensorConnection) runRecv(ctx context.Context, grpcServer central.SensorService_CommunicateServer) {
 	queues := make(map[string]*dedupingqueue.DedupingQueue[string])
 	for !c.stopSig.IsDone() {
@@ -204,7 +195,7 @@ func (c *sensorConnection) runRecv(ctx context.Context, grpcServer central.Senso
 			c.stopSig.SignalWithError(errors.Wrap(err, "recv error"))
 			return
 		}
-		metrics.SetGRPCLastMessageSizeReceived(getSensorMessageTypeString(msg), float64(msg.SizeVT()))
+		metrics.SetGRPCLastMessageSizeReceived(event.GetSensorMessageTypeString(msg), float64(msg.SizeVT()))
 		c.multiplexedPush(ctx, msg, queues)
 	}
 }

--- a/pkg/sensor/event/event.go
+++ b/pkg/sensor/event/event.go
@@ -8,6 +8,15 @@ import (
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
+func GetSensorMessageTypeString(msg *central.MsgFromSensor) string {
+	messageType := reflectutils.Type(msg.GetMsg())
+	var eventType string
+	if msg.GetEvent() != nil {
+		eventType = GetEventTypeWithoutPrefix(msg.GetEvent().GetResource())
+	}
+	return fmt.Sprintf("%s_%s", messageType, eventType)
+}
+
 // GetEventTypeWithoutPrefix trims the *central.SensorEvent_ from the event type
 func GetEventTypeWithoutPrefix(i interface{}) string {
 	return stringutils.GetAfter(reflectutils.Type(i), "_")

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -130,4 +130,5 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 	conn.Set(centralConnection)
 	f.changeState(centralConnection.GetState(), nil)
 	log.Infof("Initial gRPC connection with central state: %s", centralConnection.GetState())
+	// TODO: gRPC connection state may change after we leave this function!!!
 }

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -117,6 +117,6 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 	}
 
 	conn.Set(centralConnection)
-	f.okSignal.Signal()
+	f.okSignal.Signal() // this is too early to call the connection open!
 	log.Info("Initial gRPC connection with central successful")
 }

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -297,7 +297,7 @@ func (e *Store) purgeNoLock(deploymentID string) {
 		}
 	}
 	for containerID := range e.reverseContainerIDMap[deploymentID] {
-		log.Infof("Removing container %s from containerIDMap", containerID)
+		//log.Infof("Removing container %s from containerIDMap", containerID)
 		delete(e.containerIDMap, containerID)
 	}
 
@@ -380,7 +380,7 @@ func (e *Store) applySingleNoLock(deploymentID string, data EntityData) {
 			e.reverseContainerIDMap[deploymentID] = reverseContainerIDs
 		}
 		reverseContainerIDs[containerID] = struct{}{}
-		log.Infof("Adding container %s to containerIDMap", containerID)
+		//log.Infof("Adding container %s to containerIDMap", containerID)
 		e.containerIDMap[containerID] = metadata
 		mdsForCallback = append(mdsForCallback, metadata)
 	}

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -86,7 +86,7 @@ func NewStoreWithMemory(numTicks uint16) *Store {
 func (e *Store) initMaps() {
 	e.historyMutex.Lock()
 	defer e.historyMutex.Unlock()
-	log.Info("Cleaning containerIDMap")
+	log.Debug("Cleaning containerIDMap")
 	e.ipMap = make(map[net.IPAddress]map[string]struct{})
 	e.endpointMap = make(map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]struct{})
 	e.containerIDMap = make(map[string]ContainerMetadata)
@@ -424,7 +424,7 @@ func (e *Store) LookupByEndpoint(endpoint net.NumericEndpoint) []LookupResult {
 func (e *Store) LookupByContainerID(containerID string) (ContainerMetadata, bool) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
-	log.Infof("Searching for container %s in containerIDMap", containerID)
+	log.Debugf("Searching for container %s in containerIDMap", containerID)
 	metadata, ok := e.containerIDMap[containerID]
 	return metadata, ok
 }

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -424,7 +424,6 @@ func (e *Store) LookupByEndpoint(endpoint net.NumericEndpoint) []LookupResult {
 func (e *Store) LookupByContainerID(containerID string) (ContainerMetadata, bool) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
-	log.Debugf("Searching for container %s in containerIDMap", containerID)
 	metadata, ok := e.containerIDMap[containerID]
 	return metadata, ok
 }

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -3,13 +3,17 @@ package clusterentities
 import (
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/clusterentities/metrics"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // ContainerMetadata is the container metadata that is stored per instance

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -297,7 +297,6 @@ func (e *Store) purgeNoLock(deploymentID string) {
 		}
 	}
 	for containerID := range e.reverseContainerIDMap[deploymentID] {
-		//log.Infof("Removing container %s from containerIDMap", containerID)
 		delete(e.containerIDMap, containerID)
 	}
 
@@ -380,7 +379,6 @@ func (e *Store) applySingleNoLock(deploymentID string, data EntityData) {
 			e.reverseContainerIDMap[deploymentID] = reverseContainerIDs
 		}
 		reverseContainerIDs[containerID] = struct{}{}
-		//log.Infof("Adding container %s to containerIDMap", containerID)
 		e.containerIDMap[containerID] = metadata
 		mdsForCallback = append(mdsForCallback, metadata)
 	}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -526,9 +526,8 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 	log.Infof("enrichConnection: conn=%+v, status=%+v", *conn, *status)
 
 	container, ok := m.clusterEntities.LookupByContainerID(conn.containerID)
-	log.Infof("enrichConnection: all known cluster entities: %v", m.clusterEntities) // this causes DATA race, but we cannot access m.clusterEntities.mutex from here
+	log.Infof("enrichConnection: container %s found?=%t", conn.containerID, ok)
 	if !ok {
-		log.Infof("enrichConnection: container %s not found", conn.containerID)
 		// Expire the connection if the container cannot be found within the clusterEntityResolutionWaitPeriod
 		log.Infof("enrichConnection: timeElapsedSinceFirstSeen=%s", timeElapsedSinceFirstSeen.String())
 		if timeElapsedSinceFirstSeen > maxContainerResolutionWaitPeriod {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -862,15 +862,6 @@ func (m *networkFlowManager) enrichProcessesListening(hostConns *hostConnections
 
 func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (map[networkConnIndicator]timestamp.MicroTS, map[containerEndpointIndicator]timestamp.MicroTS) {
 	allHostConns := m.getAllHostConnections()
-	for i, conn := range allHostConns {
-		concurrency.WithLock(&conn.mutex, func() {
-			for c, status := range conn.connections {
-				log.Debugf("currentEnrichedConnsAndEndpoints: allHostConns: [%d]: host=%s conn=%+v, status=%+v",
-					i, conn.hostname, c, *status)
-
-			}
-		})
-	}
 
 	enrichedConnections := make(map[networkConnIndicator]timestamp.MicroTS)
 	enrichedEndpoints := make(map[containerEndpointIndicator]timestamp.MicroTS)
@@ -878,7 +869,7 @@ func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (map[networkConn
 		m.enrichHostConnections(hostConns, enrichedConnections)
 		m.enrichHostContainerEndpoints(hostConns, enrichedEndpoints)
 	}
-	log.Infof("currentEnrichedConnsAndEndpoints: enrichedConnections: %+v", enrichedConnections)
+	log.Debugf("Current enriched connections: %+v", enrichedConnections)
 
 	return enrichedConnections, enrichedEndpoints
 }
@@ -989,11 +980,6 @@ func (m *networkFlowManager) RegisterCollector(hostname string) (HostNetworkInfo
 			endpoints:   make(map[containerEndpoint]*connStatus),
 		}
 		m.connectionsByHost[hostname] = conns
-	}
-	for _, connections := range m.connectionsByHost {
-		if connections.connections == nil {
-			continue
-		}
 	}
 
 	conns.mutex.Lock()

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -339,6 +339,7 @@ func (m *networkFlowManager) Notify(e common.SensorComponentEvent) {
 	case common.SensorComponentEventResourceSyncFinished:
 		if features.SensorCapturesIntermediateEvents.Enabled() {
 			if m.initialSync.CompareAndSwap(false, true) {
+				log.Info("Resetting enricher ticker - inital sync false -> true")
 				m.enricherTicker.Reset(tickerTime)
 			}
 			return
@@ -346,6 +347,7 @@ func (m *networkFlowManager) Notify(e common.SensorComponentEvent) {
 		m.resetContext()
 		m.resetLastSentState()
 		m.centralReady.Signal()
+		log.Info("Resetting enricher ticker - sync finished")
 		m.enricherTicker.Reset(tickerTime)
 	case common.SensorComponentEventOfflineMode:
 		if features.SensorCapturesIntermediateEvents.Enabled() {
@@ -380,6 +382,8 @@ func (m *networkFlowManager) sendToCentral(msg *central.MsgFromSensor) bool {
 			// If the m.sensorUpdates queue is full, we bounce the Network Flow update.
 			// They will still be processed by the detection engine for newer entities, but
 			// sensor will not keep ordered updates indefinitely in memory.
+
+			log.Infof("Message %+v cannot be enqueued", msg)
 			return false
 		}
 	} else {
@@ -422,6 +426,7 @@ func (m *networkFlowManager) enrichConnections(tickerC <-chan time.Time) {
 		case <-m.stopper.Flow().StopRequested():
 			return
 		case <-tickerC:
+			log.Info("enriching connections tick")
 			if !features.SensorCapturesIntermediateEvents.Enabled() && !m.centralReady.IsDone() {
 				log.Info("Sensor is in offline mode: skipping enriching until connection is back up")
 				continue
@@ -445,8 +450,13 @@ func (m *networkFlowManager) getCurrentContext() context.Context {
 func (m *networkFlowManager) enrichAndSend() {
 	currentConns, currentEndpoints := m.currentEnrichedConnsAndEndpoints()
 
+	log.Infof("enrichAndSend: m.enrichedConnsLastSentState: %+v", m.enrichedConnsLastSentState)
+	log.Infof("enrichAndSend: m.enrichedEndpointsLastSentState: %+v", m.enrichedEndpointsLastSentState)
+
 	updatedConns := computeUpdatedConns(currentConns, m.enrichedConnsLastSentState, &m.lastSentStateMutex)
 	updatedEndpoints := computeUpdatedEndpoints(currentEndpoints, m.enrichedEndpointsLastSentState, &m.lastSentStateMutex)
+	log.Infof("enrichAndSend: updatedConns: %+v", updatedConns)
+	log.Infof("enrichAndSend: updatedEndpoints: %+v", updatedEndpoints)
 
 	if len(updatedConns)+len(updatedEndpoints) == 0 {
 		return
@@ -469,15 +479,18 @@ func (m *networkFlowManager) enrichAndSend() {
 		m.policyDetector.ProcessNetworkFlow(detectionContext, flow)
 	}
 
-	log.Debugf("Flow update : %v", protoToSend)
+	log.Infof("Sending flow update to central: %v", protoToSend)
 	if m.sendToCentral(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_NetworkFlowUpdate{
 			NetworkFlowUpdate: protoToSend,
 		},
 	}) {
+		log.Info("Flow has been enqueued in sensorUpdates")
 		m.updateConnectionStates(currentConns, currentEndpoints)
 		metrics.IncrementTotalNetworkFlowsSentCounter(len(protoToSend.Updated))
 		metrics.IncrementTotalNetworkEndpointsSentCounter(len(protoToSend.UpdatedEndpoints))
+	} else {
+		log.Info("Flow has NOT been enqueued in sensorUpdates")
 	}
 	metrics.SetNetworkFlowBufferSizeGauge(len(m.sensorUpdates))
 }
@@ -516,6 +529,8 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		if timeElapsedSinceFirstSeen > maxContainerResolutionWaitPeriod {
 			if activeConn, found := m.activeConnections[*conn]; found {
 				enrichedConnections[*activeConn] = timestamp.Now()
+				log.Debugf("Expiring connection %q. Reason: more time has elapsed than %s",
+					conn.String(), maxContainerResolutionWaitPeriod.String())
 				delete(m.activeConnections, *conn)
 				flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 				return
@@ -559,6 +574,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		// If the address is set and is not resolvable, we want to we wait for `clusterEntityResolutionWaitPeriod` time
 		// before associating it to a known network or INTERNET.
 		if isFresh && conn.remote.IPAndPort.Address.IsValid() {
+			log.Debugf("Cluster entity not found, but connection %q is fresh and has valid IP", conn.String())
 			return
 		}
 
@@ -568,6 +584,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		}
 
 		if isFresh {
+			log.Debugf("Cluster entity not found, but connection %q is fresh", conn.String())
 			return
 		}
 
@@ -641,8 +658,9 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		}
 		status.used = true
 		if conn.incoming {
-			// Only report incoming connections from outside of the cluster. These are already taken care of by the
+			// Only report incoming connections from outside the cluster. These are already taken care of by the
 			// corresponding outgoing connection from the other end.
+			log.Debugf("Skipping enriching connection %q because it originates outside of the cluster", conn.String())
 			return
 		}
 	}
@@ -665,12 +683,19 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			// Multiple connections from a collector can result in a single enriched connection
 			// hence update the timestamp only if we have a more recent connection than the one we have already enriched.
 			if oldTS, found := enrichedConnections[indicator]; !found || oldTS < status.lastSeen {
+				if !found {
+					log.Debugf("Connection %q not found in previously enriched connections", conn.String())
+				} else {
+					log.Debugf("Connection %q - updating lastSeen", conn.String())
+				}
 				enrichedConnections[indicator] = status.lastSeen
 				if features.SensorCapturesIntermediateEvents.Enabled() {
 					if status.lastSeen == timestamp.InfiniteFuture {
 						m.activeConnections[*conn] = &indicator
+						log.Debugf("Connection %q: adding to active connections", conn.String())
 						flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 					} else {
+						log.Debugf("Connection %q: removing from active connections", conn.String())
 						delete(m.activeConnections, *conn)
 						flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 					}
@@ -773,8 +798,11 @@ func (m *networkFlowManager) enrichHostConnections(hostConns *hostConnections, e
 	prevSize := len(hostConns.connections)
 	for conn, status := range hostConns.connections {
 		m.enrichConnection(&conn, status, enrichedConnections)
-		if status.rotten || (status.used && status.lastSeen != timestamp.InfiniteFuture) {
+		noLongerActive := status.used && status.lastSeen != timestamp.InfiniteFuture
+		if status.rotten || noLongerActive {
 			// connections that are no longer active and have already been used can be deleted.
+			log.Debugf("Connection %q is rotten=%t or no longer active=%t (used=%t, lastSeen=%d)",
+				conn.String(), status.rotten, noLongerActive, status.used, status.lastSeen)
 			delete(hostConns.connections, conn)
 		}
 	}
@@ -821,6 +849,12 @@ func (m *networkFlowManager) enrichProcessesListening(hostConns *hostConnections
 
 func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (map[networkConnIndicator]timestamp.MicroTS, map[containerEndpointIndicator]timestamp.MicroTS) {
 	allHostConns := m.getAllHostConnections()
+	for i, conn := range allHostConns {
+		concurrency.WithLock(&conn.mutex, func() {
+			log.Infof("currentEnrichedConnsAndEndpoints: allHostConns: [%d]:%+v", i, conn)
+
+		})
+	}
 
 	enrichedConnections := make(map[networkConnIndicator]timestamp.MicroTS)
 	enrichedEndpoints := make(map[containerEndpointIndicator]timestamp.MicroTS)
@@ -828,6 +862,8 @@ func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (map[networkConn
 		m.enrichHostConnections(hostConns, enrichedConnections)
 		m.enrichHostContainerEndpoints(hostConns, enrichedEndpoints)
 	}
+	log.Infof("currentEnrichedConnsAndEndpoints: enrichedConnections: %+v", enrichedConnections)
+	log.Infof("currentEnrichedConnsAndEndpoints: enrichedEndpoints: %+v", enrichedEndpoints)
 
 	return enrichedConnections, enrichedEndpoints
 }
@@ -939,6 +975,15 @@ func (m *networkFlowManager) RegisterCollector(hostname string) (HostNetworkInfo
 		}
 		m.connectionsByHost[hostname] = conns
 	}
+	for host, connections := range m.connectionsByHost {
+		if connections.connections == nil {
+			log.Infof("RegisterCollector: connections.connections for hostname %s is nil", host)
+			continue
+		}
+		for conn, status := range connections.connections {
+			log.Infof("RegisterCollector: connection for host [%s]: %s, status: %v", host, conn.String(), status)
+		}
+	}
 
 	conns.mutex.Lock()
 	defer conns.mutex.Unlock()
@@ -972,6 +1017,7 @@ func (m *networkFlowManager) deleteHostConnections(hostname string) {
 		return
 	}
 	flowMetrics.HostConnectionsRemoved.Add(float64(len(conns.connections)))
+	log.Infof("deleteHostConnections: deleting connection for host: %s", hostname)
 	delete(m.connectionsByHost, hostname)
 }
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -542,7 +542,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 	*/
 
 	container, ok := m.clusterEntities.LookupByContainerID(conn.containerID)
-	log.Infof("enrichConnection: all known cluster entities: %v", m.clusterEntities)
+	log.Infof("enrichConnection: all known cluster entities: %v", m.clusterEntities) // this causes DATA race, but we cannot access m.clusterEntities.mutex from here
 	if !ok {
 		log.Infof("enrichConnection: container %s not found", conn.containerID)
 		// Expire the connection if the container cannot be found within the clusterEntityResolutionWaitPeriod

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -525,22 +525,6 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 
 	log.Infof("enrichConnection: conn=%+v, status=%+v", *conn, *status)
 
-	/*
-		hostname:fake-collector
-		connections:map[
-			{
-				local:{Address:{data:<nil>} Port:0 IPNetwork:{ip:{data:<nil>} prefixLen:0}}
-				remote:{IPAndPort:{Address:{data:[34 118 224 251]} Port:80 IPNetwork:{ip:{data:<nil>} prefixLen:0}} L4Proto:0}
-				containerID:32b0ff124fa4 incoming:false
-			}:0xc0027c8b70 <- to jest status!
-			{
-				local:{Address:{data:<nil>} Port:80 IPNetwork:{ip:{data:<nil>} prefixLen:0}}
-				remote:{IPAndPort:{Address:{data:[10 57 162 11]} Port:0 IPNetwork:{ip:{data:<nil>} prefixLen:0}} L4Proto:0}
-				containerID:4762073dc1bb incoming:true
-			}:0xc0027c8b88
-		]
-	*/
-
 	container, ok := m.clusterEntities.LookupByContainerID(conn.containerID)
 	log.Infof("enrichConnection: all known cluster entities: %v", m.clusterEntities) // this causes DATA race, but we cannot access m.clusterEntities.mutex from here
 	if !ok {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -539,7 +539,7 @@ func (m *networkFlowManager) handleContainerNotFound(conn *connection, status *c
 			flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 			return
 		}
-		reasons = append(reasons, fmt.Sprintf("connection is inactive"))
+		reasons = append(reasons, "connection is inactive")
 		status.rotten = true
 		// Only increment metric once the connection is marked rotten
 		flowMetrics.ContainerIDMisses.Inc()

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -482,6 +482,10 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		exponential.Reset()
 		log.Infof("Waiting for sensor or central communication to stop...")
 		select {
+		case <-s.centralConnectionFactory.StopSignal().WaitC():
+			log.Infof("CentralConnectionFactory stopped")
+			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
+			return wrapOrNewErrorf(s.centralCommunication.Stopped().Err(), "communication stopped (stopped signal)")
 		case <-s.centralCommunication.Stopped().WaitC():
 			if err := s.centralCommunication.Stopped().Err(); err != nil {
 				if errors.Is(err, errCantReconcile) {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -501,11 +501,13 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 }
 
 func (s *Sensor) goOnlineWhenGRPCReady(ctx context.Context) {
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Second):
+		case <-timer.C:
 			state, _ := s.centralConnectionFactory.ConnectionState()
 			if state == connectivity.Ready {
 				s.changeState(common.SensorComponentEventCentralReachable)

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -455,7 +455,6 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			s.changeState(common.SensorComponentEventCentralReachable)
 		case connectivity.Connecting:
 			// Do nothing, let it connect
-			go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection, s.certLoader)
 			return errors.New("Connection is in connecting state")
 		default:
 			s.changeState(common.SensorComponentEventOfflineMode)

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -43,6 +43,10 @@ func MakeFakeConnectionFactory(c *grpc.ClientConn) *fakeGRPCClient {
 	}
 }
 
+func (f *fakeGRPCClient) StopSignal() concurrency.ReadOnlyErrorSignal {
+	return &f.stopSig
+}
+
 func (f *fakeGRPCClient) ConnectionState() (connectivity.State, error) {
 	f.connMtx.Lock()
 	defer f.connMtx.Unlock()

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -43,6 +43,8 @@ func MakeFakeConnectionFactory(c *grpc.ClientConn) *fakeGRPCClient {
 	}
 }
 
+// StopSignal is raised when there is an error during establishing gRPC connection.
+// It should be used to trigger another retry in cases when the connection cannot self-heal.
 func (f *fakeGRPCClient) StopSignal() concurrency.ReadOnlyErrorSignal {
 	return &f.stopSig
 }

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -62,9 +62,12 @@ func (f *fakeGRPCClient) OverwriteCentralConnection(newConn *grpc.ClientConn) {
 // SetCentralConnectionWithRetries is the implementation of the concurrent function SetCentralConnectionWithRetries
 // that sensor uses to set the gRPC connection to all its components. Present test version simply.
 func (f *fakeGRPCClient) SetCentralConnectionWithRetries(ptr *util.LazyClientConn, _ centralclient.CertLoader) {
+	defer roxlog.Infof("SetCentralConnectionWithRetries: done")
+	roxlog.Infof("SetCentralConnectionWithRetries: waiting for conn mutex")
 	concurrency.WithLock(f.connMtx, func() {
 		ptr.Set(f.conn)
 	})
+	roxlog.Infof("SetCentralConnectionWithRetries: waiting for state mutex")
 	concurrency.WithLock(f.stateMtx, func() {
 		if f.currentState != f.conn.GetState() {
 			roxlog.Infof("State change from %s to %s", f.currentState.String(), f.conn.GetState().String())

--- a/sensor/tests/complianceoperator/crd_test.go
+++ b/sensor/tests/complianceoperator/crd_test.go
@@ -22,9 +22,10 @@ func Test_ComplianceOperatorCRDsDetection(t *testing.T) {
 		InitialSystemPolicies: nil,
 		CertFilePath:          "../../../tools/local-sensor/certs/",
 	}, startSensor.WaitC())
+	t.Cleanup(c.Stop)
 	require.NoError(t, err)
 
-	t.Cleanup(c.Stop)
+	t.Log("Starting sensor")
 	startSensor.Signal()
 
 	t.Log("Starting testcase")

--- a/sensor/tests/complianceoperator/crd_test.go
+++ b/sensor/tests/complianceoperator/crd_test.go
@@ -24,9 +24,12 @@ func Test_ComplianceOperatorCRDsDetection(t *testing.T) {
 
 	require.NoError(t, err)
 
+	t.Log("Starting testcase")
 	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 		// Wait for the first sync
+		t.Log("Waiting for sync event")
 		testContext.WaitForSyncEvent(t, 10*time.Second)
+		t.Log("Clearing central buffer")
 		testContext.GetFakeCentral().ClearReceivedBuffer()
 
 		// Create the Compliance Operator CRDs
@@ -39,6 +42,7 @@ func Test_ComplianceOperatorCRDsDetection(t *testing.T) {
 		})
 
 		// Sensor should sync again after the CRDs are detected
+		t.Log("Waiting for sync event after detecting CRDs")
 		testContext.WaitForSyncEventf(t, 10*time.Second, "expected restart connection after CRDs are detected")
 		testContext.GetFakeCentral().ClearReceivedBuffer()
 
@@ -46,6 +50,7 @@ func Test_ComplianceOperatorCRDsDetection(t *testing.T) {
 		require.NoError(t, deleteCRDsFn())
 
 		// Sensor should sync again after the CRDs removal is detected
+		t.Log("Waiting for sync event after removing CRDs")
 		testContext.WaitForSyncEventf(t, 10*time.Second, "expected restart connection after CRDs are removed")
 	}))
 

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -91,6 +91,7 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		require.NotEqual(t, "", talkIP)
 
 		if !helper.UseRealCollector.BooleanSetting() {
+			t.Log("Using fake collector messages for the test")
 			nginxPodIDs, nginxContainerIDs := c.GetContainerIdsFromDeployment(nginxObj)
 			require.Len(t, nginxPodIDs, 1)
 			require.Len(t, nginxContainerIDs, 1)
@@ -152,8 +153,10 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		}, time.Minute)
 		assert.NoError(t, err)
 		assert.NotNil(t, msg)
+		t.Logf("Expecting Network Flow for %s -> %s", talkUID, nginxUID)
 		msg, err = testContext.WaitForMessageWithMatcher(func(event *central.MsgFromSensor) bool {
 			for _, flow := range event.GetNetworkFlowUpdate().GetUpdated() {
+				t.Logf("Processing Flow: %v - %v", flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity())
 				if flow.GetProps().GetSrcEntity().GetId() == talkUID && flow.GetProps().GetDstEntity().GetId() == nginxUID {
 					return true
 				}

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -67,7 +67,9 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		// Wait for collector to connect
 		waitIfRealCollector(30 * time.Second)
 		testContext.GetFakeCentral().ClearReceivedBuffer()
+		t.Log("Stopping Central GRPC")
 		testContext.StopCentralGRPC()
+		t.Log("Central GRPC stopped")
 
 		// Nginx deployment
 		nginxObj := helper.ObjByKind(NginxDeployment.Kind)
@@ -136,6 +138,7 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		require.NoError(t, messagesReceivedSignal.Wait())
 
 		// We need to wait here at least 30s to make sure the network flows are processed
+		t.Log("Waiting 60s for Sensor to process the network flows")
 		time.Sleep(60 * time.Second)
 
 		require.NoError(t, deleteTalk())
@@ -144,7 +147,9 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		require.NoError(t, testContext.WaitForResourceDeleted(nginxObj))
 		require.NoError(t, deleteService())
 
+		t.Log("Starting GRPC connection to fake Central")
 		testContext.StartFakeGRPC()
+		t.Log("Waiting for sync event")
 		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
 		msg, err := testContext.WaitForMessageWithMatcher(func(event *central.MsgFromSensor) bool {

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -58,7 +58,8 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 	var fakeCollector *collector.FakeCollector
 	if !helper.UseRealCollector.BooleanSetting() {
 		fakeCollector = collector.NewFakeCollector(collector.WithDefaultConfig().WithCertsPath(config.CertFilePath))
-		require.NoError(t, fakeCollector.Start())
+		t.Logf("Starting fake collector (requires sensor to be up and running)")
+		require.NoErrorf(t, fakeCollector.Start(), "Could not start fake collector")
 	}
 
 	t.Log("Starting testcase")

--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -141,8 +141,7 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 		require.NoError(t, messagesReceivedSignal.Wait())
 
 		// We need to wait here at least 30s to make sure the network flows are processed
-		t.Log("Messages from Collector received")
-		t.Log("Waiting 60s for Sensor to process the network flows")
+		t.Log("Messages from Collector received. Waiting 60s for Sensor to process the network flows")
 		time.Sleep(60 * time.Second)
 
 		t.Log("Deleting test resources")

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -931,15 +931,10 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService, l log
 	}()
 
 	l.Logf("Creating new grpc client")
-	conn, err := grpc.NewClient("",
-		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-			return listener.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	//conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-	//	return listener.Dial()
-	//}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// DialContext is deprecated, but when this is called with NewClient, then the connection status is stuck in IDLE state
+	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	if err != nil {
 		panic(err)

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -927,7 +927,7 @@ func (c *TestContext) startSensorInstance(t *testing.T, env *envconf.Config, cfg
 		c.fakeCentral.KillSwitch.Done()
 		centralHTTPServer.Close()
 	}
-	t.Logf("Running starting Sensor")
+	t.Logf("Asynchronously starting Sensor...")
 	go s.Start()
 	t.Logf("Waiting for Central connection to be established")
 	c.fakeCentral.ConnectionStarted.Wait()

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -921,6 +921,7 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService, l log
 
 	go func() {
 		utils.IgnoreError(func() error {
+			l.Logf("Starting fake Central server")
 			err := fakeCentral.ServerPointer.Serve(listener)
 			if err != nil {
 				l.Logf("failed to start fake Central server: %v", err)
@@ -929,9 +930,16 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService, l log
 		})
 	}()
 
-	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-		return listener.Dial()
-	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	l.Logf("Creating new grpc client")
+	conn, err := grpc.NewClient("",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	//conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+	//	return listener.Dial()
+	//}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	if err != nil {
 		panic(err)

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -210,7 +210,7 @@ func NewContextWithConfigAndStart(t *testing.T, config Config, start <-chan stru
 		tc.StartFakeGRPC(config.CentralCaps...)
 		t.Logf("Starting sensor")
 		tc.startSensorInstance(t, envConfig, config)
-		t.Logf("Started")
+		t.Logf("Sensor started")
 	}()
 	return &tc, nil
 }
@@ -320,6 +320,7 @@ func (c *TestContext) RestartFakeCentralConnection(centralCaps ...string) {
 
 // StartFakeGRPC will start a gRPC server to act as Central.
 func (c *TestContext) StartFakeGRPC(centralCaps ...string) {
+	defer c.l.Logf("Fake GRPC start triggered")
 	c.deduperStateLock.Lock()
 	defer c.deduperStateLock.Unlock()
 	c.centralStopped.Store(false)
@@ -341,6 +342,7 @@ func (c *TestContext) StartFakeGRPC(centralCaps ...string) {
 	if c.grpcFactory == nil {
 		c.grpcFactory = centralDebug.MakeFakeConnectionFactory(conn)
 	} else {
+		c.l.Logf("Overwriting Central connection")
 		c.grpcFactory.OverwriteCentralConnection(conn)
 	}
 

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -958,12 +958,6 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService, l log
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	//conn, err := grpc.NewClient("",
-	//	grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-	//		return listener.Dial()
-	//	}),
-	//	grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
 	}

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -932,10 +932,19 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService, l log
 
 	l.Logf("Creating new grpc client")
 	// DialContext is deprecated, but when this is called with NewClient, then the connection status is stuck in IDLE state
+	// DialContext explicitly states that: "At the end of this method, we kick the channel out of idle, rather than
+	// waiting for the first rpc".
+	// Treating state IDLE as a condition for Sensor to go online results in error:
+	// Communication with Central stopped: opening stream: failed to exit idle mode: dns resolver: missing address. Retrying.
 	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 		return listener.Dial()
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 
+	//conn, err := grpc.NewClient("",
+	//	grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+	//		return listener.Dial()
+	//	}),
+	//	grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
 	}

--- a/tools/local-sensor/scripts/local-sensor.sh
+++ b/tools/local-sensor/scripts/local-sensor.sh
@@ -13,6 +13,7 @@ LOCAL_SENSOR_BIN=local-sensor
 EXEC=$OUTPUT_DIR/$LOCAL_SENSOR_BIN
 PROMETHEUS_ENDPOINT=http://localhost:9090
 ROX_METRICS_PORT=:9091
+LOGLEVEL=debug
 PROMETHEUS_QUERY=rox_sensor_sensor_events
 PROMETHEUS_DUMP=$OUTPUT_DIR/sensor_events_dump.json
 
@@ -43,6 +44,7 @@ function generate_k8s_events() {
 function run_test() {
   [[ "$VERBOSE" == "false" ]] || echo "Running tests with: $K8S_EVENTS_FILE"
   export ROX_METRICS_PORT=$ROX_METRICS_PORT
+  export LOGLEVEL=$LOGLEVEL
   { time $EXEC -replay -replay-in="$K8S_EVENTS_FILE" -delay=0s -with-metrics -with-policies="$POLICIES_FILE" -central-out=/dev/null > "$OUTPUT_DIR"/test.log 2>&1 ; } > "$TIME_FILE" 2>&1 &
   TIME_PID=$!
   SENSOR_PID=$(pgrep -P $TIME_PID)


### PR DESCRIPTION
### Description

Opened as a continuation to https://github.com/stackrox/stackrox/pull/12781 cause the limit of auto-retest attempts was exhausted.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [x] CI, including sensor integration tests
- [x] Manual tests on GKE cluster including:
    - Killing Central pod randomly 
    - Killing Sensor pod randomly 
    - Using toxi-proxy with profiles: latency, reset_peer, timeout
 
 ... and making sure that the connection is reestablished.
