### PR TITLE
chore(ui): Replace columns configuration in PoliciesTable

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -18,7 +18,16 @@ import {
     DropdownSeparator,
     DropdownToggle,
 } from '@patternfly/react-core/deprecated';
-import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
+import {
+    ActionsColumn,
+    ExpandableRowContent,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
 import { CaretDownIcon } from '@patternfly/react-icons';
 
 import { ListPolicy } from 'types/policy.proto';
@@ -37,7 +46,6 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { policiesBasePath } from 'routePaths';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { SearchFilter } from 'types/search';
-import { columns } from './PoliciesTable.utils';
 import {
     LabelAndNotifierIdsForType,
     formatLifecycleStages,
@@ -354,7 +362,7 @@ function PoliciesTable({
                                     isSelected: allRowsSelected,
                                 }}
                             />
-                            {columns.map(({ Header, width }) => {
+                            {/* columns.map(({ Header, width }) => {
                                 // const sortParams = {
                                 //     sort: {
                                 //         sortBy: {
@@ -375,7 +383,25 @@ function PoliciesTable({
                                         {Header}
                                     </Th>
                                 );
-                            })}
+                            }) */}
+                            <Th modifier="wrap" sort={getSortParams('Policy')} width={30}>
+                                Policy
+                            </Th>
+                            <Th modifier="wrap" sort={getSortParams('Status')}>
+                                Status
+                            </Th>
+                            <Th modifier="wrap" sort={getSortParams('Origin')} width={20}>
+                                Origin
+                            </Th>
+                            <Th modifier="wrap" sort={getSortParams('Notifiers')}>
+                                Notifiers
+                            </Th>
+                            <Th modifier="wrap" sort={getSortParams('Severity')}>
+                                Severity
+                            </Th>
+                            <Th modifier="wrap" sort={getSortParams('Lifecycle')}>
+                                Lifecycle
+                            </Th>
                             <Th>
                                 <span className="pf-v5-screen-reader">Row actions</span>
                             </Th>
@@ -500,11 +526,9 @@ function PoliciesTable({
                                     <Td dataLabel="Lifecycle">
                                         {formatLifecycleStages(lifecycleStages)}
                                     </Td>
-                                    <Td
-                                        actions={{
-                                            items: actionItems,
-                                        }}
-                                    />
+                                    <Td isActionCell>
+                                        <ActionsColumn items={actionItems} />
+                                    </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
                                     <Td />

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -363,6 +363,11 @@ function PoliciesTable({
                                 }}
                             />
                             {/* columns.map(({ Header, width }) => {
+                                // https://github.com/stackrox/stackrox/pull/10316
+                                // Move client-side sorting from PoliciesTable to PoliciesTablePage.
+                                // After the Policies API is paginated in the API,
+                                // we can use start passing the URL sort parameters that I (Van) have added here directly to the API call.
+                                //
                                 // const sortParams = {
                                 //     sort: {
                                 //         sortBy: {

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -7,7 +7,6 @@ export const columns = [
         Header: 'Policy',
         accessor: 'name',
         sortMethod: (a: ListPolicy, b: ListPolicy) => sortAsciiCaseInsensitive(a.name, b.name),
-        width: 30 as const,
     },
     {
         Header: 'Status',
@@ -18,7 +17,6 @@ export const columns = [
         accessor: 'isDefault',
         sortMethod: (a: ListPolicy, b: ListPolicy) =>
             sortAsciiCaseInsensitive(getPolicyOriginLabel(a), getPolicyOriginLabel(b)),
-        width: 20 as const,
     },
     {
         Header: 'Notifiers',


### PR DESCRIPTION
### Description

Replace `map` method for `columns` with individual `Th` and `Td` elements:
* To benefit from lint rules for consistency.
* To be able to generate table columns for comparison.
* To increase our ability to reuse knowledge and skills to update tables easily.

Also replace `items` prop of empty `Td` element:
* `isActionsCell` prop
* `ActionsColumn` child element

### User-facing documentation

- [x] CHANGELOG update is not needed
- [ ] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619921 - 4619921
        total 387 = 11745226 - 11744839
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180
3. `npm run start` in ui/apps/platform

#### Manual testing

No visual nor behavioral (sorting) change for `Th` elements.

1. Visit /main/policy-management/policies

    * Before changes without `isActionCell` prop, see alignment of row actions at 1440px.
        ![PoliciesTable_1440px_baseline](https://github.com/user-attachments/assets/0115e439-d2d6-4a5e-9bf7-697f5a511e91)

    * Before changes with `isActionCell` prop, see alignment of row actions at 1440px.
        ![PoliciesTable_1440px_isActionCell](https://github.com/user-attachments/assets/58456046-e0ae-40ba-9381-76e53447174b)

    * Before changes without `isActionCell` prop, see alignment of row actions at 760px.
        ![PoliciesTable_760px_baseline](https://github.com/user-attachments/assets/fa5384b1-b5e3-4511-b802-2ddec44194cb)

    * Before changes with `isActionCell` prop, see alignment of row actions at 760px.
        ![PoliciesTable_760px_isActionCell](https://github.com/user-attachments/assets/10782a6a-bab1-4189-9f29-936ca6695ab1)

2. Expand a row to see description.

    * At 1440px.
        ![PoliciesTable_isExpanded_1440px](https://github.com/user-attachments/assets/a42f8ec6-f3ab-4f95-bf11-09c0559c5777)

    * At 760px.
        ![PoliciesTable_isExpanded_760px](https://github.com/user-attachments/assets/d7a7ace9-1779-4e96-8380-5a4527aa766e)