### PR TITLE
ROX-24767: Ignore function call if the function is nil

### DIFF
--- a/pkg/utils/ignore_error.go
+++ b/pkg/utils/ignore_error.go
@@ -3,12 +3,7 @@ package utils
 // IgnoreError is useful when you want to defer a func that returns an error,
 // but ignore the error.
 func IgnoreError(f func() error) {
-	_ = f()
-}
-
-// IgnoreErrorAndCheckNil calls IgnoreError if the function is not nil.
-func IgnoreErrorAndCheckNil(f func() error) {
 	if f != nil {
-		IgnoreError(f)
+		_ = f()
 	}
 }

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -113,20 +113,20 @@ func matchBinding(namespace, id string) helper.MatchResource {
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 		deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxDeployment, nil)
-		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteDep)
 
 		var binding v12.RoleBinding
 		deleteRoleBinding, err := testC.ApplyResourceAndWait(context.Background(), t, "sensor-integration", &NginxRoleBinding, &binding, nil)
-		defer utils.IgnoreError(deleteRoleBinding)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteRoleBinding)
 
 		testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
 
 		var role v12.Role
 		deleteRole, err := testC.ApplyResourceAndWait(context.Background(), t, "sensor-integration", &NginxRole, &role, nil)
-		defer utils.IgnoreError(deleteRole)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteRole)
 
 		testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
 
@@ -173,17 +173,16 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 		deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxDeployment, nil)
-		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteDep)
 
 		deleteRoleBinding, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxRoleBinding, nil)
-		defer utils.IgnoreError(deleteRoleBinding)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteRoleBinding)
 
 		deleteRole, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxRole, nil)
-
-		defer utils.IgnoreError(deleteRole)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteRole)
 
 		testC.LastDeploymentState(t, "nginx-deployment",
 			assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -336,8 +336,8 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 		deployment := &appsv1.Deployment{}
 		deleteDep, err := testC.ApplyResourceAndWait(context.Background(), t, helper.DefaultNamespace, &NginxDeployment, deployment, nil)
-		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
+		defer utils.IgnoreError(deleteDep)
 
 		port := getPort(t)
 		svc := &v1.Service{}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Sensor integration tests create k8s resources to test sensor's behavior. This resources are deleted after the test execution most of the times with defered calls to remove functions. If the resource creation fails the remove functions will be nil. The defered calls to these remove functions need to check whether the remove function is nil or not, otherwise the test will panic.

This PR introduces three changes:

1. Modifies the `IgnoreError` function to check whether the passed function is nil or not.
2. Changes the use of `t.Fatal` in some functions of the integration tests helper to avoid the subtest calling FailNow and therefore failing the parent tests.
3. The defered calls to remove functions should be done after `require.NoError`. If `err != nil` the resource was not created so it's not necessary to call the remove function. Also, if `err != nil` the remove function will be nil (which is handled by (1) but still we can save one call to `IgnoreError`). 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] The integration tests should pass.
