### PR TITLE
ROX-26720: Reset dele scan config at end of suite

### DIFF
--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -226,6 +226,9 @@ func (ts *DelegatedScanningSuite) TearDownSuite() {
 	// Changing the log level may result in pod restarts and logs lost.
 	ts.handleFailure()
 
+	// Reset the delegated scanning config back so that other tests are not impacted.
+	ts.resetConfig(ctx)
+
 	// Reset the log level back to its original value so that other e2e tests are
 	// not impacted by the additional logging.
 	if ts.origSensorLogLevel != deleScanDesiredLogLevel {


### PR DESCRIPTION
### Description

Make sure the delegated scanning config is reset at end of test suite so that other tests are not impacted.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI