### PR TITLE
fix: build-container instead of build-image-index in operator-bundle

### DIFF
--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -762,9 +762,9 @@ spec:
   - name: rpms-signature-scan
     params:
     - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
### Description

Context: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1729514992332749?thread_ts=1729502472.979589&cid=C04PZ7H0VA8

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~[ ] added unit tests~
- ~[ ] added e2e tests~
- ~[ ] added regression tests~
- ~[ ] added compatibility tests~
- ~[ ] modified existing tests~

#### How I validated my change

`operator-bundle` Konflux pipeline appears in the PR checks: https://github.com/stackrox/stackrox/pull/13068/checks?check_run_id=31826851633