### PR TITLE
chore(ui): Replace more properties with strings in table cells

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -9,12 +9,6 @@ import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getURLLinkToDeployment } from 'Containers/NetworkGraph/utils/networkGraphURLUtils';
 
-const columnNames = {
-    deployment: 'Deployment',
-    resourceLocation: 'Resource location',
-    riskPriority: 'Risk priority',
-};
-
 function riskPageLinkToDeployment(id: string, name: string, searchFilter: SearchFilter): string {
     const query = getUrlQueryStringForSearchFilter({
         ...searchFilter,
@@ -36,11 +30,9 @@ function DeploymentsAtMostRiskTable({
         <Table aria-label="Deployments at most risk" variant="compact" borders={false}>
             <Thead>
                 <Tr>
-                    <Th className="pf-v5-u-pl-0">{columnNames.deployment}</Th>
-                    <Th>{columnNames.resourceLocation}</Th>
-                    <Th className="pf-v5-u-pr-0 pf-v5-u-text-align-center-on-md">
-                        {columnNames.riskPriority}
-                    </Th>
+                    <Th className="pf-v5-u-pl-0">Deployment</Th>
+                    <Th>Resource location</Th>
+                    <Th className="pf-v5-u-pr-0 pf-v5-u-text-align-center-on-md">Risk priority</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -52,14 +44,14 @@ function DeploymentsAtMostRiskTable({
                     });
                     return (
                         <Tr key={deploymentId}>
-                            <Td className="pf-v5-u-pl-0" dataLabel={columnNames.deployment}>
+                            <Td className="pf-v5-u-pl-0" dataLabel="Deployment">
                                 <Link
                                     to={riskPageLinkToDeployment(deploymentId, name, searchFilter)}
                                 >
                                     <Truncate position="middle" content={name} />
                                 </Link>
                             </Td>
-                            <Td width={45} dataLabel={columnNames.resourceLocation}>
+                            <Td width={45} dataLabel="Resource location">
                                 <span>
                                     in &ldquo;
                                     <Link to={networkGraphLink}>{`${cluster} / ${namespace}`}</Link>
@@ -69,7 +61,7 @@ function DeploymentsAtMostRiskTable({
                             <Td
                                 width={20}
                                 className="pf-v5-u-pr-0 pf-v5-u-text-align-center-on-md"
-                                dataLabel={columnNames.riskPriority}
+                                dataLabel="Risk priority"
                             >
                                 {priority}
                             </Td>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
@@ -52,13 +52,6 @@ export type ImagesAtMostRiskProps = {
     cveStatusOption: CveStatusOption;
 };
 
-const columnNames = {
-    imageName: 'Images',
-    riskPriority: 'Risk priority',
-    criticalCves: 'Critical CVEs',
-    importantCves: 'Important CVEs',
-};
-
 function linkToImage(id: string) {
     return `${vulnManagementPath}/image/${id}#image-findings`;
 }
@@ -69,17 +62,17 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
             <Thead>
                 <Tr>
                     <Th width={35} className="pf-v5-u-pl-0">
-                        {columnNames.imageName}
+                        Image
                     </Th>
-                    <Th className="pf-v5-u-text-align-center-on-md">{columnNames.riskPriority}</Th>
-                    <Th>{columnNames.criticalCves}</Th>
-                    <Th className="pf-v5-u-pr-0">{columnNames.importantCves}</Th>
+                    <Th className="pf-v5-u-text-align-center-on-md">Risk priority</Th>
+                    <Th>Critical CVEs</Th>
+                    <Th className="pf-v5-u-pr-0">Important CVEs</Th>
                 </Tr>
             </Thead>
             <Tbody>
                 {images.map(({ id, name, priority, imageVulnerabilityCounter }) => (
                     <Tr key={id}>
-                        <Td className="pf-v5-u-pl-0" dataLabel={columnNames.imageName}>
+                        <Td className="pf-v5-u-pl-0" dataLabel="Image">
                             <Link
                                 to={linkToImage(id)}
                                 scroll={(el: HTMLElement) =>
@@ -98,13 +91,10 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                 </Tooltip>
                             </Link>
                         </Td>
-                        <Td
-                            className="pf-v5-u-text-align-center-on-md"
-                            dataLabel={columnNames.riskPriority}
-                        >
+                        <Td className="pf-v5-u-text-align-center-on-md" dataLabel="Risk priority">
                             {priority}
                         </Td>
-                        <Td dataLabel={columnNames.criticalCves}>
+                        <Td dataLabel="Critical CVEs">
                             <CriticalSeverityIcon
                                 className="pf-v5-u-display-inline pf-v5-u-mr-xs"
                                 color={
@@ -119,7 +109,7 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                                     : `${imageVulnerabilityCounter.critical.total} CVEs`}
                             </span>
                         </Td>
-                        <Td className="pf-v5-u-pr-0" dataLabel={columnNames.importantCves}>
+                        <Td className="pf-v5-u-pr-0" dataLabel="Important CVEs">
                             <ImportantSeverityIcon
                                 className="pf-v5-u-display-inline pf-v5-u-mr-xs"
                                 color={

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -35,12 +35,6 @@ type ExternalGroupSideBarProps = {
     onNodeSelect: (id: string) => void;
 };
 
-const columnNames = {
-    entity: 'Entity',
-    address: 'Address',
-    activeTraffic: 'Active traffic',
-};
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ExternalGroupSideBar({
     labelledById,
@@ -115,9 +109,9 @@ function ExternalGroupSideBar({
                         <Table aria-label="External to cluster table" variant="compact">
                             <Thead>
                                 <Tr>
-                                    <Th width={50}>{columnNames.entity}</Th>
-                                    <Th>{columnNames.address}</Th>
-                                    <Th>{columnNames.activeTraffic}</Th>
+                                    <Th width={50}>Entity</Th>
+                                    <Th>Address</Th>
+                                    <Th>Active traffic</Th>
                                 </Tr>
                             </Thead>
                             <Tbody>
@@ -136,7 +130,7 @@ function ExternalGroupSideBar({
                                     const relevantEdges = getEdgesByNodeId(edges, externalNode.id);
                                     return (
                                         <Tr key={externalNode.id}>
-                                            <Td dataLabel={columnNames.entity}>
+                                            <Td dataLabel="Entity">
                                                 <Flex>
                                                     <FlexItem>{entityIcon}</FlexItem>
                                                     <FlexItem>
@@ -152,8 +146,8 @@ function ExternalGroupSideBar({
                                                     </FlexItem>
                                                 </Flex>
                                             </Td>
-                                            <Td dataLabel={columnNames.address}>{address}</Td>
-                                            <Td dataLabel={columnNames.activeTraffic}>
+                                            <Td dataLabel="Address">{address}</Td>
+                                            <Td dataLabel="Active traffic">
                                                 {relevantEdges.length}
                                             </Td>
                                         </Tr>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -13,11 +13,6 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import usePagination from 'hooks/patternfly/usePagination';
 
-const columnNames = {
-    DEPLOYMENT: 'Deployment',
-    ACTIVE_TRAFFIC: 'Active traffic',
-};
-
 type NamespaceDeploymentsProps = {
     deployments: { id: string; name: string; numFlows: number }[];
     onNodeSelect: (id: string) => void;
@@ -79,14 +74,14 @@ function NamespaceDeployments({ deployments, onNodeSelect }: NamespaceDeployment
                     <Table aria-label="Simple table" variant="compact">
                         <Thead>
                             <Tr>
-                                <Th>{columnNames.DEPLOYMENT}</Th>
-                                <Th>{columnNames.ACTIVE_TRAFFIC}</Th>
+                                <Th>Deployment</Th>
+                                <Th modifier="fitContent">Active traffic</Th>
                             </Tr>
                         </Thead>
                         <Tbody>
                             {filteredDeployments.map((deployment) => (
                                 <Tr key={deployment.id}>
-                                    <Td dataLabel={columnNames.DEPLOYMENT}>
+                                    <Td dataLabel="Deployment">
                                         <Button
                                             variant="link"
                                             isInline
@@ -95,9 +90,7 @@ function NamespaceDeployments({ deployments, onNodeSelect }: NamespaceDeployment
                                             {deployment.name}
                                         </Button>
                                     </Td>
-                                    <Td dataLabel={columnNames.ACTIVE_TRAFFIC}>
-                                        {deployment.numFlows} flows
-                                    </Td>
+                                    <Td dataLabel="Active traffic">{deployment.numFlows} flows</Td>
                                 </Tr>
                             ))}
                         </Tbody>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -15,11 +15,6 @@ type NotifyYAMLModalProps = {
     modification: NetworkPolicyModification | null;
 };
 
-const columnNames = {
-    name: 'Name',
-    type: 'Type',
-};
-
 function NotifyYAMLModal({
     isModalOpen,
     setIsModalOpen,
@@ -71,8 +66,8 @@ function NotifyYAMLModal({
                                 isSelected: allRowsSelected,
                             }}
                         />
-                        <Th>{columnNames.name}</Th>
-                        <Th>{columnNames.type}</Th>
+                        <Th>Name</Th>
+                        <Th>Type</Th>
                     </Tr>
                 </Thead>
                 <Tbody>
@@ -86,8 +81,8 @@ function NotifyYAMLModal({
                                         isSelected: selected[rowIndex],
                                     }}
                                 />
-                                <Td dataLabel={columnNames.name}>{notifier.name}</Td>
-                                <Td dataLabel={columnNames.type}>{notifier.type}</Td>
+                                <Td dataLabel="Name">{notifier.name}</Td>
+                                <Td dataLabel="Type">{notifier.type}</Td>
                             </Tr>
                         );
                     })}


### PR DESCRIPTION
### Description

Found 5 more files in addition to FlowsTable.ts in #13193
1. DeploymentsAtMostRiskTable.tsx
2. ImagesAtMostRiskTable.tsx
3. ExternalGroupSideBar.tsx
4. NamespaceDeployments.tsx
5. NotifyYAMLModal.tsx

Replace object properties with strings as text of `Th` and `dataLabel` of `Td` elements:
* To benefit from lint rules for consistency.
* To be able to generate table columns for comparison.
* To increase our ability to reuse knowledge and skills to update tables easily.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4637804 - 4637804
        total 51 = 11749557 - 11749506
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/dashboard

    DeploymentsAtMostRiskTable.tsx file has **Deployment** singular:

    * Before and after changes, see text of `Th` and `dataLabel` ot `Td` at 1440px.
        ![DeploymentsAtMostRiskTable_1440px](https://github.com/user-attachments/assets/97e44423-ea73-4269-b6f9-bf87d10d1095)

    * Before and after changes, see text of `Th` and `dataLabel` ot `Td` at 760px.
        ![DeploymentsAtMostRiskTable_760px](https://github.com/user-attachments/assets/83aaff2e-9535-4304-8b34-07e540103c0a)

    ImagesAtMostRiskTable.tsx file had **Images** plural but replace with **Image** singular:

    * After changes, see text of `Th` and `dataLabel` ot `Td` at 1440px.
![ImagesAtMostRiskTable_1440px](https://github.com/user-attachments/assets/bde30d6f-988a-4a70-a001-f8795d40f6ed)

    * After changes, see text of `Th` and `dataLabel` ot `Td` at 760px.
        ![ImagesAtMostRiskTable_760px](https://github.com/user-attachments/assets/3ae65df0-3cb5-4d8d-9712-f8f2fe24a8a0)

2. Visit /main/network-graph select cluster and namespace.

    ExternalGroupSideBar.tsx file: click **External to cluster**

    * Before and after changes, see text of `Th` and `dataLabel` of `Td` at 1440px.
        ![ExternalGroupSideBar_1440px](https://github.com/user-attachments/assets/6f79e345-009b-459f-9be5-b4ddf492a1d8)

    * Before and after changes, see text of `Th` and `dataLabel` of `Td` at 760px.
        ![ExternalGroupSideBar_760px](https://github.com/user-attachments/assets/f390114d-7416-49c0-8048-ba51b81d3563)

    NamespaceDeployments.tsx file: click a namespace like **stackrox**

    * Before changes, see text of `Th` **with** ellipsis and `dataLabel` of `Td` at 1440px.
        ![NamespaceDeployments_1440px_ellipsis](https://github.com/user-attachments/assets/ee5ae42a-88e0-4543-a419-74b4c81ebb2a)

    * After changes, see text of `Th` **without** ellipsis and `dataLabel` ot `Td` at 1440px.
        ![NamespaceDeployments_1440px_fitContent](https://github.com/user-attachments/assets/240cdcff-a2f9-477b-914c-258d6443dc08)

    * Before and after changes, see text of `Th` and `dataLabel` ot `Td` at 760px.
        ![NamespaceDeployments_760px](https://github.com/user-attachments/assets/5dab918d-cd00-42e7-a144-55e512ddf11c)

    NotifyYAMLModal.tsx file: click **Network policy generator**, click **Generate and simulate network policies**, click **Actions**, and then click **Share YAML with notifiers**

    * Before and after changes, see text of `Th` and `dataLabel` of `Td` at 1440px.
        ![NotifyYAMLModal_1440px](https://github.com/user-attachments/assets/fc325f4e-ec7b-490f-af9b-23f9dbbc7a41)

    * Before and after changes, see text of `Th` and `dataLabel` of `Td` at 760px.
        ![NotifyYAMLModal_760px](https://github.com/user-attachments/assets/03aa4bd1-66b7-4184-b559-2d151923bd94)
