### PR TITLE
ROX-27042: Allow selecting columns not present in destination struct

### DIFF
--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -129,18 +129,8 @@ func (r *resourceCountByImageCVESeverity) GetLowSeverityCount() common.ResourceC
 
 type imageResponse struct {
 	ImageID string `db:"image_sha"`
-
-	// Following are supported sort options.
-	ImageFullName   string     `db:"image"`
-	OperatingSystem string     `db:"image_os"`
-	ScanTime        *time.Time `db:"image_scan_time"`
 }
 
 type deploymentResponse struct {
 	DeploymentID string `db:"deployment_id"`
-
-	// Following are supported sort options.
-	DeploymentName string `db:"deployment"`
-	Cluster        string `db:"cluster"`
-	Namespace      string `db:"namespace"`
 }

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -445,12 +445,12 @@ func (s *ImageCVEViewTestSuite) TestCountBySeverity() {
 
 func (s *ImageCVEViewTestSuite) testCases() []testCase {
 	return []testCase{
-		//{
-		//	desc:        "search all",
-		//	ctx:         context.Background(),
-		//	q:           search.EmptyQuery(),
-		//	matchFilter: matchAllFilter(),
-		//},
+		{
+			desc:        "search all",
+			ctx:         context.Background(),
+			q:           search.EmptyQuery(),
+			matchFilter: matchAllFilter(),
+		},
 		{
 			desc: "search one cve",
 			ctx:  context.Background(),

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,7 +48,14 @@ type testCase struct {
 	testOrder      bool
 }
 
+type imageIDsPaginationTestCase struct {
+	desc string
+	q    *v1.Query
+	less lessFuncForImages
+}
+
 type lessFunc func(records []*imageCVECoreResponse) func(i, j int) bool
+type lessFuncForImages func(records []*storage.Image) func(i, j int) bool
 
 type filterImpl struct {
 	matchImage func(image *storage.Image) bool
@@ -262,9 +270,28 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDs() {
 			query.Pagination = nil
 			actualAffectedImageIDs, err := s.cveView.GetImageIDs(sac.WithAllAccess(tc.ctx), query)
 			assert.NoError(t, err)
-			expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, tc.matchFilter)
+			expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, tc.matchFilter, nil)
 			assert.ElementsMatch(t, expectedAffectedImages, actualAffectedImageIDs)
 		})
+	}
+}
+
+func (s *ImageCVEViewTestSuite) TestGetImageIDsPagination() {
+	for _, tc := range s.testCases() {
+		// Such testcases are meant only for Get().
+		if tc.expectedErr != "" {
+			return
+		}
+		for _, paginationTc := range s.paginationTestCasesForImageIDs() {
+			s.T().Run(fmt.Sprintf("%s_;_%s", tc.desc, paginationTc.desc), func(t *testing.T) {
+				query := tc.q.CloneVT()
+				query.Pagination = paginationTc.q.GetPagination()
+				actualAffectedImageIDs, err := s.cveView.GetImageIDs(sac.WithAllAccess(tc.ctx), query)
+				assert.NoError(t, err)
+				expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, tc.matchFilter, paginationTc.less)
+				assert.EqualValues(t, expectedAffectedImages, actualAffectedImageIDs)
+			})
+		}
 	}
 }
 
@@ -294,7 +321,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageIDsSAC() {
 					return false
 				})
 
-				expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, &matchFilter)
+				expectedAffectedImages := compileExpectedAffectedImageIDs(s.testImages, &matchFilter, nil)
 				assert.ElementsMatch(t, expectedAffectedImages, actualAffectedImageIDs)
 			})
 		}
