### PR TITLE
ROX-26667: Render information about NVD CVSS field in policy wizard

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Alert,
     Card,
     CardHeader,
     CardTitle,
@@ -126,7 +127,7 @@ function PolicyGroupCard({
                             <Stack>
                                 <StackItem>{descriptor.shortName}</StackItem>
                                 {headerLongText && headerLongText !== descriptor.shortName && (
-                                    <StackItem className="pf-v5-u-font-weight-normal">
+                                    <StackItem className="pf-v5-u-font-size-sm pf-v5-u-font-weight-normal">
                                         {headerLongText}:
                                     </StackItem>
                                 )}
@@ -136,6 +137,15 @@ function PolicyGroupCard({
                 </CardHeader>
                 <Divider component="div" />
                 <CardBody>
+                    {descriptor.infoText && (
+                        <Alert
+                            variant="info"
+                            isInline
+                            title={descriptor.infoText}
+                            component="p"
+                            className="pf-v5-u-mb-md"
+                        />
+                    )}
                     {group.values.map((_, valueIndex) => {
                         const name = `policySections[${sectionIndex}].policyGroups[${groupIndex}].values[${valueIndex}]`;
                         const groupName = `policySections[${sectionIndex}].policyGroups[${groupIndex}]`;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -182,6 +182,7 @@ export const mountPropagationCriteriaName = 'Mount Propagation';
     defaultValue: the default value to set, if provided
     disabled: disables the field entirely
     reverse: will reverse boolean value on store
+    infoText: optional short text for title of info Alert element in card body of policy field in wizard
     featureFlagDependency: optional property to filter descriptor by feature flags enabled or disabled
  */
 
@@ -219,6 +220,7 @@ type BaseDescriptor = {
     name: string;
     shortName: string;
     longName?: string;
+    infoText?: string;
     category: string;
     type: DescriptorType;
     disabled?: boolean;
@@ -487,6 +489,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         shortName: 'NVD CVSS',
         longName:
             'Common Vulnerability Scoring System (CVSS) score from National Vulnerability Database (NVD)',
+        infoText: 'NVD CVSS scores require Scanner V4',
         category: policyCriteriaCategories.IMAGE_CONTENTS,
         type: 'group',
         subComponents: [
@@ -506,7 +509,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         ],
         canBooleanLogic: true,
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
-        featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_NVD_CVSS_UI'],
+        featureFlagDependency: ['ROX_NVD_CVSS_UI'],
     },
     {
         label: 'Severity',


### PR DESCRIPTION
### Description

### Problem

1. One side of coin: it is risky to hide **NVD CVSS** field if `ROX_SCANNER_V4` feature flag is not enabled, because it is possible that filed could come from outside UI:
    * imported policy JSON file
    * declarative custom resource for policy
2. Other side of coin: users need to know that NVD CVSS scores require Scanner V4.
    * The policy field does nothing without scores.
    * Van commented that information might motivate some customers to adopt Scanner V4.

### Analysis

Optional information for a policy field is worthwhile to support generically.

### Solution

Mansur approved `Alert` element via Slack.

1. Edit policyCriteriaDescriptors.tsx file.
    * Add optional `infoText` property.
    * Delete `ROX_SCANNER_V4` from `featureFlagDependencies` property.
2. Edit PolicyGroupCard.tsx file.
    * Add `pf-v5-u-font-size-sm` as counterpart to `pf-v5-u-font-weight-normal` for optional long subtitle so it does not compete with short card title.
    * Add conditional rendering for `Alert` element in card body.
        Besides being more appropriate for card body, initial attempt to render in card title looked awful (apparently unexpected composition of elements caused conflict between PatternFly styles).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Prerequisite before `npm run deploy` in ui folder

```sh
export ROX_NVD_CVSS_UI=true
```

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/policy-management/policies/?action=create, advance to **Rules** step:

    * Before changes, see absence of **NVD CVSS** policy field under **Image contents**
        ![NVD_CVSS_absence](https://github.com/user-attachments/assets/7547a7a0-624a-4eab-86c8-2fe35da90326)

    * After changes, see presence of **NVD CVSS** policy field and info alert.
        No accessibility issues, by the way.
        ![NVD_CVSS_presence](https://github.com/user-attachments/assets/596f2980-2052-4d4b-9c5f-593097a93e14)


    * After changes, see absence of info alert for **CVSS** policy field to verify conditional rendering.
        For initial screen shot, I rendered unconditionally for all policies XD
        ![CVSS_Alert_absence](https://github.com/user-attachments/assets/d478eb1d-aadc-499f-80ea-047ee409c44a)
