### PR TITLE
ROX-26699: Introduce unified transmissions metric

### DIFF
--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -131,10 +131,12 @@ func (c *Compliance) manageNodeScanLoop(ctx context.Context) <-chan *sensor.MsgF
 				if c.cache == nil {
 					log.Debug("Requested to retry but cache is empty. Resetting scan timer.")
 					cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionResendingCacheMiss, cmetrics.ScannerVersionV2)
+					cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionResendingCacheMiss, cmetrics.ScannerVersionV2)
 					t.Reset(time.Second)
 				} else if ok {
 					nodeInventoriesC <- c.cache
 					cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionResendingCacheHit, cmetrics.ScannerVersionV2)
+					cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionResendingCacheHit, cmetrics.ScannerVersionV2)
 				}
 			case <-t.C:
 				if c.nodeScanner.IsActive() {
@@ -169,6 +171,7 @@ func (c *Compliance) runNodeInventoryScan(ctx context.Context) *sensor.MsgFromCo
 	}
 	cmetrics.ObserveNodeInventoryScan(msg.GetNodeInventory())
 	cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV2)
+	cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV2)
 	c.umh.ObserveSending()
 	c.cache = msg.CloneVT()
 	return msg
@@ -191,6 +194,7 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 	msg := c.createIndexMsg(report, nodeName)
 	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV4)
 	cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)
+	cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)
 	return msg
 }
 

--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -130,12 +130,10 @@ func (c *Compliance) manageNodeScanLoop(ctx context.Context) <-chan *sensor.MsgF
 			case _, ok := <-c.umh.RetryCommand():
 				if c.cache == nil {
 					log.Debug("Requested to retry but cache is empty. Resetting scan timer.")
-					cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionResendingCacheMiss, cmetrics.ScannerVersionV2)
 					cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionResendingCacheMiss, cmetrics.ScannerVersionV2)
 					t.Reset(time.Second)
 				} else if ok {
 					nodeInventoriesC <- c.cache
-					cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionResendingCacheHit, cmetrics.ScannerVersionV2)
 					cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionResendingCacheHit, cmetrics.ScannerVersionV2)
 				}
 			case <-t.C:
@@ -170,7 +168,6 @@ func (c *Compliance) runNodeInventoryScan(ctx context.Context) *sensor.MsgFromCo
 		return nil
 	}
 	cmetrics.ObserveNodeInventoryScan(msg.GetNodeInventory())
-	cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV2)
 	cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV2)
 	c.umh.ObserveSending()
 	c.cache = msg.CloneVT()
@@ -193,7 +190,6 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 	log.Debugf("Completed Node Index Report with %d packages", len(report.GetContents().GetPackages()))
 	msg := c.createIndexMsg(report, nodeName)
 	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV4)
-	cmetrics.ObserveNodeInventorySending(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)
 	cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)
 	return msg
 }

--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -189,7 +189,7 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 	cmetrics.ObserveNodeIndexReport(report, nodeName)
 	log.Debugf("Completed Node Index Report with %d packages", len(report.GetContents().GetPackages()))
 	msg := c.createIndexMsg(report, nodeName)
-	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV4)
+	cmetrics.ObserveReportProtobufMessage(msg, cmetrics.ScannerVersionV4)
 	cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionScan, cmetrics.ScannerVersionV4)
 	return msg
 }

--- a/compliance/collection/compliance/node_scanner.go
+++ b/compliance/collection/compliance/node_scanner.go
@@ -68,6 +68,6 @@ func (n *NodeInventoryComponentScanner) ScanNode(ctx context.Context) (*sensor.M
 		Node: result.GetNodeName(),
 		Msg:  &sensor.MsgFromCompliance_NodeInventory{NodeInventory: inv},
 	}
-	cmetrics.ObserveInventoryProtobufMessage(msg, cmetrics.ScannerVersionV2)
+	cmetrics.ObserveReportProtobufMessage(msg, cmetrics.ScannerVersionV2)
 	return msg, nil
 }

