### PR TITLE
ugly debug

### DIFF
--- a/pkg/sync/mutex_dave.go
+++ b/pkg/sync/mutex_dave.go
@@ -1,0 +1,52 @@
+//go:build !release
+
+package sync
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type DaveRWMutex struct {
+	sync.RWMutex
+	acquireTime time.Time // Lock only, not RLock
+}
+
+// RLock acquires a reader lock on the mutex.
+func (m *DaveRWMutex) RLock(trace string, span string) {
+	name := fmt.Sprintf("DaveRWMutex.RLock (trace %q, span %q)", trace, span)
+	panicOnTimeout(name, m.RWMutex.RLock, lockTimeout)
+}
+
+// Lock acquires a writer (exclusive) lock on the mutex.
+func (m *DaveRWMutex) Lock(trace string, span string) {
+	name := fmt.Sprintf("DaveRWMutex.Lock (trace %q, span %q)", trace, span)
+	panicOnTimeout(name, m.RWMutex.Lock, lockTimeout)
+	m.acquireTime = time.Now()
+}
+
+// TryRLock wraps the call to sync.RWMutex TryRLock. It returns true if the lock was acquired.
+func (m *DaveRWMutex) TryRLock() bool {
+	if m.RWMutex.TryRLock() {
+		m.acquireTime = time.Now()
+		return true
+	}
+	return false
+}
+
+// TryLock wraps the call to sync.RWMutex TryLock. It returns true if the lock was acquired.
+func (m *DaveRWMutex) TryLock() bool {
+	if m.RWMutex.TryLock() {
+		m.acquireTime = time.Now()
+		return true
+	}
+	return false
+}
+
+// Unlock releases an acquired writer (exclusive) lock on the mutex.
+func (m *DaveRWMutex) Unlock(trace string, span string) {
+	name := fmt.Sprintf("DaveRWMutex.Unlock (trace %q, span %q)", trace, span)
+	panicIfTooMuchTimeElapsed(name, m.acquireTime, lockTimeout, 1)
+	defer m.RWMutex.Unlock() // suppress the roxvet error for calling Unlock()
+}

--- a/sensor/common/registry/lazy_tls_factory.go
+++ b/sensor/common/registry/lazy_tls_factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/rhel"
 	"github.com/stackrox/rox/pkg/registries/types"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 var (
@@ -63,6 +64,8 @@ func (e *lazyFactory) CreateRegistry(source *storage.ImageIntegration, options .
 	}
 
 	return &lazyTLSCheckRegistry{
+		id:               uuid.NewV4().String(),
+		name:             source.GetName(),
 		source:           source,
 		creator:          creator,
 		creatorOptions:   options,


### PR DESCRIPTION
Throw away PR to identify root cause of sync lock panic.

Adds ids to logs to help identify what was waiting for the lock, for how long, and why.

trace = the lazy registry instance (will be unique per 'pull secret')
span = the lazy registry method (will be unique for each invocation of the method)

span is used to track the start/end timings of method calls, trace is used to identify method invocations that share a RWMutex instance 