### PR TITLE
ROX-26929: handle security data redirects and empty files

### DIFF
--- a/.github/workflows/scanner-mapping-update.yaml
+++ b/.github/workflows/scanner-mapping-update.yaml
@@ -22,13 +22,7 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Download repository mappings
-      run: |
-        curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs \
-          -o '${{env.REPOMAPPING_DIR}}/#1' \
-          'https://security.access.redhat.com/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
-        for f in ${{env.REPOMAPPING_DIR}}/*; do
-          jq empty "$f"
-        done
+      run: scanner/image/scanner/download-mappings.sh "${{env.REPOMAPPING_DIR}}"
 
     - name: Upload repository mappings to Google Cloud Storage
       run: |

--- a/scanner/image/scanner/download-mappings.sh
+++ b/scanner/image/scanner/download-mappings.sh
@@ -20,7 +20,11 @@ urls=(
 for url in "${urls[@]}"; do
     filename=$(basename "$url")
     echo "Downloading ${url} > ${output_dir}/$filename"
-    curl --retry 3 -sS --fail -o "${output_dir}/$filename" "$url"
+    curl --retry 3 -sSL --fail -o "${output_dir}/$filename" "$url"
+    if [[ ! (-s "${output_dir}/$filename") ]]; then
+        echo "${output_dir}/$filename is empty"
+        exit 1
+    fi
 done
 
 echo "Done"


### PR DESCRIPTION
### Description

Future proofing: follow redirects for Red Hat security data, and also ensure the files are not empty.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

Ported this over into the Scanner CI image and modified the first URL to point to `https://access.redhat.com/security/data/metrics/repository-to-cpe.json` and removed the `L` flag. Found the following:

```
# ./download-mappings.sh repomapping
Downloading https://access.redhat.com/security/data/metrics/repository-to-cpe.json > repomapping/repository-to-cpe.json
repomapping/repository-to-cpe.json is empty
```

Re-added the L flag and got:

```
# ./download-mappings.sh repomapping
Downloading https://access.redhat.com/security/data/metrics/repository-to-cpe.json > repomapping/repository-to-cpe.json
Downloading https://security.access.redhat.com/data/metrics/container-name-repos-map.json > repomapping/container-name-repos-map.json
Done
# ls -lh repomapping/
total 2.4M
-rw-r--r--. 1 root root  83K Nov 13 01:36 container-name-repos-map.json
-rw-r--r--. 1 root root 2.3M Nov 13 01:36 repository-to-cpe.json
# jq --version
jq-1.6
# jq -e . >/dev/null 2>&1 < repomapping/container-name-repos-map.json; echo $?
0
# jq -e . >/dev/null 2>&1 < repomapping/repository-to-cpe.json; echo $?
0
# cat repomapping/idk.json 
{lsdkfjsldkjf}
# jq -e . >/dev/null 2>&1 < repomapping/idk.json; echo $?
4
```

This verifies the files were downloaded successfully and are valid JSON