### PR TITLE
ROX-26866: Add button to trigger SBOM generation on Image page

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -165,6 +165,39 @@ export function interceptAndWatchRequests(routeMatcherMap, staticResponseMap) {
     });
 }
 
+/**
+ * Shorthand function to override user permissions. Will overwrite the permissions for the user
+ * with the provided permissions, keeping the rest of the permissions the same.
+ * @param {Record<string, string>} overrides Resource to access level mapping
+ */
+export function interceptAndOverridePermissions(overrides) {
+    return cy.intercept('GET', '/v1/mypermissions', (req) => {
+        req.continue((res) => {
+            Object.entries(overrides).forEach(([resource, accessLevel]) => {
+                res.body.resourceToAccess[resource] = accessLevel;
+            });
+        });
+    });
+}
+
+/**
+ * Shortcut function to override feature flags. Will overwrite the feature flags for the user
+ * with the provided enabled/disabled statuses, keeping the rest of the feature flags the same.
+ * @param {Record<string, boolean>} overrides Feature flag env var to enabled boolean mapping
+ */
+export function interceptAndOverrideFeatureFlags(overrides) {
+    return cy.intercept('GET', '/v1/featureflags', (req) =>
+        req.continue((res) => {
+            Object.entries(overrides).forEach(([feature, enabled]) => {
+                const flag = res.body.featureFlags.find((flag) => flag.envVar === feature);
+                if (flag) {
+                    flag.enabled = enabled;
+                }
+            });
+        })
+    );
+}
+
 export function expectRequestedSort(expectedSort) {
     return (variables) => {
         const { sortOption, sortOptions } = variables.pagination;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -28,10 +28,12 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
+import useHasGenerateSBOMAbility from '../../hooks/useHasGenerateSBOMAbility';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
 import ImagePageResources from './ImagePageResources';
 import { detailsTabValues } from '../../types';
@@ -42,8 +44,6 @@ import ImageDetailBadges, {
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getImageBaseNameDisplay } from '../utils/images';
-import useHasGenerateSBOMAbility from 'Containers/Vulnerabilities/hooks/useHasGenerateSBOMAbility';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 
 const workloadCveOverviewImagePath = getOverviewPagePath('Workload', {
     vulnerabilityState: 'OBSERVED',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -1,8 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import {
+    Alert,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
+    Button,
     ClipboardCopy,
     Divider,
     Flex,
@@ -13,7 +15,7 @@ import {
     Tabs,
     TabTitleText,
     Title,
-    Alert,
+    Tooltip,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router-dom';
@@ -40,6 +42,8 @@ import ImageDetailBadges, {
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getImageBaseNameDisplay } from '../utils/images';
+import useHasGenerateSBOMAbility from 'Containers/Vulnerabilities/hooks/useHasGenerateSBOMAbility';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 const workloadCveOverviewImagePath = getOverviewPagePath('Workload', {
     vulnerabilityState: 'OBSERVED',
@@ -61,7 +65,14 @@ export const imageDetailsQuery = gql`
     }
 `;
 
+function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
+    return (
+        <Tooltip content="SBOM generation requires Scanner V4 to be enabled">{children}</Tooltip>
+    );
+}
+
 function ImagePage() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { imageId } = useParams();
     const { data, error } = useQuery<
         {
@@ -84,6 +95,9 @@ function ImagePage() {
     const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
 
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+
+    const hasGenerateSBOMAbility = useHasGenerateSBOMAbility();
+    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
     const imageData = data && data.image;
     const imageName = imageData?.name;
@@ -109,6 +123,7 @@ function ImagePage() {
             </PageSection>
         );
     } else {
+        const SBOMButtonWrapper = isScannerV4Enabled ? React.Fragment : ScannerV4RequiredTooltip;
         const sha = imageData?.id;
         mainContent = (
             <>
@@ -116,22 +131,40 @@ function ImagePage() {
                     {imageData ? (
                         <Flex
                             direction={{ default: 'column' }}
-                            alignItems={{ default: 'alignItemsFlexStart' }}
+                            alignItems={{ default: 'alignItemsStretch' }}
                         >
-                            <Title headingLevel="h1" className="pf-v5-u-m-0">
-                                {imageDisplayName}
-                            </Title>
-                            {sha && (
-                                <ClipboardCopy
-                                    hoverTip="Copy SHA"
-                                    clickTip="Copied!"
-                                    variant="inline-compact"
-                                    className="pf-v5-u-display-inline-flex pf-v5-u-align-items-center pf-v5-u-mt-sm pf-v5-u-mb-md pf-v5-u-font-size-sm"
+                            <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                                <Flex
+                                    direction={{ default: 'column' }}
+                                    spaceItems={{ default: 'spaceItemsSm' }}
                                 >
-                                    {sha}
-                                </ClipboardCopy>
-                            )}
-                            <ImageDetailBadges imageData={imageData} />
+                                    <Title headingLevel="h1">{imageDisplayName}</Title>
+                                    {sha && (
+                                        <ClipboardCopy
+                                            hoverTip="Copy SHA"
+                                            clickTip="Copied!"
+                                            variant="inline-compact"
+                                            className="pf-v5-u-font-size-sm"
+                                        >
+                                            {sha}
+                                        </ClipboardCopy>
+                                    )}
+                                    <ImageDetailBadges imageData={imageData} />
+                                </Flex>
+                                {hasGenerateSBOMAbility && (
+                                    <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                                        <SBOMButtonWrapper>
+                                            <Button
+                                                variant="secondary"
+                                                onClick={() => {}}
+                                                isAriaDisabled={!isScannerV4Enabled}
+                                            >
+                                                Generate SBOM
+                                            </Button>
+                                        </SBOMButtonWrapper>
+                                    </FlexItem>
+                                )}
+                            </Flex>
                             {!isEmpty(scanMessage) && (
                                 <Alert
                                     className="pf-v5-u-w-100"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasGenerateSBOMAbility.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useHasGenerateSBOMAbility.ts
@@ -1,0 +1,14 @@
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+
+export default function useHasGenerateSBOMAbility() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadWriteAccess } = usePermissions();
+
+    return (
+        // Gate functionality for incremental implementation
+        isFeatureFlagEnabled('ROX_SBOM_GENERATION') &&
+        // SBOM Generation mutates image scan state, so requires write access to 'Image'
+        hasReadWriteAccess('Image')
+    );
+}


### PR DESCRIPTION
### Description

As titled. Only adds the button, does not add functionality.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit an image single page either without the `ROX_SBOM_GENERATION` feature flag enabled, or without "READ_WRITE" access to "Image":
![image](https://github.com/user-attachments/assets/727103e5-a98d-4b18-86bf-888d0b8bdaed)

Visit with both, but without Scanner V4 enabled:
![image](https://github.com/user-attachments/assets/e7326fd1-8fe1-43bc-8753-03476a6fcbe5)

Hovering or tab-navigating to the button displays a tooltip explaining why the button is disabled:
![image](https://github.com/user-attachments/assets/3f016358-d867-4322-8ae8-7c028ca81f99)

Visit with both and with Scanner V4 enabled. No tooltip is rendered on the button.
![image](https://github.com/user-attachments/assets/2edab937-d216-491f-bcf9-2a0c00331e52)
