### PR TITLE
chore(scanner): change loglevel to reduce noise

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -339,7 +339,7 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 		}
 		metrics, err := cvssMetrics(ctx, v, &nvdVuln)
 		if err != nil {
-			zlog.Warn(ctx).
+			zlog.Debug(ctx).
 				Err(err).
 				Str("vuln_id", v.ID).
 				Str("vuln_name", v.Name).


### PR DESCRIPTION
### Description

This warning has proven to be very noisy, especially when an NVD score is missing (which is common these days...). Let's make this Debug level to reduce regular noise

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

I didn't
