### PR TITLE
ROX-26784: Only trigger Konflux builds against master

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: central-db

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: main

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: operator

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: operator-bundle

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: roxctl

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-v4

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-v4-db


### PR DESCRIPTION
This is primarily intended to stop triggering builds in Konflux for "master" components when there are PRs or pushes on release branches.

This retains the branch naming and label conventions to reduce load on Konflux.

One side effect of this change is that PRs against branches other than master or release branches will not have Konflux builds ever run against them.