### PR TITLE
chore(ui): Replace Td actions with Td isActionCell and ActionsColumn

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
 import { Role } from 'services/RolesService';
@@ -98,22 +98,22 @@ function AccessScopesList({
                                     entityId={id}
                                 />
                             </Td>
-                            <Td
-                                actions={{
-                                    isDisabled:
+                            <Td isActionCell>
+                                <ActionsColumn
+                                    isDisabled={
                                         !hasWriteAccessForPage ||
                                         idDeleting === id ||
                                         !isUserResource(traits) ||
-                                        roles.some(({ accessScopeId }) => accessScopeId === id),
-                                    items: [
+                                        roles.some(({ accessScopeId }) => accessScopeId === id)
+                                    }
+                                    items={[
                                         {
                                             title: 'Delete access scope',
                                             onClick: () => onClickDelete(id),
                                         },
-                                    ],
-                                }}
-                                className="pf-v5-u-text-align-right"
-                            />
+                                    ]}
+                                />
+                            </Td>
                         </Tr>
                     ))}
                 </Tbody>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -3,7 +3,7 @@ import pluralize from 'pluralize';
 import { useSelector, useDispatch } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Button, Modal } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';
@@ -100,9 +100,9 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                                 <Td dataLabel="Assigned rules">
                                     {`${groups.length} ${pluralize('rules', groups.length)}`}
                                 </Td>
-                                <Td
-                                    actions={{
-                                        items: [
+                                <Td isActionCell>
+                                    <ActionsColumn
+                                        items={[
                                             {
                                                 title: 'Delete auth provider',
                                                 onClick: () => onClickDelete(name, id),
@@ -117,10 +117,9 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                                                           ? 'Cannot delete unmodifiable auth provider'
                                                           : '',
                                             },
-                                        ],
-                                    }}
-                                    className="pf-v5-u-text-align-right"
-                                />
+                                        ]}
+                                    />
+                                </Td>
                             </Tr>
                         );
                     })}

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { PermissionSet, Role } from 'services/RolesService';
 
@@ -98,24 +98,24 @@ function PermissionSetsList({
                                         entityId={id}
                                     />
                                 </Td>
-                                <Td
-                                    actions={{
-                                        isDisabled:
+                                <Td isActionCell>
+                                    <ActionsColumn
+                                        isDisabled={
                                             !hasWriteAccessForPage ||
                                             idDeleting === id ||
                                             !isUserResource(traits) ||
                                             roles.some(
                                                 ({ permissionSetId }) => permissionSetId === id
-                                            ),
-                                        items: [
+                                            )
+                                        }
+                                        items={[
                                             {
                                                 title: 'Delete permission set',
                                                 onClick: () => onClickDelete(id),
                                             },
-                                        ],
-                                    }}
-                                    className="pf-v5-u-text-align-right"
-                                />
+                                        ]}
+                                    />
+                                </Td>
                             </Tr>
                         ))}
                     </Tbody>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import { AccessScope } from 'services/AccessScopesService';
 import { Group } from 'services/AuthService';
@@ -133,22 +133,22 @@ function RolesList({
                                             entityName={getAccessScopeName(accessScopeId)}
                                         />
                                     </Td>
-                                    <Td
-                                        actions={{
-                                            isDisabled:
+                                    <Td isActionCell>
+                                        <ActionsColumn
+                                            isDisabled={
                                                 !hasWriteAccessForPage ||
                                                 nameDeleting === name ||
                                                 !isUserResource(traits) ||
-                                                getHasRoleName(groups, name),
-                                            items: [
+                                                getHasRoleName(groups, name)
+                                            }
+                                            items={[
                                                 {
                                                     title: 'Delete role',
                                                     onClick: () => onClickDelete(name),
                                                 },
-                                            ],
-                                        }}
-                                        className="pf-v5-u-text-align-right"
-                                    />
+                                            ]}
+                                        />
+                                    </Td>
                                 </Tr>
                             )
                         )}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -8,7 +8,7 @@ import {
     PageSectionVariants,
     Title,
 } from '@patternfly/react-core';
