### PR TITLE
ROX-24326: Prevent UI crashes when vuln req is null in response

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEActionsColumn.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { ActionsColumn } from '@patternfly/react-table';
 import { DeferredCVEsToBeAssessed } from './types';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
@@ -13,7 +13,7 @@ function DeferredCVEActionsColumn({
     row,
     setVulnsToBeAssessed,
     canReobserveCVE,
-}: DeferredCVEActionsColumnProps): ReactElement {
+}: DeferredCVEActionsColumnProps) {
     const items = [
         {
             title: 'Reobserve CVE',
@@ -22,13 +22,13 @@ function DeferredCVEActionsColumn({
                 setVulnsToBeAssessed({
                     type: 'DEFERRAL',
                     action: 'UNDO',
-                    requestIDs: [row.vulnerabilityRequest.id],
+                    requestIDs: [row.vulnerabilityRequest?.id ?? ''],
                 });
             },
             isDisabled: !canReobserveCVE,
         },
     ];
-    return <ActionsColumn items={items} />;
+    return row.vulnerabilityRequest ? <ActionsColumn items={items} /> : null;
 }
 
 export default DeferredCVEActionsColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -97,12 +97,13 @@ function DeferredCVEsTable({
                 selectedIds.includes(row.id) &&
                 (canApproveRequests ||
                     (canCreateRequests &&
-                        row.vulnerabilityRequest.requestor.id === currentUser.userId))
+                        row.vulnerabilityRequest?.requestor.id === currentUser.userId))
             );
         })
         .map((row) => {
-            return row.vulnerabilityRequest.id;
-        });
+            return row.vulnerabilityRequest?.id;
+        })
+        .filter((id): id is string => id !== undefined);
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEActionsColumns.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEActionsColumns.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { ActionsColumn } from '@patternfly/react-table';
 import { FalsePositiveCVEsToBeAssessed } from './types';
 import { Vulnerability } from '../imageVulnerabilities.graphql';
@@ -13,7 +13,7 @@ function FalsePositiveCVEActionsColumn({
     row,
     setVulnsToBeAssessed,
     canReobserveCVE,
-}: FalsePositiveCVEActionsColumnProps): ReactElement {
+}: FalsePositiveCVEActionsColumnProps) {
     const items = [
         {
             title: 'Reobserve CVE',
@@ -22,13 +22,13 @@ function FalsePositiveCVEActionsColumn({
                 setVulnsToBeAssessed({
                     type: 'FALSE_POSITIVE',
                     action: 'UNDO',
-                    requestIDs: [row.vulnerabilityRequest.id],
+                    requestIDs: [row.vulnerabilityRequest?.id ?? ''],
                 });
             },
             isDisabled: !canReobserveCVE,
         },
     ];
-    return <ActionsColumn items={items} />;
+    return row.vulnerabilityRequest ? <ActionsColumn items={items} /> : null;
 }
 
 export default FalsePositiveCVEActionsColumn;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -96,12 +96,13 @@ function FalsePositiveCVEsTable({
                 selectedIds.includes(row.id) &&
                 (canApproveRequests ||
                     (canCreateRequests &&
-                        row.vulnerabilityRequest.requestor.id === currentUser.userId))
+                        row.vulnerabilityRequest?.requestor.id === currentUser.userId))
             );
         })
         .map((row) => {
-            return row.vulnerabilityRequest.id;
-        });
+            return row.vulnerabilityRequest?.id;
+        })
+        .filter((id): id is string => id !== undefined);
 
     return (
         <>
@@ -202,7 +203,7 @@ function FalsePositiveCVEsTable({
                             const canReobserveCVE =
                                 canApproveRequests ||
                                 (canCreateRequests &&
-                                    row.vulnerabilityRequest.requestor.id === currentUser.userId);
+                                    row.vulnerabilityRequest?.requestor.id === currentUser.userId);
 
                             return (
                                 <Tr key={row.cve}>
@@ -221,9 +222,13 @@ function FalsePositiveCVEsTable({
                                         <VulnerabilitySeverityIconText severity={row.severity} />
                                     </Td>
                                     <Td dataLabel="Scope">
-                                        <VulnerabilityRequestScope
-                                            scope={row.vulnerabilityRequest.scope}
-                                        />
+                                        {row.vulnerabilityRequest ? (
+                                            <VulnerabilityRequestScope
+                                                scope={row.vulnerabilityRequest.scope}
+                                            />
+                                        ) : (
+                                            'N/A'
+                                        )}
                                     </Td>
                                     <Td dataLabel="Affected components">
                                         <Button
@@ -237,15 +242,21 @@ function FalsePositiveCVEsTable({
                                         </Button>
                                     </Td>
                                     <Td dataLabel="Comments">
-                                        <RequestCommentsButton
-                                            comments={row.vulnerabilityRequest.comments}
-                                            cve={row.vulnerabilityRequest.cves.cves[0]}
-                                        />
+                                        {row.vulnerabilityRequest ? (
+                                            <RequestCommentsButton
+                                                comments={row.vulnerabilityRequest.comments}
+                                                cve={row.vulnerabilityRequest.cves.cves[0]}
+                                            />
+                                        ) : (
+                                            'N/A'
+                                        )}
                                     </Td>
                                     <Td dataLabel="Approver">
-                                        {row.vulnerabilityRequest.approvers
-                                            .map((user) => user.name)
-                                            .join(',')}
+                                        {row.vulnerabilityRequest
+                                            ? row.vulnerabilityRequest.approvers
+                                                  .map((user) => user.name)
+                                                  .join(',')
+                                            : 'N/A'}
                                     </Td>
                                     <Td className="pf-u-text-align-right">
                                         <FalsePositiveCVEActionsColumn

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/imageVulnerabilities.graphql.ts
@@ -30,7 +30,7 @@ export type Vulnerability = {
     scoreVersion: string;
     discoveredAtImage: string;
     components: EmbeddedImageScanComponent[];
-    vulnerabilityRequest: VulnerabilityRequest;
+    vulnerabilityRequest?: VulnerabilityRequest;
 };
 
 // This type is specific to the way we query using GraphQL


### PR DESCRIPTION
### Description

This is a 4.4 specific fix.

Resolves a customer issue in the old VM images page where the `vulnerabilityRequest` object in a network response is `null` for CVEs that have _approved false positive vulnerability requests_. This `null` is not handled on the front end and results in a runtime error, crashing the page.

Note that this is a partial fix and does not resolve the underlying issue of `vulnerabilityRequest` being `null`, which logically should not occur. The fix here is to prevent the entirety of the page crashing when this behavior is encountered.

The fix displays `'N/A'` in the table fields, which is the existing behavior in the Deferred CVEs table. Additionally the menu from the row is removed, as the functionality from the menu option is invalid if there is no `vulnerabilityRequest`.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Mock data so that `vulnerabilityRequest` is `null` in the list of CVEs with false positive request approvals.

Before:
![image](https://github.com/user-attachments/assets/711a7fb2-a8bb-4ced-b24b-60e101cba787)

After:
![image](https://github.com/user-attachments/assets/d3c79f42-df8b-45a0-a09f-32c80587e2c5)
