### PR TITLE
ROX-27007: Prune compliance reports and blobs

### DIFF
--- a/central/blob/datastore/datastore_test.go
+++ b/central/blob/datastore/datastore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stackrox/rox/central/blob/datastore/search"
 	"github.com/stackrox/rox/central/blob/datastore/store"
+	"github.com/stackrox/rox/central/reports/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
@@ -77,13 +78,13 @@ func (s *blobTestSuite) createBlobs(prefix string, size int, n int, modTime time
 
 func (s *blobTestSuite) TestSearch() {
 	searchTime := timeutil.MustParse(time.RFC3339, "2020-03-09T12:00:00Z")
-	blobs1 := s.createBlobs("/path1", 10, 2, searchTime)
-	blobs2 := s.createBlobs("/path2", 20, 3, time.Now())
+	blobs1 := s.createBlobs(common.ReportBlobPathPrefix, 10, 2, searchTime)
+	blobs2 := s.createBlobs(common.ComplianceReportBlobPathPrefix, 20, 3, time.Now())
 
 	s.testQuery(s.ctx, pkgSearch.NewQueryBuilder().AddDocIDs(blobs2[0].GetName()).ProtoQuery(), []*storage.Blob{blobs2[0]}, nil)
 	s.testQuery(s.ctx, pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.BlobLength, "20").ProtoQuery(), blobs2, nil)
 	s.testQuery(s.ctx, pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.BlobModificationTime, "03/09/2020 UTC").ProtoQuery(), blobs1, nil)
-	s.testQuery(s.ctx, pkgSearch.NewQueryBuilder().AddRegexes(pkgSearch.BlobName, "/path1/.+").ProtoQuery(), blobs1, nil)
+	s.testQuery(s.ctx, pkgSearch.NewQueryBuilder().AddRegexes(pkgSearch.BlobName, common.ReportBlobRegex).ProtoQuery(), append(blobs1, blobs2...), nil)
 
 	// Global access context without access to Blob
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/complianceoperator/v2/report/datastore/datastore.go
+++ b/central/complianceoperator/v2/report/datastore/datastore.go
@@ -2,10 +2,12 @@ package datastore
 
 import (
 	"context"
+	"testing"
 
 	pgStore "github.com/stackrox/rox/central/complianceoperator/v2/report/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
 )
 
 // DataStore is the entry point for storing/retrieving compliance operator report snapshot objects.
@@ -29,4 +31,9 @@ func New(reportSnapshotStorage pgStore.Store) DataStore {
 	return &datastoreImpl{
 		store: reportSnapshotStorage,
 	}
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
+	return New(pgStore.New(pool))
 }

