### PR TITLE
ROX-26635: Conditionally render NVD CVSS only if ROX_SCANNER_V4

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -506,7 +506,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         ],
         canBooleanLogic: true,
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
-        featureFlagDependency: ['ROX_NVD_CVSS_UI'],
+        featureFlagDependency: ['ROX_NVD_CVSS_UI', 'ROX_SCANNER_V4'],
     },
     {
         label: 'Severity',

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -506,7 +506,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         ],
         canBooleanLogic: true,
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
-        featureFlagDependency: ['ROX_NVD_CVSS_UI', 'ROX_SCANNER_V4'],
+        featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_NVD_CVSS_UI'],
     },
     {
         label: 'Severity',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
@@ -29,7 +29,8 @@ function ReportParametersDetails({
     formValues,
 }: ReportParametersDetailsProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssEnabled = isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const isIncludeNvdCvssEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
 
     const cveSeverities =
         formValues.reportParameters.cveSeverities.length !== 0 ? (
@@ -114,7 +115,7 @@ function ReportParametersDetails({
                             {getCVEsDiscoveredSinceText(formValues.reportParameters)}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
-                    {isNvdCvssEnabled && formValues.reportParameters.includeNvdCvss && (
+                    {isIncludeNvdCvssEnabled && formValues.reportParameters.includeNvdCvss && (
                         <DescriptionListGroup>
                             <DescriptionListTerm>Optional columns</DescriptionListTerm>
                             <DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -41,7 +41,8 @@ export type ReportParametersFormParams = {
 
 function ReportParametersForm({ title, formik }: ReportParametersFormParams): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssEnabled = isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const isIncludeNvdCvssEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
 
     const handleTextChange =
         (fieldName: string) =>
@@ -282,7 +283,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                         />
                     </FormLabelGroup>
                 )}
-                {isNvdCvssEnabled && (
+                {isIncludeNvdCvssEnabled && (
                     <FormLabelGroup
                         label="Optional columns"
                         fieldId="reportParameters.includeNvdCvss"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -6,6 +6,7 @@ import {
     Flex,
     FlexItem,
     Form,
+    FormGroup,
     PageSection,
     TextArea,
     TextInput,
@@ -284,18 +285,14 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                     </FormLabelGroup>
                 )}
                 {isIncludeNvdCvssEnabled && (
-                    <FormLabelGroup
-                        label="Optional columns"
-                        fieldId="reportParameters.includeNvdCvss"
-                        errors={formik.errors}
-                    >
+                    <FormGroup label="Optional columns" isInline>
                         <Checkbox
                             label="Include NVD CVSS"
                             id="reportParameters.includeNvdCvss"
                             isChecked={formik.values.reportParameters.includeNvdCvss}
                             onChange={onChange}
                         />
-                    </FormLabelGroup>
+                    </FormGroup>
                 )}
                 <FormLabelGroup
                     label="Configure collection included"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -36,7 +36,7 @@ import {
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { useManagedColumns } from 'hooks/useManagedColumns';
+import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import {
     SearchOption,
@@ -191,7 +191,14 @@ function ImagePageVulnerabilities({
         error,
         searchFilter,
     });
-    const managedColumnState = useManagedColumns(tableId, defaultColumns);
+
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const filteredColumns = filterManagedColumns(
+        defaultColumns,
+        (key: keyof typeof defaultColumns) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
+    );
+    const managedColumnState = useManagedColumns(tableId, filteredColumns);
 
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -196,7 +196,7 @@ function ImagePageVulnerabilities({
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
-        (key: keyof typeof defaultColumns) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
+        (key) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -45,7 +45,7 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { useManagedColumns } from 'hooks/useManagedColumns';
+import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import {
     SearchOption,
@@ -303,10 +303,19 @@ function ImageCvePage() {
         },
         skip: entityTab !== 'Deployment',
     });
+
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const affectedImagesFilteredColumns = filterManagedColumns(
+        affectedImagesDefaultColumns,
+        (key: keyof typeof affectedImagesDefaultColumns) =>
+            key !== 'nvdCvss' || isNvdCvssColumnEnabled
+    );
     const imageTableColumnState = useManagedColumns(
         affectedImagesTableId,
-        affectedImagesDefaultColumns
+        affectedImagesFilteredColumns
     );
+
     const deploymentTableColumnState = useManagedColumns(
         affectedDeploymentsTableId,
         affectedDeploymentsDefaultColumns

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -308,8 +308,7 @@ function ImageCvePage() {
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
     const affectedImagesFilteredColumns = filterManagedColumns(
         affectedImagesDefaultColumns,
-        (key: keyof typeof affectedImagesDefaultColumns) =>
-            key !== 'nvdCvss' || isNvdCvssColumnEnabled
+        (key) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
     );
     const imageTableColumnState = useManagedColumns(
         affectedImagesTableId,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -82,7 +82,7 @@ function CVEsTableContainer({
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
-        (key: keyof typeof defaultColumns) => key !== 'topNvdCvss' || isNvdCvssColumnEnabled
+        (key) => key !== 'topNvdCvss' || isNvdCvssColumnEnabled
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -14,7 +14,8 @@ import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/use
 import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
-import { useManagedColumns } from 'hooks/useManagedColumns';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import WorkloadCVEOverviewTable, {
     ImageCVE,
@@ -76,7 +77,14 @@ function CVEsTableContainer({
 
     const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
 
-    const managedColumnState = useManagedColumns(tableId, defaultColumns);
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const filteredColumns = filterManagedColumns(
+        defaultColumns,
+        (key: keyof typeof defaultColumns) => key !== 'topNvdCvss' || isNvdCvssColumnEnabled
+    );
+    const managedColumnState = useManagedColumns(tableId, filteredColumns);
 
     const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
     const {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -29,8 +29,8 @@ import { VulnerabilitySeverityLabel } from '../../types';
 
 export const tableId = 'WorkloadCvesAffectedDeploymentsTable';
 export const defaultColumns = {
-    cvesBySeverity: {
-        title: 'CVEs by severity',
+    imagesBySeverity: {
+        title: 'Images by severity',
         isShownByDefault: true,
     },
     cluster: {
@@ -118,7 +118,7 @@ function AffectedDeploymentsTable({
                 <Tr>
                     <ExpandRowTh />
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>
-                    <Th className={getVisibilityClass('cvesBySeverity')}>
+                    <Th className={getVisibilityClass('imagesBySeverity')}>
                         Images by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
@@ -191,7 +191,7 @@ function AffectedDeploymentsTable({
                                         </Flex>
                                     </Td>
                                     <Td
-                                        className={getVisibilityClass('cvesBySeverity')}
+                                        className={getVisibilityClass('imagesBySeverity')}
                                         modifier="nowrap"
                                         dataLabel="Images by severity"
                                     >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -39,7 +39,7 @@ import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayo
 
 export const tableId = 'WorkloadCvesAffectedImagesTable';
 export const defaultColumns = {
-    cvesBySeverity: {
+    cveSeverity: {
         title: 'CVE severity',
         isShownByDefault: true,
     },
@@ -154,7 +154,7 @@ function AffectedImagesTable({
                     <ExpandRowTh />
                     <Th sort={getSortParams('Image')}>Image</Th>
                     <Th
-                        className={getVisibilityClass('cvesBySeverity')}
+                        className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
                     >
                         CVE severity
@@ -228,7 +228,7 @@ function AffectedImagesTable({
                                         )}
                                     </Td>
                                     <Td
-                                        className={getVisibilityClass('cvesBySeverity')}
+                                        className={getVisibilityClass('cveSeverity')}
                                         dataLabel="CVE severity"
                                         modifier="nowrap"
                                     >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -40,7 +40,7 @@ import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayo
 export const tableId = 'WorkloadCvesAffectedImagesTable';
 export const defaultColumns = {
     cvesBySeverity: {
-        title: 'CVEs by severity',
+        title: 'CVE severity',
         isShownByDefault: true,
     },
     cveStatus: {
@@ -137,14 +137,15 @@ function AffectedImagesTable({
     onClearFilters,
     tableConfig,
 }: AffectedImagesTableProps) {
+    const expandedRowSet = useSet<string>();
+
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
-    const expandedRowSet = useSet<string>();
-    const colSpan = 8 + -hiddenColumnCount;
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const colSpan = 8 + (isNvdCvssColumnEnabled ? 1 : 0) + -hiddenColumnCount;
 
     return (
         <Table variant="compact">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -143,7 +143,8 @@ function AffectedImagesTable({
     const colSpan = 8 + -hiddenColumnCount;
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssEnabled = isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
 
     return (
         <Table variant="compact">
@@ -162,7 +163,7 @@ function AffectedImagesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('cvss')}>CVSS</Th>
-                    {isNvdCvssEnabled && (
+                    {isNvdCvssColumnEnabled && (
                         <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     )}
                     <Th
@@ -249,7 +250,7 @@ function AffectedImagesTable({
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
 
-                                    {isNvdCvssEnabled && (
+                                    {isNvdCvssColumnEnabled && (
                                         <Td
                                             className={getVisibilityClass('nvdCvss')}
                                             dataLabel="NVD CVSS"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -142,10 +142,11 @@ function ImageVulnerabilitiesTable({
     const showExceptionDetailsLink = vulnerabilityState && vulnerabilityState !== 'OBSERVED';
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssEnabled = isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
 
     const colSpan =
-        (isNvdCvssEnabled ? 7 : 6) +
+        (isNvdCvssColumnEnabled ? 7 : 6) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +
@@ -171,7 +172,7 @@ function ImageVulnerabilitiesTable({
                     <Th className={getVisibilityClass('cvss')} sort={getSortParams('CVSS')}>
                         CVSS
                     </Th>
-                    {isNvdCvssEnabled && (
+                    {isNvdCvssColumnEnabled && (
                         <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     )}
                     <Th className={getVisibilityClass('affectedComponents')}>
@@ -275,7 +276,7 @@ function ImageVulnerabilitiesTable({
                                     >
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
-                                    {isNvdCvssEnabled && (
+                                    {isNvdCvssColumnEnabled && (
                                         <Td
                                             className={getVisibilityClass('nvdCvss')}
                                             modifier="nowrap"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -185,10 +185,11 @@ function WorkloadCVEOverviewTable({
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssEnabled = isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
+    const isNvdCvssColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_NVD_CVSS_UI');
 
     const colSpan =
-        (isNvdCvssEnabled ? 7 : 6) +
+        (isNvdCvssColumnEnabled ? 7 : 6) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +
@@ -219,7 +220,7 @@ function WorkloadCVEOverviewTable({
                     >
                         Top CVSS
                     </TooltipTh>
-                    {isNvdCvssEnabled && (
+                    {isNvdCvssColumnEnabled && (
                         <TooltipTh
                             className={getVisibilityClass('topNvdCvss')}
                             tooltip="Highest CVSS score (from National Vulnerability Database) of this CVE across images"
@@ -359,7 +360,7 @@ function WorkloadCVEOverviewTable({
                                                 }
                                             />
                                         </Td>
-                                        {isNvdCvssEnabled && (
+                                        {isNvdCvssColumnEnabled && (
                                             <Td
                                                 className={getVisibilityClass('topNvdCvss')}
                                                 dataLabel="Top NVD CVSS"

--- a/ui/apps/platform/src/hooks/useManagedColumns.ts
+++ b/ui/apps/platform/src/hooks/useManagedColumns.ts
@@ -53,6 +53,19 @@ function getCurrentColumnConfig<ColumnKey extends string>(
     return tableConfig as Record<ColumnKey, ColumnConfig>;
 }
 
+// Helper function to filter columns based on a predicate like feature flag dependency
+// For example, (key: keyof typeof defaultColumns) => key !== 'whatever' || isWhateverEnabled
+export function filterManagedColumns<T extends Record<string, InitialColumnConfig>>(
+    defaultColumns: T,
+    predicate: (key: keyof T) => boolean
+) {
+    // Break potential chain into steps so easier to see types (and maybe remove casts in the future).
+    const entries = Object.entries(defaultColumns) as [[keyof T, InitialColumnConfig]];
+    const entriesFiltered = entries.filter(([key]) => predicate(key));
+    const fromEntries = Object.fromEntries(entriesFiltered) as T;
+    return fromEntries;
+}
+
 // Helper function to generate a visibility class based on the current column state
 export function generateVisibilityForColumns<T extends Record<string, ColumnConfig>>(
     columnVisibilityState: T

--- a/ui/apps/platform/src/hooks/useManagedColumns.ts
+++ b/ui/apps/platform/src/hooks/useManagedColumns.ts
@@ -54,7 +54,7 @@ function getCurrentColumnConfig<ColumnKey extends string>(
 }
 
 // Helper function to filter columns based on a predicate like feature flag dependency
-// For example, (key: keyof typeof defaultColumns) => key !== 'whatever' || isWhateverEnabled
+// For example, (key) => key !== 'whatever' || isWhateverEnabled
 export function filterManagedColumns<T extends Record<string, InitialColumnConfig>>(
     defaultColumns: T,
     predicate: (key: keyof T) => boolean


### PR DESCRIPTION
### Description

Follow up from pre bug bash meeting.

Add `ROX_SCANNER_V4` wherever conditional rendering has `ROX_NVD_CVSS_UI` feature flag.

After release, we will keep the former even though we delete the latter.

1. Rename `isNvdCvssEnabled` as `isNvdCvssColumnEnabled` in Workflow CVEs.
    * Add omitted `isNvdCvssColumnEnabled` for `colSpan` in AffectedImagesTable.tsx file.
2. Rename `isNvdCvssEnabled` as `isIncludeNvdCvssEnabled` in Vulnerability Reporting.
    * Replace `FormLabelGroup` with `FormGroup` element following example in DefaultFilterModal.tsx file. Same appearance, but allows more checkboxes in the future.
3. Edit `featureFlagDependency` property in policyCriteriaDescriptor.ts file.
4. Add `filterManagedColumns` function in useManagedColumns.ts file.

### Residue

1. What if policy has omitted field? This is not a new problem.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Prerequisite before `npm run deploy` in ui folder

```sh
export ROX_NVD_CVSS_UI=true
```

But **not** `ROX_SCANNER_V4` feature flag.

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves for WorkloadCVEOverviewTable.tsx file:

    * Before changes, see presence of **Top NVD CVSS** column.
        ![WorkloadCVEOverviewTable_presence](https://github.com/user-attachments/assets/7494ad6f-68cb-400c-908c-c036e1ec215d)

    * After changes, see absence of **Top NVD CVSS** column.
        ![WorkloadCVEOverviewTable_absence](https://github.com/user-attachments/assets/2b2db9d7-0870-47b7-8d5d-66fff835b7da)

2. Click **Manage columns** button in CVEsTableContainer.tsx file.

    * Before changes, see presence of **Top NVD CVSS** checkbox.
        ![Manage_columns_CVEsTableContainer_presence](https://github.com/user-attachments/assets/b9f03ba4-8754-4f5b-83ca-60d012bb72c3)

    * After changes, see absence of **Top NVD CVSS** checkbox.
        ![Manage_columns_CVEsTableContainer_absence](https://github.com/user-attachments/assets/a18ea245-c4fc-45b4-bf24-1d49de8c6c2c)

3. Click a vulnerability link for AffectedImagesTable.tsx file.

    * Before changes, see presence of **NVD CVSS** column.
        ![AffectedImagesTable_presence](https://github.com/user-attachments/assets/c51e3542-6b02-491e-83d2-daac258e5c8d)

    * After changes, see absence of **NVD CVSS** column.
        ![AffectedImagesTable_absence](https://github.com/user-attachments/assets/40135612-31e5-447f-a1a5-32b37e556376)

4. Click **Manage columns** button in ImageCvePage.tsx file.

    * Before changes, see presence of **NVD CVSS** checkbox.
        ![Manage_columns_ImageCvePage_presence](https://github.com/user-attachments/assets/34cc1282-6b6d-4e6a-8e42-2e20a6337db9)

    * After changes, see absence of **NVD CVSS** checkbox.
        ![Manage_columns_ImageCvePage_absence](https://github.com/user-attachments/assets/6beb2ee4-3a0e-432f-9d43-626bad71f42d)

5. Click an image link for ImageVulnerabilities.tsx file.

    * Before changes, see presence of **NVD CVSS** column.
        ![ImageVulnerabilitiesTable_presence](https://github.com/user-attachments/assets/32749d1b-4b8e-43af-b526-440514ef77ac)

    * After changes, see absence of **NVD CVSS** column.
        ![ImageVulnerabilitiesTable_absence](https://github.com/user-attachments/assets/7a0ab0d0-d797-496c-b0c7-9055e3f91a5e)

6. Click **Manage columns** button for ImagePageVulnerabilities.tsx file.

    * Before changes, see presence of **NVD CVSS** checkbox.
        ![Manage_columns_ImagePageVulnerabilities_presence](https://github.com/user-attachments/assets/c5709ec6-1f9c-496e-87ad-3c2375b328a6)

    * After changes, see absence of **NVD CVSS** checkbox.
        ![Manage_columns_ImagePageVulnerabilities_absence](https://github.com/user-attachments/assets/635d2233-d964-4c46-bf39-75827ee278e9)

7. Visit /main/vulnerabilities/reports?action=create

    * Before changes, see presence of **Include NVD CVSS** checkbox under **Optional columns**.

    * After changes, see absence of **Include NVD CVSS** checkbox under **Optional columns**.

8. Advance to **Review** step:

    * Before changes, see presence of **Include NVD CVSS** text under **Optional columns**.
        ![Vulnerability_Reporting_Parameters_presence](https://github.com/user-attachments/assets/fe5ac4c3-5b86-488d-bce7-7a29a4ae5350)

    * After changes, see absence of **Include NVD CVSS** text under **Optional columns**.
        ![Vulnerability_Reporting_Parameters_absence](https://github.com/user-attachments/assets/bfba94f9-07fa-4fce-8e1a-c906a6bad906)

9. Save, and then visit /main/vulnerabilities/reports/id

    * Before changes, see presence of **Include NVD CVSS** text under **Optional columns**.
        ![Vulnerability_Reports_page_presence](https://github.com/user-attachments/assets/2230380d-ef1f-4d8c-8b8f-1514e360fa30)

    * After changes, see absence of **Include NVD CVSS** text under **Optional columns**.
        ![Vulnerability_Reports_page_absence](https://github.com/user-attachments/assets/39fb7110-7989-4775-9769-cf5388fc8be1)

10. Visit /main/policy-management/policies/?action=create and advance to **Rules** step:

    * Before changes, see presence of **NVD CVSS** field.
        ![Policies_Rules_presence](https://github.com/user-attachments/assets/17ea86dd-3d25-4c48-89fa-c917db1cc4f8)

    * After changes, see absence of **NVD CVSS** field.
        ![Policies_Rules_absence](https://github.com/user-attachments/assets/ce1912c6-aac6-4c78-9532-bb4b6291f81d)
