### PR TITLE
fix(ui): Add dataLabel prop to Td element elsewhere

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -214,7 +214,7 @@ function IntegrationsTable({
                                                     column.Header === 'Configuration')
                                             ) {
                                                 return (
-                                                    <Td key="name">
+                                                    <Td key="name" dataLabel={column.Header}>
                                                         <Link
                                                             to={getPathToViewDetails(
                                                                 source,
@@ -231,7 +231,7 @@ function IntegrationsTable({
                                                 );
                                             }
                                             return (
-                                                <Td key={column.Header}>
+                                                <Td key={column.Header} dataLabel={column.Header}>
                                                     <TableCellValue
                                                         row={integration}
                                                         column={column}

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -94,7 +94,7 @@ function EnableDisableNotificationModal({
                                     isSelected: allRowsSelected,
                                 }}
                             />
-                            <Th modifier="wrap">Select notifers</Th>
+                            <Th modifier="wrap">Notifier</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -108,7 +108,7 @@ function EnableDisableNotificationModal({
                                             isSelected: selected[rowIndex],
                                         }}
                                     />
-                                    <Td>{name}</Td>
+                                    <Td dataLabel="Notifier">{name}</Td>
                                 </Tr>
                             );
                         })}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -135,7 +135,10 @@ function TableModal({
                                                     {columns.map((column) => {
                                                         if (column.Header === 'Name') {
                                                             return (
-                                                                <Td key="name">
+                                                                <Td
+                                                                    key="name"
+                                                                    dataLabel={column.Header}
+                                                                >
                                                                     <Link to={link}>
                                                                         <TableCellValue
                                                                             row={row}
@@ -146,7 +149,10 @@ function TableModal({
                                                             );
                                                         }
                                                         return (
-                                                            <Td key={column.Header}>
+                                                            <Td
+                                                                key={column.Header}
+                                                                dataLabel={column.Header}
+                                                            >
                                                                 <TableCellValue
                                                                     row={row}
                                                                     column={column}


### PR DESCRIPTION
### Description

Prerequisite for lint rule to require `dataLabel` prop.

### Residue

1. FlowsTable.tsx file: Investigate pro and con of `columnNames` versus literal strings.
2. ViolationsTablePanel.tsx file: Investigate pro and con of `violationTableColumnDescriptors` versus literal strings.
3. AccessScopesTable.tsx and PermissionSetsTable.tsx files: Investigate `dataLabel` prop for radio buttons.
4. RiskAcceptance folder: Investigate possibility to delete unreachable files.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [ ] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619653 - 4619653
        total 90 = 11801491 - 11801401
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178

#### Manual testing

1. Visit /main/integrations/imageIntegrations/docker

    IntegrationsTable.tsx file.

    * Before changes without `dataLabel` props, see absence of responsive labels at 760px width.
        ![IntegrationsTable_absence](https://github.com/user-attachments/assets/816c476c-f3c1-40a1-bfa1-e479c00383b3)

    * After changes with `dataLabel` props, see presence of responsive labels at 760px width.
        ![ImageIntegrations_presence](https://github.com/user-attachments/assets/f5f46da1-579b-46ad-a9d4-9359227cafbc)

    * Before and after changes, see column head text at 1440px width.
        ![IntegrationsTable_1440px](https://github.com/user-attachments/assets/b6718ac8-e691-473b-b7c2-91aef49e557d)

2. Visit /main/policy-management/policies/?action=create and 

    EnableDisableNotificationModal.tsx file.

    * Before changes without `dataLabel` props, see absence of `data-label` attributes at 760px width.
         ![EnableDisableNotificationModal_absence](https://github.com/user-attachments/assets/19cd4954-2ad4-4321-a0e7-af2acfc36b63)

    * After changes with `dataLabel` props, see presence of responsive label at 760px width.
![EnableDisableNotificationModal_presence](https://github.com/user-attachments/assets/369da35f-8af6-4870-812e-89671514324c)

    * After changes, see **Notifier** column head text at 1440px width.
        ![EnableDisableNotificationModal_1440px](https://github.com/user-attachments/assets/bf13e326-baa7-4e64-90f0-1680c4667235)