### PR TITLE
feat(debug): Add more logging in the gRPC server package

### DIFF
--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -64,7 +64,7 @@ func (a *MarshalerTest) TestDurationParsing() {
 	url := fmt.Sprintf("https://localhost:%d/v1/nodecves/suppress", testDefaultPort)
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	api := NewAPI(defaultConf())
+	api := newAPIForTest(a.T(), defaultConf())
 	grpcServiceHandler := &supressCveServiceTestErrorImpl{}
 	api.Register(grpcServiceHandler)
 	a.Require().NoError(api.Start().Wait())

--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -60,7 +61,7 @@ func (s *supressCveServiceTestErrorImpl) SuppressCVEs(_ context.Context, req *v1
 
 func (a *MarshalerTest) TestDurationParsing() {
 
-	url := "https://localhost:8080/v1/nodecves/suppress"
+	url := fmt.Sprintf("https://localhost:%d/v1/nodecves/suppress", testDefaultPort)
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	api := NewAPI(defaultConf())

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -126,6 +126,8 @@ type apiImpl struct {
 
 	grpcServer         *grpc.Server
 	shutdownInProgress *atomic.Bool
+
+	debugLog *debugLoggerImpl
 }
 
 // A Config configures the server.
@@ -193,7 +195,7 @@ func (a *apiImpl) Stop() bool {
 	a.listenersLock.Lock()
 	defer a.listenersLock.Unlock()
 
-	log.Infof("Stopping %d listeners", len(a.listeners))
+	a.debugLog.Logf("Stopping %d listeners", len(a.listeners))
 	for _, listener := range a.listeners {
 		debugMsg := "unknown listener type: "
 		switch listener.srv.(type) {
@@ -208,7 +210,7 @@ func (a *apiImpl) Stop() bool {
 		} else {
 			debugMsg += fmt.Sprintf("not stopped in loop. Comparing with grpcServer pointer with listener.srv pointer (%p : %p)", a.grpcServer, listener.srv)
 		}
-		log.Info(debugMsg)
+		a.debugLog.Log(debugMsg)
 	}
 	return true
 }

--- a/pkg/grpc/server_ratelimit_test.go
+++ b/pkg/grpc/server_ratelimit_test.go
@@ -92,7 +92,7 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 				},
 			}
 
-			api := NewAPI(cfg)
+			api := newAPIForTest(a.T(), cfg)
 			grpcService := &pingServiceTestImpl{}
 			api.Register(grpcService)
 			a.Assert().NoError(api.Start().Wait())

--- a/pkg/grpc/server_ratelimit_test.go
+++ b/pkg/grpc/server_ratelimit_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -99,10 +100,10 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 			a.T().Cleanup(func() { api.Stop() })
 			var urls []string
 			if tt.useHTTP {
-				urls = append(urls, "https://localhost:8080/test")
+				urls = append(urls, fmt.Sprintf("https://localhost:%d/test", testDefaultPort))
 			}
 			if tt.useGRPC {
-				urls = append(urls, "https://localhost:8080/v1/ping")
+				urls = append(urls, fmt.Sprintf("https://localhost:%d/v1/ping", testDefaultPort))
 			}
 
 			hitLimit := false

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	testDefaultPort = 8080
+	testDefaultPort = 8484
 )
 
 type APIServerSuite struct {

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	testDefaultPort = 8484
+	testDefaultPort = 8080
 )
 
 type APIServerSuite struct {
@@ -217,9 +217,19 @@ func setUpPrintSocketInfoFunction(t *testing.T, ports ...uint64) {
 		if r := recover(); r != nil {
 			if err, ok := r.(string); ok {
 				if strings.Contains(err, syscall.EADDRINUSE.Error()) {
+					t.Log("-----------------------------------------------")
+					t.Log(" STACK TRACE INFO")
+					t.Log("-----------------------------------------------")
+					if printErr := testPrintStackTraceInfo(t); printErr != nil {
+						t.Log(printErr)
+					}
+					t.Log("-----------------------------------------------")
+					t.Log(" SOCKET INFO")
+					t.Log("-----------------------------------------------")
 					if printErr := testPrintSocketInfo(t, ports...); printErr != nil {
 						t.Log(printErr)
 					}
+					t.Log("-----------------------------------------------")
 					panic(err)
 				}
 			}

--- a/pkg/grpc/testutils.go
+++ b/pkg/grpc/testutils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"testing"
@@ -147,4 +148,14 @@ func testPrintSocketInfoFromProcFile(t *testing.T, fName string, ports ...uint64
 		t.Logf("Port %d is in %q state", port, getStateString(code))
 	}
 	return err
+}
+
+func testPrintStackTraceInfo(_ *testing.T) error {
+	errList := errorhelpers.NewErrorList("print stacktrace info")
+	for _, p := range pprof.Profiles() {
+		if err := p.WriteTo(os.Stderr, 2); err != nil {
+			errList.AddError(err)
+		}
+	}
+	return errList.ToError()
 }

--- a/pkg/grpc/testutils.go
+++ b/pkg/grpc/testutils.go
@@ -64,7 +64,7 @@ func CreateTestGRPCStreamingService(
 }
 
 var (
-	// TODO: Remove this after the gather more information
+	// TODO: Remove this after gathering more information.
 	// This is just to log extra information in the server_tests.go if they panic.
 	// It should be removed after the investigation is finished.
 	printSocketInfo = dummyPrintSocketInfo

--- a/pkg/grpc/testutils.go
+++ b/pkg/grpc/testutils.go
@@ -71,6 +71,35 @@ var (
 	procFiles       = []string{"/proc/net/tcp", "/proc/net/tcp6"}
 )
 
+type debugLogger interface {
+	Log(args ...any)
+	Logf(format string, args ...any)
+}
+
+type debugLoggerImpl struct {
+	log debugLogger
+}
+
+func (d *debugLoggerImpl) Log(args ...any) {
+	if d == nil || d.log == nil {
+		return
+	}
+	d.log.Log(args)
+}
+
+func (d *debugLoggerImpl) Logf(format string, args ...any) {
+	if d == nil || d.log == nil {
+		return
+	}
+	d.log.Logf(format, args)
+}
+
+func newDebugLogger(t *testing.T) *debugLoggerImpl {
+	return &debugLoggerImpl{
+		log: t,
+	}
+}
+
 func dummyPrintSocketInfo(_ *testing.T) {}
 
 func testPrintSocketInfo(t *testing.T, ports ...uint64) error {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds more logging to the `Stop` function of the gRPC Server in `pkg/grpc`. It also adds a function to print the state of the ports if the unit tests panic due to `syscall.EADDRINUSE`.

This should help debugging the flake [ROX-22816](https://issues.redhat.com/browse/ROX-22816). These changes should be reverted once the problem is solved.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Tested debug functions with the following test to intentionally trigger the panic.

```golang
func (a *APIServerSuite) Test_ForcePanic() {
	api1 := NewAPI(defaultConf())
	api2 := NewAPI(defaultConf())
        a.Assert().NoError(api1.Start().Wait())
        a.Assert().NoError(api2.Start().Wait())
}
```
