### PR TITLE
chore(ui): Add ESLint plugin for json files in ui

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -52,7 +52,7 @@ module.exports = [
             'cypress/downloads/*.json', // StackRox_Exported_Policies_*.json
         ],
 
-        // language: 'json/json',
+        language: 'json/json',
 
         // https://github.com/eslint/json/blob/main/src/index.js
         ...pluginJSON.configs.recommended,

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -6,6 +6,7 @@ const parserTypeScriptESLint = require('@typescript-eslint/parser');
 
 const pluginCypress = require('eslint-plugin-cypress');
 const pluginESLint = require('@eslint/js'); // eslint-disable-line import/no-extraneous-dependencies
+const pluginJSON = require('@eslint/json').default;
 const pluginESLintComments = require('eslint-plugin-eslint-comments');
 const pluginImport = require('eslint-plugin-import');
 const pluginJest = require('eslint-plugin-jest');
@@ -43,6 +44,18 @@ module.exports = [
             'src/setupTests.js',
             'cypress.d.ts',
         ],
+    },
+    {
+        files: ['*.json', 'cypress/**/*.json', 'src/**/*.json'],
+        ignores: [
+            'package-lock.json', // ignore because it is auto-generated
+            'cypress/downloads/*.json', // StackRox_Exported_Policies_*.json
+        ],
+
+        // language: 'json/json',
+
+        // https://github.com/eslint/json/blob/main/src/index.js
+        ...pluginJSON.configs.recommended,
     },
     {
         files: ['**/*.{js,jsx,ts,tsx}'], // generic configuration

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -46,13 +46,23 @@ module.exports = [
         ],
     },
     {
-        files: ['*.json', 'cypress/**/*.json', 'src/**/*.json'],
+        files: ['*.json', 'cypress/**/*.json', 'src/**/*.json'], // JSON without comments
         ignores: [
             'package-lock.json', // ignore because it is auto-generated
+            'tsconfig.eslint.json', // contains comments, see below
             'cypress/downloads/*.json', // StackRox_Exported_Policies_*.json
+            'cypress/tsconfig.json', // contains comments, see below
         ],
 
         language: 'json/json',
+
+        // https://github.com/eslint/json/blob/main/src/index.js
+        ...pluginJSON.configs.recommended,
+    },
+    {
+        files: ['tsconfig.eslint.json', 'cypress/tsconfig.json'], // JSON with comments
+
+        language: 'json/jsonc',
 
         // https://github.com/eslint/json/blob/main/src/index.js
         ...pluginJSON.configs.recommended,

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -3011,16 +3011,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@eslint/object-schema": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
         "node_modules/@eslint/json": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.5.0.tgz",
@@ -3031,6 +3021,16 @@
                 "@eslint/plugin-kit": "^0.2.0",
                 "@humanwhocodes/momoa": "^3.2.1"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3117,13 +3117,6 @@
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha1-5SEUUt8GD6hSK1XHs8DE0ZgcsEQ= sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-            "deprecated": "Use @eslint/object-schema instead",
-            "dev": true
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.3.1",

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -100,6 +100,7 @@
                 "@babel/preset-react": "^7.24.7",
                 "@babel/preset-typescript": "^7.24.7",
                 "@babel/runtime": "^7.25.6",
+                "@eslint/json": "^0.5.0",
                 "@tailwindcss/forms": "^0.2.1",
                 "@testing-library/cypress": "^10.0.2",
                 "@testing-library/dom": "^10.4.0",
@@ -3020,6 +3021,20 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/json": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.5.0.tgz",
+            "integrity": "sha512-3cTSkHj/Mw/lLwrrVUgnhgWUH1FT2aJ3OLqi5gDvwunHMHBlf6ausKdsrxshH4vXx6mYS65dxG1dvWJI0U+Cuw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/plugin-kit": "^0.2.0",
+                "@humanwhocodes/momoa": "^3.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/plugin-kit": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
@@ -3092,6 +3107,23 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
             }
+        },
+        "node_modules/@humanwhocodes/momoa": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.1.tgz",
+            "integrity": "sha512-ziEs1ET0n+04L2c3jaZ/NEEkQwwAF+aj1l1m9aXfhW/aH7bEPv/cDou60D1291gLkVPz/oXfCADa33wf4UdpmA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@humanwhocodes/object-schema": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+            "integrity": "sha1-5SEUUt8GD6hSK1XHs8DE0ZgcsEQ= sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "deprecated": "Use @eslint/object-schema instead",
+            "dev": true
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.3.1",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -123,6 +123,7 @@
         "@babel/preset-react": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
         "@babel/runtime": "^7.25.6",
+        "@eslint/json": "^0.5.0",
         "@tailwindcss/forms": "^0.2.1",
         "@testing-library/cypress": "^10.0.2",
         "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
### Description

https://www.npmjs.com/package/@eslint/json

> This plugin requires ESLint v9.6.0 or higher and you must be using the new configuration system.

Upgraded to ESLint 9.13.0 in #13164

https://eslint.org/blog/2024/10/eslint-json-markdown-support/#json-linting-with-%40eslint%2Fjson

> JSON linting is accomplished using the `@eslint/json` plugin, which is an officially supported language plugin.

> The plugin provides parsing for JSON, JSONC (JSON with comments), and JSON5.

Recommended rules:

* `no-duplicate-keys`

    > Disallow duplicate keys in JSON objects

* `no-empty-keys`

    > Disallow empty keys in JSON objects

    > note: package-lock.json uses empty keys intentionally

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint plugin
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform to see that 2 .json files contain comments

#### Manual testing

1. After `npm install`, restart Visual Studio Code, and the provoke both errors in a cypress test fixture JSON file.