### PR TITLE
fix(CI): disable roxctl scan results upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -677,7 +677,6 @@ jobs:
         directory: 'junit-reports'
 
   scan-images-with-roxctl:
-    if: github.event_name == 'push'
     needs:
       - build-and-push-main
       - build-and-push-operator
@@ -737,12 +736,14 @@ jobs:
           roxctl image scan --retries=10 --retry-delay=15 --force --severity=CRITICAL,IMPORTANT --output=sarif \
             --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
             > results.sarif
+          cat results.sarif
 
-      - name: Upload roxctl scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          category: ${{ matrix.image }}
-          sarif_file: results.sarif
+      # TODO: re-enable roxctl scan results upload once quota issue has been resolved
+      # - name: Upload roxctl scan results to GitHub Security tab
+      #   uses: github/codeql-action/upload-sarif@v3
+      #   with:
+      #     category: ${{ matrix.image }}
+      #     sarif_file: results.sarif
 
   slack-on-build-failure:
     env:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -346,12 +346,14 @@ jobs:
         roxctl image scan --retries=10 --retry-delay=15 --force --severity=IMPORTANT,CRITICAL --output=sarif \
           --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
           > results.sarif
+        cat results.sarif
 
-    - name: Upload roxctl scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        category: ${{ matrix.image }}
-        sarif_file: results.sarif
+    # TODO: re-enable roxctl scan results upload once quota issue has been resolved
+    # - name: Upload roxctl scan results to GitHub Security tab
+    #   uses: github/codeql-action/upload-sarif@v3
+    #   with:
+    #     category: ${{ matrix.image }}
+    #     sarif_file: results.sarif
 
   run-e2e-tests:
     name: Run standalone E2E test


### PR DESCRIPTION
### Description

Disabling the roxctl scan results upload 

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

Pure change on CI. 

#### How I validated my change

- 620b7cc70fd8cc1d8c8a222abecc7e4787d0fec7 verified that the scan upload is skipped
- the second commit in this PR re-disabled the scan on PRs. 