### PR TITLE
ROX-24468: Link source container to the index image

### DIFF
--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -444,7 +444,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(tasks.build-container-amd64.results.IMAGE_URL)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT


### PR DESCRIPTION
### Description

See https://github.com/stackrox/scanner/pull/1679 for description.
In `stackrox` repo, only `main` wasn't set up right.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No automated testing changes.

#### How I validated my change

Main build source will fail due to KFLUXBUGS-1508 but I'll check that the build gets to that failure.
The already mentioned https://github.com/stackrox/scanner/pull/1679 and other container pipelines are the evidence that the source image can be linked to the index image without problems.