### PR TITLE
ROX-26662: Node Indexing Tasks

### DIFF
--- a/central/imageintegration/store/defaults.go
+++ b/central/imageintegration/store/defaults.go
@@ -7,7 +7,6 @@ import (
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/clairify"
-	"github.com/stackrox/rox/pkg/scanners/scannerv4"
 	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
 )
 
@@ -171,10 +170,6 @@ var (
 	DelayedIntegrations = []DelayedIntegration{
 		makeDelayedIntegration(defaultScanner, func() scanners.Creator {
 			_, creator := clairify.Creator(nil)
-			return creator
-		}),
-		makeDelayedIntegration(DefaultScannerV4Integration, func() scanners.Creator {
-			_, creator := scannerv4.Creator(nil)
 			return creator
 		}),
 	}

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -93,8 +93,8 @@ func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSen
 	if err != nil {
 		return errors.WithMessagef(err, "enriching node %s with index report", nodeId)
 	}
-	log.Debugf("Successfully enriched node %s with %s report - found %d components (id: %s)",
-		node.GetName(), node.GetScan().GetScannerVersion().String(), len(node.GetScan().GetComponents()), nodeId)
+	log.Infof("Scanned index report for node %s - found %d components (id: %s)",
+		nodeDatastore.NodeString(node), len(node.GetScan().GetComponents()), nodeId)
 
 	// Update the whole node in the database with the new and previous information.
 	err = p.riskManager.CalculateRiskAndUpsertNode(node)

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -61,7 +61,7 @@ func (p pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	if !env.NodeIndexEnabled.BooleanSetting() || !features.ScannerV4.Enabled() {
 		// Node Indexing only works correctly when both, itself and Scanner v4 are enabled
-		log.Debugf("Skipping node index message (Node Indexing Enabled: %s, Scanner V4 Enabled: %s",
+		log.Debugf("Skipping node index message (Node Indexing Enabled: %t, Scanner V4 Enabled: %t",
 			env.NodeIndexEnabled.BooleanSetting(), features.ScannerV4.Enabled())
 		return nil
 	}

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -99,8 +99,7 @@ func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSen
 	// Update the whole node in the database with the new and previous information.
 	err = p.riskManager.CalculateRiskAndUpsertNode(node)
 	if err != nil {
-		log.Error(err)
-		return err
+		return errors.Wrapf(err, "failed calculating risk and upserting node %s", nodeDatastore.NodeString(node))
 	}
 
 	return nil

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -93,8 +93,8 @@ func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSen
 	if err != nil {
 		return errors.WithMessagef(err, "enriching node %s with index report", nodeId)
 	}
-	log.Infof("Scanned index report for node %s - found %d components (id: %s)",
-		nodeDatastore.NodeString(node), len(node.GetScan().GetComponents()), nodeId)
+	log.Infof("Scanned index report and found %d components for node %s",
+		len(node.GetScan().GetComponents()), nodeDatastore.NodeString(node))
 
 	// Update the whole node in the database with the new and previous information.
 	err = p.riskManager.CalculateRiskAndUpsertNode(node)

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/nodes/enricher"
@@ -58,8 +59,10 @@ func (p pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 }
 
 func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
-	if !features.ScannerV4.Enabled() {
-		// If Scanner V4 is disabled do not run this pipeline
+	if !env.NodeIndexEnabled.BooleanSetting() || !features.ScannerV4.Enabled() {
+		// Node Indexing only works correctly when both, itself and Scanner v4 are enabled
+		log.Debugf("Skipping node index message (Node Indexing Enabled: %s, Scanner V4 Enabled: %s",
+			env.NodeIndexEnabled.BooleanSetting(), features.ScannerV4.Enabled())
 		return nil
 	}
 	event := msg.GetEvent()

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -1,0 +1,150 @@
+package nodeindex
+
+import (
+	"testing"
+
+	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
+	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
+	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPipelineWithEmptyIndex(t *testing.T) {
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	p := &pipelineImpl{}
+	expectedError := "unexpected resource type"
+
+	err := p.Run(nil, "", nil, nil)
+
+	assert.Contains(t, err.Error(), expectedError)
+}
+
+func TestPipelineWithIncorrectAction(t *testing.T) {
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	p := &pipelineImpl{}
+	msg := createMsg()
+	msg.GetEvent().Action = central.ResourceAction_REMOVE_RESOURCE
+
+	err := p.Run(nil, "", msg, nil)
+
+	assert.Nil(t, err)
+}
+
+func TestPipelineEnrichesAndUpserts(t *testing.T) {
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	node := storage.Node{
+		Id: "1",
+	}
+	ctrl := gomock.NewController(t)
+	clusterStore := clusterDatastoreMocks.NewMockDataStore(ctrl)
+	nodeDatastore := nodeDatastoreMocks.NewMockDataStore(ctrl)
+	nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq("1")).Times(1).Return(&node, true, nil)
+	riskManager := riskManagerMocks.NewMockManager(ctrl)
+	riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil)
+	enricher := nodesEnricherMocks.NewMockNodeEnricher(ctrl)
+	enricher.EXPECT().EnrichNodeWithInventory(gomock.Any(), nil, gomock.Any()).Times(1).Return(nil)
+
+	p := &pipelineImpl{
+		clusterStore:  clusterStore,
+		nodeDatastore: nodeDatastore,
+		riskManager:   riskManager,
+		enricher:      enricher,
+	}
+	msg := createMsg()
+	msg.GetEvent().Action = central.ResourceAction_UNSET_ACTION_RESOURCE
+
+	err := p.Run(nil, "", msg, nil)
+
+	assert.Nil(t, err)
+}
+
+func createMsg() *central.MsgFromSensor {
+	return &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id: "1",
+				Resource: &central.SensorEvent_IndexReport{
+					IndexReport: createIndexReport(),
+				},
+			},
+		},
+	}
+}
+
+func createIndexReport() *v4.IndexReport {
+	return &v4.IndexReport{
+		HashId:  "",
+		State:   "7", // IndexFinished
+		Success: true,
+		Err:     "",
+		Contents: &v4.Contents{
+			Packages: []*v4.Package{
+				{
+					Id:      "0",
+					Name:    "openssh-clients",
+					Version: "8.7p1-38.el9",
+					Kind:    "binary",
+					Source: &v4.Package{
+						Name:    "openssh",
+						Version: "8.7p1-38.el9",
+						Kind:    "source",
+						Source:  nil,
+						Cpe:     "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					},
+					PackageDb:      "sqlite:usr/share/rpm",
+					RepositoryHint: "hash:sha256:f52ca767328e6919ec11a1da654e92743587bd3c008f0731f8c4de3af19c1830|key:199e2f91fd431d51",
+					Arch:           "x86_64",
+					Cpe:            "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+				},
+				{
+					Id:      "1",
+					Name:    "skopeo",
+					Version: "2:1.14.4-2.rhaos4.16.el9",
+					Kind:    "binary",
+					Source: &v4.Package{
+						Name:    "skopeo",
+						Version: "2:1.14.4-2.rhaos4.16.el9",
+						Kind:    "source",
+						Cpe:     "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					},
+					PackageDb:      "sqlite:usr/share/rpm",
+					RepositoryHint: "hash:sha256:072a75d1b9b36457751ef05031fd69615f21ebaa935c30d74d827328b78fa694|key:199e2f91fd431d51",
+					Arch:           "x86_64",
+					Cpe:            "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+				},
+			},
+			Repositories: []*v4.Repository{
+				{
+					Id:   "0",
+					Name: "cpe:/o:redhat:enterprise_linux:9::fastdatapath",
+					Key:  "rhel-cpe-repository",
+					Cpe:  "cpe:2.3:o:redhat:enterprise_linux:9:*:fastdatapath:*:*:*:*:*",
+				},
+				{
+					Id:   "1",
+					Name: "cpe:/a:redhat:openshift:4.16::el9",
+					Key:  "rhel-cpe-repository",
+					Cpe:  "cpe:2.3:a:redhat:openshift:4.16:*:el9:*:*:*:*:*",
+				},
+			},
+			Environments: map[string]*v4.Environment_List{"1": {Environments: []*v4.Environment{
+				{
+					PackageDb:     "sqlite:usr/share/rpm",
+					IntroducedIn:  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					RepositoryIds: []string{"0", "1"},
+				},
+			},
+			}},
+		},
+	}
+}

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -1,6 +1,7 @@
 package nodeindex
 
 import (
+	"context"
 	"testing"
 
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
@@ -22,7 +23,7 @@ func TestPipelineWithEmptyIndex(t *testing.T) {
 	p := &pipelineImpl{}
 	expectedError := "unexpected resource type"
 
-	err := p.Run(nil, "", nil, nil)
+	err := p.Run(context.Background(), "", nil, nil)
 
 	assert.Contains(t, err.Error(), expectedError)
 }
@@ -34,7 +35,7 @@ func TestPipelineWithIncorrectAction(t *testing.T) {
 	msg := createMsg()
 	msg.GetEvent().Action = central.ResourceAction_REMOVE_RESOURCE
 
-	err := p.Run(nil, "", msg, nil)
+	err := p.Run(context.Background(), "", msg, nil)
 
 	assert.Nil(t, err)
 }
@@ -63,7 +64,7 @@ func TestPipelineEnrichesAndUpserts(t *testing.T) {
 	msg := createMsg()
 	msg.GetEvent().Action = central.ResourceAction_UNSET_ACTION_RESOURCE
 
-	err := p.Run(nil, "", msg, nil)
+	err := p.Run(context.Background(), "", msg, nil)
 
 	assert.Nil(t, err)
 }

--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -99,7 +99,7 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	if features.ScannerV4.Enabled() && env.NodeIndexEnabled.BooleanSetting() {
 		// To prevent resending the inventory, still acknowledge receipt of it
 		sendComplianceAck(ctx, node, ninv, injector)
-		log.Debugf("Discarding v2 NodeScan in favor of v4 NodeScan")
+		log.Debug("Discarding v2 NodeScan in favor of v4 NodeScan")
 		return nil
 	}
 

--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -187,7 +187,6 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 		return nil
 	}
 	cmetrics.ObserveNodeIndexReport(report, nodeName)
-	log.Debugf("Completed Node Index Report with %d packages", len(report.GetContents().GetPackages()))
 	msg := c.createIndexMsg(report, nodeName)
 	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV4)
 	cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)

--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -161,7 +161,6 @@ func (c *Compliance) manageNodeScanLoop(ctx context.Context) <-chan *sensor.MsgF
 
 func (c *Compliance) runNodeInventoryScan(ctx context.Context) *sensor.MsgFromCompliance {
 	nodeName := c.nodeNameProvider.GetNodeName()
-	log.Infof("Scanning node %q", nodeName)
 	msg, err := c.nodeScanner.ScanNode(ctx)
 	if err != nil {
 		log.Errorf("Error running node scan: %v", err)
@@ -175,8 +174,8 @@ func (c *Compliance) runNodeInventoryScan(ctx context.Context) *sensor.MsgFromCo
 }
 
 func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance {
-	log.Infof("Creating v4 Node Index Report")
 	nodeName := c.nodeNameProvider.GetNodeName()
+	log.Infof("Creating v4 Node Index report for node %s", nodeName)
 	cmetrics.ObserveIndexesTotal(nodeName)
 	startTime := time.Now()
 	report, err := c.nodeIndexer.IndexNode(ctx)

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -222,7 +222,7 @@ func runRepositoryScanner(ctx context.Context, cfg *NodeIndexerConfig, l *clairc
 }
 
 func constructLayer(ctx context.Context, digest string, hostPath string) (*claircore.Layer, error) {
-	log.Infof("Realizing mount path: %s", hostPath)
+	log.Debugf("Realizing mount path: %s", hostPath)
 	desc := &claircore.LayerDescription{
 		Digest:    digest,
 		URI:       hostPath,

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/quay/claircore/indexer/controller"
 	"github.com/quay/claircore/rhel"
 	rpm2 "github.com/quay/claircore/rpm"
+	"github.com/quay/zlog"
+	"github.com/rs/zerolog"
 	"github.com/stackrox/rox/compliance/collection/compliance"
 	"github.com/stackrox/rox/compliance/collection/intervals"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -33,6 +36,16 @@ var (
 	log         = logging.LoggerForModule()
 )
 
+// ClairCore is using zlog and needs separate configuration, as it's logging on debug level by default.
+func configureClairCoreLogging() {
+	l := zerolog.New(os.Stderr)
+	l = l.Level(zerolog.InfoLevel)
+	if os.Getenv("LOGLEVEL") == "DEBUG" {
+		l = l.Level(zerolog.DebugLevel)
+	}
+	zlog.Set(&l)
+}
+
 type NodeIndexerConfig struct {
 	DisableAPI         bool
 	API                string
@@ -41,6 +54,7 @@ type NodeIndexerConfig struct {
 }
 
 func NewNodeIndexerConfigFromEnv() *NodeIndexerConfig {
+	configureClairCoreLogging()
 	return &NodeIndexerConfig{
 		DisableAPI:         false,
 		API:                env.NodeIndexContainerAPI.Setting(), // TODO(ROX-25540): Set in sync with Scanner via Helm charts

--- a/compliance/index/v4/node.go
+++ b/compliance/index/v4/node.go
@@ -40,7 +40,7 @@ var (
 func configureClairCoreLogging() {
 	l := zerolog.New(os.Stderr)
 	l = l.Level(zerolog.InfoLevel)
-	if os.Getenv("LOGLEVEL") == "DEBUG" {
+	if logging.GetGlobalLogLevel().CapitalString() == "DEBUG" {
 		l = l.Level(zerolog.DebugLevel)
 	}
 	zlog.Set(&l)

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -113,6 +113,8 @@ spec:
           value: "true"
         {{- end }}
         {{- if ._rox.env.managedServices }}
+        - name: ROX_NODE_INDEX_ENABLED
+          value: "true"
         - name: ROX_MANAGED_CENTRAL
           value: "true"
         - name: ROX_ENABLE_CENTRAL_DIAGNOSTICS

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -217,8 +217,8 @@ func (s *Sensor) Start() {
 		s.AddNotifiable(wrapNotifiable(koCacheSource, "Kernel object cache"))
 	}
 
-	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Scanner v4 is enabled.
-	// Scanner v4 / Node Indexing requires access to the repo to cpe mapping file hosted by central.
+	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Node Indexing is enabled.
+	// Node Indexing requires access to the repo to cpe mapping file hosted by central.
 	if env.LocalImageScanningEnabled.BooleanSetting() || env.NodeIndexEnabled.BooleanSetting() {
 		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
 		if err != nil {

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -94,7 +94,7 @@ export const imageIntegrationsDescriptors: ImageIntegrationDescriptor[] = [
         type: 'clairify',
     },
     {
-        categories: 'Scanner',
+        categories: 'Image Scanner + Node Scanner',
         image: logo,
         label: 'Scanner V4',
         type: 'scannerv4',


### PR DESCRIPTION
A collection of tasks that were discovered in demos or explorative testing

- Remove Scanner v4 from delayed integration (to prevent race conditions)
- Update categories of Scanner v4 integration in UI to reflect changed roles
- Ensure Central NodeIndex pipeline only runs if Scanner v4 and NodeIndex are enabled
- Enable NodeIndex pipeline by default on central
- Set up ClairCore logger to remove default debug logging on compliance

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
1. Deploy changes to an OpenShift 4 cluster with primary SSD storage enabled (required for Scanner v4/Matcher) with `export ROX_SCANNER_V4=true MONITORING_SUPPORT=true`  for the deploy script.
2. Enable Indexing on Central 
- `ks set env deployment/central ROX_NODE_INDEX_ENABLED=true`
3. (Optional) Lower initial and rescan interval of the index
- `ks set env daemonset/collector ROX_NODE_SCANNING_INTERVAL=90s`
- `ks set env daemonset/collector ROX_NODE_SCANNING_MAX_INITIAL_WAIT=10s`

Observe that nodes on central are correctly updated with Scanner v4 results.
This can either be observed by the number of CVEs per node (<300, with ~1 fixable), or via API call: 
`curl -k -s -u admin:PASSWORD CENTRAL_ENDPOINT/v1/nodes/CLUSTER_ID/NODE_ID | jq` - which shows the scanner version in `scan.scannerVersion`

