### PR TITLE
ROX-26596: Fix text assertion - cluster is helm managed

### DIFF
--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -231,7 +231,7 @@ class CertRotationTest extends BaseSpecification {
 
     def "Test sensor cert rotation with upgrader fails for Helm clusters"() {
         when:
-        "Check that the cluster is Helm-managed"
+        "Check that the cluster is managed by external tools"
         def cluster = ClusterService.getCluster()
         assert cluster
 
@@ -246,7 +246,7 @@ class CertRotationTest extends BaseSpecification {
             SensorUpgradeService.triggerCertRotation(cluster.getId())
         } catch (StatusRuntimeException exc) {
             caughtException = true
-            assert exc.status.description.contains("cluster is Helm-managed")
+            assert exc.status.description.contains("External tools (Helm or Operator) control the secured cluster version.")
         }
         assert caughtException
     }

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -32,6 +32,9 @@ import spock.lang.Tag
 @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
 class CertRotationTest extends BaseSpecification {
 
+    private static final String CLUSTER_VERSION_MANAGED_ERROR =
+      "External tools (Helm or Operator) control the secured cluster version."
+
     def generateCerts(String path, String expectedFileName, JsonObject data = null) {
         def resp = DirectHTTPService.post(path, data)
         assert resp.getResponseCode() == 200
@@ -246,7 +249,7 @@ class CertRotationTest extends BaseSpecification {
             SensorUpgradeService.triggerCertRotation(cluster.getId())
         } catch (StatusRuntimeException exc) {
             caughtException = true
-            assert exc.status.description.contains("External tools (Helm or Operator) control the secured cluster version.")
+            assert exc.status.description.contains(CLUSTER_VERSION_MANAGED_ERROR)
         }
         assert caughtException
     }


### PR DESCRIPTION
### Description

Part of: [ROX-26411](https://issues.redhat.com/browse/ROX-26411)
This has not been caught in #12833.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

CI
