### PR TITLE
ROX-26854: external entities garbage collection (in EntityStore)

### DIFF
--- a/central/networkgraph/entity/datastore/datastore.go
+++ b/central/networkgraph/entity/datastore/datastore.go
@@ -32,5 +32,7 @@ type EntityDataStore interface {
 	DeleteExternalNetworkEntity(ctx context.Context, id string) error
 	DeleteExternalNetworkEntitiesForCluster(ctx context.Context, clusterID string) error
 
+	RemoveOrphanedEntities(ctx context.Context) error
+
 	RegisterCluster(ctx context.Context, clusterID string)
 }

--- a/central/networkgraph/entity/datastore/datastore.go
+++ b/central/networkgraph/entity/datastore/datastore.go
@@ -32,7 +32,7 @@ type EntityDataStore interface {
 	DeleteExternalNetworkEntity(ctx context.Context, id string) error
 	DeleteExternalNetworkEntitiesForCluster(ctx context.Context, clusterID string) error
 
-	RemoveOrphanedEntities(ctx context.Context) error
+	RemoveOrphanedEntities(ctx context.Context) (int64, error)
 
 	RegisterCluster(ctx context.Context, clusterID string)
 }

--- a/central/networkgraph/entity/datastore/datastore_bench_test.go
+++ b/central/networkgraph/entity/datastore/datastore_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkNetEntityCreates(b *testing.B) {
 		db := pgtest.ForT(b)
 		defer db.Teardown(b)
 
-		store := postgres.New(db.DB)
+		store := postgres.NewFullStore(db.DB)
 
 		treeMgr := networktree.Singleton()
 		defer treeMgr.DeleteNetworkTree(ctx, "c1")
@@ -67,7 +67,7 @@ func BenchmarkNetEntityCreateBatch(b *testing.B) {
 		db := pgtest.ForT(b)
 		defer db.Teardown(b)
 
-		store := postgres.New(db.DB)
+		store := postgres.NewFullStore(db.DB)
 
 		ds := NewEntityDataStore(store, mocks.NewMockDataStore(mockCtrl), networktree.Singleton(), connection.ManagerSingleton())
 
@@ -90,7 +90,7 @@ func BenchmarkNetEntityUpdates(b *testing.B) {
 	db := pgtest.ForT(b)
 	defer db.Teardown(b)
 
-	store := postgres.New(db.DB)
+	store := postgres.NewFullStore(db.DB)
 	ds := NewEntityDataStore(store, mocks.NewMockDataStore(mockCtrl), networktree.Singleton(), connection.ManagerSingleton())
 
 	entities, err := testutils.GenRandomExtSrcNetworkEntity(pkgNet.IPv4, 10000, "c1")

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -446,11 +446,11 @@ func (ds *dataStoreImpl) DeleteExternalNetworkEntitiesForCluster(ctx context.Con
 	return nil
 }
 
-func (ds *dataStoreImpl) RemoveOrphanedEntities(ctx context.Context) error {
+func (ds *dataStoreImpl) RemoveOrphanedEntities(ctx context.Context) (int64, error) {
 	if ok, err := ds.writeAllowed(ctx, "__glob"); err != nil {
-		return err
+		return 0, err
 	} else if !ok {
-		return sac.ErrResourceAccessDenied
+		return 0, sac.ErrResourceAccessDenied
 	}
 
 	return ds.storage.RemoveOrphanedEntities(ctx)

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -79,7 +79,7 @@ func (suite *NetworkEntityDataStoreTestSuite) SetupSuite() {
 	suite.mockCtrl = gomock.NewController(suite.T())
 	suite.db = pgtest.ForT(suite.T())
 
-	suite.store = postgres.New(suite.db.DB)
+	suite.store = postgres.NewFullStore(suite.db.DB)
 
 	suite.mockCtrl = gomock.NewController(suite.T())
 	suite.graphConfig = graphConfigMocks.NewMockDataStore(suite.mockCtrl)

--- a/central/networkgraph/entity/datastore/internal/store/mocks/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/mocks/store.go
@@ -130,6 +130,21 @@ func (mr *MockEntityStoreMockRecorder) GetIDs(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDs", reflect.TypeOf((*MockEntityStore)(nil).GetIDs), ctx)
 }
 
+// RemoveOrphanedEntities mocks base method.
+func (m *MockEntityStore) RemoveOrphanedEntities(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOrphanedEntities", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveOrphanedEntities indicates an expected call of RemoveOrphanedEntities.
+func (mr *MockEntityStoreMockRecorder) RemoveOrphanedEntities(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanedEntities", reflect.TypeOf((*MockEntityStore)(nil).RemoveOrphanedEntities), ctx)
+}
+
 // Upsert mocks base method.
 func (m *MockEntityStore) Upsert(ctx context.Context, entity *storage.NetworkEntity) error {
 	m.ctrl.T.Helper()

--- a/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
@@ -20,12 +20,12 @@ const (
 	pruneOrphanExternalNetworkEntitiesSrcStmt = `DELETE FROM %s entity WHERE NOT EXISTS
 		(SELECT 1 FROM %s flow WHERE flow.Props_SrcEntity_Type = 4
 		AND flow.Props_SrcEntity_Id = entity.Info_Id
-		AND entity.Info_ExternalSource_Learned = true);`
+		AND entity.Info_ExternalSource_Discovered = true);`
 
 	pruneOrphanExternalNetworkEntitiesDstStmt = `DELETE FROM %s entity WHERE NOT EXISTS
 		(SELECT 1 FROM %s flow WHERE flow.Props_DstEntity_Type = 4
 		AND flow.Props_DstEntity_Id = entity.Info_Id
-		AND entity.Info_ExternalSource_Learned = true);`
+		AND entity.Info_ExternalSource_Discovered = true);`
 )
 
 var (

--- a/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
@@ -2,31 +2,78 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/networkgraph/entity/datastore/internal/store"
+	"github.com/stackrox/rox/pkg/env"
+	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
+	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
+)
+
+const (
+	networkFlowsTable    = pkgSchema.NetworkFlowsTableName
+	networkEntitiesTable = pkgSchema.NetworkEntitiesTableName
+
+	pruneOrphanExternalNetworkEntitiesSrcStmt = `DELETE FROM %s entity WHERE NOT EXISTS
+		(SELECT 1 FROM %s flow WHERE flow.Props_SrcEntity_Type = 4
+		AND flow.Props_SrcEntity_Id = entity.Info_Id
+		AND entity.Info_ExternalSource_Learned = true);`
+
+	pruneOrphanExternalNetworkEntitiesDstStmt = `DELETE FROM %s entity WHERE NOT EXISTS
+		(SELECT 1 FROM %s flow WHERE flow.Props_DstEntity_Type = 4
+		AND flow.Props_DstEntity_Id = entity.Info_Id
+		AND entity.Info_ExternalSource_Learned = true);`
+)
+
+var (
+	queryTimeout = env.PostgresDefaultNetworkFlowQueryTimeout.DurationSetting()
 )
 
 // NewFullStore augments the generated store with RemoveOrphanedEntities function.
 func NewFullStore(db postgres.DB) store.EntityStore {
 	return &fullStoreImpl{
+		db:    db,
 		Store: New(db),
 	}
 }
 
-// FullStoreWrap augments the wrapped store with ListDeployment functions.
-func FullStoreWrap(wrapped Store) Store {
-	return &fullStoreImpl{
-		Store: wrapped,
-	}
-}
-
 type fullStoreImpl struct {
+	db postgres.DB
+
 	Store
 }
 
 // RemoveOrphanedEntities prunes 'discovered' external entities that are not referenced by any flow.
 func (f *fullStoreImpl) RemoveOrphanedEntities(ctx context.Context) error {
-	// TODO
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.RemoveMany, "NetworkEntitiesPruning")
+
+	pruneStmt := fmt.Sprintf(pruneOrphanExternalNetworkEntitiesSrcStmt, networkEntitiesTable, networkFlowsTable)
+	err := f.pruneEntities(ctx, pruneStmt)
+	if err != nil {
+		return err
+	}
+
+	pruneStmt = fmt.Sprintf(pruneOrphanExternalNetworkEntitiesDstStmt, networkEntitiesTable, networkFlowsTable)
+	return f.pruneEntities(ctx, pruneStmt)
+}
+
+func (f *fullStoreImpl) pruneEntities(ctx context.Context, deleteStmt string) error {
+	conn, err := f.db.Acquire(ctx)
+	if err != nil {
+		return nil
+	}
+
+	defer conn.Release()
+
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+
+	if _, err := conn.Exec(ctx, deleteStmt); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/full_store.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/networkgraph/entity/datastore/internal/store"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// NewFullStore augments the generated store with RemoveOrphanedEntities function.
+func NewFullStore(db postgres.DB) store.EntityStore {
+	return &fullStoreImpl{
+		Store: New(db),
+	}
+}
+
+// FullStoreWrap augments the wrapped store with ListDeployment functions.
+func FullStoreWrap(wrapped Store) Store {
+	return &fullStoreImpl{
+		Store: wrapped,
+	}
+}
+
+type fullStoreImpl struct {
+	Store
+}
+
+// RemoveOrphanedEntities prunes 'discovered' external entities that are not referenced by any flow.
+func (f *fullStoreImpl) RemoveOrphanedEntities(ctx context.Context) error {
+	// TODO
+	return nil
+}

--- a/central/networkgraph/entity/datastore/internal/store/postgres/full_store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/full_store_test.go
@@ -1,0 +1,101 @@
+//go:build sql_integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/central/networkgraph/entity/datastore/internal/store"
+	flow "github.com/stackrox/rox/central/networkgraph/flow/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stretchr/testify/suite"
+)
+
+type EntityFullStoreTestSuite struct {
+	suite.Suite
+
+	tested    store.EntityStore
+	flowStore flow.FlowDataStore
+
+	allAccess context.Context
+	db        *pgtest.TestPostgres
+}
+
+func TestEntityFullStore(t *testing.T) {
+	suite.Run(t, new(EntityFullStoreTestSuite))
+}
+
+// SetupSuite runs before any tests
+func (s *EntityFullStoreTestSuite) SetupSuite() {
+	s.db = pgtest.ForT(s.T())
+	s.tested = NewFullStore(s.db.DB)
+
+	clusterDataStore, err := flow.GetTestPostgresClusterDataStore(s.T(), s.db.DB)
+	s.NoError(err)
+
+	s.allAccess = sac.WithAllAccess(context.Background())
+
+	s.flowStore, err = clusterDataStore.CreateFlowStore(s.allAccess, fixtureconsts.ClusterFake1)
+	s.NoError(err)
+}
+
+func (s *EntityFullStoreTestSuite) TeardownSuite() {
+	s.db.Teardown(s.T())
+}
+
+// TestStore tests FullEntityStore pruning behavior
+func (s *EntityFullStoreTestSuite) TestStore() {
+	t1 := time.Now().UTC()
+	extEntity1 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
+	extEntity2 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
+	// extEntity3 is not linked to any flow
+	extEntity3 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{3, 4, 5, 6, 32})).ToProto()
+	flows := []*storage.NetworkFlow{
+		{
+			Props: &storage.NetworkFlowProperties{
+				SrcEntity:  extEntity1,
+				DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: fixtureconsts.Deployment1},
+				DstPort:    1,
+				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			},
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(t1),
+			ClusterId:         fixtureconsts.ClusterFake1,
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				SrcEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: fixtureconsts.Deployment2},
+				DstEntity:  extEntity2,
+				DstPort:    2,
+				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			},
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(t1),
+			ClusterId:         fixtureconsts.ClusterFake1,
+		},
+	}
+	var err error
+
+	updateTS := timestamp.Now() - 1000000
+	err = s.flowStore.UpsertFlows(s.allAccess, flows, updateTS)
+	s.NoError(err, "upsert should succeed on first insert")
+
+	err = s.tested.UpsertMany(s.allAccess, []*storage.NetworkEntity{
+		{Info: extEntity1},
+		{Info: extEntity2},
+		{Info: extEntity3},
+	})
+	s.NoError(err, "upsert should succeed on first insert")
+	//	s.Error(err)
+	rowsAffected, err := s.tested.RemoveOrphanedEntities(s.allAccess)
+
+	s.NoError(err)
+	s.Equal(int64(1), rowsAffected, "Only one entity is expected to be pruned")
+}

--- a/central/networkgraph/entity/datastore/internal/store/postgres/full_store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/full_store_test.go
@@ -52,8 +52,8 @@ func (s *EntityFullStoreTestSuite) TeardownSuite() {
 	s.db.Teardown(s.T())
 }
 
-// TestStore tests FullEntityStore pruning behavior
-func (s *EntityFullStoreTestSuite) TestStore() {
+// TestPruning verifies the FullEntityStore pruning behavior
+func (s *EntityFullStoreTestSuite) TestPruning() {
 	t1 := time.Now().UTC()
 	extEntity1 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
 	extEntity2 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
@@ -93,9 +93,14 @@ func (s *EntityFullStoreTestSuite) TestStore() {
 		{Info: extEntity3},
 	})
 	s.NoError(err, "upsert should succeed on first insert")
-	//	s.Error(err)
+
 	rowsAffected, err := s.tested.RemoveOrphanedEntities(s.allAccess)
 
 	s.NoError(err)
 	s.Equal(int64(1), rowsAffected, "Only one entity is expected to be pruned")
+
+	ids, err := s.tested.GetIDs(s.allAccess)
+
+	s.NoError(err)
+	s.ElementsMatch(ids, []string{extEntity1.GetId(), extEntity2.GetId()})
 }

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -25,4 +25,6 @@ type EntityStore interface {
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkEntity) error) error
 
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkEntity, error)
+
+	RemoveOrphanedEntities(ctx context.Context) error
 }

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -26,5 +26,5 @@ type EntityStore interface {
 
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkEntity, error)
 
