### PR TITLE
ROX-23364: Indicate only active scanner health info displayed

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
@@ -76,7 +76,11 @@ const ScannerStatus = ({ healthStatus, isList = false }: ScannerStatusProps) => 
         return isList ? (
             <Tooltip
                 content={
-                    <DetailedTooltipContent title="Scanner Health Information" body={infoElement} />
+                    <DetailedTooltipContent
+                        body={infoElement}
+                        footer="*active scanner only"
+                        title="Scanner Health Information"
+                    />
                 }
             >
                 <div className="inline">{healthStatusElement}</div>


### PR DESCRIPTION
### Description

#### Indicate "Active Scanner" in Scanner Health Panel 

Currently, the tooltip only displays the health status of the active scanner, which may cause confusion when users see pods for both `scanner-slim` and `scanner-v4` but only receive health data for one.

As a short-term change, we've added a message to the tooltip indicating that the health status reflects only the active scanner.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before:
![Screenshot 2024-10-22 at 11 27 40 AM](https://github.com/user-attachments/assets/bd5ea019-fd3c-46e4-be4b-042f4df37d34)


After:
![Screenshot 2024-10-22 at 11 29 52 AM](https://github.com/user-attachments/assets/5114c855-7617-4aee-b79a-bb8149bdf6b5)

