### PR TITLE
chore(ui): Add Td-defaultColumns lint rule in pluginGeneric

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -154,6 +154,83 @@ const rules = {
             };
         },
     },
+    'Th-defaultColumns': {
+        // Require that Th element has key and text from defaultColumns configuration.
+        // That is, if Th element has prop for column management:
+        // className={getVisibilityClass('whichever')}
+        // Whatever as text
+        // Then defaultColumns has whichever: {title: "Whatever"} property.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require that Th element has key and text from defaultColumns configuration',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (typeof node.name?.name === 'string' && node.name.name.endsWith('Th')) {
+                        const classNameJSXAttribute = node.attributes.find(
+                            (attribute) =>
+                                attribute.name?.name === 'className' &&
+                                attribute.value?.expression?.callee?.name ===
+                                    'getVisibilityClass' &&
+                                attribute.value?.expression?.arguments?.length === 1 &&
+                                typeof attribute.value.expression.arguments[0]?.value === 'string'
+                        );
+                        if (classNameJSXAttribute) {
+                            const ancestors = context.sourceCode.getAncestors(node);
+                            const defaultColumnsVariableDeclaration = ancestors[0]?.body?.find(
+                                (item) =>
+                                    item?.declaration?.declarations?.[0]?.id?.name ===
+                                    'defaultColumns'
+                            );
+                            if (!defaultColumnsVariableDeclaration) {
+                                context.report({
+                                    node,
+                                    message: `Th has className={getVisibilityClass(…)} but file does not have defaultColumns`,
+                                });
+                            } else {
+                                const argument =
+                                    classNameJSXAttribute.value.expression.arguments[0].value;
+                                const defaultColumnProperty =
+                                    defaultColumnsVariableDeclaration.declaration.declarations[0].init?.expression?.properties?.find(
+                                        (property) => property.key?.name === argument
+                                    );
+                                if (!defaultColumnProperty) {
+                                    context.report({
+                                        node,
+                                        message: `Th has className={getVisibilityClass("${argument}")} but argument is not a key in defaultColumns`,
+                                    });
+                                } else {
+                                    const parent = ancestors[ancestors.length - 1];
+                                    const value = parent.children?.find(
+                                        (child) => typeof child.value === 'string'
+                                    )?.value;
+                                    if (typeof value === 'string') {
+                                        const text = value.trim();
+                                        const title = defaultColumnProperty.value?.properties?.find(
+                                            (property) => property.key?.name === 'title'
+                                        )?.value?.value;
+                                        // TypeScript reports absence of title property in default column property.
+                                        if (text !== title) {
+                                            // Another rule reports inconsistency between Td dataLabel and Th text.
+                                            context.report({
+                                                node,
+                                                message: `Th has "${text}" as text but defaultColumns has ${argument}: {title: "${title}"}`,
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
     'anchor-target-rel': {
         // Require props for consistent behavior and security of external links.
         meta: {


### PR DESCRIPTION
### Description

Add lint rule for **managed columns** to prevent future inconsistencies like some fixed in #13085

### Problem

Inconsistencies are easy to overlook, especially for responsive data label:
* When we change column heading text.
* When we add column management to an existing table.

### Solution

```js
// Require that Td element has key and title from defaultColumns configuration.
// That is, if Td element has props for column management:
// className={getVisibilityClass('whichever')}
// dataLabel="Whatever"
// Then defaultColumns has whichever: {title: "Whatever"} property.
```

Added corresponding rule for `Th` element:

```js
// Require that Th element has key and text from defaultColumns configuration.
// That is, if Th element has prop for column management:
// className={getVisibilityClass('whichever')}
// Whatever as text
// Then defaultColumns has whichever: {title: "Whatever"} property.
```

### Residue

Add rules after to new pluginPatternFly.js file for PatternFly style.

1. Add `Td-dataLabel` rule.
    `// Another rule reports absence of dataLabel prop in Td element.`
2. Add `Td-dataLabel-Th-text` rule.
    `// Another rule reports inconsistency between Td dataLabel and Th text.`

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build`

#### Manual testing

Restart Visual Studio Code editor, and then make temporary changes to verify expected errors in DeploymentVulnerabilitiesTable.tsx.tsx file:

1. Comment out `defaultColumns` declaration.
    Besides TypeScript errors, lint rule report 6 errors:

    > Td has className={getVisibilityClass(…)} but file does not have defaultColumns

2. Either change a key or comment out a property in `defaultColumns` declaration.
    Besides TypeScript errors, lint rule reports 1 error:

    > Td has className={getVisibilityClass("operatingSystem")} but argument is not a key in defaultColumns 

3. Change the value of a `title` property in `defaultColumns` declaration.
    Although no TypeScript errors, lint rule reports 1 error:

    > Td has dataLabel="Operating system" but defaultColumns has operatingSystem: {title: "OS"}

4. Delete `dataLabel` prop of `Td` element.
    No error yes. See **Residue**

5. Make `dataLabel` prop of `Td` element inconsistent with text of `Th` element.
    No error yes. See **Residue**