### PR TITLE
ROX-24588: Reintroduce Published date in VM 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -102,6 +102,7 @@ export const imageCveMetadataQuery = gql`
         imageCVE(cve: $cve) {
             cve
             firstDiscoveredInSystem
+            publishedOn
             distroTuples {
                 summary
                 link

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -35,6 +35,7 @@ export const deploymentComponentVulnerabilitiesFragment = gql`
             scoreVersion
             fixedByVersion
             discoveredAtImage
+            publishedOn
             pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
         }
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -215,7 +215,11 @@ function DeploymentVulnerabilitiesTable({
                                         modifier="nowrap"
                                         dataLabel="Published"
                                     >
-                                        <DateDistance date={publishedOn} />
+                                        {publishedOn ? (
+                                            <DateDistance date={publishedOn} />
+                                        ) : (
+                                            'Not available'
+                                        )}
                                     </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -49,6 +49,10 @@ export const defaultColumns = {
         title: 'First discovered',
         isShownByDefault: true,
     },
+    publishedOn: {
+        title: 'Published',
+        isShownByDefault: true,
+    },
 } as const;
 
 export const deploymentWithVulnerabilitiesFragment = gql`
@@ -62,6 +66,7 @@ export const deploymentWithVulnerabilitiesFragment = gql`
             vulnerabilityId: id
             cve
             operatingSystem
+            publishedOn
             summary
             pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
             images(query: $query) {
@@ -119,6 +124,7 @@ function DeploymentVulnerabilitiesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('firstDiscovered')}>First discovered</Th>
+                    <Th className={getVisibilityClass('publishedOn')}>Published</Th>
                 </Tr>
             </Thead>
             <TbodyUnified
@@ -138,6 +144,7 @@ function DeploymentVulnerabilitiesTable({
                             images,
                             affectedComponentsText,
                             discoveredAtImage,
+                            publishedOn,
                             pendingExceptionCount,
                         } = vulnerability;
                         const isExpanded = expandedRowSet.has(vulnerabilityId);
@@ -202,6 +209,13 @@ function DeploymentVulnerabilitiesTable({
                                         dataLabel="First discovered"
                                     >
                                         <DateDistance date={discoveredAtImage} />
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('publishedOn')}
+                                        modifier="nowrap"
+                                        dataLabel="Published"
+                                    >
+                                        <DateDistance date={publishedOn} />
                                     </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -74,6 +74,10 @@ export const defaultColumns = {
         title: 'First discovered',
         isShownByDefault: true,
     },
+    publishedOn: {
+        title: 'Published',
+        isShownByDefault: true,
+    },
 } as const;
 
 export const imageVulnerabilitiesFragment = gql`
@@ -87,6 +91,7 @@ export const imageVulnerabilitiesFragment = gql`
         nvdCvss
         nvdScoreVersion
         discoveredAtImage
+        publishedOn
         pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
         imageComponents(query: $query) {
             ...ImageComponentVulnerabilities
@@ -103,6 +108,7 @@ export type ImageVulnerability = {
     nvdCvss: number;
     nvdScoreVersion: string; // for example, V3 or UNKNOWN_VERSION
     discoveredAtImage: string | null;
+    publishedOn: string | null;
     pendingExceptionCount: number;
     imageComponents: ImageComponentVulnerability[];
 };
@@ -180,6 +186,7 @@ function ImageVulnerabilitiesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('firstDiscovered')}>First discovered</Th>
+                    <Th className={getVisibilityClass('publishedOn')}>Published</Th>
                     {showExceptionDetailsLink && (
                         <TooltipTh tooltip="View information about this exception request">
                             Request details
@@ -209,6 +216,7 @@ function ImageVulnerabilitiesTable({
                             nvdScoreVersion,
                             imageComponents,
                             discoveredAtImage,
+                            publishedOn,
                             pendingExceptionCount,
                         } = vulnerability;
                         const vulnerabilities = imageComponents.flatMap(
@@ -301,6 +309,12 @@ function ImageVulnerabilitiesTable({
                                         dataLabel="First discovered"
                                     >
                                         <DateDistance date={discoveredAtImage} />
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('publishedOn')}
+                                        dataLabel="Published"
+                                    >
+                                        <DateDistance date={publishedOn} />
                                     </Td>
                                     {showExceptionDetailsLink && (
                                         <ExceptionDetailsCell

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -185,8 +185,12 @@ function ImageVulnerabilitiesTable({
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th className={getVisibilityClass('firstDiscovered')}>First discovered</Th>
-                    <Th className={getVisibilityClass('publishedOn')}>Published</Th>
+                    <Th className={getVisibilityClass('firstDiscovered')} modifier="nowrap">
+                        First discovered
+                    </Th>
+                    <Th className={getVisibilityClass('publishedOn')} modifier="nowrap">
+                        Published
+                    </Th>
                     {showExceptionDetailsLink && (
                         <TooltipTh tooltip="View information about this exception request">
                             Request details
@@ -314,7 +318,11 @@ function ImageVulnerabilitiesTable({
                                         className={getVisibilityClass('publishedOn')}
                                         dataLabel="Published"
                                     >
-                                        <DateDistance date={publishedOn} />
+                                        {publishedOn ? (
+                                            <DateDistance date={publishedOn} />
+                                        ) : (
+                                            'Not available'
+                                        )}
                                     </Td>
                                     {showExceptionDetailsLink && (
                                         <ExceptionDetailsCell

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -394,14 +394,20 @@ function WorkloadCVEOverviewTable({
                                         <Td
                                             dataLabel="First discovered"
                                             className={getVisibilityClass('firstDiscovered')}
+                                            modifier="nowrap"
                                         >
                                             <DateDistance date={firstDiscoveredInSystem} />
                                         </Td>
                                         <Td
                                             dataLabel="Published"
                                             className={getVisibilityClass('publishedOn')}
+                                            modifier="nowrap"
                                         >
-                                            <DateDistance date={publishedOn} />
+                                            {publishedOn ? (
+                                                <DateDistance date={publishedOn} />
+                                            ) : (
+                                                'Not available'
+                                            )}
                                         </Td>
                                         {showExceptionDetailsLink && (
                                             <ExceptionDetailsCell

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -74,6 +74,10 @@ export const defaultColumns = {
         title: 'First discovered',
         isShownByDefault: true,
     },
+    publishedOn: {
+        title: 'Published',
+        isShownByDefault: true,
+    },
 } as const;
 
 export const cveListQuery = gql`
@@ -101,6 +105,7 @@ export const cveListQuery = gql`
             topCVSS
             affectedImageCount
             firstDiscoveredInSystem
+            publishedOn
             topNvdCVSS
             distroTuples {
                 summary
@@ -136,6 +141,7 @@ export type ImageCVE = {
     topCVSS: number;
     affectedImageCount: number;
     firstDiscoveredInSystem: string | null;
+    publishedOn: string | null;
     topNvdCVSS: number;
     distroTuples: {
         summary: string;
@@ -244,6 +250,12 @@ function WorkloadCVEOverviewTable({
                         First discovered
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
+                    <TooltipTh
+                        className={getVisibilityClass('publishedOn')}
+                        tooltip="Time when the CVE was made public and assigned a number"
+                    >
+                        Published
+                    </TooltipTh>
                     {showExceptionDetailsLink && (
                         <TooltipTh tooltip="View information about this exception request">
                             Request details
@@ -271,6 +283,7 @@ function WorkloadCVEOverviewTable({
                                 topNvdCVSS,
                                 affectedImageCount,
                                 firstDiscoveredInSystem,
+                                publishedOn,
                                 distroTuples,
                                 pendingExceptionCount,
                             },
@@ -383,6 +396,12 @@ function WorkloadCVEOverviewTable({
                                             className={getVisibilityClass('firstDiscovered')}
                                         >
                                             <DateDistance date={firstDiscoveredInSystem} />
+                                        </Td>
+                                        <Td
+                                            dataLabel="Published"
+                                            className={getVisibilityClass('publishedOn')}
+                                        >
+                                            <DateDistance date={publishedOn} />
                                         </Td>
                                         {showExceptionDetailsLink && (
                                             <ExceptionDetailsCell

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import { min } from 'date-fns';
+import { min, parse } from 'date-fns';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
@@ -74,6 +74,7 @@ export type DeploymentComponentVulnerability = Omit<
         scoreVersion: string;
         fixedByVersion: string;
         discoveredAtImage: string | null;
+        publishedOn: string | null;
         pendingExceptionCount: number;
     }[];
 };
@@ -216,6 +217,7 @@ export type DeploymentWithVulnerabilities = {
         vulnerabilityId: string;
         cve: string;
         operatingSystem: string;
+        publishedOn: string | null;
         summary: string;
         pendingExceptionCount: number;
         images: {
@@ -237,6 +239,7 @@ export type FormattedDeploymentVulnerability = {
     severity: VulnerabilitySeverity;
     isFixable: boolean;
     discoveredAtImage: Date | null;
+    publishedOn: Date | null;
     summary: string;
     affectedComponentsText: string;
     images: DeploymentVulnerabilityImageMapping[];
@@ -283,6 +286,8 @@ export function formatVulnerabilityData(
                     !!vulnImageMap.imageMetadataContext
             );
 
+        const publishedOnDate = parse(allVulnerabilities[0].publishedOn || '');
+
         return {
             vulnerabilityId,
             cve,
@@ -290,6 +295,7 @@ export function formatVulnerabilityData(
             severity: highestVulnSeverity,
             isFixable: isFixableInDeployment,
             discoveredAtImage: oldestDiscoveredVulnDate,
+            publishedOn: publishedOnDate,
             summary,
             affectedComponentsText,
             images: vulnerabilityImages,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -286,7 +286,9 @@ export function formatVulnerabilityData(
                     !!vulnImageMap.imageMetadataContext
             );
 
-        const publishedOnDate = parse(allVulnerabilities[0].publishedOn || '');
+        const publishedOnDate = allVulnerabilities[0].publishedOn
+            ? parse(allVulnerabilities[0].publishedOn)
+            : null;
 
         return {
             vulnerabilityId,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -12,6 +12,7 @@ import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
 export type CveMetadata = {
     cve: string;
     firstDiscoveredInSystem: string | null;
+    publishedOn: string | null;
     distroTuples: {
         summary: string;
         link: string;
@@ -42,9 +43,13 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
                 {data.cve}
             </Title>
             {data.firstDiscoveredInSystem && (
-                <LabelGroup numLabels={1}>
+                <LabelGroup numLabels={2}>
                     <Label>
                         First discovered in system: {getDateTime(data.firstDiscoveredInSystem)}
+                    </Label>
+                    <Label>
+                        Published:{' '}
+                        {data.publishedOn ? getDateTime(data.publishedOn) : 'Not available'}
                     </Label>
                 </LabelGroup>
             )}


### PR DESCRIPTION
### Description

This change re-introduces the date a CVE was published to the folllowing new Vulnerability Management views:

1. Workload CVEs table
2. Workload CVE single detail view
3. Image single detail view, CVEs in image table
4. Deployment single detail view, CVEs in deployment table

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

tbd

- [x] the change is production ready: the change is GA
- [x] CI results are inspected

#### Automated testing

- [ ] modified existing tests

#### How I validated my change

tbd

Workload CVEs with "Published" column heading with tooltip
![Screenshot 2024-10-18 at 5 08 47 PM](https://github.com/user-attachments/assets/79fe12be-e69e-49bc-835c-48e07efc65aa)

Workload CVEs Published date with tooltip showing absolute date, instead of the inane relative date
![Screenshot 2024-10-18 at 5 08 51 PM](https://github.com/user-attachments/assets/7e2430e9-9f7e-4487-92da-5759cb0bdbac)

CVE detail view with Published in header:
![Screenshot 2024-10-21 at 5 25 38 PM](https://github.com/user-attachments/assets/f657ad98-8758-4299-8e4f-f3ee8f8bdd77)

Image detail CVEs table with "Published" column heading with tooltip
![Screenshot 2024-10-18 at 5 09 32 PM](https://github.com/user-attachments/assets/2e950a04-d8a0-4eb5-acbb-22488f46efba)

Image detail CVEs table with Published date with tooltip showing absolute date, instead of the inane relative date
![Screenshot 2024-10-18 at 5 09 35 PM](https://github.com/user-attachments/assets/c68550d6-7030-4b85-bc50-e7029348e95b)

Deployment detail CVEs table with "Published" column heading
![Screenshot 2024-10-21 at 5 48 27 PM](https://github.com/user-attachments/assets/260b1227-48fe-431d-8cc4-fa4a6539a039)

