### PR TITLE
feat(certwatch): log issuer, fix typo

### DIFF
--- a/pkg/mtls/certwatch/certwatch.go
+++ b/pkg/mtls/certwatch/certwatch.go
@@ -58,8 +58,8 @@ func (h *handler) OnStableUpdate(val interface{}, err error) {
 		if cert == nil {
 			log.Infof("No TLS certificate found. Using internal certificates for HTTPS. Watch dir: %q", h.dir)
 		} else {
-			log.Infof("TLS certificate loaded, using the following cert for HTTPS: (SerialNumber: %s, Subject: %s, DNSNames, %s), watch dir: %q",
-				cert.Leaf.SerialNumber, cert.Leaf.Subject, cert.Leaf.DNSNames, h.dir)
+			log.Infof("TLS certificate loaded, using the following cert for HTTPS: (SerialNumber: %s, Subject: %s, DNSNames: %s, Issuer: %s), watch dir: %q",
+				cert.Leaf.SerialNumber, cert.Leaf.Subject, cert.Leaf.DNSNames, cert.Leaf.Issuer, h.dir)
 
 			parsedChain, err := x509utils.ParseCertificateChain(cert.Certificate)
 			if err != nil {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Line breaks mine for readability:
Before:
```
pkg/mtls/certwatch: 2024/11/04 10:18:33.861395 certwatch.go:61: Info: TLS certificate loaded, using the following cert for HTTPS:
 (SerialNumber: 8653177060486310112,
 Subject: CN=*.scanner-v4-indexer.rhacs-operator.svc,
 DNSNames, [*.scanner-v4-indexer.rhacs-operator.svc *.scanner-v4-indexer.rhacs-operator.svc.cluster.local scanner-v4-indexer.rhacs-operator.svc scanner-v4-indexer.rhacs-operator.svc.cluster.local]),
 watch dir: "/run/secrets/stackrox.io/monitoring-tls"
```
After:
```
pkg/mtls/certwatch: 2024/11/05 07:52:39.252566 certwatch.go:61: Info: TLS certificate loaded, using the following cert for HTTPS:
 (SerialNumber: 8653177060486310112,
 Subject: CN=*.scanner-v4-indexer.rhacs-operator.svc,
 DNSNames: [*.scanner-v4-indexer.rhacs-operator.svc *.scanner-v4-indexer.rhacs-operator.svc.cluster.local scanner-v4-indexer.rhacs-operator.svc scanner-v4-indexer.rhacs-operator.svc.cluster.local],
 Issuer: CN=openshift-service-serving-signer@1730708956),
 watch dir: "/run/secrets/stackrox.io/monitoring-tls"
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
- [x] no tests changed

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Took a look at the logs in a dev cluster, see above.