### PR TITLE
ROX-25990: Add history for containerIDs in Sensor

### DIFF
--- a/sensor/common/clusterentities/metrics/metrics.go
+++ b/sensor/common/clusterentities/metrics/metrics.go
@@ -12,6 +12,12 @@ var (
 		Name:      "num_containers_in_entity_store",
 		Help:      "A gauge to track the number of containers in the entity store",
 	})
+	historicalContainersStored = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "num_historical_containers_in_entity_store",
+		Help:      "A gauge to track the number of historical containers in the entity store",
+	})
 )
 
 // UpdateNumberContainersInEntityStored update number of containers stored
@@ -19,6 +25,12 @@ func UpdateNumberContainersInEntityStored(num int) {
 	containersStored.Set(float64(num))
 }
 
+// UpdateNumberHistoricalContainersInEntityStored update number of containers stored
+func UpdateNumberHistoricalContainersInEntityStored(num int) {
+	historicalContainersStored.Set(float64(num))
+}
+
 func init() {
 	prometheus.MustRegister(containersStored)
+	prometheus.MustRegister(historicalContainersStored)
 }

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -383,6 +383,7 @@ func (e *Store) purgeNoLock(deploymentID string) {
 			// as it is an equivalent of: delete(e.containerIDMap, containerID)
 			e.removeHistoricalExpiredContainerIDs(containerID, meta)
 		}
