### PR TITLE
fix(ui): Make dataLabel consistent in DeploymentVulnerabilitiesTable

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemHealth.js
+++ b/ui/apps/platform/cypress/constants/SystemHealth.js
@@ -6,7 +6,7 @@ export const selectors = {
         startingTimeMessage: '[data-testid="starting-time-message"]',
     },
     integrations: {
-        errorMessage: '[data-testid="error-message"]',
+        errorMessage: '[data-label="Error messsage"]',
         healthyText: '[data-testid="healthy-text"]',
         integrationName: '[data-testid="integration-name"]',
         integrationLabel: '[data-testid="integration-label"]',

--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -134,7 +134,7 @@ describe('System Health Integrations fixtures', () => {
             'Error scanning "docker.io/library/nginx:latest" with scanner "Stackrox Scanner": dial tcp 10.0.1.229:5432: connect: connection refused';
         const itemSelector = getCardBodyDescendantSelector('Image Integrations', 'tbody tr:first');
         cy.get(`${itemSelector} td[data-label="Name"]`).should('have.text', name);
-        cy.get(`${itemSelector} td[data-label="Error"]`).should('have.text', errorMessage);
+        cy.get(`${itemSelector} td[data-label="Error message"]`).should('have.text', errorMessage);
     });
 
     it('should have a list with 1 declarative configuration error', () => {
@@ -158,7 +158,10 @@ describe('System Health Integrations fixtures', () => {
         const { widgets } = selectors.integrations;
         const itemSelector = `${widgets.declarativeConfigs} tr:first`;
         cy.get(`${itemSelector} td[data-label="Name"]`).should('have.text', healthName);
-        cy.get(`${itemSelector} td[data-label="Error"]`).should('have.text', errorMessageText);
+        cy.get(`${itemSelector} td[data-label="Error message"]`).should(
+            'have.text',
+            errorMessageText
+        );
     });
 
     it('should have no declarative configuration errors displayed', () => {

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
@@ -68,7 +68,7 @@ function ReportJobsTable<T extends Snapshot>({
                         Completed
                     </Th>
                     <Th width={25}>Status</Th>
-                    <Th width={50}>Requestor</Th>
+                    <Th width={50}>Requester</Th>
                     <Th>
                         <span className="pf-v5-screen-reader">Row actions</span>
                     </Th>

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -114,7 +114,7 @@ function ListeningEndpointsTable({
                             </Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
-                            <Td dataLabel="Listening endpoints count">{count}</Td>
+                            <Td dataLabel="Count">{count}</Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>
                             <Td colSpan={5}>

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
@@ -28,7 +28,7 @@ const IntegrationsHealth = ({ integrations }: Props): ReactElement => {
                         <Td dataLabel="Label" modifier="breakWord" data-testid="label">
                             {label}
                         </Td>
-                        <Td dataLabel="Error" modifier="breakWord" data-testid="error-message">
+                        <Td dataLabel="Error message" modifier="breakWord">
                             {errorMessage.length === 0 ? '-' : errorMessage}
                         </Td>
                         <Td dataLabel="Date">{getDateTime(lastTimestamp)}</Td>

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -97,7 +97,7 @@ function DeclarativeConfigurationHealthCard({
                             <Thead>
                                 <Tr>
                                     <Th width={40}>Name</Th>
-                                    <Th width={40}>Error</Th>
+                                    <Th width={40}>Error message</Th>
                                     <Th width={20}>Date</Th>
                                 </Tr>
                             </Thead>
@@ -111,11 +111,7 @@ function DeclarativeConfigurationHealthCard({
                                         >
                                             {name}
                                         </Td>
-                                        <Td
-                                            dataLabel="Error"
-                                            modifier="breakWord"
-                                            data-testid="error-message"
-                                        >
+                                        <Td dataLabel="Error message" modifier="breakWord">
                                             {errorMessage}
                                         </Td>
                                         <Td dataLabel="Date">{getDateTime(lastTimestamp)}</Td>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -120,10 +120,7 @@ function AffectedComponentsModal({
                                     <Td dataLabel="Fixed in">{component.fixedIn || '-'}</Td>
                                 </Tr>
                                 <Tr isExpanded={isComponentExpanded(component)}>
-                                    <Td
-                                        dataLabel="Dockerfile line where component is added"
-                                        colSpan={4}
-                                    >
+                                    <Td colSpan={4}>
                                         <ExpandableRowContent>
                                             <CodeBlock>
                                                 <Grid hasGutter>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
@@ -182,7 +182,7 @@ function ApprovedDeferralsTable({
                             <Th modifier="fitContent">Scope</Th>
                             <Th>Impacted entities</Th>
                             <Th>Comments</Th>
-                            <Th>Requestor</Th>
+                            <Th>Requester</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -234,7 +234,7 @@ function ApprovedDeferralsTable({
                                             cve={row.cves.cves[0]}
                                         />
                                     </Td>
-                                    <Td dataLabel="Requestor">{row.requestor.name}</Td>
+                                    <Td dataLabel="Requester">{row.requestor.name}</Td>
                                     <Td className="pf-v5-u-text-align-right">
                                         <ApprovedDeferralActionsColumn
                                             row={row}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
@@ -165,7 +165,7 @@ function ApprovedFalsePositivesTable({
                             <Th modifier="fitContent">Scope</Th>
                             <Th>Impacted entities</Th>
                             <Th>Comments</Th>
-                            <Th>Requestor</Th>
+                            <Th>Requester</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -210,7 +210,7 @@ function ApprovedFalsePositivesTable({
                                             cve={row.cves.cves[0]}
                                         />
                                     </Td>
-                                    <Td dataLabel="Requestor">{row.requestor.name}</Td>
+                                    <Td dataLabel="Requester">{row.requestor.name}</Td>
                                     <Td className="pf-v5-u-text-align-right">
                                         <ApprovedFalsePositiveActionsColumn
                                             row={row}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -171,7 +171,7 @@ function DeferredCVEsTable({
                         <Th sort={getSortParams('Severity')}>Severity</Th>
                         <Th>Expires</Th>
                         <Th modifier="fitContent">Scope</Th>
-                        <Th>Affected Components</Th>
+                        <Th>Affected components</Th>
                         <Th>Comments</Th>
                         <Th>Approver</Th>
                     </Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -169,7 +169,7 @@ function FalsePositiveCVEsTable({
                         <Th>Fixable</Th>
                         <Th sort={getSortParams('Severity')}>Severity</Th>
                         <Th modifier="fitContent">Scope</Th>
-                        <Th>Affected Components</Th>
+                        <Th>Affected components</Th>
                         <Th>Comments</Th>
                         <Th>Approver</Th>
                     </Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
@@ -260,7 +260,7 @@ function PendingApprovalsTable({
                             <Th modifier="fitContent">Scope</Th>
                             <Th>Impacted entities</Th>
                             <Th>Comments</Th>
-                            <Th>Requestor</Th>
+                            <Th>Requester</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -313,7 +313,7 @@ function PendingApprovalsTable({
                                             cve={row.cves.cves[0]}
                                         />
                                     </Td>
-                                    <Td dataLabel="Requestor">{row.requestor.name}</Td>
+                                    <Td dataLabel="Requester">{row.requestor.name}</Td>
                                     <Td className="pf-v5-u-text-align-right">
                                         {row.targetState === 'DEFERRED' && (
                                             <DeferralRequestActionsColumn

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
@@ -34,7 +34,7 @@ function RequestOverview({ exception, context }: RequestOverviewProps) {
                 <Title headingLevel="h2">Overview</Title>
                 <DescriptionList className="vulnerability-exception-request-overview">
                     <DescriptionListGroup>
-                        <DescriptionListTerm>Requestor</DescriptionListTerm>
+                        <DescriptionListTerm>Requester</DescriptionListTerm>
                         <DescriptionListDescription>
                             {exception.requester?.name || '-'}
                         </DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -196,7 +196,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                 Completed
                             </Th>
                             <Th width={25}>Status</Th>
-                            <Th width={50}>Requestor</Th>
+                            <Th width={50}>Requester</Th>
                             <Th>
                                 <span className="pf-v5-screen-reader">Row actions</span>
                             </Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -186,14 +186,14 @@ function DeploymentVulnerabilitiesTable({
                                     <Td
                                         className={getVisibilityClass('cveSeverity')}
                                         modifier="nowrap"
-                                        dataLabel="Severity"
+                                        dataLabel="CVE severity"
                                     >
                                         <VulnerabilitySeverityIconText severity={severity} />
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('cveStatus')}
                                         modifier="nowrap"
-                                        dataLabel="CVE Status"
+                                        dataLabel="CVE status"
                                     >
                                         <VulnerabilityFixableIconText isFixable={isFixable} />
                                     </Td>


### PR DESCRIPTION
### Description

Fix errors reported by first draft of lint rules for managed columns.

1. **CVE severity** and **CVE status**
    * Edit DeploymentVulnerabilitiesTable.tsx file.

And then, fix some reported by first draft of lint rule for consistent text of `Th` and `dataLabel` prop of `Td` element.

1. **Error message**
    * Edit IntegrationsHealth.tsx file.
        Temporarily edit IntegrationHealthWidgetVisual.tsx file to provide response from staging.
    * Edit DeclarativeConfigurationHealthCard.tsx file for consistency.
    * Edit SystemHealth.js file to replace `data-testid` with `data-label` attribute.
    * Edit integrations.test.js file.

2. **Affected components**
    Too bad, so sad, Risk Acceptance is orphan code.
    * Edit DeferredCVEsTable.tsx file.
    * Edit FalsePositiveCVEsTable.tsx file.

3. **Dockerfile line where component is added**
    Too bad, so sad, Risk Acceptance is orphan code.
    * Edit AffectedComponentsModal.tsx file.

4. **Requester**
    Kerry, thank you for confirmation from IBM Style:
    **requestor** *noun* Do not use. Use **requester**.
    * Edit ReportJobsTable.tsx file.
    * Edit ReportJobs.tsx file.
    Too bad, so sad, Risk Acceptance is orphan code.
    * Edit RequestOverview.tsx file.
    * Edit ApprovedDeferralsTable.tsx file.
    * Edit ApprovedFalsePositivesTable.tsx file.

### Residue

1. Follow up on lint rule:
    * Investigate screen reader columns, for example:
        src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
        src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
    * Investigate `Tr` elements that have `isExpanded` prop.
2. Replace column configuration with `Th` elements in PolicyTable.tsx file (so lint is possible).
3. Delete `ROX_AUTH_MACHINE_TO_MACHINE` from machineAccessConfigs.test.js file.
    Found by accident when I mixed up tests in integrations folder with integration.test.js file in systemHealth folder
4. Move SystemHealth.js file from constants into test folder and replace `data-testid` with `data-label` attributes.
5. Delete orphan RiskAcceptance folder.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves/deployments/id

    * See **CVE severity** and **CVE status** column headings.
        ![1440px](https://github.com/user-attachments/assets/27b72dd8-1b06-4d5a-a4d0-24cb5c19001b)

2. Reduce screen width from 1440px above to 760px for responsive layout.

    * Before changes, see inconsistent **Severity** and **CVE Status** (Title Case) from `dataLabel` props.
        ![760px_inconsistent](https://github.com/user-attachments/assets/2cbc250f-9d69-40f9-bcc9-341f669356aa)

    * After changes, see consistent **CVE severity** and **CVE status** (Sentence case) from `dataLabel` props.
        ![760px_consistent](https://github.com/user-attachments/assets/3731045b-8085-4138-be18-bced906d3171)

3. Visit /main/listening-endpoints

    * See **Count** column heading.
        ![ListeningEndpointsTable_1440px](https://github.com/user-attachments/assets/a66c259c-d094-4437-a92a-2c61746a9e0d)

    * Before changes, see inconsistent **Listening endpoints count** from `dataLabel` prop.
        ![ListeningEndpointsTable_760px_inconsistent](https://github.com/user-attachments/assets/42eb9b13-5a22-4193-87dd-0b81884dbe93)

    * After changes, see consistent **Count** from `dataLabel` prop.
        ![ListeningEndpointsTable_760px_consistent](https://github.com/user-attachments/assets/296e0194-97c4-43cb-b3de-a02b6f519caa)

4. Visit /main/system-health and then scroll down to **Integrations** cards.

    * See **Error message** column heading.
        ![IntegrationsHealth_1440px](https://github.com/user-attachments/assets/3c7d17c5-b283-4d5a-9413-4246a28b5619)

    * Before changes, see inconsistent **Error** from `dataLabel` prop.
        ![IntegrationsHealth_760px_inconsistent](https://github.com/user-attachments/assets/c055cba3-783e-41db-9633-a5662c066bca)

    * After changes, see consistent **Error message** from `dataLabel` prop.
        ![IntegrationsHealth_760px_consistent](https://github.com/user-attachments/assets/91f77fd9-f456-4dc2-99ec-9325b71af223)

5. Visit /main/vulnerabilities/reports/id on staging.

    * See inconsistent **Requestor** column heading.
        ![ReportJobs_1440px](https://github.com/user-attachments/assets/fb29b02e-0025-4990-9cbe-16106d9671aa)

    * See **Requester** from `dataLabel` prop.
        ![ReportJobs_760px](https://github.com/user-attachments/assets/cff5b03e-c5e8-4a83-9f69-1cb6323c67af)

#### Integration testing

* systemHealth/clusters.test.js
* systemHealth/declarativeConfiguration.test.js
* systemHealth/integrations.test.js
* systemHealth/systemHealthGeneral.test.js
