### PR TITLE
fix(ui): Omit the Violations Platform Component filter when ff off

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -141,9 +141,13 @@ function ViolationsTablePage(): ReactElement {
 
     // When any of the deps to this effect change, we want to reload the alerts and count.
     useEffect(() => {
+        const filteredWorkflowFilter = isPlatformComponentsEnabled
+            ? getFilteredWorkflowViewSearchFilter(filteredWorkflowView)
+            : {};
+
         const alertSearchFilter: SearchFilter = {
             ...searchFilter,
-            ...getFilteredWorkflowViewSearchFilter(filteredWorkflowView),
+            ...filteredWorkflowFilter,
             'Violation State': activeViolationStateTab,
         };
 


### PR DESCRIPTION
### Description

When the `ROX_PLATFORM_COMPONENTS` flag is `false`, do not send any `Platform Components` filter in the query.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Flag off, observe network calls:
![image](https://github.com/user-attachments/assets/84a2391c-e0a9-4b4b-9ec6-77c083ecf013)