--- a/central/postgres/compliance_report_pruning_test.go
+++ b/central/postgres/compliance_report_pruning_test.go
@@ -1,0 +1,357 @@
+//go:build sql_integration
+
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	blobDS "github.com/stackrox/rox/central/blob/datastore"
+	snapshotDS "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore"
+	scanConfigDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
+	"github.com/stackrox/rox/central/reports/common"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	day = time.Hour * 24
+)
+
+var (
+	report1  = uuid.NewV4().String()
+	report2  = uuid.NewV4().String()
+	report3  = uuid.NewV4().String()
+	report4  = uuid.NewV4().String()
+	report5  = uuid.NewV4().String()
+	report6  = uuid.NewV4().String()
+	report7  = uuid.NewV4().String()
+	report8  = uuid.NewV4().String()
+	report9  = uuid.NewV4().String()
+	report10 = uuid.NewV4().String()
+	report11 = uuid.NewV4().String()
+	report12 = uuid.NewV4().String()
+
+	idToHumanReadable = map[string]string{
+		report1:  "report-1",
+		report2:  "report-2",
+		report3:  "report-3",
+		report4:  "report-4",
+		report5:  "report-5",
+		report6:  "report-6",
+		report7:  "report-7",
+		report8:  "report-8",
+		report9:  "report-9",
+		report10: "report-10",
+		report11: "report-11",
+		report12: "report-12",
+	}
+
+	blobData = []byte("some-test-date")
+)
+
+type ComplianceReportPruningSuite struct {
+	suite.Suite
+	ctx          context.Context
+	db           *pgtest.TestPostgres
+	snapshotDS   snapshotDS.DataStore
+	scanConfigDS scanConfigDS.DataStore
+	blobDS       blobDS.Datastore
+}
+
+func TestComplianceReportPruning(t *testing.T) {
+	suite.Run(t, new(ComplianceReportPruningSuite))
+}
+
+var _ suite.SetupAllSuite = (*ComplianceReportPruningSuite)(nil)
+var _ suite.TearDownTestSuite = (*ComplianceReportPruningSuite)(nil)
+var _ suite.TearDownAllSuite = (*ComplianceReportPruningSuite)(nil)
+
+func (s *ComplianceReportPruningSuite) SetupSuite() {
+	s.db = pgtest.ForT(s.T())
+	s.ctx = sac.WithAllAccess(context.Background())
+
+	s.scanConfigDS = scanConfigDS.GetTestPostgresDataStore(s.T(), s.db)
+	s.snapshotDS = snapshotDS.GetTestPostgresDataStore(s.T(), s.db)
+	s.blobDS = blobDS.NewTestDatastore(s.T(), s.db)
+
+	for _, id := range []string{config1, config2, config3, config4} {
+		s.Require().NoError(s.scanConfigDS.UpsertScanConfiguration(s.ctx, newScanConfig(id)))
+	}
+}
+
+func (s *ComplianceReportPruningSuite) TearDownTest() {
+	tag, err := s.db.Exec(s.ctx, fmt.Sprintf("TRUNCATE %s CASCADE", schema.ComplianceOperatorReportSnapshotV2TableName))
+	s.T().Logf("%s %v", schema.ComplianceOperatorReportSnapshotV2TableName, tag)
+	s.Require().NoError(err)
+
+	tag, err = s.db.Exec(s.ctx, fmt.Sprintf("TRUNCATE %s CASCADE", schema.BlobsTableName))
+	s.T().Logf("%s %v", schema.BlobsTableName, tag)
+	s.Require().NoError(err)
+}
+
+func (s *ComplianceReportPruningSuite) TearDownSuite() {
+	s.db.Teardown(s.T())
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobOneDownload() {
+	// All downloads; all delivered; outside retention window
+	// These should not be deleted because they are the last successful job for each Scan Configuration
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobOnDemandOneEmail() {
+	// All emails; all delivered; all on demand; outside retention window
+	// These should not be deleted because they are the last successful job for each Scan Configuration
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobScheduledOneEmail() {
+	// All emails; all delivered; all scheduled; outside retention window
+	// These should not be deleted because they are the last successful job for each Scan Configuration
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobNewerDownloadsOlderFailedEmails() {
+	// Newer delivered downloads; older failed scheduled; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+
+		newComplianceReportSnapshot(report5, config1, 10*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report6, config2, 10*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report7, config3, 10*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report8, config4, 10*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	expectedDeletions := set.NewStringSet(report1, report2, report3, report4)
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func newScanConfig(id string) *storage.ComplianceOperatorScanConfigurationV2 {
+	return &storage.ComplianceOperatorScanConfigurationV2{
+		Id:             id,
+		ScanConfigName: id,
+	}
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobOlderDownloadsNewerFailedEmails() {
+	// Older delivered downloads; newer failed scheduled; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+
+		newComplianceReportSnapshot(report5, config1, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report6, config2, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report7, config3, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report8, config4, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+	}
+	expectedDeletions := set.NewStringSet(report5, report6, report7, report8)
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobOldMixedEmailsNewerMixedEmails() {
+	// Older mixed scheduled; newer mixed scheduled; even newer mixed on demand emails; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+
+		newComplianceReportSnapshot(report5, config1, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report6, config2, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report7, config3, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report8, config4, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+
+		newComplianceReportSnapshot(report9, config1, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, true),
+		newComplianceReportSnapshot(report10, config2, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report11, config3, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, true),
+		newComplianceReportSnapshot(report12, config4, 10*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	expectedDeletions := set.NewStringSet(report2, report4, report5, report7, report9, report11)
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobAllEmails() {
+	// All emails; all scheduled; all delivered; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+
+		newComplianceReportSnapshot(report5, config1, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report6, config2, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report7, config3, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report8, config4, 20*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+	}
+	expectedDeletions := set.NewStringSet(report1, report2, report3, report4)
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobAllDownloads() {
+	// All downloads; some delivered; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+
+		newComplianceReportSnapshot(report5, config1, 20*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report6, config2, 20*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report7, config3, 20*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report8, config4, 20*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	expectedDeletions := set.NewStringSet(report1, report2, report3, report4)
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteUnfinishedJobs() {
+	// All unfinished; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_WAITING, true),
+		newComplianceReportSnapshot(report2, config2, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_WAITING, true),
+		newComplianceReportSnapshot(report3, config3, 100*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_PREPARING, true),
+		newComplianceReportSnapshot(report4, config4, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_PREPARING, true),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteIfBlobExists() {
+	// Blob still exits; outside retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_GENERATED, true),
+		newComplianceReportSnapshot(report2, config1, 100*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+	}
+	blobs := []*storage.Blob{
+		newBlob(common.GetComplianceReportBlobPath(config1, report1), blobData),
+		newBlob(common.GetComplianceReportBlobPath(config1, report2), blobData),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	for _, blob := range blobs {
+		s.Require().NoError(s.blobDS.Upsert(s.ctx, blob, bytes.NewBuffer(blobData)))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) Test_MustNotDeleteJobsInTheRetentionWindow() {
+	// Mixed jobs; all in the retention window
+	snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+		newComplianceReportSnapshot(report1, config1, 1*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_WAITING, false),
+		newComplianceReportSnapshot(report2, config2, 1*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_WAITING, true),
+		newComplianceReportSnapshot(report3, config3, 1*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_PREPARING, false),
+		newComplianceReportSnapshot(report4, config4, 1*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_PREPARING, true),
+
+		newComplianceReportSnapshot(report5, config1, 2*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, false),
+		newComplianceReportSnapshot(report6, config2, 2*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report7, config3, 2*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, false),
+		newComplianceReportSnapshot(report8, config4, 2*day, storage.ComplianceOperatorReportStatus_DOWNLOAD, storage.ComplianceOperatorReportStatus_FAILURE, true),
+
+		newComplianceReportSnapshot(report9, config1, 3*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_WAITING, true),
+		newComplianceReportSnapshot(report10, config2, 3*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_PREPARING, true),
+		newComplianceReportSnapshot(report11, config3, 3*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_DELIVERED, true),
+		newComplianceReportSnapshot(report12, config4, 3*day, storage.ComplianceOperatorReportStatus_EMAIL, storage.ComplianceOperatorReportStatus_FAILURE, true),
+	}
+	expectedDeletions := set.NewStringSet()
+	for _, snapshot := range snapshots {
+		s.Require().NoError(s.snapshotDS.UpsertSnapshot(s.ctx, snapshot))
+	}
+	s.PruneAndAssert(snapshots, expectedDeletions)
+}
+
+func (s *ComplianceReportPruningSuite) PruneAndAssert(snapshots []*storage.ComplianceOperatorReportSnapshotV2, expectedDeletions set.StringSet) {
+	PruneComplianceReportHistory(s.ctx, s.db, retentionDuration)
+	for _, snapshot := range snapshots {
+		_, found, err := s.snapshotDS.GetSnapshot(s.ctx, snapshot.GetReportId())
+		s.Require().NoError(err)
+		s.Assert().Equal(expectedDeletions.Contains(snapshot.GetReportId()), !found, "report %s should be deleted == %t but found == %t", idToHumanReadable[snapshot.GetReportId()], expectedDeletions.Contains(snapshot.GetReportId()), found)
+	}
+}
+
+func newComplianceReportSnapshot(
+	id string,
+	scanConfigID string,
+	completedAt time.Duration,
+	notificationMethod storage.ComplianceOperatorReportStatus_NotificationMethod,
+	state storage.ComplianceOperatorReportStatus_RunState,
+	onDemand bool,
+) *storage.ComplianceOperatorReportSnapshotV2 {
+	requestType := storage.ComplianceOperatorReportStatus_SCHEDULED
+	if onDemand || notificationMethod == storage.ComplianceOperatorReportStatus_DOWNLOAD {
+		requestType = storage.ComplianceOperatorReportStatus_ON_DEMAND
+	}
+	return &storage.ComplianceOperatorReportSnapshotV2{
+		ReportId:            id,
+		ScanConfigurationId: scanConfigID,
+		ReportStatus: &storage.ComplianceOperatorReportStatus{
+			RunState:                 state,
+			ReportRequestType:        requestType,
+			CompletedAt:              protoconv.NowMinus(completedAt),
+			ReportNotificationMethod: notificationMethod,
+		},
+	}
+}

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -75,6 +75,42 @@ const (
 			AND (snapshots.reportstatus_completedat < now() AT time zone 'utc' - INTERVAL '%d MINUTES')
 		)`
 
+	// (snapshots.reportstatus_runstate = 2 OR snapshots.reportstatus_runstate = 3 OR snapshots.reportstatus_runstate = 4)
+	// ...gives us the report jobs that are in final state.
+	//
+	// (SELECT MAX(latest.reportstatus_completedat) FROM ` + schema.ReportSnapshotsTableName + ` latest
+	// WHERE latest.reportstatus_completedat IS NOT NULL
+	// AND snapshots.reportconfigurationid = latest.reportconfigurationid
+	// AND latest.reportstatus_runstate = 3
+	// GROUP BY latest.reportstatus_reportnotificationmethod, latest.reportstatus_reportrequesttype)
+	//	...gives us the last successful report job for each config, for each notificated method, and each request type.
+	//
+	// (SELECT 1 FROM ` + schema.BlobsTableName + ` blobs
+	//	WHERE blobs.name not ilike '%/snapshots.reportid')
+	// ...tells us if the report still exists in the blob store.
+	//
+	// (reportstatus_completedat < now() AT time zone 'utc' - INTERVAL '%d MINUTES')
+	// ...gives us the reports that are outside the retention window.
+	pruneOldComplianceReportHistory = `DELETE FROM ` + schema.ComplianceOperatorReportSnapshotV2TableName + ` WHERE reportid IN
+		(
+			SELECT snapshots.reportid FROM ` + schema.ComplianceOperatorReportSnapshotV2TableName + ` snapshots
+			WHERE (snapshots.reportstatus_runstate = 2 OR snapshots.reportstatus_runstate = 3 OR snapshots.reportstatus_runstate = 4)
+			AND snapshots.reportstatus_completedat NOT IN
+			(
+				SELECT MAX(latest.reportstatus_completedat) FROM ` + schema.ComplianceOperatorReportSnapshotV2TableName + ` latest
+				WHERE latest.reportstatus_completedat IS NOT NULL
+				AND snapshots.scanconfigurationid = latest.scanconfigurationid
+				AND latest.reportstatus_runstate = 3
+				GROUP BY latest.reportstatus_reportnotificationmethod, latest.reportstatus_reportrequesttype
+			)
+			AND NOT EXISTS
+			(
+				SELECT 1 FROM ` + schema.BlobsTableName + ` blobs
+				WHERE blobs.name ilike CONCAT('%%/',snapshots.reportid)
+			)
+			AND (snapshots.reportstatus_completedat < now() AT time zone 'utc' - INTERVAL '%d MINUTES')
+		)`
+
 	// Delete the log imbues with old timestamp
 	pruneLogImbues = `DELETE FROM log_imbues WHERE timestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
 
@@ -191,6 +227,17 @@ func PruneReportHistory(ctx context.Context, pool postgres.DB, retentionDuration
 	query := fmt.Sprintf(pruneOldReportHistory, int(retentionDuration.Minutes()))
 	if _, err := pool.Exec(pruneCtx, query); err != nil {
 		log.Errorf("failed to prune report history: %v", err)
+	}
+}
+
+// PruneComplianceReportHistory prunes compliance report history as per specified retentionDuration and a few static criteria.
+func PruneComplianceReportHistory(ctx context.Context, pool postgres.DB, retentionDuration time.Duration) {
+	pruneCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, pruningTimeout)
+	defer cancel()
+
+	query := fmt.Sprintf(pruneOldComplianceReportHistory, int(retentionDuration.Minutes()))
+	if _, err := pool.Exec(pruneCtx, query); err != nil {
+		log.Errorf("failed to prune compliance report history: %v", err)
 	}
 }
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -181,6 +181,7 @@ func (g *garbageCollectorImpl) pruneBasedOnConfig() {
 	g.removeExpiredVulnRequests()
 	g.collectClusters(pvtConfig)
 	g.removeOldReportHistory(pvtConfig)
+	g.removeOldComplianceReportHistory(pvtConfig)
 	g.removeOldReportBlobs(pvtConfig)
 	g.removeExpiredAdministrationEvents(pvtConfig)
 	g.removeExpiredDiscoveredClusters()
@@ -633,6 +634,13 @@ func (g *garbageCollectorImpl) removeOldReportHistory(config *storage.PrivateCon
 	reportHistoryRetentionConfig := config.GetReportRetentionConfig().GetHistoryRetentionDurationDays()
 	dur := time.Duration(reportHistoryRetentionConfig) * 24 * time.Hour
 	postgres.PruneReportHistory(pruningCtx, g.postgres, dur)
+}
+
+func (g *garbageCollectorImpl) removeOldComplianceReportHistory(config *storage.PrivateConfig) {
+	defer metrics.SetPruningDuration(time.Now(), "ComplianceReportHistory")
+	reportHistoryRetentionConfig := config.GetReportRetentionConfig().GetHistoryRetentionDurationDays()
+	dur := time.Duration(reportHistoryRetentionConfig) * 24 * time.Hour
+	postgres.PruneComplianceReportHistory(pruningCtx, g.postgres, dur)
 }
 
 func (g *garbageCollectorImpl) removeOldReportBlobs(config *storage.PrivateConfig) {

--- a/central/reports/common/blob.go
+++ b/central/reports/common/blob.go
@@ -5,14 +5,14 @@ import (
 )
 
 const (
-	reportBlobPathPrefix   = "/central/reports/"
-	reportBlobPathTemplate = reportBlobPathPrefix + "%s/%s"
+	ReportBlobPathPrefix   = "/central/reports/"
+	reportBlobPathTemplate = ReportBlobPathPrefix + "%s/%s"
 
 	// ReportBlobRegex matches all downloadable report blob names
-	ReportBlobRegex = "^" + reportBlobPathPrefix + ".+"
+	ReportBlobRegex = "^(" + ReportBlobPathPrefix + "|" + ComplianceReportBlobPathPrefix + ").+"
 
-	complianceReportBlobPathPrefix   = "/central/compliance/reports/"
-	complianceReportBlobPathTemplate = complianceReportBlobPathPrefix + "%s/%s"
+	ComplianceReportBlobPathPrefix   = "/central/compliance/reports/"
+	complianceReportBlobPathTemplate = ComplianceReportBlobPathPrefix + "%s/%s"
 )
 
 // GetReportBlobPath creates the Blob path for report


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Prune compliance reports and blobs using the same criteria as VM.

Finished reports (delivered, generated, or failed) outside of the retention window will be deleted unless:

- The report is the last report (the report is the only report of that type for that given scan configuration).
- The report is not finished (the report is not in the delivered, generated, or failed state).
- The report has a blob (if there is a blob for a given report, we do not delete the report).
- The report is inside the retention window (the report has not expired).

Blobs are pruned if:

- The blob is outside of the retention window (the report has expired).
- The blob is bigger than the allowed space left (report-size > total-allowed-space - used-space).

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Modified existing tests to test the new regex to match VM blobs and Compliance blobs.
- [x] Added integration tests for the compliance report pruning function.
- [x] Manually tested the reports and blobs get deleted once they're outside the retention window.
