### PR TITLE
ROX-27053: Fix subjects handling for user and group kind

### DIFF
--- a/central/compliance/checks/nist80053/check_ac_14/check.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check.go
@@ -75,7 +75,7 @@ func checkNoExtraPrivilegesForUnauthenticated(ctx framework.ComplianceContext) {
 	clusterRoleIDs := set.NewStringSet()
 	namespaceRoleIDs := make(map[string]set.StringSet)
 	for _, binding := range k8sRoleBindings {
-		for _, subject := range binding.GetSubjects() {
+		for _, subject := range k8srbac.GetSubjectsAdjustedByKind(binding) {
 			if subject.GetName() == systemUnauthenticatedSubject && subject.GetKind() == storage.SubjectKind_GROUP {
 				if k8srbac.IsClusterRoleBinding(binding) {
 					clusterRoleIDs.Add(binding.GetRoleId())

--- a/central/rbac/service/get_subject.go
+++ b/central/rbac/service/get_subject.go
@@ -36,7 +36,7 @@ func getSubjectFromStores(ctx context.Context, subjectName string, roleDS k8sRol
 	}
 
 	var subject *storage.Subject
-	for _, subj := range relevantBindings[0].GetSubjects() {
+	for _, subj := range k8srbac.GetSubjectsAdjustedByKind(relevantBindings[0]) {
 		if subj.GetKind() != storage.SubjectKind_USER || subj.GetKind() != storage.SubjectKind_GROUP {
 			continue
 		}

--- a/central/sensor/service/pipeline/rolebindings/pipeline_test.go
+++ b/central/sensor/service/pipeline/rolebindings/pipeline_test.go
@@ -1,0 +1,135 @@
+package rolebindings
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/k8srbac"
+	"github.com/stackrox/rox/pkg/protoassert"
+)
+
+func Test_enrichSubjects(t *testing.T) {
+	clusterId := "cluster-id-1"
+	clusterName := "cluster-name-1"
+
+	tests := map[string]struct {
+		binding *storage.K8SRoleBinding
+		expect  *storage.K8SRoleBinding
+	}{
+		"nil rolebinding": {
+			binding: nil,
+			expect:  nil,
+		},
+		"nil subjects": {
+			binding: &storage.K8SRoleBinding{},
+			expect:  &storage.K8SRoleBinding{},
+		},
+		"empty subjects": {
+			binding: &storage.K8SRoleBinding{Subjects: make([]*storage.Subject, 0)},
+			expect:  &storage.K8SRoleBinding{Subjects: make([]*storage.Subject, 0)},
+		},
+		"all rolebinding kinds": {
+			binding: &storage.K8SRoleBinding{
+				ClusterId:   clusterId,
+				ClusterName: clusterName,
+				Subjects: []*storage.Subject{
+					{Kind: storage.SubjectKind_UNSET_KIND, Name: "sub-1"},
+					{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Name: "sub-2"},
+					{Kind: storage.SubjectKind_USER, Name: "sub-3"},
+					{Kind: storage.SubjectKind_GROUP, Name: "sub-4"},
+				},
+			},
+			expect: &storage.K8SRoleBinding{
+				ClusterId:   clusterId,
+				ClusterName: clusterName,
+				Subjects: []*storage.Subject{
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-1"),
+						Kind:        storage.SubjectKind_UNSET_KIND,
+						Name:        "sub-1",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-2"),
+						Kind:        storage.SubjectKind_SERVICE_ACCOUNT,
+						Name:        "sub-2",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-3"),
+						Kind:        storage.SubjectKind_USER,
+						Name:        "sub-3",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-4"),
+						Kind:        storage.SubjectKind_GROUP,
+						Name:        "sub-4",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+				},
+			},
+		},
+		"all rolebinding kinds with namespace": {
+			binding: &storage.K8SRoleBinding{
+				ClusterId:   clusterId,
+				ClusterName: clusterName,
+				Subjects: []*storage.Subject{
+					{Kind: storage.SubjectKind_UNSET_KIND, Name: "sub-1", Namespace: "ns-1"},
+					{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Name: "sub-2", Namespace: "ns-2"},
+					{Kind: storage.SubjectKind_USER, Name: "sub-3", Namespace: "ns-3"},
+					{Kind: storage.SubjectKind_GROUP, Name: "sub-4", Namespace: "ns-4"},
+				},
+			},
+			expect: &storage.K8SRoleBinding{
+				ClusterId:   clusterId,
+				ClusterName: clusterName,
+				Subjects: []*storage.Subject{
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-1"),
+						Kind:        storage.SubjectKind_UNSET_KIND,
+						Name:        "sub-1",
+						Namespace:   "ns-1",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-2"),
+						Kind:        storage.SubjectKind_SERVICE_ACCOUNT,
+						Name:        "sub-2",
+						Namespace:   "ns-2",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-3"),
+						Kind:        storage.SubjectKind_USER,
+						Name:        "sub-3",
+						Namespace:   "ns-3",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+					{
+						Id:          k8srbac.CreateSubjectID(clusterId, "sub-4"),
+						Kind:        storage.SubjectKind_GROUP,
+						Name:        "sub-4",
+						Namespace:   "ns-4",
+						ClusterId:   clusterId,
+						ClusterName: clusterName,
+					},
+				},
+			},
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			enrichSubjects(tt.binding)
+			protoassert.Equal(t, tt.expect, tt.binding)
+		})
+	}
+}

--- a/pkg/k8srbac/evaluator_impl.go
+++ b/pkg/k8srbac/evaluator_impl.go
@@ -59,7 +59,7 @@ func getSubjectsGrantedClusterAdmin(roles []*storage.K8SRole, roleBindings []*st
 	subjectsWithClusterAdmin := NewSubjectSet()
 	for _, binding := range roleBindings {
 		if !IsDefaultRoleBinding(binding) && clusterAdminRoleIDs.Contains(binding.GetRoleId()) {
-			subjectsWithClusterAdmin.Add(binding.GetSubjects()...)
+			subjectsWithClusterAdmin.Add(GetSubjectsAdjustedByKind(binding)...)
 		}
 	}
 	return subjectsWithClusterAdmin.ToSlice()
@@ -70,7 +70,7 @@ func isSubjectClusterAdmin(subject *storage.Subject, roles []*storage.K8SRole, r
 	subjectsWithClusterAdmin := NewSubjectSet()
 	for _, binding := range roleBindings {
 		if clusterAdminRoleIDs.Contains(binding.GetRoleId()) {
-			subjectsWithClusterAdmin.Add(binding.GetSubjects()...)
+			subjectsWithClusterAdmin.Add(GetSubjectsAdjustedByKind(binding)...)
 		}
 	}
 	for _, s := range subjectsWithClusterAdmin.ToSlice() {
@@ -116,7 +116,7 @@ func buildMap(roles []*storage.K8SRole, bindings []*storage.K8SRoleBinding) map[
 		if _, hasEntry := roleIDToSubjects[binding.GetRoleId()]; !hasEntry {
 			roleIDToSubjects[binding.GetRoleId()] = NewSubjectSet()
 		}
-		roleIDToSubjects[binding.GetRoleId()].Add(binding.GetSubjects()...)
+		roleIDToSubjects[binding.GetRoleId()].Add(GetSubjectsAdjustedByKind(binding)...)
 	}
 
 	// Complete the map so that we can test subjects and get the role for it.

--- a/pkg/k8srbac/subjects.go
+++ b/pkg/k8srbac/subjects.go
@@ -17,6 +17,32 @@ func CreateSubjectID(clusterID, subjectName string) string {
 	return fmt.Sprintf("%s:%s", clusterEncoded, subjectEncoded)
 }
 
+// GetSubjectsAdjustedByKind returns subjects adjusted by kind scope.
+// User and Group kind do not have namespace defined and such entities should not exist,
+// but k8s storage allows it. Docs:
+// https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-binding-v1/ -> subjects.namespace
+func GetSubjectsAdjustedByKind(binding *storage.K8SRoleBinding) []*storage.Subject {
+	if binding == nil {
+		return nil
+	}
+
+	adjustedSubjectSet := NewSubjectSet()
+	for _, subject := range binding.GetSubjects() {
+		// Minimize number of CloneVT() calls.
+		if subject.GetNamespace() != "" && (subject.GetKind() == storage.SubjectKind_USER || subject.GetKind() == storage.SubjectKind_GROUP) {
+			adjustedSubject := subject.CloneVT()
+			adjustedSubject.Namespace = ""
+			adjustedSubjectSet.Add(adjustedSubject)
+
+			continue
+		}
+
+		adjustedSubjectSet.Add(subject)
+	}
+
+	return adjustedSubjectSet.ToSlice()
+}
+
 // SplitSubjectID returns the components of the ID
 func SplitSubjectID(id string) (string, string, error) {
 	clusterEncoded, subjectEncoded := stringutils.Split2(id, ":")
@@ -64,7 +90,7 @@ func GetSubjectForServiceAccount(sa *storage.ServiceAccount) *storage.Subject {
 func GetAllSubjects(bindings []*storage.K8SRoleBinding, kinds ...storage.SubjectKind) []*storage.Subject {
 	subjectsSet := NewSubjectSet()
 	for _, binding := range bindings {
-		for _, subject := range binding.GetSubjects() {
+		for _, subject := range GetSubjectsAdjustedByKind(binding) {
 			for _, kind := range kinds {
 				if subject.GetKind() == kind {
 					subjectsSet.Add(subject)
@@ -80,7 +106,7 @@ func GetAllSubjects(bindings []*storage.K8SRoleBinding, kinds ...storage.Subject
 func GetSubject(subjectName string, bindings []*storage.K8SRoleBinding) (*storage.Subject, bool, error) {
 	// Find the subject we want.
 	for _, binding := range bindings {
-		for _, subject := range binding.GetSubjects() {
+		for _, subject := range GetSubjectsAdjustedByKind(binding) {
 			// We only want to look for a user or a group.
 			if subject.GetKind() != storage.SubjectKind_USER && subject.GetKind() != storage.SubjectKind_GROUP {
 				continue

--- a/pkg/k8srbac/subjects_test.go
+++ b/pkg/k8srbac/subjects_test.go
@@ -1,0 +1,106 @@
+package k8srbac
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoassert"
+)
+
+func TestGetSubjectsAdjustedByKind(t *testing.T) {
+	tests := map[string]struct {
+		rb     *storage.K8SRoleBinding
+		expect []*storage.Subject
+	}{
+		"nil rolebinding": {
+			rb:     nil,
+			expect: nil,
+		},
+		"nil subjects": {
+			rb:     &storage.K8SRoleBinding{},
+			expect: nil,
+		},
+		"empty subjects": {
+			rb:     &storage.K8SRoleBinding{Subjects: make([]*storage.Subject, 0)},
+			expect: nil,
+		},
+		"all kinds supported": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT},
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT},
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP},
+			},
+		},
+		"namespaced kinds preserve namespace": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Namespace: "namespace"},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Namespace: "namespace"},
+			},
+		},
+		"non-namespaced kinds are adjusted": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_GROUP, Namespace: "namespace"},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP},
+			},
+		},
+		"only non-namespaced kinds are adjusted for list of mixed kinds": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_UNSET_KIND},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_USER, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_GROUP, Namespace: "namespace"},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_UNSET_KIND, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_UNSET_KIND},
+				{Kind: storage.SubjectKind_SERVICE_ACCOUNT, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP},
+			},
+		},
+		"non-namespaced duplicates are adjusted": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_GROUP},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER},
+				{Kind: storage.SubjectKind_GROUP},
+			},
+		},
+		"only namespace removed": {
+			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER, Name: "user-1", Namespace: "namespace", Id: "cluster-1:user-1", ClusterId: "cluster-1", ClusterName: "cluster-name"},
+				{Kind: storage.SubjectKind_GROUP, Name: "group-1", Namespace: "namespace", Id: "cluster-1:group-1", ClusterId: "cluster-1", ClusterName: "cluster-name"},
+			}},
+			expect: []*storage.Subject{
+				{Kind: storage.SubjectKind_USER, Name: "user-1", Id: "cluster-1:user-1", ClusterId: "cluster-1", ClusterName: "cluster-name"},
+				{Kind: storage.SubjectKind_GROUP, Name: "group-1", Id: "cluster-1:group-1", ClusterId: "cluster-1", ClusterName: "cluster-name"},
+			},
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			protoassert.ElementsMatch(t, tt.expect, GetSubjectsAdjustedByKind(tt.rb))
+		})
+	}
+}

