### PR TITLE
ROX-26347: e2e tests for collector runtime config

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -927,12 +927,24 @@ function launch_sensor {
       NAMESPACE="${sensor_namespace}" "${k8s_dir}/sensor-deploy/sensor.sh"
     fi
 
+    collector_env=()
+
     if [[ -n "${ROX_AFTERGLOW_PERIOD}" ]]; then
-       kubectl -n "${sensor_namespace}" set env ds/collector ROX_AFTERGLOW_PERIOD="${ROX_AFTERGLOW_PERIOD}"
+      collector_env+=("ROX_AFTERGLOW_PERIOD=${ROX_AFTERGLOW_PERIOD}")
+      #kubectl -n "${sensor_namespace}" set env ds/collector ROX_AFTERGLOW_PERIOD="${ROX_AFTERGLOW_PERIOD}"
     fi
 
     if [[ -n "${ROX_NON_AGGREGATED_NETWORKS}" ]]; then
-      kubectl -n "${sensor_namespace}" set env ds/collector ROX_NON_AGGREGATED_NETWORKS="${ROX_NON_AGGREGATED_NETWORKS}"
+      collector_env+=("ROX_NON_AGGREGATED_NETWORKS=${ROX_NON_AGGREGATED_NETWORKS}")
+      #kubectl -n "${sensor_namespace}" set env ds/collector ROX_NON_AGGREGATED_NETWORKS="${ROX_NON_AGGREGATED_NETWORKS}"
+    fi
+
+    if [[ -n "${ROX_NETWORK_GRAPH_EXTERNAL_IPS}" ]]; then
+      collector_env+=("ROX_NETWORK_GRAPH_EXTERNAL_IPS=${ROX_NETWORK_GRAPH_EXTERNAL_IPS}")
+    fi
+
+    if [[ "${#collector_env[@]}" -gt 0 ]]; then
+      kubectl -n "${sensor_namespace}" set env ds/collector "${collector_env[@]}"
     fi
 
     # For local installations (e.g. on Colima): hotload binary

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -931,12 +931,10 @@ function launch_sensor {
 
     if [[ -n "${ROX_AFTERGLOW_PERIOD}" ]]; then
       collector_env+=("ROX_AFTERGLOW_PERIOD=${ROX_AFTERGLOW_PERIOD}")
-      #kubectl -n "${sensor_namespace}" set env ds/collector ROX_AFTERGLOW_PERIOD="${ROX_AFTERGLOW_PERIOD}"
     fi
 
     if [[ -n "${ROX_NON_AGGREGATED_NETWORKS}" ]]; then
       collector_env+=("ROX_NON_AGGREGATED_NETWORKS=${ROX_NON_AGGREGATED_NETWORKS}")
-      #kubectl -n "${sensor_namespace}" set env ds/collector ROX_NON_AGGREGATED_NETWORKS="${ROX_NON_AGGREGATED_NETWORKS}"
     fi
 
     if [[ -n "${ROX_NETWORK_GRAPH_EXTERNAL_IPS}" ]]; then

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -943,6 +943,10 @@ function launch_sensor {
       collector_env+=("ROX_NETWORK_GRAPH_EXTERNAL_IPS=${ROX_NETWORK_GRAPH_EXTERNAL_IPS}")
     fi
 
+    if [[ -n "${ROX_COLLECTOR_INTROSPECTION_ENABLE}" ]]; then
+      collector_env+=("ROX_COLLECTOR_INTROSPECTION_ENABLE=${ROX_COLLECTOR_INTROSPECTION_ENABLE}")
+    fi
+
     if [[ "${#collector_env[@]}" -gt 0 ]]; then
       kubectl -n "${sensor_namespace}" set env ds/collector "${collector_env[@]}"
     fi

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -937,10 +937,6 @@ function launch_sensor {
       collector_env+=("ROX_NON_AGGREGATED_NETWORKS=${ROX_NON_AGGREGATED_NETWORKS}")
     fi
 
-    if [[ -n "${ROX_NETWORK_GRAPH_EXTERNAL_IPS}" ]]; then
-      collector_env+=("ROX_NETWORK_GRAPH_EXTERNAL_IPS=${ROX_NETWORK_GRAPH_EXTERNAL_IPS}")
-    fi
-
     if [[ -n "${ROX_COLLECTOR_INTROSPECTION_ENABLE}" ]]; then
       collector_env+=("ROX_COLLECTOR_INTROSPECTION_ENABLE=${ROX_COLLECTOR_INTROSPECTION_ENABLE}")
     fi

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1987,7 +1987,7 @@ class Kubernetes {
     List<LocalPortForward> createCollectorPortForwards(int port) {
         // since Collector's a daemonset, we can match the behavior of
         // kubectl, and pick a pod to forward to.
-        def collectorPods = getPods("stackrox", "collector")
+        def collectorPods = getPods(Constants.STACKROX_NAMESPACE, "collector")
 
         return collectorPods.collect {
             this.client.pods()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1,10 +1,10 @@
 package orchestratormanager
 
-import common.Constants
-
 import static util.Helpers.evaluateWithRetry
 import static util.Helpers.withK8sClientRetry
 import static util.Helpers.withRetry
+
+import common.Constants
 
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1,5 +1,7 @@
 package orchestratormanager
 
+import common.Constants
+
 import static util.Helpers.evaluateWithRetry
 import static util.Helpers.withK8sClientRetry
 import static util.Helpers.withRetry

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -94,7 +94,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation
 import io.fabric8.kubernetes.client.dsl.Resource
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource
 import io.fabric8.kubernetes.client.dsl.ScalableResource
-import io.fabric8.kubernetes.client.LocalPortForward;
+import io.fabric8.kubernetes.client.LocalPortForward
 import org.apache.commons.exec.CommandLine
 
 import common.YamlGenerator
@@ -1995,7 +1995,6 @@ class Kubernetes {
                 .portForward(port)
         }
     }
-
 
     /*
         Private K8S Support functions

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -94,6 +94,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation
 import io.fabric8.kubernetes.client.dsl.Resource
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource
 import io.fabric8.kubernetes.client.dsl.ScalableResource
+import io.fabric8.kubernetes.client.LocalPortForward;
 import org.apache.commons.exec.CommandLine
 
 import common.YamlGenerator
@@ -1981,6 +1982,20 @@ class Kubernetes {
                 getStatefulSetCount(ns).size() +
                 getJobCount(ns).size()
     }
+
+    List<LocalPortForward> createCollectorPortForwards(int port) {
+        // since Collector's a daemonset, we can match the behavior of
+        // kubectl, and pick a pod to forward to.
+        def collectorPods = getPods("stackrox", "collector")
+
+        return collectorPods.collect {
+            this.client.pods()
+                .inNamespace("stackrox")
+                .withName(it.getMetadata().getName())
+                .portForward(port)
+        }
+    }
+
 
     /*
         Private K8S Support functions

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1989,7 +1989,7 @@ class Kubernetes {
 
         return collectorPods.collect {
             this.client.pods()
-                .inNamespace("stackrox")
+                .inNamespace(Constants.STACKROX_NAMESPACE)
                 .withName(it.getMetadata().getName())
                 .portForward(port)
         }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -86,7 +86,6 @@ import io.fabric8.kubernetes.api.model.rbac.Subject
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientBuilder
 import io.fabric8.kubernetes.client.KubernetesClientException
-import io.fabric8.kubernetes.client.LocalPortForward
 import io.fabric8.kubernetes.client.dsl.Deletable
 import io.fabric8.kubernetes.client.dsl.ExecListener
 import io.fabric8.kubernetes.client.dsl.ExecWatch

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -45,6 +45,20 @@ class NetworkGraphService extends BaseService {
         }
     }
 
+    static getExternalNetworkEntities(String query = null) {
+        try {
+            GetExternalNetworkEntitiesRequest.Builder request =
+                   GetExternalNetworkEntitiesRequest.newBuilder()
+                           .setClusterId(ClusterService.getClusterId())
+            if (query != null) {
+                request.setQuery(query)
+            }
+            return getNetworkGraphClient().getExternalNetworkEntities(request.build())
+        } catch (Exception e) {
+            log.error("Exception fetching external entities", e)
+        }
+    }
+
     static createNetworkEntity(String clusterId, String name, String cidr, Boolean isSystemGenerated) {
         try {
             if (clusterId == null) {

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -45,20 +45,6 @@ class NetworkGraphService extends BaseService {
         }
     }
 
-    static getExternalNetworkEntities(String query = null) {
-        try {
-            GetExternalNetworkEntitiesRequest.Builder request =
-                   GetExternalNetworkEntitiesRequest.newBuilder()
-                           .setClusterId(ClusterService.getClusterId())
-            if (query != null) {
-                request.setQuery(query)
-            }
-            return getNetworkGraphClient().getExternalNetworkEntities(request.build())
-        } catch (Exception e) {
-            log.error("Exception fetching external entities", e)
-        }
-    }
-
     static createNetworkEntity(String clusterId, String name, String cidr, Boolean isSystemGenerated) {
         try {
             if (clusterId == null) {

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -91,7 +91,7 @@ class CollectorUtil {
     }
 
     static private setExternalIps(Kubernetes orchestrator, String state) {
-        // TODO(ROX-29045): Use a yaml serializer 
+        // TODO(ROX-29045): Use a yaml serializer
         String runtimeConfig = """|
                                   |networking:
                                   |  externalIps:

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -91,6 +91,7 @@ class CollectorUtil {
     }
 
     static private setExternalIps(Kubernetes orchestrator, String state) {
+        // TODO(ROX-29045): Use a yaml serializer 
         String runtimeConfig = """|
                                   |networking:
                                   |  externalIps:

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -1,8 +1,8 @@
 package util
 
-import common.Constants
-
 import static util.Helpers.withRetry
+
+import common.Constants
 
 import groovy.util.logging.Slf4j
 import groovy.transform.CompileStatic

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -9,6 +9,7 @@ import com.google.protobuf.util.JsonFormat
 import sensor.Collector
 
 @Slf4j
+@CompileStatic
 class CollectorUtil {
     static final String RUNTIME_CONFIG_MAP_NAME = "collector-config"
     static final String RUNTIME_CONFIG_MAP_KEY = "runtime_config.yaml"
@@ -17,7 +18,7 @@ class CollectorUtil {
     static final String DISABLED_VALUE = "DISABLED"
 
     static parseJsonToProtobuf(String json) {
-        sensor.Collector.CollectorConfig.Builder builder = sensor.Collector.CollectorConfig.newBuilder()
+        Collector.CollectorConfig.Builder builder = Collector.CollectorConfig.newBuilder()
         JsonFormat.parser().merge(json, builder)
         return builder.build()
     }

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -5,7 +5,7 @@ import groovy.transform.CompileStatic
 import java.net.HttpURLConnection
 import java.net.URL
 
-import orchestratormanager.OrchestratorMain
+import orchestratormanager.Kubernetes
 
 import com.google.protobuf.util.JsonFormat
 
@@ -52,7 +52,7 @@ class CollectorUtil {
         }
     }
 
-    static waitForConfigToHaveState(OrchestratorMain orchestrator, String state, int timeout = 90, int port = 8080) {
+    static waitForConfigToHaveState(Kubernetes orchestrator, String state, int timeout = 90, int port = 8080) {
         def portForwards = orchestrator.createCollectorPortForwards(port)
 
         log.info "Waiting for Collector Config propagation (${portForwards.size()} pods)"
@@ -82,21 +82,21 @@ class CollectorUtil {
         return success
     }
 
-    static enableExternalIps(OrchestratorMain orchestrator, int timeoutSeconds = 90) {
+    static enableExternalIps(Kubernetes orchestrator, int timeoutSeconds = 90) {
         setExternalIps(orchestrator, ENABLED_VALUE)
         waitForConfigToHaveState(orchestrator, ENABLED_VALUE, timeoutSeconds)
     }
 
-    static disableExternalIps(OrchestratorMain orchestrator, int timeoutSeconds = 90) {
+    static disableExternalIps(Kubernetes orchestrator, int timeoutSeconds = 90) {
         setExternalIps(orchestrator, DISABLED_VALUE)
         waitForConfigToHaveState(orchestrator, DISABLED_VALUE, timeoutSeconds)
     }
 
-    static deleteRuntimeConfig(OrchestratorMain orchestrator) {
+    static deleteRuntimeConfig(Kubernetes orchestrator) {
         orchestrator.deleteConfigMap(RUNTIME_CONFIG_MAP_NAME, "stackrox")
     }
 
-    static private setExternalIps(OrchestratorMain orchestrator, String state) {
+    static private setExternalIps(Kubernetes orchestrator, String state) {
         String runtimeConfig = """\
 networking:
   externalIps:

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -65,7 +65,7 @@ class CollectorUtil {
         log.info "Waiting for Collector Config propagation (${portForwards.size()} pods)"
         int intervalSeconds = 1
         int waitTime = 0
-        int nretry = timeout / intervalSeconds
+        int nretry = (timeout / intervalSeconds).toInteger()
         withRetry(nretry, intervalSeconds) {
             // if a pod has the right config, remove it from the list
             // we need to check

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -65,7 +65,8 @@ class CollectorUtil {
         log.info "Waiting for Collector Config propagation (${portForwards.size()} pods)"
         int intervalSeconds = 1
         int waitTime = 0
-        withRetry(timeout, intervalSeconds) {
+        int nretry = timeout / intervalSeconds
+        withRetry(nretry, intervalSeconds) {
             // if a pod has the right config, remove it from the list
             // we need to check
             portForwards.removeAll {

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -4,9 +4,6 @@ import groovy.util.logging.Slf4j
 
 import orchestratormanager.OrchestratorMain
 
-import java.net.HttpURLConnection
-import java.net.URL
-
 import com.google.protobuf.util.JsonFormat
 
 import sensor.Collector
@@ -47,14 +44,13 @@ class CollectorUtil {
         }
     }
 
-    static waitForConfigToHaveState(OrchestratorMain orchestrator, String state, int timeoutSeconds = 90, int port = 8080) {
+    static waitForConfigToHaveState(OrchestratorMain orchestrator, String state, int timeout = 90, int port = 8080) {
         def portForwards = orchestrator.createCollectorPortForwards(port)
 
         log.info "Waiting for Collector Config propagation (${portForwards.size()} pods)"
         int intervalSeconds = 1
         int waitTime
-        def startTime = System.currentTimeMillis()
-        for (waitTime = 0; waitTime <= timeoutSeconds / intervalSeconds; waitTime++) {
+        for (waitTime = 0; waitTime <= timeout / intervalSeconds; waitTime++) {
             if (portForwards.size() == 0) {
                 break
             }
@@ -68,12 +64,12 @@ class CollectorUtil {
             sleep intervalSeconds * 1000
         }
 
-        def success = waitTime <= timeoutSeconds / intervalSeconds
+        def success = waitTime <= timeout / intervalSeconds
         if (success) {
             def waitTimeSeconds = waitTime * intervalSeconds
             log.info "Waited for ${waitTimeSeconds} seconds for Collector runtime configuration to be updated"
         } else {
-            log.info "Waiting for Collector runtime configuration timed out after ${timeoutSeconds} seconds"
+            log.info "Waiting for Collector runtime configuration timed out after ${timeout} seconds"
         }
 
         // if we timed out, some collectors have not updated

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -46,9 +46,7 @@ class CollectorUtil {
     private static introspectionQuery(String collectorAddress, String endpoint) {
         String uri = "http://${collectorAddress}${endpoint}"
         URL url = new URL(uri)
-        HttpURLConnection connection = null
-
-        connection = (HttpURLConnection) url.openConnection()
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection()
 
         // this might be unneeded?
         connection.setRequestMethod("GET")

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -1,17 +1,15 @@
 package util
 
+import static util.Helpers.withRetry
+
 import groovy.util.logging.Slf4j
 import groovy.transform.CompileStatic
-import java.net.HttpURLConnection
-import java.net.URL
 
 import orchestratormanager.Kubernetes
 
 import com.google.protobuf.util.JsonFormat
 
 import sensor.Collector
-
-import static util.Helpers.withRetry
 
 @Slf4j
 @CompileStatic

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -1,6 +1,9 @@
 package util
 
 import groovy.util.logging.Slf4j
+import groovy.transform.CompileStatic
+import java.net.HttpURLConnection
+import java.net.URL
 
 import orchestratormanager.OrchestratorMain
 
@@ -25,7 +28,8 @@ class CollectorUtil {
 
     static introspectionQuery(String collectorAddress, String endpoint) {
         String uri = "http://${collectorAddress}${endpoint}"
-        HttpURLConnection connection = new URL(uri).openConnection()
+        URL url = new URL(uri)
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection()
 
         // this might be unneeded?
         connection.setRequestMethod("GET")
@@ -60,7 +64,8 @@ class CollectorUtil {
             // we need to check
             portForwards.removeAll {
                 def config = introspectionQuery("127.0.0.1:${it.getLocalPort()}", "/state/runtime-config")
-                return config.networking.externalIps.enabled.name() == state
+                def configTyped = (Collector.CollectorConfig) config
+                return configTyped.networking.externalIps.enabled.name() == state
             }
             sleep intervalSeconds * 1000
         }

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -48,21 +48,17 @@ class CollectorUtil {
         URL url = new URL(uri)
         HttpURLConnection connection = null
 
-        try {
-            connection = (HttpURLConnection) url.openConnection()
+        connection = (HttpURLConnection) url.openConnection()
 
-            // this might be unneeded?
-            connection.setRequestMethod("GET")
-            connection.connect()
+        // this might be unneeded?
+        connection.setRequestMethod("GET")
+        connection.connect()
 
-            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("IntrospectionQuery failed with ${connection.responseMessage}")
-            }
-            def jsonResponse = connection.inputStream.text
-            return parseJsonToProtobuf(jsonResponse)
-        } catch (Exception e) {
-            throw new RuntimeException("Error making request: ${e.message}", e)
+        if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+            throw new RuntimeException("IntrospectionQuery failed with ${connection.responseMessage}")
         }
+        def jsonResponse = connection.inputStream.text
+        return parseJsonToProtobuf(jsonResponse)
     }
 
     private static waitForConfigToHaveState(Kubernetes orchestrator, String state, int timeout = 90, int port = 8080) {
@@ -79,8 +75,8 @@ class CollectorUtil {
                 def configTyped = (Collector.CollectorConfig) config
                 return configTyped.networking.externalIps.enabled.name() == state
             }
-            assert portForwards.isEmpty()
             waitTime += intervalSeconds
+            assert portForwards.isEmpty()
         }
 
         def success = portForwards.isEmpty()

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -29,12 +29,13 @@ class CollectorUtil {
     static introspectionQuery(String collectorAddress, String endpoint) {
         String uri = "http://${collectorAddress}${endpoint}"
         URL url = new URL(uri)
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection()
-
-        // this might be unneeded?
-        connection.setRequestMethod("GET")
+        HttpURLConnection connection = null
 
         try {
+            connection = (HttpURLConnection) url.openConnection()
+
+            // this might be unneeded?
+            connection.setRequestMethod("GET")
             connection.connect()
 
             if (connection.responseCode != HttpURLConnection.HTTP_OK) {

--- a/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/CollectorUtil.groovy
@@ -1,0 +1,110 @@
+package util
+
+import groovy.util.logging.Slf4j
+
+import orchestratormanager.OrchestratorMain
+
+import java.net.HttpURLConnection
+import java.net.URL
+
+import com.google.protobuf.util.JsonFormat
+
+import sensor.Collector
+
+@Slf4j
+class CollectorUtil {
+    static final String RUNTIME_CONFIG_MAP_NAME = "collector-config"
+    static final String RUNTIME_CONFIG_MAP_KEY = "runtime_config.yaml"
+
+    static final String ENABLED_VALUE = "ENABLED"
+    static final String DISABLED_VALUE = "DISABLED"
+
+    static parseJsonToProtobuf(String json) {
+        sensor.Collector.CollectorConfig.Builder builder = sensor.Collector.CollectorConfig.newBuilder()
+        JsonFormat.parser().merge(json, builder)
+        return builder.build()
+    }
+
+    static introspectionQuery(String collectorAddress, String endpoint) {
+        String uri = "http://${collectorAddress}${endpoint}"
+        HttpURLConnection connection = new URL(uri).openConnection()
+
+        // this might be unneeded?
+        connection.setRequestMethod("GET")
+
+        try {
+            connection.connect()
+
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                throw new RuntimeException("IntrospectionQuery failed with ${connection.responseMessage}")
+            }
+            def jsonResponse = connection.inputStream.text
+            return parseJsonToProtobuf(jsonResponse)
+        } catch (Exception e) {
+            throw new RuntimeException("Error making request: ${e.message}", e)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    static waitForConfigToHaveState(OrchestratorMain orchestrator, String state, int timeoutSeconds = 90, int port = 8080) {
+        def portForwards = orchestrator.createCollectorPortForwards(port)
+
+        log.info "Waiting for Collector Config propagation (${portForwards.size()} pods)"
+        int intervalSeconds = 1
+        int waitTime
+        def startTime = System.currentTimeMillis()
+        for (waitTime = 0; waitTime <= timeoutSeconds / intervalSeconds; waitTime++) {
+            if (portForwards.size() == 0) {
+                break
+            }
+
+            // if a pod has the right config, remove it from the list
+            // we need to check
+            portForwards.removeAll {
+                def config = introspectionQuery("127.0.0.1:${it.getLocalPort()}", "/state/runtime-config")
+                return config.networking.externalIps.enabled.name() == state
+            }
+            sleep intervalSeconds * 1000
+        }
+
+        def success = waitTime <= timeoutSeconds / intervalSeconds
+        if (success) {
+            def waitTimeSeconds = waitTime * intervalSeconds
+            log.info "Waited for ${waitTimeSeconds} seconds for Collector runtime configuration to be updated"
+        } else {
+            log.info "Waiting for Collector runtime configuration timed out after ${timeoutSeconds} seconds"
+        }
+
+        // if we timed out, some collectors have not updated
+        // the config, so return false
+        return success
+    }
+
+    static enableExternalIps(OrchestratorMain orchestrator, int timeoutSeconds = 90) {
+        setExternalIps(orchestrator, ENABLED_VALUE)
+        waitForConfigToHaveState(orchestrator, ENABLED_VALUE, timeoutSeconds)
+    }
+
+    static disableExternalIps(OrchestratorMain orchestrator, int timeoutSeconds = 90) {
+        setExternalIps(orchestrator, DISABLED_VALUE)
+        waitForConfigToHaveState(orchestrator, DISABLED_VALUE, timeoutSeconds)
+    }
+
+    static deleteRuntimeConfig(OrchestratorMain orchestrator) {
+        orchestrator.deleteConfigMap(RUNTIME_CONFIG_MAP_NAME, "stackrox")
+    }
+
+    static private setExternalIps(OrchestratorMain orchestrator, String state) {
+        String runtimeConfig = """\
+networking:
+  externalIps:
+    enabled: ${state}
+"""
+        Map<String, String> data = [
+            (RUNTIME_CONFIG_MAP_KEY): runtimeConfig,
+        ]
+
+        orchestrator.createConfigMap(RUNTIME_CONFIG_MAP_NAME, data, "stackrox")
+    }
+}

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -484,7 +484,7 @@ class NetworkFlowTest extends BaseSpecification {
            "runtime_config.yaml": """
 networking:
     externalIps:
-        enable: true
+        enable: false
 """
         ]
 

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -485,10 +485,13 @@ class NetworkFlowTest extends BaseSpecification {
         log.info "Checking for edge from ${EXTERNALDESTINATION} to external target"
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         def graph = NetworkGraphService.getNetworkGraph(null, null)
+        def node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         then:
         "There should be an edge from A to external entities and it should be the only edge"
         assert edges
         assert edges.size() == 1
+        assert node
+        assert node.outEdgesMap.size() == 1
 
         when: "External IPs is enabled"
         CollectorUtil.enableExternalIps(orchestrator)
@@ -496,7 +499,7 @@ class NetworkFlowTest extends BaseSpecification {
 
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         graph = NetworkGraphService.getNetworkGraph()
-        def node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
+        node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         then:
         "The edge should still be there and it should still be the only edge from A"
         assert edges

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -487,7 +487,6 @@ class NetworkFlowTest extends BaseSpecification {
         then:
         "There should be an edge from A to external entities and it should be the only edge"
         assert edges
-        def nedges = edges.size()
         assert edges.size() == 1
 
         when: "External IPs is enabled"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -244,6 +244,7 @@ class NetworkFlowTest extends BaseSpecification {
 
     def cleanupSpec() {
         destroyDeployments()
+        CollectorUtil.deleteRuntimeConfig(orchestrator)
     }
 
     @Tag("NetworkFlowVisualization")
@@ -528,8 +529,6 @@ class NetworkFlowTest extends BaseSpecification {
         // // Collector reports the unnormalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)
-
-        CollectorUtil.deleteRuntimeConfig(orchestrator)
     }
 
     @Tag("NetworkFlowVisualization")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -494,7 +494,7 @@ class NetworkFlowTest extends BaseSpecification {
         sleep 65000 // Wait for the collector scrape interval and for sensor to send connections to sensor
 
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
-        graph = NetworkGraphService.getNetworkGraph(null, null)
+        graph = NetworkGraphService.getNetworkGraph()
         def node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         then:
         "The edge should still be there and it should still be the only edge from A"
@@ -503,7 +503,7 @@ class NetworkFlowTest extends BaseSpecification {
         assert edges.size() == 1
         assert node
         // There should only be one connection and it should be to the generic external entity.
-        assert node.outEdges.size() == 1
+        assert node.outEdgesMap.size() == 1
         // // Collector reports the normalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)
@@ -515,7 +515,7 @@ class NetworkFlowTest extends BaseSpecification {
         sleep 65000 // Wait for the collector scrape interval and for sensor to send connections to sensor
 
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
-        graph = NetworkGraphService.getNetworkGraph(null, null)
+        graph = NetworkGraphService.getNetworkGraph()
         node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         then:
         "The edge should still be there and it should still be the only edge from A"
@@ -528,6 +528,8 @@ class NetworkFlowTest extends BaseSpecification {
         // // Collector reports the unnormalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)
+
+        CollectorUtil.deleteRuntimeConfig(orchestrator)
     }
 
     @Tag("NetworkFlowVisualization")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -254,6 +254,9 @@ class NetworkFlowTest extends BaseSpecification {
         String targetUid = deployments.find { it.name == NGINXCONNECTIONTARGET }?.deploymentUid
         assert targetUid != null
         String sourceUid = deployments.find { it.name == SINGLECONNECTIONSOURCE }?.deploymentUid
+        log.info "${targetUid}"
+        log.info "${sourceUid}"
+        sleep 100000
         assert sourceUid != null
 
         when:
@@ -475,11 +478,11 @@ class NetworkFlowTest extends BaseSpecification {
         String deploymentUid = deployments.find { it.name == EXTERNALDESTINATION }?.deploymentUid
         assert deploymentUid != null
 
-        expect:
-        "Check for edge in network graph"
         log.info "Checking for edge from ${EXTERNALDESTINATION} to external target"
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         assert edges
+
+        orchestrator.createConfigMap(CONFIG_MAP_NAME, CONFIG_MAP_DATA)
     }
 
     @Tag("NetworkFlowVisualization")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -256,9 +256,6 @@ class NetworkFlowTest extends BaseSpecification {
         String targetUid = deployments.find { it.name == NGINXCONNECTIONTARGET }?.deploymentUid
         assert targetUid != null
         String sourceUid = deployments.find { it.name == SINGLECONNECTIONSOURCE }?.deploymentUid
-        log.info "${targetUid}"
-        log.info "${sourceUid}"
-        sleep 100000
         assert sourceUid != null
 
         when:

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -488,7 +488,7 @@ class NetworkFlowTest extends BaseSpecification {
         assert edges
         def nedges = edges.size()
         int i
-        for (i=0;i<nedges;i++) {
+        for (i=0 ; i<nedges ; i++) {
             log.info ""
             log.info "external edge"
             log.info "${edges[i].getLastActiveTimestamp()}"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -484,20 +484,10 @@ class NetworkFlowTest extends BaseSpecification {
         log.info "Checking for edge from ${EXTERNALDESTINATION} to external target"
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         def graph = NetworkGraphService.getNetworkGraph(null, null)
-        log.info "graph0 = ${graph}"
         then:
-        "There should be an edge fro A to external entities and it should be the only edge"
+        "There should be an edge from A to external entities and it should be the only edge"
         assert edges
         def nedges = edges.size()
-        int i
-        for (i=0 ; i<nedges ; i++) {
-            log.info ""
-            log.info "external edge"
-            log.info "${edges[i].getLastActiveTimestamp()}"
-            log.info "${edges[i].getProtocol()}"
-            log.info "${edges[i].getPort()}"
-            log.info ""
-        }
         assert edges.size() == 1
 
         when: "External IPs is enabled"
@@ -507,7 +497,6 @@ class NetworkFlowTest extends BaseSpecification {
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         graph = NetworkGraphService.getNetworkGraph(null, null)
         def node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
-        log.info "graph1 = ${graph}"
         then:
         "The edge should still be there and it should still be the only edge from A"
         assert edges
@@ -533,7 +522,6 @@ class NetworkFlowTest extends BaseSpecification {
         "The edge should still be there and it should still be the only edge from A"
         assert edges
         // Disbling external IPs should not change the number of edges
-        log.info "graph2 = ${graph}"
         assert edges.size() == 1
         assert node
         // There should only be one connection and it should be to the generic external entity.

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -489,7 +489,7 @@ networking:
 
         log.info "Checking for edge from ${EXTERNALDESTINATION} to external target"
 
-	sleep 60000
+	sleep 180000
 
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         assert edges
@@ -505,6 +505,7 @@ networking:
 """
        ]
         orchestrator.createConfigMap(CONFIG_MAP_NAME, CONFIG_MAP_DATA, "stackrox")
+	sleep 180000
 
         assert waitForEdgeToBeClosed(edges.get(0), 165)
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
@@ -522,6 +523,7 @@ networking:
        ]
 
         orchestrator.createConfigMap(CONFIG_MAP_NAME, CONFIG_MAP_DATA, "stackrox")
+	sleep 180000
         assert waitForEdgeUpdate(edges.get(0), 90)
 	graph = NetworkGraphService.getNetworkGraph(null, null)
 	log.info "${graph}"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -483,17 +483,30 @@ class NetworkFlowTest extends BaseSpecification {
         log.info "Checking for edge from ${EXTERNALDESTINATION} to external target"
 
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
+        def graph = NetworkGraphService.getNetworkGraph(null, null)
+        log.info "graph0 = ${graph}"
         assert edges
+        def nedges = edges.size()
+        int i
+        for (i=0;i<nedges;i++) {
+            log.info ""
+            log.info "external edge"
+            log.info "${edges[i].getLastActiveTimestamp()}"
+            log.info "${edges[i].getProtocol()}"
+            log.info "${edges[i].getPort()}"
+            log.info ""
+        }
         assert edges.size() == 1
 
         CollectorUtil.enableExternalIps(orchestrator)
         sleep 65000 // Wait for the collector scrape interval and for sensor to send connections to sensor
 
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
+        graph = NetworkGraphService.getNetworkGraph(null, null)
+        log.info "graph1 = ${graph}"
         assert edges
         // Enabling external IPs should not change the number of edges
         assert edges.size() == 1
-        def graph = NetworkGraphService.getNetworkGraph(null, null)
         def node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         assert node
         // There should only be one connection and it should be to the generic external entity.
@@ -501,10 +514,7 @@ class NetworkFlowTest extends BaseSpecification {
         // // Collector reports the normalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)
-        // // The unnormalized connection is then reported as being opened by collector. This connection
-        // // is normlized later before appearing in the API response.
-        // // We probably don't want this assert either.
-        // assert waitForEdgeUpdate(edges.get(0))
+        // assert !waitForEdgeToBeClosed(edges.get(0), 165) // This assert was failing
 
         // Disable external IPs at the end of the test and check the relevant edge
         CollectorUtil.disableExternalIps(orchestrator)
@@ -513,8 +523,9 @@ class NetworkFlowTest extends BaseSpecification {
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         assert edges
         // Disbling external IPs should not change the number of edges
-        assert edges.size() == 1
         graph = NetworkGraphService.getNetworkGraph(null, null)
+        log.info "graph2 = ${graph}"
+        assert edges.size() == 1
         node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         assert node
         // There should only be one connection and it should be to the generic external entity.
@@ -522,9 +533,6 @@ class NetworkFlowTest extends BaseSpecification {
         // // Collector reports the unnormalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)
-        // // The normalized connection is then reported as being opened by collector.
-        // // We probably don't want this assert either.
-        // assert waitForEdgeUpdate(edges.get(0))
     }
 
     @Tag("NetworkFlowVisualization")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -493,6 +493,9 @@ networking:
 
         List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
         assert edges
+	log.info "${edges}"
+	def graph = NetworkGraphService.getNetworkGraph(null, null)
+	log.info "${graph}"
 
         CONFIG_MAP_DATA = [
            "runtime_config.yaml": """
@@ -505,6 +508,10 @@ networking:
 
         assert waitForEdgeToBeClosed(edges.get(0), 165)
         edges = NetworkGraphUtil.checkForEdge(deploymentUid, Constants.INTERNET_EXTERNAL_SOURCE_ID)
+	log.info "${edges}"
+        log.info "asdf"
+	graph = NetworkGraphService.getNetworkGraph(null, null)
+	log.info "${graph}"
 
         CONFIG_MAP_DATA = [
            "runtime_config.yaml": """
@@ -516,6 +523,8 @@ networking:
 
         orchestrator.createConfigMap(CONFIG_MAP_NAME, CONFIG_MAP_DATA, "stackrox")
         assert waitForEdgeUpdate(edges.get(0), 90)
+	graph = NetworkGraphService.getNetworkGraph(null, null)
+	log.info "${graph}"
     }
 
     @Tag("NetworkFlowVisualization")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -529,7 +529,7 @@ class NetworkFlowTest extends BaseSpecification {
         node = NetworkGraphUtil.findDeploymentNode(graph, deploymentUid)
         assert node
         // There should only be one connection and it should be to the generic external entity.
-        assert node.outEdges.size() == 1
+        assert node.outEdgesMap.size() == 1
         // // Collector reports the unnormalized connection as being closed. There is no assert here
         // // as we don't want this behavior long term.
         // waitForEdgeToBeClosed(edges.get(0), 165)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -452,18 +452,14 @@ deploy_sensor_via_operator() {
 
     if [[ -n "${ROX_AFTERGLOW_PERIOD:-}" ]]; then
        collector_envs+=("ROX_AFTERGLOW_PERIOD=${ROX_AFTERGLOW_PERIOD}")
-       #kubectl -n "${sensor_namespace}" set env ds/collector ROX_AFTERGLOW_PERIOD="${ROX_AFTERGLOW_PERIOD}"
     fi
 
     if [[ -n "${ROX_COLLECTOR_INTROSPECTION_ENABLE:-}" ]]; then
        collector_envs+=("ROX_COLLECTOR_INTROSPECTION_ENABLE=${ROX_COLLECTOR_INTROSPECTION_ENABLE}")
-       #kubectl -n "${sensor_namespace}" set env ds/collector ROX_COLLECTOR_INTROSPECTION_ENABLE="${ROX_COLLECTOR_INTROSPECTION_ENABLE}"
     fi
 
     if [[ -n "${ROX_PROCESSES_LISTENING_ON_PORT:-}" ]]; then
        collector_envs+=("ROX_PROCESSES_LISTENING_ON_PORT=${ROX_PROCESSES_LISTENING_ON_PORT}")
-       kubectl -n "${sensor_namespace}" set env deployment/sensor ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
-       #kubectl -n "${sensor_namespace}" set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
     fi
 
     if [[ ${#collector_envs[@]} -gt 0 ]]; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -360,7 +360,7 @@ deploy_sensor() {
 
     info "Deploying sensor into namespace ${sensor_namespace} (central is expected in namespace ${central_namespace})"
 
-    ci_export ROX_AFTERGLOW_PERIOD "0"
+    ci_export ROX_AFTERGLOW_PERIOD "15"
     ci_export ROX_COLLECTOR_INTROSPECTION_ENABLE "true"
 
     if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -459,6 +459,7 @@ deploy_sensor_via_operator() {
     fi
 
     if [[ -n "${ROX_PROCESSES_LISTENING_ON_PORT:-}" ]]; then
+       kubectl -n "${sensor_namespace}" set env deployment/sensor ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
        collector_envs+=("ROX_PROCESSES_LISTENING_ON_PORT=${ROX_PROCESSES_LISTENING_ON_PORT}")
     fi
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -360,7 +360,7 @@ deploy_sensor() {
 
     info "Deploying sensor into namespace ${sensor_namespace} (central is expected in namespace ${central_namespace})"
 
-    ci_export ROX_AFTERGLOW_PERIOD "15"
+    ci_export ROX_AFTERGLOW_PERIOD "0"
     ci_export ROX_COLLECTOR_INTROSPECTION_ENABLE "true"
 
     if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Modifies the existing "Verify connections to external sources" to check what happens when the external IPs feature goes from being disabled to enabled to disabled. The existing test creates a pod which repeatedly connects to google.com, which is obviously external to the cluster, and checks that the edge appears in the network graph. The test now creates the collector-config ConfigMap. It initially does so with external IPs being disabled. It then performs the existing check for the edge. Each time the configuration is set, it waits to confirm that collector has the correct configuration, before proceeding. External IPs is then enabled and after waiting for confirmation that the configuration has been updated and enough time has been given for the network graph to be updated, the edge is checked again. Finally external IPs is disabled and edge is checked again. At each point there is a check that there is only one connection involving the deployment.

The changes here increase the time taken by the test from about four minutes to about seven minutes.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~~- [ ] added unit tests~~
- [x] added e2e tests
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~

This PR only adds e2e tests so adding other types of tests doesn't apply. 

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI and running locally.