--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -306,18 +306,16 @@ const (
 	InventoryTransmissionResendingCacheMiss InventoryTransmission = "scanning and resending "
 )
 
-// ObserveNodeInventorySending observes the metric.
-func ObserveNodeInventorySending(nodeName string, sendingType InventoryTransmission, scannerVersion string) {
-	inventoryTransmissions.With(prometheus.Labels{
+// ObserveNodePackageReportTransmissions observes the metric.
+func ObserveNodePackageReportTransmissions(nodeName string, sendingType InventoryTransmission, scannerVersion string) {
+	nodePackageReportTransmissions.With(prometheus.Labels{
 		"node_name":         nodeName,
 		"transmission_type": string(sendingType),
 		"scanner_version":   scannerVersion,
 	}).Inc()
-}
-
-// ObserveNodePackageReportTransmissions observes the metric.
-func ObserveNodePackageReportTransmissions(nodeName string, sendingType InventoryTransmission, scannerVersion string) {
-	nodePackageReportTransmissions.With(prometheus.Labels{
+	// Record the old metric for backwards compatibility.
+	// Remove the block below after Scanner v2 is out of support for clusters
+	inventoryTransmissions.With(prometheus.Labels{
 		"node_name":         nodeName,
 		"transmission_type": string(sendingType),
 		"scanner_version":   scannerVersion,

--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -32,11 +32,41 @@ var (
 			"scanner_version",
 		})
 
+	numberOfReportPackages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "packages_in_package_report",
+		Help:      "Number of packages discovered by the last v2 Node Inventory or v4 IndexReport (per Node)",
+	},
+		[]string{
+			// The Node this scan belongs to
+			"node_name",
+			// The OS name and version of the Node
+			"os_namespace",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
+		})
+
 	numberOfContentSets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.ComplianceSubsystem.String(),
 		Name:      "content_sets_in_inventory",
 		Help:      "Number of content sets discovered by the last Node Inventory (per Node)",
+	},
+		[]string{
+			// The Node this scan belongs to
+			"node_name",
+			// The OS name and version of the Node
+			"os_namespace",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
+		})
+
+	numberOfReportContentSets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "content_sets_in_package_report",
+		Help:      "Number of content sets discovered by the last v2 Node Inventory or v4 Node Index (per Node)",
 	},
 		[]string{
 			// The Node this scan belongs to
@@ -99,7 +129,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.ComplianceSubsystem.String(),
 		Name:      "rescan_interval_seconds",
-		Help:      "Time in seconds between Node Inventory runs",
+		Help:      "Time in seconds between runs (identical for v2 Node Inventories and v4 Index Reports)",
 	},
 		[]string{
 			// The Node this scan belongs to
@@ -111,6 +141,20 @@ var (
 		Subsystem: metrics.ComplianceSubsystem.String(),
 		Name:      "protobuf_inventory_message_size_bytes",
 		Help:      "Message size of sent Node Inventory gRPC messages (per Node) in bytes",
+		Buckets:   []float64{500, 1000, 10000, 50000, 100000, 500000, 1000000},
+	},
+		[]string{
+			// The Node this scan belongs to
+			"node_name",
+			// The version of Scanner this metric was generated for
+			"scanner_version",
+		})
+
+	protobufReportMessageSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "protobuf_report_message_size_bytes",
+		Help:      "Message size of sent v2 Node Inventory or v4 Node Index gRPC messages (per Node) in bytes",
 		Buckets:   []float64{500, 1000, 10000, 50000, 100000, 500000, 1000000},
 	},
 		[]string{
@@ -189,21 +233,13 @@ func ObserveNodeInventoryScan(inventory *storage.NodeInventory) {
 	if components.GetRhelComponents() != nil {
 		rhelPackageCount = len(components.GetRhelComponents())
 	}
-	numberOfRHELPackages.With(prometheus.Labels{
-		"node_name":       inventory.GetNodeName(),
-		"os_namespace":    components.GetNamespace(),
-		"scanner_version": ScannerVersionV2,
-	}).Set(float64(rhelPackageCount))
+	observePackages(inventory.GetNodeName(), components.GetNamespace(), ScannerVersionV2, rhelPackageCount)
 
 	rhelContentSets := 0
 	if components.GetRhelContentSets() != nil {
 		rhelContentSets = len(components.GetRhelContentSets())
 	}
-	numberOfContentSets.With(prometheus.Labels{
-		"node_name":       inventory.GetNodeName(),
-		"os_namespace":    components.GetNamespace(),
-		"scanner_version": ScannerVersionV2,
-	}).Set(float64(rhelContentSets))
+	observeContentSets(inventory.GetNodeName(), components.GetNamespace(), ScannerVersionV2, rhelContentSets)
 }
 
 // ObserveNodeIndexReport observes the metric for Scanner v4.
@@ -218,21 +254,43 @@ func ObserveNodeIndexReport(report *v4.IndexReport, nodeName string) {
 	if contents.GetPackages() != nil {
 		rhelPackageCount = len(contents.GetPackages())
 	}
-	numberOfRHELPackages.With(prometheus.Labels{
-		"node_name":       nodeName,
-		"os_namespace":    "", // Not available in node index
-		"scanner_version": ScannerVersionV4,
-	}).Set(float64(rhelPackageCount))
+	observePackages(nodeName, "", ScannerVersionV4, rhelPackageCount)
 
 	rhelContentSets := 0
 	if contents.GetRepositories() != nil {
 		rhelContentSets = len(contents.GetRepositories())
 	}
+	observeContentSets(nodeName, "", ScannerVersionV4, rhelContentSets)
+}
+
+func observePackages(nodeName string, osNamespace string, scannerVersion string, packageCount int) {
+	numberOfReportPackages.With(prometheus.Labels{
+		"node_name":       nodeName,
+		"os_namespace":    osNamespace,
+		"scanner_version": scannerVersion,
+	}).Set(float64(packageCount))
+	// Record the old metric for backwards compatibility
+	// Remove the block below after Scanner v2 is out of support for clusters
+	numberOfRHELPackages.With(prometheus.Labels{
+		"node_name":       nodeName,
+		"os_namespace":    osNamespace,
+		"scanner_version": scannerVersion,
+	}).Set(float64(packageCount))
+}
+
+func observeContentSets(nodeName string, osNamespace string, scannerVersion string, contentSetCount int) {
+	numberOfReportContentSets.With(prometheus.Labels{
+		"node_name":       nodeName,
+		"os_namespace":    osNamespace,
+		"scanner_version": scannerVersion,
+	}).Set(float64(contentSetCount))
+	// Record the old metric for backwards compatibility
+	// Remove the block below after Scanner v2 is out of support for clusters
 	numberOfContentSets.With(prometheus.Labels{
 		"node_name":       nodeName,
-		"os_namespace":    "", // Not available in node index
-		"scanner_version": ScannerVersionV4,
-	}).Set(float64(rhelContentSets))
+		"os_namespace":    osNamespace,
+		"scanner_version": scannerVersion,
+	}).Set(float64(contentSetCount))
 }
 
 // ObserveNodeInventoryCallDuration observes the metric.