-	RemoveOrphanedEntities(ctx context.Context) error
+	RemoveOrphanedEntities(ctx context.Context) (int64, error)
 }

--- a/central/networkgraph/entity/datastore/mocks/datastore.go
+++ b/central/networkgraph/entity/datastore/mocks/datastore.go
@@ -221,6 +221,21 @@ func (mr *MockEntityDataStoreMockRecorder) RegisterCluster(ctx, clusterID any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCluster", reflect.TypeOf((*MockEntityDataStore)(nil).RegisterCluster), ctx, clusterID)
 }
 
+// RemoveOrphanedEntities mocks base method.
+func (m *MockEntityDataStore) RemoveOrphanedEntities(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOrphanedEntities", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveOrphanedEntities indicates an expected call of RemoveOrphanedEntities.
+func (mr *MockEntityDataStoreMockRecorder) RemoveOrphanedEntities(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanedEntities", reflect.TypeOf((*MockEntityDataStore)(nil).RemoveOrphanedEntities), ctx)
+}
+
 // UpdateExternalNetworkEntity mocks base method.
 func (m *MockEntityDataStore) UpdateExternalNetworkEntity(ctx context.Context, entity *storage.NetworkEntity, skipPush bool) error {
 	m.ctrl.T.Helper()

--- a/central/networkgraph/entity/datastore/singleton.go
+++ b/central/networkgraph/entity/datastore/singleton.go
@@ -17,7 +17,7 @@ var (
 // Singleton provides the instance of EntityDataStore to use.
 func Singleton() EntityDataStore {
 	once.Do(func() {
-		storage := pgStore.New(globaldb.GetPostgres())
+		storage := pgStore.NewFullStore(globaldb.GetPostgres())
 		ds = NewEntityDataStore(storage, graphConfigDS.Singleton(), networktree.Singleton(), connection.ManagerSingleton())
 	})
 	return ds

--- a/central/networkgraph/flow/datastore/cluster.go
+++ b/central/networkgraph/flow/datastore/cluster.go
@@ -44,5 +44,5 @@ func GetTestPostgresClusterDataStore(t testing.TB, pool postgres.DB) (ClusterDat
 	if err != nil {
 		return nil, err
 	}
-	return NewClusterDataStore(dbstore, configStore, networkTreeMgr, nil), nil
+	return NewClusterDataStore(dbstore, configStore, networkTreeMgr, cache.DeletedDeploymentsSingleton()), nil
 }

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -350,6 +350,8 @@ func (g *garbageCollectorImpl) removeOrphanedResources() {
 
 	if features.ExternalIPs.Enabled() || env.ExternalIPsPruning.BooleanSetting() {
 		g.removeOrphanedNetworkEntities()
+	} else {
+		log.Info("[Entity pruning] disabled")
 	}
 
 	g.removeOrphanedPods()
@@ -595,12 +597,15 @@ func (g *garbageCollectorImpl) removeOrphanedNetworkFlows(clusters set.FrozenStr
 }
 
 func (g *garbageCollectorImpl) removeOrphanedNetworkEntities() {
-	err := g.networkentities.RemoveOrphanedEntities(pruningCtx)
+
+	affectedRows, err := g.networkentities.RemoveOrphanedEntities(pruningCtx)
 
 	if err != nil {
-		log.Errorf("[Pruning] error removing orphaned network entities: %v", err)
+		log.Errorf("[Entity pruning] error removing orphaned network entities: %v", err)
 		return
 	}
+
+	log.Infof("[Entity pruning] Found %d orphaned entities", affectedRows)
 }
 
 func (g *garbageCollectorImpl) collectImages(config *storage.PrivateConfig) {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/maputil"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
@@ -347,7 +348,9 @@ func (g *garbageCollectorImpl) removeOrphanedResources() {
 	g.markOrphanedAlertsAsResolved()
 	g.removeOrphanedNetworkFlows(clusterIDSet)
 
-	g.removeOrphanedNetworkEntities()
+	if features.ExternalIPs.Enabled() || env.ExternalIPsPruning.BooleanSetting() {
+		g.removeOrphanedNetworkEntities()
+	}
 
 	g.removeOrphanedPods()
 	g.removeOrphanedNodes()

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -592,7 +592,12 @@ func (g *garbageCollectorImpl) removeOrphanedNetworkFlows(clusters set.FrozenStr
 }
 
 func (g *garbageCollectorImpl) removeOrphanedNetworkEntities() {
-	g.networkentities.RemoveOrphanedEntities(pruningCtx)
+	err := g.networkentities.RemoveOrphanedEntities(pruningCtx)
+
+	if err != nil {
+		log.Errorf("[Pruning] error removing orphaned network entities: %v", err)
+		return
+	}
 }
 
 func (g *garbageCollectorImpl) collectImages(config *storage.PrivateConfig) {

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -4,6 +4,7 @@ package pruning
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 	"time"
@@ -1749,6 +1750,25 @@ func (s *PruningTestSuite) TestRemoveOrphanedNetworkFlows() {
 			gci.removeOrphanedNetworkFlows(set.NewFrozenStringSet(fixtureconsts.Cluster1))
 		})
 	}
+}
+
+func (s *PruningTestSuite) TestRemoveOrphanedNetworkEntities() {
+	ctrl := gomock.NewController(s.T())
+	networkEntities := netEntityMocks.NewMockEntityDataStore(ctrl)
+
+	gci := &garbageCollectorImpl{
+		networkentities: networkEntities,
+	}
+
+	networkEntities.EXPECT().RemoveOrphanedEntities(pruningCtx).Return(int64(42), nil)
+
+	gci.removeOrphanedNetworkEntities()
+
+	networkEntities.EXPECT().RemoveOrphanedEntities(pruningCtx).Return(int64(0), errors.New("fake DB error"))
+
+	gci.removeOrphanedNetworkEntities()
+
+	ctrl.Finish()
 }
 
 func (s *PruningTestSuite) TestRemoveOrphanedImageRisks() {

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -555,7 +555,7 @@ func (s *PruningTestSuite) TestImagePruning() {
 			nodes := s.generateNodeDataStructures()
 
 			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, pods,
-				nil, nil, nil, config, nil, nil, nil,
+				nil, nil, nil, nil, config, nil, nil, nil,
 				nil, nil, nil, nil, nil, nil,
 				nil, nil).(*garbageCollectorImpl)
 
@@ -819,7 +819,7 @@ func (s *PruningTestSuite) TestClusterPruning() {
 			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil,
 				nil, nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil, nil,
-				nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(c.config)
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -946,7 +946,7 @@ func (s *PruningTestSuite) TestClusterPruningCentralCheck() {
 			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil,
 				nil, nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil, nil,
-				nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(getCluserRetentionConfig(60, 90, 72))
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -1122,7 +1122,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			nodes := s.generateNodeDataStructures()
 
 			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, nil,
-				nil, nil, nil, config, nil, nil,
+				nil, nil, nil, nil, config, nil, nil,
 				nil, nil, nil, nil, nil, nil,
 				nil, nil, nil).(*garbageCollectorImpl)
 

--- a/central/pruning/singleton.go
+++ b/central/pruning/singleton.go
@@ -10,6 +10,7 @@ import (
 	imagesDatastore "github.com/stackrox/rox/central/image/datastore"
 	imageComponentDatastore "github.com/stackrox/rox/central/imagecomponent/datastore"
 	logimbueStore "github.com/stackrox/rox/central/logimbue/store"
+	networkEntityDatastore "github.com/stackrox/rox/central/networkgraph/entity/datastore"
 	networkFlowsDataStore "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	nodeDatastore "github.com/stackrox/rox/central/node/datastore"
 	podDatastore "github.com/stackrox/rox/central/pod/datastore"
@@ -42,6 +43,7 @@ func Singleton() GarbageCollector {
 			processDatastore.Singleton(),
 			processBaselineDatastore.Singleton(),
 			networkFlowsDataStore.Singleton(),
+			networkEntityDatastore.Singleton(),
 			configDatastore.Singleton(),
 			imageComponentDatastore.Singleton(),
 			riskDataStore.Singleton(),

--- a/pkg/env/external_ips.go
+++ b/pkg/env/external_ips.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// ExternalIPsPruning enables the pruning of 'discovered' external entities.
+	// The pruning is always enabled when ROX_EXTERNAL_IPS is enabled.
+	ExternalIPsPruning = RegisterBooleanSetting("ROX_EXTERNAL_IPS_PRUNING", false)
+)

--- a/pkg/sac/resources/list.go
+++ b/pkg/sac/resources/list.go
@@ -82,6 +82,7 @@ var (
 	ComplianceOperator = newInternalResourceMetadata("ComplianceOperator", permissions.GlobalScope)
 	InstallationInfo   = newInternalResourceMetadata("InstallationInfo", permissions.GlobalScope)
 	Notifications      = newInternalResourceMetadata("Notifications", permissions.GlobalScope)
+	Pruning            = newInternalResourceMetadata("Pruning", permissions.GlobalScope)
 	Version            = newInternalResourceMetadata("Version", permissions.GlobalScope)
 	Hash               = newInternalResourceMetadata("Hash", permissions.GlobalScope)
 


### PR DESCRIPTION
### Description

With the addition of the External-IPs feature, we now receive and store 'discovered' external entities into the network_entities table. As all the preexisting entities, 'discovered' entities are references as src or dst from network flows.

Up to now, all network entities stored in the database were static (or almost, since custom CIDR-blocks can be added/removed via API, and default entities are either enabled or disabled. But they were not discovered from the network). So we need a way to prune the database to ensure that the number of 'discovered' entities does not grow infinitely.

This PR adds a new step to central pruner.

We are deleting all 'discovered' external entities for which there is no flow remaining that is pointing a them.

This is a reimplementation of #12858 but at global scope, instead of cluster scope.

The pruning is enabled when any of `ROX_EXTERNAL_IPS` or `ROX_EXTERNAL_IPS_PRUNING` is set.

The iteration over network-entities is potentially disrupting database performance. In order to circumvent this, we implement a paginated iteration.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I plan to do some manual testing by generating connections to a large number of external entities, and retrieve the execution report in postgresql.