### PR TITLE
chore(ui): Add pluginPatternFly with limited no-Variant lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -1,0 +1,71 @@
+/* globals module */
+
+const rules = {
+    // ESLint naming convention for positive rules:
+    // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
+
+    // ESLint naming convention for negative rules.
+    // If your rule only disallows something, prefix it with no.
+    // However, we can write forbid instead of disallow as the verb in description and message.
+
+    'no-Variant': {
+        // Replace Variant enum member with corresponding string literal.
+        // Because TypeScript string enumeration is source of truth for prop.
+        // For example, replace variant={AlertVariant.info} with variant="info"
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Replace Variant enum member with corresponding string literal',
+            },
+            schema: [],
+        },
+        create(context) {
+            // Temporary forbid list limits changed files per contribution.
+            const variants = [
+                'ClipboardCopyVariant',
+                'EmptyStateVariant',
+                'ExpandableSectionVariant',
+            ];
+            return {
+                ImportDeclaration(node) {
+                    if (node.source.value === '@patternfly/react-core') {
+                        if (
+                            node.specifiers.some(
+                                (specifier) =>
+                                    typeof specifier.imported?.name === 'string' &&
+                                    // specifier.imported.name.endsWith('Variant')
+                                    variants.includes(specifier.imported.name)
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Replace Variant enum member with corresponding string literal',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
+};
+
+const pluginKey = 'patternfly'; // key of pluginPatternFly in eslint.config.js file
+
+const pluginPatternFly = {
+    meta: {
+        name: 'pluginPatternFly',
+        version: '0.0.1',
+    },
+    rules,
+    // ...pluginPatternFly.configs.recommended.rules means all rules in eslint.config.js file.
+    configs: {
+        recommended: {
+            rules: Object.fromEntries(
+                Object.keys(rules).map((ruleKey) => [`${pluginKey}/${ruleKey}`, 'error'])
+            ),
+        },
+    },
+};
+
+module.exports = pluginPatternFly;

--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -20,21 +20,17 @@ const rules = {
             schema: [],
         },
         create(context) {
-            // Temporary forbid list limits changed files per contribution.
-            const variants = [
-                'ClipboardCopyVariant',
-                'EmptyStateVariant',
-                'ExpandableSectionVariant',
-            ];
             return {
                 ImportDeclaration(node) {
-                    if (node.source.value === '@patternfly/react-core') {
+                    if (
+                        typeof node.source?.value === 'string' &&
+                        node.source.value.startsWith('@patternfly/react-core') // startsWith also matches deprecated
+                    ) {
                         if (
                             node.specifiers.some(
                                 (specifier) =>
                                     typeof specifier.imported?.name === 'string' &&
-                                    // specifier.imported.name.endsWith('Variant')
-                                    variants.includes(specifier.imported.name)
+                                    specifier.imported.name.endsWith('Variant')
                             )
                         ) {
                             context.report({

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -20,6 +20,7 @@ const { browser: browserGlobals, jest: jestGlobals, node: nodeGlobals } = requir
 
 const pluginAccessibility = require('./eslint-plugins/pluginAccessibility');
 const pluginGeneric = require('./eslint-plugins/pluginGeneric');
+const pluginPatternFly = require('./eslint-plugins/pluginPatternFly');
 
 const parserAndOptions = {
     parser: parserTypeScriptESLint,
@@ -534,12 +535,14 @@ module.exports = [
             accessibility: pluginAccessibility,
             generic: pluginGeneric,
             import: pluginImport,
+            patternfly: pluginPatternFly,
             react: pluginReact,
             'react-hooks': pluginReactHooks,
         },
         rules: {
             ...pluginAccessibility.configs.recommended.rules,
             ...pluginGeneric.configs.recommended.rules,
+            ...pluginPatternFly.configs.recommended.rules,
 
             'no-restricted-imports': [
                 'error',

--- a/ui/apps/platform/src/Components/EmptyStateTemplate/EmptyStateTemplate.tsx
+++ b/ui/apps/platform/src/Components/EmptyStateTemplate/EmptyStateTemplate.tsx
@@ -3,7 +3,6 @@ import {
     EmptyState,
     EmptyStateIcon,
     EmptyStateBody,
-    EmptyStateVariant,
     EmptyStateHeader,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
@@ -24,7 +23,7 @@ function EmptyStateTemplate({
     iconClassName = '',
 }: EmptyStateTemplateProps): ReactElement {
     return (
-        <EmptyState variant={EmptyStateVariant.lg}>
+        <EmptyState variant="lg">
             <EmptyStateHeader
                 titleText={<>{title}</>}
                 icon={<EmptyStateIcon className={iconClassName} icon={icon} />}

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -4,7 +4,6 @@ import {
     Button,
     EmptyState,
     EmptyStateIcon,
-    EmptyStateVariant,
     Flex,
     FormGroup,
     EmptyStateHeader,
@@ -94,7 +93,7 @@ function BacklogTable<Item>({
                     </Tbody>
                 </Table>
             ) : (
-                <EmptyState variant={EmptyStateVariant.xs}>
+                <EmptyState variant="xs">
                     <EmptyStateHeader icon={<EmptyStateIcon icon={CubesIcon} />} />
                     <EmptyStateFooter>
                         <p>No items remaining</p>

--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -1,10 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import {
-    Select,
-    SelectOptionObject,
-    SelectOptionProps,
-    SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOptionObject, SelectOptionProps } from '@patternfly/react-core/deprecated';
 
 export type CheckboxSelectProps = {
     id?: string;
@@ -57,7 +52,7 @@ function CheckboxSelect({
         <Select
             id={id}
             name={name}
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             toggleIcon={toggleIcon}
             onToggle={(_event, isExpanded: boolean) => onToggle(isExpanded)}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import useMultiSelect from 'hooks/useMultiSelect';
 import { IntervalType } from 'services/ComplianceScanConfigurationService';
@@ -95,7 +95,7 @@ function DayPickerDropdown({
 
     return (
         <Select
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             aria-label="Select one or more days"
             onToggle={onToggleDaySelect}
             onSelect={onSelectDay}

--- a/ui/apps/platform/src/Components/PatternFly/FormMultiSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormMultiSelect.tsx
@@ -1,6 +1,6 @@
 /* PatternFly Component */
 import React, { ReactElement, useState } from 'react';
-import { Select, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select } from '@patternfly/react-core/deprecated';
 
 export type FormMultiSelectProps = {
     id: string;
@@ -42,7 +42,7 @@ const FormMultiSelect = ({
     return (
         <Select
             id={id}
-            variant={SelectVariant.typeaheadMulti}
+            variant="typeaheadmulti"
             selections={values}
             onToggle={(_event, toggleOpen) => onToggle(toggleOpen)}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Select, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select } from '@patternfly/react-core/deprecated';
 
 export type SelectSingleProps = {
     toggleIcon?: ReactElement;
@@ -36,8 +36,6 @@ function SelectSingle({
 }: SelectSingleProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
-    const isTypeahead = variant === 'typeahead' ? SelectVariant.typeahead : SelectVariant.single;
-
     function onSelect(_event, selection) {
         // The mouse event is not useful.
         setIsOpen(false);
@@ -46,7 +44,7 @@ function SelectSingle({
 
     return (
         <Select
-            variant={isTypeahead}
+            variant={variant === 'typeahead' ? 'typeahead' : 'single'}
             toggleIcon={toggleIcon}
             toggleAriaLabel={toggleAriaLabel}
             id={id}

--- a/ui/apps/platform/src/Containers/AccessControl/SelectSingle.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/SelectSingle.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Select, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select } from '@patternfly/react-core/deprecated';
 
 export type SelectSingleProps = {
     id: string;
@@ -26,7 +26,7 @@ function SelectSingle({
 
     return (
         <Select
-            variant={SelectVariant.single}
+            variant="single"
             id={id}
             isDisabled={isDisabled}
             isOpen={isOpen}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -4,7 +4,6 @@ import {
     Divider,
     EmptyState,
     EmptyStateIcon,
-    EmptyStateVariant,
     Flex,
     FlexItem,
     SearchInput,
@@ -152,7 +151,7 @@ function CollectionResults({
 
     if (configError) {
         content = (
-            <EmptyState variant={EmptyStateVariant.xs}>
+            <EmptyState variant="xs">
                 <EmptyStateHeader
                     icon={
                         <EmptyStateIcon
@@ -176,7 +175,7 @@ function CollectionResults({
         );
     } else if (!selectorRulesExist) {
         content = (
-            <EmptyState variant={EmptyStateVariant.xs}>
+            <EmptyState variant="xs">
                 <EmptyStateHeader icon={<EmptyStateIcon icon={ListIcon} />} />
                 <EmptyStateFooter>
                     <p>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-    ExpandableSectionVariant,
     ExpandableSection,
     Flex,
     FlexItem,
@@ -75,7 +74,7 @@ function ProfileDetailsHeader({
                         isExpanded={isExpanded}
                         toggleText={isExpanded ? 'Show less' : 'Show more'}
                         truncateMaxLines={5}
-                        variant={ExpandableSectionVariant.truncate}
+                        variant="truncate"
                         onToggle={onToggleDescription}
                     >
                         {description}

--- a/ui/apps/platform/src/Containers/Dashboard/ClusterSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/ClusterSelect.tsx
@@ -1,11 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { Divider } from '@patternfly/react-core';
-import {
-    Select,
-    SelectOption,
-    SelectOptionObject,
-    SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectOptionObject } from '@patternfly/react-core/deprecated';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { flattenFilterValue } from 'utils/searchUtils';
@@ -84,7 +79,7 @@ function ClusterSelect({
     return (
         <Select
             toggleAriaLabel="Select clusters"
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             isOpen={isOpen}
             onToggle={(_e, v) => onToggle(v)}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Containers/Dashboard/NamespaceSelect.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/NamespaceSelect.tsx
@@ -5,7 +5,6 @@ import {
     SelectGroup,
     SelectOption,
     SelectOptionObject,
-    SelectVariant,
 } from '@patternfly/react-core/deprecated';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
@@ -96,7 +95,7 @@ function NamespaceSelect({
         <Select
             toggleAriaLabel="Select namespaces"
             className="namespace-select"
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             isOpen={isOpen}
             onToggle={(_e, v) => onToggle(v)}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/NoDataEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/NoDataEmptyState.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     EmptyState,
-    EmptyStateVariant,
     EmptyStateIcon,
     EmptyStateHeader,
     EmptyStateFooter,
@@ -10,7 +9,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 
 function NoDataEmptyState() {
     return (
-        <EmptyState className="pf-v5-u-h-100" variant={EmptyStateVariant.xs}>
+        <EmptyState className="pf-v5-u-h-100" variant="xs">
             <EmptyStateHeader
                 icon={<EmptyStateIcon className="pf-v5-u-font-size-xl" icon={SearchIcon} />}
             />

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Alert, ClipboardCopy, ClipboardCopyVariant, Text } from '@patternfly/react-core';
+import { Alert, ClipboardCopy, Text } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
 import { accessControlBasePath } from 'routePaths';
@@ -79,7 +79,7 @@ function InviteUsersConfirmationNoEmail({
                         isExpanded
                         hoverTip="Copy"
                         clickTip="Copied"
-                        variant={ClipboardCopyVariant.expansion}
+                        variant="expansion"
                         className="pf-v5-u-mb-md"
                     >
                         {emailBuckets.newEmails.join(', ')}
@@ -89,7 +89,7 @@ function InviteUsersConfirmationNoEmail({
                         isExpanded
                         hoverTip="Copy"
                         clickTip="Copied"
-                        variant={ClipboardCopyVariant.expansion}
+                        variant="expansion"
                         className="pf-v5-u-mb-md"
                     >
                         You have been invited to use Red Hat Advanced Cluster Security. Please use

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
@@ -4,7 +4,6 @@ import {
     SelectGroup,
     SelectOption,
     SelectPosition,
-    SelectVariant,
 } from '@patternfly/react-core/deprecated';
 
 import useMultiSelect from 'hooks/useMultiSelect';
@@ -71,7 +70,7 @@ function AdvancedFlowsFilter({
     return (
         <Select
             className="advanced-flows-filters-select"
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             onToggle={(_event, isOpen: boolean) => onFilterDropdownToggle(isOpen)}
             onSelect={onTrafficFilterSelect}
             selections={selections}
@@ -92,7 +91,7 @@ function AdvancedFlowsFilter({
             <SelectGroup label="Ports">
                 <Select
                     className="pf-v5-u-px-md"
-                    variant={SelectVariant.typeaheadMulti}
+                    variant="typeaheadmulti"
                     toggleAriaLabel="Select ports"
                     onToggle={onTogglePortsSelect}
                     onSelect={onSelectPorts}

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -6,7 +6,6 @@ import {
     Button,
     Divider,
     EmptyState,
-    EmptyStateVariant,
     Spinner,
     Stack,
     StackItem,
@@ -126,7 +125,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
             <>
                 {policyErrorBanner}
                 <Bullseye>
-                    <EmptyState variant={EmptyStateVariant.xs}>
+                    <EmptyState variant="xs">
                         <EmptyStateHeader titleText="No network policies" headingLevel="h4" />
                     </EmptyState>
                 </Bullseye>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
-import {
-    Select,
-    SelectVariant,
-    SelectGroup,
-    SelectOption,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectGroup, SelectOption } from '@patternfly/react-core/deprecated';
 import { PficonNetworkRangeIcon } from '@patternfly/react-icons';
 
 import { ReactComponent as NoPolicyRules } from 'images/network-graph/no-policy-rules.svg';
@@ -50,7 +45,7 @@ function DisplayOptionsSelect({
 
     return (
         <Select
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             isOpen={isOpen}
             onToggle={onToggle}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -7,7 +7,6 @@ import {
     DescriptionListTerm,
     Divider,
     EmptyState,
-    EmptyStateVariant,
     ExpandableSection,
     Flex,
     FlexItem,
@@ -389,7 +388,7 @@ function DeploymentDetails({
                                 })}
                             </Stack>
                         ) : (
-                            <EmptyState variant={EmptyStateVariant.xs}>
+                            <EmptyState variant="xs">
                                 <EmptyStateHeader
                                     titleText="No ports available"
                                     headingLevel="h4"
@@ -412,7 +411,7 @@ function DeploymentDetails({
                                 })}
                             </Stack>
                         ) : (
-                            <EmptyState variant={EmptyStateVariant.xs}>
+                            <EmptyState variant="xs">
                                 <EmptyStateHeader
                                     titleText="No containers available"
                                     headingLevel="h4"

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import {
     Bullseye,
     EmptyState,
-    EmptyStateVariant,
     Stack,
     StackItem,
     EmptyStateHeader,
@@ -48,7 +47,7 @@ function ViewActiveYamls({
     if (networkPolicies.length === 0) {
         return (
             <Bullseye>
-                <EmptyState variant={EmptyStateVariant.xs}>
+                <EmptyState variant="xs">
                     <EmptyStateHeader titleText="No network policies" headingLevel="h4" />
                 </EmptyState>
             </Bullseye>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, ReactElement } from 'react';
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { useField } from 'formik';
 
 import { getPolicyCategories } from 'services/PolicyCategoriesService';
@@ -42,7 +42,7 @@ function PolicyCategoriesSelectField(): ReactElement {
     return (
         <FormGroup fieldId="policy-categories" label="Categories" isRequired>
             <Select
-                variant={SelectVariant.typeaheadMulti}
+                variant="typeaheadmulti"
                 name={field.name}
                 value={field.value}
                 isOpen={isCategoriesOpen}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useField } from 'formik';
 import { TextInput, ToggleGroup, ToggleGroupItem, FormGroup } from '@patternfly/react-core';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaFieldSubInput from './PolicyCriteriaFieldSubInput';
@@ -154,7 +154,7 @@ function PolicyCriteriaFieldInput({
                         selections={value.value === '' ? [] : value.value}
                         onClear={handleChangeSelectedValue([])}
                         placeholderText={descriptor.placeholder || 'Select one or more options'}
-                        variant={SelectVariant.typeaheadMulti}
+                        variant="typeaheadmulti"
                         menuAppendTo={() => document.body}
                     >
                         {descriptor.options?.map((option) => (

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -5,7 +5,6 @@ import {
     Modal,
     ModalBoxBody,
     ModalBoxFooter,
-    ModalVariant,
     PageSection,
     TextInput,
 } from '@patternfly/react-core';
@@ -84,7 +83,7 @@ function TableModal({
             <Modal
                 title={`Add ${typeText}s to policy criteria`}
                 isOpen={isModalOpen}
-                variant={ModalVariant.large}
+                variant="large"
                 onClose={onCloseModalHandler}
                 aria-label={`Select ${typeText}s modal`}
                 hasNoBodyWrapper

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -13,7 +13,7 @@ import {
     HelperText,
     HelperTextItem,
 } from '@patternfly/react-core';
-import { Select, SelectVariant, SelectOption } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import { ClientPolicy } from 'types/policy.proto';
 import { ListImage } from 'types/image.proto';
@@ -191,7 +191,7 @@ function PolicyScopeForm() {
                         <Select
                             onToggle={() => setIsExcludeImagesOpen(!isExcludeImagesOpen)}
                             isOpen={isExcludeImagesOpen}
-                            variant={SelectVariant.typeaheadMulti}
+                            variant="typeaheadmulti"
                             selections={excludedImageNames}
                             onSelect={handleChangeMultiSelect}
                             isCreatable

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 export type CategoryFilter = 'Default categories' | 'Custom categories';
 
@@ -26,7 +26,7 @@ function PolicyCategoriesFilterSelect({
 
     return (
         <Select
-            variant={SelectVariant.checkbox}
+            variant="checkbox"
             onToggle={(_event, val) => setIsOpen(val)}
             onSelect={onSelect}
             isOpen={isOpen}

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Select, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select } from '@patternfly/react-core/deprecated';
 
 export type FormSelectProps = {
     id: string;
@@ -23,7 +23,7 @@ const FormSelect = ({ id, value, onChange, children }: FormSelectProps): ReactEl
     return (
         <Select
             id={id}
-            variant={SelectVariant.single}
+            variant="single"
             selections={value}
             onToggle={(_event, toggleOpen) => onToggle(toggleOpen)}
             onSelect={onSelect}

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -8,7 +8,7 @@ import {
     HelperTextItem,
     TextInput,
 } from '@patternfly/react-core';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import usePermissions from 'hooks/usePermissions';
 import { fetchClusters } from 'services/ClustersService';
@@ -85,7 +85,7 @@ function DiagnosticBundleForm({
                 <FormGroup label="Filter by clusters" fieldId="filterByClusters">
                     <Select
                         id="filterByClusters"
-                        variant={SelectVariant.typeaheadMulti}
+                        variant="typeaheadmulti"
                         typeAheadAriaLabel="Type a cluster name"
                         onToggle={toggleClusterSelect}
                         onSelect={onSelect}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -17,7 +17,6 @@ import {
     EmptyState,
     EmptyStateIcon,
     EmptyStateBody,
-    EmptyStateVariant,
     Text,
     Toolbar,
     ToolbarContent,
@@ -275,7 +274,7 @@ function VulnReportsPage() {
                                 </div>
                             )}
                             {fetchError && (
-                                <EmptyState variant={EmptyStateVariant.sm}>
+                                <EmptyState variant="sm">
                                     <EmptyStateHeader
                                         titleText="Unable to get vulnerability reports"
                                         icon={

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -1,11 +1,6 @@
 import React, { useMemo, useState, ReactElement, useCallback } from 'react';
 import { Button, Flex, FlexItem, ValidatedOptions } from '@patternfly/react-core';
-import {
-    Select,
-    SelectOption,
-    SelectProps,
-    SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectProps } from '@patternfly/react-core/deprecated';
 import sortBy from 'lodash/sortBy';
 import uniqBy from 'lodash/uniqBy';
 
@@ -164,7 +159,7 @@ function CollectionSelection({
                         onSelect={onScopeChange}
                         selections={selectedScope?.id}
                         placeholderText="Select a collection"
-                        variant={SelectVariant.typeahead}
+                        variant="typeahead"
                         isOpen={isOpen}
                         onToggle={(_e, isExpanded) => onToggle(isExpanded)}
                         onTypeaheadInputChanged={(value) => {


### PR DESCRIPTION
### Description

Merge **after** 4.6 code freeze.

### Problem

1. In general, more consistency lowers the barrier to contributors from other teams.
2. In specific, `WhateverVariant` enum is an extra import.

### Analysis

The source of truth for prop values of PatternFly elements is string **enumeration**, not string **enum**.

For example,

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/EmptyState/EmptyState.tsx#L29

```tsx
variant?: 'xs' | 'sm' | 'lg' | 'xl' | 'full';
```

**not**

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/EmptyState/EmptyState.tsx#L7-L13

```tsx
export enum EmptyStateVariant {
  'xs' = 'xs',
  sm = 'sm',
  lg = 'lg',
  'xl' = 'xl',
  full = 'full'
}
```

Although `PageSectionVariants` and `TextVariants` (plural instead of singular) have same problem, it looks like PatternFly 6 upgrade will affect them, so leave source history intact until then.

### Solution

Although pluginAccessibility and pluginGeneric have rules for PatternFly elements, this rule is specifically for PatternFly **style**.

1. Add ui/apps/platform/eslint-plugins/pluginPatternFly.js file.
    Start with specific examples that affect fewest files.
    * `ClipboardCopyVariant` affects 1 file.
    * `EmptyStateVariant` affects 8 files.
    * `ExpandableSectionVariant` affects 1 file.
2. Also replaced `SelectVariant` which I had missed because **deprecated** subfolder of import source.

### Observation

Mismatch disrupted my pattern to enclose enum member in quote marks:
* enum member is `typeaheadMulti`
* string value is `'typeaheadmulti'`

https://github.com/patternfly/patternfly-react/blob/v5/packages/react-core/src/deprecated/components/Select/selectConstants.tsx#L26

### Residue

Verify style guideline with the team before follow up:

1. Add `AlertVariant` that affects 30 files.
2. Add `ButtonVariant` that affects 19 files.
3. Replace `variants.includes(specifier.imported.name)` with `specifier.imported.name.endsWith('Variant')` to end with (pardon pun) `ModalVariant` that affects 29 files.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -17 = 4619636 - 4619653
        total -101 = 11801284 - 11801385
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178