### PR TITLE
ROX-26474: Expand metrics for Node Indexing

### DIFF
--- a/compliance/collection/compliance/node_scanner.go
+++ b/compliance/collection/compliance/node_scanner.go
@@ -68,6 +68,6 @@ func (n *NodeInventoryComponentScanner) ScanNode(ctx context.Context) (*sensor.M
 		Node: result.GetNodeName(),
 		Msg:  &sensor.MsgFromCompliance_NodeInventory{NodeInventory: inv},
 	}
-	cmetrics.ObserveInventoryProtobufMessage(msg)
+	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV2)
 	return msg, nil
 }

--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -146,6 +146,7 @@ var (
 			"scanner_version",
 		})
 
+	// TODO(ROX-26699): Duplicate and rename metric
 	inventoryTransmissions = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.ComplianceSubsystem.String(),

--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	ScannerVersionV2 = "2"
-	ScannerVersionV4 = "4"
+	ScannerVersionV2 = "Stackrox Scanner"
+	ScannerVersionV4 = "Scanner V4"
 )
 
 var (
@@ -59,6 +59,8 @@ var (
 			"node_name",
 			// Whether the inventory run was completed successfully
 			"error",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
 		})
 
 	indexDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -66,13 +68,15 @@ var (
 		Subsystem: metrics.ComplianceSubsystem.String(),
 		Name:      "index_duration_seconds",
 		Help:      "Generation duration for Node IndexReports (per Node) in seconds",
-		Buckets:   []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100, 500, 1000},
+		Buckets:   []float64{0.1, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100, 500, 1000},
 	},
 		[]string{
 			// The Node this scan belongs to
 			"node_name",
 			// Whether the inventory run was completed successfully
 			"error",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
 		})
 
 	callToNodeInventoryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -87,6 +91,8 @@ var (
 			"node_name",
 			// Whether the inventory run was completed successfully
 			"error",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
 		})
 
 	rescanInterval = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -123,17 +129,21 @@ var (
 		[]string{
 			// The Node this scan belongs to
 			"node_name",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
 		})
 
 	indexesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.ComplianceSubsystem.String(),
-		Name:      "index_total",
+		Name:      "index_reports_total",
 		Help:      "Number of generated node index reports since container start",
 	},
 		[]string{
 			// The Node this scan belongs to
 			"node_name",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
 		})
 
 	inventoryTransmissions = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -212,24 +222,27 @@ func ObserveNodeIndexReport(report *v4.IndexReport, nodeName string) {
 // ObserveNodeInventoryCallDuration observes the metric.
 func ObserveNodeInventoryCallDuration(d time.Duration, nodeName string, e error) {
 	callToNodeInventoryDuration.With(prometheus.Labels{
-		"node_name": nodeName,
-		"error":     strconv.FormatBool(e != nil),
+		"node_name":       nodeName,
+		"error":           strconv.FormatBool(e != nil),
+		"scanner_version": ScannerVersionV2,
 	}).Observe(d.Seconds())
 }
 
 // ObserveScanDuration observes the metric.
 func ObserveScanDuration(d time.Duration, nodeName string, e error) {
 	scanDuration.With(prometheus.Labels{
-		"node_name": nodeName,
-		"error":     strconv.FormatBool(e != nil),
+		"node_name":       nodeName,
+		"error":           strconv.FormatBool(e != nil),
+		"scanner_version": ScannerVersionV2,
 	}).Observe(d.Seconds())
 }
 
 // ObserveIndexDuration observes the metric.
 func ObserveIndexDuration(d time.Duration, nodeName string, e error) {
 	indexDuration.With(prometheus.Labels{
-		"node_name": nodeName,
-		"error":     strconv.FormatBool(e != nil),
+		"node_name":       nodeName,
+		"error":           strconv.FormatBool(e != nil),
+		"scanner_version": ScannerVersionV4,
 	}).Observe(d.Seconds())
 }
 
@@ -243,14 +256,16 @@ func ObserveRescanInterval(d time.Duration, nodeName string) {
 // ObserveScansTotal observed the metric
 func ObserveScansTotal(nodeName string) {
 	scansTotal.With(prometheus.Labels{
-		"node_name": nodeName,
+		"node_name":       nodeName,
+		"scanner_version": ScannerVersionV2,
 	}).Inc()
 }
 
 // ObserveIndexesTotal observed the metric
 func ObserveIndexesTotal(nodeName string) {
 	indexesTotal.With(prometheus.Labels{
-		"node_name": nodeName,
+		"node_name":       nodeName,
+		"scanner_version": ScannerVersionV4,
 	}).Inc()
 }
 

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -126,20 +126,17 @@ func (e *enricherImpl) enrichNodeWithScanner(node *storage.Node, nodeInventory *
 	var scan *storage.NodeScan
 	var err error
 
-	var scannerVersion int
-
 	scanStartTime := time.Now()
 	if scanner.Type() == types.ScannerV4 {
 		scan, err = scanner.GetNodeInventoryScan(node, nil, indexReport)
-		scannerVersion = 4
+		e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
+		e.metrics.SetNodeInventoryNumberComponents(len(indexReport.GetContents().GetPackages()), node.GetClusterName(), node.GetName(), scanner.Name())
 	} else {
 		scan, err = scanner.GetNodeInventoryScan(node, nodeInventory, nil)
-		scannerVersion = 2
+		e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
+		e.metrics.SetNodeInventoryNumberComponents(len(nodeInventory.GetComponents().GetRhelComponents()), node.GetClusterName(), node.GetName(), scanner.Name())
 	}
 
-	e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
-	e.metrics.SetNodeInventoryNumberComponents(len(nodeInventory.GetComponents().GetRhelComponents()), node.GetClusterName(), node.GetName())
-	e.metrics.SetNodeScanScannerVersion(scannerVersion, node.GetClusterName(), node.GetName())
 	if err != nil {
 		return errors.Wrapf(err, "Error scanning '%s:%s' with scanner %q", node.GetClusterName(), node.GetName(), scanner.Name())
 	}


### PR DESCRIPTION
### Description

For the introduction of Node Indexing (Node Scanning on Scanner v4), we also want to update the existing metrics.
I have added a label indicating the scanner version to existing metrics where possible, everywhere else I have introduced a new metric for Node Indexing following the pattern of the old metric.
The latter was done in most places where we would need a service release of Scanner v2 to account for the new labels, which is a lot of work for a deprecated component.
The only exception is the metric `calltToNodeInventoryDuration`, which isn't applicable to Node Indexing, as we do not call an external service component anymore, so I did not add/migrate that.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

On a running OpenShift 4 cluster with ACS / Scanner v4 deployed, updated the Compliance and Central images and verified that the new/updated metrics are available at `/metrics` .
I did this for both, Scanner v4 enabled and disabled.
* For compliance: It is needed to set `ROX_METRICS_PORT` to `:9091` (note the colon) for the compliance container for metrics to be exposed correctly
