### PR TITLE
ROX-22791: Bump axios and axios-fetch to latest versions

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -10,7 +10,7 @@
             "license": "UNLICENSED",
             "dependencies": {
                 "@apollo/client": "^3.6.3",
-                "@lifeomic/axios-fetch": "^3.0.1",
+                "@lifeomic/axios-fetch": "^3.1.0",
                 "@patternfly/react-charts": "^7.2.2",
                 "@patternfly/react-code-editor": "^5.2.2",
                 "@patternfly/react-component-groups": "^5.2.0",
@@ -20,7 +20,7 @@
                 "@patternfly/react-table": "^5.2.2",
                 "@patternfly/react-topology": "^5.2.1",
                 "@patternfly/react-user-feedback": "^5.0.0",
-                "axios": "^0.25.0",
+                "axios": "^1.7.7",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.2",
                 "core-js": "^3.38.1",
@@ -3525,9 +3525,10 @@
             "dev": true
         },
         "node_modules/@lifeomic/axios-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@lifeomic/axios-fetch/-/axios-fetch-3.0.1.tgz",
-            "integrity": "sha1-oPE1Rw17tU0M6CsKLzsZ2qe/d+I= sha512-bwEgYXtGrn/F+yYqoUIAWBRzyqQ7yB1VL84gCq0uAk36GRoyoWyOzbE35VWeXlmkkoby91FnAwh4UhgayMM/og==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@lifeomic/axios-fetch/-/axios-fetch-3.1.0.tgz",
+            "integrity": "sha512-C6ceAnh8W19KuekFsCiK1A+AMBirQFTnoEqMZQ7HE6VXJ18zjGofdXxLU8RTo2gZp/yZK5ufmPwIvRtejj1gxg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node-fetch": "^2.5.10"
             },
@@ -6360,12 +6361,35 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha1-NJz7sxMxqbRFMZB5F2Co01sJPgo= sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/axobject-query": {
             "version": "3.2.1",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -14,7 +14,7 @@
     "license": "UNLICENSED",
     "dependencies": {
         "@apollo/client": "^3.6.3",
-        "@lifeomic/axios-fetch": "^3.0.1",
+        "@lifeomic/axios-fetch": "^3.1.0",
         "@patternfly/react-charts": "^7.2.2",
         "@patternfly/react-code-editor": "^5.2.2",
         "@patternfly/react-component-groups": "^5.2.0",
@@ -24,7 +24,7 @@
         "@patternfly/react-table": "^5.2.2",
         "@patternfly/react-topology": "^5.2.1",
         "@patternfly/react-user-feedback": "^5.0.0",
-        "axios": "^0.25.0",
+        "axios": "^1.7.7",
         "computed-style-to-inline-style": "^3.0.0",
         "connected-react-router": "^6.9.2",
         "core-js": "^3.38.1",

--- a/ui/apps/platform/src/utils/responseErrorUtils.ts
+++ b/ui/apps/platform/src/utils/responseErrorUtils.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 
-function isAxiosError(error: Error): error is AxiosError {
+function isAxiosError(error: Error): error is AxiosError<{ message?: string }> {
     return (
         Object.prototype.hasOwnProperty.call(error, 'response') ||
         Object.prototype.hasOwnProperty.call(error, 'request')


### PR DESCRIPTION
### Description

As titled.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

The changes a dependency that is used on every network call and essentially impacts every piece of the UI for the app. I have done smoke testing of read-only requests throughout that app, as well as smoke testing of write requests in Integrations, Policies, and VM.

Since the only import of runtime code for `axios` is in the `instance.js` file, it should be unlikely that we hit any API edge cases that are missed with the manual testing above and the coverage we get via Cypress tests.
