### PR TITLE
ROX-26055: TLS certs loader init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-26849: Introduce report caching for RHCOS Node Indexing
 - ROX-25638: Introduce configurable log rotation. `ROX_LOGGING_MAX_ROTATION_FILES` and `ROX_LOGGING_MAX_SIZE_MB` variables allow for configuring the number and the size of a central log rotation file.
+- ROX-14332: Auto certificate renewal for Secured Clusters
 
 ### Removed Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-26849: Introduce report caching for RHCOS Node Indexing
 - ROX-25638: Introduce configurable log rotation. `ROX_LOGGING_MAX_ROTATION_FILES` and `ROX_LOGGING_MAX_SIZE_MB` variables allow for configuring the number and the size of a central log rotation file.
-- ROX-14332: Auto certificate renewal for Secured Clusters
+- ROX-14332: Automatic service certificate renewal for Secured Clusters installed using Helm or operator.
 
 ### Removed Features
 

--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,7 @@ main-build-dockerized: build-volumes
 main-build-nodeps: central-build-nodeps migrator-build-nodeps config-controller-build-nodeps
 	$(GOBUILD) sensor/kubernetes sensor/admission-control compliance/cmd/compliance
 	$(GOBUILD) sensor/upgrader
+	$(GOBUILD) sensor/init-tls-certs
 ifndef CI
 	CGO_ENABLED=0 $(GOBUILD) roxctl
 endif
@@ -673,6 +674,7 @@ endif
 endif
 	cp bin/linux_$(GOARCH)/migrator image/rhel/bin/migrator
 	cp bin/linux_$(GOARCH)/kubernetes        image/rhel/bin/kubernetes-sensor
+	cp bin/linux_$(GOARCH)/init-tls-certs    image/rhel/bin/init-tls-certs
 	cp bin/linux_$(GOARCH)/upgrader          image/rhel/bin/sensor-upgrader
 	cp bin/linux_$(GOARCH)/admission-control image/rhel/bin/admission-control
 	cp bin/linux_$(GOARCH)/compliance        image/rhel/bin/compliance

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -85,6 +85,7 @@ COPY bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
 COPY bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
 COPY bin/admission-control  /stackrox/bin/admission-control
 COPY bin/config-controller  /stackrox/bin/config-controller
+COPY bin/init-tls-certs     /stackrox/bin/init-tls-certs
 COPY bin/roxctl*            /assets/downloads/cli/
 
 RUN ln -s /assets/downloads/cli/roxctl-linux-${TARGET_ARCH} /stackrox/roxctl && \

