### PR TITLE
ROX-26605: return error on matching fail for delegated ad-hoc scans

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -568,6 +568,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 					// to help troubleshoot potential image name or caching issues log the request's image
 					// name as well.
 					logging.String("request_image", request.GetImageName().GetFullName()),
+					logging.String("request_id", request.GetRequestId()),
 				)
 
 				if imgExists || request.GetRequestId() != "" {

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -570,9 +570,9 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 					logging.String("request_image", request.GetImageName().GetFullName()),
 				)
 
-				if imgExists {
-					// In case we hit an error during enriching, and the image previously existed, we will _not_ upsert it in
-					// central, since it could lead to us overriding an enriched image with a non-enriched image.
+				if imgExists || request.GetRequestId() != "" {
+					// If the image already exists in Central DB or this was an ad-hoc request
+					// further processing is unnecessary, return the error immediately.
 					s.informScanWaiter(request.GetRequestId(), nil, err)
 					return nil, err
 				}


### PR DESCRIPTION
### Description

Fixes an issue with roxctl (or API) scans that are delegated to a secured cluster.  When the metadata pull + indexing succeeds but matching fails the output appears to be a 'successful' scan - however `.scan` will be missing from the scan result (will include metadata only).

Now an error will be returned.

Also adds logging the delegated scanning request ID to the error so when examining administrative events or central logs we can differentiate between ad-hoc scans and non.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No additional tests added.

#### How I validated my change

Deployed ACS 4.5.3 and while Scanner V4 was still loading vulns delegated a scan.  

This scan 'SHOULD' return an error instead of a 'partial' response:
```
$ rctl image scan -f --image=nginx --cluster=remote | jq ".name,.metadata.dataSource,.notes,.scan"
{
  "registry": "docker.io",
  "remote": "library/nginx",
  "tag": "latest",
  "fullName": "docker.io/library/nginx:latest"
}
{
  "id": "10d3b4dc-8295-41bc-bb50-6da5484cdb1a",
  "name": "Public DockerHub"
}
[
  "MISSING_SIGNATURE"
]
null
```
After the change, notice the scans will now return an error
```
$ oc set image deploy/central *=quay.io/rhacs-eng/main:4.6.x-742-gdf55853f2a

$ rctl image scan -f --image=nginx --cluster=remote | jq ".name,.metadata.dataSource,.notes,.scan"
ERROR:	Scanning image failed: could not scan image: "nginx": rpc error: code = FailedPrecondition desc = error delegating scan to cluster "b1a9eb99-4359-45d2-991f-6f05ebfac2b2" for image "docker.io/library/nginx:latest": retrieving image vulnerabilities from Scanner V4 [scannerv4]: get vulnerability report (reference: "index.docker.io/library/nginx@sha256:367678a80c0be120f67f3adfccc2f408bd2c1319ed98c1975ac88e750d0efe26"): get vulns: rpc error: code = FailedPrecondition desc = the matcher is not initialized: initial load for the vulnerability store is in progress. Retrying after 3 seconds...

```

