### PR TITLE
ROX-21658: Mock CVE response in exception config test

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCVEList.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCVEList.json
@@ -1,0 +1,86 @@
+{
+    "data": {
+        "imageCVEs": [
+            {
+                "cve": "MOCK-2023-123456",
+                "affectedImageCountBySeverity": {
+                    "critical": {
+                        "total": 4,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "topCVSS": 9.800000190734863,
+                "affectedImageCount": 4,
+                "firstDiscoveredInSystem": "2024-03-25T14:35:43.111026Z",
+                "publishedOn": "2023-10-14T02:15:00Z",
+                "topNvdCVSS": 0,
+                "distroTuples": [
+                    {
+                        "summary": "This is a MOCKED CYPRESS RESPONSE for a CVE",
+                        "operatingSystem": "debian:11",
+                        "cvss": 9.8,
+                        "scoreVersion": "V3",
+                        "nvdCvss": 0,
+                        "nvdScoreVersion": "UNKNOWN_VERSION",
+                        "__typename": "ImageVulnerability"
+                    }
+                ],
+                "pendingExceptionCount": 0,
+                "__typename": "ImageCVECore"
+            },
+            {
+                "cve": "MOCK-2024-123456",
+                "affectedImageCountBySeverity": {
+                    "critical": {
+                        "total": 2,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "important": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "moderate": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "__typename": "ResourceCountByCVESeverity"
+                },
+                "topCVSS": 9.8,
+                "affectedImageCount": 2,
+                "firstDiscoveredInSystem": "2024-06-21T17:02:53.144435Z",
+                "publishedOn": "2023-07-01T05:15:00Z",
+                "topNvdCVSS": 0,
+                "distroTuples": [
+                    {
+                        "summary": "This is a MOCKED CYPRESS RESPONSE for a CVE",
+                        "operatingSystem": "debian:12",
+                        "cvss": 9.800000190734863,
+                        "scoreVersion": "V3",
+                        "nvdCvss": 0,
+                        "nvdScoreVersion": "UNKNOWN_VERSION",
+                        "__typename": "ImageVulnerability"
+                    }
+                ],
+                "pendingExceptionCount": 0,
+                "__typename": "ImageCVECore"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/integration/exceptionConfiguration/vulnerabilitiesExceptionConfig.test.js
+++ b/ui/apps/platform/cypress/integration/exceptionConfiguration/vulnerabilitiesExceptionConfig.test.js
@@ -1,5 +1,6 @@
 import withAuth from '../../helpers/basicAuth';
 import {
+    interactAndWaitForCveList,
     selectSingleCveForException,
     visitWorkloadCveOverview,
 } from '../vulnerabilities/workloadCves/WorkloadCves.helpers';
@@ -105,45 +106,48 @@ describe('Vulnerabilities Exception Configuration', () => {
         cy.get(selectors.saveButton).click();
         cy.get('.pf-v5-c-alert:contains("The configuration was updated successfully")');
 
-        // Visit the Workload CVE page, open a deferral modal, and verify that the specified options are available
-        visitWorkloadCveOverview();
-        selectSingleCveForException('DEFERRAL');
-        cy.get('button:contains("Options")').click();
+        // Mock the CVE list response on the Workload CVE page to prevent flakiness when no CVEs are reported
+        interactAndWaitForCveList(() => {
+            // Visit the Workload CVE page, open a deferral modal, and verify that the specified options are available
+            visitWorkloadCveOverview();
+            selectSingleCveForException('DEFERRAL');
+            cy.get('button:contains("Options")').click();
 
-        cy.get('label')
-            .contains(/For \d+ days/)
-            .should('have.length', 0);
-        cy.get("label:contains('When any CVE is fixable')");
-        cy.get("label:contains('When all CVEs are fixable')");
-        cy.get("label:contains('Until a specific date')");
-        cy.get("label:contains('Indefinitely')");
+            cy.get('label')
+                .contains(/For \d+ days/)
+                .should('have.length', 0);
+            cy.get("label:contains('When any CVE is fixable')");
+            cy.get("label:contains('When all CVEs are fixable')");
+            cy.get("label:contains('Until a specific date')");
+            cy.get("label:contains('Indefinitely')");
 
-        // Revisit the config page and enable all day options, and disable the previously enabled options
-        visitExceptionConfig('vulnerabilities');
-        [0, 1, 2, 3].forEach((index) => {
-            cy.get(selectors.dayOptionEnabledSwitch(index)).check({ force: true });
-            cy.get(selectors.dayOptionInput(index)).type(`{selectall}${index + 1}`);
+            // Revisit the config page and enable all day options, and disable the previously enabled options
+            visitExceptionConfig('vulnerabilities');
+            [0, 1, 2, 3].forEach((index) => {
+                cy.get(selectors.dayOptionEnabledSwitch(index)).check({ force: true });
+                cy.get(selectors.dayOptionInput(index)).type(`{selectall}${index + 1}`);
+            });
+            cy.get(selectors.whenAllCveFixableSwitch).uncheck({ force: true });
+            cy.get(selectors.whenAnyCveFixableSwitch).uncheck({ force: true });
+            cy.get(selectors.customDateSwitch).uncheck({ force: true });
+            cy.get(selectors.indefiniteOptionEnabledSwitch).uncheck({ force: true });
+
+            cy.get(selectors.saveButton).click();
+            cy.get('.pf-v5-c-alert:contains("The configuration was updated successfully")');
+
+            // Revisit Workload CVEs and verify that the updated options are available
+            visitWorkloadCveOverview();
+            selectSingleCveForException('DEFERRAL');
+            cy.get('button:contains("Options")').click();
+
+            cy.get('label:contains("For 1 days")');
+            cy.get('label:contains("For 2 days")');
+            cy.get('label:contains("For 3 days")');
+            cy.get('label:contains("For 4 days")');
+            cy.get("label:contains('When any CVE is fixable')").should('not.exist');
+            cy.get("label:contains('When all CVEs are fixable')").should('not.exist');
+            cy.get("label:contains('Until a specific date')").should('not.exist');
+            cy.get("label:contains('Indefinitely')").should('not.exist');
         });
-        cy.get(selectors.whenAllCveFixableSwitch).uncheck({ force: true });
-        cy.get(selectors.whenAnyCveFixableSwitch).uncheck({ force: true });
-        cy.get(selectors.customDateSwitch).uncheck({ force: true });
-        cy.get(selectors.indefiniteOptionEnabledSwitch).uncheck({ force: true });
-
-        cy.get(selectors.saveButton).click();
-        cy.get('.pf-v5-c-alert:contains("The configuration was updated successfully")');
-
-        // Revisit Workload CVEs and verify that the updated options are available
-        visitWorkloadCveOverview();
-        selectSingleCveForException('DEFERRAL');
-        cy.get('button:contains("Options")').click();
-
-        cy.get('label:contains("For 1 days")');
-        cy.get('label:contains("For 2 days")');
-        cy.get('label:contains("For 3 days")');
-        cy.get('label:contains("For 4 days")');
-        cy.get("label:contains('When any CVE is fixable')").should('not.exist');
-        cy.get("label:contains('When all CVEs are fixable')").should('not.exist');
-        cy.get("label:contains('Until a specific date')").should('not.exist');
-        cy.get("label:contains('Indefinitely')").should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -455,8 +455,10 @@ export function changeObservedCveViewingMode(modeText) {
 export function interactAndWaitForCveList(callback) {
     const cveListOpname = 'getImageCVEList';
     const cveListRouteMatcherMap = getRouteMatcherMapForGraphQL([cveListOpname]);
-    cveListRouteMatcherMap[cveListOpname].times = 1;
-    return interactAndWaitForResponses(callback, cveListRouteMatcherMap);
+    const staticResponseMap = {
+        [cveListOpname]: { fixture: 'vulnerabilities/workloadCves/getImageCVEList.json' },
+    };
+    return interactAndWaitForResponses(callback, cveListRouteMatcherMap, staticResponseMap);
 }
 
 /**


### PR DESCRIPTION
### Description

**Easier to review with "Hide whitespace" enabled**

Mocks the CVE list when visiting the Workload CVE page during integration tests in order to avoid flakes when Scanner has not completed a single image scan at the point that the Exception Configuration test suite runs. The functionality under test does not depend on true e2e CVE responses.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Local Cypress run.

CI.