### PR TITLE
ROX-26581: Disable failing scanner v4 tests

### DIFF
--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -297,6 +297,7 @@ EOF
 }
 
 @test "Fresh installation of HEAD Helm charts with Scanner v4 enabled in multi-namespace mode" {
+    skip "Constantly failing: ROX-26581"
     local central_namespace="$CUSTOM_CENTRAL_NAMESPACE"
     local sensor_namespace="$CUSTOM_SENSOR_NAMESPACE"
 

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -384,6 +384,14 @@ EOF
 }
 
 @test "[Operator] Fresh multi-namespace installation with Scanner V4 enabled" {
+    skip "ROX-26581: Operator installation to custom namespace fails"
+    # Reason for failure:
+    # Unable to continue with install:
+    # CustomResourceDefinition "securitypolicies.config.stackrox.io" in namespace "" exists and cannot be imported
+    # into the current release:
+    # invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace"
+    # must equal "stackrox-central": current value is "stackrox"
+
     if [[ "${ORCHESTRATOR_FLAVOR:-}" != "openshift" ]]; then
         skip "This test is currently only supported on OpenShift"
     fi
@@ -412,6 +420,14 @@ EOF
 }
 
 @test "[Operator] Upgrade multi-namespace installation" {
+    skip "ROX-26581: Operator installation to custom namespace fails"
+    # Reason for failure:
+    # Unable to continue with install:
+    # CustomResourceDefinition "securitypolicies.config.stackrox.io" in namespace "" exists and cannot be imported
+    # into the current release:
+    # invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace"
+    # must equal "stackrox-central": current value is "stackrox"
+
     if [[ "${ORCHESTRATOR_FLAVOR:-}" != "openshift" ]]; then
         skip "This test is currently only supported on OpenShift"
     fi


### PR DESCRIPTION
### Description

Disable test for ROX-26581: run-scanner-v4.bats: Fresh installation of HEAD Helm charts with Scanner v4 enabled in multi-namespace mode.

Apparently, the operator refuses to install central into non-standard namespace and provides the following reason:
```
Status:
  Central:
    Admin Password:
      Admin Password Secret Reference:  central-admin-pass
      Info:                             The admin password is configured to match the "password" entry in the central-admin-pass secret.
  Conditions:
    Last Transition Time:  2024-10-23T09:06:57Z
    Status:                False
    Type:                  Deployed
    Last Transition Time:  2024-10-23T09:06:57Z
    Status:                True
    Type:                  Initialized
    Last Transition Time:  2024-10-23T09:11:48Z
    Message:               Unable to continue with install: CustomResourceDefinition "securitypolicies.config.stackrox.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "stackrox-central": current value is "stackrox"
    Reason:                ReconcileError
    Status:                True
    Type:                  Irreconcilable
    Last Transition Time:  2024-10-23T09:06:57Z
    Message:               Proxy configuration has been applied successfully
    Reason:                ProxyConfigApplied
    Status:                False
    Type:                  ProxyConfigFailed
    Last Transition Time:  2024-10-23T09:06:57Z
    Message:               Unable to continue with install: CustomResourceDefinition "securitypolicies.config.stackrox.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "stackrox-central": current value is "stackrox"
    Reason:                InstallError
    Status:                True
    Type:                  ReleaseFailed
  Product Version:         4.6.x-807-g4506dc9344
Events:                    <none>
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

CI

![Screenshot 2024-10-23 at 16 44 23](https://github.com/user-attachments/assets/3b646ca1-9ce1-4f9f-9fdf-3f2337fc7727)


