### PR TITLE
ROX-24991: Compliance scheduling analytics

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -5,6 +5,10 @@ import { FormikProvider } from 'formik';
 import { complianceEnhancedSchedulesPath } from 'routePaths';
 import isEqual from 'lodash/isEqual';
 
+import useAnalytics, {
+    COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED,
+    COMPLIANCE_SCHEDULES_WIZARD_STEP_CHANGED,
+} from 'hooks/useAnalytics';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useRestQuery from 'hooks/useRestQuery';
 import { saveScanConfig } from 'services/ComplianceScanConfigurationService';
@@ -37,6 +41,7 @@ type ScanConfigWizardFormProps = {
 };
 
 function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const history = useHistory();
     const formik = useFormikScanConfig(initialFormValues);
     const [isCreating, setIsCreating] = useState(false);
@@ -64,8 +69,20 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
 
         try {
             await saveScanConfig(complianceScanConfig);
+            analyticsTrack({
+                event: COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED,
+                properties: {
+                    success: true,
+                },
+            });
             history.push(complianceEnhancedSchedulesPath);
         } catch (error) {
+            analyticsTrack({
+                event: COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED,
+                properties: {
+                    success: false,
+                },
+            });
             setCreateScanConfigError(getAxiosErrorMessage(error));
         } finally {
             setIsCreating(false);
@@ -78,7 +95,15 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
         }
     }
 
-    function wizardStepChanged() {
+    function wizardStepChanged(step: WizardStep) {
+        if (typeof step.id === 'string') {
+            analyticsTrack({
+                event: COMPLIANCE_SCHEDULES_WIZARD_STEP_CHANGED,
+                properties: {
+                    step: step.id,
+                },
+            });
+        }
         handleProfilesUpdate();
         setCreateScanConfigError('');
     }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -73,6 +73,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                 event: COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED,
                 properties: {
                     success: true,
+                    errorMessage: '',
                 },
             });
             history.push(complianceEnhancedSchedulesPath);
@@ -81,6 +82,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                 event: COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED,
                 properties: {
                     success: false,
+                    errorMessage: getAxiosErrorMessage(error),
                 },
             });
             setCreateScanConfigError(getAxiosErrorMessage(error));

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -370,6 +370,7 @@ export type AnalyticsEvent =
           event: typeof COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED;
           properties: {
               success: true | false;
+              errorMessage: string;
           };
       }
     | {

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -66,6 +66,8 @@ export const COMPLIANCE_REPORT_MANUAL_SEND_TRIGGERED = 'Compliance Report Manual
 export const COMPLIANCE_REPORT_JOBS_TABLE_VIEWED = 'Compliance Report Jobs Table Viewed';
 export const COMPLIANCE_REPORT_JOBS_VIEW_TOGGLED = 'Compliance Report Jobs View Toggled';
 export const COMPLIANCE_REPORT_RUN_STATE_FILTERED = 'Compliance Report Run State Filtered';
+export const COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED = 'Compliance Schedules Wizard Save Clicked';
+export const COMPLIANCE_SCHEDULES_WIZARD_STEP_CHANGED = 'Compliance Schedules Wizard Step Changed';
 
 /**
  * Boolean fields should be tracked with 0 or 1 instead of true/false. This
@@ -362,6 +364,18 @@ export type AnalyticsEvent =
           event: typeof COMPLIANCE_REPORT_RUN_STATE_FILTERED;
           properties: {
               value: ('WAITING' | 'PREPARING' | 'GENERATED' | 'DELIVERED' | 'FAILURE')[];
+          };
+      }
+    | {
+          event: typeof COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED;
+          properties: {
+              success: true | false;
+          };
+      }
+    | {
+          event: typeof COMPLIANCE_SCHEDULES_WIZARD_STEP_CHANGED;
+          properties: {
+              step: string;
           };
       };
 


### PR DESCRIPTION
### Description

#### Add Telemetry to Compliance Scheduling

This update introduces tracking for the following events:
- **Wizard Step Changes:** Tracks when users move between steps in the policy wizard. This should help identify areas where users may encounter difficulties or abandon the process.
- **Wizard "Save" Button Clicks:** Tracks the frequency of successful schedule creations versus failed attempts – include why a failure occurred.

#### How Can We Use This Information?
An example use case for this telemetry is tracking unique visits at each step of the wizard. This can help identify where users are most likely to abort the wizard.
![Screenshot 2024-10-22 at 10 54 04 AM](https://github.com/user-attachments/assets/2000cbf0-75fb-4d08-9bc5-17eeba150e5c)


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Segment overview:
![Screenshot 2024-10-22 at 10 25 44 AM](https://github.com/user-attachments/assets/33a5bd8d-c0ed-43f2-a17b-e0636fd0d307)

Raw data:
![Screenshot 2024-10-22 at 10 25 53 AM](https://github.com/user-attachments/assets/fd9f8058-ee66-4552-9081-40321238713c)
![Screenshot 2024-10-22 at 10 25 58 AM](https://github.com/user-attachments/assets/751fff04-7001-417c-b068-cf0f80d4c0df)
![Screenshot 2024-10-22 at 10 51 13 AM](https://github.com/user-attachments/assets/2b93937a-264b-4a50-990e-28c95ecb119f)

