### PR TITLE
build: Switch `git-url` from `repo_url` to `source_url`

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: image/postgres/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: image/rhel/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: operator/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: operator/konflux.bundle.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   # TODO(ROX-24530): return expiration for non-released images to 13w
   - name: image-expires-after
     value: '52w'

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: image/roxctl/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: scanner/image/scanner/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: scanner/image/db/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'


### PR DESCRIPTION
### Description

When looking for information about `CHAINS-GIT_URL` in the scope of ROX-24468, I ran into a few mentions that `source_url` is a better choice than `repo_url`. I couldn't parse exactly where or when the difference matters but it seems about handling forked builds and Konflux integration tests. Without thinking much about it, I suggest we just switch provided new templates render with `source_url` (and we flipped back to `repo_url` for consistency with our oldest pipelines).

- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1702354906424429
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1717768756743769?thread_ts=1717750916.369879&cid=C04PZ7H0VA8

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No updates to automated testing.

#### How I validated my change

If Konflux CI gets sufficiently far, it's good enough.