@@ -418,12 +445,12 @@ func (s *ImageCVEViewTestSuite) TestCountBySeverity() {
 
 func (s *ImageCVEViewTestSuite) testCases() []testCase {
 	return []testCase{
-		{
-			desc:        "search all",
-			ctx:         context.Background(),
-			q:           search.EmptyQuery(),
-			matchFilter: matchAllFilter(),
-		},
+		//{
+		//	desc:        "search all",
+		//	ctx:         context.Background(),
+		//	q:           search.EmptyQuery(),
+		//	matchFilter: matchAllFilter(),
+		//},
 		{
 			desc: "search one cve",
 			ctx:  context.Background(),
@@ -689,6 +716,59 @@ func (s *ImageCVEViewTestSuite) paginationTestCases() []testCase {
 	}
 }
 
+func (s *ImageCVEViewTestSuite) paginationTestCasesForImageIDs() []imageIDsPaginationTestCase {
+	return []imageIDsPaginationTestCase{
+		{
+			desc: "sort by image name",
+			q: search.NewQueryBuilder().WithPagination(
+				search.NewPagination().
+					AddSortOption(search.NewSortOption(search.ImageName)).
+					AddSortOption(search.NewSortOption(search.ImageSHA)),
+			).ProtoQuery(),
+			less: func(records []*storage.Image) func(i int, j int) bool {
+				return func(i, j int) bool {
+					if records[i].GetName().GetFullName() == records[j].GetName().GetFullName() {
+						return strings.Compare(records[i].GetId(), records[j].GetId()) < 0
+					}
+					return strings.Compare(records[i].GetName().GetFullName(), records[j].GetName().GetFullName()) < 0
+				}
+			},
+		},
+		{
+			desc: "sort by image OS",
+			q: search.NewQueryBuilder().WithPagination(
+				search.NewPagination().
+					AddSortOption(search.NewSortOption(search.ImageOS)).
+					AddSortOption(search.NewSortOption(search.ImageSHA)),
+			).ProtoQuery(),
+			less: func(records []*storage.Image) func(i int, j int) bool {
+				return func(i, j int) bool {
+					if records[i].GetScan().GetOperatingSystem() == records[j].GetScan().GetOperatingSystem() {
+						return strings.Compare(records[i].GetId(), records[j].GetId()) < 0
+					}
+					return strings.Compare(records[i].GetScan().GetOperatingSystem(), records[j].GetScan().GetOperatingSystem()) < 0
+				}
+			},
+		},
+		{
+			desc: "sort by image scan time",
+			q: search.NewQueryBuilder().WithPagination(
+				search.NewPagination().
+					AddSortOption(search.NewSortOption(search.ImageScanTime)).
+					AddSortOption(search.NewSortOption(search.ImageSHA)),
+			).ProtoQuery(),
+			less: func(records []*storage.Image) func(i int, j int) bool {
+				return func(i, j int) bool {
+					if protocompat.CompareTimestamps(records[i].GetScan().GetScanTime(), records[j].GetScan().GetScanTime()) == 0 {
+						return strings.Compare(records[i].GetId(), records[j].GetId()) < 0
+					}
+					return protocompat.CompareTimestamps(records[i].GetScan().GetScanTime(), records[j].GetScan().GetScanTime()) < 0
+				}
+			},
+		},
+	}
+}
+
 func (s *ImageCVEViewTestSuite) sacTestCases() map[string]map[string]bool {
 	s.Require().Len(s.testImages, 5)
 
@@ -927,8 +1007,8 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 	return ret
 }
 
-func compileExpectedAffectedImageIDs(images []*storage.Image, filter *filterImpl) []string {
-	var affectedImageIDs []string
+func compileExpectedAffectedImageIDs(images []*storage.Image, filter *filterImpl, less lessFuncForImages) []string {
+	var affectedImages []*storage.Image
 	for _, image := range images {
 		if !filter.matchImage(image) {
 			continue
@@ -943,12 +1023,23 @@ func compileExpectedAffectedImageIDs(images []*storage.Image, filter *filterImpl
 				}
 			}
 			if vulnFilterPassed {
-				affectedImageIDs = append(affectedImageIDs, image.GetId())
+				affectedImages = append(affectedImages, image)
 				break
 			}
 		}
 	}
-	return affectedImageIDs
+	if less != nil {
+		sort.SliceStable(affectedImages, less(affectedImages))
+	}
+
+	ret := make([]string, 0, len(affectedImages))
+	for _, image := range affectedImages {
+		ret = append(ret, image.GetId())
+	}
+	if len(ret) == 0 {
+		return nil
+	}
+	return ret
 }
 
 func compileExpectedCountBySeverity(images []*storage.Image, filter *filterImpl) *resourceCountByImageCVESeverity {

--- a/central/views/nodecve/db_response.go
+++ b/central/views/nodecve/db_response.go
@@ -149,12 +149,6 @@ func (c *resourceCountByFixability) GetFixable() int {
 
 type nodeResponse struct {
 	NodeID string `db:"node_id"`
-
-	// Following are supported sort options.
-	NodeName        string     `db:"node_name"`
-	ClusterName     string     `db:"cluster"`
-	OperatingSystem string     `db:"operating_system"`
-	ScanTime        *time.Time `db:"node_scan_time"`
 }
 
 func (r *nodeResponse) GetNodeID() string {

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -4,6 +4,7 @@ package postgres_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -417,6 +418,41 @@ func TestSelectQuery(t *testing.T) {
 		{
 			desc: "nil query",
 			q:    nil,
+		},
+		{
+			desc: "Order by a field from joined table where the field not present in dst struct",
+			q: search.NewQueryBuilder().
+				AddSelectFields(
+					search.NewQuerySelect(search.TestString),
+					search.NewQuerySelect(search.TestTimestamp),
+				).WithPagination(
+				search.NewPagination().
+					AddSortOption(search.NewSortOption(search.TestNestedString).Reversed(true)),
+			).ProtoQuery(),
+			resultStruct: Struct5{},
+			expectedQuery: "select test_structs.String_ as test_string, test_structs.Timestamp as test_timestamp, " +
+				"test_structs_nesteds.Nested as test_nested_string " +
+				"from test_structs inner join test_structs_nesteds " +
+				"on test_structs.Key1 = test_structs_nesteds.test_structs_Key1 " +
+				"order by test_structs_nesteds.Nested desc",
+			expectedResult: []*Struct5{
+				{
+					TestString:    "bcs",
+					TestTimestamp: nil,
+				},
+				{
+					TestString:    "bcs",
+					TestTimestamp: nil,
+				},
+				{
+					TestString:    "bcs",
+					TestTimestamp: nil,
+				},
+				{
+					TestString:    "acs",
+					TestTimestamp: nil,
+				},
+			},
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
@@ -1049,6 +1085,7 @@ func runTest(ctx context.Context, t *testing.T, testDB *pgtest.TestPostgres, tc 
 		return
 	}
 
+	fmt.Println(results)
 	if tc.q.GetPagination() != nil {
 		assert.Equal(t, tc.expectedResult, results)
 	} else {

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -4,7 +4,6 @@ package postgres_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -1085,7 +1084,6 @@ func runTest(ctx context.Context, t *testing.T, testDB *pgtest.TestPostgres, tc 
 		return
 	}
 
-	fmt.Println(results)
 	if tc.q.GetPagination() != nil {
 		assert.Equal(t, tc.expectedResult, results)
 	} else {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The search framework sometimes adds columns used in order by and group by clauses to the select part of the query. This is necessary to make a valid query as per SQL spec. For the destination struct used to consume results of such queries, we currently need to guess what extra columns will be added by the search framework and create fields for them in destination struct. In the imageResponse example below, the users of the struct are only interested in the ImageID values and use the other fields just for sorting the IDs. 

```
type imageResponse struct {	
    ImageID string `db:"image_sha"`
	
    // Following are supported sort options.	
    ImageFullName   string     `db:"image"`	
    OperatingSystem string     `db:"image_os"`	
    ScanTime        *time.Time `db:"image_scan_time"`
}
```
This can be avoided by configuring the scanner that is used to read the db results into destination struct to allow.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [X] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests
