### PR TITLE
chore(telemetry): add Version to the telemetry context

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -30,7 +30,7 @@ func trackClusterRegistered(cluster *storage.Cluster) {
 		// cluster 'user' to the Tenant group:
 		cfg.Telemeter().Track("Secured Cluster Static Properties", nil,
 			telemeter.WithTraits(makeClusterProperties(cluster)),
-			telemeter.WithClient(cluster.GetId(), securedClusterClient),
+			telemeter.WithClient(cluster.GetId(), securedClusterClient, cluster.GetMainImage()),
 			groups)
 	}
 }
@@ -55,7 +55,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 			Track("Secured Cluster Initialized", map[string]any{
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
-				telemeter.WithClient(cluster.GetId(), securedClusterClient),
+				telemeter.WithClient(cluster.GetId(), securedClusterClient, cluster.GetMainImage()),
 				telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	}
 }
@@ -118,7 +118,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 	props["Orchestrator Version"] = omd.GetVersion()
 
 	opts := []telemeter.Option{
-		telemeter.WithClient(clusterID, securedClusterClient),
+		telemeter.WithClient(clusterID, securedClusterClient, cluster.GetMainImage()),
 		telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
 		telemeter.WithTraits(props),
 		telemeter.WithNoDuplicates(time.Now().Format(time.DateOnly)),

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -77,14 +77,15 @@ func getInstanceConfig(id string, key string) (*phonehome.Config, map[string]any
 			// batch. Setting BatchSize to 1, instead of default 250, may reduce
 			// the number of (none) values, appearing on Amplitude charts, by
 			// introducing a slight delay between consequent events.
-			BatchSize:    1,
-			ClientID:     id,
-			ClientName:   "Central",
-			GroupType:    "Tenant",
-			GroupID:      tenantID,
-			StorageKey:   key,
-			Endpoint:     env.TelemetryEndpoint.Setting(),
-			PushInterval: env.TelemetryFrequency.DurationSetting(),
+			BatchSize:     1,
+			ClientID:      id,
+			ClientName:    "Central",
+			ClientVersion: version.GetMainVersion(),
+			GroupType:     "Tenant",
+			GroupID:       tenantID,
+			StorageKey:    key,
+			Endpoint:      env.TelemetryEndpoint.Setting(),
+			PushInterval:  env.TelemetryFrequency.DurationSetting(),
 		}, map[string]any{
 			"Image Flavor":       defaults.GetImageFlavorNameFromEnv(),
 			"Central version":    version.GetMainVersion(),

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -33,6 +33,8 @@ type Config struct {
 	ClientID string
 	// ClientName tells what kind of client is sending data.
 	ClientName string
+	// ClientVersion is the client version.
+	ClientVersion string
 	// GroupType identifies the main group type to which the client belongs.
 	GroupType string
 	// GroupID identifies the ID of the GroupType group.
@@ -94,6 +96,7 @@ func (cfg *Config) Telemeter() telemeter.Telemeter {
 				cfg.Endpoint,
 				cfg.ClientID,
 				cfg.ClientName,
+				cfg.ClientVersion,
 				cfg.PushInterval,
 				cfg.BatchSize)
 		} else {

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -6,6 +6,7 @@ type CallOptions struct {
 	AnonymousID     string
 	ClientID        string
 	ClientType      string
+	ClientVersion   string
 	MessageIDPrefix string
 
 	// [group type: [group id]]
@@ -35,13 +36,14 @@ func WithUserID(userID string) Option {
 }
 
 // WithClient allows for modifying the ClientID and ClientType call options.
-func WithClient(clientID string, clientType string) Option {
+func WithClient(clientID string, clientType, clientVersion string) Option {
 	return func(o *CallOptions) {
 		if o.UserID == "" {
 			o.AnonymousID = clientID
 		}
 		o.ClientID = clientID
 		o.ClientType = clientType
+		o.ClientVersion = clientVersion
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -9,7 +9,7 @@ import (
 func Test_With(t *testing.T) {
 	opts := ApplyOptions([]Option{
 		WithUserID("userID"),
-		WithClient("clientID", "clientType"),
+		WithClient("clientID", "clientType", "clientVersion"),
 		WithGroups("groupA", "groupA_id1"),
 		WithGroups("groupA", "groupA_id2"),
 		WithGroups("groupB", "groupB_id"),
@@ -19,6 +19,7 @@ func Test_With(t *testing.T) {
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
+	assert.Equal(t, "clientVersion", opts.ClientVersion)
 	assert.Equal(t, "test", opts.MessageIDPrefix)
 
 	props := map[string][]string{


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The PR adds version information to the telemetry object context, so that we could see version change on the analytics platform. And also the User-Agent of the actual sender.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

*Segment receives*:

```json
{
  "anonymousId": "0121d10e-e4ce-43b0-b780-e7bf604d24a5",
  "context": {
    "app": {
      "build": "development",
      "version": "4.6.x-806-gdbcb79fc0e"
    },
    "device": {
      "id": "0121d10e-e4ce-43b0-b780-e7bf604d24a5",
      "type": "Central Server",
      "version": "4.6.x-806-gdbcb79fc0e"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "userAgent": "Rox Central/4.6.x-806-gdbcb79fc0e (linux; amd64)"
  },
  "event": "Telemetry Enabled",
  "integrations": {},
  "messageId": "4f791d61-4b26-45ab-9923-a40a96fc6421",
  "originalTimestamp": "2024-10-24T12:34:23.559067784Z",
  "receivedAt": "2024-10-24T12:34:23.848Z",
  "sentAt": "2024-10-24T12:34:23.559Z",
  "timestamp": "2024-10-24T12:34:23.848Z",
  "type": "track"
}
```
```json
{
  "anonymousId": "e6f4900f-686c-44a1-8b6c-1b0f3527bdef",
  "context": {
    "app": {
      "build": "development",
      "version": "4.6.x-806-gdbcb79fc0e"
    },
    "device": {
      "id": "e6f4900f-686c-44a1-8b6c-1b0f3527bdef",
      "type": "Secured Cluster Server",
      "version": "quay.io/rhacs-eng/main:4.5.3"
    },
    "groups": {
      "Tenant": [
        "0121d10e-e4ce-43b0-b780-e7bf604d24a5"
      ]
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Admission Controller": true,
      "CPU Capacity": 32,
      "Cluster Type": "KUBERNETES_CLUSTER",
      "Collection Method": "CORE_BPF",
      "Collector Image": "",
      "Main Image": "quay.io/rhacs-eng/main:4.5.3",
      "Managed By": "MANAGER_TYPE_UNKNOWN",
      "Orchestrator Version": "v1.30.4-gke.1348001",
      "Priority": 2,
      "Provider": "Google",
      "Provider Region": "us-central1",
      "Provider Verified": true,
      "Provider Zone": "us-central1-b",
      "Slim Collector": false,
      "Total Nodes": 2
    },
    "userAgent": "Rox Central/4.6.x-806-gdbcb79fc0e (linux; amd64)"
  },
  "event": "Updated Secured Cluster Identity",
  "integrations": {},
  "messageId": "2024-10-24-931a2413a8d76e96",
  "originalTimestamp": "2024-10-24T12:40:14.651778038Z",
  "receivedAt": "2024-10-24T12:40:14.974Z",
  "sentAt": "2024-10-24T12:40:14.651Z",
  "timestamp": "2024-10-24T12:40:14.974Z",
  "type": "track"
}
```

*Amplitude receives*:
