### PR TITLE
chore(CI): Fix issue with mix of nightly and merge commit builds

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1308,7 +1308,7 @@ openshift_ci_mods() {
     fi
 
     # Target a tag if HEAD is tagged.
-    BUILD_TAG="$(git tag --sort=creatordate --contains | tail -1)" || echo "Warning: Cannot get tag"
+    BUILD_TAG="$(git describe --exact-match --tags HEAD)" || echo "Warning: Cannot get tag"
     export BUILD_TAG
 
     # For gradle


### PR DESCRIPTION
### Description

This PR should fix issue where nightly build is taken for merge commits.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no changes

#### How I validated my change

Tested on following commits:
- `e58fa182d0799191eacd1b97e982da7b4ef41cf5` - not nightly
- `c6d1447df8c794e5acaeb8d716becc452e11b60f` - tagged as nightly

- **old code first**

```
❯ git checkout e58fa182d0799191eacd1b97e982da7b4ef41cf5
❯ BUILD_TAG="$(git tag --sort=creatordate --contains | tail -1)" || echo "Warning: Cannot get tag"
❯ echo $BUILD_TAG
4.6.x-nightly-20241028

❯ git checkout c6d1447df8c794e5acaeb8d716becc452e11b60f
❯ BUILD_TAG="$(git tag --sort=creatordate --contains | tail -1)" || echo "Warning: Cannot get tag"
❯ echo $BUILD_TAG
4.6.x-nightly-20241028
```

- **new code**
```
❯ git checkout e58fa182d0799191eacd1b97e982da7b4ef41cf5
❯ BUILD_TAG="$(git describe --exact-match --tags HEAD)" || echo "Warning: Cannot get tag"
fatal: no tag exactly matches 'e58fa182d0799191eacd1b97e982da7b4ef41cf5'
Warning: Cannot get tag
❯ echo $BUILD_TAG

❯ git checkout c6d1447df8c794e5acaeb8d716becc452e11b60f
❯ BUILD_TAG="$(git describe --exact-match --tags HEAD)" || echo "Warning: Cannot get tag"
❯ echo $BUILD_TAG
4.6.x-nightly-20241028
```
