### PR TITLE
ROX-24540: Add custom route to get sbom

### DIFF
--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -1,10 +1,14 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	clusterUtil "github.com/stackrox/rox/central/cluster/util"
@@ -14,12 +18,12 @@ import (
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/integration"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 
 const (
-	NumberBytes = 100
+	NumberBytes = 100 * 1024
+	timeout     = 10 * time.Minute
 )
 
 type sbomRequestBody struct {
@@ -28,41 +32,62 @@ type sbomRequestBody struct {
 	Force     bool   `json:"force"`
 }
 
-type httpHandler struct {
+type sbomHttpHandler struct {
 	integration      integration.Set
 	enricher         enricher.ImageEnricher
 	clusterSACHelper sachelper.ClusterSacHelper
 }
 
-var _ http.Handler = (*httpHandler)(nil)
+var _ http.Handler = (*sbomHttpHandler)(nil)
 
-// Handler returns a handler for policy http requests
-func Handler(integration integration.Set, enricher enricher.ImageEnricher, clusterSACHelper sachelper.ClusterSacHelper) http.Handler {
-	return httpHandler{
+// SBOMHandler returns a handler for get sbom http request
+func SBOMHandler(integration integration.Set, enricher enricher.ImageEnricher, clusterSACHelper sachelper.ClusterSacHelper) http.Handler {
+	return sbomHttpHandler{
 		integration:      integration,
 		enricher:         enricher,
 		clusterSACHelper: clusterSACHelper,
 	}
 
 }
-func (h httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	var params sbomRequestBody
-	const maxSize = NumberBytes * 1024 // (100 KiB is way more than needed for this request, ideally make this configurable)
-
-	lr := io.LimitReader(r.Body, maxSize)
-	err := json.NewDecoder(lr).Decode(&params)
-	if err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, err)
+	// verify scanner v4 is enabled
+	if !features.ScannerV4.Enabled() {
+		httputil.WriteGRPCStyleError(w, codes.NotFound, errors.New("Scanner v4 is not enabled. Enabled scanner v4 to get SBOMs"))
 		return
 	}
-	bytes, err := h.getSbom(params, r.Context())
+	if !features.SBOMGeneration.Enabled() {
+		httputil.WriteGRPCStyleError(w, codes.NotFound, errors.New("SBOM feature is not enabled"))
+		return
+	}
+	var params sbomRequestBody
+	reqSizeLimit := NumberBytes
+	reqSizeBytes := os.Getenv("ROX_SBOM_API_REQ_SIZE")
+	if reqSizeBytes != "" {
+		reqSizeLimitInt, err := strconv.Atoi(reqSizeBytes)
+		if err == nil {
+			reqSizeLimit = reqSizeLimitInt
+		}
+	}
+	// timeout api after 10 minutes
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeout))
+	defer cancel()
+	//for testing only
+	log.Infof("request size is %d", reqSizeLimit)
+	lr := io.LimitReader(r.Body, int64(reqSizeLimit))
+	err := json.NewDecoder(lr).Decode(&params)
 	if err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "decoding json request body"))
+		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, errors.Wrap(err, "decoding json request body"))
+		return
+	}
+	bytes, err := h.getSbom(ctx, params)
+	if err != nil {
+		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "error generating SBOM"))
 		return
 	}
 
@@ -71,10 +96,9 @@ func (h httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	w.Header().Add("Content-Length", fmt.Sprint(len(bytes)))
 	_, _ = w.Write(bytes)
-	return
 }
 
