### PR TITLE
Sanitize column values when rendering PDFs

### DIFF
--- a/ui/apps/platform/src/utils/pdfUtils.js
+++ b/ui/apps/platform/src/utils/pdfUtils.js
@@ -128,7 +128,7 @@ const createPDFTable = (tableData, entityType, query, pdfId, tableColumns) => {
                             String(flattenedObj[key]).replace(/\s+/g, ' ').trim()) ||
                         'N/A';
                 }
-                td.innerHTML = colValue;
+                td.innerHTML = colValue.replace(/<\/?[^>]+(>|$)/g, "");
                 tr.appendChild(td);
             });
             tbdy.appendChild(tr);


### PR DESCRIPTION
This is a copy of #13336 to trigger CI.  This should be closed once #13336 gets merged.

### Description

Sanitize the column values so HTML doesn't get accidentally rendered when creating PDFs.

### User-facing documentation

N/A

### Testing and quality
- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag

#### Automated testing

No automated tests needed.
