### PR TITLE
ROX-26663: Add additional retries to Delegated Scanning Tests

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -73,7 +73,7 @@ func testContexts(t *testing.T, name string, timeout time.Duration) (testCtx con
 		testCancel    func()
 	)
 	cleanupTimeout := 10 * time.Minute
-	t.Logf("Running %s with a timeout of %s plus %s for cleanup", name, timeout, cleanupTimeout)
+	logf(t, "Running %s with a timeout of %s plus %s for cleanup", name, timeout, cleanupTimeout)
 	overallTimeout := timeout + cleanupTimeout
 	overallErr := fmt.Errorf("overall %s test+cleanup timeout of %s reached", name, overallTimeout)
 	testErr := fmt.Errorf("%s test timeout of %s reached", name, timeout)
@@ -308,7 +308,7 @@ func teardownDeploymentWithoutCheck(t *testing.T, deploymentName string) {
 	// we can trigger deletion and assume that it will be deleted eventually.
 	cmd := exec.Command(`kubectl`, `delete`, `deployment`, deploymentName, `--ignore-not-found=true`, `--grace-period=1`)
 	if err := cmd.Run(); err != nil {
-		t.Logf("Deleting deployment %q failed: %v", deploymentName, err)
+		logf(t, "Deleting deployment %q failed: %v", deploymentName, err)
 	}
 }
 
@@ -647,7 +647,7 @@ func mustCreateAPIToken(t *testing.T, ctx context.Context, name string, roles []
 	})
 	require.NoError(err)
 
-	t.Logf("Created API Token %q (%v): %v", name, tokResp.GetMetadata().GetId(), roles)
+	logf(t, "Created API Token %q (%v): %v", name, tokResp.GetMetadata().GetId(), roles)
 	return tokResp.GetMetadata().GetId(), tokResp.GetToken()
 }
 
@@ -665,7 +665,7 @@ func revokeAPIToken(t *testing.T, ctx context.Context, idOrName string) {
 		if tok.GetId() == idOrName || tok.GetName() == idOrName {
 			_, err = service.RevokeToken(ctx, &v1.ResourceByID{Id: tok.GetId()})
 			require.NoError(t, err)
-			t.Logf("Revoked API token %q (%s)", tok.GetName(), tok.GetId())
+			logf(t, "Revoked API token %q (%s)", tok.GetName(), tok.GetId())
 			return
 		}
 	}
@@ -679,7 +679,7 @@ func mustCreatePermissionSet(t *testing.T, ctx context.Context, permissionSet *s
 	ps, err := service.PostPermissionSet(ctx, permissionSet)
 	require.NoError(t, err)
 
-	t.Logf("Created permission set: %v", ps)
+	logf(t, "Created permission set: %v", ps)
 	return ps.GetId()
 }
 
@@ -695,7 +695,7 @@ func deletePermissionSet(t *testing.T, ctx context.Context, idOrName string) {
 		if ps.GetId() == idOrName || ps.GetName() == idOrName {
 			_, err = service.DeletePermissionSet(ctx, &v1.ResourceByID{Id: ps.GetId()})
 			require.NoError(t, err)
-			t.Logf("Deleted permission set %q (%s)", ps.GetName(), ps.GetId())
+			logf(t, "Deleted permission set %q (%s)", ps.GetName(), ps.GetId())
 			return
 		}
 	}
@@ -712,7 +712,7 @@ func mustCreateRole(t *testing.T, ctx context.Context, role *storage.Role) {
 	})
 	require.NoError(t, err)
 
-	t.Logf("Created role: %v", role)
+	logf(t, "Created role: %v", role)
 }
 
 // deleteRole will delete the specified role.
@@ -727,7 +727,7 @@ func deleteRole(t *testing.T, ctx context.Context, name string) {
 		if role.GetName() == name {
 			_, err = service.DeleteRole(ctx, &v1.ResourceByID{Id: name})
 			require.NoError(t, err)
-			t.Logf("Deleted role %q", name)
+			logf(t, "Deleted role %q", name)
 			return
 		}
 	}
