### PR TITLE
ROX-26415: Remove install-specific URL data in telemetry

### DIFF
--- a/ui/apps/platform/src/hooks/useAnalytics.test.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.test.ts
@@ -16,61 +16,109 @@ describe('getRedactedOriginProperties', () => {
     });
 
     test('scrubs installation-specific search value', () => {
+        const originalSearchParams = ['s[Cluster][0]=control-cluster'].join('&');
+        const redactedSearchParams = [`s[Cluster][0]=${redactedSearchReplacement}`].join('&');
         expect(
             getRedactedOriginProperties(
-                'https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=control-cluster'
+                `https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?${originalSearchParams}`
             )
         ).toEqual({
-            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=${redactedSearchReplacement}`,
-            search: `?s[Cluster][0]=${redactedSearchReplacement}`,
+            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?${redactedSearchParams}`,
+            search: `?${redactedSearchParams}`,
             referrer: '',
         });
     });
 
     test('does not scrub allow-listed search keys', () => {
+        const originalSearchParams = [
+            's[Cluster][0]=control-cluster',
+            's[Compliance%20Check%20Name][0]=apiserver',
+        ].join('&');
+        const redactedSearchParams = [
+            `s[Cluster][0]=${redactedSearchReplacement}`,
+            's[Compliance%20Check%20Name][0]=apiserver',
+        ].join('&');
         expect(
             getRedactedOriginProperties(
-                'https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=control-cluster&s[Compliance%20Check%20Name][0]=apiserver'
+                `https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?${originalSearchParams}`
             )
         ).toEqual({
-            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=${redactedSearchReplacement}&s[Compliance%20Check%20Name][0]=apiserver`,
-            search: `?s[Cluster][0]=${redactedSearchReplacement}&s[Compliance%20Check%20Name][0]=apiserver`,
+            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?${redactedSearchParams}`,
+            search: `?${redactedSearchParams}`,
             referrer: '',
         });
     });
 
     test('scrubs top level string search values', () => {
+        const originalSearchParams = [
+            's[groupBy]=CLUSTER',
+            's[standard]=NIST%20SP%20800-53',
+            's[bogus]=bogus',
+        ].join('&');
+        const redactedSearchParams = [
+            's[groupBy]=CLUSTER',
+            's[standard]=NIST%20SP%20800-53',
+            `s[bogus]=${redactedSearchReplacement}`,
+        ].join('&');
         expect(
             getRedactedOriginProperties(
-                'https://example.stackrox.com/main/compliance/controls?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=bogus'
+                `https://example.stackrox.com/main/compliance/controls?${originalSearchParams}`
             )
         ).toEqual({
-            url: `https://${redactedHostReplacement}/main/compliance/controls?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=${redactedSearchReplacement}`,
-            search: `?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=${redactedSearchReplacement}`,
+            url: `https://${redactedHostReplacement}/main/compliance/controls?${redactedSearchParams}`,
+            search: `?${redactedSearchParams}`,
             referrer: '',
         });
     });
 
     test('scrubs only s and s2 search keys', () => {
+        const originalSearchParams = [
+            's[bogus%20standard]=NIST%20SP%20800-190',
+            's2[bogus%20standard]=NIST%20SP%20800-190',
+            's3[bogus%20standard]=NIST%20SP%20800-190',
+        ].join('&');
+        const redactedSearchParams = [
+            `s[bogus%20standard]=${redactedSearchReplacement}`,
+            `s2[bogus%20standard]=${redactedSearchReplacement}`,
+            's3[bogus%20standard]=NIST%20SP%20800-190',
+        ].join('&');
         expect(
             getRedactedOriginProperties(
-                'https://example.stackrox.com/main/compliance/controls?s[bogus%20standard]=NIST%20SP%20800-190&s2[bogus%20standard]=NIST%20SP%20800-190&s3[bogus%20standard]=NIST%20SP%20800-190'
+                `https://example.stackrox.com/main/compliance/controls?${originalSearchParams}`
             )
         ).toEqual({
-            url: `https://${redactedHostReplacement}/main/compliance/controls?s[bogus%20standard]=${redactedSearchReplacement}&s2[bogus%20standard]=${redactedSearchReplacement}&s3[bogus%20standard]=NIST%20SP%20800-190`,
-            search: `?s[bogus%20standard]=${redactedSearchReplacement}&s2[bogus%20standard]=${redactedSearchReplacement}&s3[bogus%20standard]=NIST%20SP%20800-190`,
+            url: `https://${redactedHostReplacement}/main/compliance/controls?${redactedSearchParams}`,
+            search: `?${redactedSearchParams}`,
             referrer: '',
         });
     });
 
     test('scrubs mixed search value structures', () => {
+        const originalSearchParams = [
+            's[External%20Hostname]=test',
+            's[Cluster]=control-cluster',
+            's[Namespace][0]=cert-manager',
+            's[Namespace][1]=kube-public',
+            's[Deployment][0]=cert-manager',
+            's[Deployment][1]=cert-manager',
+            'simulation=networkPolicy',
+        ].join('&');
+        const redactedSearchParams = [
+            `s[External%20Hostname]=${redactedSearchReplacement}`,
+            `s[Cluster]=${redactedSearchReplacement}`,
+            `s[Namespace][0]=${redactedSearchReplacement}`,
+            `s[Namespace][1]=${redactedSearchReplacement}`,
+            `s[Deployment][0]=${redactedSearchReplacement}`,
+            `s[Deployment][1]=${redactedSearchReplacement}`,
+            'simulation=networkPolicy',
+        ].join('&');
         expect(
             getRedactedOriginProperties(
-                'https://example.stackrox.com:443/main/network-graph?s[External Hostname]=test&s[Cluster]=control-cluster&s[Namespace][0]=cert-manager&s[Namespace][1]=kube-public&s[Deployment][0]=cert-manager&s[Deployment][1]=cert-manager&simulation=networkPolicy'
+                `https://example.stackrox.com:443/main/network-graph?${originalSearchParams}`
             )
         ).toEqual({
-            url: `https://${redactedHostReplacement}/main/network-graph?s[External%20Hostname]=${redactedSearchReplacement}&s[Cluster]=${redactedSearchReplacement}&s[Namespace][0]=${redactedSearchReplacement}&s[Namespace][1]=${redactedSearchReplacement}&s[Deployment][0]=${redactedSearchReplacement}&s[Deployment][1]=${redactedSearchReplacement}&simulation=networkPolicy`,
-            search: `?s[External%20Hostname]=${redactedSearchReplacement}&s[Cluster]=${redactedSearchReplacement}&s[Namespace][0]=${redactedSearchReplacement}&s[Namespace][1]=${redactedSearchReplacement}&s[Deployment][0]=${redactedSearchReplacement}&s[Deployment][1]=${redactedSearchReplacement}&simulation=networkPolicy`,
+            url: `https://${redactedHostReplacement}/main/network-graph?${redactedSearchParams}`,
+            search: `?${redactedSearchParams}`,
             referrer: '',
         });
     });

