### PR TITLE
chore(ci): Fix JUnit iframe in prow

### DIFF
--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -58,7 +58,7 @@ run_ui_e2e_tests() {
 
     make -C ui test-e2e || touch FAIL
 
-    store_test_results "ui/test-results/reports" "reports"
+    store_test_results "ui/test-results/reports/cypress/integration/." "cy-reps"
 
     if is_OPENSHIFT_CI; then
         cp -a ui/test-results/artifacts/* "${ARTIFACT_DIR}/" || true


### PR DESCRIPTION
### Description

We are currently facing an issue with loading JUnit iframe in prow because of a long URL. This change should fix that.

This is related to the ticket: https://issues.redhat.com/browse/ROX-26907

**Notes for reviewers**
- UI Team: can we copy reports only from `ui/test-results/reports/cypress/integration` - or do we still need to include `cypress/integration`?

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- no changes on tests

#### How I validated my change

```
# mkdir rep1
# touch rep1/test1.txt

### target directory does not exist
# cp -a rep1 rep2
# ls -al rep2
<...> test1.txt

# mkdir rep3

### target directory exists
# cp -a rep1 rep3
# ls -al rep3
<...> rep1

# mkdir rep4

### target directory exists, but we are using "/*"
# cp -a rep1/* rep4
# ls -al rep4
<...> test1.txt

# mkdir rep5

### target directory exists, but we are using "/"
# cp -a rep1/ rep5
# ls -al rep5
<...> test1.txt

### === There is a difference between MacOS and Linux cp command behavior === ###
### === The example for "rep5" does not work as expected on Linux === ###

### Tested on Linux

# docker run -it registry.access.redhat.com/ubi8/toolbox:latest /bin/bash

# mkdir rep
# touch rep/test.txt
# mkdir rep/sub-rep
# touch rep/sub-rep/test.txt
# ls -al rep
<...> sub-rep
<...> test.txt

# mkdir rep2
# cp -a rep/ rep2
# ls -al rep2
<...> rep

# mkdir rep3
# cp -a rep/. rep3
# ls -al rep3
<...> sub-rep
<...> test.txt
```