### PR TITLE
ROX-26109, ROX-25497: Standard logging, resync period changes

### DIFF
--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -23,16 +23,20 @@ import (
 	"github.com/pkg/errors"
 	configstackroxiov1alpha1 "github.com/stackrox/rox/config-controller/api/v1alpha1"
 	"github.com/stackrox/rox/config-controller/pkg/client"
+	"github.com/stackrox/rox/pkg/logging"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	policyFinalizer = "securitypolicies.config.stackrox.io/finalizer"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // SecurityPolicyReconciler reconciles a SecurityPolicy object
@@ -47,8 +51,7 @@ type SecurityPolicyReconciler struct {
 //+kubebuilder:rbac:groups=config.stackrox.io,resources=policies/finalizers,verbs=update
 
 func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	rlog := log.FromContext(ctx)
-	rlog.Info("Reconciling", "namespace", req.Namespace, "name", req.Name)
+	log.Infof("Reconciling resource %q/%q", req.Namespace, req.Name)
 
 	// Get the policy CR
 	policyCR := &configstackroxiov1alpha1.SecurityPolicy{}
@@ -82,8 +85,9 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			Message:  retErr.Error(),
 		}
 		if err := r.K8sClient.Status().Update(ctx, policyCR); err != nil {
-			rlog.Error(err, "error updating status for securitypolicy '%s'", policyCR.GetName())
-			return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Failed to set status on security policy resource '%s'", policyCR.GetName()))
+			errMsg := fmt.Sprintf("error updating status for securitypolicy '%s'", policyCR.GetName())
+			log.Debug(errMsg)
+			return ctrl.Result{}, errors.Wrap(err, errMsg)
 		}
 		// We do not want this reconcile request to be requeued since it has a name collision
 		// with an existing default policy hence return nil error.
@@ -134,6 +138,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// policy create or update flow
 	var retErr error
 	if desiredState.GetId() != "" {
+		log.Debugf("Updating policy %q (ID: %q)", desiredState.GetName(), desiredState.GetId())
 		if err := r.PolicyClient.UpdatePolicy(ctx, desiredState); err != nil {
 			retErr = errors.Wrap(err, fmt.Sprintf("Failed to update policy '%s'", desiredState.GetName()))
 			policyCR.Status = configstackroxiov1alpha1.SecurityPolicyStatus{
@@ -148,6 +153,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 	} else {
+		log.Debugf("Creating policy with name %q", desiredState.GetName())
 		if createdPolicy, err := r.PolicyClient.CreatePolicy(ctx, desiredState); err != nil {
 			retErr = errors.Wrap(err, fmt.Sprintf("Failed to create policy '%s'", desiredState.GetName()))
 			policyCR.Status = configstackroxiov1alpha1.SecurityPolicyStatus{
@@ -170,8 +176,9 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if err := r.K8sClient.Status().Update(ctx, policyCR); err != nil {
-		rlog.Error(err, "error updating status for securitypolicy", "name", policyCR.GetName())
-		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Failed to set status on security policy resource '%s'", policyCR.GetName()))
+		errMsg := fmt.Sprintf("error updating status for securitypolicy %q", policyCR.GetName())
+		log.Debug(errMsg)
+		return ctrl.Result{}, errors.Wrap(err, errMsg)
 	}
 
 	return ctrl.Result{}, retErr

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -8,20 +8,22 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/size"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var centralHostPort = fmt.Sprintf("central.%s.svc:443", env.Namespace.Setting())
+var (
+	centralHostPort = fmt.Sprintf("central.%s.svc:443", env.Namespace.Setting())
+	log             = logging.LoggerForModule()
+)
 
 // The config-controller often becomes ready before Central.
 // Therefore it's common for this client to need to try to connect to Central several times before it succeeds.
@@ -48,7 +50,7 @@ func (c *perRPCCreds) RequireTransportSecurity() bool {
 }
 
 func (c *perRPCCreds) refreshToken(ctx context.Context) error {
-	getLogger(ctx).Info("Refreshing Central API token")
+	log.Info("Refreshing Central API token")
 	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return errors.WithMessage(err, "error reading service account token file")
@@ -212,13 +214,13 @@ func New(ctx context.Context, opts ...clientOptions) (CachedPolicyClient, error)
 		err := retry.WithRetry(func() error {
 			gc, innerErr := newGrpcClient(ctx)
 			if innerErr != nil {
-				getLogger(ctx).Error(innerErr, "Failed to connect to Central")
+				log.Error(innerErr, "Failed to connect to Central")
 			}
 
 			c.svc = gc
 
 			if innerErr = c.EnsureFresh(ctx); innerErr != nil {
-				getLogger(ctx).Error(innerErr, "Failed to initialize client")
+				log.Error(innerErr, "Failed to initialize client")
 			}
 
 			return innerErr
@@ -229,7 +231,7 @@ func New(ctx context.Context, opts ...clientOptions) (CachedPolicyClient, error)
 		}
 	} else {
 		if err := c.EnsureFresh(ctx); err != nil {
-			getLogger(ctx).Error(err, "Failed to initialize client")
+			log.Error(err, "Failed to initialize client")
 		}
 	}
 
@@ -250,7 +252,7 @@ func (c *client) GetPolicy(_ context.Context, name string) (*storage.Policy, boo
 }
 
 func (c *client) CreatePolicy(ctx context.Context, policy *storage.Policy) (*storage.Policy, error) {
-	getLogger(ctx).Info("POST", "policyName", policy.Name)
+	log.Infof("Creating policy %q", policy.Name)
 	createdPolicy, err := c.svc.PostPolicy(ctx, policy)
 
 	if err != nil {
@@ -264,7 +266,7 @@ func (c *client) CreatePolicy(ctx context.Context, policy *storage.Policy) (*sto
 }
 
 func (c *client) UpdatePolicy(ctx context.Context, policy *storage.Policy) error {
-	getLogger(ctx).Info("PUT", "policyName", policy.Name)
+	log.Infof("Updating policy %q", policy.Name)
 
 	var existingPolicyName string
 	if id, ok := c.policyNameToIDCache[policy.GetName()]; ok {
@@ -286,7 +288,7 @@ func (c *client) UpdatePolicy(ctx context.Context, policy *storage.Policy) error
 }
 
 func (c *client) DeletePolicy(ctx context.Context, name string) error {
-	getLogger(ctx).Info("DELETE", "policyName", name)
+	log.Infof("Deleting policy %q", name)
 	policyID, ok := c.policyNameToIDCache[name]
 	if !ok {
 		return nil
@@ -310,9 +312,9 @@ func (c *client) FlushCache(ctx context.Context) error {
 		return nil
 	}
 
-	getLogger(ctx).Info("Flushing policy cache")
+	log.Info("Flushing policy cache")
 
-	getLogger(ctx).Info("LIST")
+	log.Debug("Listing policies")
 	allPolicies, err := c.svc.ListPolicies(ctx)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list policies")
@@ -322,7 +324,7 @@ func (c *client) FlushCache(ctx context.Context) error {
 	newPolicyNameToIDCache := make(map[string]string, len(allPolicies))
 
 	for _, listPolicy := range allPolicies {
-		getLogger(ctx).Info("GET", "Name", listPolicy.GetName())
+		log.Debugf("Get policy: %s", listPolicy.GetName())
 		policy, err := c.svc.GetPolicy(ctx, listPolicy.Id)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to fetch policy %s", listPolicy.Id)
@@ -348,8 +350,4 @@ func (c *client) EnsureFresh(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func getLogger(ctx context.Context) logr.Logger {
-	return log.FromContext(ctx).WithName("central-client")
 }


### PR DESCRIPTION
### Description
1.  Use the standard rox logging library in pkg for logging instead of the controller framework logging.
2.  Modify logs to debug and reword info logs for readability and consistency.
3.  Set the manager cache option for resync period to 4h (default is 10h) to allow the config controller to force resync CRs every 4h.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manual for logging, forced resync untested.