### PR TITLE
fix(be): CRD validation desc optional

### DIFF
--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -40,6 +40,7 @@ type SecurityPolicySpec struct {
 	// +kubebuilder:validation:Pattern=`^[^\n\r\$]{5,128}$`
 	// PolicyName is the name of the policy as it appears in the API and UI.  Note that changing this value will rename the policy as stored in the database.  This field must be unique.
 	PolicyName string `json:"policyName"`
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern=`^[^\$]{0,800}$`
 	// Description is a free-form text description of this policy.
 	Description string `json:"description"`

--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -43,7 +43,7 @@ type SecurityPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern=`^[^\$]{0,800}$`
 	// Description is a free-form text description of this policy.
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	Rationale   string `json:"rationale,omitempty"`
 	// Remediation describes how to remediate a violation of this policy.
 	Remediation string `json:"remediation,omitempty"`

--- a/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
+++ b/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
@@ -253,7 +253,6 @@ spec:
                 type: string
             required:
             - categories
-            - description
             - lifecycleStages
             - policyName
             - policySections

--- a/image/templates/helm/stackrox-central/crds/config.stackrox.io_securitypolicies.yaml
+++ b/image/templates/helm/stackrox-central/crds/config.stackrox.io_securitypolicies.yaml
@@ -253,7 +253,6 @@ spec:
                 type: string
             required:
             - categories
-            - description
             - lifecycleStages
             - policyName
             - policySections


### PR DESCRIPTION
### Description

Setting description field to optional specifically for it to be removed from the list of required fields in the generated CRD spec.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manually on a cluster, applied a policy CR with the description field missing from the spec and verified policy gets created.

```
$:~/go/src/github.com/stackrox/stackrox/c/helm/chart$ kubectl -n stackrox create -f /tmp/policy-cr.yaml 
securitypolicy.config.stackrox.io/boo-test created
$:~/go/src/github.com/stackrox/stackrox/c/helm/chart$ cat /tmp/policy-cr.yaml 
apiVersion: config.stackrox.io/v1alpha1
kind: SecurityPolicy
metadata:
  name: boo-test
spec:
  policyName: boo-test
  rationale: A demo!
  categories:
  - Anomalous Activity
  - DevOps Best Practices
  lifecycleStages:
  - DEPLOY
  scope:
  - namespace: "boo-namespace"
  severity: HIGH_SEVERITY
  policySections:
  - sectionName: Policy Section 1
    policyGroups:
    - fieldName: Image Scan Age
      booleanOperator: OR
      values:
      - value: "5"

```
