### PR TITLE
chore(CI): Bump junit2jira to v0.0.22

### DIFF
--- a/.github/actions/junit2jira/action.yaml
+++ b/.github/actions/junit2jira/action.yaml
@@ -31,7 +31,7 @@ runs:
   - name: Download junit2jira
     shell: bash
     env:
-      VERSION: "v0.0.21"
+      VERSION: "v0.0.22"
     run: |
       set -u
       LOCATION="https://github.com/stackrox/junit2jira/releases/download/$VERSION/junit2jira"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1560,7 +1560,7 @@ post_process_test_results() {
         # we will fallback to short commit
         base_link="$(echo "$JOB_SPEC" | jq ".refs.base_link | select( . != null )" -r)"
         calculated_base_link="https://github.com/stackrox/stackrox/commit/$(make --quiet --no-print-directory shortcommit)"
-        curl --retry 5 --retry-connrefused -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.21/junit2jira -o junit2jira && \
+        curl --retry 5 --retry-connrefused -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.22/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
         ./junit2jira \
             -base-link "${base_link:-$calculated_base_link}" \


### PR DESCRIPTION
### Description

Bump junit2jira to `v0.0.22` - that includes a fix for self-linking Jira tickets.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- no test modifications

#### How I validated my change

Will check CI execution
