### PR TITLE
ROX-26674: Grant config-controller ability to view notifiers

### DIFF
--- a/central/role/datastore/defaults.go
+++ b/central/role/datastore/defaults.go
@@ -135,6 +135,7 @@ var defaultPermissionSets = map[string]permSetAttributes{
 		description: "For automation: Used by config-controller and grants access to config objects managed by the controller",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.Modify(resources.WorkflowAdministration),
+			permissions.View(resources.Integration),
 		},
 	},
 }


### PR DESCRIPTION
**Note**: Intended to be merged after https://github.com/stackrox/stackrox/pull/13091 because it includes the commits from that PR.

Since config-controller's role did not have the ability to view notifiers, it was unable to create policies that referred to notifiers.

This commit contains a couple of changes:

* Grants read-only access to config-controller for "integrations", which includes notifiers
* Adds a notifier to the "create" integration test to validate this behavior.
* Fixes the TestSaveAsCRUpdateDelete test to add the notifier to the policy when creating in Central.  Before it was setting it on the policy struct returned from Central, which was later only used to pull an ID (i.e. the whole policy struct was never used again).