--- a/image/rhel/README.md
+++ b/image/rhel/README.md
@@ -3,7 +3,3 @@
 The RedHat based main image is currently used for the RedHat marketplace as well as for DoD customers.
 
 This image is built in opinionated way based on the DoD Centralized Artifacts Repository (DCAR) requirements outlined [here](https://dccscr.dsop.io/dsop/dccscr/tree/master/contributor-onboarding)
-
-## Adding new files to the main-rhel container
-
-To add a new file artifact to the rhel container, include it in `create-bundle.sh` script, do not add it to the Dockerfile in this directory.

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -96,6 +96,7 @@ COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/kubern
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/sensor-upgrader /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/admission-control /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/config-controller /stackrox/bin/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/init-tls-certs /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/static-bin/* /stackrox/
 RUN GOARCH=$(uname -m) ; \
     case $GOARCH in x86_64) GOARCH=amd64 ;; aarch64) GOARCH=arm64 ;; esac ; \

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -49,7 +49,7 @@ spec:
       {{- if ._rox.scanner.priorityClassName }}
       priorityClassName: {{ ._rox.scanner.priorityClassName }}
       {{- end }}
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -173,7 +173,7 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -280,7 +280,7 @@ spec:
       priorityClassName: {{ ._rox.scanner.dbPriorityClassName }}
       {{- end }}
       initContainers:
-        {{- if ._rox.env.securedClusterCertRefresh }}
+        {{- if ._rox._securedClusterCertRefresh }}
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
           command:
@@ -357,7 +357,7 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -49,7 +49,7 @@ spec:
       {{- if ._rox.scanner.priorityClassName }}
       priorityClassName: {{ ._rox.scanner.priorityClassName }}
       {{- end }}
-      {{- if not ._rox.env.centralServices }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -169,11 +169,7 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      {{- if ._rox.env.centralServices }}
-      - name: certs
-        secret:
-          secretName: scanner-tls
-      {{- else }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -184,6 +180,10 @@ spec:
         secret:
           secretName: tls-cert-scanner
           optional: true
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: scanner-tls
       {{- end }}
       - name: vuln-temp-db
         emptyDir: {}
@@ -276,7 +276,7 @@ spec:
       priorityClassName: {{ ._rox.scanner.dbPriorityClassName }}
       {{- end }}
       initContainers:
-        {{- if not ._rox.env.centralServices }}
+        {{- if ._rox.env.securedClusterCertRefresh }}
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
           command:
@@ -349,19 +349,7 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      {{- if ._rox.env.centralServices }}
-      - name: certs
-        secret:
-          secretName: scanner-db-tls
-          defaultMode: 0640
-          items:
-          - key: cert.pem
-            path: server.crt
-          - key: key.pem
-            path: server.key
-          - key: ca.pem
-            path: root.crt
-      {{- else }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -379,6 +367,18 @@ spec:
         secret:
           secretName: tls-cert-scanner-db
           optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: scanner-db-tls
+          defaultMode: 0640
           items:
           - key: cert.pem
             path: server.crt

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -56,9 +56,9 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           args:
-          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          - --legacy=/run/secrets/stackrox.io/certs-legacy/
+          - --new=/run/secrets/stackrox.io/certs-new/
+          - --destination=/run/secrets/stackrox.io/certs/
           resources:
             {{- ._rox.scanner._resources | nindent 12 }}
           securityContext:
@@ -66,13 +66,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-legacy/
             readOnly: true
           - name: certs-new
-            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-new/
             readOnly: true
           - name: certs
-            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       - name: scanner
@@ -286,9 +286,9 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           args:
-          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          - --legacy=/run/secrets/stackrox.io/certs-legacy/
+          - --new=/run/secrets/stackrox.io/certs-new/
+          - --destination=/run/secrets/stackrox.io/certs/
           resources:
             {{- ._rox.scanner._dbResources | nindent 12 }}
           securityContext:
@@ -296,13 +296,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-legacy/
             readOnly: true
           - name: certs-new
-            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-new/
             readOnly: true
           - name: certs
-            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs/
         {{- end }}
         - name: init-db
           {{ if eq ._rox.scanner.mode "slim" -}}

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -56,7 +56,7 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           resources:
-            {{- ._rox.admissionControl._resources | nindent 12 }}
+            {{- ._rox.scanner._resources | nindent 12 }}
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
@@ -282,7 +282,7 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           resources:
-            {{- ._rox.admissionControl._resources | nindent 12 }}
+            {{- ._rox.scanner._dbResources | nindent 12 }}
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -49,6 +49,27 @@ spec:
       {{- if ._rox.scanner.priorityClassName }}
       priorityClassName: {{ ._rox.scanner.priorityClassName }}
       {{- end }}
+      {{- if not ._rox.env.centralServices }}
+      initContainers:
+        - name: init-tls-certs
+          image: {{ quote ._rox.image.main.fullRef }}
+          command:
+          - /stackrox/bin/init-tls-certs
+          resources:
+            {{- ._rox.admissionControl._resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: certs-legacy
+            mountPath: /tmp/certs-legacy
+            readOnly: true
+          - name: certs-new
+            mountPath: /tmp/certs-new
+            readOnly: true
+          - name: certs
+            mountPath: /tmp/certs
+      {{- end }}
       containers:
       - name: scanner
         {{ if eq ._rox.scanner.mode "slim" -}}
@@ -115,7 +136,7 @@ spec:
         - name: scanner-config-volume
           mountPath: /etc/scanner
           readOnly: true
-        - name: scanner-tls-volume
+        - name: certs
           mountPath: /run/secrets/stackrox.io/certs/
           readOnly: true
         - name: vuln-temp-db
@@ -148,9 +169,22 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      - name: scanner-tls-volume
+      {{- if ._rox.env.centralServices }}
+      - name: certs
         secret:
           secretName: scanner-tls
+      {{- else }}
+      - name: certs
+        emptyDir: {}
+      - name: certs-legacy
+        secret:
+          secretName: scanner-tls
+          optional: true
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner
+          optional: true
+      {{- end }}
       - name: vuln-temp-db
         emptyDir: {}
       - name: proxy-config-volume
@@ -242,6 +276,26 @@ spec:
       priorityClassName: {{ ._rox.scanner.dbPriorityClassName }}
       {{- end }}
       initContainers:
+        {{- if not ._rox.env.centralServices }}
+        - name: init-tls-certs
+          image: {{ quote ._rox.image.main.fullRef }}
+          command:
+          - /stackrox/bin/init-tls-certs
+          resources:
+            {{- ._rox.admissionControl._resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: certs-legacy
+            mountPath: /tmp/certs-legacy
+            readOnly: true
+          - name: certs-new
+            mountPath: /tmp/certs-new
+            readOnly: true
+          - name: certs
+            mountPath: /tmp/certs
+        {{- end }}
         - name: init-db
           {{ if eq ._rox.scanner.mode "slim" -}}
           image: {{ ._rox.scanner.slimDBImage.fullRef | quote }}
@@ -258,7 +312,7 @@ spec:
           volumeMounts:
             - name: scanner-db-data
               mountPath: /var/lib/postgresql/data
-            - name: scanner-db-tls-volume
+            - name: certs
               mountPath: /run/secrets/stackrox.io/certs
               readOnly: true
             - name: scanner-db-password
@@ -282,7 +336,7 @@ spec:
         volumeMounts:
           - name: scanner-db-data
             mountPath: /var/lib/postgresql/data
-          - name: scanner-db-tls-volume
+          - name: certs
             mountPath: /run/secrets/stackrox.io/certs
             readOnly: true
       serviceAccountName: scanner
@@ -295,10 +349,8 @@ spec:
       - name: scanner-config-volume
         configMap:
           name: scanner-config
-      - name: scanner-tls-volume
-        secret:
-          secretName: scanner-tls
-      - name: scanner-db-tls-volume
+      {{- if ._rox.env.centralServices }}
+      - name: certs
         secret:
           secretName: scanner-db-tls
           defaultMode: 0640
@@ -309,6 +361,32 @@ spec:
             path: server.key
           - key: ca.pem
             path: root.crt
+      {{- else }}
+      - name: certs
+        emptyDir: {}
+      - name: certs-legacy
+        secret:
+          secretName: scanner-db-tls
+          optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner-db
+          optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      {{- end }}
       - name: scanner-db-data
         emptyDir: {}
       - name: scanner-db-password

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -55,6 +55,10 @@ spec:
           image: {{ quote ._rox.image.main.fullRef }}
           command:
           - /stackrox/bin/init-tls-certs
+          args:
+          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
           resources:
             {{- ._rox.scanner._resources | nindent 12 }}
           securityContext:
@@ -62,13 +66,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: /tmp/certs-legacy
+            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
             readOnly: true
           - name: certs-new
-            mountPath: /tmp/certs-new
+            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
             readOnly: true
           - name: certs
-            mountPath: /tmp/certs
+            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       containers:
       - name: scanner
@@ -281,6 +285,10 @@ spec:
           image: {{ quote ._rox.image.main.fullRef }}
           command:
           - /stackrox/bin/init-tls-certs
+          args:
+          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
           resources:
             {{- ._rox.scanner._dbResources | nindent 12 }}
           securityContext:
@@ -288,13 +296,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: /tmp/certs-legacy
+            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
             readOnly: true
           - name: certs-new
-            mountPath: /tmp/certs-new
+            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
             readOnly: true
           - name: certs
-            mountPath: /tmp/certs
+            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
         {{- end }}
         - name: init-db
           {{ if eq ._rox.scanner.mode "slim" -}}

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -51,28 +51,28 @@ spec:
       {{- end }}
       {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
-        - name: init-tls-certs
-          image: {{ quote ._rox.image.main.fullRef }}
-          command:
-          - /stackrox/bin/init-tls-certs
-          args:
-          - --legacy=/run/secrets/stackrox.io/certs-legacy/
-          - --new=/run/secrets/stackrox.io/certs-new/
-          - --destination=/run/secrets/stackrox.io/certs/
-          resources:
-            {{- ._rox.scanner._resources | nindent 12 }}
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-          volumeMounts:
-          - name: certs-legacy
-            mountPath: /run/secrets/stackrox.io/certs-legacy/
-            readOnly: true
-          - name: certs-new
-            mountPath: /run/secrets/stackrox.io/certs-new/
-            readOnly: true
-          - name: certs
-            mountPath: /run/secrets/stackrox.io/certs/
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
+        resources:
+          {{- ._rox.scanner._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
+          readOnly: true
+        - name: certs-new
+          mountPath: /run/secrets/stackrox.io/certs-new/
+          readOnly: true
+        - name: certs
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       - name: scanner
@@ -280,52 +280,52 @@ spec:
       priorityClassName: {{ ._rox.scanner.dbPriorityClassName }}
       {{- end }}
       initContainers:
-        {{- if ._rox._securedClusterCertRefresh }}
-        - name: init-tls-certs
-          image: {{ quote ._rox.image.main.fullRef }}
-          command:
-          - /stackrox/bin/init-tls-certs
-          args:
-          - --legacy=/run/secrets/stackrox.io/certs-legacy/
-          - --new=/run/secrets/stackrox.io/certs-new/
-          - --destination=/run/secrets/stackrox.io/certs/
-          resources:
-            {{- ._rox.scanner._dbResources | nindent 12 }}
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-          volumeMounts:
-          - name: certs-legacy
-            mountPath: /run/secrets/stackrox.io/certs-legacy/
-            readOnly: true
-          - name: certs-new
-            mountPath: /run/secrets/stackrox.io/certs-new/
-            readOnly: true
+      {{- if ._rox._securedClusterCertRefresh }}
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
+        resources:
+          {{- ._rox.scanner._dbResources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
+          readOnly: true
+        - name: certs-new
+          mountPath: /run/secrets/stackrox.io/certs-new/
+          readOnly: true
+        - name: certs
+          mountPath: /run/secrets/stackrox.io/certs/
+      {{- end }}
+      - name: init-db
+        {{ if eq ._rox.scanner.mode "slim" -}}
+        image: {{ ._rox.scanner.slimDBImage.fullRef | quote }}
+        {{ else -}}
+        image: {{ ._rox.scanner.dbImage.fullRef | quote }}
+        {{ end -}}
+        env:
+          - name: POSTGRES_PASSWORD_FILE
+            value: "/run/secrets/stackrox.io/secrets/password"
+          - name: ROX_SCANNER_DB_INIT
+            value: "true"
+        resources:
+          {{- ._rox.scanner._dbResources | nindent 12 }}
+        volumeMounts:
+          - name: scanner-db-data
+            mountPath: /var/lib/postgresql/data
           - name: certs
-            mountPath: /run/secrets/stackrox.io/certs/
-        {{- end }}
-        - name: init-db
-          {{ if eq ._rox.scanner.mode "slim" -}}
-          image: {{ ._rox.scanner.slimDBImage.fullRef | quote }}
-          {{ else -}}
-          image: {{ ._rox.scanner.dbImage.fullRef | quote }}
-          {{ end -}}
-          env:
-            - name: POSTGRES_PASSWORD_FILE
-              value: "/run/secrets/stackrox.io/secrets/password"
-            - name: ROX_SCANNER_DB_INIT
-              value: "true"
-          resources:
-            {{- ._rox.scanner._dbResources | nindent 12 }}
-          volumeMounts:
-            - name: scanner-db-data
-              mountPath: /var/lib/postgresql/data
-            - name: certs
-              mountPath: /run/secrets/stackrox.io/certs
-              readOnly: true
-            - name: scanner-db-password
-              mountPath: /run/secrets/stackrox.io/secrets
-              readOnly: true
+            mountPath: /run/secrets/stackrox.io/certs
+            readOnly: true
+          - name: scanner-db-password
+            mountPath: /run/secrets/stackrox.io/secrets
+            readOnly: true
       containers:
       - name: db
         {{ if eq ._rox.scanner.mode "slim" -}}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -53,9 +53,9 @@ spec:
         command:
         - /stackrox/bin/init-tls-certs
         args:
-        - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-        - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-        - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
         resources:
           {{- ._rox.scannerV4.db._resources | nindent 12 }}
         securityContext:
@@ -63,13 +63,13 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: certs-legacy
-          mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
           readOnly: true
         - name: certs-new
-          mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs-new/
           readOnly: true
         - name: certs
-          mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       - name: init-db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         command:
         - /stackrox/bin/init-tls-certs
         resources:
-          {{- ._rox.admissionControl._resources | nindent 12 }}
+          {{- ._rox.scannerV4.db._resources | nindent 12 }}
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -47,6 +47,26 @@ spec:
       serviceAccountName: scanner-v4
       terminationGracePeriodSeconds: 120
       initContainers:
+      {{- if not ._rox.env.centralServices }}
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        resources:
+          {{- ._rox.admissionControl._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /tmp/certs-legacy
+          readOnly: true
+        - name: certs-new
+          mountPath: /tmp/certs-new
+          readOnly: true
+        - name: certs
+          mountPath: /tmp/certs
+      {{- end }}
       - name: init-db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}
         env:
@@ -108,7 +128,7 @@ spec:
           mountPath: /var/lib/postgresql/data
         - name: config-volume
           mountPath: /etc/stackrox.d/config/
-        - name: scanner-db-tls-volume
+        - name: certs
           mountPath: /run/secrets/stackrox.io/certs
         - name: shared-memory
           mountPath: /dev/shm
@@ -120,7 +140,8 @@ spec:
       - name: config-volume
         configMap:
           name: {{ default "scanner-v4-db-config" ._rox.scannerV4.db.configOverride }}
-      - name: scanner-db-tls-volume
+      {{- if ._rox.env.centralServices }}
+      - name: certs
         secret:
           secretName: scanner-v4-db-tls
           defaultMode: 0640
@@ -131,6 +152,32 @@ spec:
             path: server.key
           - key: ca.pem
             path: root.crt
+      {{- else }}
+      - name: certs
+        emptyDir: {}
+      - name: certs-legacy
+        secret:
+          secretName: scanner-v4-db-tls
+          optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner-v4-db
+          optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      {{- end }}
       - name: shared-memory
         emptyDir:
           medium: Memory

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: scanner-v4
       terminationGracePeriodSeconds: 120
       initContainers:
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: init-tls-certs
         image: {{ quote ._rox.image.main.fullRef }}
         command:
@@ -141,7 +141,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ default "scanner-v4-db-config" ._rox.scannerV4.db.configOverride }}
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -90,9 +90,6 @@ spec:
           readOnly: true
         resources:
           {{- ._rox.scannerV4.db._resources | nindent 10 }}
-        securityContext:
-          runAsUser: 70
-          runAsGroup: 70
       containers:
       - name: db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}
@@ -120,9 +117,6 @@ spec:
           timeoutSeconds: 1
         resources:
           {{- ._rox.scannerV4.db._resources | nindent 10 }}
-        securityContext:
-          runAsUser: 70
-          runAsGroup: 70
         volumeMounts:
         - name: disk
           mountPath: /var/lib/postgresql/data
@@ -134,6 +128,9 @@ spec:
           mountPath: /dev/shm
       securityContext:
         fsGroup: 70
+        runAsUser: 70
+        runAsNonRoot: true
+        runAsGroup: 70
       volumes:
       - name: disk
         {{- toYaml ._rox.scannerV4.db.persistence._volumeCfg | nindent 8 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: scanner-v4
       terminationGracePeriodSeconds: 120
       initContainers:
-      {{- if not ._rox.env.centralServices }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: init-tls-certs
         image: {{ quote ._rox.image.main.fullRef }}
         command:
@@ -137,19 +137,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ default "scanner-v4-db-config" ._rox.scannerV4.db.configOverride }}
-      {{- if ._rox.env.centralServices }}
-      - name: certs
-        secret:
-          secretName: scanner-v4-db-tls
-          defaultMode: 0640
-          items:
-          - key: cert.pem
-            path: server.crt
-          - key: key.pem
-            path: server.key
-          - key: ca.pem
-            path: root.crt
-      {{- else }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -167,6 +155,18 @@ spec:
         secret:
           secretName: tls-cert-scanner-v4-db
           optional: true
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: scanner-v4-db-tls
+          defaultMode: 0640
           items:
           - key: cert.pem
             path: server.crt

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -52,6 +52,10 @@ spec:
         image: {{ quote ._rox.image.main.fullRef }}
         command:
         - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+        - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+        - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
         resources:
           {{- ._rox.scannerV4.db._resources | nindent 12 }}
         securityContext:
@@ -59,13 +63,13 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: certs-legacy
-          mountPath: /tmp/certs-legacy
+          mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
           readOnly: true
         - name: certs-new
-          mountPath: /tmp/certs-new
+          mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
           readOnly: true
         - name: certs
-          mountPath: /tmp/certs
+          mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       - name: init-db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -155,6 +155,10 @@ spec:
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
       securityContext:
         runAsNonRoot: true
+        {{- if not ._rox.env.openshift }}
+        runAsUser: 4000
+        fsGroup: 4000
+        {{- end }}
       serviceAccountName: scanner-v4
       volumes:
       - name: additional-ca-volume

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -51,9 +51,9 @@ spec:
         command:
         - /stackrox/bin/init-tls-certs
         args:
-        - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-        - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-        - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
         resources:
           {{- ._rox.scannerV4.indexer._resources | nindent 12 }}
         securityContext:
@@ -61,13 +61,13 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: certs-legacy
-          mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
           readOnly: true
         - name: certs-new
-          mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs-new/
           readOnly: true
         - name: certs
-          mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       - name: indexer

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -44,6 +44,27 @@ spec:
       {{- if ._rox.scannerV4.indexer.hostAliases }}
       hostAliases: {{ toYaml ._rox.scannerV4.indexer.hostAliases | nindent 8 }}
       {{- end }}
+      {{- if not ._rox.env.centralServices }}
+      initContainers:
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        resources:
+          {{- ._rox.admissionControl._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /tmp/certs-legacy
+          readOnly: true
+        - name: certs-new
+          mountPath: /tmp/certs-new
+          readOnly: true
+        - name: certs
+          mountPath: /tmp/certs
+      {{- end }}
       containers:
       - name: indexer
         image: {{ ._rox.scannerV4.indexer.image.fullRef | quote }}
@@ -112,7 +133,7 @@ spec:
           mountPath: /etc/ssl
         - name: etc-pki-volume
           mountPath: /etc/pki/ca-trust
-        - name: tls-volume
+        - name: certs
           mountPath: /run/secrets/stackrox.io/certs/
           readOnly: true
         - name: config-volume
@@ -148,9 +169,22 @@ spec:
         emptyDir: {}
       - name: etc-pki-volume
         emptyDir: {}
-      - name: tls-volume
+      {{- if ._rox.env.centralServices }}
+      - name: certs
         secret:
           secretName: scanner-v4-indexer-tls
+      {{- else }}
+      - name: certs
+        emptyDir: {}
+      - name: certs-legacy
+        secret:
+          secretName: scanner-v4-indexer-tls
+          optional: true
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner-v4-indexer
+          optional: true
+      {{- end }}
       - name: config-volume
         configMap:
           name: scanner-v4-indexer-config

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- if ._rox.scannerV4.indexer.hostAliases }}
       hostAliases: {{ toYaml ._rox.scannerV4.indexer.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if not ._rox.env.centralServices }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       initContainers:
       - name: init-tls-certs
         image: {{ quote ._rox.image.main.fullRef }}
@@ -173,11 +173,7 @@ spec:
         emptyDir: {}
       - name: etc-pki-volume
         emptyDir: {}
-      {{- if ._rox.env.centralServices }}
-      - name: certs
-        secret:
-          secretName: scanner-v4-indexer-tls
-      {{- else }}
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -188,6 +184,10 @@ spec:
         secret:
           secretName: tls-cert-scanner-v4-indexer
           optional: true
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: scanner-v4-indexer-tls
       {{- end }}
       - name: config-volume
         configMap:

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -50,6 +50,10 @@ spec:
         image: {{ quote ._rox.image.main.fullRef }}
         command:
         - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+        - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+        - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
         resources:
           {{- ._rox.scannerV4.indexer._resources | nindent 12 }}
         securityContext:
@@ -57,13 +61,13 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: certs-legacy
-          mountPath: /tmp/certs-legacy
+          mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
           readOnly: true
         - name: certs-new
-          mountPath: /tmp/certs-new
+          mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
           readOnly: true
         - name: certs
-          mountPath: /tmp/certs
+          mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       containers:
       - name: indexer

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- if ._rox.scannerV4.indexer.hostAliases }}
       hostAliases: {{ toYaml ._rox.scannerV4.indexer.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
       - name: init-tls-certs
         image: {{ quote ._rox.image.main.fullRef }}
@@ -177,7 +177,7 @@ spec:
         emptyDir: {}
       - name: etc-pki-volume
         emptyDir: {}
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -51,7 +51,7 @@ spec:
         command:
         - /stackrox/bin/init-tls-certs
         resources:
-          {{- ._rox.admissionControl._resources | nindent 12 }}
+          {{- ._rox.scannerV4.indexer._resources | nindent 12 }}
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -1,0 +1,19 @@
+{{/*
+  srox.setSecuredClusterCertRefresh
+
+  Checks if Secured Cluster certificate refresh is enabled in the current context, and sets
+  the securedClusterCertRefresh accordingly.
+
+  It should be enabled for Helm and Operator installs, and only on Secured Clusters.
+   */}}
+
+{{ define "srox.setSecuredClusterCertRefresh" }}
+
+{{ $ := index . 0 }}
+{{ $env := $._rox.env }}
+
+{{ if and (not $env.centralServices) (ne $env.installMethod "manifest") }}
+  {{ $_ := set $env "securedClusterCertRefresh" true }}
+{{ end }}
+
+{{ end }}

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -13,7 +13,7 @@
 {{ $env := $._rox.env }}
 
 {{ if and (not $env.centralServices) (ne $env.installMethod "manifest") }}
