### PR TITLE
ROX-26574: Sort images table by cve severity count

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -31,8 +31,8 @@ import {
     aggregateByDistinctCount,
     getScoreVersionsForTopCVSS,
     sortCveDistroList,
-    getWorkloadSortFields,
-    getDefaultWorkloadSortOption,
+    getWorkloadCveOverviewSortFields,
+    getWorkloadCveOverviewDefaultSortOption,
     getSeveritySortOptions,
 } from '../../utils/sortUtils';
 import {
@@ -60,8 +60,8 @@ function RequestCVEsTable({
 }: RequestCVEsTableProps) {
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: getWorkloadSortFields('CVE'),
-        defaultSortOption: getDefaultWorkloadSortOption('CVE'),
+        sortFields: getWorkloadCveOverviewSortFields('CVE'),
+        defaultSortOption: getWorkloadCveOverviewDefaultSortOption('CVE'),
         onSort: () => setPage(1),
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -17,7 +17,6 @@ import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { getDefaultWorkloadSortOption, getWorkloadSortFields } from '../../utils/sortUtils';
 import ImageResourceTable, { ImageResources, imageResourcesFragment } from './ImageResourceTable';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
@@ -40,8 +39,8 @@ function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageRes
     const { baseSearchFilter } = useWorkloadCveViewContext();
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: getWorkloadSortFields('Image'),
-        defaultSortOption: getDefaultWorkloadSortOption('Image'),
+        sortFields: ['Image'],
+        defaultSortOption: { field: 'Image', direction: 'asc' },
         onSort: () => setPage(1),
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -17,7 +17,6 @@ import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { getDefaultWorkloadSortOption, getWorkloadSortFields } from '../../utils/sortUtils';
 import DeploymentResourceTable, {
     DeploymentResources,
     deploymentResourcesFragment,
@@ -43,8 +42,8 @@ function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
     const { baseSearchFilter } = useWorkloadCveViewContext();
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
-        sortFields: getWorkloadSortFields('Deployment'),
-        defaultSortOption: getDefaultWorkloadSortOption('Deployment'),
+        sortFields: ['Deployment', 'Cluster', 'Namespace', 'Created'],
+        defaultSortOption: { field: 'Deployment', direction: 'asc' },
         onSort: () => setPage(1),
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -28,9 +28,9 @@ import useAnalytics, {
 import useLocalStorage from 'hooks/useLocalStorage';
 import { SearchFilter } from 'types/search';
 import {
-    getDefaultWorkloadSortOption,
+    getWorkloadCveOverviewDefaultSortOption,
     getDefaultZeroCveSortOption,
-    getWorkloadSortFields,
+    getWorkloadCveOverviewSortFields,
     syncSeveritySortOption,
 } from 'Containers/Vulnerabilities/utils/sortUtils';
 import useURLSort from 'hooks/useURLSort';
@@ -182,7 +182,7 @@ function WorkloadCvesOverviewPage() {
           });
 
     const getDefaultSortOption = isViewingWithCves
-        ? getDefaultWorkloadSortOption
+        ? getWorkloadCveOverviewDefaultSortOption
         : getDefaultZeroCveSortOption;
 
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -220,7 +220,7 @@ function WorkloadCvesOverviewPage() {
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     const sort = useURLSort({
-        sortFields: getWorkloadSortFields(activeEntityTabKey),
+        sortFields: getWorkloadCveOverviewSortFields(activeEntityTabKey),
         defaultSortOption: getDefaultSortOption(activeEntityTabKey, searchFilter),
         onSort: () => pagination.setPage(1),
     });
@@ -276,7 +276,7 @@ function WorkloadCvesOverviewPage() {
         // Reset all filters, sorting, and pagination and apply to the current history entry
         setActiveEntityTabKey('CVE');
         setSearchFilter({});
-        sort.setSortOption(getDefaultWorkloadSortOption('CVE'));
+        sort.setSortOption(getWorkloadCveOverviewDefaultSortOption('CVE'));
         pagination.setPage(1);
         setObservedCveMode('WITH_CVES');
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -28,6 +28,7 @@ import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../../types';
 import ImageScanningIncompleteLabel from '../components/ImageScanningIncompleteLabelLayout';
 import getImageScanMessage from '../utils/getImageScanMessage';
+import { getSeveritySortOptions } from '../../utils/sortUtils';
 
 export const tableId = 'WorkloadCvesImageOverviewTable';
 
@@ -163,6 +164,10 @@ function ImageOverviewTable({
                         <TooltipTh
                             className={getVisibilityClass('cvesBySeverity')}
                             tooltip="CVEs by severity across this image"
+                            sort={getSortParams(
+                                'CVEs By Severity',
+                                getSeveritySortOptions(filteredSeverities)
+                            )}
                         >
                             CVEs by severity
                             {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -29,7 +29,9 @@ export const aggregateByCreatedTime: SortAggregate = {
  * @param entityTab The chosen entity
  * @returns The available sort fields
  */
-export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | string[])[] {
+export function getWorkloadCveOverviewSortFields(
+    entityTab: WorkloadEntityTab
+): (string | string[])[] {
     switch (entityTab) {
         case 'CVE':
             return [
@@ -45,7 +47,18 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | s
                 'CVE Created Time',
             ];
         case 'Image':
-            return ['Image', 'Image OS', 'Image Created Time', 'Image Scan Time'];
+            return [
+                'Image',
+                [
+                    'Critical Severity Count',
+                    'Important Severity Count',
+                    'Moderate Severity Count',
+                    'Low Severity Count',
+                ],
+                'Image OS',
+                'Image Created Time',
+                'Image Scan Time',
+            ];
         case 'Deployment':
             return ['Deployment', 'Cluster', 'Namespace', 'Created'];
         default:
@@ -59,23 +72,24 @@ export function getWorkloadSortFields(entityTab: WorkloadEntityTab): (string | s
  * @param entityTab The chosen entity
  * @returns The default sort option
  */
-export function getDefaultWorkloadSortOption(
+export function getWorkloadCveOverviewDefaultSortOption(
     entityTab: WorkloadEntityTab,
     searchFilter?: SearchFilter
 ): SortOption | NonEmptyArray<SortOption> {
+    // Array.prototype.map does not currently retain the arity of an input tuple, so
+    // we need to cast the return value to a NonEmptyArray<SortOption>. This may be fixed
+    // soon in a future version of TypeScript https://github.com/microsoft/TypeScript/issues/29841
+    const appliedSeveritySortOptions = getSeveritySortOptions(
+        getAppliedSeverities(searchFilter ?? {})
+    ).map((o) => ({ ...o, direction: 'desc' })) as NonEmptyArray<SortOption>;
+
     switch (entityTab) {
         case 'CVE':
-            // Array.prototype.map does not currently retain the arity of an input tuple, so
-            // we need to cast the return value to a NonEmptyArray<SortOption>. This may be fixed
-            // soon in a future version of TypeScript https://github.com/microsoft/TypeScript/issues/29841
-            return getSeveritySortOptions(getAppliedSeverities(searchFilter ?? {})).map((o) => ({
-                ...o,
-                direction: 'desc',
-            })) as NonEmptyArray<SortOption>;
+            return appliedSeveritySortOptions;
         case 'Deployment':
             return { field: 'Deployment', direction: 'asc' };
         case 'Image':
-            return { field: 'Image created time', direction: 'asc' };
+            return appliedSeveritySortOptions;
         default:
             return ensureExhaustive(entityTab);
     }


### PR DESCRIPTION
### Description

~Do not merge - we are reverting the back end change that supports this functionality and will revisit in the future.~

**This has been retested against the new backend changes.**

Adds the ability to sort by CVE severity count on the Workload CVE images tab.

Additionally splits out the default sort options for Image/Deployment resource tables, as it is not correct that those tables use the same counterpart as the overview tables.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit Workload CVEs and click the Images tab - CVEs by severity should be the default sort and should correctly sort by multi severity. (_Note that this requires an image >= ~`4.6.x-722-gc5c4dce480`~ The most recent tests were done with image `4.7.x-492-g33369d5c7d`_)
![image](https://github.com/user-attachments/assets/0d27db2f-6e3f-4c4c-a253-f657dc0d1cc5)

Sort descending:
![image](https://github.com/user-attachments/assets/4963ff64-e559-4d3a-a5f2-70920de170d5)

Test sort with applied filter, e.g. "Fixable:true":
![image](https://github.com/user-attachments/assets/0f6088cd-0a51-42f5-902b-f7d31ef87ecc)
![image](https://github.com/user-attachments/assets/4ca87022-007f-4620-8e2d-7b335c66ce95)


