### PR TITLE
chore(ui): Replace AlertVariant enum with string

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Alert, AlertVariant } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 
 export type FormResponseMessage = {
     message: string;
@@ -12,7 +12,7 @@ export type FormMessageProps = {
 
 function FormMessage({ message }: FormMessageProps): ReactElement {
     const title = message?.isError ? 'Failure' : 'Success';
-    const variant = message?.isError ? AlertVariant.danger : AlertVariant.success;
+    const variant = message?.isError ? 'danger' : 'success';
     return (
         <div id="form-message-alert">
             {message && (

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlRouteNotFound.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlRouteNotFound.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactElement } from 'react';
-import { Alert, AlertVariant, List, ListItem, PageSection } from '@patternfly/react-core';
+import { Alert, List, ListItem, PageSection } from '@patternfly/react-core';
 
 import AccessControlHeading from './AccessControlHeading';
 
@@ -16,7 +16,7 @@ function AccessControlRouteNotFound(): ReactElement {
                 <Alert
                     title="Access Control route not found"
                     component="p"
-                    variant={AlertVariant.warning}
+                    variant="warning"
                     isInline
                 >
                     <List style={styleList}>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { FormikContextType } from 'formik';
 import {
     Alert,
-    AlertVariant,
     Flex,
     FlexItem,
     Form,
@@ -104,7 +103,7 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
                     <Alert
                         title="Compute effective access scope failed"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -3,7 +3,6 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 import {
     Alert,
-    AlertVariant,
     Button,
     Label,
     Title,
@@ -99,7 +98,7 @@ function AccessScopeFormWrapper({
                     <Alert
                         title="Failed to save access scope"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -4,7 +4,6 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import {
     Alert,
     AlertActionCloseButton,
-    AlertVariant,
     Bullseye,
     Button,
     PageSection,
@@ -68,7 +67,7 @@ function AccessScopes(): ReactElement {
                     <Alert
                         title="Fetch access scopes failed"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}
@@ -93,7 +92,7 @@ function AccessScopes(): ReactElement {
                     <Alert
                         title="Fetch roles failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -1,14 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Button,
-    Modal,
-    ModalVariant,
-    PageSection,
-    pluralize,
-    Title,
-} from '@patternfly/react-core';
+import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
 import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
@@ -53,7 +44,7 @@ function AccessScopesList({
                     <Alert
                         title="Delete access scope failed"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}
@@ -128,7 +119,7 @@ function AccessScopesList({
                 </Tbody>
             </Table>
             <Modal
-                variant={ModalVariant.small}
+                variant="small"
                 title="Permanently delete access scope?"
                 isOpen={typeof nameConfirmingDelete === 'string'}
                 onClose={onCancelDelete}

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -3,7 +3,6 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 import {
     Alert,
-    AlertVariant,
     Badge,
     Button,
     Form,
@@ -97,7 +96,7 @@ function PermissionSetForm({
                     <Alert
                         title="Failed to save permission set"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -4,7 +4,6 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import {
     Alert,
     AlertActionCloseButton,
-    AlertVariant,
     Bullseye,
     Button,
     PageSection,
@@ -72,7 +71,7 @@ function PermissionSets(): ReactElement {
                     <Alert
                         title="Fetch permission sets failed"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}
@@ -97,7 +96,7 @@ function PermissionSets(): ReactElement {
                     <Alert
                         title="Fetch resources failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >
@@ -121,7 +120,7 @@ function PermissionSets(): ReactElement {
                     <Alert
                         title="Fetch roles failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -1,14 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Button,
-    Modal,
-    ModalVariant,
-    PageSection,
-    pluralize,
-    Title,
-} from '@patternfly/react-core';
+import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
 import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { PermissionSet, Role } from 'services/RolesService';
@@ -52,7 +43,7 @@ function PermissionSetsList({
                     <Alert
                         title="Delete permission set failed"
                         component="p"
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         isInline
                     >
                         {error.message}
@@ -131,7 +122,7 @@ function PermissionSetsList({
                 </Table>
             )}
             <Modal
-                variant={ModalVariant.small}
+                variant="small"
                 title="Permanently delete permission set?"
                 isOpen={typeof nameConfirmingDelete === 'string'}
                 onClose={onCancelDelete}

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -3,7 +3,6 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 import {
     Alert,
-    AlertVariant,
     Button,
     Form,
     FormGroup,
@@ -92,12 +91,7 @@ function RoleForm({
         handleSubmit(values)
             .catch((error) => {
                 setAlertSubmit(
-                    <Alert
-                        title="Failed to save role"
-                        component="p"
-                        variant={AlertVariant.danger}
-                        isInline
-                    >
+                    <Alert title="Failed to save role" component="p" variant="danger" isInline>
                         {error.message}
                     </Alert>
                 );

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -4,7 +4,6 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import {
     Alert,
     AlertActionCloseButton,
-    AlertVariant,
     Bullseye,
     Button,
     PageSection,
@@ -89,12 +88,7 @@ function Roles(): ReactElement {
             })
             .catch((error) => {
                 setAlertRoles(
-                    <Alert
-                        title="Fetch roles failed"
-                        component="p"
-                        variant={AlertVariant.danger}
-                        isInline
-                    >
+                    <Alert title="Fetch roles failed" component="p" variant="danger" isInline>
                         {error.message}
                     </Alert>
                 );
@@ -132,7 +126,7 @@ function Roles(): ReactElement {
                     <Alert
                         title="Fetch auth providers or groups failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >
@@ -156,7 +150,7 @@ function Roles(): ReactElement {
                     <Alert
                         title="Fetch permission sets failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >
@@ -180,7 +174,7 @@ function Roles(): ReactElement {
                     <Alert
                         title="Fetch access scopes failed"
                         component="p"
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         isInline
                         actionClose={actionClose}
                     >

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -1,14 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Button,
-    Modal,
-    ModalVariant,
-    PageSection,
-    pluralize,
-    Title,
-} from '@patternfly/react-core';
+import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
 import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
@@ -62,12 +53,7 @@ function RolesList({
         handleDelete(nameDeleting)
             .catch((error) => {
                 setAlertDelete(
-                    <Alert
-                        title="Delete role failed"
-                        component="p"
-                        variant={AlertVariant.danger}
-                        isInline
-                    >
+                    <Alert title="Delete role failed" component="p" variant="danger" isInline>
                         {error.message}
                     </Alert>
                 );
@@ -170,7 +156,7 @@ function RolesList({
                 </Table>
             )}
             <Modal
-                variant={ModalVariant.small}
+                variant="small"
                 title="Permanently delete role?"
                 isOpen={typeof nameConfirmingDelete === 'string'}
                 onClose={onCancelDelete}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, ReactElement, ReactFragment } from 'react';
 import {
     Alert,
-    AlertVariant,
     Breadcrumb,
     BreadcrumbItem,
     Button,
@@ -28,7 +27,7 @@ import DelegatedScanningSettings from './Components/DelegatedScanningSettings';
 import DelegatedRegistriesList from './Components/DelegatedRegistriesList';
 
 type AlertObj = {
-    type: AlertVariant.danger | AlertVariant.success;
+    type: 'danger' | 'success';
     title: string;
     body: ReactElement | ReactFragment;
 };
@@ -89,7 +88,7 @@ function DelegateScanningPage() {
             })
             .catch((error) => {
                 const newErrorObj: AlertObj = {
-                    type: AlertVariant.danger,
+                    type: 'danger',
                     title: 'Problem retrieving the delegated scanning configuration from the server',
                     body: (
                         <>
@@ -113,7 +112,7 @@ function DelegateScanningPage() {
             })
             .catch((error) => {
                 const newErrorObj: AlertObj = {
-                    type: AlertVariant.danger,
+                    type: 'danger',
                     title: 'Problem retrieving clusters eligible for delegated scanning',
                     body: (
                         <>
@@ -222,7 +221,7 @@ function DelegateScanningPage() {
         updateDelegatedRegistryConfig(delegatedRegistryConfig)
             .then(() => {
                 const newSuccessObj: AlertObj = {
-                    type: AlertVariant.success,
+                    type: 'success',
                     title: 'Delegated scanning configuration saved successfully',
                     body: <></>,
                 };
@@ -230,7 +229,7 @@ function DelegateScanningPage() {
             })
             .catch((error) => {
                 const newErrorObj: AlertObj = {
-                    type: AlertVariant.danger,
+                    type: 'danger',
                     title: 'Problem saving the delegated scanning configuration to the server',
                     body: (
                         <>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import {
     Alert,
     AlertGroup,
-    AlertVariant,
     Card,
     CardBody,
     Divider,
@@ -222,7 +221,7 @@ function ReportJobs({ scanConfigId, isComplianceReportingEnabled }: ReportJobsPr
                     {deleteDownloadError && (
                         <Alert
                             isInline
-                            variant={AlertVariant.danger}
+                            variant="danger"
                             title={deleteDownloadError}
                             component="p"
                             className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
@@ -1,14 +1,6 @@
 /* eslint-disable no-void */
 import React, { ReactElement, useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Checkbox,
-    Form,
-    PageSection,
-    TextInput,
-    Popover,
-} from '@patternfly/react-core';
+import { Alert, Checkbox, Form, PageSection, TextInput, Popover } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core/deprecated';
 import { HelpIcon } from '@patternfly/react-icons';
 import * as yup from 'yup';
@@ -281,7 +273,7 @@ function EmailIntegrationForm({
                                     className="pf-v5-u-mt-md"
                                     title="Security Warning"
                                     component="p"
-                                    variant={AlertVariant.warning}
+                                    variant="warning"
                                     isInline
                                 >
                                     <p>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -2,7 +2,6 @@ import * as yup from 'yup';
 import React, { ReactElement, useEffect, useState } from 'react';
 import {
     Alert,
-    AlertVariant,
     Button,
     Flex,
     FlexItem,
@@ -117,12 +116,7 @@ function MachineAccessIntegrationForm({
     return (
         <>
             {alertRoles && (
-                <Alert
-                    title="Fetch roles failed"
-                    component="p"
-                    variant={AlertVariant.warning}
-                    isInline
-                >
+                <Alert title="Fetch roles failed" component="p" variant="warning" isInline>
                     {alertRoles}
                 </Alert>
             )}

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo } from 'react';
 import {
     Alert,
     AlertGroup,
-    AlertVariant,
     Bullseye,
     Button,
     Divider,
@@ -95,7 +94,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
         return (
             <Alert
                 isInline
-                variant={AlertVariant.danger}
+                variant="danger"
                 title={getAxiosErrorMessage(error)}
                 component="p"
                 className="pf-v5-u-mb-lg"
@@ -111,7 +110,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                 {networkPolicyErrors.map((networkPolicyError) => (
                     <Alert
                         isInline
-                        variant={AlertVariant.warning}
+                        variant="warning"
                         title="There was an error loading network policy data"
                         component="p"
                     >

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Alert,
-    AlertVariant,
     Bullseye,
     Button,
     Checkbox,
@@ -151,7 +150,7 @@ function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: Deploym
             {errorMessage && (
                 <Alert
                     isInline
-                    variant={AlertVariant.danger}
+                    variant="danger"
                     title={errorMessage}
                     component="p"
                     className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Alert,
-    AlertVariant,
     Bullseye,
     Divider,
     EmptyState,
@@ -147,7 +146,7 @@ function DeploymentFlows({
             {(networkFlowsError || modifyError) && (
                 <Alert
                     isInline
-                    variant={AlertVariant.danger}
+                    variant="danger"
                     title={networkFlowsError || modifyError}
                     component="p"
                     className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, CSSProperties } from 'react';
 import {
     Alert,
-    AlertVariant,
     Bullseye,
     Flex,
     FlexItem,
@@ -124,7 +123,7 @@ function DeploymentSideBar({
                 </StackItem>
                 <StackItem>
                     <Alert
-                        variant={AlertVariant.danger}
+                        variant="danger"
                         title={error.toString()}
                         component="p"
                         className="pf-v5-u-my-lg pf-v5-u-mx-lg"

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-    Modal,
-    ModalVariant,
-    Button,
-    Bullseye,
-    Spinner,
-    AlertVariant,
-    Alert,
-} from '@patternfly/react-core';
+import { Alert, Bullseye, Button, Modal, Spinner } from '@patternfly/react-core';
 
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import useFetchNotifiers from 'hooks/useFetchNotifiers';
@@ -106,7 +98,7 @@ function NotifyYAMLModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title="Share network policy YAML with team"
             isOpen={isModalOpen}
             onClose={onClose}
@@ -122,7 +114,7 @@ function NotifyYAMLModal({
             {errorMessage && (
                 <Alert
                     isInline
-                    variant={AlertVariant.danger}
+                    variant="danger"
                     title={errorMessage}
                     component="p"
                     className="pf-v5-u-mb-lg"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback } from 'react';
 import {
     Alert,
     AlertActionCloseButton,
-    AlertVariant,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
@@ -176,7 +175,7 @@ function ExceptionRequestDetailsPage() {
             <PageTitle title="Exception Management - Request Details" />
             {successMessage && (
                 <Alert
-                    variant={AlertVariant.success}
+                    variant="success"
                     isInline
                     title={successMessage}
                     component="p"
@@ -184,12 +183,7 @@ function ExceptionRequestDetailsPage() {
                 />
             )}
             {expired && (
-                <Alert
-                    variant={AlertVariant.warning}
-                    isInline
-                    title="Request Canceled."
-                    component="p"
-                >
+                <Alert variant="warning" isInline title="Request Canceled." component="p">
                     You are viewing a canceled request. If this cancelation was not intended, please
                     submit a new request
                 </Alert>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -1,13 +1,5 @@
 import React, { useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Button,
-    Form,
-    Modal,
-    TextArea,
-    pluralize,
-} from '@patternfly/react-core';
+import { Alert, Button, Form, Modal, TextArea, pluralize } from '@patternfly/react-core';
 import * as yup from 'yup';
 import { useFormik } from 'formik';
 import isEqual from 'lodash/isEqual';
@@ -101,12 +93,7 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
                 showClose={false}
             >
                 {errorMessage && (
-                    <Alert
-                        isInline
-                        variant={AlertVariant.danger}
-                        title={errorMessage}
-                        component="p"
-                    />
+                    <Alert isInline variant="danger" title={errorMessage} component="p" />
                 )}
                 <Form>
                     <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, AlertVariant, Button, Flex, Modal, Text } from '@patternfly/react-core';
+import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import {
     VulnerabilityException,
@@ -63,12 +63,7 @@ function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonM
             >
                 <Flex className="pf-v5-u-py-md">
                     {errorMessage && (
-                        <Alert
-                            isInline
-                            variant={AlertVariant.danger}
-                            title={errorMessage}
-                            component="p"
-                        />
+                        <Alert isInline variant="danger" title={errorMessage} component="p" />
                     )}
                     <Alert
                         variant="warning"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -1,14 +1,5 @@
 import React, { useState } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Button,
-    Flex,
-    Form,
-    Modal,
-    Text,
-    TextArea,
-} from '@patternfly/react-core';
+import { Alert, Button, Flex, Form, Modal, Text, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 import { useFormik } from 'formik';
 import isEqual from 'lodash/isEqual';
@@ -100,12 +91,7 @@ function RequestDenialButtonModal({ exception, onSuccess }: RequestDenialButtonM
             >
                 <Flex direction={{ default: 'column' }}>
                     {errorMessage && (
-                        <Alert
-                            isInline
-                            variant={AlertVariant.danger}
-                            title={errorMessage}
-                            component="p"
-                        />
+                        <Alert isInline variant="danger" title={errorMessage} component="p" />
                     )}
                     <Alert
                         variant="warning"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormErrorAlert.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormErrorAlert.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Alert, AlertVariant } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 
 function ReportFormErrorAlert({ error }) {
     const alertRef = React.useRef<HTMLInputElement>(null);
@@ -18,7 +18,7 @@ function ReportFormErrorAlert({ error }) {
             {error && (
                 <Alert
                     isInline
-                    variant={AlertVariant.danger}
+                    variant="danger"
                     title={error}
                     component="p"
                     className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -12,7 +12,6 @@ import {
 import {
     Alert,
     AlertGroup,
-    AlertVariant,
     Bullseye,
     Button,
     Card,
@@ -411,7 +410,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                     {deleteDownloadError && (
                         <Alert
                             isInline
-                            variant={AlertVariant.danger}
+                            variant="danger"
                             title={deleteDownloadError}
                             component="p"
                             className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -4,7 +4,6 @@ import {
     Alert,
     AlertActionCloseButton,
     AlertGroup,
-    AlertVariant,
     PageSection,
     Title,
     Divider,
@@ -170,9 +169,7 @@ function ViewVulnReportPage() {
                     </Alert>
                 ))}
             </AlertGroup>
-            {runError && (
-                <Alert variant={AlertVariant.danger} isInline title={runError} component="p" />
-            )}
+            {runError && <Alert variant="danger" isInline title={runError} component="p" />}
             <PageTitle title="View vulnerability report" />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
@@ -340,7 +337,7 @@ function ViewVulnReportPage() {
                         return (
                             <Alert
                                 isInline
-                                variant={AlertVariant.danger}
+                                variant="danger"
                                 title={`Failed to delete "${reportConfiguration.name}"`}
                                 component="p"
                                 className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, generatePath, useHistory } from 'react-router-dom';
 import isEmpty from 'lodash/isEmpty';
 import {
+    Alert,
     AlertActionCloseButton,
     AlertGroup,
     PageSection,
@@ -18,8 +19,6 @@ import {
     EmptyStateBody,
     EmptyStateVariant,
     Text,
-    Alert,
-    AlertVariant,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
@@ -185,9 +184,7 @@ function VulnReportsPage() {
                 ))}
             </AlertGroup>
             <PageTitle title="Vulnerability reporting" />
-            {runError && (
-                <Alert variant={AlertVariant.danger} isInline title={runError} component="p" />
-            )}
+            {runError && <Alert variant="danger" isInline title={runError} component="p" />}
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex
                     direction={{ default: 'row' }}
@@ -562,7 +559,7 @@ function VulnReportsPage() {
                     {numSuccessfulDeletions > 0 && (
                         <Alert
                             isInline
-                            variant={AlertVariant.success}
+                            variant="success"
                             title={`Successfully deleted ${numSuccessfulDeletions} ${pluralize(
                                 'report',
                                 numSuccessfulDeletions
@@ -581,7 +578,7 @@ function VulnReportsPage() {
                         return (
                             <Alert
                                 isInline
-                                variant={AlertVariant.danger}
+                                variant="danger"
                                 title={`Failed to delete "${report.name}"`}
                                 component="p"
                                 className="pf-v5-u-mb-sm"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -1,14 +1,5 @@
 import React, { ReactElement } from 'react';
-import {
-    Alert,
-    AlertVariant,
-    Divider,
-    Flex,
-    FlexItem,
-    Form,
-    PageSection,
-    Title,
-} from '@patternfly/react-core';
+import { Alert, Divider, Flex, FlexItem, Form, PageSection, Title } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 
 import { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
@@ -93,7 +84,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPar
             {cvesDiscoveredSinceError && (
                 <Alert
                     isInline
-                    variant={AlertVariant.danger}
+                    variant="danger"
                     title="Delivery destination & schedule are both required to be configured since the 'Last scheduled report that was successfully sent' option has been selected in Step 1."
                     component="p"
                 />


### PR DESCRIPTION
### Description

Because of change to 4.6 code freeze, replace enum first, and then add `no-Variant` lint rule after.

### Problem

1. In general, more consistency lowers the barrier to contributors from other teams.
2. In specific, `AlertVariant` enum is an extra import.

### Analysis

The source of truth for prop values of PatternFly elements is string **enumeration**, not string **enum**.

For example,

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Alert/Alert.tsx#L80

```tsx
variant?: 'success' | 'danger' | 'warning' | 'info' | 'custom';
```

**not**

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Alert/Alert.tsx#L12-L18

```tsx
export enum AlertVariant {
  success = 'success',
  danger = 'danger',
  warning = 'warning',
  info = 'info',
  custom = 'custom'
}
```

### Solution

1. Delete `AlertVariant` from import statement.
    Also delete `ModalVariant` in parallel in a few files where it would cause a merge conflict to replace in sequence.
2. Replace member of `AlertVariant` enum with corresponding string from enumeration.
    Ditto the above.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -8 = 4619645 - 4619653
        total -120 = 11801281 - 11801401
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178