### PR TITLE
chore(ui): Add missing isActionCell prop to Td elements

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -345,7 +345,7 @@ function ViolationsTablePanel({
                                         );
                                     })}
                                     {hasActions && (
-                                        <Td>
+                                        <Td isActionCell>
                                             <ActionsColumn
                                                 // menuAppendTo={() => document.body}
                                                 isDisabled={actionItems.length === 0}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -218,7 +218,7 @@ function CVEsTable({
                                         <DateDistance date={firstDiscoveredInSystem} />
                                     </Td>
                                     {canSelectRows && (
-                                        <Td className="pf-v5-u-px-0">
+                                        <Td isActionCell>
                                             <ActionsColumn items={createRowActions({ cve })} />
                                         </Td>
                                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -187,7 +187,7 @@ function CVEsTable({
                                         clusters
                                     </Td>
                                     {canSelectRows && (
-                                        <Td className="pf-v5-u-px-0">
+                                        <Td isActionCell>
                                             <ActionsColumn items={createRowActions({ cve })} />
                                         </Td>
                                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -331,7 +331,7 @@ function ImageVulnerabilitiesTable({
                                         />
                                     )}
                                     {createTableActions && (
-                                        <Td className="pf-v5-u-px-0">
+                                        <Td isActionCell>
                                             <ActionsColumn
                                                 // menuAppendTo={() => document.body}
                                                 items={createTableActions({


### PR DESCRIPTION
### Description

Thank you, **David** for telling me about `isActionCell` prop!

### Problem

Besides inconsistent layout, inconsistent props for cells that have exceptions prevent a lint rule to require `dataLabel` prop.

### Analysis

1. Find in Files `isActionCell` has 10 results in 9 files
2. Find in Files `<ActionsColumn` has 19 results in 18 files
3. Find in Files `pf-v5-u-px-0` has 7 results in 7 files
    * 3 for `Td` element relevant here
    * 4 for `ToolbarContent` element not relevant here

### Solution

1. Add (or replace `className` prop with) `isActionCell` prop.

### Residue

1. Replace `className="pf-v5-u-text-align-right"` prop of empty `Td` cell with:
    * `isActionCell` prop
    * `ActionsColumn` child element

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619995 - 4619995
        total -11 = 11745291 - 11745302
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180

#### Manual testing

1. Visit /main/violations

    * Before changes without `isActionCell` prop, see absence of visible problem at 1440px.
        ![ViolationsTablePanel_1440px_without_baseline](https://github.com/user-attachments/assets/a6129e2a-9e0f-4bc7-bbec-b6e804b89df8)

    * Before changes without `isActionCell` prop, temporarily omit several columns to see presence of visible problem at 1440px. That is, kebab does not have right alignment because row actions cell width increases.
        ![ViolationsTablePanel_1440px_without_misaligned](https://github.com/user-attachments/assets/9397bd12-d5ea-49f9-8ad9-1798982b5b76)

    * After changes with `isActionCell` prop, temporarily omit several columns to see absence of visible problem at 1440px. That is, kebab has right alignment because row actions cell width does not increase.
        ![ViolationsTablePanel_1440px_with_aligned](https://github.com/user-attachments/assets/5b33ccfd-bcaa-4c1a-8edf-0c05554515ce)

    * After changes with `isActionCell` prop, see responsive layout at 760px (but see step 4 for something I missed).
        ![ViolationsTablePanel_760px_with](https://github.com/user-attachments/assets/86d910cf-821c-409f-9872-b910193b6416)

2. Visit /main/vulnerabilities/node-cves?entityTab=CVE

    * Before changes without `isActionCell` prop, see absence of visible problem at 1440px.
        ![NodeCves_Overview_CVEsTable_1440px_without_baseline](https://github.com/user-attachments/assets/f75b337d-ea29-449f-b1a7-5c55f5eae12c)

    * Before changes without `isActionCell` prop, temporarily omit several columns to see presence of visible problem at 1440px. That is, kebab does not have right alignment because row actions cell width increases.
        ![ViolationsTablePanel_1440px_without_misaligned](https://github.com/user-attachments/assets/079c9cfb-7149-4f68-b629-97c6db87a810)

    * After changes with `isActionCell` prop, temporarily omit several columns to see absence of visible problem at 1440px. That is, kebab has right alignment because row actions cell width does not increase.
        ![ViolationsTablePanel_1440px_with_aligned](https://github.com/user-attachments/assets/8f780410-7356-4d51-a741-1f831aed3960)

    * After changes with `isActionCell` prop, see responsive layout at 760px (but see step 4 for something I missed).
        ![NodeCves_Overview_CVEsTable_760px_with](https://github.com/user-attachments/assets/4565e511-e57e-4ed9-a162-8a02d1bf8d3b)

3. Visit /main/vulnerabilities/platform-cves?entityTab=CVE

    Ditto.

4. Visit /main/vulnerabilities/workload-cves/images/

    Ditto, but compare responsive layout:

    * Before changes without `isActionCell` prop, see lower right alignment at 760px.
        ![ImageVulnerabilitiesTable_760px_without](https://github.com/user-attachments/assets/e70cfc9c-b382-46c1-8e67-e1f6565e7347)

    * After changes with `isActionCell` prop, see upper right alignment at 760px.
        ![ImageVulnerabilitiesTable_760px_with](https://github.com/user-attachments/assets/cb789d73-2b1a-459b-aeb5-c41d4ba10ef3)