+		delete(e.containerIDMap, containerID)
 	}
 
 	delete(e.reverseIPMap, deploymentID)

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -340,11 +340,9 @@ func (e *Store) purgeNoLock(deploymentID string) {
 	for containerID := range e.reverseContainerIDMap[deploymentID] {
 		if meta, found := e.containerIDMap[containerID]; found {
 			e.markContainerIDHistorical(containerID, meta)
-			// This must be called here in case memorySize is set to 0
+			// If memorySize is set to 0, this must be called here
+			// as it is an equivalent of: delete(e.containerIDMap, containerID)
 			e.removeHistoricalExpiredContainerIDs(containerID, meta)
-		}
-		if len(e.containerIDMap) == 0 {
-			delete(e.containerIDMap, containerID)
 		}
 	}
 

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -96,9 +96,7 @@ func (e *Store) initMaps() {
 	e.historicalContainerIDs = make(map[string]map[ContainerMetadata]*entityStatus)
 }
 
-func (e *Store) resetMaps() {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
+func (e *Store) resetMapsNoLock() {
 	// Maps holding historical data must not be wiped on reset! Instead, all entities must be marked as historical.
 	// Must be called before the respective source maps are wiped!
 	e.resetHistoricalMapsNoLock()
@@ -169,8 +167,8 @@ func (e *Store) updateMetrics() {
 func (e *Store) Cleanup() {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	defer e.updateMetrics()
-	e.resetMaps()
+	e.resetMapsNoLock()
+	e.updateMetrics()
 }
 
 // Apply applies an update to the store. If incremental is true, data will be added; otherwise, data for each deployment

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -250,6 +250,26 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"pod1": true, "pod2": true},
 			},
 		},
+		"Unknown containers shall not be found": {
+			numTicksToRemember: 2,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  true,
+					},
+				},
+			},
+			endpointsAfterTick: []map[string]bool{
+				{"10.0.0.1": true},
+			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true, "unknown": false},
+			},
+		},
 	}
 	for name, tCase := range cases {
 		s.Run(name, func() {

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -590,7 +590,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 				{"pod1": nowhere},
 			},
 		},
-		"Re-adding normally deleted container should reset the history status": {
+		"Re-adding normally deleted container after history expired should reset the history status": {
 			numTicksToRemember: 2,
 			entityUpdates: map[int][]eUpdate{
 				0: {
@@ -619,6 +619,36 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 				// adding container again
 				{"pod1": theMap}, // after tick 5: should be normally added to the map
 				{"pod1": theMap}, // after tick 6: should stay in the map until the next deletion or reset
+				{"pod1": theMap},
+			},
+		},
+		"Re-adding normally deleted container before history expired should reset the history status": {
+			numTicksToRemember: 1,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true,
+					},
+				},
+				3: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true,
+					},
+				},
+			},
+			operationAfterTick: map[int]operation{1: deleteDeployment1},
+			containerIDsAfterTick: []map[string]whereContainerIDisStored{
+				{"pod1": theMap}, // before tick 1: container should be added immediately
+				{"pod1": theMap}, // after tick 1
+				// container deletion
+				{"pod1": history}, // after tick 2: will remember that for a single tick
+				// adding container again
+				{"pod1": theMap}, // after tick 3: should be normally added to the map
+				{"pod1": theMap}, // after tick 4: should stay in the map until the next deletion or reset
 				{"pod1": theMap},
 			},
 		},

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -708,7 +708,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 					s.T().Logf("Exec operation=%s (tick %d). State after operation:", op, tickNo)
 					switch op {
 					case mapReset:
-						entityStore.resetMaps()
+						entityStore.Cleanup()
 					case deleteDeployment1:
 						// purgeNoLock accepts deploymentID, not containerID
 						entityStore.purgeNoLock("depl1")

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -1,10 +1,15 @@
 package clusterentities
 
 import (
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/net"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/maps"
 )
 
 func TestClusterEntitiesStore(t *testing.T) {
@@ -26,7 +31,7 @@ func buildEndpoint(ip string) net.NumericEndpoint {
 	}
 }
 
-func entityUpdate(ip string, port uint16) *EntityData {
+func entityUpdate(ip, contID string, port uint16) *EntityData {
 	ed := &EntityData{}
 	ep := buildEndpoint(ip)
 	ed.AddEndpoint(ep, EndpointTargetInfo{
@@ -34,36 +39,51 @@ func entityUpdate(ip string, port uint16) *EntityData {
 		PortName:      "ehlo",
 	})
 	ed.AddIP(ep.IPAndPort.Address)
+	ed.AddContainerID(contID, ContainerMetadata{
+		DeploymentID:  "",
+		DeploymentTS:  0,
+		PodID:         "",
+		PodUID:        "",
+		ContainerName: "name-of-" + contID,
+		ContainerID:   contID,
+		Namespace:     "",
+		StartTime:     nil,
+		ImageID:       "",
+	})
 	return ed
 }
 
 func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 	type eUpdate struct {
-		containerID string
-		ipAddr      string
-		port        uint16
-		incremental bool
+		deploymentID string
+		containerID  string
+		ipAddr       string
+		port         uint16
+		incremental  bool
 	}
 	cases := map[string]struct {
-		numTicksToRemember uint16
-		entityUpdates      map[int][]eUpdate // tick -> updates
-		endpointsAfterTick []map[string]bool
+		numTicksToRemember    uint16
+		entityUpdates         map[int][]eUpdate // tick -> updates
+		endpointsAfterTick    []map[string]bool
+		containerIDsAfterTick []map[string]bool
 	}{
 		"Memory disabled should forget 10.0.0.1 immediately": {
 			numTicksToRemember: 0,
 			entityUpdates: map[int][]eUpdate{
 				0: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.0.0.1",
-						port:        80,
-						incremental: true, // append
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  true, // append
 					},
 					{
-						containerID: "pod1",
-						ipAddr:      "10.3.0.1",
-						port:        80,
-						incremental: false, // replace
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.3.0.1",
+						port:         80,
+						incremental:  false, // replace
 					},
 				},
 			},
@@ -72,22 +92,29 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"10.0.0.1": false, "10.3.0.1": true}, // tick 1: only 10.3.0.1 should exist
 				{"10.0.0.1": false, "10.3.0.1": true}, // tick 2: only 10.3.0.1 should exist
 			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true}, // before tick 1: container should be added immediately
+				{"pod1": true}, // tick 1: update of IP should not cause the container ID to disappear
+				{"pod1": true}, // tick 2: nothing has happened that would cause the container ID to disappear
+			},
 		},
 		"Old IPs should be gone on the first tick": {
 			numTicksToRemember: 1,
 			entityUpdates: map[int][]eUpdate{
 				0: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.0.0.1",
-						port:        80,
-						incremental: true,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  true,
 					},
 					{
-						containerID: "pod1",
-						ipAddr:      "10.3.0.1",
-						port:        80,
-						incremental: false,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.3.0.1",
+						port:         80,
+						incremental:  false,
 					},
 				},
 			},
