### PR TITLE
chore(ui): Replace properties with strings in FlowsTable cells

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -10,16 +10,7 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import {
-    Button,
-    Flex,
-    FlexItem,
-    Icon,
-    Text,
-    TextContent,
-    TextVariants,
-    Tooltip,
-} from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Icon, Text, TextContent, Tooltip } from '@patternfly/react-core';
 import {
     ExclamationCircleIcon,
     ExclamationTriangleIcon,
@@ -48,13 +39,6 @@ type FlowsTableProps = {
     onSelectFlow: (entityId: string) => void;
 };
 
-const columnNames = {
-    entity: 'Entity',
-    direction: 'Direction',
-    // @TODO: This would be a good point to update with i18n translation ability
-    portAndProtocol: 'Port / protocol',
-};
-
 function getFlowSubtext(flow: Flow): string {
     switch (flow.type) {
         case 'DEPLOYMENT':
@@ -81,39 +65,6 @@ function getBaselineSimulatedRowStyle(
         customStyle = {};
     }
     return customStyle;
-}
-
-function ExtraneousFlowsRow({
-    isEditable,
-    numExtraneousEgressFlows,
-    direction,
-}: {
-    isEditable: boolean;
-    numExtraneousEgressFlows: number;
-    direction: 'Ingress' | 'Egress';
-}) {
-    return (
-        <Tbody>
-            <Tr>
-                <Td />
-                {isEditable && <Td />}
-                <Td dataLabel={columnNames.entity}>
-                    <Flex direction={{ default: 'row' }}>
-                        <FlexItem>
-                            <div>+ {numExtraneousEgressFlows} allowed flows</div>
-                            <div>
-                                <TextContent>
-                                    <Text component={TextVariants.small}>Across this cluster</Text>
-                                </TextContent>
-                            </div>
-                        </FlexItem>
-                    </Flex>
-                </Td>
-                <Td dataLabel={columnNames.direction}>{direction}</Td>
-                <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
-            </Tr>
-        </Tbody>
-    );
 }
 
 function AnomalousIcon({ type }: { type: FlowEntityType }) {
@@ -196,9 +147,9 @@ function FlowsTable({
                         />
                     )}
                     {isBaselineSimulation && <Td />}
-                    <Th>{columnNames.entity}</Th>
-                    <Th modifier="nowrap">{columnNames.direction}</Th>
-                    <Th modifier="nowrap">{columnNames.portAndProtocol}</Th>
+                    <Th>Entity</Th>
+                    <Th modifier="nowrap">Direction</Th>
+                    <Th modifier="nowrap">Port / protocol</Th>
                     {isEditable && (
                         <Th>
                             <span className="pf-v5-screen-reader">Row actions</span>
@@ -263,7 +214,7 @@ function FlowsTable({
                                 />
                             )}
                             {isBaselineSimulation && (
-                                <Td dataLabel={columnNames.direction}>
+                                <Td dataLabel="TODO">
                                     {row.baselineSimulationDiffState === 'ADDED' && (
                                         <Tooltip content={<div>Baseline added</div>}>
                                             <Icon size="sm">
@@ -280,7 +231,7 @@ function FlowsTable({
                                     )}
                                 </Td>
                             )}
-                            <Td dataLabel={columnNames.entity}>
+                            <Td dataLabel="Entity">
                                 <Flex direction={{ default: 'row' }}>
                                     <FlexItem>
                                         <div>
@@ -294,9 +245,7 @@ function FlowsTable({
                                         </div>
                                         <div>
                                             <TextContent>
-                                                <Text component={TextVariants.small}>
-                                                    {getFlowSubtext(row)}
-                                                </Text>
+                                                <Text component="small">{getFlowSubtext(row)}</Text>
                                             </TextContent>
                                         </div>
                                     </FlexItem>
@@ -307,8 +256,8 @@ function FlowsTable({
                                     )}
                                 </Flex>
                             </Td>
-                            <Td dataLabel={columnNames.direction}>{row.direction}</Td>
-                            <Td dataLabel={columnNames.portAndProtocol}>
+                            <Td dataLabel="Direction">{row.direction}</Td>
+                            <Td dataLabel="Port / protocol">
                                 {row.port} / {protocolLabel[row.protocol]}
                             </Td>
                             {isEditable && (
@@ -353,7 +302,7 @@ function FlowsTable({
                                                 }}
                                             />
                                         )}
-                                        <Td>
+                                        <Td colSpan={1}>
                                             <ExpandableRowContent>
                                                 <Flex direction={{ default: 'row' }}>
                                                     <FlexItem>
@@ -373,12 +322,12 @@ function FlowsTable({
                                                 </Flex>
                                             </ExpandableRowContent>
                                         </Td>
-                                        <Td>
+                                        <Td colSpan={1}>
                                             <ExpandableRowContent>
                                                 {child.direction}
                                             </ExpandableRowContent>
                                         </Td>
-                                        <Td>
+                                        <Td colSpan={1}>
                                             <ExpandableRowContent>
                                                 {child.port} / {protocolLabel[child.protocol]}
                                             </ExpandableRowContent>
@@ -395,18 +344,48 @@ function FlowsTable({
                 );
             })}
             {numExtraneousEgressFlows > 0 && (
-                <ExtraneousFlowsRow
-                    isEditable
-                    numExtraneousEgressFlows={numExtraneousEgressFlows}
-                    direction="Egress"
-                />
+                <Tbody>
+                    <Tr>
+                        <Td />
+                        {isEditable && <Td />}
+                        <Td dataLabel="Entity">
+                            <Flex direction={{ default: 'row' }}>
+                                <FlexItem>
+                                    <div>+ {numExtraneousEgressFlows} allowed flows</div>
+                                    <div>
+                                        <TextContent>
+                                            <Text component="small">Across this cluster</Text>
+                                        </TextContent>
+                                    </div>
+                                </FlexItem>
+                            </Flex>
+                        </Td>
+                        <Td dataLabel="Direction">Egress</Td>
+                        <Td dataLabel="Port / protocol">Any / Any</Td>
+                    </Tr>
+                </Tbody>
             )}
             {numExtraneousIngressFlows > 0 && (
-                <ExtraneousFlowsRow
-                    isEditable
-                    numExtraneousEgressFlows={numExtraneousIngressFlows}
-                    direction="Ingress"
-                />
+                <Tbody>
+                    <Tr>
+                        <Td />
+                        {isEditable && <Td />}
+                        <Td dataLabel="Entity">
+                            <Flex direction={{ default: 'row' }}>
+                                <FlexItem>
+                                    <div>+ {numExtraneousIngressFlows} allowed flows</div>
+                                    <div>
+                                        <TextContent>
+                                            <Text component="small">Across this cluster</Text>
+                                        </TextContent>
+                                    </div>
+                                </FlexItem>
+                            </Flex>
+                        </Td>
+                        <Td dataLabel="Direction">Ingress</Td>
+                        <Td dataLabel="Port / protocol">Any / Any</Td>
+                    </Tr>
+                </Tbody>
             )}
         </Table>
     );


### PR DESCRIPTION
### Description

Work in progress. Need to collaborate with Saif to verify conditional rendering:
* TODO for ADDED and REMOVED that had copy-paste duplicate `dataLabel` but no `Th` text.
* `isExpanded`including

Replace object properties with strings as text of `Th` and `dataLabel` of `Td` elements:
* To benefit from lint rules for consistency.
* To be able to generate table columns for comparison.
* To increase our ability to reuse knowledge and skills to update tables easily.

Addtional changes:
1. Move `Tbody` from `ExtraneousFlowsRow` inline for lint rule to verify consistency of `Td` in `Tbody` and `Th` in `Thead` element.
2. Add `colSpan={1}` prop to `Td` elements that have `ExpandableRowContent` as child:
    * to follow same pattern as elsewhere
    * as exception in lint rule for `dataLabel` props

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4619921 - 4619921
        total 392 = 11745231 - 11744839
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/network-graph select cluster and namespace, click a deployment to open side panel, and then click **Flows** tab.
        ![FlowsTable_1440px](https://github.com/user-attachments/assets/4e551c8c-de62-4e84-b57c-d3cf16794a84)
