### PR TITLE
ROX-26626: Sensor serving mappings

### DIFF
--- a/compliance/index/v4/node_test.go
+++ b/compliance/index/v4/node_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/quay/claircore"
+	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -80,6 +82,10 @@ func (s *nodeIndexerSuite) TestConstructLayerIllegalDigest() {
 }
 
 func (s *nodeIndexerSuite) TestRunRespositoryScanner() {
+	cwd, err := os.Getwd()
+	s.NoError(err)
+	s.T().Setenv(mtls.CertFilePathEnvName, path.Join(cwd, "testdata", "certs", "cert.pem"))
+	s.T().Setenv(mtls.KeyFileEnvName, path.Join(cwd, "testdata", "certs", "key.pem"))
 	layer, err := createLayer("testdata")
 	s.NoError(err)
 	server := createTestServer(s.T())
@@ -94,6 +100,10 @@ func (s *nodeIndexerSuite) TestRunRespositoryScanner() {
 }
 
 func (s *nodeIndexerSuite) TestRunRespositoryScannerAnyPath() {
+	cwd, err := os.Getwd()
+	s.NoError(err)
+	s.T().Setenv(mtls.CertFilePathEnvName, path.Join(cwd, "testdata", "certs", "cert.pem"))
+	s.T().Setenv(mtls.KeyFileEnvName, path.Join(cwd, "testdata", "certs", "key.pem"))
 	layer, err := createLayer(s.T().TempDir())
 	s.NoError(err)
 	server := createTestServer(s.T())
@@ -132,10 +142,13 @@ func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 }
 
 func (s *nodeIndexerSuite) TestIndexerE2E() {
+	cwd, err := os.Getwd()
+	s.NoError(err)
+	s.T().Setenv(mtls.CertFilePathEnvName, path.Join(cwd, "testdata", "certs", "cert.pem"))
+	s.T().Setenv(mtls.KeyFileEnvName, path.Join(cwd, "testdata", "certs", "key.pem"))
 	testdir, err := filepath.Abs("testdata")
 	s.NoError(err)
-	err = os.Setenv("ROX_NODE_INDEX_HOST_PATH", testdir)
-	s.NoError(err)
+	s.T().Setenv("ROX_NODE_INDEX_HOST_PATH", testdir)
 	srv := createTestServer(s.T())
 	defer srv.Close()
 	ni := NewNodeIndexer(createConfig(srv.URL))

--- a/compliance/index/v4/testdata/certs
+++ b/compliance/index/v4/testdata/certs
@@ -1,0 +1,1 @@
+../../../../sensor/common/centralclient/testdata/central

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -110,6 +110,8 @@ spec:
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"
+        - name: ROX_NODE_INDEX_ENABLED
+          value: "true"
         {{- end }}
         [<- if (not .KubectlOutput) >]
         {{- if ._rox.sensor.localImageScanning.enabled }}

--- a/pkg/env/node_scan_v4.go
+++ b/pkg/env/node_scan_v4.go
@@ -12,5 +12,5 @@ var (
 	NodeIndexContainerAPI = RegisterSetting("ROX_NODE_INDEX_CONTAINER_API", WithDefault("https://catalog.redhat.com/api/containers/"))
 
 	// NodeIndexMappingURL Defines the endpoint for the RepositoryScanner to download mapping information from
-	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://central.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe"))
+	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://sensor.stackrox.svc/scanner/definitions?file=repo2cpe"))
 )

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -219,7 +219,7 @@ func (s *Sensor) Start() {
 
 	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Scanner v4 is enabled.
 	// Scanner v4 / Node Indexing requires access to the repo to cpe mapping file hosted by central.
-	if env.LocalImageScanningEnabled.BooleanSetting() || features.ScannerV4.Enabled() {
+	if env.LocalImageScanningEnabled.BooleanSetting() || env.NodeIndexEnabled.BooleanSetting() {
 		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
 		if err != nil {
 			utils.Should(errors.Wrap(err, "Failed to create scanner definition route"))


### PR DESCRIPTION

### Description

The ClairCore components that are running inside Compliance for NodeIndex require a mapping JSON file to be available.
This file needs to be served through Central, going through Sensor, to ensure proper adherence to our architecture and offline functionality. The endpoint already existed for delegated scanning and needed slight modifications.

I want to highlight the following changes:
- Add collector to Sensor authorizer
- Update default mapping url setting

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
- Deploy this image to an OS4 cluster
- Observe Node Index on compliance to be able to successfully generate a report (previously not possible)
