### PR TITLE
build: Try build `main` image's source container harder

### DIFF
--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -465,6 +465,10 @@ spec:
     - input: $(params.build-source-image)
       operator: in
       values: [ "true" ]
+    # Pushing source container for main is known to fail a lot with timeout in Quay. See KFLUXBUGS-1508
+    # By trying a few more times, we hope to make this step succeed and not fail the pipeline.
+    # TODO: remove retries once KFLUXBUGS-1508 gets resolved.
+    retries: 3
 
   - name: deprecated-base-image-check
     params:


### PR DESCRIPTION
### Description

See https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1728643044463389

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change to automated testing.

#### How I validated my change

If it passes CI, the fix helped.