--- a/ui/apps/platform/src/hooks/useAnalytics.test.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,77 @@
+import {
+    getRedactedOriginProperties,
+    redactedHostReplacement,
+    redactedSearchReplacement,
+} from './useAnalytics';
+
+describe('getRedactedOriginProperties', () => {
+    test('scrubs installation-specific host value', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-pci-dss-4-0/checks'
+            ).url
+        ).toEqual(
+            `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-pci-dss-4-0/checks`
+        );
+    });
+
+    test('scrubs installation-specific search value', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=control-cluster'
+            )
+        ).toEqual({
+            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=${redactedSearchReplacement}`,
+            search: `?s[Cluster][0]=${redactedSearchReplacement}`,
+            referrer: '',
+        });
+    });
+
+    test('does not scrub allow-listed search keys', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=control-cluster&s[Compliance%20Check%20Name][0]=apiserver'
+            )
+        ).toEqual({
+            url: `https://${redactedHostReplacement}/main/compliance/coverage/profiles/ocp4-cis-node-1-5/checks?s[Cluster][0]=${redactedSearchReplacement}&s[Compliance%20Check%20Name][0]=apiserver`,
+            search: `?s[Cluster][0]=${redactedSearchReplacement}&s[Compliance%20Check%20Name][0]=apiserver`,
+            referrer: '',
+        });
+    });
+
+    test('scrubs top level string search values', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com/main/compliance/controls?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=bogus'
+            )
+        ).toEqual({
+            url: `https://${redactedHostReplacement}/main/compliance/controls?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=${redactedSearchReplacement}`,
+            search: `?s[groupBy]=CLUSTER&s[standard]=NIST%20SP%20800-53&s[bogus]=${redactedSearchReplacement}`,
+            referrer: '',
+        });
+    });
+
+    test('scrubs only s and s2 search keys', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com/main/compliance/controls?s[bogus%20standard]=NIST%20SP%20800-190&s2[bogus%20standard]=NIST%20SP%20800-190&s3[bogus%20standard]=NIST%20SP%20800-190'
+            )
+        ).toEqual({
+            url: `https://${redactedHostReplacement}/main/compliance/controls?s[bogus%20standard]=${redactedSearchReplacement}&s2[bogus%20standard]=${redactedSearchReplacement}&s3[bogus%20standard]=NIST%20SP%20800-190`,
+            search: `?s[bogus%20standard]=${redactedSearchReplacement}&s2[bogus%20standard]=${redactedSearchReplacement}&s3[bogus%20standard]=NIST%20SP%20800-190`,
+            referrer: '',
+        });
+    });
+
+    test('scrubs mixed search value structures', () => {
+        expect(
+            getRedactedOriginProperties(
+                'https://example.stackrox.com:443/main/network-graph?s[External Hostname]=test&s[Cluster]=control-cluster&s[Namespace][0]=cert-manager&s[Namespace][1]=kube-public&s[Deployment][0]=cert-manager&s[Deployment][1]=cert-manager&simulation=networkPolicy'
+            )
+        ).toEqual({
+            url: `https://${redactedHostReplacement}/main/network-graph?s[External%20Hostname]=${redactedSearchReplacement}&s[Cluster]=${redactedSearchReplacement}&s[Namespace][0]=${redactedSearchReplacement}&s[Namespace][1]=${redactedSearchReplacement}&s[Deployment][0]=${redactedSearchReplacement}&s[Deployment][1]=${redactedSearchReplacement}&simulation=networkPolicy`,
+            search: `?s[External%20Hostname]=${redactedSearchReplacement}&s[Cluster]=${redactedSearchReplacement}&s[Namespace][0]=${redactedSearchReplacement}&s[Namespace][1]=${redactedSearchReplacement}&s[Deployment][0]=${redactedSearchReplacement}&s[Deployment][1]=${redactedSearchReplacement}&simulation=networkPolicy`,
+            referrer: '',
+        });
+    });
+});

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import Raven from 'raven-js';
+import mapValues from 'lodash/mapValues';
 
 import { Telemetry } from 'types/config.proto';
 import { selectors } from 'reducers';
