### PR TITLE
ROX-25948: Secured Clusters certificate refresher

### DIFF
--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -63,4 +63,7 @@ const (
 
 	// SecuredClusterCertificatesReissue identifies the capability of Central to reissue a new set of Secured Clusters certificates
 	SecuredClusterCertificatesReissue = "SecuredClusterCertificatesReissue"
+
+	// SecuredClusterCertificatesRefresh identifies the capability to maintain the Secured Cluster TLS certificates refreshed
+	SecuredClusterCertificatesRefresh SensorCapability = "SecuredClusterCertificatesRefresh"
 )

--- a/sensor/kubernetes/certrefresh/certificates/certificates.go
+++ b/sensor/kubernetes/certrefresh/certificates/certificates.go
@@ -41,3 +41,24 @@ func NewResponseFromLocalScannerCerts(response *central.IssueLocalScannerCertsRe
 
 	return res
 }
+
+// NewResponseFromSecuredClusterCerts creates a certificates.Response from a
+// protobuf central.IssueSecuredClusterCertsResponse message
+func NewResponseFromSecuredClusterCerts(response *central.IssueSecuredClusterCertsResponse) *Response {
+	if response == nil {
+		return nil
+	}
+
+	res := &Response{
+		RequestId: response.GetRequestId(),
+	}
+
+	if response.GetError() != nil {
+		errMsg := response.GetError().GetMessage()
+		res.ErrorMessage = &errMsg
+	} else {
+		res.Certificates = response.GetCertificates()
+	}
+
+	return res
+}

--- a/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository.go
+++ b/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository.go
@@ -135,7 +135,7 @@ func (r *ServiceCertificatesRepoSecrets) getServiceCertificate(ctx context.Conte
 	}, secretData[secretSpec.CaCertFileName], nil
 }
 
-// EnsureServiceCertificates ensures the services for certificates exists, and that they contain the certificates
+// EnsureServiceCertificates ensures the k8s secrets for the services exist, and that they contain the certificates
 // in their data.
 // This operation is idempotent but not atomic in sense that on error some secrets might be created and updated,
 // while others are not.

--- a/sensor/kubernetes/certrefresh/localscanner/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/localscanner/certificate_requester.go
@@ -34,6 +34,12 @@ func NewCertificateRequester(sendC chan<- *message.ExpiringMessage,
 	}
 }
 
+// certificateRequesterImpl implements the certificates.Requester interface for Local Scanner certificates.
+// Note that there is a nearly identical certificateRequesterImpl in the securedcluster package (using a different
+// gRPC API), and any changes or fixes in this file should be carried over to that file as well.
+//
+// The local scanner certificates requester is currently provided for compatibility with older versions of Central,
+// and will eventually be deprecated.
 type certificateRequesterImpl struct {
 	sendC    chan<- *message.ExpiringMessage
 	receiveC <-chan *central.IssueLocalScannerCertsResponse

--- a/sensor/kubernetes/certrefresh/localscanner/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/localscanner/certificate_requester.go
@@ -70,7 +70,7 @@ func (r *certificateRequesterImpl) dispatchResponses() {
 			}
 			r.requests.Delete(msg.GetRequestId())
 			// Doesn't block even if the corresponding call to RequestCertificates is cancelled and no one
-			// ever reads this, because requestC has buffer of 1, and we removed it from `r.request` above,
+			// ever reads this, because requestC has buffer of 1, and we removed it from `r.requests` above,
 			// in case we get more than 1 response for `msg.GetRequestId()`.
 			responseC.(chan *central.IssueLocalScannerCertsResponse) <- msg
 		}

