### PR TITLE
ROX-25007: Allow named port to be set with the --dnsport flag

### DIFF
--- a/roxctl/netpol/generate/generate.go
+++ b/roxctl/netpol/generate/generate.go
@@ -1,9 +1,9 @@
 package generate
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	npguard "github.com/np-guard/cluster-topology-analyzer/v2/pkg/analyzer"
@@ -28,7 +28,7 @@ const (
 type NetpolGenerateOptions struct {
 	StopOnFirstError      bool
 	TreatWarningsAsErrors bool
-	DNSPort               uint16
+	DNSPort               string
 	OutputFolderPath      string
 	OutputFilePath        string
 	RemoveOutputPath      bool
@@ -42,6 +42,8 @@ type netpolGenerateCmd struct {
 	inputFolderPath string
 	mergeMode       bool
 	splitMode       bool
+	dnsPortNum      int
+	dnsPortName     string
 
 	// injected or constructed values
 	env     environment.Environment
@@ -53,7 +55,7 @@ func (cmd *netpolGenerateCmd) AddFlags(c *cobra.Command) *cobra.Command {
 	c.Flags().BoolVar(&cmd.Options.TreatWarningsAsErrors, "strict", false, "Treat warnings as errors")
 	c.Flags().BoolVar(&cmd.Options.StopOnFirstError, "fail", false, "Fail on the first encountered error")
 	c.Flags().BoolVar(&cmd.Options.RemoveOutputPath, "remove", false, "Remove the output path if it already exists")
-	c.Flags().Uint16Var(&cmd.Options.DNSPort, "dnsport", npguard.DefaultDNSPort, "Set DNS port to be used in egress rules of synthesized NetworkPolicies")
+	c.Flags().StringVarP(&cmd.Options.DNSPort, "dnsport", "", "", "Set the DNS port (port number or port name) to be used in egress rules of synthesized NetworkPolicies")
 	c.Flags().StringVarP(&cmd.Options.OutputFolderPath, "output-dir", "d", "", "Save generated policies into target folder - one file per policy")
 	c.Flags().StringVarP(&cmd.Options.OutputFilePath, "output-file", "f", "", "Save and merge generated policies into a single yaml file")
 	return c
@@ -80,8 +82,20 @@ func (cmd *netpolGenerateCmd) construct(args []string, c *cobra.Command) (*npgua
 	cmd.inputFolderPath = args[0]
 	cmd.splitMode = c.Flags().Changed("output-dir")
 	cmd.mergeMode = c.Flags().Changed("output-file")
+	dnsPortNum, err := strconv.Atoi(cmd.Options.DNSPort)
+	if err == nil {
+		cmd.dnsPortNum = dnsPortNum
+	} else {
+		cmd.dnsPortName = cmd.Options.DNSPort
+	}
 
-	opts := []npguard.PoliciesSynthesizerOption{npguard.WithDNSPort(int(cmd.Options.DNSPort))}
+	opts := []npguard.PoliciesSynthesizerOption{}
+	if cmd.dnsPortNum != 0 {
+		opts = append(opts, npguard.WithDNSPort(cmd.dnsPortNum))
+	} else if cmd.dnsPortName != "" {
+		opts = append(opts, npguard.WithDNSNamedPort(cmd.dnsPortName))
+	}
+
 	if cmd.env != nil && cmd.env.Logger() != nil {
 		opts = append(opts, npguard.WithLogger(npg.NewLogger(cmd.env.Logger())))
 	}
@@ -105,9 +119,17 @@ func (cmd *netpolGenerateCmd) validate() error {
 		}
 	}
 
-	portErrs := validation.IsValidPortNum(int(cmd.Options.DNSPort))
-	if len(portErrs) > 0 {
-		return fmt.Errorf("illegal port number: %s", portErrs[0])
+	if cmd.dnsPortName != "" {
+		portErrs := validation.IsValidPortName(cmd.dnsPortName)
+		if len(portErrs) > 0 {
+			return errox.InvalidArgs.Newf("illegal port name: %s", portErrs[0])
+		}
+	} else if cmd.Options.DNSPort != "" { // user set a value which could be interpreted as an integer
+		portErrs := validation.IsValidPortNum(cmd.dnsPortNum)
+		if len(portErrs) > 0 {
+			return errox.InvalidArgs.Newf("illegal port number: %s", portErrs[0])
+		}
+
 	}
 
 	return nil

--- a/roxctl/netpol/generate/generate_test.go
+++ b/roxctl/netpol/generate/generate_test.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"testing"
 
-	npguard "github.com/np-guard/cluster-topology-analyzer/v2/pkg/analyzer"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common/environment/mocks"
@@ -28,6 +27,7 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 		outFile               string
 		outDir                string
 		removeOutputPath      bool
+		dnsPort               string
 
 		expectedValidationError error
 		expectedWarnings        []string
@@ -96,6 +96,30 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 			expectedWarnings:        []string{},
 			expectedErrors:          []string{},
 		},
+		"should report bad port name": {
+			inputFolderPath: "testdata/minimal",
+			dnsPort:         "bad@chars",
+
+			expectedValidationError: errox.InvalidArgs,
+			expectedWarnings:        []string{},
+			expectedErrors:          []string{},
+		},
+		"should report bad port number": {
+			inputFolderPath: "testdata/minimal",
+			dnsPort:         "100000",
+
+			expectedValidationError: errox.InvalidArgs,
+			expectedWarnings:        []string{},
+			expectedErrors:          []string{},
+		},
+		"should report 0 as a bad port number": {
+			inputFolderPath: "testdata/minimal",
+			dnsPort:         "0",
+
+			expectedValidationError: errox.InvalidArgs,
+			expectedWarnings:        []string{},
+			expectedErrors:          []string{},
+		},
 	}
 
 	for name, tt := range cases {
@@ -113,7 +137,7 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 					OutputFolderPath:      tt.outDir,
 					OutputFilePath:        tt.outFile,
 					RemoveOutputPath:      tt.removeOutputPath,
-					DNSPort:               npguard.DefaultDNSPort,
+					DNSPort:               tt.dnsPort,
 				},
 				offline:         true,
 				inputFolderPath: "", // set through construct

--- a/roxctl/netpol/generate/generate_test.go
+++ b/roxctl/netpol/generate/generate_test.go
@@ -120,6 +120,14 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 			expectedWarnings:        []string{},
 			expectedErrors:          []string{},
 		},
+		"should report a negative port as a bad port number": {
+			inputFolderPath: "testdata/minimal",
+			dnsPort:         "-17",
+
+			expectedValidationError: errox.InvalidArgs,
+			expectedWarnings:        []string{},
+			expectedErrors:          []string{},
+		},
 	}
 
 	for name, tt := range cases {
@@ -128,6 +136,7 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 			testCmd := &cobra.Command{Use: "test"}
 			testCmd.Flags().String("output-dir", "", "")
 			testCmd.Flags().String("output-file", "", "")
+			testCmd.Flags().String("dnsport", "", "")
 
 			env, _, _ := mocks.NewEnvWithConn(nil, d.T())
 			generateNetpolCmd := netpolGenerateCmd{
@@ -149,6 +158,9 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 			}
 			if tt.outFile != "" {
 				d.Assert().NoError(testCmd.Flags().Set("output-file", tt.outFile))
+			}
+			if tt.dnsPort != "" {
+				d.Assert().NoError(testCmd.Flags().Set("dnsport", tt.dnsPort))
 			}
 
 			generator, err := generateNetpolCmd.construct([]string{tt.inputFolderPath}, testCmd)

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
@@ -115,6 +115,28 @@ teardown() {
     assert_line --index 5 'doc: 2'
 }
 
+@test "roxctl-development netpol generate generates network policies with custom dns named port" {
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
+    echo "Writing network policies to ${ofile}" >&3
+    dns_port="dns"
+    run roxctl-development netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ${dns_port}
+    assert_success
+
+    echo "$output" > "$ofile"
+    assert_file_exist "$ofile"
+    yaml_valid "$ofile"
+
+    # Ensure that dns ports are properly set
+    run yq e '.spec.egress[1].ports[0].port | ({"match": ., "doc": di})' "${ofile}"
+    assert_line --index 0 'match: null'
+    assert_line --index 1 'doc: 0'
+    assert_line --index 2 'match: '${dns_port}
+    assert_line --index 3 'doc: 1'
+    assert_line --index 4 'match: null'
+    assert_line --index 5 'doc: 2'
+}
+
 @test "roxctl-development netpol generate fails with dns port set to 0" {
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
@@ -145,6 +145,14 @@ teardown() {
     assert_output --regexp 'ERROR:.*illegal port number'
 }
 
+@test "roxctl-development netpol generate fails with dns port set to empty string" {
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
+    run roxctl-development netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ""
+    assert_failure
+    assert_output --regexp 'ERROR:.*illegal port name'
+}
+
 @test "roxctl-development netpol generate produces no output when all yamls are templated" {
     mkdir -p "$out_dir"
     write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-XXXXXX.yaml")"

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
@@ -137,6 +137,28 @@ teardown() {
     assert_line --index 5 'doc: 2'
 }
 
+@test "roxctl-development netpol generate generates network policies with custom dns named port" {
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
+    echo "Writing network policies to ${ofile}" >&3
+    dns_port="dns"
+    run roxctl-development netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ${dns_port}
+    assert_success
+
+    echo "$output" > "$ofile"
+    assert_file_exist "$ofile"
+    yaml_valid "$ofile"
+
+    # Ensure that dns ports are properly set
+    run yq e '.spec.egress[1].ports[0].port | ({"match": ., "doc": di})' "${ofile}"
+    assert_line --index 0 'match: null'
+    assert_line --index 1 'doc: 0'
+    assert_line --index 2 'match: '${dns_port}
+    assert_line --index 3 'doc: 1'
+    assert_line --index 4 'match: null'
+    assert_line --index 5 'doc: 2'
+}
+
 @test "roxctl-release netpol generate fails with dns port set to 0" {
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
@@ -137,12 +137,12 @@ teardown() {
     assert_line --index 5 'doc: 2'
 }
 
-@test "roxctl-development netpol generate generates network policies with custom dns named port" {
+@test "roxctl-release netpol generate generates network policies with custom dns named port" {
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
     assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
     echo "Writing network policies to ${ofile}" >&3
     dns_port="dns"
-    run roxctl-development netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ${dns_port}
+    run roxctl-release netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ${dns_port}
     assert_success
 
     echo "$output" > "$ofile"
@@ -165,6 +165,14 @@ teardown() {
     run roxctl-release netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport 0
     assert_failure
     assert_output --regexp 'ERROR:.*illegal port number'
+}
+
+@test "roxctl-release netpol generate fails with dns port set to empty string" {
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/frontend.yaml"
+    assert_file_exist "${test_data}/np-guard/scenario-minimal-service/backend.yaml"
+    run roxctl-release netpol generate "${test_data}/np-guard/scenario-minimal-service" --dnsport ""
+    assert_failure
+    assert_output --regexp 'ERROR:.*illegal port name'
 }
 
 @test "roxctl-release netpol generate produces no output when all yamls are templated" {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This change is only relevant for the `roxctl netpol generate` command.
Previously, the `--dnsport` flag only allowed an integer as its argument.
This prevented users from specifying a named port as the default DNS port.
With the proposed change, users will be able to specify both strings and integers as the argument of `--dnsport`.
If the argument can be safely converted to an integer, it will be interpreted as such. Otherwise, it is interpreted as string.
Validity checks were modified accordingly.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests (for bad path) and e2e tests (for good path) should cover this small change.