-  {{ $_ := set $env "securedClusterCertRefresh" true }}
+  {{ $_ := set $._rox "_securedClusterCertRefresh" true }}
 {{ end }}
 
 {{ end }}

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -14,7 +14,7 @@
 
 {{ $_ := set $._rox "_securedClusterCertRefresh" false }}
 
-{{ if and (not $env.centralServices) (ne $env.installMethod "manifest") }}
+{{ if and (not $env.centralServices) (ne $._rox.managedBy "MANAGER_TYPE_MANUAL") }}
   {{ $_ := set $._rox "_securedClusterCertRefresh" true }}
 {{ end }}
 

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -10,11 +10,10 @@
 {{ define "srox.setSecuredClusterCertRefresh" }}
 
 {{ $ := index . 0 }}
-{{ $env := $._rox.env }}
 
 {{ $_ := set $._rox "_securedClusterCertRefresh" false }}
 
-{{ if and (not $env.centralServices) (ne $._rox.managedBy "MANAGER_TYPE_MANUAL") }}
+{{ if and (not $._rox.env.centralServices) (ne $._rox.managedBy "MANAGER_TYPE_MANUAL") }}
   {{ $_ := set $._rox "_securedClusterCertRefresh" true }}
 {{ end }}
 

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -17,15 +17,3 @@
 {{ end }}
 
 {{ end }}