@@ -285,8 +343,14 @@ func ObserveIndexesTotal(nodeName string) {
 	}).Inc()
 }
 
-// ObserveInventoryProtobufMessage observes the metric.
-func ObserveInventoryProtobufMessage(cmsg *sensor.MsgFromCompliance, scannerVersion string) {
+// ObserveReportProtobufMessage observes the metric.
+func ObserveReportProtobufMessage(cmsg *sensor.MsgFromCompliance, scannerVersion string) {
+	protobufReportMessageSize.With(prometheus.Labels{
+		"node_name":       cmsg.GetNode(),
+		"scanner_version": scannerVersion,
+	}).Observe(float64(cmsg.SizeVT()))
+	// Record the old metric for backwards compatibility
+	// Remove the block below after Scanner v2 is out of support for clusters
 	protobufMessageSize.With(prometheus.Labels{
 		"node_name":       cmsg.GetNode(),
 		"scanner_version": scannerVersion,
@@ -313,7 +377,7 @@ func ObserveNodePackageReportTransmissions(nodeName string, sendingType Inventor
 		"transmission_type": string(sendingType),
 		"scanner_version":   scannerVersion,
 	}).Inc()
-	// Record the old metric for backwards compatibility.
+	// Record the old metric for backwards compatibility
 	// Remove the block below after Scanner v2 is out of support for clusters
 	inventoryTransmissions.With(prometheus.Labels{
 		"node_name":         nodeName,
@@ -328,8 +392,11 @@ func init() {
 		inventoryTransmissions,
 		nodePackageReportTransmissions,
 		numberOfRHELPackages,
+		numberOfReportPackages,
 		numberOfContentSets,
+		numberOfReportContentSets,
 		protobufMessageSize,
+		protobufReportMessageSize,
 		rescanInterval,
 		scanDuration,
 		indexDuration,


### PR DESCRIPTION
### Description

This PR introduces updated metrics to better address the new reality of two scanner versions being available for generating Node Package information.
No metric is removed, as we need to keep the old metrics around for as long as Scanner v2 is officially supported to maintain backwards compatibility.
The idea is to introduce new versions of the metrics with correct names, deprecating the old ones where possible. For this case, metrics are duplicated and given the correct name and help text.
Some metrics are directly observed in the old Scanner v2 code (stackrox/scanner), . In these cases, the metric is created seperately and exists once for Scanner v2 and once for Scanner v4.

Overview: 
- numberofRHELPackages: **Duplication added**
- numberOfContentSets: **Duplication added**
- scanDuration / indexDuration: Two separated metrics (code called in Scanner v2)
- callToNodeInventoryDuration: Not applicable to v4
- rescanInterval: Updated help text
- protobufMessageSize: **Duplication added**
- scansTotal / indexesTotal: Two separated metrics (code called in Scanner v2)
- inventoryTransmissions: **Duplication added**


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Deploy ACS on OpenShift with `ROX_SCANNER_V4=true MONITORING_SUPPORT=true`
- Start debug pod on one of the collector pods: `kubectl -n stackrox debug -it collector-6255l --image=nicolaka/netshoot`
- curl compliance metrics: 
```
curl -s http://localhost:9091/metrics | grep -i package
# HELP rox_compliance_node_package_reports_total Number of total v2 node inventory scans and v4 index reports sent to sensor
# TYPE rox_compliance_node_package_reports_total counter
rox_compliance_node_package_reports_total{node_name="mm-10-24-nodescanning-lcfl7-worker-c-7jt5l",scanner_version="Scanner V4",transmission_type="scanning"} 3
rox_compliance_node_package_reports_total{node_name="mm-10-24-nodescanning-lcfl7-worker-c-7jt5l",scanner_version="Stackrox Scanner",transmission_type="scanning"} 3

```
Ensure this number is the same than its sister metric, `inventory_transmissions_total`: 
```
curl -s http://localhost:9091/metrics | grep -i inventory_transmissions_total
# HELP rox_compliance_inventory_transmissions_total Number of node inventory scans sent to sensor
# TYPE rox_compliance_inventory_transmissions_total counter
rox_compliance_inventory_transmissions_total{node_name="mm-10-24-nodescanning-lcfl7-worker-c-7jt5l",scanner_version="Scanner V4",transmission_type="scanning"} 3
rox_compliance_inventory_transmissions_total{node_name="mm-10-24-nodescanning-lcfl7-worker-c-7jt5l",scanner_version="Stackrox Scanner",transmission_type="scanning"} 3

```

Repeat these steps for the remaining added metrics