### PR TITLE
ROX-26669, ROX-26670: Deprecate StackRox Scanner and GCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   each with an optional fraction and a unit suffix (e.g., "300ms", "-1.5h", or "2h45m").
   The currently valid time units "ns", "us" (or "µs"), "ms", "m", and "h" will no longer be supported.
 - ROX-24169: API token authentication has been deprecated by Red Hat OpenShift Cluster Manager. The corresponding cloud source integration now uses service accounts for authentication.
+- ROX-26669: StackRox Scanner is now deprecated. Users should use Scanner V4, instead, for all image scanning needs. StackRox Scanner is still required for full Node and Orchestrator scanning, though.
+- ROX-26670: Google Container Registry integration is now deprecated. Users should use Artifact Registry as a registry replacement and Scanner V4 as a scanner replacement.
 
 ### Technical Changes
 - ROX-24897: Sensor will now perform TLS checks lazily during delegated scanning instead of when secrets are first discovered, this should reduce Sensor startup time.

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -99,10 +99,7 @@ function ClairIntegrationForm({
                     isInline
                     className="pf-v5-u-mb-lg"
                 >
-                    <Text>
-                        CoreOS Clair v2 integration will be removed in Red Hat Advanced Cluster
-                        Security 4.5 release.
-                    </Text>
+                    <Text>CoreOS Clair integration will be removed in a future release.</Text>
                     <Text>Use Clair v4 integration instead.</Text>
                 </Alert>
                 <FormMessage message={message} />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -1,13 +1,5 @@
 import React, { ReactElement } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Checkbox,
-    Form,
-    PageSection,
-    Text,
-    TextInput,
-} from '@patternfly/react-core';
+import { Alert, Checkbox, Form, PageSection, Text, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';
 import merge from 'lodash/merge';
 
@@ -95,7 +87,7 @@ function ClairIntegrationForm({
                 <Alert
                     title="Deprecation notice"
                     component="p"
-                    variant={AlertVariant.warning}
+                    variant={'warning'}
                     isInline
                     className="pf-v5-u-mb-lg"
                 >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import {
     Alert,
-    AlertVariant,
     Form,
     PageSection,
     Text,
@@ -93,11 +92,12 @@ function ClairifyIntegrationForm({
                 <Alert
                     title="Deprecation notice"
                     component="p"
-                    variant={AlertVariant.warning}
+                    variant={'warning'}
                     isInline
                     className="pf-v5-u-mb-lg"
                 >
                     <Text>StackRox Scanner will be removed in a future release.</Text>
+                    <Text>No new enhancements for StackRox Scanner will be done or accepted.</Text>
                     <Text>It is recommended to use Scanner V4, instead.</Text>
                 </Alert>
                 <FormMessage message={message} />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
@@ -1,5 +1,14 @@
 import React, { ReactElement } from 'react';
-import { Form, PageSection, TextInput, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import {
+    Alert,
+    AlertVariant,
+    Form,
+    PageSection,
+    Text,
+    TextInput,
+    ToggleGroup,
+    ToggleGroupItem
+} from '@patternfly/react-core';
 import * as yup from 'yup';
 import merge from 'lodash/merge';
 
@@ -81,6 +90,16 @@ function ClairifyIntegrationForm({
     return (
         <>
             <PageSection variant="light" isFilled hasOverflowScroll>
+                <Alert
+                    title="Deprecation notice"
+                    component="p"
+                    variant={AlertVariant.warning}
+                    isInline
+                    className="pf-v5-u-mb-lg"
+                >
+                    <Text>StackRox Scanner will be removed in a future release.</Text>
+                    <Text>It is recommended to use Scanner V4, instead.</Text>
+                </Alert>
                 <FormMessage message={message} />
                 <Form isWidthLimited>
                     <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairifyIntegrationForm.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     TextInput,
     ToggleGroup,
-    ToggleGroupItem
+    ToggleGroupItem,
 } from '@patternfly/react-core';
 import * as yup from 'yup';
 import merge from 'lodash/merge';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
@@ -160,11 +160,12 @@ function GoogleIntegrationForm({
                 >
                     <Text>Google Container Registry will be removed in a future release.</Text>
                     <Text>
-                        It is recommended to use Google Artifact Registry as a registry
-                        replacement and Scanner V4 as a scanner replacement.
+                        It is recommended to use Google Artifact Registry as a registry replacement
+                        and Scanner V4 as a scanner replacement.
                     </Text>
                     <Text>
-                        See https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation
+                        See
+                        https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation
                         for more information.
                     </Text>
                 </Alert>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
@@ -1,8 +1,11 @@
 import React, { ReactElement } from 'react';
 import {
+    Alert,
+    AlertVariant,
     Checkbox,
     Form,
     PageSection,
+    Text,
     TextArea,
     TextInput,
     ToggleGroup,
@@ -148,6 +151,23 @@ function GoogleIntegrationForm({
     return (
         <>
             <PageSection variant="light" isFilled hasOverflowScroll>
+                <Alert
+                    title="Deprecation notice"
+                    component="p"
+                    variant={AlertVariant.warning}
+                    isInline
+                    className="pf-v5-u-mb-lg"
+                >
+                    <Text>Google Container Registry will be removed in a future release.</Text>
+                    <Text>
+                        It is recommended to use Google Artifact Registry as a registry
+                        replacement and Scanner V4 as a scanner replacement.
+                    </Text>
+                    <Text>
+                        See https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation
+                        for more information.
+                    </Text>
+                </Alert>
                 <FormMessage message={message} />
                 <Form isWidthLimited>
                     <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import {
     Alert,
-    AlertVariant,
     Checkbox,
     Form,
     PageSection,
@@ -21,6 +20,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useIntegrationForm from '../useIntegrationForm';
 import { IntegrationFormProps } from '../integrationFormTypes';
 
@@ -154,7 +154,7 @@ function GoogleIntegrationForm({
                 <Alert
                     title="Deprecation notice"
                     component="p"
-                    variant={AlertVariant.warning}
+                    variant={'warning'}
                     isInline
                     className="pf-v5-u-mb-lg"
                 >
@@ -164,8 +164,16 @@ function GoogleIntegrationForm({
                         and Scanner V4 as a scanner replacement.
                     </Text>
                     <Text>
-                        See
-                        https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation
+                        See the{' '}
+                        <ExternalLink>
+                            <a
+                                href="https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Container Registry deprecation notice
+                            </a>
+                        </ExternalLink>
                         for more information.
                     </Text>
                 </Alert>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
@@ -7,6 +7,7 @@ import {
     CardTitle,
     Flex,
     GalleryItem,
+    Truncate,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
@@ -51,7 +52,7 @@ function IntegrationTile({
                     </CardHeader>
                     <CardTitle className="pf-v5-u-color-100" style={{ whiteSpace: 'nowrap' }}>
                         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                            <span>{label}</span>
+                            <Truncate position="middle" content={label} />
                             {isTechPreview && <TechPreviewLabel />}
                         </Flex>
                     </CardTitle>

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -90,7 +90,7 @@ export const imageIntegrationsDescriptors: ImageIntegrationDescriptor[] = [
     {
         categories: 'Image Scanner + Node Scanner',
         image: logo,
-        label: 'StackRox Scanner',
+        label: '[DEPRECATED] StackRox Scanner',
         type: 'clairify',
     },
     {
@@ -115,7 +115,7 @@ export const imageIntegrationsDescriptors: ImageIntegrationDescriptor[] = [
     {
         categories: 'Registry + Scanner',
         image: googleregistry,
-        label: 'Google Container Registry',
+        label: '[DEPRECATED] Google Container Registry',
         type: 'google',
     },
     {


### PR DESCRIPTION
### Description

StackRox team is developing Scanner V4, which is the replacement for StackRox Scanner. It is time to deprecate the old one.

GCR has been deprecated by Google for some time, and it will be shut down in 2025 (see https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation).

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

<img width="367" alt="Screenshot 2024-10-18 at 12 27 49 PM" src="https://github.com/user-attachments/assets/8a88c36f-0067-4215-9287-9792e0473cf7">

<img width="1301" alt="Screenshot 2024-10-18 at 12 27 58 PM" src="https://github.com/user-attachments/assets/b2bf9572-7524-468e-ad54-9cfdadfdb58a">

<img width="1149" alt="Screenshot 2024-10-18 at 12 28 10 PM" src="https://github.com/user-attachments/assets/86aa089e-cb0a-4e18-9b85-13bd8cd063ff">