@@ -96,24 +123,31 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"10.0.0.1": false, "10.3.0.1": true}, // after-tick 1: only 10.3.0.1 should exist
 				{"10.0.0.1": false, "10.3.0.1": true}, // after-tick 2: only 10.3.0.1 should exist
 			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true}, // before tick 1
+				{"pod1": true}, // tick 1
+				{"pod1": true}, // tick 2
+			},
 		},
 		"Updates of the same IP should not expire": {
 			numTicksToRemember: 2,
 			entityUpdates: map[int][]eUpdate{
 				0: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.0.0.1",
-						port:        80,
-						incremental: false,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  false,
 					},
 				},
 				2: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.0.0.1",
-						port:        80,
-						incremental: false,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  false,
 					},
 				},
 			},
@@ -125,21 +159,32 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"10.0.0.1": true}, // tick 4: update2 must exist
 				{"10.0.0.1": true}, // tick 5: update2 must exist
 			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true},
+				{"pod1": true},
+				{"pod1": true},
+				{"pod1": true},
+				{"pod1": true},
+				{"pod1": true},
+			},
 		},
 		"Old IPs should be gone on the 2nd tick": {
 			numTicksToRemember: 2,
 			entityUpdates: map[int][]eUpdate{
-				0: {{
-					containerID: "pod1",
-					ipAddr:      "10.0.0.1",
-					port:        80,
-					incremental: true,
-				},
+				0: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.3.0.1",
-						port:        80,
-						incremental: false,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  true,
+					},
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.3.0.1",
+						port:         80,
+						incremental:  false,
 					},
 				},
 			},
@@ -148,34 +193,43 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"10.0.0.1": true, "10.3.0.1": true},  // after-tick 1: both must exist
 				{"10.0.0.1": false, "10.3.0.1": true}, // after-tick 2: only 10.3.0.1 should exist
 			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true},
+				{"pod1": true},
+				{"pod1": true},
+			},
 		},
 		"Old IPs should be gone for selected pods only": {
 			numTicksToRemember: 2,
 			entityUpdates: map[int][]eUpdate{
 				0: {
 					{
-						containerID: "pod1",
-						ipAddr:      "10.0.0.1",
-						port:        80,
-						incremental: true,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.0.0.1",
+						port:         80,
+						incremental:  true,
 					},
 					{
-						containerID: "pod1",
-						ipAddr:      "10.3.0.1",
-						port:        80,
-						incremental: false,
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						ipAddr:       "10.3.0.1",
+						port:         80,
+						incremental:  false,
 					},
 					{
-						containerID: "pod2",
-						ipAddr:      "20.0.0.1",
-						port:        80,
-						incremental: true,
+						deploymentID: "depl2",
+						containerID:  "pod2",
+						ipAddr:       "20.0.0.1",
+						port:         80,
+						incremental:  true,
 					},
 					{
-						containerID: "pod2",
-						ipAddr:      "20.3.0.1",
-						port:        80,
-						incremental: true,
+						deploymentID: "depl2",
+						containerID:  "pod2",
+						ipAddr:       "20.3.0.1",
+						port:         80,
+						incremental:  true,
 					},
 				},
 			},
@@ -184,23 +238,32 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 				{"10.0.0.1": true, "10.3.0.1": true, "20.0.0.1": true, "20.3.0.1": true},
 				{"10.0.0.1": false, "10.3.0.1": true, "20.0.0.1": true, "20.3.0.1": true},
 			},
