### PR TITLE
ROX-26618: Tweak timeouts for wait-for-image

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -58,6 +58,7 @@ spec:
   pipelineRef:
     name: basic-component-pipeline
 
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # The tasks regularly takes 1h30m to finish.
     tasks: 1h30m

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -58,6 +58,8 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
+  # here might might require tweaking the timeout for the operator bundle as well.
   timeouts:
     # Slow multiarch builds may take around 2h to finish.
     tasks: 2h30m

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -58,8 +58,7 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
-  # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
-  # here might might require tweaking the timeout for the operator bundle as well.
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # Slow multiarch builds may take around 2h to finish.
     tasks: 2h30m

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -301,8 +301,6 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
-    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-container-ppc64le
@@ -346,8 +344,6 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
-    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-container-arm64
@@ -391,8 +387,6 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
-    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
-    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-image-index

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -301,6 +301,8 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
+    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-container-ppc64le
@@ -344,6 +346,8 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
+    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-container-arm64
@@ -387,6 +391,8 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+    # See comment in operator-bundle-build.yaml for spec.timeouts; adjustments of this timeout
+    # here might might require tweaking the timeout for the operator bundle as well.
     timeout: 2h0m0s
 
   - name: build-image-index

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -71,6 +71,7 @@ spec:
         requests:
           cpu: 2
 
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # The tasks regularly takes 1h to finish.
     tasks: 1h

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -73,6 +73,6 @@ spec:
   #    E.g. if `wait-for-main-image` is the longest and has timeout `2h40m`, operator-bundle's `spec.timeouts.tasks`
   #    becomes `3h10m` and `spec.timeouts.pipeline` should be `3h20m`.
   timeouts:
-    tasks: 2h50m
+    tasks: 3h10m
     finally: 10m
-    pipeline: 3h
+    pipeline: 3h20m

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -69,9 +69,9 @@ spec:
   #
   # 2. the overall timeouts for the respective image-building PipelineRuns.
   #
-  # For example, in main-pipeline.yaml the maximum timeout for building main images is set to 2h.
-  # Hence we set the tasks timeout here to 2h50m, because we need to give extra time for (i) completion
-  # of the whole PipelineRun for building main images and for (ii) assembling of the operator-bundle.
+  # For example, in main-build.yaml the maximum timeout for building main images is set to 2h40m.
+  # Hence we set the tasks timeout here to 3h, because we need to give extra time for assembling
+  # the operator-bundle.
   timeouts:
     tasks: 2h50m
     finally: 10m

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -57,10 +57,22 @@ spec:
   pipelineRef:
     name: operator-bundle-pipeline
 
+  # The successful completion of the operator-bundle pipeline depends on all other ACS images
+  # having been built, since their image digests need to be injected in the bundle's
+  # ClusterServiceVersion file.
+  #
+  # To account for this inter-pipeline dependency, the cumulative tasks timeout set here
+  # needs to be kept in sync with
+  #
+  # 1. the timeouts for waiting for ACS images;
+  #    see  spec.tasks[] | select(.name | test("^wait-for-")) in operator-bundle-pipeline.yaml).
+  #
+  # 2. the overall timeouts for the respective image-building PipelineRuns.
+  #
+  # For example, in main-pipeline.yaml the maximum timeout for building main images is set to 2h.
+  # Hence we set the tasks timeout here to 2h50m, because we need to give extra time for (i) completion
+  # of the whole PipelineRun for building main images and for (ii) assembling of the operator-bundle.
   timeouts:
-    # The tasks regularly takes 1h to finish. Due to recently hit timeouts,
-    # let's try with 30m more.
-    tasks: 1h30m
-    # Reserve time for final tasks to run.
+    tasks: 2h50m
     finally: 10m
-    pipeline: 1h40m
+    pipeline: 3h

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -57,21 +57,21 @@ spec:
   pipelineRef:
     name: operator-bundle-pipeline
 
-  # The successful completion of the operator-bundle pipeline depends on all other ACS images
-  # having been built, since their image digests need to be injected in the bundle's
-  # ClusterServiceVersion file.
+  # When building the operator-bundle, we must resolve image digests for all other ACS product images in order to inject
+  # these digests in the bundle's ClusterServiceVersion file. For this, the bundle pipeline waits for each image to be
+  # built, i.e. its pipeline to complete.
   #
-  # To account for this inter-pipeline dependency, the cumulative tasks timeout set here
-  # needs to be kept in sync with
+  # You must make sure:
   #
-  # 1. the timeouts for waiting for ACS images;
-  #    see  spec.tasks[] | select(.name | test("^wait-for-")) in operator-bundle-pipeline.yaml).
-  #
-  # 2. the overall timeouts for the respective image-building PipelineRuns.
-  #
-  # For example, in main-build.yaml the maximum timeout for building main images is set to 2h40m.
-  # Hence we set the tasks timeout here to 3h, because we need to give extra time for assembling
-  # the operator-bundle.
+  # 1. For every `wait-for-image` task in `operator-bundle-pipeline.yaml` the `timeout` is equal to the timeout of the
+  #    corresponding pipeline.
+  #    E.g. if `main-build.yaml` has `spec.timeouts.pipeline` set to `2h40m`, make `wait-for-main-image`'s `timeout`
+  #    (in `operator-bundle-pipeline.yaml`) also `2h40m`.
+  # 2. The timeout for the operator-bundle build itself must be the maximum timeout of `wait-for-image` tasks plus
+  #    30 minutes. Set this value in `spec.timeouts.tasks` (here in `operator-bundle-build.yaml`). Set
+  #    `spec.timeouts.pipeline` to be `spec.timeouts.tasks` plus 10 minutes.
+  #    E.g. if `wait-for-main-image` is the longest and has timeout `2h40m`, operator-bundle's `spec.timeouts.tasks`
+  #    becomes `3h10m` and `spec.timeouts.pipeline` should be `3h20m`.
   timeouts:
     tasks: 2h50m
     finally: 10m

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -319,6 +319,8 @@ spec:
       value: "$(params.scanner-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-scanner-db-image
     params:
