### PR TITLE
chore(ui): Replace ModalVariant enum with string

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -2,7 +2,7 @@ import React, { useState, ReactElement } from 'react';
 import pluralize from 'pluralize';
 import { useSelector, useDispatch } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { selectors } from 'reducers';
@@ -127,7 +127,7 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                 </Tbody>
             </Table>
             <Modal
-                variant={ModalVariant.small}
+                variant="small"
                 title="Permanently delete auth provider?"
                 isOpen={!!authProviderToDelete}
                 onClose={clearPendingDelete}

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect, ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import {
-    Alert,
-    Button,
-    Modal,
-    ModalVariant,
-    ModalBoxBody,
-    ModalBoxFooter,
-    Text,
-} from '@patternfly/react-core';
+import { Alert, Button, Modal, ModalBoxBody, ModalBoxFooter, Text } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
@@ -211,7 +203,7 @@ function InviteUsersModal(): ReactElement | null {
         <Modal
             title="Invite users"
             isOpen={showInviteModal}
-            variant={ModalVariant.small}
+            variant="small"
             onClose={onClose}
             aria-label="Invite users"
             hasNoBodyWrapper

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Modal, ModalVariant } from '@patternfly/react-core';
+import { Modal } from '@patternfly/react-core';
 
 import { importPolicies } from 'services/PoliciesService';
 import { Policy } from 'types/policy.proto';
