### PR TITLE
chore(ui): workload CVE toolbar layout tweaks

### DIFF
--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -67,7 +67,7 @@ export function assertOnEachRowForColumn(
 
 // Opens the column management modal, resets the columns to default, and saves the changes
 function resetManagedColumns() {
-    cy.get('button:contains("Manage columns")').click();
+    cy.get('button:contains("Columns")').click();
     cy.get('button:contains("Reset to default")').click();
     cy.get('button:contains("Save")').click();
 }
@@ -85,7 +85,7 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
     resetManagedColumns();
 
     // Open the colum management modal and get the list of columns
-    cy.get('button:contains("Manage columns")').click();
+    cy.get('button:contains("Columns")').click();
     cy.get('.pf-v5-c-modal-box label')
         .then(($labels) => {
             cy.get('.pf-v5-c-modal-box button:contains("Cancel")').click();
@@ -100,7 +100,7 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
                 cy.get(tableSelector).contains('th', columnLabel).should('be.visible');
 
                 // Hide the column
-                cy.get('button:contains("Manage columns")').click();
+                cy.get('button:contains("Columns")').click();
                 cy.get('label').contains(columnLabel).click();
                 cy.get('button:contains("Save")').click();
 

--- a/ui/apps/platform/src/Components/ColumnManagementButton.tsx
+++ b/ui/apps/platform/src/Components/ColumnManagementButton.tsx
@@ -4,6 +4,7 @@ import { ColumnManagementModal } from '@patternfly/react-component-groups';
 import { Button } from '@patternfly/react-core';
 
 import { ColumnConfig, ManagedColumns } from 'hooks/useManagedColumns';
+import { CogIcon } from '@patternfly/react-icons';
 
 export type ColumnManagementButtonProps<ColumnKey extends string> = {
     managedColumnState: ManagedColumns<ColumnKey>;
@@ -32,6 +33,7 @@ function ColumnManagementButton<ColumnKey extends string>({
                 onClose={() => setOpen(false)}
             />
             <Button
+                icon={<CogIcon />}
                 onClick={() => setOpen(true)}
                 variant="secondary"
                 countOptions={{
@@ -39,7 +41,7 @@ function ColumnManagementButton<ColumnKey extends string>({
                     count: enabledColumnCount,
                 }}
             >
-                Manage columns
+                Columns
             </Button>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -138,37 +138,34 @@ function CVEsTableContainer({
                     <ColumnManagementButton managedColumnState={managedColumnState} />
                 </ToolbarItem>
                 {canSelectRows && (
-                    <>
-                        <ToolbarItem>
-                            <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
-                                <DropdownItem
-                                    key="bulk-defer-cve"
-                                    component="button"
-                                    onClick={() =>
-                                        showModal({
-                                            type: 'DEFERRAL',
-                                            cves: Array.from(selectedCves.values()),
-                                        })
-                                    }
-                                >
-                                    Defer CVEs
-                                </DropdownItem>
-                                <DropdownItem
-                                    key="bulk-mark-false-positive"
-                                    component="button"
-                                    onClick={() =>
-                                        showModal({
-                                            type: 'FALSE_POSITIVE',
-                                            cves: Array.from(selectedCves.values()),
-                                        })
-                                    }
-                                >
-                                    Mark as false positives
-                                </DropdownItem>
-                            </BulkActionsDropdown>
-                        </ToolbarItem>
-                        <ToolbarItem variant="separator" />
-                    </>
+                    <ToolbarItem>
+                        <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                            <DropdownItem
+                                key="bulk-defer-cve"
+                                component="button"
+                                onClick={() =>
+                                    showModal({
+                                        type: 'DEFERRAL',
+                                        cves: Array.from(selectedCves.values()),
+                                    })
+                                }
+                            >
+                                Defer CVEs
+                            </DropdownItem>
+                            <DropdownItem
+                                key="bulk-mark-false-positive"
+                                component="button"
+                                onClick={() =>
+                                    showModal({
+                                        type: 'FALSE_POSITIVE',
+                                        cves: Array.from(selectedCves.values()),
+                                    })
+                                }
+                            >
+                                Mark as false positives
+                            </DropdownItem>
+                        </BulkActionsDropdown>
+                    </ToolbarItem>
                 )}
             </TableEntityToolbar>
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
@@ -1,5 +1,12 @@
 import React, { ReactNode } from 'react';
-import { Divider, Toolbar, ToolbarItem, ToolbarContent, Pagination } from '@patternfly/react-core';
+import {
+    Divider,
+    Toolbar,
+    ToolbarItem,
+    ToolbarContent,
+    Pagination,
+    ToolbarGroup,
+} from '@patternfly/react-core';
 
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 
@@ -40,25 +47,29 @@ function TableEntityToolbar({
             {filterToolbar}
             <Divider component="div" />
             <Toolbar>
-                <ToolbarContent>
-                    <ToolbarItem>{entityToggleGroup}</ToolbarItem>
-                    {isFiltered && (
-                        <ToolbarItem alignSelf="center">
-                            <DynamicTableLabel />
+                <ToolbarContent className="pf-v5-u-justify-content-space-between">
+                    <ToolbarGroup className="pf-v5-u-flex-grow-1">
+                        <ToolbarItem>{entityToggleGroup}</ToolbarItem>
+                        {isFiltered && (
+                            <ToolbarItem alignSelf="center">
+                                <DynamicTableLabel />
+                            </ToolbarItem>
+                        )}
+                    </ToolbarGroup>
+                    <ToolbarGroup align={{ default: 'alignLeft' }}>
+                        {children}
+                        <ToolbarItem variant="pagination">
+                            <Pagination
+                                itemCount={tableRowCount}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    setPerPage(newPerPage);
+                                }}
+                            />
                         </ToolbarItem>
-                    )}
-                    {children}
-                    <ToolbarItem align={{ default: 'alignRight' }} variant="pagination">
-                        <Pagination
-                            itemCount={tableRowCount}
-                            page={page}
-                            perPage={perPage}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => {
-                                setPerPage(newPerPage);
-                            }}
-                        />
-                    </ToolbarItem>
+                    </ToolbarGroup>
                 </ToolbarContent>
             </Toolbar>
         </>


### PR DESCRIPTION
### Description

A couple of small changes to better handle layout of the VM toolbar on screens smaller than the 2xl or 3xl width. A small enhancement until we are able to do a more thorough revisit of the toolbar layout and markup throughout VM.

1. Removed an extraneous "separator" element
2. Changed the "Manage columns" button to "⚙️ Columns"
3. Group the right side elements into a `<ToolbarGroup>` in order to allow wrapping this is less disjoint

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before:
![image](https://github.com/user-attachments/assets/7787356e-8963-401f-943f-13ccea6a257b)
![image](https://github.com/user-attachments/assets/7d5872c1-3044-4051-a53d-69dfc2700968)


After:
![image](https://github.com/user-attachments/assets/ab9bde46-920e-4c67-acf7-4df2587debb7)
![image](https://github.com/user-attachments/assets/b1e347a5-8362-426e-b6bc-f2fe2b0a967d)

