### PR TITLE
ROX-22770: Improve CI JIRA automation for compatibility tests

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -35,7 +35,6 @@ compatibility_test() {
     short_central_tag="$(shorten_tag "${central_version}")"
     short_sensor_tag="$(shorten_tag "${sensor_version}")"
 
-    #junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
     _compatibility_test "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
 }
 
@@ -103,14 +102,13 @@ update_junit_prefix_with_central_and_sensor_version() {
 
 shorten_tag() {
     if [[ "$#" -ne 1 ]]; then
-        die "Expected a version tag as parameter in mask_minor_version: mask_minor_version <tag>"
+        die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
     fi
 
     input_tag="$1"
 
     development_version_regex='([0-9]+\.[0-9]+\.[xX])'
     with_minor_version_regex='([0-9]+\.[0-9]+)\.[0-9]+'
-    combined_regex='[0-9]+\.[0-9]+\.[0-9xX]+'
 
     if [[ $input_tag =~ $development_version_regex ]]; then
         echo "${BASH_REMATCH[1]}"
@@ -118,7 +116,8 @@ shorten_tag() {
         echo "${BASH_REMATCH[1]}.z"
     else
         echo "${input_tag}"
-        >&2 echo "Failed to shorten tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
+        >&2 echo "Failed to shorten tag ${input_tag} as it did not match any of the following regexes:
+        \"${development_version_regex}\", \"${with_minor_version_regex}\""
         exit 1
     fi
 }

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -118,7 +118,7 @@ shorten_tag() {
         echo "${BASH_REMATCH[1]}.z"
     else
         echo "${input_tag}"
-        >&2 echo "Failed to shorten version of tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
+        >&2 echo "Failed to shorten tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
         exit 1
     fi
 }

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -35,8 +35,8 @@ compatibility_test() {
     short_central_tag="$(shorten_tag "${central_version}")"
     short_sensor_tag="$(shorten_tag "${sensor_version}")"
 
-    junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
-        _compatibility_test "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
+    #junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
+    _compatibility_test "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
 }
 
 _compatibility_test() {
@@ -103,18 +103,22 @@ update_junit_prefix_with_central_and_sensor_version() {
 
 shorten_tag() {
     if [[ "$#" -ne 1 ]]; then
-        die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
+        die "Expected a version tag as parameter in mask_minor_version: mask_minor_version <tag>"
     fi
 
-    long_tag="$1"
+    input_tag="$1"
 
-    short_tag_regex='([0-9]+\.[0-9]+\.[0-9xX]+)'
+    development_version_regex='([0-9]+\.[0-9]+\.[xX])'
+    with_minor_version_regex='([0-9]+\.[0-9]+)\.[0-9]+'
+    combined_regex='[0-9]+\.[0-9]+\.[0-9xX]+'
 
-    if [[ $long_tag =~ $short_tag_regex ]]; then
+    if [[ $input_tag =~ $development_version_regex ]]; then
         echo "${BASH_REMATCH[1]}"
+    elif [[ $input_tag =~ $with_minor_version_regex ]]; then
+        echo "${BASH_REMATCH[1]}.z"
     else
-        echo "${long_tag}"
-        >&2 echo "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
+        echo "${input_tag}"
+        >&2 echo "Failed to shorten version of tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
         exit 1
     fi
 }

--- a/tests/e2e/run-compatibility.sh
+++ b/tests/e2e/run-compatibility.sh
@@ -30,7 +30,6 @@ run_compatibility_tests() {
 
     info "Starting go compatibility tests with central v${short_central_tag} and sensor v${short_sensor_tag}"
 
-    #junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
     _run_compatibility_tests "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
 }
 
@@ -116,14 +115,13 @@ prepare_for_endpoints_test() {
 
 shorten_tag() {
     if [[ "$#" -ne 1 ]]; then
-        die "Expected a version tag as parameter in mask_minor_version: mask_minor_version <tag>"
+        die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
     fi
 
     input_tag="$1"
 
     development_version_regex='([0-9]+\.[0-9]+\.[xX])'
     with_minor_version_regex='([0-9]+\.[0-9]+)\.[0-9]+'
-    combined_regex='[0-9]+\.[0-9]+\.[0-9xX]+'
 
     if [[ $input_tag =~ $development_version_regex ]]; then
         echo "${BASH_REMATCH[1]}"
@@ -131,7 +129,8 @@ shorten_tag() {
         echo "${BASH_REMATCH[1]}.z"
     else
         echo "${input_tag}"
-        >&2 echo "Failed to shorten tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
+        >&2 echo "Failed to shorten tag ${input_tag} as it did not match any of the following regexes:
+        \"${development_version_regex}\", \"${with_minor_version_regex}\""
         exit 1
     fi
 }

--- a/tests/e2e/run-compatibility.sh
+++ b/tests/e2e/run-compatibility.sh
@@ -30,8 +30,8 @@ run_compatibility_tests() {
 
     info "Starting go compatibility tests with central v${short_central_tag} and sensor v${short_sensor_tag}"
 
-    junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
-        _run_compatibility_tests "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
+    #junit_wrap CentralSensorVersionCompatibility "central: ${short_central_tag}, sensor: ${short_sensor_tag}" "" \
+    _run_compatibility_tests "${central_version}" "${sensor_version}" "${short_central_tag}" "${short_sensor_tag}"
 }
 
 _run_compatibility_tests() {
@@ -116,21 +116,26 @@ prepare_for_endpoints_test() {
 
 shorten_tag() {
     if [[ "$#" -ne 1 ]]; then
-        die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
+        die "Expected a version tag as parameter in mask_minor_version: mask_minor_version <tag>"
     fi
 
-    long_tag="$1"
+    input_tag="$1"
 
-    short_tag_regex='([0-9]+\.[0-9]+\.[0-9xX]+)'
+    development_version_regex='([0-9]+\.[0-9]+\.[xX])'
+    with_minor_version_regex='([0-9]+\.[0-9]+)\.[0-9]+'
+    combined_regex='[0-9]+\.[0-9]+\.[0-9xX]+'
 
-    if [[ $long_tag =~ $short_tag_regex ]]; then
+    if [[ $input_tag =~ $development_version_regex ]]; then
         echo "${BASH_REMATCH[1]}"
+    elif [[ $input_tag =~ $with_minor_version_regex ]]; then
+        echo "${BASH_REMATCH[1]}.z"
     else
-        echo "${long_tag}"
-        >&2 echo "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
+        echo "${input_tag}"
+        >&2 echo "Failed to shorten version of tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
         exit 1
     fi
 }
+
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -ne 2 ]]; then

--- a/tests/e2e/run-compatibility.sh
+++ b/tests/e2e/run-compatibility.sh
@@ -131,7 +131,7 @@ shorten_tag() {
         echo "${BASH_REMATCH[1]}.z"
     else
         echo "${input_tag}"
-        >&2 echo "Failed to shorten version of tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
+        >&2 echo "Failed to shorten tag ${input_tag} as it did not match the regex: \"${combined_regex}\""
         exit 1
     fi
 }

--- a/tests/e2e/run-compatibility.sh
+++ b/tests/e2e/run-compatibility.sh
@@ -135,7 +135,6 @@ shorten_tag() {
     fi
 }
 
-
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -ne 2 ]]; then
         info "run-compatibility.sh Args: $*, Numargs: $#"


### PR DESCRIPTION
### Description

For version tags that include a minor version each time that version is bumped up failing compatibility tests create new JIRA tickets. The goal of this PR is to avoid that by cutting off the minor tags and replacing them with `z`. I'm doing this for both the `gke-version-compatibility-tests` and `gke-nongroovy-compatibility-tests` which still share some code duplication (to be addressed later).

While at it I would also like to remove the test summary which creates an additional JIRA ticket for each failing version tuple (extra noise)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I'm going to run the tests and see how CI stores the results and how the logs look.
