### PR TITLE
fix(ui): Compliance Reporting fixes

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -185,6 +185,7 @@ function ViewScanConfigDetail({
                                 title={alertObj.title}
                                 component="p"
                                 variant={alertObj.type}
+                                isInline
                                 className="pf-v5-u-mb-lg pf-v5-u-mx-lg"
                                 actionClose={<AlertActionCloseButton onClose={clearAlertObj} />}
                             >

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -88,7 +88,7 @@ function ReportJobs({ scanConfigId, isComplianceReportingEnabled }: ReportJobsPr
         isLoading,
         error,
         refetch,
-    } = useRestQuery(fetchComplianceReportHistoryCallback);
+    } = useRestQuery(fetchComplianceReportHistoryCallback, { clearErrorBeforeRequest: false });
 
     const {
         openDeleteDownloadModal,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
@@ -9,6 +9,8 @@ import {
     PendingIcon,
 } from '@patternfly/react-icons';
 import { Button, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import capitalize from 'lodash/capitalize';
+
 import { ReportStatus } from 'types/reportJob';
 
 export type ReportJobStatusProps = {
@@ -42,7 +44,9 @@ function ReportJobStatus({
     } else if (reportStatus.runState === 'FAILURE') {
         statusColorClass = 'pf-v5-u-danger-color-100';
         statusIcon = (
-            <Tooltip content={reportStatus?.errorMsg || genericMsg}>
+            <Tooltip
+                content={reportStatus?.errorMsg ? capitalize(reportStatus.errorMsg) : genericMsg}
+            >
                 <ExclamationCircleIcon title="Report run was unsuccessful" />
             </Tooltip>
         );

--- a/ui/apps/platform/src/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/hooks/useRestQuery.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 import noop from 'lodash/noop';
 import { CancellableRequest, isCancellableRequest } from 'services/cancellationUtils';
 
+export type UseRequestQueryOptions = {
+    clearErrorBeforeRequest?: boolean;
+};
+
 export type UseRestQueryReturn<ReturnType> = {
     data: ReturnType | undefined;
     isLoading: boolean;
@@ -10,11 +14,16 @@ export type UseRestQueryReturn<ReturnType> = {
 };
 
 export default function useRestQuery<ReturnType>(
-    requestFn: () => CancellableRequest<ReturnType> | Promise<ReturnType>
+    requestFn: () => CancellableRequest<ReturnType> | Promise<ReturnType>,
+    options: UseRequestQueryOptions = {}
 ): UseRestQueryReturn<ReturnType> {
     const [data, setData] = useState<ReturnType>();
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<Error | undefined>();
+
+    const {
+        clearErrorBeforeRequest = true, // Default behavior: clear error before request
+    } = options;
 
     const execFetch = useCallback(() => {
         let isMounted = true;
@@ -22,7 +31,9 @@ export default function useRestQuery<ReturnType>(
         const request = isCancellableRequest(requestResult) ? requestResult.request : requestResult;
         const cancel = isCancellableRequest(requestResult) ? requestResult.cancel : noop;
 
-        setError(undefined);
+        if (clearErrorBeforeRequest) {
+            setError(undefined);
+        }
         setIsLoading(true);
 
         request
@@ -44,7 +55,7 @@ export default function useRestQuery<ReturnType>(
             isMounted = false;
             cancel();
         };
-    }, [requestFn]);
+    }, [clearErrorBeforeRequest, requestFn]);
 
     useEffect(execFetch, [execFetch]);
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds a few more bug fixes for Compliance Reporting:
- Using the right type of Alert 
- Allowing the ability to pass an `options` object to `useRestQuery` which tweaks the behavior. We had an issue where an Error state would flicker during polling because of how our table state logic was organized. Because every repeated request would clear the error message, we would get an `Idle` state between polls. This resulted in the Error state disappearing and reappearing.
- We capitalize the error message shown in the tooltips

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no tests added

### Screenshots and Screen recordings

#### Using an inline alert
<img width="721" alt="Screenshot 2024-10-18 at 10 28 01 AM" src="https://github.com/user-attachments/assets/ec1b6d60-6e72-4d11-8d40-11aacc1bc832">

#### No flickering during polling
https://github.com/user-attachments/assets/bea171ad-ecf7-4c44-8707-0be7c4ea8524

#### Capitalizing error message in tooltip
<img width="413" alt="Screenshot 2024-10-18 at 10 29 19 AM" src="https://github.com/user-attachments/assets/8f394ad7-843c-4e8d-806b-61394f814a95">
