### PR TITLE
ROX-25751: Update npm-ci audit to show vulns in prod deps only

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -10,7 +10,7 @@ ROX_PRODUCT_BRANDING ?= $(shell $(MAKE) --quiet --no-print-directory -C .. produ
 export REACT_APP_ROX_PRODUCT_BRANDING := $(ROX_PRODUCT_BRANDING)
 
 deps: apps/platform/package.json apps/platform/package-lock.json
-	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-fund $(UI_PKG_INSTALL_EXTRA_ARGS)
+	cd apps/platform && npm ci --prefer-offline --fetch-timeout=$(UI_PKG_INSTALL_NETWORK_TIMEOUT) --no-audit --no-fund $(UI_PKG_INSTALL_EXTRA_ARGS) && npm audit --omit=dev || true
 	@touch deps
 
 .PHONY: printsrcs


### PR DESCRIPTION
### Description

Silences the `npm-audit` output when running `make deps` from the UI level. In replacement, this also adds an explicit `npm audit --omit=dev || true` in order to output vulnerabilities in production level packages for UI code.

This will focus on dependency vulnerabilities that are most likely to affect the product and should be a good target to keep clean from findings before they are reported in security-labelled Jira tickets.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

`make clean && make deps` from ui/ folder and see presence of detected issues. Detected issues should not fail the command/build.
![image](https://github.com/user-attachments/assets/ca819352-7663-46e2-b662-3e28fb37a6b8)

