### PR TITLE
chore(ui): Replace ButtonVariant enum with string

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
-import { Modal, ModalVariant, Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 type ConfirmationModalProps = {
     ariaLabel: string;
@@ -29,13 +29,13 @@ function ConfirmationModal({
     return (
         <Modal
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant="small"
             title={title || ''}
             titleIconVariant="warning"
             actions={[
                 <Button
                     key="confirm"
-                    variant={isDestructive ? ButtonVariant.danger : ButtonVariant.primary}
+                    variant={isDestructive ? 'danger' : 'primary'}
                     onClick={onConfirm}
                     className="pf-confirmation-modal-confirm-btn"
                     isDisabled={isConfirmDisabled || isLoading}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import {
     Button,
-    ButtonVariant,
     Pagination,
     SearchInput,
     Toolbar,
@@ -158,7 +157,7 @@ function CollectionsTable({
                         children: (
                             <div>
                                 <Button
-                                    variant={ButtonVariant.primary}
+                                    variant="primary"
                                     component={LinkShim}
                                     href={`${collectionsBasePath}?action=create`}
                                 >

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -6,7 +6,6 @@ import {
     Button,
     Flex,
     FlexItem,
-    ButtonVariant,
     Divider,
     Alert,
     AlertActionCloseButton,
@@ -97,7 +96,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                     {hasWriteAccessForCollections && (
                         <FlexItem align={{ default: 'alignRight' }}>
                             <Button
-                                variant={ButtonVariant.primary}
+                                variant="primary"
                                 component={LinkShim}
                                 href={`${collectionsBasePath}?action=create`}
                             >

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { Button, ButtonVariant, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
 
 import { violationsBasePath } from 'routePaths';
 import { SearchFilter } from 'types/search';
@@ -25,7 +25,7 @@ function SeverityTile({ severity, violationCount, link }: SeverityTileProps) {
             }
             className="pf-severity-tile pf-v5-u-w-100 pf-v5-u-px-md pf-v5-u-py-sm pf-v5-u-align-items-center"
             key={severity}
-            variant={ButtonVariant.link}
+            variant="link"
             component={LinkShim}
             href={link}
         >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -3,7 +3,6 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Button,
-    ButtonVariant,
     Divider,
     Flex,
     FlexItem,
@@ -80,7 +79,7 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                             {editDisabledMessage ? (
                                 <Tooltip content={editDisabledMessage}>
                                     <Button
-                                        variant={ButtonVariant.secondary}
+                                        variant="secondary"
                                         component={LinkShim}
                                         href={integrationEditPath}
                                         isAriaDisabled={!!editDisabledMessage}
@@ -90,7 +89,7 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                                 </Tooltip>
                             ) : (
                                 <Button
-                                    variant={ButtonVariant.secondary}
+                                    variant="secondary"
                                     component={LinkShim}
                                     href={integrationEditPath}
                                 >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Button,
-    ButtonVariant,
     Divider,
     Flex,
     FlexItem,
@@ -119,7 +118,7 @@ function IntegrationsTable({
                             {permissions[source].write && !isReadOnly && (
                                 <FlexItem>
                                     <Button
-                                        variant={ButtonVariant.primary}
+                                        variant="primary"
                                         component={LinkShim}
                                         href={getPathToCreate(source, type)}
                                         data-testid="add-integration"

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import pluralize from 'pluralize';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 
 type NodeUpdateSectionProps = {
     isLoading: boolean;
@@ -18,7 +18,7 @@ const NodesUpdateSection = ({
     if (!isLoading && nodeUpdatesCount > 0) {
         return (
             <Button
-                variant={ButtonVariant.secondary}
+                variant="secondary"
                 onClick={updateNetworkNodes}
                 aria-label="Click to refresh the graph"
             >

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
     Button,
-    ButtonVariant,
     Modal,
     ModalBoxBody,
     ModalBoxFooter,
@@ -75,7 +74,7 @@ function TableModal({
             <Button
                 key="open-select-modal"
                 data-testid="table-modal-open-button"
-                variant={ButtonVariant.primary}
+                variant="primary"
                 onClick={() => {
                     setIsModalOpen(true);
                 }}

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactElement } from 'react';
-import { Button, ButtonVariant, Flex, Popover, PopoverPosition } from '@patternfly/react-core';
+import { Button, Flex, Popover, PopoverPosition } from '@patternfly/react-core';
 import { AngleDownIcon, AngleUpIcon, DownloadIcon } from '@patternfly/react-icons';
 import { useFormik } from 'formik';
 import { parse } from 'date-fns';
@@ -77,7 +77,7 @@ function GenerateDiagnosticBundle(): ReactElement {
     const footerContent = (
         <Flex spaceItems={{ default: 'spaceItemsLg' }}>
             <Button
-                variant={ButtonVariant.primary}
+                variant="primary"
                 onClick={submitForm}
                 icon={isSubmitting ? null : <DownloadIcon />}
                 spinnerAriaValueText={isSubmitting ? 'Downloading' : undefined}
@@ -129,7 +129,7 @@ function GenerateDiagnosticBundle(): ReactElement {
             showClose={false}
             isVisible={isOpen}
         >
-            <Button variant={ButtonVariant.secondary}>
+            <Button variant="secondary">
                 <Flex
                     alignItems={{ default: 'alignItemsCenter' }}
                     spaceItems={{ default: 'spaceItemsXs' }}

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonVariant, Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core';
+import { Button, Modal, ModalBoxBody } from '@patternfly/react-core';
 import useModal from 'hooks/useModal';
 import AdministrationUsageForm from './AdministrationUsageForm';
 
@@ -11,7 +11,7 @@ function ShowAdministrationUsage(): ReactElement {
             <Button
                 key="open-select-modal"
                 data-testid="administration-usage-modal-open-button"
-                variant={ButtonVariant.secondary}
+                variant="secondary"
                 onClick={openModal}
             >
                 Show administration usage
@@ -20,7 +20,7 @@ function ShowAdministrationUsage(): ReactElement {
                 title="Administration usage"
                 description="The page shows the collected administration usage data: number of secured Kubernetes nodes and CPU units. The current usage is computed from the latest metrics received from sensors, and there can be a delay of about 5 minutes. The maximum usage is aggregated hourly and only includes clusters that are still connected. The date range is inclusive and depends on the user's timezone. Data shown is not sent to Red Hat or displayed as Prometheus metrics."
                 isOpen={isModalOpen}
-                variant={ModalVariant.large}
+                variant="large"
                 onClose={closeModal}
                 aria-label="Administration usage"
                 hasNoBodyWrapper

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsSearchFilter.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import {
     Button,
-    ButtonVariant,
     Flex,
     FlexItem,
     InputGroup,
@@ -76,7 +75,7 @@ function ApprovedDeferralsSearchFilter({
                         </InputGroupItem>
                         <InputGroupItem>
                             <Button
-                                variant={ButtonVariant.control}
+                                variant="control"
                                 aria-label="search button for search input"
                                 onClick={() => handleSearchChange(inputValue)}
                             >

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesSearchFilter.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import {
-    Button,
-    ButtonVariant,
-    InputGroup,
-    TextInput,
-    InputGroupItem,
-} from '@patternfly/react-core';
+import { Button, InputGroup, TextInput, InputGroupItem } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import { SearchFilter } from 'types/search';
@@ -52,7 +46,7 @@ function ApprovedFalsePositivesSearchFilter({
             </InputGroupItem>
             <InputGroupItem>
                 <Button
-                    variant={ButtonVariant.control}
+                    variant="control"
                     aria-label="search button for search input"
                     onClick={() => handleSearchChange(inputValue)}
                 >

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/DeferredCVEsTable.tsx
@@ -3,7 +3,6 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,
-    ButtonVariant,
     Divider,
     PageSection,
     PageSectionVariants,
@@ -242,7 +241,7 @@ function DeferredCVEsTable({
                                     </Td>
                                     <Td dataLabel="Affected components">
                                         <Button
-                                            variant={ButtonVariant.link}
+                                            variant="link"
                                             isInline
                                             onClick={() => {
                                                 showComponentDetails(row.components, row.cve);

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/FalsePositiveCVEsTable.tsx
@@ -3,7 +3,6 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
     Bullseye,
     Button,
-    ButtonVariant,
     Divider,
     PageSection,
     PageSectionVariants,
@@ -227,7 +226,7 @@ function FalsePositiveCVEsTable({
                                     </Td>
                                     <Td dataLabel="Affected components">
                                         <Button
-                                            variant={ButtonVariant.link}
+                                            variant="link"
                                             isInline
                                             onClick={() => {
                                                 showComponentDetails(row.components, row.cve);

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImageVulnsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImageVulnsSearchFilter.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import {
     Button,
-    ButtonVariant,
     Flex,
     FlexItem,
     InputGroup,
@@ -81,7 +80,7 @@ function ImageVulnsSearchFilter({
                         </InputGroupItem>
                         <InputGroupItem>
                             <Button
-                                variant={ButtonVariant.control}
+                                variant="control"
                                 aria-label="search button for CVE search input"
                                 onClick={() => handleSearchChange(inputValue)}
                             >

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntities.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntities.tsx
@@ -1,6 +1,6 @@
 import React, { useState, ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Button, ButtonVariant, Flex, FlexItem, Label } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Label } from '@patternfly/react-core';
 
 import entityTypes from 'constants/entityTypes';
 import ImpactedEntitiesModal from './ImpactedEntitiesModal';
@@ -33,7 +33,7 @@ function ImpactedEntities({
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                 <FlexItem>
                     <Button
-                        variant={ButtonVariant.link}
+                        variant="link"
                         isInline
                         onClick={() => {
                             openModal(entityTypes.DEPLOYMENT);
@@ -46,7 +46,7 @@ function ImpactedEntities({
                 </FlexItem>
                 <FlexItem>
                     <Button
-                        variant={ButtonVariant.link}
+                        variant="link"
                         isInline
                         onClick={() => {
                             openModal(entityTypes.IMAGE);

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/ObservedCVEsTable.tsx
@@ -5,7 +5,6 @@ import { Table, Thead, Tbody, Tr, Th, Td, IActions } from '@patternfly/react-tab
 import {
     Bullseye,
     Button,
-    ButtonVariant,
     Divider,
     Flex,
     FlexItem,
@@ -280,7 +279,7 @@ function ObservedCVEsTable({
                                     <Td dataLabel="CVSS score">{Number(row.cvss).toFixed(1)}</Td>
                                     <Td dataLabel="Affected components">
                                         <Button
-                                            variant={ButtonVariant.link}
+                                            variant="link"
                                             isInline
                                             onClick={() => {
                                                 showComponentDetails(row.components, row.cve);

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsSearchFilter.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import {
     Button,
-    ButtonVariant,
     Flex,
     FlexItem,
     InputGroup,
@@ -80,7 +79,7 @@ function PendingApprovalsSearchFilter({
                         </InputGroupItem>
                         <InputGroupItem>
                             <Button
-                                variant={ButtonVariant.control}
+                                variant="control"
                                 aria-label="search button for search input"
                                 onClick={() => handleSearchChange(inputValue)}
                             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, ReactElement, useCallback } from 'react';
-import { Button, ButtonVariant, Flex, FlexItem, ValidatedOptions } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, ValidatedOptions } from '@patternfly/react-core';
 import {
     Select,
     SelectOption,
@@ -210,7 +210,7 @@ function CollectionSelection({
                 {isRouteEnabledForCollections && (
                     <FlexItem spacer={{ default: 'spacerMd' }}>
                         <Button
-                            variant={ButtonVariant.tertiary}
+                            variant="tertiary"
                             onClick={onOpenViewCollectionModal}
                             isDisabled={!selectedScope}
                         >


### PR DESCRIPTION
### Description

Because of change to 4.6 code freeze, replace enum first, and then add `no-Variant` lint rule after.

### Problem

1. In general, more consistency lowers the barrier to contributors from other teams.
2. In specific, `ButtonVariant` enum is an extra import.

### Analysis

The source of truth for prop values of PatternFly elements is string **enumeration**, not string **enum**.

For example,

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Button/Button.tsx#L79

```tsx
variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'warning' | 'link' | 'plain' | 'control' | 'stateful';
```

**not**

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Button/Button.tsx#L8-L18

```tsx
export enum ButtonVariant {
  primary = 'primary',
  secondary = 'secondary',
  tertiary = 'tertiary',
  danger = 'danger',
  warning = 'warning',
  link = 'link',
  plain = 'plain',
  control = 'control',
  stateful = 'stateful'
}
```

### Solution

1. Delete `ButtonVariant` from import statement.
    Also delete `ModalVariant` in parallel in a few files where it would cause a merge conflict to replace in sequence.
2. Replace member of `ButtonVariant` enum with corresponding string from enumeration.
    Ditto the above.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619653 - 4619653
        total -97 = 11801304 - 11801401
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178