### PR TITLE
ROX-25706: Increase url search filter array limit

### DIFF
--- a/ui/apps/platform/src/utils/queryStringUtils.test.ts
+++ b/ui/apps/platform/src/utils/queryStringUtils.test.ts
@@ -1,0 +1,23 @@
+import { getQueryObject } from './queryStringUtils';
+
+describe('getQueryObject', () => {
+    /**
+     * This test ensures `getQueryObject` correctly parses url filters up to the `arrayLimit` of 200 elements.
+     * Beyond this limit, the result becomes an object, which `parseFilter` inside `useURLSearch` does not handle properly.
+     */
+    it('should parse url array filters up to the arrayLimit of 200 elements', () => {
+        const numElements = 200;
+        let largeArrayQuery = '?';
+
+        for (let i = 0; i < numElements; i += 1) {
+            largeArrayQuery += `Namespace%20ID[${i}]=${i}&`;
+        }
+
+        const result = getQueryObject(largeArrayQuery);
+
+        expect(Array.isArray(result['Namespace ID'])).toBe(true);
+
+        expect(result['Namespace ID']?.[0] ?? 'undefined').toBe('0');
+        expect(result['Namespace ID']?.[numElements - 1] ?? 'undefined').toBe(`${numElements - 1}`);
+    });
+});

--- a/ui/apps/platform/src/utils/queryStringUtils.ts
+++ b/ui/apps/platform/src/utils/queryStringUtils.ts
@@ -6,7 +6,7 @@ export type BasePageAction = 'create' | 'edit';
 export type ExtendedPageAction = BasePageAction | 'clone' | 'generate';
 
 export function getQueryObject(search: string): qs.ParsedQs {
-    return qs.parse(search, { ignoreQueryPrefix: true });
+    return qs.parse(search, { ignoreQueryPrefix: true, arrayLimit: 200 });
 }
 
 export function getQueryString<T>(


### PR DESCRIPTION
### Description

Increase `qs.parse` arrayLimit to fix search filter handling

This change addresses an issue where search filters with more than 20 elements were being converted to objects due to the default `arrayLimit` in `qs.parse`. Since `parseFilter` inside `useURLSearch` does not handle objects, this was causing filters to be ignored during the sanitization step

Considerations:

- A future enhancement could involve modifying `parseFilter` to handle objects in addition to arrays. This would eliminate the need to set an arbitrary `arrayLimit` and allow search filters with more than 200 elements to be processed correctly without conversion to an object causing issues.
```js
// parseFilter inside useURLSearch
Object.entries(rawFilter).forEach(([searchKey, searchVal]) => {
    if (typeof searchVal === 'string') {
        ...
    } else if (Array.isArray(searchVal)) {
        ...
    } else if (searchVal && typeof searchVal === 'object') {
        parsedFilter[searchKey] = Array.from(
            { length: Object.keys(searchVal).length },
            (_, index) => searchVal?.[index]
        ).filter((val) => typeof val === 'string');
    }
});
```


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manually tested namespace selection on the dashboard to make sure more filters could be selected

Example with 50 namespaces selected:
![Screenshot 2024-10-21 at 1 40 44 PM](https://github.com/user-attachments/assets/92b0a101-842a-4e6f-b8f8-b0c4b55d0ba9)

