### PR TITLE
chore(ui): Remove d3-color 3.0.1 and depend on 3.1.0

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -8811,14 +8811,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/d3-interpolate/node_modules/d3-color": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
-            "integrity": "sha1-AzFuWVlV0fzTnZ82EK1Bu5AZTQo= sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/d3-path": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
@@ -8905,14 +8897,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/d3-scale-chromatic/node_modules/d3-color": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
-            "integrity": "sha1-AzFuWVlV0fzTnZ82EK1Bu5AZTQo= sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/d3-scale/node_modules/d3-format": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
@@ -8988,14 +8972,6 @@
             },
             "peerDependencies": {
                 "d3-selection": "2 - 3"
-            }
-        },
-        "node_modules/d3-transition/node_modules/d3-color": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
-            "integrity": "sha1-AzFuWVlV0fzTnZ82EK1Bu5AZTQo= sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/d3-transition/node_modules/d3-selection": {

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -11716,18 +11716,6 @@
             "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI= sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/yaml": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-            "integrity": "sha1-8mqr9zhZCrYe+spQI1jkjcnzSLI= sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.3"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/form-data": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -15873,9 +15861,13 @@
             }
         },
         "node_modules/monaco-yaml/node_modules/yaml": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-            "integrity": "sha1-MBS/BILc0VFHqo5WEJzoYyzWDOQ= sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+            "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
                 "node": ">= 14"
             }
@@ -23887,7 +23879,8 @@
         "node_modules/yaml": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks= sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "license": "ISC",
             "engines": {
                 "node": ">= 6"
             }


### PR DESCRIPTION
### Description

Removes transitive nested dependencies on d3-color 3.0.1 and relies on the version compatible top-level 3.1.0.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Smoke testing of pages that rely on d3-color.
![image](https://github.com/user-attachments/assets/2205d123-9c39-4fa4-a75c-0d8253901640)
![image](https://github.com/user-attachments/assets/8fa76408-5624-4544-9ee5-21c76f02e418)
![image](https://github.com/user-attachments/assets/76be9fb4-27c1-42e2-ab78-d06682016d30)