--- a/pkg/k8srbac/subjects_test.go
+++ b/pkg/k8srbac/subjects_test.go
@@ -76,10 +76,10 @@ func TestGetSubjectsAdjustedByKind(t *testing.T) {
 		},
 		"non-namespaced duplicates are adjusted": {
 			rb: &storage.K8SRoleBinding{Subjects: []*storage.Subject{
-				{Kind: storage.SubjectKind_USER, Namespace: "namespace"},
+				{Kind: storage.SubjectKind_USER, Namespace: "is-first-in-the-list"},
 				{Kind: storage.SubjectKind_USER},
-				{Kind: storage.SubjectKind_GROUP, Namespace: "namespace"},
 				{Kind: storage.SubjectKind_GROUP},
+				{Kind: storage.SubjectKind_GROUP, Namespace: "is-second-in-the-list"},
 			}},
 			expect: []*storage.Subject{
 				{Kind: storage.SubjectKind_USER},

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -304,9 +304,8 @@ class K8sRbacTest extends BaseSpecification {
         assert stackroxSubjects.size() == orchestratorSubjects.size()
         for (Rbac.Subject sub : stackroxSubjects) {
             K8sSubject subject = orchestratorSubjects.find {
-                it.name == sub.name &&
-                        it.namespace == sub.namespace &&
-                        it.kind.toLowerCase() == sub.kind.toString().toLowerCase()
+                // orchestratorSubjects contains only User and Group kind where namespace is not relevant.
+                it.name == sub.name && it.kind.toLowerCase() == sub.kind.toString().toLowerCase()
             }
             assert subject
         }


### PR DESCRIPTION
### Description

We have failing tests on GKE. The difference comes from non-namespaced subjects.

With GKE - Kubernetes version`v1.31.2-gke.1384000`, we have two role bindings. One is normal (namespace) role binding, and the other is cluster (non-namespace) role binding.

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: konnectivity-server-leases
  namespace: kube-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: leases-writer
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:konnectivity-server
  namespace: kube-system
```

and

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system:konnectivity-server
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:auth-delegator
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:konnectivity-server
```

The problem that we are facing is that subjects of kind User and Group are non-namespace subjects and they should not have set `namespace` property. They are actually the same subject, but ACS considers it as two separate subjects.

Kubernetes documentation: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-binding-v1/
```
subjects.namespace (string)

Namespace of the referenced object. If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
```

This PR introduces a helper function that will adjust subjects for role binding and remove the namespace for non-namespaced subjects.

The test is also adjusted because it uses the namespace property during comparison.

Additional information is provided in Jira.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added new unit tests
- [x] modified existing tests

#### How I validated my change

I have added unit tests for service and worked on implementation after that.
After I had finished implementation, I moved tests from service to function unit tests because they fit better there and are easier to understand.

#### Use the latest GKE version

/pragma: gke_cluster_version:latest
