### PR TITLE
ROX-26900: Re-add Cachi2 artifact to main's build-source task

### DIFF
--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -454,9 +454,8 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    # TODO(ROX-26900): uncomment CACHI2_ARTIFACT after KFLUXBUGS-1508 is resolved.
-    # - name: CACHI2_ARTIFACT
-    #   value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     taskRef:
       params:
       - name: name

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -472,10 +472,6 @@ spec:
     - input: $(params.build-source-image)
       operator: in
       values: [ "true" ]
-    # Pushing source container for main is known to fail a lot with timeout in Quay. See KFLUXBUGS-1508
-    # By trying a few more times, we hope to make this step succeed and not fail the pipeline.
-    # TODO: remove retries once KFLUXBUGS-1508 gets resolved.
-    retries: 3
 
   - name: deprecated-base-image-check
     params:


### PR DESCRIPTION
### Description

Per ticket.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

Nope.

#### How I validated my change

Successful main build.