### PR TITLE
ROX-26671: revert to previous behavior and use RHSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-20578: Sensor will now store pull secrets by secret name and registry host (instead of only registry host). This will reduce Delegated Scanning authentication failures when multiple secrets exist for the same registry within a namespace and more closely aligns with k8s secret handling.
   - Setting `ROX_SENSOR_PULL_SECRETS_BY_NAME` to `false` on Sensor will disable this feature and cause secrets to be stored by only registry host.
 - ROX-25981: Scanner V4 now fetches vulnerability data from [Red Hat's VEX files](https://security.access.redhat.com/data/csaf/v2/vex/) instead of [Red Hat's OVAL feed](https://security.access.redhat.com/data/oval/v2/) for RPMs installed in RHEL-based image containers.
-  - Fixed vulnerabilities affecting RHEL-based images are no longer identified by the respective RHSA, RHBA, nor RHEA. Instead, they will be identified by CVE.
+  - Fixed vulnerabilities affecting RHEL-based images are still identified by the respective RHSA, RHBA, or RHEA, by default. They may be identified by CVE, instead, by setting the feature flag `ROX_SCANNER_V4_RED_HAT_CVES` to `true` in Scanner V4 Matcher.
     - This will also apply to vulnerabilities obtained from the [CVE map](https://security.access.redhat.com/data/metrics/cvemap.xml) (used for container-first scanning).
-    - This may potentially disrupt policies created around RHSAs.
+    - Setting the feature flag may potentially disrupt policies created around RHSAs.
   - Scanner V4 now only considers vulnerabilities affecting Red Hat products dated back to 2014.
     - Previously when reading Red Hat's OVAL data, the vulnerabilities dated back to pre-2000, but ClairCore only reads back to 2014.
   - Scanner V4 DB requires less space for vulnerability data, and its initialization time has improved from about 1 hour on SSD to about 10 minutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-25981: Scanner V4 now fetches vulnerability data from [Red Hat's VEX files](https://security.access.redhat.com/data/csaf/v2/vex/) instead of [Red Hat's OVAL feed](https://security.access.redhat.com/data/oval/v2/) for RPMs installed in RHEL-based image containers.
   - Fixed vulnerabilities affecting RHEL-based images are still identified by the respective RHSA, RHBA, or RHEA, by default. They may be identified by CVE, instead, by setting the feature flag `ROX_SCANNER_V4_RED_HAT_CVES` to `true` in Scanner V4 Matcher.
     - This will also apply to vulnerabilities obtained from the [CVE map](https://security.access.redhat.com/data/metrics/cvemap.xml) (used for container-first scanning).
-    - Setting the feature flag may potentially disrupt policies created around RHSAs.
+    - Setting the feature flag will disrupt policies created around RHSAs, as RHSAs will no longer be tracked.
   - Scanner V4 now only considers vulnerabilities affecting Red Hat products dated back to 2014.
     - Previously when reading Red Hat's OVAL data, the vulnerabilities dated back to pre-2000, but ClairCore only reads back to 2014.
   - Scanner V4 DB requires less space for vulnerability data, and its initialization time has improved from about 1 hour on SSD to about 10 minutes.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -128,4 +128,8 @@ var (
 
 	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
 	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
+
+	// ScannerV4RedHatCVEs enables displaying CVEs instead of RHSAs/RHEAs/RHBAs in the place of fixed vulnerabilities affected Red Hat products.
+	// TODO(ROX-26672): Remove this once we can show both CVEs and RHSAs in the UI + reports.
+	ScannerV4RedHatCVEs = registerFeature("Scanner V4 will output CVEs instead of RHSAs/RHBAs/RHEAs for fixed Red Hat vulnerabilities", "ROX_SCANNER_V4_RED_HAT_CVES")
 )

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -20,6 +20,7 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/scanners/scannerv4"
@@ -31,6 +32,8 @@ const (
 	nvdCVEURLPrefix    = "https://nvd.nist.gov/vuln/detail/"
 	osvCVEURLPrefix    = "https://osv.dev/vulnerability/"
 	redhatCVEURLPrefix = "https://access.redhat.com/security/cve/"
+	// TODO(ROX-26672): Remove this when we stop tracking RHSAs as the vuln name.
+	redhatErrataURLPrefix = "https://access.redhat.com/errata/"
 )
 
 var (
@@ -49,11 +52,15 @@ var (
 	awsUpdaterPrefix = `aws-`
 	osvUpdaterPrefix = `osv/`
 	rhelUpdaterName  = (*vex.Updater)(nil).Name()
+	// TODO(ROX-26672): This won't be needed when we show CVEs as the top-level vuln name.
+	rhccUpdaterName = "rhel-container-updater"
 
 	// Name patterns are regexes to match against vulnerability fields to
 	// extract their name according to their updater.
 
 	awsVulnNamePattern = regexp.MustCompile(`ALAS\d*-\d{4}-\d+`)
+	// TODO(ROX-26672): Remove this and show CVE as the vulnerability name.
+	rhelVulnNamePattern = regexp.MustCompile(`(RHSA|RHBA|RHEA)-\d{4}:\d+`)
 
 	// vulnNamePatterns is a default prioritized list of regexes to match
 	// vulnerability names.
@@ -337,7 +344,7 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 				}
 			}
 		}
-		metrics, err := cvssMetrics(ctx, v, &nvdVuln)
+		metrics, err := cvssMetrics(ctx, v, name, &nvdVuln)
 		if err != nil {
 			zlog.Debug(ctx).
 				Err(err).
@@ -649,7 +656,9 @@ func pkgFixedBy(enrichments map[string][]json.RawMessage) (map[string]string, er
 // An error is returned when there is a failure to collect CVSS metrics from all sources;
 // however, the returned slice of metrics will still be populated with any successfully gathered metrics.
 // It is up to the caller to ensure the returned slice is populated prior to using it.
-func cvssMetrics(_ context.Context, vuln *claircore.Vulnerability, nvdVuln *nvdschema.CVEAPIJSON20CVEItem) ([]*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
+//
+// TODO(ROX-26672): Remove vulnName parameter. It's a temporary patch until we stop makeing RHSAs the top-level vulnerability.
+func cvssMetrics(_ context.Context, vuln *claircore.Vulnerability, vulnName string, nvdVuln *nvdschema.CVEAPIJSON20CVEItem) ([]*v4.VulnerabilityReport_Vulnerability_CVSS, error) {
 	var metrics []*v4.VulnerabilityReport_Vulnerability_CVSS
 
 	var preferredCVSS *v4.VulnerabilityReport_Vulnerability_CVSS
@@ -657,6 +666,10 @@ func cvssMetrics(_ context.Context, vuln *claircore.Vulnerability, nvdVuln *nvds
 	switch {
 	case strings.EqualFold(vuln.Updater, rhelUpdaterName):
 		preferredCVSS, preferredErr = vulnCVSS(vuln, v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT)
+		// TODO(ROX-26672): Remove this
+		if !features.ScannerV4RedHatCVEs.Enabled() && preferredCVSS != nil && rhelVulnNamePattern.MatchString(vulnName) {
+			preferredCVSS.Url = redhatErrataURLPrefix + vulnName
+		}
 	case strings.HasPrefix(vuln.Updater, osvUpdaterPrefix) && !isOSVDBSpecificSeverity(vuln.Severity):
 		preferredCVSS, preferredErr = vulnCVSS(vuln, v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV)
 	case strings.EqualFold(vuln.Updater, constants.ManualUpdaterName):
@@ -833,6 +846,13 @@ func vulnerabilityName(vuln *claircore.Vulnerability) string {
 	case strings.HasPrefix(vuln.Updater, awsUpdaterPrefix):
 		if v, ok := findName(vuln, awsVulnNamePattern); ok {
 			return v
+		}
+	// TODO(ROX-26672): Remove this to show CVE as the vuln name.
+	case strings.EqualFold(vuln.Updater, rhelUpdaterName), strings.EqualFold(vuln.Updater, rhccUpdaterName):
+		if !features.ScannerV4RedHatCVEs.Enabled() {
+			if v, ok := findName(vuln, rhelVulnNamePattern); ok {
+				return v
+			}
 		}
 	}
 	// Default patterns.

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -32,6 +32,7 @@ pkg/fixtures/image.go
 pkg/fixtures/image/files/*
 pkg/mitre/files/mitre.json
 pkg/mocks/github.com/aws/aws-sdk-go/service/securityhub/securityhubiface/mocks/mocks.go
+pkg/scannerv4/mappers/mappers_test.go
 pkg/sliceutils/gen-builtins-generic.go
 proto/storage/proto.lock
 qa-tests-backend/artifacts/**/*


### PR DESCRIPTION
### Description

Since we are not ready to display both CVEs and RHSAs in the UI and reports (separating CVEs from RHSAs), we must continue to show RHSAs instead of CVEs for fixed vulnerabilities affecting Red Hat products.

This is configurable via feature flag; however, for those who may choose to just have a complete break away from RHSAs.

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

CI + tested with `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:ca6719b04994956335e2a57af104cc185576838ff26a2405e49e42bf0f8cca94`:

The RHSAs look correct, and the NVD CVSS scores look correct, too

<img width="1359" alt="Screenshot 2024-10-30 at 11 51 53 AM" src="https://github.com/user-attachments/assets/66f8e087-e2ff-47e9-9c01-2f464cffcb2f">