-
-{{- define "srox.securedClusterCertRefresh.certsPath" -}}
-/tmp/certs
-{{- end }}
-
-{{- define "srox.securedClusterCertRefresh.newCertsPath" -}}
-/tmp/certs-new
-{{- end }}
-
-{{- define "srox.securedClusterCertRefresh.legacyCertsPath" -}}
-/tmp/certs-legacy
-{{- end }}

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -12,6 +12,8 @@
 {{ $ := index . 0 }}
 {{ $env := $._rox.env }}
 
+{{ $_ := set $._rox "_securedClusterCertRefresh" false }}
+
 {{ if and (not $env.centralServices) (ne $env.installMethod "manifest") }}
   {{ $_ := set $._rox "_securedClusterCertRefresh" true }}
 {{ end }}

--- a/image/templates/helm/shared/templates/_certrefresh.tpl
+++ b/image/templates/helm/shared/templates/_certrefresh.tpl
@@ -17,3 +17,15 @@
 {{ end }}
 
 {{ end }}
+
+{{- define "srox.securedClusterCertRefresh.certsPath" -}}
+/tmp/certs
+{{- end }}
+
+{{- define "srox.securedClusterCertRefresh.newCertsPath" -}}
+/tmp/certs-new
+{{- end }}
+
+{{- define "srox.securedClusterCertRefresh.legacyCertsPath" -}}
+/tmp/certs-legacy
+{{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -129,8 +129,6 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
-{{ include "srox.setSecuredClusterCertRefresh" (list $) }}
-
 {{ include "srox.applyDefaults" $ }}
 {{ include "srox.ensureCentralEndpointContainsPort" $ }}
 
@@ -272,6 +270,8 @@ The following block checks for the validity of the provided init bundle. (`helm 
 {{- if not ._rox.helmManaged }}
   {{ $_ = set $._rox "managedBy" "MANAGER_TYPE_MANUAL" }}
 {{- end }}
+
+{{ include "srox.setSecuredClusterCertRefresh" (list $) }}
 
 [< if (not .KubectlOutput) ->]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -129,6 +129,8 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
+{{ include "srox.setSecuredClusterCertRefresh" (list $) }}
+
 {{ include "srox.applyDefaults" $ }}
 {{ include "srox.ensureCentralEndpointContainsPort" $ }}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -53,6 +53,7 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: admission-control
+      {{- if ._rox.env.securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -72,6 +73,7 @@ spec:
             readOnly: true
           - name: certs
             mountPath: /tmp/certs
+      {{- end }}
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}
           imagePullPolicy: {{ ._rox.admissionControl.imagePullPolicy }}
@@ -131,6 +133,7 @@ spec:
               readOnly: true
             {{- include "srox.injectedCABundleVolumeMount" . | nindent 12 }}
       volumes:
+        {{- if ._rox.env.securedClusterCertRefresh }}
         - name: certs
           emptyDir: {}
         - name: certs-legacy
@@ -148,6 +151,19 @@ spec:
           secret:
             secretName: tls-cert-admission-control
             optional: true
+        {{- else }}
+        - name: certs
+          secret:
+            secretName: admission-control-tls
+            optional: true
+            items:
+            - key: admission-control-cert.pem
+              path: cert.pem
+            - key: admission-control-key.pem
+              path: key.pem
+            - key: ca.pem
+              path: ca.pem
+        {{- end }}
         - name: ca
           secret:
             secretName: service-ca

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -67,6 +67,9 @@ spec:
           - name: certs-legacy
             mountPath: /tmp/certs-legacy
             readOnly: true
+          - name: certs-new
+            mountPath: /tmp/certs-new
+            readOnly: true
           - name: certs
             mountPath: /tmp/certs
       containers:
@@ -141,6 +144,17 @@ spec:
                 path: key.pem
               - key: ca.pem
                 path: ca.pem
+        - name: certs-new
+          secret:
+            secretName: tls-cert-admission-control
+            optional: true
+            items:
+            - key: cert.pem
+              path: cert.pem
+            - key: key.pem
+              path: key.pem
+            - key: ca.pem
+              path: ca.pem
         - name: ca
           secret:
             secretName: service-ca

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -53,7 +53,7 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: admission-control
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -137,7 +137,7 @@ spec:
               readOnly: true
             {{- include "srox.injectedCABundleVolumeMount" . | nindent 12 }}
       volumes:
-        {{- if ._rox.env.securedClusterCertRefresh }}
+        {{- if ._rox._securedClusterCertRefresh }}
         - name: certs
           emptyDir: {}
         - name: certs-legacy

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -60,9 +60,9 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           args:
-          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          - --legacy=/run/secrets/stackrox.io/certs-legacy/
+          - --new=/run/secrets/stackrox.io/certs-new/
+          - --destination=/run/secrets/stackrox.io/certs/
           resources:
             {{- ._rox.admissionControl._resources | nindent 12 }}
           securityContext:
@@ -70,13 +70,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-legacy/
             readOnly: true
           - name: certs-new
-            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-new/
             readOnly: true
           - name: certs
-            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -63,6 +63,12 @@ spec:
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: certs-legacy
+            mountPath: /tmp/certs-legacy
+            readOnly: true
+          - name: certs
+            mountPath: /tmp/certs
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}
           imagePullPolicy: {{ ._rox.admissionControl.imagePullPolicy }}
@@ -123,6 +129,8 @@ spec:
             {{- include "srox.injectedCABundleVolumeMount" . | nindent 12 }}
       volumes:
         - name: certs
+          emptyDir: {}
+        - name: certs-legacy
           secret:
             secretName: admission-control-tls
             optional: true

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -148,13 +148,6 @@ spec:
           secret:
             secretName: tls-cert-admission-control
             optional: true
-            items:
-            - key: cert.pem
-              path: cert.pem
-            - key: key.pem
-              path: key.pem
-            - key: ca.pem
-              path: ca.pem
         - name: ca
           secret:
             secretName: service-ca

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -55,28 +55,28 @@ spec:
       serviceAccountName: admission-control
       {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
-        - name: init-tls-certs
-          image: {{ quote ._rox.image.main.fullRef }}
-          command:
-          - /stackrox/bin/init-tls-certs
-          args:
-          - --legacy=/run/secrets/stackrox.io/certs-legacy/
-          - --new=/run/secrets/stackrox.io/certs-new/
-          - --destination=/run/secrets/stackrox.io/certs/
-          resources:
-            {{- ._rox.admissionControl._resources | nindent 12 }}
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-          volumeMounts:
-          - name: certs-legacy
-            mountPath: /run/secrets/stackrox.io/certs-legacy/
-            readOnly: true
-          - name: certs-new
-            mountPath: /run/secrets/stackrox.io/certs-new/
-            readOnly: true
-          - name: certs
-            mountPath: /run/secrets/stackrox.io/certs/
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
+        resources:
+          {{- ._rox.admissionControl._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
+          readOnly: true
+        - name: certs-new
+          mountPath: /run/secrets/stackrox.io/certs-new/
+          readOnly: true
+        - name: certs
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -53,6 +53,16 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: admission-control
+      initContainers:
+        - name: init-tls-certs
+          image: {{ quote ._rox.image.main.fullRef }}
+          command:
+          - /stackrox/bin/init-tls-certs
+          resources:
+            {{- ._rox.admissionControl._resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}
           imagePullPolicy: {{ ._rox.admissionControl.imagePullPolicy }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -59,6 +59,10 @@ spec:
           image: {{ quote ._rox.image.main.fullRef }}
           command:
           - /stackrox/bin/init-tls-certs
+          args:
+          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
           resources:
             {{- ._rox.admissionControl._resources | nindent 12 }}
           securityContext:
@@ -66,13 +70,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: /tmp/certs-legacy
+            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
             readOnly: true
           - name: certs-new
-            mountPath: /tmp/certs-new
+            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
             readOnly: true
           - name: certs
-            mountPath: /tmp/certs
+            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       containers:
         - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -47,28 +47,28 @@ spec:
       serviceAccountName: collector
       {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
-        - name: init-tls-certs
-          image: {{ quote ._rox.image.main.fullRef }}
-          command:
-          - /stackrox/bin/init-tls-certs
-          args:
-          - --legacy=/run/secrets/stackrox.io/certs-legacy/
-          - --new=/run/secrets/stackrox.io/certs-new/
-          - --destination=/run/secrets/stackrox.io/certs/
-          resources:
-            {{- ._rox.collector._resources | nindent 12 }}
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-          volumeMounts:
-          - name: certs-legacy
-            mountPath: /run/secrets/stackrox.io/certs-legacy/
-            readOnly: true
-          - name: certs-new
-            mountPath: /run/secrets/stackrox.io/certs-new/
-            readOnly: true
-          - name: certs
-            mountPath: /run/secrets/stackrox.io/certs/
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
+        resources:
+          {{- ._rox.collector._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
+          readOnly: true
+        - name: certs-new
+          mountPath: /run/secrets/stackrox.io/certs-new/
+          readOnly: true
+        - name: certs
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       {{- if ne ._rox.collector.collectionMethod "NO_COLLECTION"}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -45,6 +45,7 @@ spec:
       hostAliases: {{ toYaml ._rox.collector.hostAliases | nindent 8 }}
       {{- end }}
       serviceAccountName: collector
+      {{- if ._rox.env.securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -64,6 +65,7 @@ spec:
             readOnly: true
           - name: certs
             mountPath: /tmp/certs
+      {{- end }}
       containers:
       {{- if ne ._rox.collector.collectionMethod "NO_COLLECTION"}}
       - name: collector
@@ -256,6 +258,7 @@ spec:
       - hostPath:
           path: /dev
         name: dev-ro
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -273,6 +276,19 @@ spec:
         secret:
           secretName: tls-cert-collector
           optional: true
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: collector-tls
+          optional: true
+          items:
+          - key: collector-cert.pem
+            path: cert.pem
+          - key: collector-key.pem
+            path: key.pem
+          - key: ca.pem
+            path: ca.pem
+      {{- end }}
       - hostPath:
           path: /
         name: host-root-ro

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -51,7 +51,7 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           resources:
-            {{- ._rox.admissionControl._resources | nindent 12 }}
+            {{- ._rox.collector._resources | nindent 12 }}
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -52,9 +52,9 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           args:
-          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          - --legacy=/run/secrets/stackrox.io/certs-legacy/
+          - --new=/run/secrets/stackrox.io/certs-new/
+          - --destination=/run/secrets/stackrox.io/certs/
           resources:
             {{- ._rox.collector._resources | nindent 12 }}
           securityContext:
@@ -62,13 +62,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-legacy/
             readOnly: true
           - name: certs-new
-            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-new/
             readOnly: true
           - name: certs
-            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       {{- if ne ._rox.collector.collectionMethod "NO_COLLECTION"}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -45,7 +45,7 @@ spec:
       hostAliases: {{ toYaml ._rox.collector.hostAliases | nindent 8 }}
       {{- end }}
       serviceAccountName: collector
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -262,7 +262,7 @@ spec:
       - hostPath:
           path: /dev
         name: dev-ro
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -45,6 +45,25 @@ spec:
       hostAliases: {{ toYaml ._rox.collector.hostAliases | nindent 8 }}
       {{- end }}
       serviceAccountName: collector
+      initContainers:
+        - name: init-tls-certs
+          image: {{ quote ._rox.image.main.fullRef }}
+          command:
+          - /stackrox/bin/init-tls-certs
+          resources:
+            {{- ._rox.admissionControl._resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: certs-legacy
+            mountPath: /tmp/certs-legacy
+            readOnly: true
+          - name: certs-new
+            mountPath: /tmp/certs-new
+            readOnly: true
+          - name: certs
+            mountPath: /tmp/certs
       containers:
       {{- if ne ._rox.collector.collectionMethod "NO_COLLECTION"}}
       - name: collector
@@ -238,6 +257,8 @@ spec:
           path: /dev
         name: dev-ro
       - name: certs
+        emptyDir: {}
+      - name: certs-legacy
         secret:
           secretName: collector-tls
           items:
@@ -247,6 +268,9 @@ spec:
             path: key.pem
           - key: ca.pem
             path: ca.pem
+      - name: certs-new
+        secret:
+          secretName: tls-cert-collector
       - hostPath:
           path: /
         name: host-root-ro

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -261,6 +261,7 @@ spec:
       - name: certs-legacy
         secret:
           secretName: collector-tls
+          optional: true
           items:
           - key: collector-cert.pem
             path: cert.pem
@@ -271,6 +272,7 @@ spec:
       - name: certs-new
         secret:
           secretName: tls-cert-collector
+          optional: true
       - hostPath:
           path: /
         name: host-root-ro

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -51,6 +51,10 @@ spec:
           image: {{ quote ._rox.image.main.fullRef }}
           command:
           - /stackrox/bin/init-tls-certs
+          args:
+          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
           resources:
             {{- ._rox.collector._resources | nindent 12 }}
           securityContext:
@@ -58,13 +62,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: /tmp/certs-legacy
+            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
             readOnly: true
           - name: certs-new
-            mountPath: /tmp/certs-new
+            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
             readOnly: true
           - name: certs
-            mountPath: /tmp/certs
+            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       containers:
       {{- if ne ._rox.collector.collectionMethod "NO_COLLECTION"}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -53,6 +53,7 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: sensor
+      {{- if ._rox.env.securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -72,6 +73,7 @@ spec:
             readOnly: true
           - name: certs
             mountPath: /tmp/certs
+      {{- end }}
       containers:
       - image: {{ quote ._rox.image.main.fullRef }}
         imagePullPolicy: {{ ._rox.sensor.imagePullPolicy }}
@@ -187,6 +189,7 @@ spec:
           readOnly: true
         {{- end }}
       volumes:
+      {{- if ._rox.env.securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy
@@ -204,6 +207,19 @@ spec:
         secret:
           secretName: tls-cert-sensor
           optional: true
+      {{- else }}
+      - name: certs
+        secret:
+          secretName: sensor-tls
+          optional: true
+          items:
+          - key: sensor-cert.pem
+            path: cert.pem
+          - key: sensor-key.pem
+            path: key.pem
+          - key: ca.pem
+            path: ca.pem
+      {{- end }}
       - name: sensor-etc-ssl-volume
         emptyDir: {}
       - name: sensor-etc-pki-volume

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -59,7 +59,7 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           resources:
-            {{- ._rox.admissionControl._resources | nindent 12 }}
+            {{- ._rox.sensor._resources | nindent 12 }}
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -55,28 +55,28 @@ spec:
       serviceAccountName: sensor
       {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
-        - name: init-tls-certs
-          image: {{ quote ._rox.image.main.fullRef }}
-          command:
-          - /stackrox/bin/init-tls-certs
-          args:
-          - --legacy=/run/secrets/stackrox.io/certs-legacy/
-          - --new=/run/secrets/stackrox.io/certs-new/
-          - --destination=/run/secrets/stackrox.io/certs/
-          resources:
-            {{- ._rox.sensor._resources | nindent 12 }}
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-          volumeMounts:
-          - name: certs-legacy
-            mountPath: /run/secrets/stackrox.io/certs-legacy/
-            readOnly: true
-          - name: certs-new
-            mountPath: /run/secrets/stackrox.io/certs-new/
-            readOnly: true
-          - name: certs
-            mountPath: /run/secrets/stackrox.io/certs/
+      - name: init-tls-certs
+        image: {{ quote ._rox.image.main.fullRef }}
+        command:
+        - /stackrox/bin/init-tls-certs
+        args:
+        - --legacy=/run/secrets/stackrox.io/certs-legacy/
+        - --new=/run/secrets/stackrox.io/certs-new/
+        - --destination=/run/secrets/stackrox.io/certs/
+        resources:
+          {{- ._rox.sensor._resources | nindent 12 }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: certs-legacy
+          mountPath: /run/secrets/stackrox.io/certs-legacy/
+          readOnly: true
+        - name: certs-new
+          mountPath: /run/secrets/stackrox.io/certs-new/
+          readOnly: true
+        - name: certs
+          mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -60,9 +60,9 @@ spec:
           command:
           - /stackrox/bin/init-tls-certs
           args:
-          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
-          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
-          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
+          - --legacy=/run/secrets/stackrox.io/certs-legacy/
+          - --new=/run/secrets/stackrox.io/certs-new/
+          - --destination=/run/secrets/stackrox.io/certs/
           resources:
             {{- ._rox.sensor._resources | nindent 12 }}
           securityContext:
@@ -70,13 +70,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-legacy/
             readOnly: true
           - name: certs-new
-            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs-new/
             readOnly: true
           - name: certs
-            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
+            mountPath: /run/secrets/stackrox.io/certs/
       {{- end }}
       containers:
       - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -53,6 +53,25 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: sensor
+      initContainers:
+        - name: init-tls-certs
+          image: {{ quote ._rox.image.main.fullRef }}
+          command:
+          - /stackrox/bin/init-tls-certs
+          resources:
+            {{- ._rox.admissionControl._resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: certs-legacy
+            mountPath: /tmp/certs-legacy
+            readOnly: true
+          - name: certs-new
+            mountPath: /tmp/certs-new
+            readOnly: true
+          - name: certs
+            mountPath: /tmp/certs
       containers:
       - image: {{ quote ._rox.image.main.fullRef }}
         imagePullPolicy: {{ ._rox.sensor.imagePullPolicy }}
@@ -169,12 +188,26 @@ spec:
         {{- end }}
       volumes:
       - name: certs
+        emptyDir: {}
+      - name: certs-legacy
         secret:
           secretName: sensor-tls
+          optional: true
           items:
           - key: sensor-cert.pem
             path: cert.pem
           - key: sensor-key.pem
+            path: key.pem
+          - key: ca.pem
+            path: ca.pem
+      - name: certs-new
+        secret:
+          secretName: tls-cert-sensor
+          optional: true
+          items:
+          - key: cert.pem
+            path: cert.pem
+          - key: key.pem
             path: key.pem
           - key: ca.pem
             path: ca.pem

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -59,6 +59,10 @@ spec:
           image: {{ quote ._rox.image.main.fullRef }}
           command:
           - /stackrox/bin/init-tls-certs
+          args:
+          - --legacy={{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
+          - --new={{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
+          - --destination={{ include "srox.securedClusterCertRefresh.certsPath" . }}
           resources:
             {{- ._rox.sensor._resources | nindent 12 }}
           securityContext:
@@ -66,13 +70,13 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
           - name: certs-legacy
-            mountPath: /tmp/certs-legacy
+            mountPath: {{ include "srox.securedClusterCertRefresh.legacyCertsPath" . }}
             readOnly: true
           - name: certs-new
-            mountPath: /tmp/certs-new
+            mountPath: {{ include "srox.securedClusterCertRefresh.newCertsPath" . }}
             readOnly: true
           - name: certs
-            mountPath: /tmp/certs
+            mountPath: {{ include "srox.securedClusterCertRefresh.certsPath" . }}
       {{- end }}
       containers:
       - image: {{ quote ._rox.image.main.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -53,7 +53,7 @@ spec:
         fsGroup: 4000
       {{- end }}
       serviceAccountName: sensor
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       initContainers:
         - name: init-tls-certs
           image: {{ quote ._rox.image.main.fullRef }}
@@ -193,7 +193,7 @@ spec:
           readOnly: true
         {{- end }}
       volumes:
-      {{- if ._rox.env.securedClusterCertRefresh }}
+      {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
       - name: certs-legacy

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -204,13 +204,6 @@ spec:
         secret:
           secretName: tls-cert-sensor
           optional: true
-          items:
-          - key: cert.pem
-            path: cert.pem
-          - key: key.pem
-            path: key.pem
-          - key: ca.pem
-            path: ca.pem
       - name: sensor-etc-ssl-volume
         emptyDir: {}
       - name: sensor-etc-pki-volume

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "log"
+
+func main() {
+	log.Print("Hello, world!")
+}

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -152,7 +152,7 @@ func findFiles(sourceDir string) ([]string, error) {
 
 	minRequiredFiles := 3 // CA cert + leaf cert + private key
 	if len(files) < minRequiredFiles {
-		return nil, fmt.Errorf("expecting at least %d files at %q", minRequiredFiles, sourceDir)
+		return nil, fmt.Errorf("expecting at least %d files at %q, found %d", minRequiredFiles, sourceDir, len(files))
 	}
 
 	return files, nil

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -50,6 +50,10 @@ func setupFlags() {
 
 	flag.Parse()
 
+	if legacySourceDir == "" || newSourceDir == "" || destinationDir == "" {
+		log.Fatalf("All parameters are mandatory: -legacy, -new, and -destination must be provided.")
+	}
+
 	log.Println("New certs directory:", newSourceDir)
 	log.Println("Legacy certs directory:", legacySourceDir)
 	log.Println("Destination directory:", destinationDir)

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -38,7 +38,7 @@ func copyFiles(files []string, destDir string) error {
 			return err
 		}
 		destPath := path.Join(destDir, path.Base(file))
-		if err = os.WriteFile(destPath, content, 0666); err != nil {
+		if err = os.WriteFile(destPath, content, 0600); err != nil {
 			return err
 		}
 		log.Printf("Copied %q to %q", file, destPath)

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -1,7 +1,106 @@
 package main
 
-import "log"
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	destinationDir  = "/tmp/certs"
+	legacySourceDir = "/tmp/certs-legacy"
+)
 
 func main() {
-	log.Print("Hello, world!")
+	log.Print("Started.")
+	realDest, err := sanityCheckDestination()
+	if err != nil {
+		log.Fatalf("Cannot check destination directory %q: %s", destinationDir, err)
+	}
+	log.Printf("Destination directory %q looks sane.", destinationDir)
+	files, err := waitForSource()
+	if err != nil {
+		log.Fatalf("Cannot find source files in %q: %s", legacySourceDir, err)
+	}
+	if err = copyFiles(files, realDest); err != nil {
+		log.Fatalf("Cannot copy files: %s", err)
+	}
+}
+
+func copyFiles(files []string, destDir string) error {
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		destPath := path.Join(destDir, path.Base(file))
+		if err = os.WriteFile(destPath, content, 0666); err != nil {
+			return err
+		}
+		log.Printf("Copied %q to %q", file, destPath)
+	}
+	return nil
+}
+
+func waitForSource() ([]string, error) {
+	log.Printf("Looking for files in the source directory %q.", legacySourceDir)
+	for {
+		realSource, err := filepath.EvalSymlinks(legacySourceDir)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("Walking %q.", realSource)
+		var files []string
+		err = filepath.WalkDir(realSource, func(path string, d fs.DirEntry, err error) error {
+			if strings.HasPrefix(path, ".") {
+				log.Printf("Ignoring hidden file %q", path)
+				return nil
+			}
+			realFile, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				log.Printf("Ignoring file %q: %s", path, err)
+				return nil
+			}
+			st, err := os.Stat(realFile)
+			if err != nil {
+				log.Printf("Ignoring file %q: %s", realFile, err)
+				return nil
+			}
+			if st.IsDir() {
+				return nil
+			}
+			log.Printf("Found file %q (%q)", path, realFile)
+			files = append(files, realFile)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(files) >= 3 {
+			return files, nil
+		}
+		log.Printf("Did not find (enough) files, sleeping.")
+		time.Sleep(time.Second)
+	}
+}
+
+func sanityCheckDestination() (string, error) {
+	realDest, err := filepath.EvalSymlinks(destinationDir)
+	if err != nil {
+		return "", err
+	}
+	st, err := os.Stat(realDest)
+	if err != nil {
+		return "", fmt.Errorf("stat failed: %w", err)
+	}
+	if !st.IsDir() {
+		return "", errors.New("%q is not a directory")
+	}
+	return realDest, nil
 }

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -28,9 +28,9 @@ func init() {
 func main() {
 	flag.Parse()
 
-	fmt.Println("New certs directory:", newSourceDir)
-	fmt.Println("Legacy certs directory:", legacySourceDir)
-	fmt.Println("Destination directory:", destinationDir)
+	log.Println("New certs directory:", newSourceDir)
+	log.Println("Legacy certs directory:", legacySourceDir)
+	log.Println("Destination directory:", destinationDir)
 
 	realDest, err := sanityCheckDestination()
 	if err != nil {

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/fs"
 	"log"
@@ -11,14 +12,25 @@ import (
 	"time"
 )
 
-const (
-	destinationDir  = "/tmp/certs"
-	legacySourceDir = "/tmp/certs-legacy"
-	newSourceDir    = "/tmp/certs-new"
+var (
+	destinationDir  string
+	legacySourceDir string
+	newSourceDir    string
 )
 
+func init() {
+	flag.StringVar(&legacySourceDir, "legacy", "/tmp/certs-legacy", "Source directory for legacy certs")
+	flag.StringVar(&newSourceDir, "new", "/tmp/certs-new", "Source directory for new certs")
+	flag.StringVar(&destinationDir, "destination", "/tmp/certs", "Destination directory for certs")
+}
+
 func main() {
-	log.Print("Started.")
+	flag.Parse()
+
+	fmt.Println("New certs directory:", newSourceDir)
+	fmt.Println("Legacy certs directory:", legacySourceDir)
+	fmt.Println("Destination directory:", destinationDir)
+
 	realDest, err := sanityCheckDestination()
 	if err != nil {
 		log.Fatalf("Cannot check destination directory %q: %s", destinationDir, err)
@@ -90,7 +102,7 @@ func findFiles(sourceDir string) ([]string, error) {
 		base := filepath.Base(path)
 		if strings.HasPrefix(base, ".") {
 			if d.IsDir() {
-				log.Printf("Skipping hidden dir %q", path)
+				log.Printf("Ignoring hidden dir %q", path)
 				return filepath.SkipDir
 			}
 

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -79,7 +79,11 @@ func findFiles(sourceDir string) ([]string, error) {
 	}
 	log.Printf("Walking %q.", realSource)
 	var files []string
-	err = filepath.WalkDir(realSource, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(realSource, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			log.Printf("Error accessing path %q: %s", path, walkErr)
+			return nil
+		}
 		if strings.HasPrefix(path, ".") {
 			log.Printf("Ignoring hidden file %q", path)
 			return nil

--- a/sensor/init-tls-certs/main.go
+++ b/sensor/init-tls-certs/main.go
@@ -89,6 +89,11 @@ func findFiles(sourceDir string) ([]string, error) {
 
 		base := filepath.Base(path)
 		if strings.HasPrefix(base, ".") {
+			if d.IsDir() {
+				log.Printf("Skipping hidden dir %q", path)
+				return filepath.SkipDir
+			}
+
 			log.Printf("Ignoring hidden file %q", path)
 			return nil
 		}
@@ -99,13 +104,7 @@ func findFiles(sourceDir string) ([]string, error) {
 			return nil
 		}
 
-		st, err := os.Stat(realFile)
-		if err != nil {
-			log.Printf("Ignoring file %q: %s", realFile, err)
-			return nil
-		}
-
-		if st.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 

--- a/sensor/init-tls-certs/main_test.go
+++ b/sensor/init-tls-certs/main_test.go
@@ -87,7 +87,7 @@ func (s *initTLSCertsSuite) TestFileCopy() {
 					s.Require().NoError(err, "Expected file %s to exist", file)
 
 					fileName := filepath.Base(file)
-					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with '%s', got %s", tt.expectedPrefix, fileName)
+					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with %q, got %q", tt.expectedPrefix, fileName)
 				}
 
 				err = copyFiles(files, destinationDir)
@@ -99,7 +99,7 @@ func (s *initTLSCertsSuite) TestFileCopy() {
 
 				for _, file := range destFiles {
 					fileName := file.Name()
-					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with '%s', got %s", tt.expectedPrefix, fileName)
+					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with %q, got %q", tt.expectedPrefix, fileName)
 				}
 			}
 		})

--- a/sensor/init-tls-certs/main_test.go
+++ b/sensor/init-tls-certs/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type initTLSCertsSuite struct {
+	suite.Suite
+}
+
+func TestInitTLSCerts(t *testing.T) {
+	suite.Run(t, new(initTLSCertsSuite))
+}
+
+func (s *initTLSCertsSuite) TestFileCopy() {
+	tests := []struct {
+		name           string
+		setupDirs      func()
+		expectedFiles  int
+		expectedPrefix string
+		expectedError  bool
+	}{
+		{
+			name:           "Empty source dirs",
+			setupDirs:      func() {},
+			expectedFiles:  0,
+			expectedPrefix: "",
+			expectedError:  true,
+		},
+		{
+			name: "Only legacySourceDir contains files",
+			setupDirs: func() {
+				s.createFiles(legacySourceDir, 3, "legacycert")
+			},
+			expectedFiles:  3,
+			expectedPrefix: "legacycert",
+			expectedError:  false,
+		},
+		{
+			name: "Only newSourceDir contains files",
+			setupDirs: func() {
+				s.createFiles(newSourceDir, 3, "newcert")
+			},
+			expectedFiles:  3,
+			expectedPrefix: "newcert",
+			expectedError:  false,
+		},
+		{
+			name: "Both legacySourceDir and newSourceDir contain files",
+			setupDirs: func() {
+				s.createFiles(legacySourceDir, 3, "legacycert")
+				s.createFiles(newSourceDir, 3, "newcert")
+			},
+			expectedFiles:  3,
+			expectedPrefix: "newcert", // prefer new certs if both exist
+			expectedError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.createDirs()
+			tt.setupDirs()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			files, err := waitForSource(ctx)
+
+			if tt.expectedError {
+				s.Error(err)
+				s.Nil(files)
+			} else {
+				s.Require().NoError(err)
+				s.Len(files, tt.expectedFiles, "Expected %d certificate files", tt.expectedFiles)
+
+				for _, file := range files {
+					_, err := os.Stat(file)
+					s.Require().NoError(err, "Expected file %s to exist", file)
+
+					fileName := filepath.Base(file)
+					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with '%s', got %s", tt.expectedPrefix, fileName)
+				}
+
+				err = copyFiles(files, destinationDir)
+				s.Require().NoError(err, "Failed to copy files")
+
+				destFiles, err := os.ReadDir(destinationDir)
+				s.Require().NoError(err, "Failed to read destination directory")
+				s.Len(destFiles, tt.expectedFiles, "Expected %d files in destination directory", tt.expectedFiles)
+
+				for _, file := range destFiles {
+					fileName := file.Name()
+					s.True(strings.HasPrefix(fileName, tt.expectedPrefix), "Expected file name to start with '%s', got %s", tt.expectedPrefix, fileName)
+				}
+			}
+		})
+	}
+}
+
+func (s *initTLSCertsSuite) TestSanityCheckDestination() {
+	tests := []struct {
+		name           string
+		destinationDir string
+		expectedError  bool
+	}{
+		{
+			name:           "Valid destination directory",
+			destinationDir: s.T().TempDir(),
+			expectedError:  false,
+		},
+		{
+			name:           "Invalid destination directory",
+			destinationDir: "/non/existent/dir",
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			destinationDir = tt.destinationDir
+			result, err := sanityCheckDestination()
+
+			if tt.expectedError {
+				s.Error(err)
+				s.Empty(result, "Expected empty result on error")
+			} else {
+				s.NoError(err)
+				s.NotEmpty(result, "Expected non-empty result")
+			}
+		})
+	}
+}
+
+func (s *initTLSCertsSuite) createFiles(dir string, count int, prefix string) {
+	for i := 0; i < count; i++ {
+		_, err := os.Create(filepath.Join(dir, fmt.Sprintf("%s%d", prefix, i)))
+		s.Require().NoError(err, "Failed to create cert file in %s", dir)
+	}
+}
+
+func (s *initTLSCertsSuite) createDirs() {
+	legacySourceDir = s.T().TempDir()
+	newSourceDir = s.T().TempDir()
+	destinationDir = s.T().TempDir()
+}

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -37,6 +37,7 @@ var (
 		"sensor/admission-control",
 		"sensor/common",
 		"sensor/debugger",
+		"sensor/init-tls-certs",
 		"sensor/kubernetes",
 		"sensor/tests",
 		"sensor/testutils",


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR introduces an init container that picks between new and legacy TLS service certificates, and provides them to the Secured Cluster deployments.

Starting with ACS 4.7, Secured Clusters will have a different naming scheme for the secrets that store TLS certificates for the services, and the previous secrets can still exist. `{service}-tls` is now `tls-cert-{service}`, e.g. `sensor-tls` is the legacy secret and `tls-cert-sensor` is the new secret.

The new secrets are created in two cases:
1. after registering a Secured Cluster using a [CRS](https://issues.redhat.com/browse/ROX-26088) token
2. when Secured Cluster certificates are refreshed (applies to both (a) CRS and (b) init bundle registered clusters)

Because of case (2b) above, there will be clusters that have both the legacy and the new secrets at the same time, and this PR implements a way to provide the correct ones to the services, without modifying their source code.

This is done in the following way:
* change the existing secret volume to optional
* add another optional secret volume for the new secret
* implement an init container which:
  - mounts both volumes
  - waits for one of the secrets to appear
  - copies the certs to a tmpdir volume (the new certs have precedence)
* change the main container to mount that tmpdir volume rather than the (legacy) init bundle secret

This initContainer was added to the following deployments: sensor, collector, admission-controller, scanner, scanner-db, scanner-v4-db, scanner-v4-indexer (in case of the scanner-* deployments, only for Secured Clusters and not for Central Services).

❗ A downside of the initContainer approach is that the certs are only (re-)loaded on pod start-up. The certs are updated every 6 months and are valid for 1 year, so we're counting on the fact that there should be at least one restart during that interval. Eventually (when support for legacy secrets is removed) the init container will be removed and the support for runtime-reloading of certs restored.

Ticket to update docs: https://issues.redhat.com/browse/ROX-27295

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Local deployment (using `SENSOR_HELM_MANAGED=true ./deploy/k8s/deploy-local.sh`) and checked that the initContainer picks the right certificate.

For more thorough testing that included Scanner V4, I used an infra cluster and deployed the changes in this PR with `make -C operator deploy-via-olm`. Then I installed Central and a Secured Cluster (in a different namespace so that it creates its own Scanner deployments) and tested that the pods initialize properly.

After sensor startup, we can test that the secured cluster can also work without the init bundle certs, after the refresh done after startup:
```bash
 kubectl -n stackrox-sensor delete secret sensor-tls admission-control-tls collector-tls
 kubectl -n stackrox-sensor delete pods --all
 ```
 The Secured Clusters deployments should all restart successfully.
 
 Example run for `sensor` in a `colima` cluster. It picks the legacy certs because it's the first run on a secured cluster initalized with an init bundle.
 ```
 ❯ kubectl -n stackrox logs -f sensor-86d59d4f7b-l2jgm init-tls-certs
2024/12/09 14:59:43 New certs directory: /run/secrets/stackrox.io/certs-new/
2024/12/09 14:59:43 Legacy certs directory: /run/secrets/stackrox.io/certs-legacy/
2024/12/09 14:59:43 Destination directory: /run/secrets/stackrox.io/certs/
2024/12/09 14:59:43 Destination directory "/run/secrets/stackrox.io/certs/" looks sane.
2024/12/09 14:59:43 Looking for files in the source directory "/run/secrets/stackrox.io/certs-legacy/".
2024/12/09 14:59:43 Walking "/run/secrets/stackrox.io/certs-new".
2024/12/09 14:59:43 Ignoring hidden dir "/run/secrets/stackrox.io/certs-new/..2024_12_09_14_59_43.2988054347"
2024/12/09 14:59:43 Ignoring hidden file "/run/secrets/stackrox.io/certs-new/..data"
2024/12/09 14:59:43 Error checking certificates in "/run/secrets/stackrox.io/certs-new/": expecting at least 3 files at "/run/secrets/stackrox.io/certs-new/", found 0
2024/12/09 14:59:43 Walking "/run/secrets/stackrox.io/certs-legacy".
2024/12/09 14:59:43 Ignoring hidden dir "/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036"
2024/12/09 14:59:43 Ignoring hidden file "/run/secrets/stackrox.io/certs-legacy/..data"
2024/12/09 14:59:43 Found file "/run/secrets/stackrox.io/certs-legacy/ca.pem" ("/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/ca.pem")
2024/12/09 14:59:43 Found file "/run/secrets/stackrox.io/certs-legacy/cert.pem" ("/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/cert.pem")
2024/12/09 14:59:43 Found file "/run/secrets/stackrox.io/certs-legacy/key.pem" ("/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/key.pem")
2024/12/09 14:59:43 Using 3 legacy certificates from "/run/secrets/stackrox.io/certs-legacy/".
2024/12/09 14:59:43 Copied "/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/ca.pem" to "/run/secrets/stackrox.io/certs/ca.pem"
2024/12/09 14:59:43 Copied "/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/cert.pem" to "/run/secrets/stackrox.io/certs/cert.pem"
2024/12/09 14:59:43 Copied "/run/secrets/stackrox.io/certs-legacy/..2024_12_09_14_59_43.489128036/key.pem" to "/run/secrets/stackrox.io/certs/key.pem"
 ```

Example run for `scanner-v4-indexer` in an OpenShift 4.17 cluster. This requires more time to start because it needs `sensor` to start first and retrieve its certs, and then some more time for `kubelet` to mount the secret. It picks the new certs, because scanner-v4 certs are not part of the init bundle.
 ```
 2024/12/09 16:02:36 New certs directory: /run/secrets/stackrox.io/certs-new/
2024/12/09 16:02:36 Legacy certs directory: /run/secrets/stackrox.io/certs-legacy/
2024/12/09 16:02:36 Destination directory: /run/secrets/stackrox.io/certs/
2024/12/09 16:02:36 Destination directory "/run/secrets/stackrox.io/certs/" looks sane.
2024/12/09 16:02:36 Looking for files in the source directory "/run/secrets/stackrox.io/certs-legacy/".
2024/12/09 16:02:36 Walking "/run/secrets/stackrox.io/certs-new".
2024/12/09 16:02:36 Ignoring hidden dir "/run/secrets/stackrox.io/certs-new/..2024_12_09_16_02_35.3847024723"
2024/12/09 16:02:36 Ignoring hidden file "/run/secrets/stackrox.io/certs-new/..data"
2024/12/09 16:02:36 Error checking certificates in "/run/secrets/stackrox.io/certs-new/": expecting at least 3 files at "/run/secrets/stackrox.io/certs-new/", found 0
2024/12/09 16:02:36 Walking "/run/secrets/stackrox.io/certs-legacy".
2024/12/09 16:02:36 Ignoring hidden dir "/run/secrets/stackrox.io/certs-legacy/..2024_12_09_16_02_35.3409471062"
2024/12/09 16:02:36 Ignoring hidden file "/run/secrets/stackrox.io/certs-legacy/..data"
2024/12/09 16:02:36 Error checking legacy certificates in "/run/secrets/stackrox.io/certs-legacy/": expecting at least 3 files at "/run/secrets/stackrox.io/certs-legacy/", found 0
2024/12/09 16:02:36 No certificates found. Retrying...

... redacted some similar lines ...

2024/12/09 16:03:46 Walking "/run/secrets/stackrox.io/certs-new".
2024/12/09 16:03:46 Ignoring hidden dir "/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974"
2024/12/09 16:03:46 Ignoring hidden file "/run/secrets/stackrox.io/certs-new/..data"
2024/12/09 16:03:46 Found file "/run/secrets/stackrox.io/certs-new/ca.pem" ("/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/ca.pem")
2024/12/09 16:03:46 Found file "/run/secrets/stackrox.io/certs-new/cert.pem" ("/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/cert.pem")
2024/12/09 16:03:46 Found file "/run/secrets/stackrox.io/certs-new/key.pem" ("/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/key.pem")
2024/12/09 16:03:46 Using 3 new certificate files from "/run/secrets/stackrox.io/certs-new/".
2024/12/09 16:03:46 Copied "/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/ca.pem" to "/run/secrets/stackrox.io/certs/ca.pem"
2024/12/09 16:03:46 Copied "/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/cert.pem" to "/run/secrets/stackrox.io/certs/cert.pem"
2024/12/09 16:03:46 Copied "/run/secrets/stackrox.io/certs-new/..2024_12_09_16_03_43.1934364974/key.pem" to "/run/secrets/stackrox.io/certs/key.pem"
```