### PR TITLE
fix(ui): Add dataLabel prop to Td element in Vulnerabilities

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -496,12 +496,12 @@ function VulnReportsPage() {
                                                             isSelected: selected[rowIndex],
                                                         }}
                                                     />
-                                                    <Td>
+                                                    <Td dataLabel="Report">
                                                         <Link to={vulnReportURL}>
                                                             {report.name}
                                                         </Link>
                                                     </Td>
-                                                    <Td>
+                                                    <Td dataLabel="Collection">
                                                         {isCollectionsRouteEnabled ? (
                                                             <Button
                                                                 variant="link"
@@ -518,8 +518,10 @@ function VulnReportsPage() {
                                                             collectionName
                                                         )}
                                                     </Td>
-                                                    <Td>{report.description || '-'}</Td>
-                                                    <Td>
+                                                    <Td dataLabel="Description">
+                                                        {report.description || '-'}
+                                                    </Td>
+                                                    <Td dataLabel="My last job status">
                                                         <MyLastJobStatus
                                                             snapshot={snapshot}
                                                             isLoadingSnapshots={

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -65,13 +65,15 @@ function ImageResourceTable({ data, getSortParams }: ImageResourceTableProps) {
                         }}
                     >
                         <Tr>
-                            <Td width={50}>
+                            <Td dataLabel="Name" width={50}>
                                 {name ? <ImageNameLink id={id} name={name} /> : 'NAME UNKNOWN'}
                             </Td>
                             {/* Given that this is in the context of a deployment, when would `deploymentCount` ever be less than zero? */}
-                            <Td>{deploymentCount > 0 ? 'Active' : 'Inactive'}</Td>
-                            <Td>{operatingSystem}</Td>
-                            <Td>
+                            <Td dataLabel="Image status">
+                                {deploymentCount > 0 ? 'Active' : 'Inactive'}
+                            </Td>
+                            <Td dataLabel="Image OS">{operatingSystem}</Td>
+                            <Td dataLabel="Created">
                                 <DateDistance date={scanTime} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -60,7 +60,7 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                         }}
                     >
                         <Tr>
-                            <Td>
+                            <Td dataLabel="Name">
                                 <Link
                                     to={getWorkloadEntityPagePath(
                                         'Deployment',
@@ -71,9 +71,9 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                                     {name}
                                 </Link>
                             </Td>
-                            <Td>{clusterName}</Td>
-                            <Td>{namespace}</Td>
-                            <Td>
+                            <Td dataLabel="Cluster">{clusterName}</Td>
+                            <Td dataLabel="Namespace">{namespace}</Td>
+                            <Td dataLabel="Created">
                                 <DateDistance date={created} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -109,7 +109,7 @@ function DeploymentComponentVulnerabilitiesTable({
                 return (
                     <Tbody key={`${image.id}:${name}:${version}`} style={style}>
                         <Tr>
-                            <Td>
+                            <Td dataLabel="Image">
                                 {image.name ? (
                                     <PendingExceptionLabelLayout
                                         hasPendingException={hasPendingException}
@@ -122,19 +122,19 @@ function DeploymentComponentVulnerabilitiesTable({
                                     'Image name not available'
                                 )}
                             </Td>
-                            <Td modifier="nowrap">
+                            <Td dataLabel="CVE severity" modifier="nowrap">
                                 <VulnerabilitySeverityIconText severity={severity} />
                             </Td>
-                            <Td modifier="nowrap">
+                            <Td dataLabel="CVSS" modifier="nowrap">
                                 <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
-                            <Td>{name}</Td>
-                            <Td>{version}</Td>
-                            <Td modifier="nowrap">
+                            <Td dataLabel="Component">{name}</Td>
+                            <Td dataLabel="Version">{version}</Td>
+                            <Td dataLabel="CVE fixed in" modifier="nowrap">
                                 <FixedByVersion fixedByVersion={fixedByVersion} />
                             </Td>
-                            <Td>{source}</Td>
-                            <Td>
+                            <Td dataLabel="Source">{source}</Td>
+                            <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>
                         </Tr>


### PR DESCRIPTION
### Description

Prerequisite for lint rule to require `dataLabel` prop.

### Residue

1. Investigate what to do about checkbox and kebab.
2. VulnReportsTable.tsx file: `MyLastJobStatusTh` element encapsulates text that lint rule needs to verify that `dataLabel` prop is consistent.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619653 - 4619653
        total 426 = 11801827 - 11801401
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178

#### Manual testing

1. Visit /main/vulnerabilities/reports and then create a report.

    VulnReportsPage.tsx file.

    * Before changes without `dataLabel` props, see absence of responsive labels at 760px width.
        ![VulnReportsPage_absence](https://github.com/user-attachments/assets/d6511517-38b0-4878-ba69-28e8b09017a2)

    * After changes with `dataLabel` props, see presence of responsive labels at 760px width.
        ![VulnReportsPage_presence](https://github.com/user-attachments/assets/69d02936-d9f4-413b-a761-62614dfc278d)

2. Visit /main/vulnerabilities/workload-cves/deployments/id and then click **Resources** tab.

    ImageResourceTable.tsx file.

    * Before changes without `dataLabel` props, see absence of responsive labels at 760px width.
        ![ImageResourceTable_absence](https://github.com/user-attachments/assets/1553eeb0-c2e4-4362-a1fb-32b12de5f612)

    * After changes with `dataLabel` props, see presence of responsive labels at 760px width.
        ![ImageResourceTable_presence](https://github.com/user-attachments/assets/74fddbb0-1524-432e-be8a-74ddde2069f1)

3. Visit /main/vulnerabilities/workload-cves/images/id and then click **Resources** tab.

    DeploymentResourceTable.tsx file.

    * Before changes without `dataLabel` props, see absence of responsive labels at 760px width.
        ![DeploymentResourceTable_absence](https://github.com/user-attachments/assets/afaaef9c-6a86-432c-afd1-e7e7a909421f)

    * After changes with `dataLabel` props, see presence of responsive labels at 760px width.
        ![DeploymentResourceTable_presence](https://github.com/user-attachments/assets/cba4acd1-ff47-4829-9337-117d6b76c0fa)

4. Visit /main/vulnerabilities/workload-cves/deployments/id and then expand a vulnerability.

    DeploymentComponentVulnerabilitiesTable.tsx

    * Before changes without `dataLabel` props, see absence of responsive labels at 760px width.
        ![DeploymentComponentVulnerabilitiesTable_absence](https://github.com/user-attachments/assets/58524348-43b7-417a-9d54-dfb57babdfa8)

    * After changes with `dataLabel` props, see presence of responsive labels at 760px width.
        ![DeploymentComponentVulnerabilitiesTable_presence](https://github.com/user-attachments/assets/ade8b7cb-872f-4ce9-94b5-7e328829d731)
