### PR TITLE
fix(ui): Update NG test assertion for accuracy

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -168,6 +168,8 @@ describe('Network Graph smoke tests', () => {
 
         // Check that the values are removed
         cy.get(networkGraphSelectors.manageCidrBlocksButton).click();
-        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(0)).should('not.exist');
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(0)).should('have.value', '');
+        cy.get(networkGraphSelectors.cidrBlockEntryCidrInputAt(0)).should('have.value', '');
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(1)).should('not.exist');
     });
 });


### PR DESCRIPTION
### Description

Fixes a logical inconsistency that is a possible source of test flakes in the 4.6 release CI. See comments here https://redhat-internal.slack.com/archives/CMH5M8MHN/p1731713048648539. This is potentially related to https://github.com/stackrox/stackrox/pull/12752 just by virtue of being the most recent change in this section, but it does not explain why these tests have not been failing until the past week.

Details of the fix inline.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Local Cypress run
![image](https://github.com/user-attachments/assets/8f70b04f-f1d4-48aa-b6ab-f3d62a3e7911)

CI