@@ -326,6 +328,8 @@ spec:
       value: "$(params.scanner-db-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-scanner-slim-image
     params:
@@ -333,6 +337,8 @@ spec:
       value: "$(params.scanner-slim-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-scanner-db-slim-image
     params:
@@ -340,6 +346,8 @@ spec:
       value: "$(params.scanner-db-slim-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-scanner-v4-image
     params:
@@ -365,6 +373,8 @@ spec:
       value: "$(params.collector-slim-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-collector-full-image
     params:
@@ -372,6 +382,8 @@ spec:
       value: "$(params.collector-full-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # TODO(ROX-26471): add timeout
+    # timeout: ?h?m
 
   - name: wait-for-roxctl-image
     params:

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -302,7 +302,7 @@ spec:
     taskRef:
       name: wait-for-image
     # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the operator image.
-    timeout: 1h
+    timeout: 1h10m
 
   - name: wait-for-main-image
     params:
@@ -311,7 +311,7 @@ spec:
     taskRef:
       name: wait-for-image
     # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the main image.
-    timeout: 2h20m
+    timeout: 2h40m
 
   - name: wait-for-scanner-image
     params:
@@ -401,7 +401,7 @@ spec:
     taskRef:
       name: wait-for-image
     # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the central DB image.
-    timeout: 1h30m
+    timeout: 1h40m
 
   - name: build-container
     params:

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -301,6 +301,8 @@ spec:
       value: "$(params.operator-image-repo):$(tasks.determine-operator-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the operator image.
+    timeout: 1h
 
   - name: wait-for-main-image
     params:
@@ -308,6 +310,8 @@ spec:
       value: "$(params.main-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the main image.
+    timeout: 2h20m
 
   - name: wait-for-scanner-image
     params:
@@ -343,6 +347,8 @@ spec:
       value: "$(params.scanner-v4-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the scanner V4 image.
+    timeout: 1h10m
 
   - name: wait-for-scanner-v4-db-image
     params:
@@ -350,6 +356,8 @@ spec:
       value: "$(params.scanner-v4-db-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the scanner V4 DB image.
+    timeout: 1h10m
 
   - name: wait-for-collector-slim-image
     params:
@@ -371,6 +379,8 @@ spec:
       value: "$(params.roxctl-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the roxctl image.
+    timeout: 1h10m
 
   - name: wait-for-central-db-image
     params:
@@ -378,6 +388,8 @@ spec:
       value: "$(params.central-db-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
+    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the central DB image.
+    timeout: 1h30m
 
   - name: build-container
     params:

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -301,7 +301,7 @@ spec:
       value: "$(params.operator-image-repo):$(tasks.determine-operator-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the operator image.
+    # This timeout must be the same as the pipeline timeout in `operator-build.yaml`.
     timeout: 1h10m
 
   - name: wait-for-main-image
@@ -310,7 +310,7 @@ spec:
       value: "$(params.main-image-repo):$(tasks.determine-main-image-tag-unsuffixed.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the main image.
+    # This timeout must be the same as the pipeline timeout in `main-build.yaml`.
     timeout: 2h40m
 
   - name: wait-for-scanner-image
@@ -355,7 +355,7 @@ spec:
       value: "$(params.scanner-v4-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the scanner V4 image.
+    # This timeout must be the same as the pipeline timeout in `scanner-v4-build.yaml`.
     timeout: 1h10m
 
   - name: wait-for-scanner-v4-db-image
@@ -364,7 +364,7 @@ spec:
       value: "$(params.scanner-v4-db-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the scanner V4 DB image.
+    # This timeout must be the same as the pipeline timeout in `scanner-v4-db-build.yaml`.
     timeout: 1h10m
 
   - name: wait-for-collector-slim-image
@@ -391,7 +391,7 @@ spec:
       value: "$(params.roxctl-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the roxctl image.
+    # This timeout must be the same as the pipeline timeout in `roxctl-build.yaml`.
     timeout: 1h10m
 
   - name: wait-for-central-db-image
@@ -400,7 +400,7 @@ spec:
       value: "$(params.central-db-image-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
     taskRef:
       name: wait-for-image
-    # This timeout should be kept in sync with the maximum runtime of the PipelineRun for building the central DB image.
+    # This timeout must be the same as the pipeline timeout in `central-db-build.yaml`.
     timeout: 1h40m
 
   - name: build-container

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -69,6 +69,7 @@ spec:
         requests:
           cpu: 2
 
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # The tasks regularly takes 1h to finish.
     tasks: 1h

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -69,6 +69,7 @@ spec:
         requests:
           cpu: 2
 
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # The tasks regularly takes 1h to finish.
     tasks: 1h

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -58,6 +58,7 @@ spec:
   pipelineRef:
     name: basic-component-pipeline
 
+  # IMPORTANT: when changing timeouts here, read and follow timeout instructions in operator-bundle-build.yaml.
   timeouts:
     # The tasks regularly takes 1h to finish.
     tasks: 1h


### PR DESCRIPTION
### Description

Configure timeouts for wait-for-image tasks based on the timeouts for the respective pipeline runs.

This is just a CI (Konflux change).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

Nothing added.

#### How I validated my change

Inspecting CI.
