### PR TITLE
chore(ui): Delete test skip for ROX_AUTH_MACHINE_TO_MACHINE

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/machineAccessConfigs.test.ts
+++ b/ui/apps/platform/cypress/integration/integrations/machineAccessConfigs.test.ts
@@ -13,18 +13,11 @@ import {
     getSelectButtonByLabel,
     getSelectOption,
 } from '../../helpers/formHelpers';
-import { hasFeatureFlag } from '../../helpers/features';
 
 const integrationSource = 'authProviders';
 
 describe('Machine Access Configs', () => {
     withAuth();
-
-    before(function () {
-        if (!hasFeatureFlag('ROX_AUTH_MACHINE_TO_MACHINE')) {
-            this.skip();
-        }
-    });
 
     it('should create a new Machine Access integration and then view and delete', () => {
         const integrationType = 'machineAccess';


### PR DESCRIPTION
### Description

Found last week by accident that feature flag has been turned on since 2024-02-14 in #9932

No conditional code in src folder.

### Residue

1. Ask Merlin team to delete any leftover conditional code from backend

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

#### Integration testing

* integrations/machineAccessConfigs.test.ts