### PR TITLE
ROX-26706: Mock CVE response for image in multi-cve deferral test

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
@@ -1,0 +1,115 @@
+{
+    "data": {
+        "image": {
+            "id": "sha256:abcxyz",
+            "name": {
+                "registry": "docker.io",
+                "remote": "cypress-test/image",
+                "tag": "v0.0.1",
+                "__typename": "ImageName"
+            },
+            "metadata": {
+                "v1": {
+                    "layers": [
+                        {
+                            "instruction": "ADD",
+                            "value": "file:abc123 in /",
+                            "__typename": "ImageLayer"
+                        }
+                    ],
+                    "__typename": "V1Metadata"
+                },
+                "__typename": "ImageMetadata"
+            },
+            "__typename": "Image",
+            "imageVulnerabilityCount": 2,
+            "imageCVECountBySeverity": {
+                "low": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "moderate": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "important": {
+                    "total": 2,
+                    "fixable": 2,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "critical": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "__typename": "ResourceCountByCVESeverity"
+            },
+            "imageVulnerabilities": [
+                {
+                    "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                    "cve": "CVE-2023-0464",
+                    "summary": "This is a mocked CVE in a Cypress test",
+                    "cvss": 7.5,
+                    "scoreVersion": "V3",
+                    "nvdCvss": 0,
+                    "nvdScoreVersion": "UNKNOWN_VERSION",
+                    "discoveredAtImage": "2024-03-01T17:45:32.757812569Z",
+                    "publishedOn": "2023-03-22T17:15:00Z",
+                    "pendingExceptionCount": 0,
+                    "imageComponents": [
+                        {
+                            "name": "openssl",
+                            "version": "3.0.8-r0",
+                            "location": "",
+                            "source": "OS",
+                            "layerIndex": 0,
+                            "imageVulnerabilities": [
+                                {
+                                    "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                    "fixedByVersion": "3.0.8-r1",
+                                    "pendingExceptionCount": 0,
+                                    "__typename": "ImageVulnerability"
+                                }
+                            ],
+                            "__typename": "ImageComponent"
+                        }
+                    ],
+                    "__typename": "ImageVulnerability"
+                },
+                {
+                    "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                    "cve": "CVE-2023-5363",
+                    "summary": "This is a mocked CVE in a Cypress test",
+                    "cvss": 7.5,
+                    "scoreVersion": "V3",
+                    "nvdCvss": 0,
+                    "nvdScoreVersion": "UNKNOWN_VERSION",
+                    "discoveredAtImage": "2024-03-01T17:45:32.757812569Z",
+                    "publishedOn": "2023-10-25T18:17:00Z",
+                    "pendingExceptionCount": 0,
+                    "imageComponents": [
+                        {
+                            "name": "openssl",
+                            "version": "3.0.8-r0",
+                            "location": "",
+                            "source": "OS",
+                            "layerIndex": 0,
+                            "imageVulnerabilities": [
+                                {
+                                    "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                    "fixedByVersion": "3.0.12-r0",
+                                    "pendingExceptionCount": 0,
+                                    "__typename": "ImageVulnerability"
+                                }
+                            ],
+                            "__typename": "ImageComponent"
+                        }
+                    ],
+                    "__typename": "ImageVulnerability"
+                }
+            ]
+        }
+    }
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -283,13 +283,23 @@ export function verifySelectedCvesInModal(cveNames) {
     });
 }
 
-export function visitAnyImageSinglePage() {
+export function visitAnyImageSinglePageWithMockedCves() {
+    const cveListOpname = 'getCVEsForImage';
+    const routeMatcherMapForImageCves = getRouteMatcherMapForGraphQL([cveListOpname]);
+    const staticResponseMapForImageCves = {
+        [cveListOpname]: { fixture: 'vulnerabilities/workloadCves/multipleCvesForImage.json' },
+    };
+
     visitWorkloadCveOverview();
 
-    selectEntityTab('Image');
-    cy.get('tbody tr td[data-label="Image"] a').first().click();
-
-    waitForTableLoadCompleteIndicator();
+    interactAndWaitForResponses(
+        () => {
+            selectEntityTab('Image');
+            cy.get('tbody tr td[data-label="Image"] a').first().click();
+        },
+        routeMatcherMapForImageCves,
+        staticResponseMapForImageCves
+    );
 
     return cy.get('h1').then(($h1) => {
         // Remove the SHA and/or tag from the image name

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -10,7 +10,7 @@ import {
     selectSingleCveForException,
     verifyExceptionConfirmationDetails,
     verifySelectedCvesInModal,
-    visitAnyImageSinglePage,
+    visitAnyImageSinglePageWithMockedCves,
 } from './WorkloadCves.helpers';
 
 describe('Workload CVE Image page deferral and false positive flows', () => {
@@ -39,7 +39,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should defer a single CVE', () => {
-        visitAnyImageSinglePage().then((image) => {
+        visitAnyImageSinglePageWithMockedCves().then((image) => {
             selectSingleCveForException('DEFERRAL').then((cveName) => {
                 verifySelectedCvesInModal([cveName]);
                 fillAndSubmitExceptionForm({
@@ -56,9 +56,8 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
         });
     });
 
-    // TODO ROX-26706 - Unskip this test and rework to handle the case where multiple CVEs are not available via the API
-    it.skip('should defer multiple selected CVEs', () => {
-        visitAnyImageSinglePage().then((image) => {
+    it('should defer multiple selected CVEs', () => {
+        visitAnyImageSinglePageWithMockedCves().then((image) => {
             selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({
@@ -77,7 +76,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should mark a single CVE as false positive', () => {
-        visitAnyImageSinglePage().then((image) => {
+        visitAnyImageSinglePageWithMockedCves().then((image) => {
             selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
                 verifySelectedCvesInModal([cveName]);
                 fillAndSubmitExceptionForm({ comment: 'Test comment' });
@@ -90,9 +89,8 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
         });
     });
 
-    // TODO ROX-26706 - Unskip this test and rework to handle the case where multiple CVEs are not available via the API
-    it.skip('should mark multiple selected CVEs as false positive', () => {
-        visitAnyImageSinglePage().then((image) => {
+    it('should mark multiple selected CVEs as false positive', () => {
+        visitAnyImageSinglePageWithMockedCves().then((image) => {
             selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({


### PR DESCRIPTION
### Description

Re-enables integration tests for deferring multiple CVEs as part of a single request. This change mocks the request for CVEs belonging to a single image because:
- We cannot rely on an image always having more than one CVE
- The full e2e behavior is not dependent on the CVEs that are part of an exception request being present in the system

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI