### PR TITLE
fix(link): URL to upgrader troubleshooting docs

### DIFF
--- a/sensor/upgrader/preflight/access.go
+++ b/sensor/upgrader/preflight/access.go
@@ -18,7 +18,7 @@ import (
 const (
 	defaultServiceAccountName   = `sensor-upgrader`
 	fallbackServiceAccountName  = `sensor`
-	upgraderTroubleshootingLink = "https://docs.openshift.com/acs/upgrading/upgrade-roxctl.html#troubleshooting_upgrader_upgrade-roxctl"
+	upgraderTroubleshootingLink = "https://docs.openshift.com/acs/upgrading/upgrade-roxctl.html#troubleshooting-upgrader_upgrade-roxctl"
 )
 
 var defaultClusterRoleBinding = pods.GetPodNamespace() + ":upgrade-sensors"


### PR DESCRIPTION
### Description

In one place in the like, we use `_`  instead of `-`. But at least we direct the users to the correct page. The users would need to scroll to the section at the bottom. With this fix, they will be redirected to the correct section.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- I clicked the link
