### PR TITLE
ROX-26885: fix blank line detection for imports

### DIFF
--- a/central/networkgraph/config/datastore/singleton.go
+++ b/central/networkgraph/config/datastore/singleton.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"github.com/stackrox/rox/central/globaldb"
-
 	pgStore "github.com/stackrox/rox/central/networkgraph/config/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/pkg/sync"
 )

--- a/central/sensor/service/pipeline/deploymentevents/validate_input.go
+++ b/central/sensor/service/pipeline/deploymentevents/validate_input.go
@@ -2,7 +2,6 @@ package deploymentevents
 
 import (
 	"github.com/pkg/errors"
-
 	"github.com/stackrox/rox/generated/storage"
 )
 

--- a/central/serviceaccount/service/singleton.go
+++ b/central/serviceaccount/service/singleton.go
@@ -6,7 +6,6 @@ import (
 	roleDatastore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
 	bindingDatastore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	saDatastore "github.com/stackrox/rox/central/serviceaccount/datastore"
-
 	"github.com/stackrox/rox/pkg/sync"
 )
 

--- a/central/telemetry/gatherers/singleton.go
+++ b/central/telemetry/gatherers/singleton.go
@@ -2,7 +2,6 @@ package gatherers
 
 import (
 	"github.com/pkg/errors"
-
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
 	depDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/globaldb"

--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -18,11 +18,10 @@ package v1alpha1
 
 import (
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/protocompat"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/stackrox/rox/generated/storage"
 )
 
 // +kubebuilder:validation:Enum=DEPLOY;BUILD;RUNTIME

--- a/pkg/registries/factory.go
+++ b/pkg/registries/factory.go
@@ -12,7 +12,6 @@ import (
 	nexusFactory "github.com/stackrox/rox/pkg/registries/nexus"
 	quayFactory "github.com/stackrox/rox/pkg/registries/quay"
 	rhelFactory "github.com/stackrox/rox/pkg/registries/rhel"
-
 	"github.com/stackrox/rox/pkg/registries/types"
 )
 

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -1,12 +1,11 @@
 package resources
 
 import (
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/labels"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
-
-	"github.com/stackrox/rox/generated/storage"
 )
 
 /* Matching labels using selectors

--- a/tools/import_validate.py
+++ b/tools/import_validate.py
@@ -36,10 +36,14 @@ def blank_import(data):
 
 def check_imports(data):
     # We only tolerate blank lines between first and third party imports, as well as blank (_) imports
-    line = data.get('line', '')
+    s_line = data.get('line', '').lstrip()
     import_state = data.get('import_state', TPIMPORTS)
-    # ignore . imports, but recognize 3rd party imports of the form github.com/user/proj
-    if not line.startswith('.') and '.' in line and import_state == FPIMPORTS:
+    # ignore . imports, but recognize 3rd party imports of the form github.com/user/proj;
+    # dot imports are stripped of their leading dot.
+    if s_line.startswith('.'):
+        s_line = s_line[1:]
+
+    if '.' in s_line and import_state == FPIMPORTS:
         data["import_state"] = TPIMPORTS
         check_blanks(data)
 

--- a/tools/import_validate.py
+++ b/tools/import_validate.py
@@ -61,7 +61,7 @@ def complete(data):
         print("%s:%d: Too many blank lines in imports" % (data["file"], n))
 
 PREIMPORT, IMPORTS, POSTIMPORT, EXTRACOMMENT, BLANKIMPORT = range(5)
-FPIMPORTS, TPIMPORTS = 1, 3
+FPIMPORTS, TPIMPORTS = 1, 3 # We differentiate between first party (FPIMPORTS) and third party (TPIMPORTS) imports
 
 TRANSITIONS = [
     (PREIMPORT, 'import (', IMPORTS),


### PR DESCRIPTION
The blank line detection algorithm was entering a fail state when a blank line is introduced inside the first party imports.
If so, either `fix_blanks` or `golangci-lint` will fail, depending on what last ran, `quickstyle` or the IDE import optimizer.
This PR rectifies this by introducing an updated mechanism to better detect these fail states.

I recommend to review this PR by commits. The first commit introduced the linter fix, the second commit updated files to satisfy the new linter requirements.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

To reproduce locally, introduce a newline into any first party import block **on any other branch than this PR**.
Example: [sensor/kubernetes/main.go](https://github.com/stackrox/stackrox/blob/03b81c90e74f49877e84a159f4c114593b307852/sensor/kubernetes/main.go#L4-L5) between lines 4 and 5.
- Run `quickstyle` (or `make blanks`)
- Observe removal of the second newline between first and third party imports <- fail state is introduced
- Fail state cannot be reconciled by running `gofmt`, `golangci-lint`, `quickstlye`, or even the IDE formatter. Only by manual intervention.

Revert your changes and check out this feature branch.
Repeat experiment and observe that `quickstyle` / `make blanks` will now correctly remove the **first** blank line. 
