### PR TITLE
chore: drop dependency on github.com/gofrs/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/certificate-transparency-go v1.2.1
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49

--- a/pkg/logging/module_test.go
+++ b/pkg/logging/module_test.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -63,20 +63,20 @@ func TestModuleSetLogLevel(t *testing.T) {
 }
 
 func TestModuleRefCountingWorks(t *testing.T) {
-	module := newModule(uuid.Must(uuid.NewV4()).String(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
+	module := newModule(uuid.NewString(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
 	module.ref()
 	assert.False(t, module.unref())
 	assert.True(t, module.unref())
 }
 
 func TestLoggerCreatedFromModuleReferencesModule(t *testing.T) {
-	module := newModule(uuid.Must(uuid.NewV4()).String(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
+	module := newModule(uuid.NewString(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
 	logger := module.Logger()
 	assert.Equal(t, module, logger.module)
 }
 
 func TestRegistryPurgesModulesWithRefCountOfZero(t *testing.T) {
-	name := uuid.Must(uuid.NewV4()).String()
+	name := uuid.NewString()
 	modules.getOrAddModule(name)
 	modules.unrefModule(name)
 
@@ -85,7 +85,7 @@ func TestRegistryPurgesModulesWithRefCountOfZero(t *testing.T) {
 
 func TestLoggerCreatedFromModuleUpdatesLogLevel(t *testing.T) {
 	for zapLevel := range validLevels {
-		module := newModule(uuid.Must(uuid.NewV4()).String(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
+		module := newModule(uuid.NewString(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
 		logger := module.Logger()
 		module.SetLogLevel(zapLevel)
 		assert.True(t, logger.SugaredLogger().Desugar().Core().Enabled(zapLevel))
@@ -95,7 +95,7 @@ func TestLoggerCreatedFromModuleUpdatesLogLevel(t *testing.T) {
 }
 
 func TestLoggerLevelUpdatesWithGlobalLevel(t *testing.T) {
-	module := ModuleForName(uuid.Must(uuid.NewV4()).String())
+	module := ModuleForName(uuid.NewString())
 	logger := module.Logger()
 	level := GetGlobalLogLevel()
 

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 // UUID in a universally unique identifier. The type is a wrapper around the uuid library.
@@ -32,7 +32,7 @@ func Equal(u1 UUID, u2 UUID) bool {
 
 // Bytes returns bytes slice representation of UUID.
 func (u UUID) Bytes() []byte {
-	return u.uuid.Bytes()
+	return u.uuid[:16]
 }
 
 // String returns the canonical string representation of UUID:
@@ -127,7 +127,7 @@ func FromStringOrPanic(input string) UUID {
 // NewV4 returns random generated UUID.
 func NewV4() UUID {
 	return UUID{
-		uuid: uuid.Must(uuid.NewV4()),
+		uuid: uuid.New(),
 	}
 }
 
@@ -142,14 +142,14 @@ func NewV5FromNonUUIDs(ns, name string) UUID {
 		panic(err)
 	}
 	return UUID{
-		uuid: uuid.NewV5(nsUUID, name),
+		uuid: uuid.NewSHA1(nsUUID, []byte(name)),
 	}
 }
 
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
 func NewV5(ns UUID, name string) UUID {
 	return UUID{
-		uuid: uuid.NewV5(ns.uuid, name),
+		uuid: uuid.NewSHA1(ns.uuid, []byte(name)),
 	}
 }
 


### PR DESCRIPTION
### Description

Module `github.com/google/uuid` is already being used, so complete migration to drop that extra redundant module dependency.

#### How I validated my change

`go test -v ./...` on changed parts.