### PR TITLE
ROX-26748: keep only 'safe' characters in the CSV report file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-26372: `ROX_POSTGRES_VM_STATEMENT_TIMEOUT` env var defaulting to 3 minutes to allow customers to extend the timeout for queries backing VM pages only
 - ROX-26428: Fixed a bug when using delegated scanning where newer image metadata and layers were pulled incorrectly for an older image referenced by tag when the image registry contents have changed since deployment.
   - Now the metadata and layers pulled will be based on the digest of the image provided by the container runtime (when available) instead of just the tag.
+- ROX-26748: Replaced 'unsafe' characters in the CSV report file name.
 
 ## [4.5.0]
 

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -172,20 +172,13 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	var reportName string
-	if len(configName) > 80 {
-		configName = configName[0:80] + "..."
-		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
-	} else if configName == "" {
-		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s.csv", time.Now().Format("02_January_2006"))
-	} else {
-		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
-	}
+	var reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv",
+		makeSafeFileName(configName),
+		time.Now().UTC().Format("02_January_2006"))
 
 	zipFile, err := zipWriter.Create(reportName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
-
 	}
 	_, err = zipFile.Write(buf.Bytes())
 	if err != nil {
@@ -201,6 +194,23 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 		NumDeployedImageCVEs: numDeployedImageCVEs,
 		NumWatchedImageCVEs:  numWatchedImageCVEs,
 	}, nil
+}
+
+func makeSafeFileName(configName string) string {
+	if len(configName) > 80 {
+		configName = configName[0:80]
+	}
+	const allowedSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+	const replacementRune = '_'
+
+	var builder strings.Builder
+	for _, char := range configName {
+		if !strings.ContainsRune(allowedSet, char) {
+			char = replacementRune
+		}
+		builder.WriteRune(char)
+	}
+	return builder.String()
 }
 
 // GetClusterName returns name of cluster containing the Deployment

--- a/central/reports/common/report_formatter_test.go
+++ b/central/reports/common/report_formatter_test.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_makeSafeFileName(t *testing.T) {
+	cases := map[string]string{
+		"NoSpaces":                  "NoSpaces",
+		"With Spa ces":              "With_Spa_ces",
+		" some!.other) chars=":      "_some__other__chars_",
+		strings.Repeat("long ", 18): strings.Repeat("long_", 16),
+	}
+	for configName, expectedFileName := range cases {
+		t.Run(configName, func(t *testing.T) {
+			assert.Equal(t, expectedFileName, makeSafeFileName(configName))
+		})
+	}
+}

--- a/central/reports/common/report_formatter_test.go
+++ b/central/reports/common/report_formatter_test.go
@@ -3,20 +3,39 @@ package common
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_makeSafeFileName(t *testing.T) {
+func Test_replaceUnsafeRunes(t *testing.T) {
 	cases := map[string]string{
 		"NoSpaces":                  "NoSpaces",
 		"With Spa ces":              "With_Spa_ces",
 		" some!.other) chars=":      "_some__other__chars_",
 		strings.Repeat("long ", 18): strings.Repeat("long_", 16),
+		"":                          "",
 	}
+	for configName, expected := range cases {
+		t.Run(configName, func(t *testing.T) {
+			builder := strings.Builder{}
+			replaceUnsafeRunes(&builder, configName)
+			assert.Equal(t, expected, builder.String())
+		})
+	}
+}
+
+func Test_makeFileName(t *testing.T) {
+	cases := map[string]string{
+		"file name": "RHACS_Vulnerability_Report_file_name_31_December_2023.csv",
+		"":          "RHACS_Vulnerability_Report_31_December_2023.csv",
+	}
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	today := time.Date(2024, 1, 1, 1, 1, 1, 1, loc)
+
 	for configName, expectedFileName := range cases {
 		t.Run(configName, func(t *testing.T) {
-			assert.Equal(t, expectedFileName, makeSafeFileName(configName))
+			assert.Equal(t, expectedFileName, makeFileName(configName, today))
 		})
 	}
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

We do not currently take care of the characters in the report name, while we use underscores as the separator for the prefix and the suffix, like in:
```
RHACS_Vulnerability_Report_Long file name with spaces and..._17_September_2024.csv
```

The PR suggests:
* Do not add the ellipsis for the long names, but just cut;
* Keep only a limited set of characters, replace others with '_';
* Use UTC time for the suffix.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests. Manual e2e.