-import { UnionFrom, tupleTypeGuard } from 'utils/type.utils';
+import { UnionFrom, ensureExhaustive, tupleTypeGuard } from 'utils/type.utils';
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 
 // Event Name Constants
 
@@ -95,6 +98,14 @@ export const searchCategoriesWithFilter = [
     'Lifecycle Stage',
     'Resource Type',
     'Inactive Deployment',
+    'Control',
+    'Compliance Check Name',
+    'Compliance State',
+    'Cluster Type',
+    'Cluster Platform Type',
+    'Standard',
+    // 'groupBy' is not a real filter, but is used under the 's' key in the URL in old compliance pages
+    'groupBy',
 ] as const;
 
 export const isSearchCategoryWithFilter = tupleTypeGuard(searchCategoriesWithFilter);
@@ -380,6 +391,87 @@ export type AnalyticsEvent =
           };
       };
 
+export const redactedHostReplacement = 'redacted.host';
+export const redactedSearchReplacement = '*****';
+
+// Replace the hostname, port, and search parameters with redacted values
+function redactURL(location: string): string {
+    try {
+        const url = new URL(location);
+        url.host = redactedHostReplacement;
+        url.search = redactSearchParams(location);
+        return url.toString();
+    } catch (error) {
+        Raven.captureException(error);
+        // Do not throw an error during an analytics event. If an error occurs, redact the entire URL.
+        return '';
+    }
+}
+
+type RawQueryStringValue = qs.ParsedQs[keyof qs.ParsedQs];
+
+function isAllowedSearchKey(key: string): boolean {
+    return searchCategoriesWithFilter.some((term) => key.toUpperCase() === term.toUpperCase());
+}
+
+// Given a parsed query string value, redact any properties that are not explicitly allowed
+function redactParsedQs(value: RawQueryStringValue, key: string): RawQueryStringValue {
+    if (typeof value === 'undefined') {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return (
+            value
+                .map((v: string | qs.ParsedQs) => redactParsedQs(v, key))
+                // Our search structure does not allow nested objects, so we can safely filter out any non-string values
+                // for simplicity
+                .filter((v): v is string => typeof v === 'string')
+        );
+    }
+    if (typeof value === 'object') {
+        return mapValues(value, redactParsedQs);
+    }
+    // The terminal case: if the value is a string, redact it if the key is not allowed
+    if (typeof value === 'string') {
+        return isAllowedSearchKey(key) ? value : redactedSearchReplacement;
+    }
+
+    return ensureExhaustive(value);
+}
+
+// Traverse all defined search keys and redact any properties that are not explicitly allowed
+// in analytics events.
+function redactSearchParams(location: string): string {
+    // Top level URL parameters that can contain user or installation-specific information. Any
+    // key that should have its value redacted should be added to this list.
+    const topLevelSearchKeys = ['s', 's2'];
+
+    try {
+        const url = new URL(location);
+        const queryObject = getQueryObject(url.search);
+        const redactedQueryObject = mapValues(queryObject, (v, k) =>
+            topLevelSearchKeys.includes(k) ? redactParsedQs(v, k) : v
+        );
+        url.search = getQueryString(redactedQueryObject);
+        // Re-convert via URL constructor to ensure URI encoding for search keys that matches how Segment would handle this natively
+        return new URL(url.toString()).search;
+    } catch (error) {
+        Raven.captureException(error);
+        // Do not throw an error during an analytics event. If an error occurs, redact the entire search string.
+        return '';
+    }
+}
+
+// Strip out installation-specific information from the analytics context
+export function getRedactedOriginProperties(location: string) {
+    return {
+        url: redactURL(location),
+        search: redactSearchParams(location),
+        // Referrer is unused, so we remove it entirely here to avoid sending private values to analytics
+        referrer: '',
+    };
+}
+
 const useAnalytics = () => {
     const telemetry = useSelector(selectors.publicConfigTelemetrySelector);
     const { enabled: isTelemetryEnabled } = telemetry || ({} as Telemetry);
@@ -387,7 +479,10 @@ const useAnalytics = () => {
     const analyticsPageVisit = useCallback(
         (type: string, name: string, additionalProperties = {}): void => {
             if (isTelemetryEnabled !== false) {
-                window.analytics?.page(type, name, additionalProperties);
+                window.analytics?.page(type, name, {
+                    ...additionalProperties,
+                    ...getRedactedOriginProperties(window.location.toString()),
+                });
             }
         },
         [isTelemetryEnabled]
@@ -399,10 +494,20 @@ const useAnalytics = () => {
                 return;
             }
 
+            const redactedEventContext = {
+                context: {
+                    page: getRedactedOriginProperties(window.location.toString()),
+                },
+            };
+
             if (typeof analyticsEvent === 'string') {
-                window.analytics?.track(analyticsEvent);
+                window.analytics?.track(analyticsEvent, undefined, redactedEventContext);
             } else {
-                window.analytics?.track(analyticsEvent.event, analyticsEvent.properties);
+                window.analytics?.track(
+                    analyticsEvent.event,
+                    analyticsEvent.properties,
+                    redactedEventContext
+                );
             }
         },
         [isTelemetryEnabled]


### PR DESCRIPTION
### Description

Removes hostname information and installation-specific search values from analytics metadata when page views and events are tracked.

The changes are summarized as follows:

1. The `referrer` field is replaced with an empty string unconditionally
2. The `search` field has values replaced if (a) The top level key is either `s` or `s2` (b) The filter level key _does not_ match a defined allow-list.
3. The `url` field has the hostname replaced with the text `redacted.host` and the search portion of the URL replaced as described in (2) above.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Unit tests were added to validate the behavior of the new functions.

Test the redacted properties when a PageView event is sent:
![image](https://github.com/user-attachments/assets/333197b6-02fc-4cc0-891e-69c0a6de5c26)

Test the redacted properties when a user-initiated event is sent:
![image](https://github.com/user-attachments/assets/7591736f-326a-4d62-afc2-b3521370f533)
