### PR TITLE
chore(scanner): update Red Hat sec data location (#12564)

### DIFF
--- a/.github/workflows/scanner-mapping-update.yaml
+++ b/.github/workflows/scanner-mapping-update.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs \
           -o '${{env.REPOMAPPING_DIR}}/#1' \
-          'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
+          'https://security.access.redhat.com/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
         for f in ${{env.REPOMAPPING_DIR}}/*; do
           jq empty "$f"
         done

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -6,14 +6,14 @@ indexer:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
   get_layer_timeout: 1m
-  repository_to_cpe_url: https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-  name_to_repos_url: https://access.redhat.com/security/data/metrics/container-name-repos-map.json
+  repository_to_cpe_url: https://security.access.redhat.com/data/metrics/repository-to-cpe.json
+  name_to_repos_url: https://security.access.redhat.com/data/metrics/container-name-repos-map.json
 matcher:
   enable: true
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulns.json.zst
+  vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip
+  vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -33,8 +33,8 @@ var (
 				PasswordFile: "",
 			},
 			GetLayerTimeout:    Duration(time.Minute),
-			RepositoryToCPEURL: "https://access.redhat.com/security/data/metrics/repository-to-cpe.json",
-			NameToReposURL:     "https://access.redhat.com/security/data/metrics/container-name-repos-map.json",
+			RepositoryToCPEURL: "https://security.access.redhat.com/data/metrics/repository-to-cpe.json",
+			NameToReposURL:     "https://security.access.redhat.com/data/metrics/container-name-repos-map.json",
 		},
 		Matcher: MatcherConfig{
 			Enable: true,

--- a/scanner/image/scanner/download-mappings.sh
+++ b/scanner/image/scanner/download-mappings.sh
@@ -13,7 +13,11 @@ urls=(
 for url in "${urls[@]}"; do
     filename=$(basename "$url")
     echo "Downloading ${url} > ${output_dir}/$filename"
-    curl --retry 3 -sS --fail -o "${output_dir}/$filename" "$url"
+    curl --retry 3 -sSL --fail -o "${output_dir}/$filename" "$url"
+    if [[ ! (-s "${output_dir}/$filename") ]]; then
+        echo "${output_dir}/$filename is empty"
+        exit 1
+    fi
 done
 
 echo "Done"

--- a/scanner/image/scanner/download-mappings.sh
+++ b/scanner/image/scanner/download-mappings.sh
@@ -5,5 +5,15 @@ set -euo pipefail
 output_dir="/mappings"
 mkdir $output_dir
 
-curl --retry 3 -sS --fail -o "${output_dir}/repository-to-cpe.json" https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-curl --retry 3 -sS --fail -o "${output_dir}/container-name-repos-map.json" https://access.redhat.com/security/data/metrics/container-name-repos-map.json
+urls=(
+    "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+    "https://security.access.redhat.com/data/metrics/container-name-repos-map.json"
+)
+
+for url in "${urls[@]}"; do
+    filename=$(basename "$url")
+    echo "Downloading ${url} > ${output_dir}/$filename"
+    curl --retry 3 -sS --fail -o "${output_dir}/$filename" "$url"
+done
+
+echo "Done"

--- a/scanner/updater/rhel/doc.go
+++ b/scanner/updater/rhel/doc.go
@@ -19,6 +19,6 @@
 //  2. A workaround to overcome the limitations of OVAL regarding unfixed
 //     OpenShift vulns.
 //
-// [1]: https://access.redhat.com/security/data/csaf/
+// [1]: https://security.access.redhat.com/data/csaf/v2/
 // [2]: https://github.com/quay/claircore/tree/8fd9a12427a036b9a8456cf60a555bddc2fcdf0c/rhel
 package rhel

--- a/scanner/updater/rhel/updaterset.go
+++ b/scanner/updater/rhel/updaterset.go
@@ -17,7 +17,7 @@ import (
 // DefaultManifest is the url for the Red Hat OVAL pulp repository.
 //
 //doc:url updater
-const DefaultManifest = `https://access.redhat.com/security/data/oval/v2/PULP_MANIFEST`
+const DefaultManifest = `https://security.access.redhat.com/data/oval/v2/PULP_MANIFEST`
 
 // NewFactory creates a Factory making updaters based on the contents of the
 // provided pulp manifest.


### PR DESCRIPTION
### Description

Cherry-pick changed Red Hat security data URL. This will fix issues where `curl` does not follow redirects.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

cherry-pick
