### PR TITLE
ROX-26944: UI e2e test fix for November 11 bug

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
@@ -79,7 +79,7 @@ describe('Exception Management - Approved False Positives Table', () => {
         approveRequest();
         visitApprovedFalsePositivesTab();
 
-        const requestNameSelector = 'table tr:nth(1) td[data-label="Request name"]';
+        const requestNameSelector = 'table tr:nth(1) td[data-label="Request name"] a';
 
         cy.get(requestNameSelector)
             .invoke('text')


### PR DESCRIPTION
### Description

Fixes a test flake in the Exception Management tests that currently will occur 100% of the time on November 11, and almost only on November 11.

Why?

The failing test has a section where it intercepts the Name of an Exception Request, finds the row in the table, and then clicks on the table cell containing a link to the Exception Request detail page. Once on the page, the test checks to ensure the `h1` tag contains the same text as the Name of the request.

A request name is automatically generated as follows:
1. Two characters based on the requestors user name followed by a dash
2. The date of the request in YYMMDD format followed by a dash
3. A digit representing the number of requests that exist in the system, which is `9` in the case of these CI runs.

The problem comes from the MMDD part of the Name, which on Novermber 11 is `1111`, which is coincidentally the most narrow string of four digits.

With the default browser width and the text values that are present in the other cells this results in a link that is ever so slightly smaller (84px) than half the width of the table cell (90px) that is clicked. Cypress by default will click the target element in its center, which in this case misses the link and causes the test to fail.

Table cell
![image](https://github.com/user-attachments/assets/fd7b173c-6345-4ad7-924f-52277a0b016f)
Table cell computed content width
![image](https://github.com/user-attachments/assets/562cbfda-cee6-4a3e-ab9d-bf2f5e61884f)
Target link element width
![image](https://github.com/user-attachments/assets/bf80a28e-7c75-4053-adf3-a0d0e07973c9)




### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Simulated the `UU-241111-9` request name in local Cypress test runs.
