### PR TITLE
ROX-26644: Do not pass current filter during autocomplete

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -121,7 +121,9 @@ function SearchFilterAutocomplete({
     const filteredSearchContext = Object.keys(searchContext).reduce((acc, key) => {
         // Autocomplete requests for some filters never return results if there is a 'Fixable' search filter
         // included in the query.
-        if (key !== 'FIXABLE') {
+        // We also need to exclude the current search term from the autocomplete query otherwise following
+        // autocomplete requests will return only the current search term as a suggestion.
+        if (key !== 'FIXABLE' && key.toLowerCase() !== searchTerm.toLowerCase()) {
             acc[key] = searchContext[key];
         }
         return acc;


### PR DESCRIPTION
### Description

When sending an autocomplete query, we need to exclude any filters that are already applied for the current search term we are querying. 

i.e. If we want a list of CVEs matching a query, and we have a current filter of `CVE:CVE-ABC-123`, we need to instead pass just `CVE:` otherwise the results will include at most that single CVE.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Build up the filter list with some Namespaces:
![image](https://github.com/user-attachments/assets/9be14e85-9f04-44b5-b94a-8e8d27579a56)
See that an applied namespace does not restrict the return results:
![image](https://github.com/user-attachments/assets/8ba9eba2-4c5a-4c05-8846-0157bad7b223)

Switch to image name and see that the applied **Namespace** filter affects the results:
![image](https://github.com/user-attachments/assets/1c767e20-f9f6-49ce-9414-59e8c51b0e47)
Apply an Image name filter and ensure that follow up searches return a list of images:
![image](https://github.com/user-attachments/assets/a6bc5614-668a-4ed1-bfcb-4af4b39bf5b7)

Repeat with additional fields:
![image](https://github.com/user-attachments/assets/650dfc2e-810a-487e-9460-c480a1dd0054)
![image](https://github.com/user-attachments/assets/e57e0166-863b-4f0e-aea4-e3e0839b990a)
![image](https://github.com/user-attachments/assets/3bf392dd-860e-4422-be1a-3f93b65cb0d2)