@@ -90,7 +90,7 @@ function ImportPolicyJSONModal({
         <Modal
             title="Import policy JSON"
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant="small"
             onClose={handleCancelModal}
             data-testid="import-policy-modal"
             aria-label="Import policy"

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import * as yup from 'yup';
 import {
     Modal,
-    ModalVariant,
     ModalBoxBody,
     ModalBoxFooter,
     Button,
@@ -80,7 +79,7 @@ function CreatePolicyCategoryModal({
         <Modal
             title="Create category"
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant="small"
             onClose={onCancel}
             data-testid="create-category-modal"
             aria-label="Create category"

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
     Modal,
-    ModalVariant,
     ModalBoxBody,
     ModalBoxFooter,
     Button,
@@ -74,7 +73,7 @@ function DeletePolicyCategoryModal({
         <Modal
             title="Permanently delete category?"
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant="small"
             onClose={onClose}
             data-testid="delete-category-modal"
             aria-label="Permanently delete category?"

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Flex, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, Flex, Modal } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
@@ -22,7 +22,7 @@ function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyMod
     return (
         <Modal
             title="Network policy details"
-            variant={ModalVariant.small}
+            variant="small"
             isOpen={isOpen}
             onClose={onClose}
             actions={[

--- a/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Alert, Button, Flex, Modal, ModalVariant, Text } from '@patternfly/react-core';
+import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import { excludeDeployments } from 'services/PoliciesService';
 import { DeploymentListAlert, ListAlert } from 'types/alert.proto';
@@ -64,7 +64,7 @@ function ExcludeConfirmation({
     return (
         <Modal
             isOpen={isOpen}
-            variant={ModalVariant.medium}
+            variant="medium"
             actions={[
                 <Button
                     key="confirm"

--- a/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Modal, ModalVariant, Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { resolveAlerts } from 'services/AlertsService';
 
@@ -32,7 +32,7 @@ function ResolveConfirmation({
     return (
         <Modal
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant="small"
             actions={[
                 <Button key="confirm" variant="primary" onClick={resolveAlertsAction}>
                     Confirm

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -7,7 +7,6 @@ import {
     GridItem,
     InputGroup,
     Modal,
-    ModalVariant,
     TextInput,
     InputGroupItem,
 } from '@patternfly/react-core';
@@ -57,7 +56,7 @@ function AffectedComponentsModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={`Components affected by ${cveName}`}
             isOpen={isOpen}
             onClose={onCloseHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/UpdateDeferralModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/UpdateDeferralModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Button, Form, Modal, ModalVariant, Radio, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, Radio, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import FormLabelGroup from 'Containers/Integrations/IntegrationForm/FormLabelGroup';
@@ -69,7 +69,7 @@ function UpdateDeferralFormModal({
     // @TODO: Create reusable components for the action buttons and form fields
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onHandleCancel}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/CancelDeferralModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/DeferredCVEs/CancelDeferralModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -70,7 +70,7 @@ function CancelDeferralModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title="Cancel deferral and reobserve CVE"
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/ReobserveCVEModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/FalsePositiveCVEs/ReobserveCVEModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -70,7 +70,7 @@ function ReobserveCVEModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title="Reobserve CVE"
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntitiesModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ImpactedEntities/ImpactedEntitiesModal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Flex, FlexItem, Modal, ModalVariant, Title } from '@patternfly/react-core';
+import { Flex, FlexItem, Modal, Title } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
@@ -49,7 +49,7 @@ function ImpactedEntitiesModal({
     );
 
     return (
-        <Modal variant={ModalVariant.small} header={header} isOpen={isOpen} onClose={onClose}>
+        <Modal variant="small" header={header} isOpen={isOpen} onClose={onClose}>
             <Table aria-label="Simple table" variant="compact">
                 <Thead>
                     <Tr>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/DeferralFormModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/DeferralFormModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, Radio, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, Radio, TextArea } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -110,7 +110,7 @@ function DeferralFormModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/FalsePositiveFormModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/FalsePositiveFormModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, Radio, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, Radio, TextArea } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -90,7 +90,7 @@ function FalsePositiveFormModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/ApproveDeferralModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/ApproveDeferralModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
@@ -81,7 +81,7 @@ function ApproveDeferralModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/ApproveFalsePositiveModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/ApproveFalsePositiveModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
@@ -82,7 +82,7 @@ function ApproveFalsePositiveModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/CancelVulnRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/CancelVulnRequestModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
@@ -56,7 +56,7 @@ function CancelVulnRequestModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/DenyDeferralModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/DenyDeferralModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
@@ -73,7 +73,7 @@ function DenyDeferralModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/DenyFalsePositiveModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/DenyFalsePositiveModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Form, Modal, ModalVariant, TextArea } from '@patternfly/react-core';
+import { Button, Form, Modal, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
@@ -73,7 +73,7 @@ function ApproveFalsePositiveModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RequestComments/RequestCommentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RequestComments/RequestCommentsModal.tsx
@@ -7,7 +7,6 @@ import {
     HintFooter,
     HintTitle,
     Modal,
-    ModalVariant,
 } from '@patternfly/react-core';
 
 import { RequestComment } from 'types/vuln_request.proto';
@@ -27,7 +26,7 @@ function RequestCommentsModal({
     onClose,
 }: RequestCommentsModalProps): ReactElement {
     return (
-        <Modal variant={ModalVariant.small} title={cve} isOpen={isOpen} onClose={onClose}>
+        <Modal variant="small" title={cve} isOpen={isOpen} onClose={onClose}>
             <Flex direction={{ default: 'columnReverse' }}>
                 {comments.map((comment) => {
                     return (

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/UndoVulnRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/UndoVulnRequestModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import FormMessage, { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -56,7 +56,7 @@ function UndoVulnRequestModal({
 
     return (
         <Modal
-            variant={ModalVariant.small}
+            variant="small"
             title={title}
             isOpen={isOpen}
             onClose={onCancelHandler}


### PR DESCRIPTION
### Description

Because of change to 4.6 code freeze, replace enum first, and then add `no-Variant` lint rule after.

### Problem

1. In general, more consistency lowers the barrier to contributors from other teams.
2. In specific, `ModalVariant` enum is an extra import.

### Analysis

The source of truth for prop values of PatternFly elements is string **enumeration**, not string **enum**.

For example,

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Modal/Modal.tsx#L44

```tsx
variant?: 'small' | 'medium' | 'large' | 'default';
```

**not**

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Modal/Modal.tsx#L55-L60

```tsx
export enum ModalVariant {
  small = 'small',
  medium = 'medium',
  large = 'large',
  default = 'default'
}
```

### Solution

Skip occurrences in sibling contributions that would have caused merge conflict.

1. Delete `ModalVariant` from import statement.
2. Replace member of `ModalVariant` enum with corresponding string from enumeration.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -3 = 4619650 - 4619653
        total -48 = 11801353 - 11801401
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178