-func (h httpHandler) enrichImage(params sbomRequestBody, ctx context.Context) (*storage.Image, error) {
+func (h sbomHttpHandler) enrichImage(params sbomRequestBody, ctx context.Context) (*storage.Image, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:  enricher.UseCachesIfPossible,
 		Delegable: true,
@@ -93,8 +117,6 @@ func (h httpHandler) enrichImage(params sbomRequestBody, ctx context.Context) (*
 		enrichmentCtx.ClusterID = clusterID
 	}
 
-	log.Infof("params %s", params)
-
 	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
 	if err != nil {
 		return nil, err
@@ -102,21 +124,16 @@ func (h httpHandler) enrichImage(params sbomRequestBody, ctx context.Context) (*
 	return img, nil
 }
 
-func (h httpHandler) getSbom(params sbomRequestBody, ctx context.Context) ([]byte, error) {
-	//verify scanner v4 is enabled
-	if !features.ScannerV4.Enabled() {
-		return nil, errors.New("Scanner v4 is not enabled. Enabled scanner v4 to get SBOMs")
+func (h sbomHttpHandler) getSbom(ctx context.Context, params sbomRequestBody) ([]byte, error) {
+	// enrich image checks image metadata cache if fetchopt = UseCachesIfPossible otherwise fetches metdata from registry
+	// enrich image calls get scans on image which creates index report for image if it does not exsist
+	_, err := h.enrichImage(params, ctx)
+	if err != nil {
+		return nil, err
 	}
-
-	//enrich image checks image metadata cache if fetchopt = UseCachesIfPossible otherwise fetches metdata from registry
-	//enrich image calls get scans on image which creates index report for image if it does not exsist
-	//_, err := h.enrichImage(params, ctx)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//how to verify enrichimage failed because index report not found
-	//get sbom from matcher
-	//for testing only
+	// how to verify enrichimage failed because index report not found
+	// get sbom from matcher
+	// for testing only
 	sbom := map[string]interface{}{
 		"SPDXID":      "SPDXRef-DOCUMENT",
 		"spdxVersion": "SPDX-2.3",

--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/enrichment"
+	"github.com/stackrox/rox/central/imageintegration"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/images/enricher"
+	"github.com/stackrox/rox/pkg/images/integration"
+	"github.com/stackrox/rox/pkg/scanners/types"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+)
+
+type sbomHandler struct {
+	integration integration.Set
+	enricher    enricher.ImageEnricher
+}
+
+type SBOMRequestBody struct {
+	ClusterID string `json:"clusterID"`
+	ImageName string `json:"imageName"`
+	force     bool   `json:"force"`
+}
+
+func ImageHandler() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var params SBOMRequestBody
+		err := json.NewDecoder(r.Body).Decode(&params)
+		if err != nil {
+			httputil.WriteGRPCStyleError(w, codes.Internal, err)
+			return
+		}
+		bytes, err := getSbom(params, r.Context())
+		if err != nil {
+			httputil.WriteGRPCStyleError(w, codes.Internal, err)
+			return
+		}
+
+		// Tell the browser this is a download.
+		w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="values-%s.json"`, "sbom.json"))
+		w.Header().Add("Content-Type", "text/yaml")
+		w.Header().Add("Content-Length", fmt.Sprint(len(bytes)))
+		_, _ = w.Write(bytes)
+		return
+	}
+}
+
+func enrichImage(params SBOMRequestBody, ctx context.Context) (*storage.Image, error) {
+	enrichmentCtx := enricher.EnrichmentContext{
+		FetchOpt:  enricher.UseCachesIfPossible,
+		Delegable: true,
+	}
+
+	if params.force {
+		enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
+	}
+
+	if params.ClusterID != "" {
+		enrichmentCtx.ClusterID = params.ClusterID
+	}
+
+	img, err := enricher.EnrichImageByName(ctx, enrichment.ImageEnricherSingleton(), enrichmentCtx, params.ImageName)
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}
+
+func getSbom(params SBOMRequestBody, ctx context.Context) ([]byte, error) {
+	//verify scanner v4 is enabled
+	scannerv4Enabled := false
+	scanners := imageintegration.Set().ScannerSet()
+	for _, scanner := range scanners.GetAll() {
+		if scanner.GetScanner().Type() == types.ScannerV4 {
+			scannerv4Enabled = true
+		}
+	}
+	if !scannerv4Enabled {
+		return nil, errors.New("Scanner v4 is not enabled. Enabled scanner v4 to get SBOMs")
+	}
+
+	//enrich image checks image metadata cache if fetchopt = UseCachesIfPossible otherwise fetches metdata from registry
+	//enrich image calls get scans on image which creates index report for image if it does not exsist
+	_, err := enrichImage(params, ctx)
+	if err != nil {
+		return nil, err
+	}
+	//how to verify enrichimage failed because index report not found
+	//get sbom from matcher
+	//for testing only
+	sbom := map[string]interface{}{
+		"SPDXID":      "SPDXRef-DOCUMENT",
+		"spdxVersion": "SPDX-2.3",
+		"creationInfo": map[string]interface{}{
+			"created": "2023-08-30T04:40:16Z",
+			"creators": []string{
+				"Organization: Uchiha Cortez",
+				"Tool: FOSSA v0.12.0",
+			},
+		},
+	}
+	sbomBytes, err := json.Marshal(sbom)
+	if err != nil {
+		return nil, err
+	}
+	return sbomBytes, nil
+}

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -1,0 +1,29 @@
+package service_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	imageService "github.com/stackrox/rox/central/image/service"
+	"github.com/stackrox/rox/central/imageintegration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpHandler_ServeHTTP(t *testing.T) {
+
+	// Test case: Invalid request method
+	t.Run("Invalid request method", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/sbom", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := imageService.Handler(imageintegration.Set(), nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		// Assert
+		res := recorder.Result()
+		defer res.Body.Close()
+		assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	})
+
+}

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -1,13 +1,18 @@
-package service_test
+package service
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	imageService "github.com/stackrox/rox/central/image/service"
 	"github.com/stackrox/rox/central/imageintegration"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/images/enricher"
+	enricherMock "github.com/stackrox/rox/pkg/images/enricher/mocks"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
@@ -17,13 +22,106 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/sbom", nil)
 		recorder := httptest.NewRecorder()
 
-		handler := imageService.Handler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil)
 		handler.ServeHTTP(recorder, req)
 
-		// Assert
 		res := recorder.Result()
-		defer res.Body.Close()
+		err := res.Body.Close()
+		assert.NoError(t, err)
 		assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	})
+
+	// Test case: valid json body and validate enricher being called
+	t.Run("valid json body", func(t *testing.T) {
+		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
+		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil).AnyTimes()
+
+		reqBody := &sbomRequestBody{
+			ImageName: "test-image",
+			Force:     false,
+		}
+		reqJson, err := json.Marshal(reqBody)
+		assert.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(reqJson))
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), mockEnricher, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err = res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	// Test case: invalid json body
+	t.Run("json body", func(t *testing.T) {
+		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+		invalidJson := `{"cluster": "test-cluster", "image_name": "test-image", "force": true,`
+		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewBufferString(invalidJson))
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err := res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	// Test case: Scanner V4 not enabled
+	t.Run("Scanner V4 not enabled", func(t *testing.T) {
+		t.Setenv(features.ScannerV4.EnvVar(), "false")
+		req := httptest.NewRequest(http.MethodPost, "/sbom", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err := res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
+
+	// Test case: SBOM feature not enabled
+	t.Run("SBOM feature not enabled", func(t *testing.T) {
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+		t.Setenv(features.SBOMGeneration.EnvVar(), "false")
+		req := httptest.NewRequest(http.MethodPost, "/sbom", nil)
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err := res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
+
+	// Test case: request body size exceeds limit
+	t.Run("request body size exceeds limit", func(t *testing.T) {
+		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+		t.Setenv("ROX_SBOM_API_REQ_SIZE", "2")
+		largeRequestBody := []byte(`{"cluster": "test-cluster", "image_name": "test-image", "force": true}`)
+		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(largeRequestBody))
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err := res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
 
 }

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -87,7 +87,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		res := recorder.Result()
 		err := res.Body.Close()
 		assert.NoError(t, err)
-		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+		assert.Equal(t, http.StatusNotImplemented, res.StatusCode)
 	})
 
 	// Test case: SBOM feature not enabled
@@ -103,14 +103,14 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		res := recorder.Result()
 		err := res.Body.Close()
 		assert.NoError(t, err)
-		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+		assert.Equal(t, http.StatusNotImplemented, res.StatusCode)
 	})
 
 	// Test case: request body size exceeds limit
 	t.Run("request body size exceeds limit", func(t *testing.T) {
 		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
-		t.Setenv("ROX_SBOM_API_REQ_SIZE", "2")
+		t.Setenv("ROX_SBOM_GEN_MAX_REQ_SIZE_BYTES", "2")
 		largeRequestBody := []byte(`{"cluster": "test-cluster", "image_name": "test-image", "force": true}`)
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(largeRequestBody))
 		recorder := httptest.NewRecorder()

--- a/central/main.go
+++ b/central/main.go
@@ -94,6 +94,7 @@ import (
 	"github.com/stackrox/rox/central/helmcharts"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	imageService "github.com/stackrox/rox/central/image/service"
+	"github.com/stackrox/rox/central/imageintegration"
 	iiDatastore "github.com/stackrox/rox/central/imageintegration/datastore"
 	imageintegrationsDS "github.com/stackrox/rox/central/imageintegration/datastore"
 	iiService "github.com/stackrox/rox/central/imageintegration/service"
@@ -139,6 +140,7 @@ import (
 	collectionService "github.com/stackrox/rox/central/resourcecollection/service"
 	"github.com/stackrox/rox/central/risk/handlers/timeline"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/central/role/sachelper"
 	roleService "github.com/stackrox/rox/central/role/service"
 	centralSAC "github.com/stackrox/rox/central/sac"
 	"github.com/stackrox/rox/central/scanner"
@@ -746,7 +748,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		{
 			Route:         "/api/v1/images/sboms",
 			Authorizer:    user.With(permissions.Modify(resources.Image)),
-			ServerHandler: imageService.ImageHandler(),
+			ServerHandler: imageService.Handler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton())),
 			Compression:   true,
 		},
 		{

--- a/central/main.go
+++ b/central/main.go
@@ -744,6 +744,12 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Compression:   true,
 		},
 		{
+			Route:         "/api/v1/images/sboms",
+			Authorizer:    user.With(permissions.Modify(resources.Image)),
+			ServerHandler: imageService.ImageHandler(),
+			Compression:   true,
+		},
+		{
 			Route:         "/api/splunk/ta/vulnmgmt",
 			Authorizer:    user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)),
 			ServerHandler: splunk.NewVulnMgmtHandler(deploymentDatastore.Singleton(), imageDatastore.Singleton()),

--- a/central/main.go
+++ b/central/main.go
@@ -746,9 +746,9 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Compression:   true,
 		},
 		{
-			Route:         "/api/v1/images/sboms",
-			Authorizer:    user.With(permissions.Modify(resources.Image)),
-			ServerHandler: imageService.Handler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton())),
+			Route:         "/api/v1/images/sbom",
+			Authorizer:    user.With(permissions.Modify(permissions.WithLegacyAuthForSAC(resources.Image, true))),
+			ServerHandler: imageService.SBOMHandler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton())),
 			Compression:   true,
 		},
 		{

--- a/pkg/env/image_scan.go
+++ b/pkg/env/image_scan.go
@@ -5,4 +5,7 @@ import "time"
 var (
 	// ScanTimeout defines the image scan timeout duration.
 	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 10*time.Minute)
+
+	// SBOMGenerationMaxReqSizeBytes defines the maximum allowed size of an SBOM generation API request.
+	SBOMGenerationMaxReqSizeBytes = RegisterIntegerSetting("ROX_SBOM_GEN_MAX_REQ_SIZE_BYTES", 100*1024)
 )


### PR DESCRIPTION
This PR adds

-  http handler to get sboms
- call enricher using request params to generate image metadata and index report
#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manually tested the chnages by making api call to handler using postman
![Screenshot 2024-11-21 at 11 30 02 AM](https://github.com/user-attachments/assets/b000784f-f4b7-4454-a1a6-1411ee7448b0)
![Screenshot 2024-11-20 at 5 27 53 PM](https://github.com/user-attachments/assets/ad631882-4369-47e6-849e-b046a561a231)
