### PR TITLE
ci: return bundle build to ubi9, remove golang builder use

### DIFF
--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -1,10 +1,5 @@
-FROM registry.access.redhat.com/ubi9:latest AS ubi-repo-donor
+FROM registry.access.redhat.com/ubi9:latest AS builder-runner
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder-runner
-
-# For some reason, openshift-golang-builder 9 comes without any RPM repos in /etc/yum.repos.d/
-# We, however, need to install some packages and so we need to configure RPM repos. The ones for UBI are sufficient.
-COPY --from=ubi-repo-donor /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 RUN dnf -y upgrade --nobest && dnf -y install --nodocs --noplugins jq python3-pip
 
 COPY ./operator/bundle_helpers/requirements.txt /tmp/requirements.txt
@@ -65,11 +60,6 @@ RUN echo "Checking required RELATED_IMAGE_ROXCTL"; [[ "${RELATED_IMAGE_ROXCTL}" 
 ARG RELATED_IMAGE_CENTRAL_DB
 ENV RELATED_IMAGE_CENTRAL_DB=$RELATED_IMAGE_CENTRAL_DB
 RUN echo "Checking required RELATED_IMAGE_CENTRAL_DB"; [[ "${RELATED_IMAGE_CENTRAL_DB}" != "" ]]
-
-# Reset GOFLAGS='-mod=vendor' value which comes by default in openshift-golang-builder and causes build errors like
-#  go: inconsistent vendoring in /stackrox/operator/tools/operator-sdk:
-#      github.com/operator-framework/operator-lifecycle-manager@v0.27.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
-ENV GOFLAGS=''
 
 RUN mkdir -p build/ && \
     rm -rf build/bundle && \


### PR DESCRIPTION
### Description

_note: Change requested only to simplify the image build: remove build layer and GOFLAGS variable. Not fixing anything in the created image._

For `operator/konflux.bundle.Dockerfile`,

* Return operator bundle build to ubi9 base image (remove use of `openshift-golang-builder`).
* Remove GOFLAGS variable (un)set. 

The `openshift-golang-builder` was added because the ubi9 image did not have golang 1.22 required for building the operator-sdk: https://github.com/stackrox/stackrox/pull/12687
The operator-sdk compilation was removed from the bundle build in https://github.com/stackrox/stackrox/pull/12797/files#diff-a0bd03066e74bedcc5176486cfb75755731e939937c28281f6dc3cbc7a470953L26

### Testing and quality

- [ ] CI results are inspected

#### How I validated my change

Initially proposed adding the CGO_ENABLED flag to make sure built golang binaries would be FIPS compliant, but I found no golang binaries built by it: https://github.com/stackrox/stackrox/pull/12962