### PR TITLE
ci: add action to directly run check-jira-issues.sh

### DIFF
--- a/.github/workflows/check-jira.yml
+++ b/.github/workflows/check-jira.yml
@@ -14,13 +14,9 @@ on:
         type: boolean
 
 env:
-  main_branch: ${{github.event.repository.default_branch}}
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
   DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
-  GH_TOKEN: ${{ github.token }}
-  GH_NO_UPDATE_NOTIFIER: 1
-  TIMEOUT_WAIT_FOR_IMAGES_SECONDS: 3600
 
 jobs:
   properties:


### PR DESCRIPTION
### Description

Add action to run check-jira-issues manually. To be used at the start of a release to generate the list of open jira tickets. It does ~~not comment on the jira tickets~~[It did comment on the jira tickets in my test run], and it does not create slack messages.

Example run from pr: https://github.com/stackrox/stackrox/actions/runs/11467914531?pr=13092

When run with dry_run=false open jira tickets, with fix_version of the version parameter, will get a comment like "Release 4.6.0 is ongoing. Please update the status of this issue and notify the release engineer."