--- a/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
@@ -2,7 +2,6 @@ package certrefresh
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -12,12 +11,9 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certificates"
-	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certrepo"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/localscanner"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 var (
@@ -60,12 +56,6 @@ type localScannerTLSIssuerImpl struct {
 	certRequester                certificates.Requester
 	certRefresher                concurrency.RetryTicker
 }
-
-type certificateRefresherGetter func(certsDescription string, requestCertificates requestCertificatesFunc,
-	repository certrepo.ServiceCertificatesRepo, timeout time.Duration, backoff wait.Backoff) concurrency.RetryTicker
-
-type serviceCertificatesRepoGetter func(ownerReference metav1.OwnerReference, namespace string,
-	secretsClient corev1.SecretInterface) certrepo.ServiceCertificatesRepo
 
 // Start starts the sensor component and launches a certificate refresher that immediately checks the certificates, and
 // that keeps them updated.

--- a/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
@@ -27,7 +27,7 @@ var (
 )
 
 // NewLocalScannerTLSIssuer creates a sensor component that will keep the local scanner certificates
-// up to date, using the specified retry parameters.
+// up to date, using the retry parameters in tls_issuer_common.go
 func NewLocalScannerTLSIssuer(
 	k8sClient kubernetes.Interface,
 	sensorNamespace string,
@@ -72,7 +72,7 @@ type serviceCertificatesRepoGetter func(ownerReference metav1.OwnerReference, na
 // In case a secret doesn't have the expected owner, this logs a warning and returns nil.
 // In case this component was already started it fails immediately.
 func (i *localScannerTLSIssuerImpl) Start() error {
-	log.Debug("starting local scanner TLS issuer.")
+	log.Debug("Starting local scanner TLS issuer.")
 	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
 	defer cancel()
 
@@ -96,12 +96,12 @@ func (i *localScannerTLSIssuerImpl) Start() error {
 		return i.abortStart(errors.Wrap(refreshStartErr, "starting certificate certRefresher"))
 	}
 
-	log.Debug("local scanner TLS issuer started.")
+	log.Debug("Local Scanner TLS issuer started.")
 	return nil
 }
 
 func (i *localScannerTLSIssuerImpl) abortStart(err error) error {
-	log.Errorf("local scanner TLS issuer start aborted due to error: %s", err)
+	log.Errorf("Local Scanner TLS issuer start aborted due to error: %s", err)
 	i.Stop(err)
 	return err
 }
@@ -113,7 +113,7 @@ func (i *localScannerTLSIssuerImpl) Stop(_ error) {
 	}
 
 	i.certRequester.Stop()
-	log.Debug("local scanner TLS issuer stopped.")
+	log.Debug("Local Scanner TLS issuer stopped.")
 }
 
 func (i *localScannerTLSIssuerImpl) Notify(common.SensorComponentEvent) {}

--- a/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
@@ -36,6 +36,9 @@ func NewCertificateRequester(sendC chan<- *message.ExpiringMessage,
 	}
 }
 
+// certificateRequesterImpl implements the certificates.Requester interface for Secured Cluster certificates.
+// Note that there is a nearly identical certificateRequesterImpl in the localscanner package (using a different
+// gRPC API), and any changes or fixes in this file should be carried over to that file as well.
 type certificateRequesterImpl struct {
 	sendC    chan<- *message.ExpiringMessage
 	receiveC <-chan *central.IssueSecuredClusterCertsResponse

--- a/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
@@ -1,0 +1,148 @@
+package securedcluster
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certificates"
+)
+
+var (
+	log = logging.LoggerForModule()
+
+	// ErrCertificateRequesterStopped is returned by RequestCertificates when the certificate
+	// requester is not initialized.
+	ErrCertificateRequesterStopped                        = errors.New("certificate requester stopped")
+	_                              certificates.Requester = (*certificateRequesterImpl)(nil)
+)
+
+// NewCertificateRequester creates a new Secured Cluster certificates requester that communicates through
+// the specified channels and initializes a new request ID for reach request.
+// To use it call Start, and then make requests with RequestCertificates, concurrent requests are supported.
+// This assumes that the returned certificate requester is the only consumer of `receiveC`.
+func NewCertificateRequester(sendC chan<- *message.ExpiringMessage,
+	receiveC <-chan *central.IssueSecuredClusterCertsResponse) certificates.Requester {
+	return &certificateRequesterImpl{
+		sendC:    sendC,
+		receiveC: receiveC,
+	}
+}
+
+type certificateRequesterImpl struct {
+	sendC    chan<- *message.ExpiringMessage
+	receiveC <-chan *central.IssueSecuredClusterCertsResponse
+	stopC    concurrency.ErrorSignal
+	requests sync.Map
+}
+
+// Start makes the certificate requester listen to `receiveC` and forwards responses to any request that is running
+// as a call to RequestCertificates.
+func (r *certificateRequesterImpl) Start() {
+	r.stopC.Reset()
+	go r.dispatchResponses()
+}
+
+// Stop makes the certificate stop forwarding responses to running requests. Subsequent calls to RequestCertificates
+// will fail with ErrCertificateRequesterStopped.
+// Currently active calls to RequestCertificates will continue running until cancelled or timed out via the
+// provided context.
+func (r *certificateRequesterImpl) Stop() {
+	r.stopC.Signal()
+}
+
+func (r *certificateRequesterImpl) dispatchResponses() {
+	for {
+		select {
+		case <-r.stopC.Done():
+			return
+		case msg := <-r.receiveC:
+			responseC, ok := r.requests.Load(msg.GetRequestId())
+			if !ok {
+				log.Debugf("request ID %q does not match any known request ID, dropping response",
+					msg.GetRequestId())
+				continue
+			}
+			r.requests.Delete(msg.GetRequestId())
+			// Doesn't block even if the corresponding call to RequestCertificates is cancelled and no one
+			// ever reads this, because requestC has buffer of 1, and we removed it from `r.request` above,
+			// in case we get more than 1 response for `msg.GetRequestId()`.
+			responseC.(chan *central.IssueSecuredClusterCertsResponse) <- msg
+		}
+	}
+}
+
+// RequestCertificates makes a new request for a new set of secured cluster certificates from Central.
+// This assumes the certificate requester is started, otherwise this returns ErrCertificateRequesterStopped.
+func (r *certificateRequesterImpl) RequestCertificates(ctx context.Context) (*certificates.Response, error) {
+	// Central capabilities are only available after this component is created,
+	// which is why this check is done here
+	if !centralcaps.Has(centralsensor.SecuredClusterCertificatesReissue) {
+		return nil, errors.New("TLS certificate refresh failed: missing Central capability 'SecuredClusterCertificatesReissue'")
+	}
+
+	requestID := uuid.NewV4().String()
+	receiveC := make(chan *central.IssueSecuredClusterCertsResponse, 1)
+	r.requests.Store(requestID, receiveC)
+	// Always delete this entry when leaving this scope to account for requests that are never responded, to avoid
+	// having entries in `r.requests` that are never removed.
+	defer r.requests.Delete(requestID)
+
+	if err := r.send(ctx, requestID); err != nil {
+		return nil, err
+	}
+	return receive(ctx, receiveC)
+}
+
+func (r *certificateRequesterImpl) send(ctx context.Context, requestID string) error {
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_IssueSecuredClusterCertsRequest{
+			IssueSecuredClusterCertsRequest: &central.IssueSecuredClusterCertsRequest{
+				RequestId: requestID,
+			},
+		},
+	}
+	select {
+	case <-r.stopC.Done():
+		return r.stopC.ErrorWithDefault(ErrCertificateRequesterStopped)
+	case <-ctx.Done():
+		return ctx.Err()
+	case r.sendC <- message.New(msg):
+		return nil
+	}
+}
+
+func convertToIssueCertsResponse(response *central.IssueSecuredClusterCertsResponse) *certificates.Response {
+	if response == nil {
+		return nil
+	}
+
+	res := &certificates.Response{
+		RequestId: response.GetRequestId(),
+	}
+
+	if response.GetError() != nil {
+		errMsg := response.GetError().GetMessage()
+		res.ErrorMessage = &errMsg
+	} else {
+		res.Certificates = response.GetCertificates()
+	}
+
+	return res
+}
+
+func receive(ctx context.Context, receiveC <-chan *central.IssueSecuredClusterCertsResponse) (*certificates.Response, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case response := <-receiveC:
+		return convertToIssueCertsResponse(response), nil
+	}
+}

--- a/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
@@ -119,30 +119,11 @@ func (r *certificateRequesterImpl) send(ctx context.Context, requestID string) e
 	}
 }
 
-func convertToIssueCertsResponse(response *central.IssueSecuredClusterCertsResponse) *certificates.Response {
-	if response == nil {
-		return nil
-	}
-
-	res := &certificates.Response{
-		RequestId: response.GetRequestId(),
-	}
-
-	if response.GetError() != nil {
-		errMsg := response.GetError().GetMessage()
-		res.ErrorMessage = &errMsg
-	} else {
-		res.Certificates = response.GetCertificates()
-	}
-
-	return res
-}
-
 func receive(ctx context.Context, receiveC <-chan *central.IssueSecuredClusterCertsResponse) (*certificates.Response, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case response := <-receiveC:
-		return convertToIssueCertsResponse(response), nil
+		return certificates.NewResponseFromSecuredClusterCerts(response), nil
 	}
 }