+			containerIDsAfterTick: []map[string]bool{
+				{"pod1": true, "pod2": true},
+				{"pod1": true, "pod2": true},
+				{"pod1": true, "pod2": true},
+			},
 		},
 	}
 	for name, tCase := range cases {
 		s.Run(name, func() {
 			entityStore := NewStoreWithMemory(tCase.numTicksToRemember)
 
+			require.Equalf(s.T(), len(tCase.containerIDsAfterTick), len(tCase.endpointsAfterTick),
+				"this test requires expected endpoints and expected container IDs to be specified for all ticks")
+
 			for tickNo, expectation := range tCase.endpointsAfterTick {
-				// Entities are updated based on the data from K8s
+				// Add entities to the store (mimic data arriving from the K8s informers)
 				if updatesForTick, ok := tCase.entityUpdates[tickNo]; ok {
 					for _, update := range updatesForTick {
 						entityStore.Apply(map[string]*EntityData{
-							update.containerID: entityUpdate(update.ipAddr, update.port),
+							update.deploymentID: entityUpdate(update.ipAddr, update.containerID, update.port),
 						}, update.incremental)
 					}
 				}
-				s.T().Logf("Historical IPs (tick %d): %v", tickNo, entityStore.historicalIPs)
-				s.T().Logf("All IPs (tick %d): %v", tickNo, entityStore.ipMap)
+				// Assert on IPs
+				s.T().Logf("Historical IPs (tick %d): %v", tickNo, prettyPrintHistoricalData(entityStore.historicalIPs))
+				s.T().Logf("All IPs (tick %d): %v", tickNo, maps.Keys(entityStore.ipMap))
 				for endpoint, shallExist := range expectation {
 					result := entityStore.LookupByEndpoint(buildEndpoint(endpoint))
 					if shallExist {
@@ -209,8 +272,23 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 						s.True(len(result) == 0, "Should not find endpoint %q in tick %d.  Result: %v", endpoint, tickNo, result)
 					}
 				}
+
+				// Assert on container IDs
+				s.T().Logf("Historical container IDs (tick %d): %s", tickNo, prettyPrintHistoricalData(entityStore.historicalContainerIDs))
+				s.T().Logf("All container IDs (tick %d): %v", tickNo, maps.Keys(entityStore.containerIDMap))
+				for contID, shallExists := range tCase.containerIDsAfterTick[tickNo] {
+					result, found := entityStore.LookupByContainerID(contID)
+					if shallExists {
+						s.Truef(found, "expected to find contID %q in tick %d", contID, tickNo)
+						s.Equalf(contID, result.ContainerID, "Expected the result to have contID %q in tick %d. Result: %v", contID, tickNo, result)
+					} else {
+						s.Require().Falsef(found, "expected not to find contID %q in tick %d", contID, tickNo)
+						s.Empty(result.ContainerID)
+					}
+				}
 				entityStore.RecordTick()
 			}
+
 		})
 	}
 }
