### PR TITLE
fix(ui): Make Policy tab of Violations consistent with Policies

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 
 import PolicyDetailContent from 'Containers/Policies/Detail/PolicyDetailContent';
+import { getClientWizardPolicy } from 'Containers/Policies/policies.utils';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
 import { fetchAlert } from 'services/AlertsService';
@@ -134,7 +135,7 @@ function ViolationDetailsPage(): ReactElement {
                                     Policy overview
                                 </Title>
                                 <Divider component="div" className="pf-v5-u-pb-md" />
-                                <PolicyDetailContent policy={policy} />
+                                <PolicyDetailContent policy={getClientWizardPolicy(policy)} />
                             </PageSection>
                         </Tab>
                     )}


### PR DESCRIPTION
### Description

Good eyes, Surabhi.

### Problem

Inconsistency on Policy tab of Violations for field that has relational operator, for example **Fixable Severity at Least Important** policy that has **Severity** field. See **Manual testing** below.

### Analysis

One big step forward to fix chronic TypeScript errors and one small step backward:
https://github.com/stackrox/stackrox/pull/12351/files?diff=split&w=1#diff-5c53620827639310dcbb0614ba692ae5369b2680042b73d4edde5d2deec81773R137

Visual Studio Code for 3 components render `PolicyDetailContent` element:
1. src/Containers/Policies/Detail/PolicyDetail.tsx file has `policy: ClientPolicy` tooltip
2. src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx file has `values: ClientPolicy` tooltip
3. src/Containers/Violations/Details/ViolationDetailsPage.tsx file has `policy: Policy` tooltip

### Solution

Call `getClientWizardPolicy` function to convert from (server) `Policy` to `ClientPolicy` type that policy wizard elements assume.

### Residue

Fixed width policy field cards can cause confusing ellipsis truncation at laptop screen width. For example, **Is greater tha…**
* Is greater than
* Is greater than or equal to

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/policies, and then click link of policy that has violations.
    ![Policy](https://github.com/user-attachments/assets/f20d9061-478a-4ff0-894c-99d883f165e6)

2. Clone the policy and advance to **Review** step. Close preview pane.
    ![Review](https://github.com/user-attachments/assets/512dca52-d1c6-4b05-bff6-a51ec5192ba7)

3. Visit /main/violations, click link of violation of policy, and then click **Policy** tab.

    * Before change, inconsistent without `getClientWizardPolicy` function call.
        ![Violations_without_getClientWizardPolicy](https://github.com/user-attachments/assets/f7143f0f-6f2a-4d0f-8a21-90a6810c0f58)

    * After change, consistent with `getClientWizardPolicy` function call.
        ![Violations_with_getClientWizardPolicy](https://github.com/user-attachments/assets/7d8cf834-0338-4749-bf68-241d39db5de2)
