### PR TITLE
chore: don't verify monitoring tls certs

### DIFF
--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -111,7 +111,7 @@ func NewTLSConfigurerFromEnv() verifier.TLSConfigurer {
 // watchForChanges watches for changes of the server TLS certificate files and the client CA config map.
 func (t *tlsConfigurerImpl) watchForChanges() {
 	// Watch for changes of server TLS certificate.
-	certwatch.WatchCertDir(t.certDir, t.getCertificateFromDirectory, t.updateCertificate)
+	certwatch.WatchCertDir(t.certDir, t.getCertificateFromDirectory, t.updateCertificate, certwatch.WithVerify(false))
 
 	// Watch for changes of client CA.
 	t.k8sWatcher.Watch(context.Background(), t.clientCANamespace, t.clientCAConfigMap)

--- a/pkg/mtls/certwatch/certwatch.go
+++ b/pkg/mtls/certwatch/certwatch.go
@@ -21,15 +21,18 @@ var (
 	_   k8scfgwatch.Handler = (*handler)(nil) // compile time check that the handler implements the interface
 )
 
-type loadCertificateFunc func(dir string) (*tls.Certificate, error)
-type updateCertificateFunc func(cert *tls.Certificate)
+type (
+	loadCertificateFunc   func(dir string) (*tls.Certificate, error)
+	updateCertificateFunc func(cert *tls.Certificate)
+)
 
 // WatchCertDir starts watching the directory containing certificates
-func WatchCertDir(dir string, loadCert loadCertificateFunc, updateCert updateCertificateFunc) {
+func WatchCertDir(dir string, loadCert loadCertificateFunc, updateCert updateCertificateFunc, options ...CertWatchOption) {
 	wh := &handler{
 		dir:        dir,
 		loadCert:   loadCert,
 		updateCert: updateCert,
+		cfg:        applyOptions(options...),
 	}
 
 	watchOpts := k8scfgwatch.Options{
@@ -43,6 +46,7 @@ type handler struct {
 	dir        string
 	loadCert   loadCertificateFunc
 	updateCert updateCertificateFunc
+	cfg        *CertWatchConfig
 }
 
 func (h *handler) OnChange(dir string) (interface{}, error) {
@@ -64,11 +68,13 @@ func (h *handler) OnStableUpdate(val interface{}, err error) {
 			parsedChain, err := x509utils.ParseCertificateChain(cert.Certificate)
 			if err != nil {
 				log.Errorf("Error parsing certificate #%d in the certificate chain (dir: %q): %v", len(parsedChain), h.dir, err)
-			} else if err := x509utils.VerifyCertificateChain(parsedChain, x509.VerifyOptions{}); err != nil {
-				log.Warnf("This server does not trust its own certificate! "+
-					"If you see certificate trust issues in your clients (e.g. sensors), "+
-					"please ensure that your certificate PEM file includes the entire certificate chain."+
-					"Watch dir: %q", h.dir)
+			} else if h.cfg.GetVerify() {
+				if err := x509utils.VerifyCertificateChain(parsedChain, x509.VerifyOptions{}); err != nil {
+					log.Warnf("This server does not trust its own certificate! "+
+						"If you see certificate trust issues in your clients (e.g. sensors), "+
+						"please ensure that your certificate PEM file includes the entire certificate chain. "+
+						"Watch dir: %q", h.dir)
+				}
 			}
 		}
 	}

--- a/pkg/mtls/certwatch/options.go
+++ b/pkg/mtls/certwatch/options.go
@@ -24,7 +24,7 @@ func applyOptions(options ...CertWatchOption) *CertWatchConfig {
 	return cfg
 }
 
-// WithVerify enables/disables the verification of watched certifications.
+// WithVerify enables/disables the verification of watched certificates.
 func WithVerify(verify bool) CertWatchOption {
 	return func(cfg *CertWatchConfig) *CertWatchConfig {
 		if cfg == nil {

--- a/pkg/mtls/certwatch/options.go
+++ b/pkg/mtls/certwatch/options.go
@@ -1,0 +1,36 @@
+package certwatch
+
+// CertWatchConfig configures how certificates are watched.
+type CertWatchConfig struct {
+	Verify bool
+}
+
+// GetVerify returns the verification state.
+func (c *CertWatchConfig) GetVerify() bool {
+	if c == nil {
+		return true
+	}
+	return c.Verify
+}
+
+// CertWatchOption is a functor that applies the certwatch config option.
+type CertWatchOption func(opt *CertWatchConfig) *CertWatchConfig
+
+func applyOptions(options ...CertWatchOption) *CertWatchConfig {
+	cfg := &CertWatchConfig{Verify: true}
+	for _, opt := range options {
+		cfg = opt(cfg)
+	}
+	return cfg
+}
+
+// WithVerify enables/disables the verification of watched certifications.
+func WithVerify(verify bool) CertWatchOption {
+	return func(cfg *CertWatchConfig) *CertWatchConfig {
+		if cfg == nil {
+			cfg = &CertWatchConfig{}
+		}
+		cfg.Verify = verify
+		return cfg
+	}
+}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The monitoring TLS certs are generated by the OpenShift CA operator. They do not contain the cluster root certs, and therefore verification fails. The verification was first introduced for our own stackrox certs, which do contain the root cert. To avoid customer confusion, let's disable the verification, which is expected to fail for monitoring certs.

Example log message that should be avoided:

```
pkg/mtls/certwatch: 2024/10/30 08:51:23.002130 certwatch.go:68: Warn: This server does not trust its own certificate! If you see certificate trust issues in your clients (e.g. sensors), please ensure that your certificate PEM file includes the entire certificate chain.Watch dir: "/run/secrets/stackrox.io/monitoring-tls"
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
