### PR TITLE
ROX-26326: Ignore remove functions if nil

### DIFF
--- a/pkg/utils/ignore_error.go
+++ b/pkg/utils/ignore_error.go
@@ -5,3 +5,10 @@ package utils
 func IgnoreError(f func() error) {
 	_ = f()
 }
+
+// IgnoreErrorAndCheckNil calls IgnoreError if the function is not nil.
+func IgnoreErrorAndCheckNil(f func() error) {
+	if f != nil {
+		IgnoreError(f)
+	}
+}

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -353,7 +353,7 @@ func (c *TestContext) runWithResources(t *testing.T, resources []K8sResourceInfo
 	if err != nil {
 		return errors.Errorf("failed to create namespace: %s", err)
 	}
-	defer utils.IgnoreError(removeNamespace)
+	defer utils.IgnoreErrorAndCheckNil(removeNamespace)
 	var removeFunctions []func() error
 	fileToObj := map[string]k8s.Object{}
 	for i := range resources {
@@ -367,7 +367,7 @@ func (c *TestContext) runWithResources(t *testing.T, resources []K8sResourceInfo
 	}
 	defer func() {
 		for _, fn := range removeFunctions {
-			utils.IgnoreError(fn)
+			utils.IgnoreErrorAndCheckNil(fn)
 		}
 	}()
 	testCase(t, c, fileToObj)
@@ -377,7 +377,7 @@ func (c *TestContext) runWithResources(t *testing.T, resources []K8sResourceInfo
 // runBare runs a test case without applying any resources to the cluster.
 func (c *TestContext) runBare(t *testing.T, testCase TestCallback) {
 	_, removeNamespace, err := c.createTestNs(context.Background(), t, DefaultNamespace)
-	defer utils.IgnoreError(removeNamespace)
+	defer utils.IgnoreErrorAndCheckNil(removeNamespace)
 	if err != nil {
 		t.Fatalf("failed to create namespace: %s", err)
 	}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The remove functions for resources like namespaces in the integration tests helper can be nil if the creation fails. If they are nil, the defer statements that call them will panic.

This PR adds a new function `IgnoreErrorAndCheckNil` that will call the given function if the function is not nil.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] CI should be happy
- [x] Manual test.
  - Comment [these lines](https://github.com/stackrox/stackrox/blob/fd1ef713d1d87a2ec9fbdc61f5b1bddbac9eb8d5/sensor/tests/helper/helper.go#L264-L266)
  - Manually create the namespace `sensor-integration`
  - Run any integration tests: `go test -race -count=1 github.com/stackrox/rox/sensor/tests/resource/service`
  - You should see the tests panics before these changes because the `removeNamespace` function is nil and with the changes the tests fail but not panic.
