### PR TITLE
chore(ui): Replace data-label with dataLabel in Td elements

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
@@ -84,8 +84,8 @@ function NotifiersForm() {
                                                 isSelected: field.value.includes(notifier.id),
                                             }}
                                         />
-                                        <Td data-label="Notifier">{notifier.name}</Td>
-                                        <Td data-label="Type">{notifier.type}</Td>
+                                        <Td dataLabel="Notifier">{notifier.name}</Td>
+                                        <Td dataLabel="Type">{notifier.type}</Td>
                                     </Tr>
                                 );
                             })}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -80,13 +80,13 @@ function ImageComponentVulnerabilitiesTable({
                 return (
                     <Tbody key={`${image.id}:${name}:${version}`} style={style}>
                         <Tr>
-                            <Td data-label="Component">{name}</Td>
-                            <Td data-label="Version">{version}</Td>
-                            <Td data-label="CVE fixed in" modifier="nowrap">
+                            <Td dataLabel="Component">{name}</Td>
+                            <Td dataLabel="Version">{version}</Td>
+                            <Td dataLabel="CVE fixed in" modifier="nowrap">
                                 <FixedByVersion fixedByVersion={fixedByVersion} />
                             </Td>
-                            <Td data-label="Source">{source}</Td>
-                            <Td data-label="Location">
+                            <Td dataLabel="Source">{source}</Td>
+                            <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>
                         </Tr>


### PR DESCRIPTION
### Description

Remove minor inconsistency as prerequisite for lint rule to require `dataLabel` prop.

### Residue

1. Add `no-Td-data-label` lint rule in new pluginPatternFly.js file.
2. Add `Td-dataLabel` lint rule in new pluginPatternFly.js file.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

Prerequisite: create a notifier integration.

1. Visit /main/policy-management/policies/?action=create and then advance to **Actions** step.

    * Before and after changes, see `data-label` attributes and labels at 760px screen width.
        ![NotifiersForm_760px](https://github.com/user-attachments/assets/df2510a1-b5ee-4063-928f-1a969d2fb32b)

2. Visit /main/vulnerabilities/workload-cves/images/id and expand a vulnerability

    * Before and after changes, see `data-label` attributes and labels at 760px screen width.
        ![ImageComponentVulnerabilitiesTable _760px](https://github.com/user-attachments/assets/0f9cf303-a308-465f-bae1-fe95154510a1)