### PR TITLE
ROX-26710: vm nulls of primitive query fields

### DIFF
--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -17,11 +17,11 @@ type imageCVECoreResponse struct {
 	FixableImagesWithModerateSeverity  int        `db:"fixable_moderate_severity_count"`
 	ImagesWithLowSeverity              int        `db:"low_severity_count"`
 	FixableImagesWithLowSeverity       int        `db:"fixable_low_severity_count"`
-	TopCVSS                            float32    `db:"cvss_max"`
+	TopCVSS                            *float32   `db:"cvss_max"`
 	AffectedImageCount                 int        `db:"image_sha_count"`
 	FirstDiscoveredInSystem            *time.Time `db:"cve_created_time_min"`
 	Published                          *time.Time `db:"cve_published_on_min"`
-	TopNVDCVSS                         float32    `db:"nvd_cvss_max"`
+	TopNVDCVSS                         *float32   `db:"nvd_cvss_max"`
 }
 
 func (c *imageCVECoreResponse) GetCVE() string {
@@ -46,11 +46,17 @@ func (c *imageCVECoreResponse) GetImagesBySeverity() common.ResourceCountByCVESe
 }
 
 func (c *imageCVECoreResponse) GetTopCVSS() float32 {
-	return c.TopCVSS
+	if c.TopCVSS == nil {
+		return 0.0
+	}
+	return *c.TopCVSS
 }
 
 func (c *imageCVECoreResponse) GetTopNVDCVSS() float32 {
-	return c.TopNVDCVSS
+	if c.TopNVDCVSS == nil {
+		return 0.0
+	}
+	return *c.TopNVDCVSS
 }
 
 func (c *imageCVECoreResponse) GetAffectedImageCount() int {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -903,7 +903,7 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 	}
 	if options.SkipGetTopCVSS {
 		for _, entry := range expected {
-			entry.TopCVSS = pointers.Float32(0.0)
+			entry.TopCVSS = nil
 		}
 	}
 	if options.SkipGetAffectedImages {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	imageSamples "github.com/stackrox/rox/pkg/fixtures/image"
+	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -658,10 +659,10 @@ func (s *ImageCVEViewTestSuite) paginationTestCases() []testCase {
 			).ProtoQuery(),
 			less: func(records []*imageCVECoreResponse) func(i, j int) bool {
 				return func(i, j int) bool {
-					if records[i].TopCVSS == records[j].TopCVSS {
+					if records[i].GetTopCVSS() == records[j].GetTopCVSS() {
 						return records[i].CVE < records[j].CVE
 					}
-					return records[i].TopCVSS > records[j].TopCVSS
+					return records[i].GetTopCVSS() > records[j].GetTopCVSS()
 				}
 			},
 		},
@@ -810,23 +811,23 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 				if val == nil {
 					val = &imageCVECoreResponse{
 						CVE:                     vuln.GetCve(),
-						TopCVSS:                 vuln.GetCvss(),
+						TopCVSS:                 pointers.Float32(vuln.GetCvss()),
 						FirstDiscoveredInSystem: &vulnTime,
 						Published:               &vulnPublishDate,
 					}
 					for _, metric := range vuln.CvssMetrics {
 						if metric.Source == storage.Source_SOURCE_NVD {
 							if metric.GetCvssv2() != nil {
-								val.TopNVDCVSS = metric.GetCvssv2().GetScore()
+								val.TopNVDCVSS = pointers.Float32(metric.GetCvssv2().GetScore())
 							} else {
-								val.TopNVDCVSS = metric.GetCvssv3().GetScore()
+								val.TopNVDCVSS = pointers.Float32(metric.GetCvssv3().GetScore())
 							}
 						}
 					}
 					cveMap[val.CVE] = val
 				}
 
-				val.TopCVSS = max(val.GetTopCVSS(), vuln.GetCvss())
+				val.TopCVSS = pointers.Float32(max(val.GetTopCVSS(), vuln.GetCvss()))
 
 				id := cve.ID(val.GetCVE(), image.GetScan().GetOperatingSystem())
 				var found bool
@@ -902,7 +903,7 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 	}
 	if options.SkipGetTopCVSS {
 		for _, entry := range expected {
-			entry.TopCVSS = 0
+			entry.TopCVSS = pointers.Float32(0.0)
 		}
 	}
 	if options.SkipGetAffectedImages {

--- a/pkg/pointers/pointer.go
+++ b/pkg/pointers/pointer.go
@@ -20,6 +20,11 @@ func Int(i int) *int {
 	return &i
 }
 
+// Float32 returns a pointer of the passed float32
+func Float32(f float32) *float32 {
+	return &f
+}
+
 // String returns a pointer to the passed string.
 func String(s string) *string {
 	return &s


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When we added the NVDCVSS field we saw that without a migration we failed to read data into the primitive objects particularly figuring out the max of a float.  Those fields should be pointers such that we can read the data from postgres without the need to artificially set the value to 0.  We can handle that logic in the code with the getters.

This is not a problem for count fields because a count cannot return null, just 0.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Updated the tests which prove this on when we skip the various cvss flags as those would return nil as the column isn't present and the Getters translate the nil.

Also created a cluster and manually set cvss to NULL in the database and verified that it returned 0 instead of a null.  Doing that on an old version crashed central.