--- a/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/certificate_requester.go
@@ -72,7 +72,7 @@ func (r *certificateRequesterImpl) dispatchResponses() {
 			}
 			r.requests.Delete(msg.GetRequestId())
 			// Doesn't block even if the corresponding call to RequestCertificates is cancelled and no one
-			// ever reads this, because requestC has buffer of 1, and we removed it from `r.request` above,
+			// ever reads this, because requestC has buffer of 1, and we removed it from `r.requests` above,
 			// in case we get more than 1 response for `msg.GetRequestId()`.
 			responseC.(chan *central.IssueSecuredClusterCertsResponse) <- msg
 		}

--- a/sensor/kubernetes/certrefresh/securedcluster/certificate_requester_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/certificate_requester_test.go
@@ -1,0 +1,191 @@
+package securedcluster
+
+import (
+	"context"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certificates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	numConcurrentRequests = 10
+)
+
+var (
+	testTimeout = time.Second
+)
+
+func TestCertificateRequesterRequestFailureIfStopped(t *testing.T) {
+	testCases := map[string]struct {
+		startRequester bool
+	}{
+		"requester not started":            {false},
+		"requester stopped before request": {true},
+	}
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			f := newFixture(0)
+			defer f.tearDown()
+			if tc.startRequester {
+				f.requester.Start()
+				f.requester.Stop()
+			}
+
+			certs, requestErr := f.requester.RequestCertificates(f.ctx)
+			assert.Nil(t, certs)
+			assert.Equal(t, ErrCertificateRequesterStopped, requestErr)
+		})
+	}
+}
+
+func TestCertificateRequesterRequestCancellation(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+	f := newFixture(0)
+	f.requester.Start()
+	defer f.tearDown()
+
+	f.cancelCtx()
+	certs, requestErr := f.requester.RequestCertificates(f.ctx)
+	assert.Nil(t, certs)
+	assert.Equal(t, context.Canceled, requestErr)
+}
+
+func TestCertificateRequesterRequestSuccess(t *testing.T) {
+	f := newFixture(0)
+	f.requester.Start()
+	defer f.tearDown()
+
+	go f.respondRequest(t, 0, nil)
+
+	response, err := f.requester.RequestCertificates(f.ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, f.interceptedRequestID.Load(), response.RequestId)
+}
+
+func TestCertificateRequesterResponsesWithUnknownIDAreIgnored(t *testing.T) {
+	f := newFixture(100 * time.Millisecond)
+	f.requester.Start()
+	defer f.tearDown()
+
+	// Request with different request ID should be ignored.
+	go f.respondRequest(t, 0, &central.IssueSecuredClusterCertsResponse{RequestId: "UNKNOWN"})
+
+	certs, requestErr := f.requester.RequestCertificates(f.ctx)
+	assert.Nil(t, certs)
+	assert.Equal(t, context.DeadlineExceeded, requestErr)
+}
+
+func TestCertificateRequesterRequestConcurrentRequestDoNotInterfere(t *testing.T) {
+	testCases := map[string]struct {
+		responseDelayFunc func(requestIndex int) (responseDelay time.Duration)
+	}{
+		"decreasing response delay": {func(requestIndex int) (responseDelay time.Duration) {
+			// responses are responded increasingly faster, so always out of order.
+			return time.Duration(numConcurrentRequests-(requestIndex+1)) * 10 * time.Millisecond
+		}},
+		"random response delay": {func(requestIndex int) (responseDelay time.Duration) {
+			// randomly out of order responses.
+			return time.Duration(rand.Intn(100)) * time.Millisecond
+		}},
+	}
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			f := newFixture(0)
+			f.requester.Start()
+			defer f.tearDown()
+			waitGroup := concurrency.NewWaitGroup(numConcurrentRequests)
+
+			for i := 0; i < numConcurrentRequests; i++ {
+				i := i
+				responseDelay := tc.responseDelayFunc(i)
+				go f.respondRequest(t, responseDelay, nil)
+				go func() {
+					defer waitGroup.Add(-1)
+					_, err := f.requester.RequestCertificates(f.ctx)
+					assert.NoError(t, err)
+				}()
+			}
+			ok := concurrency.WaitWithTimeout(&waitGroup, time.Duration(numConcurrentRequests)*testTimeout)
+			require.True(t, ok)
+		})
+	}
+}
+
+type certificateRequesterFixture struct {
+	sendC                chan *message.ExpiringMessage
+	receiveC             chan *central.IssueSecuredClusterCertsResponse
+	requester            certificates.Requester
+	interceptedRequestID *atomic.Value
+	ctx                  context.Context
+	cancelCtx            context.CancelFunc
+}
+
+// newFixture creates a new test fixture that uses `timeout` as context timeout if `timeout` is
+// not 0, and `testTimeout` otherwise.
+func newFixture(timeout time.Duration) *certificateRequesterFixture {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+
+	sendC := make(chan *message.ExpiringMessage)
+	receiveC := make(chan *central.IssueSecuredClusterCertsResponse)
+	requester := NewCertificateRequester(sendC, receiveC)
+	var interceptedRequestID atomic.Value
+	if timeout == 0 {
+		timeout = testTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return &certificateRequesterFixture{
+		sendC:                sendC,
+		receiveC:             receiveC,
+		requester:            requester,
+		ctx:                  ctx,
+		cancelCtx:            cancel,
+		interceptedRequestID: &interceptedRequestID,
+	}
+}
+
+func (f *certificateRequesterFixture) tearDown() {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+	f.cancelCtx()
+	f.requester.Stop()
+}
+
+// respondRequest reads a request from `f.sendC` and responds with `responseOverwrite` if not nil, or with
+// a response with the same ID as the request otherwise. If `responseDelay` is greater than 0 then this function
+// waits for that time before sending the response.
+// Before sending the response, it stores in `f.interceptedRequestID` the request ID for the requests read from `f.sendC`.
+func (f *certificateRequesterFixture) respondRequest(t *testing.T, responseDelay time.Duration, responseOverwrite *central.IssueSecuredClusterCertsResponse) {
+	select {
+	case <-f.ctx.Done():
+	case request := <-f.sendC:
+		interceptedRequestID := request.GetIssueSecuredClusterCertsRequest().GetRequestId()
+		assert.NotEmpty(t, interceptedRequestID)
+		var response *central.IssueSecuredClusterCertsResponse
+		if responseOverwrite != nil {
+			response = responseOverwrite
+		} else {
+			response = &central.IssueSecuredClusterCertsResponse{RequestId: interceptedRequestID}
+		}
+		f.interceptedRequestID.Store(response.GetRequestId())
+		if responseDelay > 0 {
+			select {
+			case <-f.ctx.Done():
+				return
+			case <-time.After(responseDelay):
+			}
+		}
+		select {
+		case <-f.ctx.Done():
+		case f.receiveC <- response:
+		}
+	}
+}

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -1,0 +1,138 @@
+package certrefresh
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certificates"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/securedcluster"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ common.SensorComponent = (*securedClusterTLSIssuerImpl)(nil)
+
+// NewSecuredClusterTLSIssuer creates a sensor component that will keep the Secured Cluster certificates
+// up to date, using the specified retry parameters.
+func NewSecuredClusterTLSIssuer(
+	k8sClient kubernetes.Interface,
+	sensorNamespace string,
+	sensorPodName string,
+) common.SensorComponent {
+	msgToCentralC := make(chan *message.ExpiringMessage)
+	msgFromCentralC := make(chan *central.IssueSecuredClusterCertsResponse)
+	return &securedClusterTLSIssuerImpl{
+		sensorNamespace:              sensorNamespace,
+		sensorPodName:                sensorPodName,
+		k8sClient:                    k8sClient,
+		msgToCentralC:                msgToCentralC,
+		msgFromCentralC:              msgFromCentralC,
+		certRefreshBackoff:           certRefreshBackoff,
+		getCertificateRefresherFn:    newCertificatesRefresher,
+		getServiceCertificatesRepoFn: securedcluster.NewServiceCertificatesRepo,
+		certRequester:                securedcluster.NewCertificateRequester(msgToCentralC, msgFromCentralC),
+	}
+}
+
+type securedClusterTLSIssuerImpl struct {
+	sensorNamespace              string
+	sensorPodName                string
+	k8sClient                    kubernetes.Interface
+	msgToCentralC                chan *message.ExpiringMessage
+	msgFromCentralC              chan *central.IssueSecuredClusterCertsResponse
+	certRefreshBackoff           wait.Backoff
+	getCertificateRefresherFn    certificateRefresherGetter
+	getServiceCertificatesRepoFn serviceCertificatesRepoGetter
+	certRequester                certificates.Requester
+	certRefresher                concurrency.RetryTicker
+}
+
+// Start starts the Sensor component and launches a certificate refresher that immediately checks the certificates,
+// and keeps them updated.
+// In case a secret doesn't have the expected owner, this logs a warning and returns nil.
+// In case this component was already started, it fails immediately.
+func (i *securedClusterTLSIssuerImpl) Start() error {
+	log.Debug("starting Secured Cluster TLS issuer.")
+	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
+	defer cancel()
+
+	if i.certRefresher != nil {
+		return i.abortStart(errors.New("already started"))
+	}
+
+	sensorOwnerReference, fetchSensorDeploymentErr := FetchSensorDeploymentOwnerRef(ctx, i.sensorPodName,
+		i.sensorNamespace, i.k8sClient, fetchSensorDeploymentOwnerRefBackoff)
+	if fetchSensorDeploymentErr != nil {
+		return i.abortStart(errors.Wrap(fetchSensorDeploymentErr, "fetching sensor deployment"))
+	}
+
+	certsRepo := i.getServiceCertificatesRepoFn(*sensorOwnerReference, i.sensorNamespace,
+		i.k8sClient.CoreV1().Secrets(i.sensorNamespace))
+	i.certRefresher = i.getCertificateRefresherFn("secured cluster certificates", i.certRequester.RequestCertificates, certsRepo,
+		certRefreshTimeout, i.certRefreshBackoff)
+
+	i.certRequester.Start()
+	if refreshStartErr := i.certRefresher.Start(); refreshStartErr != nil {
+		return i.abortStart(errors.Wrap(refreshStartErr, "starting certificate certRefresher"))
+	}
+
+	log.Debug("Secured Cluster TLS issuer started.")
+	return nil
+}
+
+func (i *securedClusterTLSIssuerImpl) abortStart(err error) error {
+	log.Errorf("Secured Cluster TLS issuer start aborted due to error: %s", err)
+	i.Stop(err)
+	return err
+}
+
+func (i *securedClusterTLSIssuerImpl) Stop(_ error) {
+	if i.certRefresher != nil {
+		i.certRefresher.Stop()
+		i.certRefresher = nil
+	}
+
+	i.certRequester.Stop()
+	log.Debug("Secured Cluster TLS issuer stopped.")
+}
+
+func (i *securedClusterTLSIssuerImpl) Notify(common.SensorComponentEvent) {}
+
+func (i *securedClusterTLSIssuerImpl) Capabilities() []centralsensor.SensorCapability {
+	return []centralsensor.SensorCapability{centralsensor.SecuredClusterCertificatesRefresh}
+}
+
+// ResponsesC is called "responses" because for other SensorComponents it is Central that
+// initiates the interaction. However, here it is Sensor which sends a request to Central.
+func (i *securedClusterTLSIssuerImpl) ResponsesC() <-chan *message.ExpiringMessage {
+	return i.msgToCentralC
+}
+
+// ProcessMessage dispatches Central's messages to Sensor received via the Central receiver.
+// This method must not block as it would prevent centralReceiverImpl from sending messages
+// to other SensorComponents.
+func (i *securedClusterTLSIssuerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+	switch m := msg.GetMsg().(type) {
+	case *central.MsgToSensor_IssueSecuredClusterCertsResponse:
+		response := m.IssueSecuredClusterCertsResponse
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), processMessageTimeout)
+			defer cancel()
+			select {
+			case <-ctx.Done():
+				// certRefresher will retry.
+				log.Errorf("timeout forwarding response %s from central: %s", response, ctx.Err())
+			case i.msgFromCentralC <- response:
+			}
+		}()
+		return nil
+	default:
+		// messages not supported by this component are ignored because unknown messages types are handled by the Central receiver.
+		return nil
+	}
+}

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -18,7 +18,7 @@ import (
 var _ common.SensorComponent = (*securedClusterTLSIssuerImpl)(nil)
 
 // NewSecuredClusterTLSIssuer creates a sensor component that will keep the Secured Cluster certificates
-// up to date, using the specified retry parameters.
+// up to date, using the retry parameters in tls_issuer_common.go
 func NewSecuredClusterTLSIssuer(
 	k8sClient kubernetes.Interface,
 	sensorNamespace string,
@@ -57,7 +57,7 @@ type securedClusterTLSIssuerImpl struct {
 // In case a secret doesn't have the expected owner, this logs a warning and returns nil.
 // In case this component was already started, it fails immediately.
 func (i *securedClusterTLSIssuerImpl) Start() error {
-	log.Debug("starting Secured Cluster TLS issuer.")
+	log.Debug("Starting Secured Cluster TLS issuer.")
 	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
 	defer cancel()
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -1,0 +1,474 @@
+package certrefresh
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/mtls"
+	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certrepo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	sensorSecretName           = "tls-cert-sensor"             // #nosec G101 not a hardcoded credential
+	collectorSecretName        = "tls-cert-collector"          // #nosec G101 not a hardcoded credential
+	admissionControlSecretName = "tls-cert-admission-control"  // #nosec G101 not a hardcoded credential
+	scannerSecretName          = "tls-cert-scanner"            // #nosec G101 not a hardcoded credential
+	scannerDbSecretName        = "tls-cert-scanner-db"         // #nosec G101 not a hardcoded credential
+	scannerV4IndexerSecretName = "tls-cert-scanner-v4-indexer" // #nosec G101 not a hardcoded credential
+	scannerV4DbSecretName      = "tls-cert-scanner-v4-db"      // #nosec G101 not a hardcoded credential
+)
+
+type securedClusterTLSIssuerFixture struct {
+	k8sClient       *fake.Clientset
+	certRequester   *certificateRequesterMock
+	certRefresher   *certificateRefresherMock
+	repo            *certsRepoMock
+	componentGetter *componentGetterMock
+	tlsIssuer       *securedClusterTLSIssuerImpl
+}
+
+func newSecuredClusterTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *securedClusterTLSIssuerFixture {
+	fixture := &securedClusterTLSIssuerFixture{
+		certRequester:   &certificateRequesterMock{},
+		certRefresher:   &certificateRefresherMock{},
+		repo:            &certsRepoMock{},
+		componentGetter: &componentGetterMock{},
+		k8sClient:       getFakeK8sClient(k8sClientConfig),
+	}
+	msgToCentralC := make(chan *message.ExpiringMessage)
+	msgFromCentralC := make(chan *central.IssueSecuredClusterCertsResponse)
+	fixture.tlsIssuer = &securedClusterTLSIssuerImpl{
+		sensorNamespace:              sensorNamespace,
+		sensorPodName:                sensorPodName,
+		k8sClient:                    fixture.k8sClient,
+		msgToCentralC:                msgToCentralC,
+		msgFromCentralC:              msgFromCentralC,
+		certRefreshBackoff:           certRefreshBackoff,
+		getCertificateRefresherFn:    fixture.componentGetter.getCertificateRefresher,
+		getServiceCertificatesRepoFn: fixture.componentGetter.getServiceCertificatesRepo,
+		certRequester:                fixture.certRequester,
+	}
+
+	return fixture
+}
+
+func (f *securedClusterTLSIssuerFixture) assertMockExpectations(t *testing.T) {
+	f.certRequester.AssertExpectations(t)
+	f.certRequester.AssertExpectations(t)
+	f.componentGetter.AssertExpectations(t)
+}
+
+// mockForStart setups the mocks for the happy path of Start
+func (f *securedClusterTLSIssuerFixture) mockForStart(conf mockForStartConfig) {
+	f.certRequester.On("Start").Once()
+	f.certRefresher.On("Start").Once().Return(conf.refresherStartErr)
+
+	f.repo.On("GetServiceCertificates", mock.Anything).Once().
+		Return((*storage.TypedServiceCertificateSet)(nil), conf.getCertsErr)
+
+	f.componentGetter.On("getServiceCertificatesRepo", mock.Anything,
+		mock.Anything, mock.Anything).Once().Return(f.repo, nil)
+
+	f.componentGetter.On("getCertificateRefresher", "secured cluster certificates", mock.Anything, f.repo,
+		certRefreshTimeout, certRefreshBackoff).Once().Return(f.certRefresher)
+}
+
+func TestSecuredClusterTLSIssuerStartStopSuccess(t *testing.T) {
+	testCases := map[string]struct {
+		getCertsErr error
+	}{
+		"no error":            {getCertsErr: nil},
+		"missing secret data": {getCertsErr: errors.Wrap(certrepo.ErrMissingSecretData, "wrap error")},
+		"inconsistent CAs":    {getCertsErr: errors.Wrap(certrepo.ErrDifferentCAForDifferentServiceTypes, "wrap error")},
+		"missing secret":      {getCertsErr: k8sErrors.NewNotFound(schema.GroupResource{Group: "Core", Resource: "Secret"}, "scanner-db-slim-tls")},
+	}
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+			fixture.mockForStart(mockForStartConfig{getCertsErr: tc.getCertsErr})
+			fixture.certRefresher.On("Stop").Once()
+			fixture.certRequester.On("Stop").Once()
+
+			startErr := fixture.tlsIssuer.Start()
+			fixture.tlsIssuer.Stop(nil)
+
+			assert.NoError(t, startErr)
+			assert.Nil(t, fixture.tlsIssuer.certRefresher)
+			fixture.assertMockExpectations(t)
+		})
+	}
+}
+
+func TestSecuredClusterTLSIssuerRefresherFailureStartFailure(t *testing.T) {
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.mockForStart(mockForStartConfig{refresherStartErr: errForced})
+	fixture.certRefresher.On("Stop").Once()
+	fixture.certRequester.On("Stop").Once()
+
+	startErr := fixture.tlsIssuer.Start()
+
+	require.Error(t, startErr)
+	fixture.assertMockExpectations(t)
+}
+
+func TestSecuredClusterTLSIssuerStartAlreadyStartedFailure(t *testing.T) {
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.mockForStart(mockForStartConfig{})
+	fixture.certRefresher.On("Stop").Once()
+	fixture.certRequester.On("Stop").Once()
+
+	startErr := fixture.tlsIssuer.Start()
+	secondStartErr := fixture.tlsIssuer.Start()
+
+	assert.NoError(t, startErr)
+	require.Error(t, secondStartErr)
+	fixture.assertMockExpectations(t)
+}
+
+func TestSecuredClusterTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure(t *testing.T) {
+	testCases := map[string]struct {
+		k8sClientConfig fakeK8sClientConfig
+	}{
+		"sensor replica set missing": {k8sClientConfig: fakeK8sClientConfig{skipSensorReplicaSet: true}},
+		"sensor pod missing":         {k8sClientConfig: fakeK8sClientConfig{skipSensorPod: true}},
+	}
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			fixture := newSecuredClusterTLSIssuerFixture(tc.k8sClientConfig)
+			fixture.certRefresher.On("Stop").Once()
+			fixture.certRequester.On("Stop").Once()
+
+			startErr := fixture.tlsIssuer.Start()
+
+			require.Error(t, startErr)
+			fixture.assertMockExpectations(t)
+		})
+	}
+}
+
+func TestSecuredClusterTLSIssuerProcessMessageKnownMessage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	processMessageDoneSignal := concurrency.NewErrorSignal()
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	expectedResponse := &central.IssueSecuredClusterCertsResponse{
+		RequestId: uuid.NewDummy().String(),
+	}
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_IssueSecuredClusterCertsResponse{
+			IssueSecuredClusterCertsResponse: expectedResponse,
+		},
+	}
+
+	go func() {
+		assert.NoError(t, fixture.tlsIssuer.ProcessMessage(msg))
+		processMessageDoneSignal.Signal()
+	}()
+
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, ctx.Err().Error())
+	case response := <-fixture.tlsIssuer.msgFromCentralC:
+		protoassert.Equal(t, expectedResponse, response)
+	}
+
+	_, ok := processMessageDoneSignal.WaitWithTimeout(100 * time.Millisecond)
+	assert.True(t, ok)
+}
+
+func TestSecuredClusterTLSIssuerProcessMessageUnknownMessage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	processMessageDoneSignal := concurrency.NewErrorSignal()
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_ReprocessDeployments{},
+	}
+
+	go func() {
+		assert.NoError(t, fixture.tlsIssuer.ProcessMessage(msg))
+		processMessageDoneSignal.Signal()
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-fixture.tlsIssuer.msgFromCentralC:
+		assert.Fail(t, "unknown message is not ignored")
+	}
+	_, ok := processMessageDoneSignal.WaitWithTimeout(100 * time.Millisecond)
+	assert.True(t, ok)
+}
+
+func TestSecuredClusterTLSIssuerIntegrationTests(t *testing.T) {
+	suite.Run(t, new(securedClusterTLSIssueIntegrationTests))
+}
+
+type securedClusterTLSIssueIntegrationTests struct {
+	suite.Suite
+}
+
+func (s *securedClusterTLSIssueIntegrationTests) SetupTest() {
+	err := testutilsMTLS.LoadTestMTLSCerts(s.T())
+	s.Require().NoError(err)
+}
+
+func (s *securedClusterTLSIssueIntegrationTests) TestSuccessfulRefresh() {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+	defer func() {
+		centralcaps.Set([]centralsensor.CentralCapability{})
+	}()
+
+	testCases := map[string]struct {
+		k8sClientConfig    fakeK8sClientConfig
+		numFailedResponses int
+	}{
+		"no secrets": {k8sClientConfig: fakeK8sClientConfig{}},
+		"corrupted data in sensor secret": {
+			k8sClientConfig: fakeK8sClientConfig{
+				secretsData: map[string]map[string][]byte{sensorSecretName: nil},
+			},
+		},
+		"corrupted data in scanner DB secret": {
+			k8sClientConfig: fakeK8sClientConfig{
+				secretsData: map[string]map[string][]byte{scannerDbSecretName: nil},
+			},
+		},
+		"corrupted data in all secured cluster secrets": {
+			k8sClientConfig: fakeK8sClientConfig{
+				secretsData: map[string]map[string][]byte{
+					sensorSecretName:           nil,
+					collectorSecretName:        nil,
+					admissionControlSecretName: nil,
+					scannerSecretName:          nil,
+					scannerDbSecretName:        nil,
+					scannerV4IndexerSecretName: nil,
+					scannerV4DbSecretName:      nil,
+				},
+			},
+		},
+		"refresh failure and retries": {k8sClientConfig: fakeK8sClientConfig{}, numFailedResponses: 2},
+	}
+
+	for tcName, tc := range testCases {
+		s.Run(tcName, func() {
+			testTimeout := 2 * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+			ca, err := mtls.CAForSigning()
+			s.Require().NoError(err)
+
+			secretsCerts := map[string]*mtls.IssuedCert{
+				sensorSecretName:           s.getCertificate(storage.ServiceType_SENSOR_SERVICE),
+				collectorSecretName:        s.getCertificate(storage.ServiceType_COLLECTOR_SERVICE),
+				admissionControlSecretName: s.getCertificate(storage.ServiceType_ADMISSION_CONTROL_SERVICE),
+				scannerSecretName:          s.getCertificate(storage.ServiceType_SCANNER_SERVICE),
+				scannerDbSecretName:        s.getCertificate(storage.ServiceType_SCANNER_DB_SERVICE),
+				scannerV4IndexerSecretName: s.getCertificate(storage.ServiceType_SCANNER_V4_INDEXER_SERVICE),
+				scannerV4DbSecretName:      s.getCertificate(storage.ServiceType_SCANNER_V4_DB_SERVICE),
+			}
+
+			k8sClient := getFakeK8sClient(tc.k8sClientConfig)
+			tlsIssuer := newSecuredClusterTLSIssuer(s.T(), k8sClient, sensorNamespace, sensorPodName)
+			tlsIssuer.certRefreshBackoff = wait.Backoff{
+				Duration: time.Millisecond,
+			}
+
+			s.Require().NoError(tlsIssuer.Start())
+			defer tlsIssuer.Stop(nil)
+			s.Require().NotNil(tlsIssuer.certRefresher)
+			s.Require().False(tlsIssuer.certRefresher.Stopped())
+
+			for i := 0; i < tc.numFailedResponses; i++ {
+				request := s.waitForRequest(ctx, tlsIssuer)
+				response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
+				err = tlsIssuer.ProcessMessage(response)
+				s.Require().NoError(err)
+			}
+
+			request := s.waitForRequest(ctx, tlsIssuer)
+			response := getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
+			err = tlsIssuer.ProcessMessage(response)
+			s.Require().NoError(err)
+
+			var secrets *v1.SecretList
+			ok := concurrency.PollWithTimeout(func() bool {
+				secrets, err = k8sClient.CoreV1().Secrets(sensorNamespace).List(context.Background(), metav1.ListOptions{})
+				s.Require().NoError(err)
+				return len(secrets.Items) == 7 && func() bool {
+					for _, secret := range secrets.Items {
+						if len(secret.Data) == 0 {
+							return false
+						}
+					}
+					return true
+				}()
+			}, 10*time.Millisecond, testTimeout)
+			s.Require().True(ok, "expected exactly 7 secrets with non-empty data available in the k8s API")
+
+			for _, secret := range secrets.Items {
+				expectedCert, exists := secretsCerts[secret.GetName()]
+				if !exists {
+					s.Require().Failf("unexpected secret name %q", secret.GetName())
+					continue
+				}
+				s.Equal(ca.CertPEM(), secret.Data[mtls.CACertFileName])
+				s.Equal(expectedCert.CertPEM, secret.Data[mtls.ServiceCertFileName])
+				s.Equal(expectedCert.KeyPEM, secret.Data[mtls.ServiceKeyFileName])
+			}
+		})
+	}
+}
+
+func (s *securedClusterTLSIssueIntegrationTests) TestUnexpectedOwnerStop() {
+	testCases := map[string]struct {
+		secretNames []string
+	}{
+		"wrong owner for sensor secret":                  {secretNames: []string{sensorSecretName}},
+		"wrong owner for collector secret":               {secretNames: []string{collectorSecretName}},
+		"wrong owner for admission controller secret":    {secretNames: []string{admissionControlSecretName}},
+		"wrong owner for scanner secret":                 {secretNames: []string{scannerSecretName}},
+		"wrong owner for scanner db secret":              {secretNames: []string{scannerDbSecretName}},
+		"wrong owner for scanner v4 indexer secret":      {secretNames: []string{scannerV4IndexerSecretName}},
+		"wrong owner for scanner v4 db secret":           {secretNames: []string{scannerV4DbSecretName}},
+		"wrong owner for scanner and scanner db secrets": {secretNames: []string{scannerSecretName, scannerDbSecretName}},
+	}
+	for tcName, tc := range testCases {
+		s.Run(tcName, func() {
+			secretsData := make(map[string]map[string][]byte, len(tc.secretNames))
+			for _, secretName := range tc.secretNames {
+				secretsData[secretName] = nil
+			}
+			k8sClient := getFakeK8sClient(fakeK8sClientConfig{
+				secretsData: secretsData,
+				secretsOwner: &metav1.OwnerReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "another-deployment",
+					UID:        types.UID(uuid.NewDummy().String()),
+				},
+			})
+			tlsIssuer := newSecuredClusterTLSIssuer(s.T(), k8sClient, sensorNamespace, sensorPodName)
+
+			s.Require().NoError(tlsIssuer.Start())
+			defer tlsIssuer.Stop(nil)
+
+			ok := concurrency.PollWithTimeout(func() bool {
+				return tlsIssuer.certRefresher != nil && tlsIssuer.certRefresher.Stopped()
+			}, 10*time.Millisecond, 100*time.Millisecond)
+			s.True(ok, "cert refresher should be stopped")
+		})
+	}
+}
+
+func (s *securedClusterTLSIssueIntegrationTests) getCertificate(serviceType storage.ServiceType) *mtls.IssuedCert {
+	cert, err := issueCertificate(serviceType, mtls.WithValidityExpiringInHours())
+	s.Require().NoError(err)
+	return cert
+}
+
+func (s *securedClusterTLSIssueIntegrationTests) waitForRequest(ctx context.Context, tlsIssuer common.SensorComponent) *central.IssueSecuredClusterCertsRequest {
+	var request *message.ExpiringMessage
+	select {
+	case request = <-tlsIssuer.ResponsesC():
+	case <-ctx.Done():
+		s.Require().Fail(ctx.Err().Error())
+	}
+	s.Require().NotNil(request.GetIssueSecuredClusterCertsRequest())
+
+	return request.GetIssueSecuredClusterCertsRequest()
+}
+
+func getSecuredClusterIssueCertsSuccessResponse(
+	requestID string,
+	caPem []byte,
+	secretsCerts map[string]*mtls.IssuedCert,
+) *central.MsgToSensor {
+	serviceTypeMap := map[string]storage.ServiceType{
+		sensorSecretName:           storage.ServiceType_SENSOR_SERVICE,
+		collectorSecretName:        storage.ServiceType_COLLECTOR_SERVICE,
+		admissionControlSecretName: storage.ServiceType_ADMISSION_CONTROL_SERVICE,
+		scannerSecretName:          storage.ServiceType_SCANNER_SERVICE,
+		scannerDbSecretName:        storage.ServiceType_SCANNER_DB_SERVICE,
+		scannerV4IndexerSecretName: storage.ServiceType_SCANNER_V4_INDEXER_SERVICE,
+		scannerV4DbSecretName:      storage.ServiceType_SCANNER_V4_DB_SERVICE,
+	}
+
+	var serviceCerts []*storage.TypedServiceCertificate
+	for secretName, cert := range secretsCerts {
+		serviceType, exists := serviceTypeMap[secretName]
+		if !exists {
+			continue
+		}
+		serviceCerts = append(serviceCerts, &storage.TypedServiceCertificate{
+			ServiceType: serviceType,
+			Cert: &storage.ServiceCertificate{
+				KeyPem:  cert.KeyPEM,
+				CertPem: cert.CertPEM,
+			},
+		})
+	}
+
+	return &central.MsgToSensor{
+		Msg: &central.MsgToSensor_IssueSecuredClusterCertsResponse{
+			IssueSecuredClusterCertsResponse: &central.IssueSecuredClusterCertsResponse{
+				RequestId: requestID,
+				Response: &central.IssueSecuredClusterCertsResponse_Certificates{
+					Certificates: &storage.TypedServiceCertificateSet{
+						CaPem:        caPem,
+						ServiceCerts: serviceCerts,
+					},
+				},
+			},
+		},
+	}
+}
+
+func getSecuredClusterIssueCertsFailureResponse(requestID string) *central.MsgToSensor {
+	return &central.MsgToSensor{
+		Msg: &central.MsgToSensor_IssueSecuredClusterCertsResponse{
+			IssueSecuredClusterCertsResponse: &central.IssueSecuredClusterCertsResponse{
+				RequestId: requestID,
+				Response: &central.IssueSecuredClusterCertsResponse_Error{
+					Error: &central.SecuredClusterCertsIssueError{
+						Message: "forced error",
+					},
+				},
+			},
+		},
+	}
+}
+
+func newSecuredClusterTLSIssuer(
+	t *testing.T,
+	k8sClient kubernetes.Interface,
+	sensorNamespace string,
+	sensorPodName string,
+) *securedClusterTLSIssuerImpl {
+	tlsIssuer := NewSecuredClusterTLSIssuer(k8sClient, sensorNamespace, sensorPodName)
+	require.IsType(t, &securedClusterTLSIssuerImpl{}, tlsIssuer)
+	return tlsIssuer.(*securedClusterTLSIssuerImpl)
+}

