### PR TITLE
docs: Instructions for installing CRD in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-26124: Added a `--with-database-only` only to diagnostic bundle.
   - `roxctl central debug download-diagnostics --with-database-only`
 - ROX-18899: Added Microsoft Sentinel notifier to send alerts and audit logs to Azure Log Analytics Workspace.
+- ROX-22216: Policy as Code -- represent policies using a SecurityPolicy Kubernetes custom resource
 
 ### Removed Features
 

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -40,6 +40,7 @@ the login page, and log in with username "admin" and the password found in the
 	kubectlInstructionTemplate = `
   - Deploy Central
     - Run central/scripts/setup.sh
+    - Run {{.K8sConfig.Command}} apply -f helm/chart/crds/config.stackrox.io_securitypolicies.yaml
     - Run {{.K8sConfig.Command}} create -R -f central
 `
 


### PR DESCRIPTION
This adds a line in the README for manifest installation to instruct users to install the SecurityPolicy CRD before installing Central.  This step is required to prevent the config-controller deployment from crashlooping due to the missing CRD.

I validated this by running:

```
roxctl central generate openshift pvc --openshift-version 4 --enable-pod-security-policies=false
```

and running the commands in the resulting README.

Also adds a changelog entry for policy as code.