### PR TITLE
ROX-25949: Add capability for Secured Cluster cert reissue

### DIFF
--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -105,6 +105,7 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		utils.Should(err)
 
 		capabilities := sliceutils.StringSlice(eventPipeline.Capabilities()...)
+		capabilities = append(capabilities, centralsensor.SecuredClusterCertificatesReissue)
 		if features.SensorReconciliationOnReconnect.Enabled() {
 			capabilities = append(capabilities, centralsensor.SendDeduperStateOnReconnect)
 		}

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -60,4 +60,7 @@ const (
 
 	// ComplianceV2ScanConfigSync identifies the capability of sensor to support scan configuration sync when connecting to central.
 	ComplianceV2ScanConfigSync SensorCapability = "ComplianceV2ScanConfigSync"
+
+	// SecuredClusterCertificatesReissue identifies the capability of Central to reissue a new set of Secured Clusters certificates
+	SecuredClusterCertificatesReissue = "SecuredClusterCertificatesReissue"
 )


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

https://github.com/stackrox/stackrox/pull/12740 added a Central API that re-issues all the Secured Cluster certificates.

It should have included also this piece, to advertise this functionality via a capability.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested by deploying with `./deploy/k8s/deploy-local.sh` that the capability gets propagated to sensor.
