### PR TITLE
chore(ui): Delete unused ESLint disable directives

### DIFF
--- a/ui/apps/platform/cypress/helpers/dndSimulatorDataTransfer.js
+++ b/ui/apps/platform/cypress/helpers/dndSimulatorDataTransfer.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-names */
 // workaround to get cypress to interact with react-dnd
 // https://github.com/cypress-io/cypress/issues/1752
 

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -53,7 +53,7 @@ module.exports = [
         // languageOptions are in specific configuration objects
 
         linterOptions: {
-            // reportUnusedDisableDirectives: 'error', // TODO fix errors
+            reportUnusedDisableDirectives: 'error', // TODO fix errors
         },
 
         // Key of plugin is namespace of its rules.

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -53,7 +53,7 @@ module.exports = [
         // languageOptions are in specific configuration objects
 
         linterOptions: {
-            reportUnusedDisableDirectives: 'error', // TODO fix errors
+            reportUnusedDisableDirectives: 'error',
         },
 
         // Key of plugin is namespace of its rules.

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
 import { SearchCategory } from 'services/SearchService';
 
 // Compound search filter types

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -142,7 +142,6 @@ function AuthProviderForm({
                 });
                 return keys.length === new Set(keys).size;
             }),
-        /* eslint-disable @typescript-eslint/no-unsafe-return */
         config: yup
             .object()
             .when('type', {
@@ -225,7 +224,6 @@ function AuthProviderForm({
                         audience: yup.string().required('An audience is required.'),
                     }),
             }),