--- a/sensor/kubernetes/certrefresh/tls_issuer_common.go
+++ b/sensor/kubernetes/certrefresh/tls_issuer_common.go
@@ -3,7 +3,11 @@ package certrefresh
 import (
 	"time"
 
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certrepo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 var (
@@ -25,3 +29,9 @@ var (
 		Cap:      10 * time.Minute,
 	}
 )
+
+type certificateRefresherGetter func(certsDescription string, requestCertificates requestCertificatesFunc,
+	repository certrepo.ServiceCertificatesRepo, timeout time.Duration, backoff wait.Backoff) concurrency.RetryTicker
+
+type serviceCertificatesRepoGetter func(ownerReference metav1.OwnerReference, namespace string,
+	secretsClient corev1.SecretInterface) certrepo.ServiceCertificatesRepo

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -193,9 +193,8 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	if securedClusterIsNotManagedManually(helmManagedConfig) {
 		// Central capabilities are not available at this point (there's no connection to Central yet),
-		// so we'll start both Secured Cluster and Local Scanner TLS issuer Sensor components.
-		// Ideally we'd only start one or the other, depending on whether Central has
-		// the `SecuredClusterCertificatesReissue` capability.
+		// so we'll start both Secured Cluster and Local Scanner TLS issuer Sensor components. The Secured Cluster
+		// certificate refresher can determine at runtime if Central has the required capability for it to work.
 
 		podName := os.Getenv("POD_NAME")
 		components = append(components,

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -191,12 +191,22 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		components = append(components, k8sadmctrl.NewConfigMapSettingsPersister(cfg.k8sClient.Kubernetes(), admCtrlSettingsMgr, sensorNamespace))
 	}
 
-	// Local scanner can be started even if scanner-tls certs are available in the same namespace because
-	// it ignores secrets not owned by Sensor.
-	if securedClusterIsNotManagedManually(helmManagedConfig) && env.LocalImageScanningEnabled.BooleanSetting() {
+	if securedClusterIsNotManagedManually(helmManagedConfig) {
+		// Central capabilities are not available at this point (there's no connection to Central yet),
+		// so we'll start both Secured Cluster and Local Scanner TLS issuer Sensor components.
+		// Ideally we'd only start one or the other, depending on whether Central has
+		// the `SecuredClusterCertificatesReissue` capability.
+
 		podName := os.Getenv("POD_NAME")
 		components = append(components,
-			certrefresh.NewLocalScannerTLSIssuer(cfg.k8sClient.Kubernetes(), sensorNamespace, podName))
+			certrefresh.NewSecuredClusterTLSIssuer(cfg.k8sClient.Kubernetes(), sensorNamespace, podName))
+
+		// Local scanner can be started even if scanner-tls certs are available in the same namespace because
+		// it ignores secrets not owned by Sensor.
+		if env.LocalImageScanningEnabled.BooleanSetting() {
+			components = append(components,
+				certrefresh.NewLocalScannerTLSIssuer(cfg.k8sClient.Kubernetes(), sensorNamespace, podName))
+		}
 	}
 
 	s := sensor.NewSensor(


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds Sensor-side handling for the gRPC endpoint implemented here: 
* https://github.com/stackrox/stackrox/pull/12740

It was preceded by several refactor PRs:
* https://github.com/stackrox/stackrox/pull/12825
* https://github.com/stackrox/stackrox/pull/13023
* https://github.com/stackrox/stackrox/pull/13000
* https://github.com/stackrox/stackrox/pull/13260

The new Sensor component (`SecuredClusterTLSIssuer`) checks for Secured Cluster TLS certificates at startup. If they’re missing or nearing expiration, it automatically requests new ones.

Additionally, it also schedules a certificate refresh when the certificates are at ~50%, so there is little risk that the certificates will become stale if Sensor never restarts in the last months of certificate validity.

The added components (the Secured Cluster TLS issuer and Certificate Requester) are based on their Local Scanner counterparts, with a few changes, common code extracted out, and tests adapted. Because these components are tightly coupled with their respective gRPC APIs, this was the easier way to do, but results in some similar code.  And the majority of certrefresh code *is* being reused anyway. It's also making it easier for the Secured Cluster cert refresh logic to diverge, if necessary. 

[This PR](https://github.com/stackrox/stackrox/pull/13280) uses generics to remove the duplication mentioned above, at the expense of adding complexity to already quite complicated code. It's also worth mentioning that from 4.7 onwards, the Local Scanner certificate refresher will be provided only for backwards compatibility with older Centrals, and will eventually be deprecated.

### ❗Important notes ❗  
* Secured Clusters using (soon to be legacy) init bundle secrets will retrieve the new refreshed certificates on startup (i.e. in 4.7 we'll have an automatic transition to the new certificates)
* the new TLS secrets have a new naming scheme, and they can co-exist with the older init bundle secrets (see [here](https://github.com/stackrox/stackrox/pull/13023/files#diff-019ec2772f9fffc4b1ee41dc2c8e689c9614c4fec077d6886c8a5944e7db679fR15))
* the new certificates are **not yet used** by the services. That will be done after this PR is merged, see [ROX-26055](https://issues.redhat.com/browse/ROX-26055). tl;dr: the services will have initContainers that will check which TLS secrets exist in the cluster, and use the preferred ones.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

With a local deployment, checked that the new set of Secured Cluster certificates are being created. I also tried running with a short refresh interval (20 seconds instead of 9 months) to check that they are being rotated.