### PR TITLE
ROX-26889: Build `main` source image without Cachi2 artifact

### DIFF
--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -454,8 +454,8 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    # - name: CACHI2_ARTIFACT
+    #   value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     taskRef:
       params:
       - name: name

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -454,6 +454,7 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    # TODO(ROX-26900): uncomment CACHI2_ARTIFACT after KFLUXBUGS-1508 is resolved.
     # - name: CACHI2_ARTIFACT
     #   value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     taskRef:


### PR DESCRIPTION
### Description

As a workaround for https://issues.redhat.com/browse/KFLUXBUGS-1508

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No contributions to automated tests.

#### How I validated my change

- [x] Main build succeeds in Konflux CI - https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/main-on-push-v5xjq
- [x] I checked EC violations (locally).

There's a chance Konflux EC won't be happy with the image, I'd request policy exception as part of the same task ROX-26889