### PR TITLE
ROX-27061: On demand reports are owned by the requester

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +79,11 @@ func (m *ManagerTestSuite) TearDownTest() {
 
 func (m *ManagerTestSuite) TestHandleReportRequest() {
 	m.T().Setenv(env.ReportExecutionMaxConcurrency.EnvVar(), "1")
-	ctx := context.Background()
+	identity := mocks.NewMockIdentity(m.mockCtrl)
+	identity.EXPECT().UID().AnyTimes().Return("user-id")
+	identity.EXPECT().FullName().AnyTimes().Return("user-name")
+	identity.EXPECT().FriendlyName().AnyTimes().Return("user-friendly-name")
+	ctx := authn.ContextWithIdentity(context.Background(), identity, m.T())
 
 	m.Run("Successful report, no watchers running", func() {
 		manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.reportGen)

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -284,7 +284,11 @@ func (s *serviceImpl) RunReport(ctx context.Context, request *v2.ComplianceRunRe
 	if !features.ComplianceReporting.Enabled() {
 		return nil, errors.Wrap(errox.NotImplemented, "Not implemented")
 	}
-	if request.GetScanConfigId() == "" {
+	requesterID := authn.IdentityFromContextOrNil(ctx)
+	if requesterID == nil {
+		return nil, errors.New("Could not determine user identity from provided context")
+	}
+	if request.GetScanConfigId() == "" && features.ScanScheduleReportJobs.Enabled() {
 		return nil, errors.Wrap(errox.InvalidArgs, "Scan configuration ID is required to run an a report")
 	}
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

On demand reports are owned by the requester and not by the owner of the scan configuration with which they are associated.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Manually request a report with a different user to the one that created the scan schedule and observed the report is owned by the requester of the report and not the user that created the scan sshedule.
