### PR TITLE
ROX-26565: Fix netgraph flows section expanders

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -201,7 +201,9 @@ function DeploymentFlows({
                                     'flow',
                                     numAnomalousFlows
                                 )}`}
-                                onToggle={() => toggleAnomalousFlowsExpandable}
+                                onToggle={(e, isExpanded) =>
+                                    toggleAnomalousFlowsExpandable(isExpanded)
+                                }
                                 isExpanded={isAnomalousFlowsExpanded}
                             >
                                 {numAnomalousFlows > 0 ? (
@@ -231,7 +233,9 @@ function DeploymentFlows({
                                     'flow',
                                     numBaselineFlows
                                 )}`}
-                                onToggle={() => toggleBaselineFlowsExpandable}
+                                onToggle={(e, isExpanded) =>
+                                    toggleBaselineFlowsExpandable(isExpanded)
+                                }
                                 isExpanded={isBaselineFlowsExpanded}
                             >
                                 {numBaselineFlows > 0 ? (


### PR DESCRIPTION
### Description

Fixes the expand/collapse functionality of the network graph flows section expanders.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit network graph and open a deployment side panel. Click the flows sections to expand/collapse.
![image](https://github.com/user-attachments/assets/6f06d632-7f2b-438a-9e61-a66afd5d878f)
![image](https://github.com/user-attachments/assets/88386d98-63e9-45be-8b07-b93a70532e0c)
![image](https://github.com/user-attachments/assets/b0471fc5-8854-46a7-b6bd-0e294d6608ee)
![image](https://github.com/user-attachments/assets/3b68aab4-2db1-41a1-9084-f10dc6e2a5bf)