-import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { ActionsColumn, Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { useParams, Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
@@ -238,15 +238,15 @@ function IntegrationsTable({
                                                 </Td>
                                             );
                                         })}
-                                        <Td
-                                            actions={{
-                                                items: actionItems,
-                                                isDisabled:
+                                        <Td isActionCell>
+                                            <ActionsColumn
+                                                isDisabled={
                                                     !permissions[source].write ||
-                                                    !isUserResource(integration.traits),
-                                            }}
-                                            className="pf-v5-u-text-align-right"
-                                        />
+                                                    !isUserResource(integration.traits)
+                                                }
+                                                items={actionItems}
+                                            />
+                                        </Td>
                                     </Tr>
                                 );
                             })}


### PR DESCRIPTION
### Description

* Follow current PatternFly example:
    https://www.patternfly.org/components/table#actions
* Increase our ability to reuse knowledge and skills to update tables easily.
* Simplify lint rules for consistency.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4637804 - 4637804
        total 4 = 11749510 - 11749506
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main//access-control/roles and add a user role

    * Before changes, with `actions` prop at 1440px.
        ![RolesList_1440px_actions](https://github.com/user-attachments/assets/3740d914-fc0d-42da-ac23-fa0131914230)

    * After changes, with `isActionCell` prop and `ActionsColumn` child element as 1440px.
        ![RolesList_1440px_ActionsColumn](https://github.com/user-attachments/assets/3395b9e8-acaf-4df8-b01a-9edaa6b2680c)

    * After changes, with `isActionCell` prop and `ActionsColumn` child element at 760px.
        ![RolesList_760px_ActionsColumn](https://github.com/user-attachments/assets/dd47fa90-5eba-41ce-aca8-f87cb4b11775)

2. Visit /main/access-control/permission-sets and add a user permission set

    * Before changes, with `actions` prop at 760px.
        ![PermissionSetsList_760px_actions](https://github.com/user-attachments/assets/32c231bc-3e9c-41e3-b2c2-083b5c3dd33b)

    * After changes, with `isActionCell` prop and `ActionsColumn` child element at 760px.
        ![PermissionSetsList_760px_ActionsColumn](https://github.com/user-attachments/assets/0865c2b7-dd7e-47ed-b7ca-da126255f4ec)

3. Visit /main/integrations/imageIntegrations/docker

    * Before changes, with `actions` prop at 1440px.
        ![IntegrationsTable_1440px_actions](https://github.com/user-attachments/assets/92cc6804-9dea-4239-aded-d5f2fdf1238f)

    * After changes, with `isActionCell` prop and `ActionsColumn` child element as 1440px.
        ![IntegrationsTable_14400px_ActionsColumn](https://github.com/user-attachments/assets/3edde87a-5a43-49d3-afad-6ac2e36918c4)

    * Before changes, with `actions` prop at 760px.
        ![IntegrationsTable_760px_actions](https://github.com/user-attachments/assets/ef3b449c-1cb1-4039-8c32-645005e43c2a)

    * After changes, with `isActionCell` prop and `ActionsColumn` child element at 760px.
        ![IntegrationsTable_760px_ActionsColumn](https://github.com/user-attachments/assets/e13f1808-a6c4-4f50-8206-9f2b45ebe563)

#### Integration testing

* accessControl/accessControlAccessScopes.test.js
* accessControl/accessControlAuthProviders.test.js
* accessControl/accessControlOrigin.test.js
* accessControl/accessControlPermissionSets.test.js
* accessControl/accessControlRoles.test.js
* integrations/apiTokens.test.js
* integrations/cloudSourceIntegrations.test.js
* integrations/externalBackups.test.js
* integrations/general.test.js
* integrations/imageIntegrations.test.js
* integrations/machineAccessConfigs.test.js
* integrations/notifiers.test.js
* integrations/signatureIntegrations.test.js