### PR TITLE
fix: Only allow CRS generation if feature flag is enabled.

### DIFF
--- a/central/clusterinit/service/service_impl.go
+++ b/central/clusterinit/service/service_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/central/clusterinit/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/set"
 	"google.golang.org/grpc"
@@ -129,6 +130,10 @@ func (s *serviceImpl) GenerateInitBundle(ctx context.Context, request *v1.InitBu
 }
 
 func (s *serviceImpl) GenerateCRS(ctx context.Context, request *v1.CRSGenRequest) (*v1.CRSGenResponse, error) {
+	if !features.ClusterRegistrationSecrets.Enabled() {
+		return nil, status.Error(codes.Unimplemented, "Support for generating Cluster Registration Secrets (CRS) is not enabled")
+	}
+
 	generated, err := s.backend.IssueCRS(ctx, request.GetName())
 	if err != nil {
 		if errors.Is(err, store.ErrInitBundleDuplicateName) {

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -750,6 +750,10 @@ function launch_sensor {
         )
       fi
 
+      if [[ -n "${ROX_CLUSTER_REGISTRATION_SECRETS:-}" ]]; then
+        helm_args+=(--set customize.central.envVars.ROX_CLUSTER_REGISTRATION_SECRETS="${ROX_CLUSTER_REGISTRATION_SECRETS}")
+      fi
+
       # Add a custom values file to Helm
       if [[ -n "$ROX_SENSOR_EXTRA_HELM_VALUES_FILE" ]]; then
         helm_args+=(

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -163,6 +163,7 @@ export_test_environment() {
     ci_export ROX_PLATFORM_COMPONENTS "${ROX_PLATFORM_COMPONENTS:-true}"
     ci_export ROX_NVD_CVSS "${ROX_NVD_CVSS_UI:-true}"
     ci_export ROX_CLUSTERS_PAGE_MIGRATION_UI "${ROX_CLUSTERS_PAGE_MIGRATION_UI:-true}"
+    ci_export ROX_CLUSTER_REGISTRATION_SECRETS "${ROX_CLUSTER_REGISTRATION_SECRETS:-true}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"


### PR DESCRIPTION
### Description

Central currently exposes CRS issuing functionality via gRPC. This is not currently used anywhere. But it is probably a good idea to tie this service call to the feature flag so that it is guaranteed for released images that we won't end up with any CRS's in the wild (as of now).

With this change CRS issuing would fail on central side. Triggered here using roxctl:
```
$ roxctl -e "$CENTRAL_ENDPOINT" central crs generate foo -o=crs.yaml
[...]
ERROR:	missing CRS support in Central: rpc error: code = Unimplemented desc = Support for generating Cluster Registration Secrets (CRS) is not enabled
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

Conducted a simple manual test using roxctl.

#### Automated testing

Nothing.

#### How I validated my change

Manually.
