### PR TITLE
chore(load-generators): Reduce process load

### DIFF
--- a/scripts/release-tools/kube-burner-configs/cluster-density/deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/deployment.yml
@@ -19,7 +19,7 @@ spec:
       - args:
         - sleep
         - infinity
-        image: quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d
+        image: quay.io/rhacs-eng/qa:berserker-1.0-63-g7b0a20bf5f
         resources:
           requests:
             memory: "150Mi"
@@ -54,14 +54,8 @@ spec:
           protocol: TCP
         name: cluster-density
         env:
-        - name: ENVVAR1
-          value: "250"
-        - name: ENVVAR2
-          value: "250"
-        - name: ENVVAR3
-          value: "250"
-        - name: ENVVAR4
-          value: "250"
+        - name: BERSERKER__WORKLOAD__ARRIVAL_RATE
+          value: "1"
       volumes:
       - name: secret-1
         secret:


### PR DESCRIPTION
### Description

Currently the process spawning rate is 10, which is roughly 10 processes per second per worker. Normally we got 8 cores on release cluster nodes, meaning that it produces 80 processes/s for a single Collector. If there are less nodes that berserkers, some of them land on the same machine making load even higher.

This leads to situations, when the load is just too high to get any meaningful results, making the whole setup unstable and imbalanced. As a workaround for now, reduce spawning rate, to produce milder load.

change me!

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not validated yet.