### PR TITLE
fix: Change Node Indexing default settings

### DIFF
--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -120,19 +120,22 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	return nil
 }
 
+// shouldDiscardMsg returns true if the pipeline should discard an incoming message or false if it should keep processing it.
 func shouldDiscardMsg(node *storage.Node) bool {
-	// In a mixed environment, there might be NodeInventory-only clusters, so there is no
-	// Scanner v4 scan available for that cluster. Keep the v2 scan in that case, even if Node Indexing is enabled.
+	// In a mixed environment, there might be v2-only clusters, so there is no Scanner v4 scan available for that cluster.
+	// If a cluster only ever produces v2 NodeScans, they need to be processed and persisted, even if Node Indexing is enabled.
 	if node.GetScan() == nil || node.GetScan().ScannerVersion != storage.NodeScan_SCANNER_V4 {
 		return false
 	}
-	// Discard a message if NodeScanning v4 and v2 are running in parallel - v4 scans are prioritized in that case.
-	// The message will be kept if any of the two switches is disabled.
-	// This ensures node scans are updated even if a customer falls back to Scanner v2.
+	// Discard this v2 message if NodeScanning v4 and v2 are running in parallel on the same cluster.
+	// v4 scans are prioritized in that case.
 	if features.ScannerV4.Enabled() && env.NodeIndexEnabled.BooleanSetting() {
 		return true
 	}
-
+	// If either ScannerV4 or the feature flag are disabled, v2 scans are processed and persisted normally,
+	// even if there are already v4 scans in the database.
+	// This is a safety fallback to keep node scanning working if a customer decides to disable v4 node indexing
+	// after it already ran at least once.
 	return false
 }
 

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -111,8 +111,6 @@ spec:
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT
           value: "true"
-        - name: ROX_NODE_INDEX_ENABLED
-          value: "true"
         {{- end }}
         {{- if ._rox.env.managedServices }}
         - name: ROX_MANAGED_CENTRAL

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -111,10 +111,10 @@ spec:
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT
           value: "true"
-        {{- end }}
-        {{- if ._rox.env.managedServices }}
         - name: ROX_NODE_INDEX_ENABLED
           value: "true"
+        {{- end }}
+        {{- if ._rox.env.managedServices }}
         - name: ROX_MANAGED_CENTRAL
           value: "true"
         - name: ROX_ENABLE_CENTRAL_DIAGNOSTICS

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -135,7 +135,7 @@ spec:
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
         - name: ROX_NODE_INDEX_ENABLED
-          value: false
+          value: "false"
       {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -135,7 +135,7 @@ spec:
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
         - name: ROX_NODE_INDEX_ENABLED
-          value: {{ eq ._rox.env.openshift 4 | quote }}
+          value: false
       {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"


### PR DESCRIPTION
### Description

This PR does three things:
1. Conditionally enable Node Indexing support on Central if deployed on OpenShift 
1. Disable Node Indexing on Compliance by default
1. Rework logic to discard v2 Node Scanning messages

---

1. is a fix for an introduced bug. Currently Node Indexing is enabled on central when running on managed services.
2. is done as Node Indexing will not be released as GA. By disabling it in Compliance, we ensure we don't generate any additional I/O or CPU load on the Collector DaemonSet by not running Node Index scans in the first place.
3. is done to ensure proper operation of NodeScanning in environments with mixed Secured Cluster versions, e.g. some clusters run v4-only, some clusters run v2-only.

---

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Deployed on a test instance with Helm and manually verified functionality.
Updated unit tests.
