### PR TITLE
chore(scale): Add scanner v4 metrics

### DIFF
--- a/tests/performance/scale/config/metrics-acs-scanner-v4-indexer.yml
+++ b/tests/performance/scale/config/metrics-acs-scanner-v4-indexer.yml
@@ -1,0 +1,449 @@
+- query: claircore_indexer_distributionbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_count
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_sum
+
+- query: claircore_indexer_distributionbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_total
+
+- query: claircore_indexer_filesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_filesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_count
+
+- query: claircore_indexer_filesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_filesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_total
+
+- query: claircore_indexer_indexfiles_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_bucket
+
+- query: claircore_indexer_indexfiles_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_count
+
+- query: claircore_indexer_indexfiles_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_sum
+
+- query: claircore_indexer_indexfiles_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_total
+
+- query: claircore_indexer_indexmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_indexmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_count
+
+- query: claircore_indexer_indexmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_sum
+
+- query: claircore_indexer_indexmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_total
+
+- query: claircore_indexer_indexpackage_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_bucket
+
+- query: claircore_indexer_indexpackage_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_count
+
+- query: claircore_indexer_indexpackage_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_sum
+
+- query: claircore_indexer_indexpackage_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_total
+
+- query: claircore_indexer_indexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_bucket
+
+- query: claircore_indexer_indexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_count
+
+- query: claircore_indexer_indexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_sum
+
+- query: claircore_indexer_indexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_total
+
+- query: claircore_indexer_layerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_layerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_count
+
+- query: claircore_indexer_layerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_sum
+
+- query: claircore_indexer_layerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_total
+
+- query: claircore_indexer_manifestscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_bucket
+
+- query: claircore_indexer_manifestscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_count
+
+- query: claircore_indexer_manifestscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_sum
+
+- query: claircore_indexer_manifestscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_total
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_count
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_packagesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_total
+
+- query: claircore_indexer_persistmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_persistmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_count
+
+- query: claircore_indexer_persistmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_sum
+
+- query: claircore_indexer_persistmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_total
+
+- query: claircore_indexer_registerscanners_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_bucket
+
+- query: claircore_indexer_registerscanners_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_count
+
+- query: claircore_indexer_registerscanners_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_sum
+
+- query: claircore_indexer_registerscanners_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_total
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_count
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_repositoriesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_total
+
+- query: claircore_indexer_scanned_manifests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_scanned_manifests
+
+- query: claircore_indexer_setindexedfinished_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexedfinished_total
+
+- query: claircore_indexer_setindexfinished_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_bucket
+
+- query: claircore_indexer_setindexfinished_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_count
+
+- query: claircore_indexer_setindexfinished_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_bucket
+
+- query: claircore_indexer_setindexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_count
+
+- query: claircore_indexer_setindexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_total
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_count
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_sum
+
+- query: claircore_indexer_setlayerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_goroutines
+
+- query: go_info{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_sum

--- a/tests/performance/scale/config/metrics-acs-scanner-v4-matcher.yml
+++ b/tests/performance/scale/config/metrics-acs-scanner-v4-matcher.yml
@@ -1,0 +1,338 @@
+- query: claircore_vulnstore_gc_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_bucket
+
+- query: claircore_vulnstore_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_count
+
+- query: claircore_vulnstore_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_sum
+
+- query: claircore_vulnstore_gc_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_total
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_getenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_total
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_bucket
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_count
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_sum
+
+- query: claircore_vulnstore_getupdateoperations_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_total
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_getvulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_total
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_updateenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_total
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_updatevulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_goroutines
+
+- query: go_info{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_sum

--- a/tests/performance/scale/config/metrics-acs.yml
+++ b/tests/performance/scale/config/metrics-acs.yml
@@ -881,3 +881,796 @@
 
 - query: rox_connections_total_sum{namespace="stackrox",container="collector"}
   metricName: collector_rox_connections_total_sum
+
+# File: metrics-acs-scanner-v4-matcher.yml
+
+- query: claircore_vulnstore_gc_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_bucket
+
+- query: claircore_vulnstore_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_count
+
+- query: claircore_vulnstore_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_sum
+
+- query: claircore_vulnstore_gc_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_total
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_getenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_total
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_bucket
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_count
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_sum
+
+- query: claircore_vulnstore_getupdateoperations_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_total
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_getvulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_total
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_updateenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_total
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_updatevulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_goroutines
+
+- query: go_info{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_sum
+
+# File: metrics-acs-scanner-v4-indexer.yml
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_count
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_sum
+
+- query: claircore_indexer_distributionbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_total
+
+- query: claircore_indexer_filesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_filesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_count
+
+- query: claircore_indexer_filesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_filesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_total
+
+- query: claircore_indexer_indexfiles_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_bucket
+
+- query: claircore_indexer_indexfiles_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_count
+
+- query: claircore_indexer_indexfiles_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_sum
+
+- query: claircore_indexer_indexfiles_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_total
+
+- query: claircore_indexer_indexmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_indexmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_count
+
+- query: claircore_indexer_indexmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_sum
+
+- query: claircore_indexer_indexmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_total
+
+- query: claircore_indexer_indexpackage_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_bucket
+
+- query: claircore_indexer_indexpackage_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_count
+
+- query: claircore_indexer_indexpackage_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_sum
+
+- query: claircore_indexer_indexpackage_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_total
+
+- query: claircore_indexer_indexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_bucket
+
+- query: claircore_indexer_indexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_count
+
+- query: claircore_indexer_indexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_sum
+
+- query: claircore_indexer_indexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_total
+
+- query: claircore_indexer_layerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_layerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_count
+
+- query: claircore_indexer_layerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_sum
+
+- query: claircore_indexer_layerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_total
+
+- query: claircore_indexer_manifestscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_bucket
+
+- query: claircore_indexer_manifestscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_count
+
+- query: claircore_indexer_manifestscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_sum
+
+- query: claircore_indexer_manifestscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_total
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_count
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_packagesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_total
+
+- query: claircore_indexer_persistmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_persistmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_count
+
+- query: claircore_indexer_persistmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_sum
+
+- query: claircore_indexer_persistmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_total
+
+- query: claircore_indexer_registerscanners_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_bucket
+
+- query: claircore_indexer_registerscanners_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_count
+
+- query: claircore_indexer_registerscanners_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_sum
+
+- query: claircore_indexer_registerscanners_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_total
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_count
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_repositoriesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_total
+
+- query: claircore_indexer_scanned_manifests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_scanned_manifests
+
+- query: claircore_indexer_setindexedfinished_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexedfinished_total
+
+- query: claircore_indexer_setindexfinished_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_bucket
+
+- query: claircore_indexer_setindexfinished_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_count
+
+- query: claircore_indexer_setindexfinished_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_bucket
+
+- query: claircore_indexer_setindexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_count
+
+- query: claircore_indexer_setindexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_total
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_count
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_sum
+
+- query: claircore_indexer_setlayerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_goroutines
+
+- query: go_info{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_sum

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -1056,3 +1056,796 @@
 
 - query: rox_connections_total_sum{namespace="stackrox",container="collector"}
   metricName: collector_rox_connections_total_sum
+
+# File: metrics-acs-scanner-v4-matcher.yml
+
+- query: claircore_vulnstore_gc_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_bucket
+
+- query: claircore_vulnstore_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_count
+
+- query: claircore_vulnstore_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_duration_seconds_sum
+
+- query: claircore_vulnstore_gc_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_gc_total
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_getenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_getenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getenrichments_total
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_bucket
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_count
+
+- query: claircore_vulnstore_getupdateoperations_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_duration_seconds_sum
+
+- query: claircore_vulnstore_getupdateoperations_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getupdateoperations_total
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_getvulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_getvulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_getvulnerabilities_total
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_bucket
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_count
+
+- query: claircore_vulnstore_updateenrichments_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_duration_seconds_sum
+
+- query: claircore_vulnstore_updateenrichments_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updateenrichments_total
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_bucket
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_count
+
+- query: claircore_vulnstore_updatevulnerabilities_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_duration_seconds_sum
+
+- query: claircore_vulnstore_updatevulnerabilities_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_claircore_vulnstore_updatevulnerabilities_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_goroutines
+
+- query: go_info{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="matcher"}
+  metricName: scanner_v4_matcher_tar_matched_file_count_per_layer_sum
+
+# File: metrics-acs-scanner-v4-indexer.yml
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_count
+
+- query: claircore_indexer_distributionbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_duration_seconds_sum
+
+- query: claircore_indexer_distributionbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_distributionbylayer_total
+
+- query: claircore_indexer_filesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_filesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_count
+
+- query: claircore_indexer_filesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_filesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_filesbylayer_total
+
+- query: claircore_indexer_indexfiles_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_bucket
+
+- query: claircore_indexer_indexfiles_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_count
+
+- query: claircore_indexer_indexfiles_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_duration_seconds_sum
+
+- query: claircore_indexer_indexfiles_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexfiles_total
+
+- query: claircore_indexer_indexmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_indexmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_count
+
+- query: claircore_indexer_indexmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_duration_seconds_sum
+
+- query: claircore_indexer_indexmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexmanifest_total
+
+- query: claircore_indexer_indexpackage_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_bucket
+
+- query: claircore_indexer_indexpackage_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_count
+
+- query: claircore_indexer_indexpackage_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_duration_seconds_sum
+
+- query: claircore_indexer_indexpackage_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexpackage_total
+
+- query: claircore_indexer_indexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_bucket
+
+- query: claircore_indexer_indexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_count
+
+- query: claircore_indexer_indexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_duration_seconds_sum
+
+- query: claircore_indexer_indexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_indexreport_total
+
+- query: claircore_indexer_layerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_layerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_count
+
+- query: claircore_indexer_layerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_duration_seconds_sum
+
+- query: claircore_indexer_layerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_layerscanned_total
+
+- query: claircore_indexer_manifestscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_bucket
+
+- query: claircore_indexer_manifestscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_count
+
+- query: claircore_indexer_manifestscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_duration_seconds_sum
+
+- query: claircore_indexer_manifestscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_manifestscanned_total
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_count
+
+- query: claircore_indexer_packagesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_packagesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_packagesbylayer_total
+
+- query: claircore_indexer_persistmanifest_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_bucket
+
+- query: claircore_indexer_persistmanifest_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_count
+
+- query: claircore_indexer_persistmanifest_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_duration_seconds_sum
+
+- query: claircore_indexer_persistmanifest_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_persistmanifest_total
+
+- query: claircore_indexer_registerscanners_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_bucket
+
+- query: claircore_indexer_registerscanners_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_count
+
+- query: claircore_indexer_registerscanners_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_duration_seconds_sum
+
+- query: claircore_indexer_registerscanners_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_registerscanners_total
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_bucket
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_count
+
+- query: claircore_indexer_repositoriesbylayer_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_duration_seconds_sum
+
+- query: claircore_indexer_repositoriesbylayer_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_repositoriesbylayer_total
+
+- query: claircore_indexer_scanned_manifests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_scanned_manifests
+
+- query: claircore_indexer_setindexedfinished_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexedfinished_total
+
+- query: claircore_indexer_setindexfinished_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_bucket
+
+- query: claircore_indexer_setindexfinished_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_count
+
+- query: claircore_indexer_setindexfinished_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexfinished_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_bucket
+
+- query: claircore_indexer_setindexreport_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_count
+
+- query: claircore_indexer_setindexreport_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_duration_seconds_sum
+
+- query: claircore_indexer_setindexreport_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setindexreport_total
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_bucket
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_count
+
+- query: claircore_indexer_setlayerscanned_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_duration_seconds_sum
+
+- query: claircore_indexer_setlayerscanned_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_claircore_indexer_setlayerscanned_total
+
+- query: file_extraction_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_bucket
+
+- query: file_extraction_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_count
+
+- query: file_extraction_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_count_sum
+
+- query: file_extraction_inaccessible_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_bucket
+
+- query: file_extraction_inaccessible_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_count
+
+- query: file_extraction_inaccessible_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_inaccessible_count_sum
+
+- query: file_extraction_match_count_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_bucket
+
+- query: file_extraction_match_count_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_count
+
+- query: file_extraction_match_count_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_file_extraction_match_count_sum
+
+- query: go_gc_duration_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds
+
+- query: go_gc_duration_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_count
+
+- query: go_gc_duration_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_duration_seconds_sum
+
+- query: go_gc_gogc_percent{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gogc_percent
+
+- query: go_gc_gomemlimit_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_gc_gomemlimit_bytes
+
+- query: go_goroutines{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_goroutines
+
+- query: go_info{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_info
+
+- query: go_memstats_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes
+
+- query: go_memstats_alloc_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_alloc_bytes_total
+
+- query: go_memstats_buck_hash_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_buck_hash_sys_bytes
+
+- query: go_memstats_frees_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_frees_total
+
+- query: go_memstats_gc_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_gc_sys_bytes
+
+- query: go_memstats_heap_alloc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_alloc_bytes
+
+- query: go_memstats_heap_idle_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_idle_bytes
+
+- query: go_memstats_heap_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_inuse_bytes
+
+- query: go_memstats_heap_objects{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_objects
+
+- query: go_memstats_heap_released_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_released_bytes
+
+- query: go_memstats_heap_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_heap_sys_bytes
+
+- query: go_memstats_last_gc_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_last_gc_time_seconds
+
+- query: go_memstats_mallocs_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mallocs_total
+
+- query: go_memstats_mcache_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_inuse_bytes
+
+- query: go_memstats_mcache_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mcache_sys_bytes
+
+- query: go_memstats_mspan_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_inuse_bytes
+
+- query: go_memstats_mspan_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_mspan_sys_bytes
+
+- query: go_memstats_next_gc_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_next_gc_bytes
+
+- query: go_memstats_other_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_other_sys_bytes
+
+- query: go_memstats_stack_inuse_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_inuse_bytes
+
+- query: go_memstats_stack_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_stack_sys_bytes
+
+- query: go_memstats_sys_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_memstats_sys_bytes
+
+- query: go_sched_gomaxprocs_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_sched_gomaxprocs_threads
+
+- query: go_threads{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_go_threads
+
+- query: grpc_server_handled_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handled_total
+
+- query: grpc_server_handling_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_bucket
+
+- query: grpc_server_handling_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_count
+
+- query: grpc_server_handling_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_handling_seconds_sum
+
+- query: grpc_server_msg_received_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_received_total
+
+- query: grpc_server_msg_sent_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_msg_sent_total
+
+- query: grpc_server_started_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_grpc_server_started_total
+
+- query: http_incoming_in_flight_requests{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_in_flight_requests
+
+- query: http_incoming_request_duration_histogram_seconds_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_bucket
+
+- query: http_incoming_request_duration_histogram_seconds_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_count
+
+- query: http_incoming_request_duration_histogram_seconds_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_duration_histogram_seconds_sum
+
+- query: http_incoming_request_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_bucket
+
+- query: http_incoming_request_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_count
+
+- query: http_incoming_request_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_request_size_histogram_bytes_sum
+
+- query: http_incoming_requests_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_requests_total
+
+- query: http_incoming_response_size_histogram_bytes_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_bucket
+
+- query: http_incoming_response_size_histogram_bytes_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_count
+
+- query: http_incoming_response_size_histogram_bytes_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_http_incoming_response_size_histogram_bytes_sum
+
+- query: pgxpool_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_count
+
+- query: pgxpool_acquire_duration_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquire_duration_seconds_total
+
+- query: pgxpool_acquired_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_acquired_conns
+
+- query: pgxpool_canceled_acquire_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_canceled_acquire_count
+
+- query: pgxpool_constructing_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_constructing_conns
+
+- query: pgxpool_empty_acquire{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_empty_acquire
+
+- query: pgxpool_idle_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_idle_conns
+
+- query: pgxpool_max_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_max_conns
+
+- query: pgxpool_total_conns{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_pgxpool_total_conns
+
+- query: process_cpu_seconds_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_cpu_seconds_total
+
+- query: process_max_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_max_fds
+
+- query: process_network_receive_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_receive_bytes_total
+
+- query: process_network_transmit_bytes_total{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_network_transmit_bytes_total
+
+- query: process_open_fds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_open_fds
+
+- query: process_resident_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_resident_memory_bytes
+
+- query: process_start_time_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_start_time_seconds
+
+- query: process_virtual_memory_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_bytes
+
+- query: process_virtual_memory_max_bytes{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_process_virtual_memory_max_bytes
+
+- query: rox_scanner_process_cpu_nr_periods{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_periods
+
+- query: rox_scanner_process_cpu_nr_throttled{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_nr_throttled
+
+- query: rox_scanner_process_cpu_throttled_time{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_process_cpu_throttled_time
+
+- query: rox_scanner_uptime_seconds{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_rox_scanner_uptime_seconds
+
+- query: tar_extracted_contents_bytes_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_bucket
+
+- query: tar_extracted_contents_bytes_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_count
+
+- query: tar_extracted_contents_bytes_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_extracted_contents_bytes_per_layer_sum
+
+- query: tar_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_bucket
+
+- query: tar_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_count
+
+- query: tar_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_file_count_per_layer_sum
+
+- query: tar_matched_file_count_per_layer_bucket{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_bucket
+
+- query: tar_matched_file_count_per_layer_count{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_count
+
+- query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="indexer"}
+  metricName: scanner_v4_indexer_tar_matched_file_count_per_layer_sum

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -50,6 +50,7 @@ sensor/tests/data/policies.json
 sensor/upgrader/preflight/testdata/k8s-1.22.json.gz
 tests/e2e/lib.sh
 tests/performance/load/package-lock.json
+tests/performance/scale/config/metrics-acs.yml
 tests/performance/scale/config/metrics-full.yml
 ui/apps/platform/package-lock.json
 ui/apps/platform/src/fonts/Open_Sans_Regular.json


### PR DESCRIPTION
### Description

This PR adds Scanner V4 metrics to be collected by kube-burner perf&scale test runs.

*Info for reviewer*

- Most of our components are prefixed with the name of the container. In the case of the scanner, there is the additional prefix (`scanner_v4_`) for metrics stored in Elastic. Please ensure that container names are correct in PormQL queries.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] no test changes

#### How I validated my change

I didn't do any validation. 😞 