@@ -762,9 +762,9 @@ func collectLogs(t *testing.T, ns string, dir string) {
 	start := time.Now()
 	err := exec.Command("../scripts/ci/collect-service-logs.sh", ns, "/tmp/e2e-test-logs/"+dir).Run()
 	if err != nil {
-		t.Logf("Collecting %q logs returned error %s", ns, err)
+		logf(t, "Collecting %q logs returned error %s", ns, err)
 	}
-	t.Logf("Log collection took: %s", time.Since(start))
+	logf(t, "Log collection took: %s", time.Since(start))
 }
 
 // isOpenshift returns true when the test env is a flavor of OCP, false otherwise.

--- a/tests/delegated_scanning_test_utils.go
+++ b/tests/delegated_scanning_test_utils.go
@@ -158,7 +158,7 @@ func (d *deleScanTestUtils) availMirroringCRs() (icspAvail bool, idmsAvail bool,
 func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg string, dce config.DockerConfigEntry) (icspAvail bool, idmsAvail bool, itmsAvail bool) {
 	start := time.Now()
 	defer func() {
-		t.Logf("Setting up mirrors took:: %v", time.Since(start))
+		logf(t, "Setting up mirrors took:: %v", time.Since(start))
 	}()
 
 	// Instantiate various API clients.
@@ -189,7 +189,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 	if icspAvail {
 		// Create an ImageContentSourcePolicy.
 		icspName := "icsp-invalid"
-		t.Logf("Applying ImageContentSourcePolicy %q", icspName)
+		logf(t, "Applying ImageContentSourcePolicy %q", icspName)
 		origIcsp, _ := opClient.ImageContentSourcePolicies().Get(ctx, icspName, v1.GetOptions{})
 
 		yamlB := d.renderTemplate(t, "testdata/delegatedscanning/mirrors/icsp.yaml.tmpl", map[string]string{"name": icspName})
@@ -197,7 +197,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 		d.applyK8sYamlOrJson(t, ctx, opClient.RESTClient(), "", "imagecontentsourcepolicies", yamlB, icsp)
 
 		if icsp.ResourceVersion != origIcsp.ResourceVersion {
-			t.Logf("ImageContentSourcePolicy %q updated", icspName)
+			logf(t, "ImageContentSourcePolicy %q updated", icspName)
 			updated = true
 		}
 	}
@@ -205,7 +205,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 	if idmsAvail {
 		// Create an ImageDigestMirrorSet.
 		idmsName := "idms-invalid"
-		t.Logf("Applying ImageDigestMirrorSet %q", idmsName)
+		logf(t, "Applying ImageDigestMirrorSet %q", idmsName)
 		origIdms, _ := cfgClient.ImageDigestMirrorSets().Get(ctx, idmsName, v1.GetOptions{})
 
 		yamlB := d.renderTemplate(t, "testdata/delegatedscanning/mirrors/idms.yaml.tmpl", map[string]string{"name": idmsName})
@@ -213,7 +213,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 		d.applyK8sYamlOrJson(t, ctx, cfgClient.RESTClient(), "", "imagedigestmirrorsets", yamlB, idms)
 
 		if idms.ResourceVersion != origIdms.ResourceVersion {
-			t.Logf("ImageDigestMirrorSet %q updated", idmsName)
+			logf(t, "ImageDigestMirrorSet %q updated", idmsName)
 			updated = true
 		}
 	}
@@ -221,7 +221,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 	if itmsAvail {
 		// Create an ImageTagMirrorSet.
 		itmsName := "itms-invalid"
-		t.Logf("Applying ImageTagMirrorSet %q", itmsName)
+		logf(t, "Applying ImageTagMirrorSet %q", itmsName)
 		origItms, _ := cfgClient.ImageTagMirrorSets().Get(ctx, itmsName, v1.GetOptions{})
 
 		yamlB := d.renderTemplate(t, "testdata/delegatedscanning/mirrors/itms.yaml.tmpl", map[string]string{"name": itmsName})
@@ -229,7 +229,7 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 		d.applyK8sYamlOrJson(t, ctx, cfgClient.RESTClient(), "", "imagetagmirrorsets", yamlB, itms)
 
 		if itms.ResourceVersion != origItms.ResourceVersion {
-			t.Logf("ImageTagMirrorSet %q updated", itmsName)
+			logf(t, "ImageTagMirrorSet %q updated", itmsName)
 			updated = true
 		}
 
@@ -237,11 +237,11 @@ func (d *deleScanTestUtils) SetupMirrors(t *testing.T, ctx context.Context, reg 
 
 	// If no resources were updated exit early.
 	if !updated {
-		t.Logf("Mirroring resources unchanged")
+		logf(t, "Mirroring resources unchanged")
 		return
 	}
 
-	t.Logf("Mirroring resources changed, waiting for cluster nodes to be updated")
+	logf(t, "Mirroring resources changed, waiting for cluster nodes to be updated")
 	d.waitForNodesToProcessConfigUpdates(t, ctx, machineCfgClient, origPools)
 	return
 }
@@ -272,7 +272,7 @@ func (d *deleScanTestUtils) addCredToOCPGlobalPullSecret(t *testing.T, ctx conte
 			dce.Password == newDce.Password &&
 			dce.Email == newDce.Email {
 
-			t.Logf("No change needed to secret %q in namespace %q", name, ns)
+			logf(t, "No change needed to secret %q in namespace %q", name, ns)
 			return false
 		}
 	}
@@ -284,7 +284,7 @@ func (d *deleScanTestUtils) addCredToOCPGlobalPullSecret(t *testing.T, ctx conte
 	secret.Data[key] = dataB
 	_, err = k8s.CoreV1().Secrets(ns).Update(ctx, secret, v1.UpdateOptions{FieldManager: ignoreFieldManager})
 	require.NoError(t, err)
-	t.Logf("Updated secret %q in namespace %q", name, ns)
+	logf(t, "Updated secret %q in namespace %q", name, ns)
 	return true
 }
 
@@ -295,7 +295,7 @@ func (d *deleScanTestUtils) waitForNodesToProcessConfigUpdates(t *testing.T, ctx
 	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
-	t.Logf("Waiting for changes to be propagated")
+	logf(t, "Waiting for changes to be propagated")
 	for {
 		select {
 		case <-ctx.Done():
@@ -309,7 +309,7 @@ func (d *deleScanTestUtils) waitForNodesToProcessConfigUpdates(t *testing.T, ctx
 				continue
 			}
 
-			t.Logf("All nodes are now updated")
+			logf(t, "All nodes are now updated")
 			return
 		}
 	}
@@ -337,7 +337,7 @@ func (d *deleScanTestUtils) logMachineConfigPoolsState(t *testing.T, poolList *m
 	}
 	utils.IgnoreError(w.Flush)
 
-	t.Logf("Machine Config Pools Status: \n%s", sb.String())
+	logf(t, "Machine Config Pools Status: \n%s", sb.String())
 }
 
 // machineConfigPoolsReady verifies that each machine config pool has fully processed
@@ -376,7 +376,7 @@ func (d *deleScanTestUtils) DeploySleeperImage(t *testing.T, ctx context.Context
 	require.NoError(t, err)
 
 	d.applyK8sYamlOrJson(t, ctx, clientset.AppsV1().RESTClient(), namespace, "deployments", yamlB, nil)
-	t.Logf("Deployed image: %q", imageStr)
+	logf(t, "Deployed image: %q", imageStr)
 }
 
 // BuildOCPInternalImage builds an image, pushes it to the OCP internal registry, and
@@ -398,7 +398,7 @@ func (d *deleScanTestUtils) BuildOCPInternalImage(t *testing.T, ctx context.Cont
 func (d *deleScanTestUtils) applyBuildConfig(t *testing.T, ctx context.Context, namespace, name string) {
 	restCfg := d.restCfg
 
-	t.Logf("Applying BuildConfig %q", name)
+	logf(t, "Applying BuildConfig %q", name)
 	buildV1Client, err := buildv1client.NewForConfig(restCfg)
 	require.NoError(t, err)
 
@@ -410,7 +410,7 @@ func (d *deleScanTestUtils) applyBuildConfig(t *testing.T, ctx context.Context, 
 func (d *deleScanTestUtils) applyImageStream(t *testing.T, ctx context.Context, namespace, name string) {
 	restCfg := d.restCfg
 
-	t.Logf("Applying ImageStream %q", name)
+	logf(t, "Applying ImageStream %q", name)
 	imageV1Client, err := imagev1client.NewForConfig(restCfg)
 	require.NoError(t, err)
 
@@ -424,7 +424,7 @@ func (d *deleScanTestUtils) getDigestFromImageStreamTag(t *testing.T, ctx contex
 
 	nameTag := fmt.Sprintf("%s:%s", name, tag)
 
-	t.Logf("Getting image digest from image stream tag: %v", nameTag)
+	logf(t, "Getting image digest from image stream tag: %v", nameTag)
 	imageV1Client, err := imagev1client.NewForConfig(restCfg)
 	require.NoError(t, err)
 
@@ -433,7 +433,7 @@ func (d *deleScanTestUtils) getDigestFromImageStreamTag(t *testing.T, ctx contex
 
 	digest := isTag.Image.GetObjectMeta().GetName()
 	require.NotEmpty(t, digest)
-	t.Logf("Digest found: %s", digest)
+	logf(t, "Digest found: %s", digest)
 
 	return digest
 }
@@ -465,7 +465,7 @@ func (d *deleScanTestUtils) buildAndPushImage(t *testing.T, ctx context.Context,
 	client := buildV1Client.RESTClient()
 
 	result := &buildv1.Build{}
-	t.Logf("Starting build for %q", name)
+	logf(t, "Starting build for %q", name)
 	err = client.Post().
 		Namespace(namespace).
 		Resource("buildconfigs").
@@ -476,11 +476,11 @@ func (d *deleScanTestUtils) buildAndPushImage(t *testing.T, ctx context.Context,
 		Into(result)
 	require.NoError(t, err)
 
-	t.Logf("Streaming build logs for %q", result.GetName())
+	logf(t, "Streaming build logs for %q", result.GetName())
 	err = d.streamBuildLogs(ctx, client, result, namespace)
 	require.NoError(t, err)
 
-	t.Logf("Waiting for build %q to complete", result.GetName())
+	logf(t, "Waiting for build %q to complete", result.GetName())
 	err = d.waitForBuildComplete(ctx, buildV1Client.Builds(namespace), result.GetName())
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Description

Adds retries to various actions that have caused the delegated scanning e2e tests to fail. Specifically:
- Retry obtaining a reference to the Sensor pod if multiple Sensor pods are found
  - When registry mirrors are set in OCP, OCP will drain every pod from every node, this takes time.  To speed up Sensor reconnecting to Central the tests restart Sensor and then wait for the Central/Sensor connection to be HEALTHY.  In one of the observed failures the connection was ready but there were two Sensor pods running (presumable one in a 'terminating' state).  The retries should give the pod enough time to shutdown before proceeding with the tests.
- Similarly, after the Central/Sensor connection was HEALTHY (which is determined via an API request to Central) - a subsequent request to the Central API triggered a 'connection refused' error from Central/k8s.
  - Retries were added when this happens to give Central / k8s enough time to stabilize.

Also increases usage to the `logf` wrapper so that timestamps appear in test output, so that can correlate timestamps between test logs to pod logs.

It may help when reviewing to review each commit in order.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI
