### PR TITLE
chore(ui): Add cypress tests for Workload CVE column mgmt

### DIFF
--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -97,7 +97,7 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
             columns.forEach((column) => {
                 const columnLabel = new RegExp(`^${column}$`, 'g');
                 // Assert that the table has a header for the column and that it is visible
-                cy.get(`${tableSelector} th`).contains(columnLabel).should('be.visible');
+                cy.get(tableSelector).contains('th', columnLabel).should('be.visible');
 
                 // Hide the column
                 cy.get('button:contains("Manage columns")').click();
@@ -105,7 +105,7 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
                 cy.get('button:contains("Save")').click();
 
                 // Assert that the table header for the column is hidden
-                cy.get(`${tableSelector} th`).contains(columnLabel).should('not.be.visible');
+                cy.get(tableSelector).contains('th', columnLabel).should('not.be.visible');
             });
         });
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
@@ -1,5 +1,6 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
+import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 
 import {
     applyLocalSeverityFilters,
@@ -120,5 +121,12 @@ describe('Workload CVE Deployment Single page', () => {
 
         // Check that table rows are filtered
         cy.get(selectors.filteredViewLabel);
+    });
+
+    describe('Column management tests', () => {
+        it('should allow the user to hide and show columns on the CVE table', () => {
+            visitFirstDeployment();
+            verifyColumnManagement({ tableSelector: 'table' });
+        });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -1,7 +1,9 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
+import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 import {
     applyLocalSeverityFilters,
+    selectEntityTab,
     typeAndSelectSearchFilterValue,
     typeAndSelectCustomSearchFilterValue as typeAndCreateResourceFilterValue,
     visitWorkloadCveOverview,
@@ -173,5 +175,18 @@ describe('Workload CVE Image CVE Single page', () => {
 
         // Go back to the CVE page
         cy.go('back');
+    });
+
+    describe('Column management tests', () => {
+        it('should allow the user to hide and show columns on the Images tab', () => {
+            visitFirstCve();
+            verifyColumnManagement({ tableSelector: 'table' });
+        });
+
+        it('should allow the user to hide and show columns on the Deployments tab', () => {
+            visitFirstCve();
+            selectEntityTab('Deployment');
+            verifyColumnManagement({ tableSelector: 'table' });
+        });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -4,6 +4,7 @@ import {
     getRouteMatcherMapForGraphQL,
     interactAndWaitForResponses,
 } from '../../../helpers/request';
+import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 import {
@@ -310,6 +311,13 @@ describe('Workload CVE Image Single page', () => {
             cy.get(fixedInCellSelector)
                 .eq(index)
                 .contains(component.imageVulnerabilities[0].fixedByVersion);
+        });
+    });
+
+    describe('Column management tests', () => {
+        it('should allow the user to hide and show columns on the CVE table', () => {
+            visitFirstImage();
+            verifyColumnManagement({ tableSelector: 'table' });
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -14,7 +14,7 @@ import {
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
-import { sortByTableHeader } from '../../../helpers/tableHelpers';
+import { sortByTableHeader, verifyColumnManagement } from '../../../helpers/tableHelpers';
 import {
     getRouteMatcherMapForGraphQL,
     expectRequestedSort,
@@ -94,6 +94,25 @@ describe('Workload CVE overview page tests', () => {
                 );
             });
             */
+        });
+    });
+
+    describe('Column management tests', () => {
+        it('should allow the user to hide and show columns on the CVE tab', () => {
+            visitWorkloadCveOverview();
+            verifyColumnManagement({ tableSelector: 'table' });
+        });
+
+        it('should allow the user to hide and show columns on the Images tab', () => {
+            visitWorkloadCveOverview();
+            selectEntityTab('Image');
+            verifyColumnManagement({ tableSelector: 'table' });
+        });
+
+        it('should allow the user to hide and show columns on the Deployment tab', () => {
+            visitWorkloadCveOverview();
+            selectEntityTab('Deployment');
+            verifyColumnManagement({ tableSelector: 'table' });
         });
     });
 


### PR DESCRIPTION
### Description

As titled.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
