### PR TITLE
chore(be): e2e test for policy CR create

### DIFF
--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -136,6 +136,10 @@ func (pc *PolicyAsCodeSuite) TestCreateCR() {
 		Version: "v1alpha1",
 		Kind:    "SecurityPolicy",
 	})
+	k8sPolicy.SetLabels(map[string]string{
+		"test": "policy-as-code",
+	})
+
 	id := pc.createCRAndObserveInCentral(k8sPolicy)
 	pc.Require().NotEmpty(id)
 	pc.checkPolicyIsDeclarative(id)
@@ -359,13 +363,15 @@ func (pc *PolicyAsCodeSuite) TearDownSuite() {
 		pc.Require().NoError(err)
 	}
 
-	log.Infof("Deleting notifier with name \"%s\"", pc.notifier.Name)
-	_, err := pc.notifierClient.DeleteNotifier(pc.ctx, &v1.DeleteNotifierRequest{
-		Id:    pc.notifier.Id,
-		Force: true,
-	})
-	pc.Require().NoError(err)
-
+	if pc.notifier != nil {
+		log.Infof("Deleting notifier with name \"%s\"", pc.notifier.Name)
+		_, err := pc.notifierClient.DeleteNotifier(pc.ctx, &v1.DeleteNotifierRequest{
+			Id:    pc.notifier.Id,
+			Force: true,
+		})
+		pc.Require().NoError(err)
+	}
+	
 	// TODO: Remove finalizers if delete fails
 	pc.Require().NoError(pc.k8sClient.DeleteCollection(pc.ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "test=policy-as-code",

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -99,7 +99,6 @@ func (pc *PolicyAsCodeSuite) TestSaveAsCRUpdateDelete() {
 	k8sPolicy := pc.saveAsCustomResource(policy)
 	k8sPolicy = pc.createPolicyInK8s(k8sPolicy)
 
-	pc.Require().Equal(k8sPolicy.Status.Message, "")
 	// Make sure the ID from Central is used to ensure controller didn't create a duplicate
 	pc.checkPolicyIsDeclarative(policy.Id)
 	pc.updateCRandObserveInCentral(k8sPolicy, policy.Id)

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -371,7 +371,6 @@ func (pc *PolicyAsCodeSuite) TearDownSuite() {
 		})
 		pc.Require().NoError(err)
 	}
-	
 	// TODO: Remove finalizers if delete fails
 	pc.Require().NoError(pc.k8sClient.DeleteCollection(pc.ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "test=policy-as-code",


### PR DESCRIPTION
### Description

1. Added new policy create by creating CR as a test.
2. Added notifier support to existing create, save as, update, delete test.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Green CI.