@@ -218,10 +296,10 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPast() {
 func (s *ClusterEntitiesStoreTestSuite) TestChangingIPsAndExternalEntities() {
 	entityStore := NewStore()
 	type eUpdate struct {
-		containerID string
-		ipAddr      string
-		port        uint16
-		incremental bool
+		deploymentID string
+		ipAddr       string
+		port         uint16
+		incremental  bool
 	}
 	cases := map[string]struct {
 		entityUpdates     []eUpdate
@@ -230,16 +308,16 @@ func (s *ClusterEntitiesStoreTestSuite) TestChangingIPsAndExternalEntities() {
 		"Incremental updates to the store shall not loose data": {
 			entityUpdates: []eUpdate{
 				{
-					containerID: "pod1",
-					ipAddr:      "10.0.0.1",
-					port:        80,
-					incremental: true,
+					deploymentID: "pod1",
+					ipAddr:       "10.0.0.1",
+					port:         80,
+					incremental:  true,
 				},
 				{
-					containerID: "pod1",
-					ipAddr:      "10.3.0.1",
-					port:        80,
-					incremental: true,
+					deploymentID: "pod1",
+					ipAddr:       "10.3.0.1",
+					port:         80,
+					incremental:  true,
 				},
 			},
 			expectedEndpoints: []string{"10.0.0.1", "10.3.0.1"},
@@ -247,22 +325,22 @@ func (s *ClusterEntitiesStoreTestSuite) TestChangingIPsAndExternalEntities() {
 		"Non-incremental updates to the store shall overwrite all data for a key": {
 			entityUpdates: []eUpdate{
 				{
-					containerID: "pod1",
-					ipAddr:      "10.0.0.1",
-					port:        80,
-					incremental: true,
+					deploymentID: "pod1",
+					ipAddr:       "10.0.0.1",
+					port:         80,
+					incremental:  true,
 				},
 				{
-					containerID: "pod1",
-					ipAddr:      "10.3.0.1",
-					port:        80,
-					incremental: false,
+					deploymentID: "pod1",
+					ipAddr:       "10.3.0.1",
+					port:         80,
+					incremental:  false,
 				},
 				{
-					containerID: "pod2",
-					ipAddr:      "10.0.0.2",
-					port:        80,
-					incremental: true,
+					deploymentID: "pod2",
+					ipAddr:       "10.0.0.2",
+					port:         80,
+					incremental:  true,
 				},
 			},
 			expectedEndpoints: []string{"10.3.0.1", "10.0.0.2"},
@@ -272,7 +350,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestChangingIPsAndExternalEntities() {
 		s.Run(name, func() {
 			for _, update := range tCase.entityUpdates {
 				entityStore.Apply(map[string]*EntityData{
-					update.containerID: entityUpdate(update.ipAddr, update.port),
+					update.deploymentID: entityUpdate(update.ipAddr, update.deploymentID, update.port),
 				}, update.incremental)
 			}
 			for _, expectedEndpoint := range tCase.expectedEndpoints {
@@ -281,6 +359,212 @@ func (s *ClusterEntitiesStoreTestSuite) TestChangingIPsAndExternalEntities() {
 			}
 		})
 	}
+}
+
+// endregion
+// region container-id history test
+
+func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
+	type eUpdate struct {
+		deploymentID string
+		containerID  string
+		incremental  bool
+	}
+
+	type whereContainerIDisStored string
+	const (
+		// the container will be found in history
+		history whereContainerIDisStored = "history"
+		// the container will be found in the containerIDMap
+		theMap whereContainerIDisStored = "the-map"
+		// the container will not be found
+		nowhere whereContainerIDisStored = "nowhere"
+	)
+
+	cases := map[string]struct {
+		numTicksToRemember uint16
+		entityUpdates      map[int][]eUpdate // tick -> updates
+		// resetAfterTick defines tick IDs after which a reset should be simulated (e.g., going offline)
+		resetAfterTick        []uint16
+		containerIDsAfterTick []map[string]whereContainerIDisStored
+	}{
+		"Memory disabled with no reset should remember pod1 forever": {
+			numTicksToRemember: 0,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true, // append
+					},
+				},
+			},
+			resetAfterTick: []uint16{}, // do not reset at all
+			containerIDsAfterTick: []map[string]whereContainerIDisStored{
+				{"pod1": theMap}, // before tick 1: container should be added immediately
+				{"pod1": theMap}, // after tick 1: nothing has happened that would cause the container ID to disappear
+				{"pod1": theMap}, // after tick 2: nothing has happened that would cause the container ID to disappear
+			},
+		},
+		"Memory disabled with reset after tick 1 should make pod1 be forgotten before tick 2": {
+			numTicksToRemember: 0,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true, // append
+					},
+				},
+			},
+			resetAfterTick: []uint16{1},
+			containerIDsAfterTick: []map[string]whereContainerIDisStored{
+				{"pod1": theMap},  // before tick 1: container should be added immediately
+				{"pod1": theMap},  // after tick 1: reset happens after this assertion
+				{"pod1": nowhere}, // after tick 2: first tick after reset
+			},
+		},
+		"Memory for 2 ticks with reset after tick 1 should make pod1 be forgotten before tick 4": {
+			numTicksToRemember: 2,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true, // append
+					},
+				},
+			},
+			resetAfterTick: []uint16{1},
+			containerIDsAfterTick: []map[string]whereContainerIDisStored{
+				{"pod1": theMap},  // before tick 1: container should be added immediately
+				{"pod1": theMap},  // after tick 1: reset happens after this assertion
+				{"pod1": history}, // after tick 2: reset happened but memory will remember that for one more tick
+				{"pod1": history}, // after tick 3: reset happened but memory will remember that for this last tick
+				{"pod1": nowhere}, // after tick 4: reset happened and memory expired - should be forgotten
+			},
+		},
+		"Re-adding successfully forgotten container should reset the history status": {
+			numTicksToRemember: 2,
+			entityUpdates: map[int][]eUpdate{
+				0: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true, // append
+					},
+				},
+				5: {
+					{
+						deploymentID: "depl1",
+						containerID:  "pod1",
+						incremental:  true, // append
+					},
+				},
+			},
+			resetAfterTick: []uint16{1},
+			containerIDsAfterTick: []map[string]whereContainerIDisStored{
+				{"pod1": theMap},  // before tick 1: container should be added immediately
+				{"pod1": theMap},  // after tick 1: reset happens after this assertion
+				{"pod1": history}, // after tick 2: reset happened but memory will remember that for one more tick
+				{"pod1": history}, // after tick 3: reset happened but memory will remember that for this last tick
+				{"pod1": nowhere}, // after tick 4: reset happened and memory expired - should be forgotten
+				{"pod1": theMap},  // after tick 5: re-added pod1 should be findable until next reset
+				{"pod1": theMap},  // after tick 6: no further reset was planned, so we should find pod1 in all ticks from now
+				{"pod1": theMap},
+				{"pod1": theMap},
+				{"pod1": theMap},
+			},
+		},
+	}
+	for name, tCase := range cases {
+		s.Run(name, func() {
+			entityStore := NewStoreWithMemory(tCase.numTicksToRemember)
+
+			// Prepare reset plan
+			resetPlan := make(map[uint16]bool) // key: tickNo, value: shall reset
+			resetPlan[0] = false               // in case tCase.resetAfterTick is empty
+			// pre-fill the reset plan
+			if len(tCase.resetAfterTick) > 0 {
+				for tick := 0; uint16(tick) < slices.Max(tCase.resetAfterTick); tick++ {
+					resetPlan[uint16(tick)] = false
+				}
+				for _, tickWithReset := range tCase.resetAfterTick {
+					resetPlan[tickWithReset] = true
+				}
+			}
+
+			for tickNo, expectation := range tCase.containerIDsAfterTick {
+				// Add entities to the store (mimic data arriving from the K8s informers)
+				if updatesForTick, ok := tCase.entityUpdates[tickNo]; ok {
+					for _, update := range updatesForTick {
+						entityStore.Apply(map[string]*EntityData{
+							update.deploymentID: entityUpdate("10.0.0.1", update.containerID, 80),
+						}, update.incremental)
+					}
+				}
+				// Assert on container IDs
+				s.T().Logf("Historical container IDs (tick %d): %s", tickNo, prettyPrintHistoricalData(entityStore.historicalContainerIDs))
+				s.T().Logf("All container IDs (tick %d): %v", tickNo, maps.Keys(entityStore.containerIDMap))
+				for contID, whereFound := range expectation {
+					result, found := entityStore.LookupByContainerID(contID)
+					resultMap, foundMap := entityStore.lookupByContainerIDNoLock(contID)
+					resultHist, foundHist := entityStore.lookupByContainerIDInHistoryNoLock(contID)
+					switch whereFound {
+					case theMap:
+						s.Truef(found, "expected to find contID %q in general in tick %d", contID, tickNo)
+						s.Equalf(contID, result.ContainerID, "Expected the general result to have contID %q in tick %d. Result: %v", contID, tickNo, result)
+
+						s.Truef(foundMap, "expected to find contID %q in the map in tick %d", contID, tickNo)
+						s.Equalf(contID, resultMap.ContainerID, "Expected the map result to have contID %q in tick %d. Result: %v", contID, tickNo, resultMap)
+
+						s.Falsef(foundHist, "expected not to find contID %q in the history in tick %d", contID, tickNo)
+						s.Empty(resultHist.ContainerID)
+					case history:
+						s.Truef(found, "expected to find contID %q in general in tick %d", contID, tickNo)
+						s.Equalf(contID, result.ContainerID, "Expected the general result to have contID %q in tick %d. Result: %v", contID, tickNo, result)
+
+						s.Truef(foundHist, "expected to find contID %q in the history in tick %d", contID, tickNo)
+						s.Equalf(contID, resultHist.ContainerID, "Expected the historical result to have contID %q in tick %d. Result: %v", contID, tickNo, resultHist)
+
+						s.Falsef(foundMap, "expected not to find contID %q in the map in tick %d", contID, tickNo)
+						s.Empty(resultMap.ContainerID)
+					case nowhere:
+						s.Falsef(found, "expected not to find contID %q at all in tick %d", contID, tickNo)
+						s.Empty(result.ContainerID)
+
+						s.Falsef(foundMap, "expected not to find contID %q in the map in tick %d", contID, tickNo)
+						s.Empty(resultMap.ContainerID)
+
+						s.Falsef(foundHist, "expected not to find contID %q in the history in tick %d", contID, tickNo)
+						s.Empty(resultHist.ContainerID)
+					}
+				}
+				entityStore.RecordTick()
+				if shallReset, ok := resetPlan[uint16(tickNo)]; ok && shallReset {
+					s.T().Logf("Resetting maps (tick %d). State after reset:", tickNo)
+					entityStore.resetMaps()
+					s.T().Logf("\tHistorical container IDs (tick %d): %v", tickNo, prettyPrintHistoricalData(entityStore.historicalContainerIDs))
+					s.T().Logf("\tAll container IDs (tick %d): %v", tickNo, entityStore.containerIDMap)
+				}
+			}
+
+		})
+	}
+}
+
+func prettyPrintHistoricalData[M ~map[K1]map[K2]*entityStatus, K1 comparable, K2 comparable](data M) string {
+	fragments := make([]string, 0, len(data))
+	if len(data) == 0 {
+		return "history is empty"
+	}
+	for ID, m := range data {
+		for _, status := range m {
+			fragments = append(fragments,
+				fmt.Sprintf("[ID=%v, isHistorical=%t, ticksLeft=%d]", ID, status.isHistorical, status.ticksLeft))
+		}
+	}
+	return strings.Join(fragments, "\n")
 }
 
 // endregion

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -395,15 +395,15 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 					{
 						deploymentID: "depl1",
 						containerID:  "pod1",
-						incremental:  true, // append
+						incremental:  true,
 					},
 				},
 			},
 			resetAfterTick: []uint16{}, // do not reset at all
 			containerIDsAfterTick: []map[string]whereContainerIDisStored{
 				{"pod1": theMap}, // before tick 1: container should be added immediately
-				{"pod1": theMap}, // after tick 1: nothing has happened that would cause the container ID to disappear
-				{"pod1": theMap}, // after tick 2: nothing has happened that would cause the container ID to disappear
+				{"pod1": theMap}, // after tick 1: no reset - should be in the map forever
+				{"pod1": theMap},
 			},
 		},
 		"Memory disabled with reset after tick 1 should make pod1 be forgotten before tick 2": {
@@ -413,15 +413,16 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 					{
 						deploymentID: "depl1",
 						containerID:  "pod1",
-						incremental:  true, // append
+						incremental:  true,
 					},
 				},
 			},
 			resetAfterTick: []uint16{1},
 			containerIDsAfterTick: []map[string]whereContainerIDisStored{
-				{"pod1": theMap},  // before tick 1: container should be added immediately
-				{"pod1": theMap},  // after tick 1: reset happens after this assertion
-				{"pod1": nowhere}, // after tick 2: first tick after reset
+				{"pod1": theMap}, // before tick 1: container should be added immediately
+				{"pod1": theMap}, // after tick 1: no reset yet, so it should be in the map
+				// reset
+				{"pod1": nowhere}, // after tick 2: should be gone
 			},
 		},
 		"Memory for 2 ticks with reset after tick 1 should make pod1 be forgotten before tick 4": {
@@ -431,17 +432,18 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 					{
 						deploymentID: "depl1",
 						containerID:  "pod1",
-						incremental:  true, // append
+						incremental:  true,
 					},
 				},
 			},
 			resetAfterTick: []uint16{1},
 			containerIDsAfterTick: []map[string]whereContainerIDisStored{
-				{"pod1": theMap},  // before tick 1: container should be added immediately
-				{"pod1": theMap},  // after tick 1: reset happens after this assertion
-				{"pod1": history}, // after tick 2: reset happened but memory will remember that for one more tick
-				{"pod1": history}, // after tick 3: reset happened but memory will remember that for this last tick
-				{"pod1": nowhere}, // after tick 4: reset happened and memory expired - should be forgotten
+				{"pod1": theMap}, // before tick 1: container should be added immediately
+				{"pod1": theMap}, // after tick 1
+				// reset
+				{"pod1": history}, // after tick 2: will remember that for one more tick
+				{"pod1": history}, // after tick 3: will remember that for this last tick
+				{"pod1": nowhere}, // after tick 4: history expired - should be forgotten
 			},
 		},
 		"Re-adding successfully forgotten container should reset the history status": {
@@ -451,26 +453,27 @@ func (s *ClusterEntitiesStoreTestSuite) TestMemoryAboutPastContainerIDs() {
 					{
 						deploymentID: "depl1",
 						containerID:  "pod1",
-						incremental:  true, // append
+						incremental:  true,
 					},
 				},
 				5: {
 					{
 						deploymentID: "depl1",
 						containerID:  "pod1",
-						incremental:  true, // append
+						incremental:  true,
 					},
 				},
 			},
 			resetAfterTick: []uint16{1},
 			containerIDsAfterTick: []map[string]whereContainerIDisStored{
-				{"pod1": theMap},  // before tick 1: container should be added immediately
-				{"pod1": theMap},  // after tick 1: reset happens after this assertion
-				{"pod1": history}, // after tick 2: reset happened but memory will remember that for one more tick
-				{"pod1": history}, // after tick 3: reset happened but memory will remember that for this last tick
-				{"pod1": nowhere}, // after tick 4: reset happened and memory expired - should be forgotten
-				{"pod1": theMap},  // after tick 5: re-added pod1 should be findable until next reset
-				{"pod1": theMap},  // after tick 6: no further reset was planned, so we should find pod1 in all ticks from now
+				{"pod1": theMap}, // before tick 1: container should be added immediately
+				{"pod1": theMap}, // after tick 1
+				// reset
+				{"pod1": history}, // after tick 2: will remember that for one more tick
+				{"pod1": history}, // after tick 3: will remember that for this last tick
+				{"pod1": nowhere}, // after tick 4: history expired - should be forgotten
+				{"pod1": theMap},  // after tick 5: re-added pod1 should be findable from now on until the next reset
+				{"pod1": theMap},  // after tick 6: no further reset was planned, so we should find pod1 forever
 				{"pod1": theMap},
 				{"pod1": theMap},
 				{"pod1": theMap},


### PR DESCRIPTION
### Description

#### Problem

When sensor transitions from offline to online it [calls Stop on the listener](https://github.com/stackrox/stackrox/blob/e8a3a75590d7c33236fbf7242abb4470cf149578/sensor/kubernetes/eventpipeline/pipeline_impl.go#L131), whereas [the listener wipes all in-memory stores](https://github.com/stackrox/stackrox/blob/9d21f921131b849948d0dc8cf0000732033e16cc/sensor/kubernetes/listener/listener_impl.go#L97). This may lead into problems where connection observed during offline will not be enriched in the following scenario:
- Collector reports a flow and Sensor stores it in memory
- enricher will wait for the tick (30s currently)
- before the tick occurs, we go offline
- next, we go online - this wipes all in-memory stores
- enricher tick finally happens
- more than [2 minutes](https://github.com/stackrox/stackrox/blob/e8be3e18d4233b3b07fd2acb9186ef14669fcf06/sensor/common/networkflow/manager/manager_impl.go#L43) have passed since the first seeing of that flow
- k8s has not reported yet the containerID to Sensor (or the container does not exist anymore),
- enriching fails, because containerID is unknown (in-memory store of containerIDs has been wiped)

#### Solution

We introduce a history for the containerID map and instead of wiping all memory stores on transition to online, we mark them as historical. That allows the network flow manager to still enrich the connections to containers that were "forgotten" and correctly identify source/destination of the flow.  

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- Unit tests with good coverage
- Deploying to the cluster and looking at the newly added metric (doing only some basic checks as this is just a number of entries in maps)
