### PR TITLE
fix(reporting): Aggregate timestamps in the scan watcher

### DIFF
--- a/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
@@ -85,6 +85,9 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 
 	switch event.GetAction() {
 	case central.ResourceAction_REMOVE_RESOURCE:
+		if err := s.reportMgr.HandleScanRemove(ctx, event.GetId()); err != nil {
+			log.Errorf("unable to handle the scan removal in the report manager: %v", err)
+		}
 		return s.v2Datastore.DeleteScan(ctx, event.GetId())
 	default:
 		scan := internaltov2storage.ComplianceOperatorScanObject(complianceScanObject, clusterID)

--- a/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
@@ -85,7 +85,7 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 
 	switch event.GetAction() {
 	case central.ResourceAction_REMOVE_RESOURCE:
-		if err := s.reportMgr.HandleScanRemove(ctx, event.GetId()); err != nil {
+		if err := s.reportMgr.HandleScanRemove(event.GetId()); err != nil {
 			log.Errorf("unable to handle the scan removal in the report manager: %v", err)
 		}
 		return s.v2Datastore.DeleteScan(ctx, event.GetId())

--- a/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline_test.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline_test.go
@@ -73,6 +73,7 @@ func (s *PipelineTestSuite) TestRunCreate() {
 func (s *PipelineTestSuite) TestRunDelete() {
 	ctx := context.Background()
 
+	s.reportMgr.EXPECT().HandleScanRemove(testutils.ScanUID).Return(nil).Times(1)
 	s.v2ScanDS.EXPECT().DeleteScan(ctx, testutils.ScanUID).Return(nil).Times(1)
 
 	msg := &central.MsgFromSensor{

--- a/central/complianceoperator/v2/report/manager/manager.go
+++ b/central/complianceoperator/v2/report/manager/manager.go
@@ -19,6 +19,6 @@ type Manager interface {
 	Stop()
 
 	HandleScan(ctx context.Context, scan *storage.ComplianceOperatorScanV2) error
-	HandleScanRemove(ctx context.Context, scanID string) error
+	HandleScanRemove(scanID string) error
 	HandleResult(ctx context.Context, result *storage.ComplianceOperatorCheckResultV2) error
 }

--- a/central/complianceoperator/v2/report/manager/manager.go
+++ b/central/complianceoperator/v2/report/manager/manager.go
@@ -19,5 +19,6 @@ type Manager interface {
 	Stop()
 
 	HandleScan(ctx context.Context, scan *storage.ComplianceOperatorScanV2) error
+	HandleScanRemove(ctx context.Context, scanID string) error
 	HandleResult(ctx context.Context, result *storage.ComplianceOperatorCheckResultV2) error
 }

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -305,7 +305,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 	return m.getWatcher(sensorCtx, id).PushScan(scan)
 }
 
-func (m *managerImpl) HandleScanRemove(sensorCtx context.Context, scanID string) error {
+func (m *managerImpl) HandleScanRemove(scanID string) error {
 	if !features.ComplianceReporting.Enabled() || !features.ScanScheduleReportJobs.Enabled() {
 		return nil
 	}

--- a/central/complianceoperator/v2/report/manager/mocks/manager.go
+++ b/central/complianceoperator/v2/report/manager/mocks/manager.go
@@ -69,17 +69,17 @@ func (mr *MockManagerMockRecorder) HandleScan(ctx, scan any) *gomock.Call {
 }
 
 // HandleScanRemove mocks base method.
-func (m *MockManager) HandleScanRemove(ctx context.Context, scanID string) error {
+func (m *MockManager) HandleScanRemove(scanID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleScanRemove", ctx, scanID)
+	ret := m.ctrl.Call(m, "HandleScanRemove", scanID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleScanRemove indicates an expected call of HandleScanRemove.
-func (mr *MockManagerMockRecorder) HandleScanRemove(ctx, scanID any) *gomock.Call {
+func (mr *MockManagerMockRecorder) HandleScanRemove(scanID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleScanRemove", reflect.TypeOf((*MockManager)(nil).HandleScanRemove), ctx, scanID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleScanRemove", reflect.TypeOf((*MockManager)(nil).HandleScanRemove), scanID)
 }
 
 // Start mocks base method.

--- a/central/complianceoperator/v2/report/manager/mocks/manager.go
+++ b/central/complianceoperator/v2/report/manager/mocks/manager.go
@@ -68,6 +68,20 @@ func (mr *MockManagerMockRecorder) HandleScan(ctx, scan any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleScan", reflect.TypeOf((*MockManager)(nil).HandleScan), ctx, scan)
 }
 
+// HandleScanRemove mocks base method.
+func (m *MockManager) HandleScanRemove(ctx context.Context, scanID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleScanRemove", ctx, scanID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleScanRemove indicates an expected call of HandleScanRemove.
+func (mr *MockManagerMockRecorder) HandleScanRemove(ctx, scanID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleScanRemove", reflect.TypeOf((*MockManager)(nil).HandleScanRemove), ctx, scanID)
+}
+
 // Start mocks base method.
 func (m *MockManager) Start() {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -237,6 +237,8 @@ func (t *testTimer) C() <-chan time.Time {
 	return t.ch
 }
 
+func (t *testTimer) Reset() {}
+
 func TestScanConfigWatcherTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"golang.org/x/mod/semver"
 )
@@ -26,6 +27,7 @@ var (
 	ErrScanAlreadyHandled                            = errors.New("the scan is already handled")
 	ErrScanTimeout                                   = errors.New("scan watcher timed out")
 	ErrScanContextCancelled                          = errors.New("scan watcher context cancelled")
+	ErrScanRemoved                                   = errors.New("scan was removed")
 	ErrComplianceOperatorNotInstalled                = errors.New("compliance operator is not installed")
 	ErrComplianceOperatorVersion                     = errors.New("compliance operator version")
 	ErrComplianceOperatorIntegrationDataStore        = errors.New("unable to retrieve compliance operator integration")
@@ -46,7 +48,7 @@ type ScanWatcher interface {
 	PushScan(v2 *storage.ComplianceOperatorScanV2) error
 	PushCheckResult(*storage.ComplianceOperatorCheckResultV2) error
 	Finished() concurrency.ReadOnlySignal
-	Stop()
+	Stop(err error)
 }
 
 // ScanWatcherResults is returned when the watcher detects that the scan is completed.
@@ -125,7 +127,7 @@ func GetWatcherIDFromScan(ctx context.Context, scan *storage.ComplianceOperatorS
 		// is sent before the scan's last update (when it changes its status to COMPLETED).
 		return "", ErrScanAlreadyHandled
 	}
-	return fmt.Sprintf("%s:%s:%s", clusterID, scanID, startTime.String()), nil
+	return fmt.Sprintf("%s:%s", clusterID, scanID), nil
 }
 
 // GetWatcherIDFromCheckResult given a CheckResult, returns a unique ID for the watcher
@@ -175,13 +177,16 @@ type scanWatcherImpl struct {
 	ctx       context.Context
 	sensorCtx context.Context
 	cancel    func()
+	timeout   Timer
 	scanC     chan *storage.ComplianceOperatorScanV2
 	resultC   chan *storage.ComplianceOperatorCheckResultV2
 	stopped   *concurrency.Signal
 
-	readyQueue  readyQueue[*ScanWatcherResults]
-	scanResults *ScanWatcherResults
-	totalChecks int
+	readyQueue      readyQueue[*ScanWatcherResults]
+	resultsLock     sync.Mutex
+	scanResults     *ScanWatcherResults
+	totalChecks     int
+	lastStartedTime *protocompat.Timestamp
 }
 
 // NewScanWatcher creates a new ScanWatcher
@@ -194,6 +199,7 @@ func NewScanWatcher(ctx, sensorCtx context.Context, watcherID string, queue read
 		ctx:        watcherCtx,
 		sensorCtx:  sensorCtx,
 		cancel:     cancel,
+		timeout:    timeout,
 		scanC:      make(chan *storage.ComplianceOperatorScanV2, defaultChanelSize),
 		resultC:    make(chan *storage.ComplianceOperatorCheckResultV2, defaultChanelSize),
 		stopped:    &finishedSignal,
@@ -204,7 +210,7 @@ func NewScanWatcher(ctx, sensorCtx context.Context, watcherID string, queue read
 			CheckResults: set.NewStringSet(),
 		},
 	}
-	go ret.run(timeout)
+	go ret.run()
 	return ret
 }
 
@@ -234,26 +240,37 @@ func (s *scanWatcherImpl) Finished() concurrency.ReadOnlySignal {
 }
 
 // Stop the watcher
-func (s *scanWatcherImpl) Stop() {
+func (s *scanWatcherImpl) Stop(err error) {
+	if err != nil {
+		concurrency.WithLock(&s.resultsLock, func() {
+			s.scanResults.Error = err
+		})
+	}
 	s.cancel()
 }
 
-func (s *scanWatcherImpl) run(timer Timer) {
+func (s *scanWatcherImpl) run() {
 	defer func() {
 		s.stopped.Signal()
 		<-s.stopped.Done()
-		timer.Stop()
+		s.timeout.Stop()
 	}()
 	for {
 		select {
 		case <-s.ctx.Done():
 			log.Infof("Stopping scan watcher for scan")
-			s.scanResults.Error = ErrScanContextCancelled
+			concurrency.WithLock(&s.resultsLock, func() {
+				if s.scanResults.Error == nil {
+					s.scanResults.Error = ErrScanContextCancelled
+				}
+			})
 			s.readyQueue.Push(s.scanResults)
 			return
-		case <-timer.C():
+		case <-s.timeout.C():
 			log.Warnf("Timeout waiting for the scan %s to finish", s.scanResults.Scan.GetScanName())
-			s.scanResults.Error = ErrScanTimeout
+			concurrency.WithLock(&s.resultsLock, func() {
+				s.scanResults.Error = ErrScanTimeout
+			})
 			s.readyQueue.Push(s.scanResults)
 			return
 		case scan := <-s.scanC:
@@ -265,7 +282,11 @@ func (s *scanWatcherImpl) run(timer Timer) {
 				log.Errorf("Unable to handle result %s for scan %s: %v", result.GetCheckName(), result.GetScanName(), err)
 			}
 		}
-		if s.totalChecks != 0 && s.totalChecks == len(s.scanResults.CheckResults) {
+		var numCheckResults int
+		concurrency.WithLock(&s.resultsLock, func() {
+			numCheckResults = len(s.scanResults.CheckResults)
+		})
+		if s.totalChecks != 0 && s.totalChecks == numCheckResults {
 			s.readyQueue.Push(s.scanResults)
 			return
 		}
@@ -281,13 +302,53 @@ func (s *scanWatcherImpl) handleScan(scan *storage.ComplianceOperatorScanV2) err
 		}
 		s.totalChecks = numChecks
 	}
+
+	s.resultsLock.Lock()
+	defer s.resultsLock.Unlock()
+
 	if s.scanResults.Scan == nil {
 		s.scanResults.Scan = scan
+	}
+	// If we received a newer timestamp we need to reset the watcher.
+	if protocompat.CompareTimestamps(s.lastStartedTime, scan.GetLastStartedTime()) < 0 {
+		s.lastStartedTime = scan.GetLastStartedTime()
+		s.scanResults.Scan = scan
+		s.scanResults.CheckResults = set.NewStringSet()
+		s.timeout.Reset()
 	}
 	return nil
 }
 
 func (s *scanWatcherImpl) handleResult(result *storage.ComplianceOperatorCheckResultV2) error {
+	var startTime string
+	var found bool
+	if startTime, found = result.GetAnnotations()[LastScannedAnnotationKey]; !found {
+		return errors.Errorf("check result does not have the %s annotation", LastScannedAnnotationKey)
+	}
+	timestamp, err := protocompat.ParseRFC3339NanoTimestamp(startTime)
+	if err != nil {
+		return errors.Errorf("unable to parse time: %v", err)
+	}
+
+	s.resultsLock.Lock()
+	defer s.resultsLock.Unlock()
+
+	timestampCmpResult := protocompat.CompareTimestamps(timestamp, s.lastStartedTime)
+	if timestampCmpResult < 0 {
+		// This is an old CheckResult, so we do not processed it.
+		// This could happen if a scan is reset mid-execution and there are old
+		// CheckResult still in sensor's pipeline.
+		return ErrComplianceOperatorReceivedOldCheckResult
+	}
+	// We received a CheckResult with a newer timestamp.
+	// This means that a new scan is about to be received, so we reset the watcher.
+	// This should never happen and is only here as a sanity check in case
+	// there is a race in sensor's pipelines.
+	if timestampCmpResult > 0 {
+		s.lastStartedTime = timestamp
+		s.scanResults.CheckResults = set.NewStringSet()
+		s.timeout.Reset()
+	}
 	s.scanResults.CheckResults.Add(result.GetCheckId())
 	return nil
 }

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -258,8 +258,8 @@ func (s *scanWatcherImpl) run() {
 	for {
 		select {
 		case <-s.ctx.Done():
-			log.Infof("Stopping scan watcher for scan")
 			concurrency.WithLock(&s.resultsLock, func() {
+				log.Infof("Stopping scan watcher for scan %s", s.scanResults.Scan.GetScanName())
 				if s.scanResults.Error == nil {
 					s.scanResults.Error = ErrScanContextCancelled
 				}
@@ -267,8 +267,8 @@ func (s *scanWatcherImpl) run() {
 			s.readyQueue.Push(s.scanResults)
 			return
 		case <-s.timeout.C():
-			log.Warnf("Timeout waiting for the scan %s to finish", s.scanResults.Scan.GetScanName())
 			concurrency.WithLock(&s.resultsLock, func() {
+				log.Warnf("Timeout waiting for the scan %s to finish", s.scanResults.Scan.GetScanName())
 				s.scanResults.Error = ErrScanTimeout
 			})
 			s.readyQueue.Push(s.scanResults)

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
@@ -28,35 +28,48 @@ var (
 
 type testEvent func(*testing.T, ScanWatcher)
 
-func handleScan(id string) func(*testing.T, ScanWatcher) {
+func handleScan(id string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
 	return func(t *testing.T, scanWatcher ScanWatcher) {
 		err := scanWatcher.PushScan(&storage.ComplianceOperatorScanV2{
-			Id: id,
+			Id:              id,
+			LastStartedTime: startTime,
 		})
 		require.NoError(t, err)
 	}
 }
 
-func handleScanWithAnnotation(id, checkCount string) func(*testing.T, ScanWatcher) {
+func handleScanWithAnnotation(id, checkCount string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
 	return func(t *testing.T, scanWatcher ScanWatcher) {
 		err := scanWatcher.PushScan(&storage.ComplianceOperatorScanV2{
-			Id:          id,
-			Annotations: map[string]string{CheckCountAnnotationKey: checkCount},
+			Id:              id,
+			Annotations:     map[string]string{CheckCountAnnotationKey: checkCount},
+			LastStartedTime: startTime,
 		})
 		require.NoError(t, err)
 	}
 }
 
-func handleResult(id string) func(*testing.T, ScanWatcher) {
+func handleResult(id string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
 	return func(t *testing.T, scanWatcher ScanWatcher) {
 		err := scanWatcher.PushCheckResult(&storage.ComplianceOperatorCheckResultV2{
 			CheckId: id,
+			Annotations: map[string]string{
+				LastScannedAnnotationKey: startTime.AsTime().Format(time.RFC3339Nano),
+			},
 		})
 		require.NoError(t, err)
 	}
 }
 
 func TestScanWatcher(t *testing.T) {
+	timestampNow := protocompat.TimestampNow()
+	timeFuture := timestampNow.AsTime().Add(10 * time.Second)
+	timestampFuture, err := protocompat.ConvertTimeToTimestampOrError(timeFuture)
+	require.NoError(t, err)
+	timePast := timestampNow.AsTime().Add(-10 * time.Second)
+	timestampPast, err := protocompat.ConvertTimeToTimestampOrError(timePast)
+	require.NoError(t, err)
+
 	cases := map[string]struct {
 		events          []testEvent
 		assertScanID    string
@@ -64,38 +77,63 @@ func TestScanWatcher(t *testing.T) {
 	}{
 		"scan ready -> result -> result": {
 			events: []testEvent{
-				handleScanWithAnnotation("id-1", "2"),
-				handleResult("id-1"),
-				handleResult("id-2"),
+				handleScanWithAnnotation("id-1", "2", timestampNow),
+				handleResult("id-1", timestampNow),
+				handleResult("id-2", timestampNow),
 			},
 			assertScanID:    "id-1",
 			assertResultIDs: []string{"id-1", "id-2"},
 		},
 		"scan -> result -> result -> scan ready": {
 			events: []testEvent{
-				handleScan("id-1"),
-				handleResult("id-1"),
-				handleResult("id-2"),
-				handleScanWithAnnotation("id-1", "2"),
+				handleScan("id-1", timestampNow),
+				handleResult("id-1", timestampNow),
+				handleResult("id-2", timestampNow),
+				handleScanWithAnnotation("id-1", "2", timestampNow),
 			},
 			assertScanID:    "id-1",
 			assertResultIDs: []string{"id-1", "id-2"},
 		},
 		"scan -> result -> scan ready -> result": {
 			events: []testEvent{
-				handleScan("id-1"),
-				handleResult("id-1"),
-				handleScanWithAnnotation("id-1", "2"),
-				handleResult("id-2"),
+				handleScan("id-1", timestampNow),
+				handleResult("id-1", timestampNow),
+				handleScanWithAnnotation("id-1", "2", timestampNow),
+				handleResult("id-2", timestampNow),
 			},
 			assertScanID:    "id-1",
 			assertResultIDs: []string{"id-1", "id-2"},
 		},
 		"result -> result -> scan ready": {
 			events: []testEvent{
-				handleResult("id-1"),
-				handleResult("id-2"),
-				handleScanWithAnnotation("id-1", "2"),
+				handleResult("id-1", timestampNow),
+				handleResult("id-2", timestampNow),
+				handleScanWithAnnotation("id-1", "2", timestampNow),
+			},
+			assertScanID:    "id-1",
+			assertResultIDs: []string{"id-1", "id-2"},
+		},
+		"scan -> result -> new scan -> new result -> new result -> scan ready": {
+			events: []testEvent{
+				handleScan("id-1", timestampNow),
+				handleResult("id-1", timestampNow),
+				handleScan("id-1", timestampFuture),
+				handleResult("id-1", timestampFuture),
+				handleResult("id-2", timestampFuture),
+				handleScanWithAnnotation("id-1", "2", timestampFuture),
+			},
+			assertScanID:    "id-1",
+			assertResultIDs: []string{"id-1", "id-2"},
+		},
+		"scan -> result -> new scan -> new result -> new result -> old result -> scan ready": {
+			events: []testEvent{
+				handleScan("id-1", timestampNow),
+				handleResult("id-1", timestampNow),
+				handleScan("id-1", timestampFuture),
+				handleResult("id-1", timestampFuture),
+				handleResult("id-2", timestampFuture),
+				handleResult("id-1", timestampPast),
+				handleScanWithAnnotation("id-1", "2", timestampFuture),
 			},
 			assertScanID:    "id-1",
 			assertResultIDs: []string{"id-1", "id-2"},
@@ -132,12 +170,13 @@ func TestScanWatcher(t *testing.T) {
 }
 
 func TestScanWatcherCancel(t *testing.T) {
+	timeNow := protocompat.TimestampNow()
 	watcherID := "id"
 	ctx, cancel := context.WithCancel(context.Background())
 	readyTestQueue := queue.NewQueue[*ScanWatcherResults]()
 	scanWatcher := NewScanWatcher(ctx, ctx, watcherID, readyTestQueue)
-	handleScan("id-1")(t, scanWatcher)
-	handleResult("id-1")(t, scanWatcher)
+	handleScan("id-1", timeNow)(t, scanWatcher)
+	handleResult("id-1", timeNow)(t, scanWatcher)
 	cancel()
 	select {
 	case <-scanWatcher.Finished().Done():
@@ -150,12 +189,13 @@ func TestScanWatcherCancel(t *testing.T) {
 }
 
 func TestScanWatcherStop(t *testing.T) {
+	timeNow := protocompat.TimestampNow()
 	watcherID := "id"
 	readyTestQueue := queue.NewQueue[*ScanWatcherResults]()
 	scanWatcher := NewScanWatcher(context.Background(), context.Background(), watcherID, readyTestQueue)
-	handleScan("id-1")(t, scanWatcher)
-	handleResult("id-1")(t, scanWatcher)
-	scanWatcher.Stop()
+	handleScan("id-1", timeNow)(t, scanWatcher)
+	handleResult("id-1", timeNow)(t, scanWatcher)
+	scanWatcher.Stop(nil)
 	select {
 	case <-scanWatcher.Finished().Done():
 	case <-time.After(100 * time.Millisecond):
@@ -167,6 +207,7 @@ func TestScanWatcherStop(t *testing.T) {
 }
 
 func TestScanWatcherTimeout(t *testing.T) {
+	timeNow := protocompat.TimestampNow()
 	readyTestQueue := queue.NewQueue[*ScanWatcherResults]()
 	ctx, cancel := context.WithCancel(context.Background())
 	finishedSignal := concurrency.NewSignal()
@@ -179,6 +220,7 @@ func TestScanWatcherTimeout(t *testing.T) {
 		ctx:        ctx,
 		sensorCtx:  ctx,
 		cancel:     cancel,
+		timeout:    timeout,
 		scanC:      make(chan *storage.ComplianceOperatorScanV2),
 		resultC:    make(chan *storage.ComplianceOperatorCheckResultV2),
 		stopped:    &finishedSignal,
@@ -189,9 +231,9 @@ func TestScanWatcherTimeout(t *testing.T) {
 			CheckResults: set.NewStringSet(),
 		},
 	}
-	go scanWatcher.run(timeout)
-	handleScan("id-1")(t, scanWatcher)
-	handleResult("id-1")(t, scanWatcher)
+	go scanWatcher.run()
+	handleScan("id-1", timeNow)(t, scanWatcher)
+	handleResult("id-1", timeNow)(t, scanWatcher)
 	// We signal the timeout
 	timeoutC <- time.Now()
 	select {
@@ -264,11 +306,11 @@ func TestGetIDFromScan(t *testing.T) {
 		})
 	id, err := GetWatcherIDFromScan(testDBAccess, scan, snapshotDS, scanConfigDS, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s:%s:%s", scan.ClusterId, scan.Id, scan.LastStartedTime), id)
+	assert.Equal(t, fmt.Sprintf("%s:%s", scan.ClusterId, scan.Id), id)
 	timeNow = protocompat.TimestampNow()
 	id, err = GetWatcherIDFromScan(testDBAccess, scan, snapshotDS, scanConfigDS, timeNow)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s:%s:%s", scan.ClusterId, scan.Id, timeNow), id)
+	assert.Equal(t, fmt.Sprintf("%s:%s", scan.ClusterId, scan.Id), id)
 }
 
 func TestGetIDFromResult(t *testing.T) {
@@ -346,11 +388,11 @@ func TestGetIDFromResult(t *testing.T) {
 	result.Annotations = map[string]string{
 		LastScannedAnnotationKey: futureTime.Format(time.RFC3339Nano),
 	}
-	futureTimeProto, err := protocompat.ConvertTimeToTimestampOrError(futureTime)
-	require.NoError(t, err)
+	//futureTimeProto, err := protocompat.ConvertTimeToTimestampOrError(futureTime)
+	//require.NoError(t, err)
 	id, err := GetWatcherIDFromCheckResult(testDBAccess, result, scanDS, snapshotDS, scanConfigDS)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("cluster-1:scan-1:%s", futureTimeProto.String()), id)
+	assert.Equal(t, "cluster-1:scan-1", id)
 
 	// The timestamp is the same
 	result.Annotations = map[string]string{
@@ -358,7 +400,7 @@ func TestGetIDFromResult(t *testing.T) {
 	}
 	id, err = GetWatcherIDFromCheckResult(testDBAccess, result, scanDS, snapshotDS, scanConfigDS)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("cluster-1:scan-1:%s", timeNow.String()), id)
+	assert.Equal(t, "cluster-1:scan-1", id)
 }
 
 func TestIsComplianceOperatorHealthy(t *testing.T) {

--- a/central/complianceoperator/v2/report/manager/watcher/utils.go
+++ b/central/complianceoperator/v2/report/manager/watcher/utils.go
@@ -6,16 +6,19 @@ import "time"
 type Timer interface {
 	Stop() bool
 	C() <-chan time.Time
+	Reset()
 }
 
 type timerWrapper struct {
-	timer *time.Timer
+	timer    *time.Timer
+	duration time.Duration
 }
 
 // NewTimer creates a new timerWrapper
 func NewTimer(duration time.Duration) *timerWrapper {
 	return &timerWrapper{
-		timer: time.NewTimer(duration),
+		timer:    time.NewTimer(duration),
+		duration: duration,
 	}
 }
 
@@ -27,4 +30,9 @@ func (t *timerWrapper) Stop() bool {
 // C returns the timer channel
 func (t *timerWrapper) C() <-chan time.Time {
 	return t.timer.C
+}
+
+// Reset the timer
+func (t *timerWrapper) Reset() {
+	t.timer.Reset(t.duration)
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR aims to handle two situations:

- (1) CO sends Scan updates with different timestamps. This happens when a Scan gets triggered, sometimes CO sends a timestamp in the PENDING phase and then a different one in the LAUNCHING phase. This will be address in CO version 1.6.1 but we still need to handle this for older CO versions. In this situation we simply reset the ScanWatcher and start watching the Scan with the newer timestamp.
- (2) CO deletes Scans and re-creates them. Sometimes when the ScanSetting and the ScanSettingBinding is created, CO creates a Scan, immediately deletes it, and then re-creates it. This is handle by stopping the ScanWatcher if a REMOVE event is received.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit tests added and modify
- [x] Manual tested the changes with different versions of CO (1.5.0 and 1.6.0). 
  - Observe that the reports are correct
  - We only create one ScanWatcher per Scan in the situation (1)
  - We cancel the ScanWatcher in the situation (2) 
