### PR TITLE
ROX-26655: Replace entity ID with name in Compliance 1.0 PDF headers

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
@@ -28,7 +28,7 @@ const EntityHeader = ({
     // Leave raw entity types in case customer depends on this convention for export file name.
     let exportFilename = listEntityType
         ? `${pluralize(listEntityType)} ACROSS ${entityType} "${entityName.toUpperCase()}"`
-        : `${entityType} "${entityId}"`;
+        : `${entityType} "${entityName}"`;
     exportFilename = `${exportFilename} Report`;
     const pdfId = listEntityType ? 'capture-list' : 'capture-dashboard';
 


### PR DESCRIPTION
### Description



### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed

### Testing and quality


- [x] the change is production ready: the change is GA
- [ ] CI results are inspected

#### Automated testing

no automated tests for PDF contents


#### How I validated my change

Before:
I saved a PDF of the Compliance 1.0 results for a cluster, and the header read **CLUSTER "2BFA1A54-66D0-4E4D-BB34-42F2CD91460D" Report**

After:
I saved a PDF of the Compliance 1.0 results for the same cluster, and the header read **CLUSTER "remote" Report**
