### PR TITLE
chore(ui): Add no-Td-data-label lint rule for PatternFly

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -8,6 +8,35 @@ const rules = {
     // If your rule only disallows something, prefix it with no.
     // However, we can write forbid instead of disallow as the verb in description and message.
 
+    'no-Td-data-label': {
+        // Although Td element renders prop as data-label attribute,
+        // require dataLabel prop to simplify other lint rules.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Replace data-label with dataLabel prop in Td element',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (typeof node.name?.name === 'string' && node.name.name.endsWith('Td')) {
+                        if (
+                            node.attributes.some(
+                                (attribute) => attribute.name?.name === 'data-label'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message: 'Replace data-label with dataLabel prop in Td element',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-Variant': {
         // Replace Variant enum member with corresponding string literal.
         // Because TypeScript string enumeration is source of truth for prop.


### PR DESCRIPTION
### Description

Add lint rule for to prevent future inconsistencies like some fixed in #13113

```js
// Although Td element renders prop as data-label attribute,
// require dataLabel prop to simplify other lint rules.
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform