### PR TITLE
ROX-27008: Prevent cloned policies from being marked as external

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
@@ -16,7 +16,7 @@ import { getClientWizardPolicy, initialPolicy } from './policies.utils';
 import PolicyDetail from './Detail/PolicyDetail';
 import PolicyWizard from './Wizard/PolicyWizard';
 
-function clonePolicy(policy: ClientPolicy) {
+function clonePolicy(policy: ClientPolicy): ClientPolicy {
     /*
      * Default policies will have the "criteriaLocked" and "mitreVectorsLocked" fields set to true.
      * When we clone these policies, we'll need to set them to false to allow users to edit
@@ -24,6 +24,7 @@ function clonePolicy(policy: ClientPolicy) {
      */
     return {
         ...policy,
+        source: 'IMPERATIVE',
         criteriaLocked: false,
         id: '',
         isDefault: false,


### PR DESCRIPTION
### Description

Prevents a cloned EXTERNAL policy from being marked as EXTERNAL when saved. Since a cloned policy only exists locally in central, without a external sync source, it should be marked INTERNAL instead.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![image](https://github.com/user-attachments/assets/8a98238c-9f0a-4b51-b19b-118e2438f161)
![image](https://github.com/user-attachments/assets/d16abf11-6000-42d8-8f0c-a7256177a62d)
![image](https://github.com/user-attachments/assets/23f6a3ef-da94-4906-9333-7f5e56c56483)
