### PR TITLE
ROX-26764: Fix bogus failing in Helm chart

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -261,7 +261,7 @@ The following block checks for the validity of the provided init bundle. (`helm 
 {{- else if and (not $helmInitBundleNotPresent) $operatorInitBundlePresent }}
     {{ include "srox.warn" (list . "It seems an init bundle in the operator format has been provided. Note that this bundle format is ignored by the Helm chart.") }}
 {{- else if $helmInitBundleNotPresent }}
-    {{ include "srox.fail" (list . "A CA certificate must be specified") }}
+    {{ include "srox.fail" "A CA certificate must be specified" }}
 {{- end }}
 
 {{/* ManagedBy related settings */}}


### PR DESCRIPTION
### Description

As described [in the issue](https://issues.redhat.com/browse/ROX-26764) the secured-cluster-services Helm chart might cause >4k lines long error dumps instead of a user-friendly error message in case the init bundles has not been provided. This is due to a wrong invocation of the `srox.fail` templating function.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

Verified manually using
```
$ roxctl helm output secured-cluster-services --remove --debug; helm install --dry-run -n stackrox --set clusterName=foo --set centralEndpoint=https://localhost:443 stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart
```

#### Automated testing

None.
