### PR TITLE
chore(ui): Update redacted host name to be under .invalid TLD

### DIFF
--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -391,7 +391,7 @@ export type AnalyticsEvent =
           };
       };
 
-export const redactedHostReplacement = 'redacted.host';
+export const redactedHostReplacement = 'redacted.host.invalid';
 export const redactedSearchReplacement = '*****';
 
 // Replace the hostname, port, and search parameters with redacted values


### PR DESCRIPTION
### Description

Great catch - better to keep this in line with the standard.

Adds the `.invalid` TLD in order to prevent potentially route-able hosts from being included in telemetry data.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Manual network tab verification.