-        /* eslint-enable @typescript-eslint/no-unsafe-return */
     });
 
     const formik = useFormik({

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -61,7 +61,6 @@ export function ResourceDescription({ resource }: ResourceDescriptionProps): Rea
                     <strong>Read</strong>: {description.slice(6, writeIndex)}
                 </p>
                 <p>
-                    {/* eslint-disable-next-line @typescript-eslint/restrict-plus-operands */}
                     <strong>Write</strong>: {description.slice(writeIndex + 8)}
                 </p>
             </>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -136,7 +136,6 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                 fetchClusterWithRetentionInformation(clusterIdToRetrieve)
                     .then((clusterResponse) => {
                         const { cluster } = clusterResponse;
-                        // eslint-disable-next-line no-param-reassign
                         // cluster.managedBy = 'MANAGER_TYPE_MANUAL';
                         // TODO: refactor to use useReducer effect
                         setSelectedCluster(cluster);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -153,7 +153,6 @@ function ClustersTablePanel({
         </div>
     ));
 
-    /* eslint-disable no-nested-ternary */
     const installMenuOptions = [
         <DropdownItem
             key="init-bundle"
@@ -182,7 +181,6 @@ function ClustersTablePanel({
             }
         />,
     ];
-    /* eslint-enable no-nested-ternary */
 
     function refreshClusterList(restSearch?: RestSearchOption[]) {
         // Although return works around typescript-eslint/no-floating-promises error elsewhere,

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-shadow */
-/* eslint-disable no-param-reassign */
-/* eslint-disable react/no-array-index-key */
-// TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-/* eslint-disable react/prop-types */
 import React, { useState } from 'react';
 import { Button, TextInput } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -40,7 +40,6 @@ const initialDelegatedState: DelegatedRegistryConfig = {
 function getUuid() {
     const MAX_RANDOM = 1000000;
 
-    // eslint-disable-next-line no-restricted-globals
     const uuid = self?.crypto?.randomUUID() ?? Math.floor(Math.random() * MAX_RANDOM).toString();
 
     return uuid;

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -78,7 +78,6 @@ function formatResourceData(data, resourceType) {
         const curEntity = aggregationKeys[entityKeyIndex].id;
         const curStandard = aggregationKeys[standardKeyIndex].id;
         const entity = keys[entityKeyIndex];
-        // eslint-disable-next-line no-underscore-dangle
         if (entity.__typename === '') {
             return;
         }

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.js
@@ -23,7 +23,6 @@ const sortByXValue = (a, b) => {
 };
 
 // Component state was needed only for deleted HoverHint, but we will not rewrite.
-/* eslint-disable react/prefer-stateless-function */
 class VerticalBarChart extends Component {
     static propTypes = {
         data: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -87,7 +87,6 @@ function ScanConfigActionDropdown({
     ];
 
     if (isComplianceReportingEnabled) {
-        /* eslint-disable no-nested-ternary */
         dropdownItems.push(
             <DropdownItem
                 key="Send report"
@@ -107,7 +106,6 @@ function ScanConfigActionDropdown({
                 Send report
             </DropdownItem>
         );
-        /* eslint-enable no-nested-ternary */
     }
 
     if (isComplianceReportingEnabled && isReportJobsEnabled) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -67,7 +67,6 @@ function ScanConfigActionsColumn({
             },
             isDisabled: isSnapshotStatusPending,
         },
-        /* eslint-disable no-nested-ternary */
         {
             title: 'Send report',
             description:
@@ -83,7 +82,6 @@ function ScanConfigActionsColumn({
             isHidden: !isComplianceReportingEnabled,
             isDisabled: notifiers.length === 0 || isSnapshotStatusPending,
         },
-        /* eslint-enable no-nested-ternary */
         {
             title: 'Generate download',
             onClick: (event) => {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { useState } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-comment-textnodes */
 // eslint-disable @typescript-eslint/ban-ts-comment
 import React, { useState } from 'react';
 import { Flex, FlexItem, Pagination, Title } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AcscsEmailIntegrationForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-void */
 import React, { ReactElement } from 'react';
 import { Form, PageSection, TextInput } from '@patternfly/react-core';
 import * as yup from 'yup';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3CompatibleIntegrationForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-void */
 import React, { ReactElement } from 'react';
 import {
     Checkbox,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-void */
 import React, { useState, ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
@@ -16,7 +16,6 @@ const OrchestratorComponentsToggle = (): ReactElement => {
     function handleToggle(value) {
         const storedValue = value ? 'true' : 'false';
         localStorage.setItem(ORCHESTRATOR_COMPONENTS_KEY, storedValue);
-        // eslint-disable-next-line no-restricted-globals
         location.reload(); // TODO instead pages could re-render on change to Redux store.
     }
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
@@ -76,7 +76,6 @@ function UserMenu({ logout, setInviteModalVisibility, userData }) {
     ];
 
     const inviteMenuItem = (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         <DropdownItem key="open-invite" onClick={onClickInviteUsers}>
             Invite users
         </DropdownItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-void */
 /* eslint-disable no-cond-assign */
-/* eslint-disable @typescript-eslint/restrict-plus-operands */
 /* eslint-disable no-return-assign */
 import * as React from 'react';
 import { observer } from 'mobx-react';
@@ -47,7 +46,6 @@ const DefaultFakeGroup = ({
     labelIcon,
     labelIconPadding,
 }) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
     let _a: number | undefined;
     const [hovered, hoverRef] = useHover();
     const [labelHover, labelHoverRef] = useHover();

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -35,7 +35,6 @@ type ExternalGroupSideBarProps = {
     onNodeSelect: (id: string) => void;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ExternalGroupSideBar({
     labelledById,
     id,

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -6,7 +6,6 @@ import NoResultsMessage from 'Components/NoResultsMessage';
 const Factor = ({ message, url }) => {
     // TODO is the link external or internal?
     /* eslint-disable generic/ExternalLink-anchor */
-    /* eslint-disable generic/anchor-target-rel */
     const renderedMessage = url ? (
         <a href={url} target="_blank" rel="noopener noreferrer">
             {message}
@@ -15,7 +14,6 @@ const Factor = ({ message, url }) => {
         message
     );
     /* eslint-enable generic/ExternalLink-anchor */
-    /* eslint-enable generic/anchor-target-rel */
 
     return (
         <div className="px-3">

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import React, { useEffect, useState, ReactElement, FormEvent } from 'react';
 import {
     Form,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -40,7 +40,6 @@ import ImageComponentVulnerabilitiesTable, {
     imageComponentVulnerabilitiesFragment,
 } from './ImageComponentVulnerabilitiesTable';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -44,7 +44,6 @@ import {
     aggregateByDistinctCount,
     getSeveritySortOptions,
 } from '../../utils/sortUtils';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -9,7 +9,6 @@ import {
 } from '@patternfly/react-core';
 
 import { useFormik } from 'formik';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DeferralValues, ScopeContext } from './utils';
 
 export const ALL = '.*';

--- a/ui/apps/platform/src/hooks/useRestMutation.test.ts
+++ b/ui/apps/platform/src/hooks/useRestMutation.test.ts
@@ -92,7 +92,6 @@ describe('useRestMutation hook', () => {
         const requestFn = (arg: string) =>
             new Promise<string>((resolve, reject) =>
                 // Using a 'string' instead of `Error` for simplicity
-                // eslint-disable-next-line prefer-promise-reject-errors
                 setTimeout(() => reject(`error with "${arg}"`), 1000)
             );
 

--- a/ui/apps/platform/src/utils/responseErrorUtils.ts
+++ b/ui/apps/platform/src/utils/responseErrorUtils.ts
@@ -22,7 +22,6 @@ export function getAxiosErrorMessage(error: unknown): string {
 
             if (typeof error.response?.data?.message === 'string') {
                 // The server responded to the request with an error.
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                 return error.response.data.message;
             }
 


### PR DESCRIPTION
### Description

Follow up upgrades in #13164

Especially delete comments that are copy-paste of integration forms by contributors from other teams to reduce potential confusion.

Find in Files `eslint-disable` after deletions
* ui/apps/platform/cypress folder has 2 results in 2 files
* ui/apps/platform/src folder has 210 results in 154 files

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint`