### PR TITLE
ROX-26867: Add Generate SBOM menu item to image list page

### DIFF
--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -18,6 +18,13 @@ export function getTableRowActionButtonByName(name: string) {
         });
 }
 
+export function openTableRowActionMenu(
+    rowSelector: string,
+    menuButtonAriaLabel: string = 'Kebab toggle'
+) {
+    return cy.get(`${rowSelector} button[aria-label="${menuButtonAriaLabel}"]`).click();
+}
+
 export function editIntegration(name: string) {
     cy.get(`tr:contains('${name}') td.pf-v5-c-table__action button`).click();
     cy.get(

--- a/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import useCentralCapabilities from 'hooks/useCentralCapabilities';
-import useFeatureFlags from 'hooks/useFeatureFlags';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import usePermissions from 'hooks/usePermissions';
 
 import AnnouncementBanner from './AnnouncementBanner';
@@ -12,7 +12,6 @@ import ServerStatusBanner from './ServerStatusBanner';
 
 function Banners(): ReactElement {
     // Assume MainPage renders this element only after feature flags and permissions are available.
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadWriteAccess } = usePermissions();
 
     const { isCentralCapabilityAvailable } = useCentralCapabilities();
@@ -20,7 +19,7 @@ function Banners(): ReactElement {
     const hasAdministrationWritePermission = hasReadWriteAccess('Administration');
     const showCertGenerateAction = centralCanUpdateCert && hasAdministrationWritePermission;
 
-    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isScannerV4Enabled = useIsScannerV4Enabled();
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -3,8 +3,8 @@ import { Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/
 
 import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useInterval from 'hooks/useInterval';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import usePermissions from 'hooks/usePermissions';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import CertificateCard from './CertificateHealth/CertificateCard';
 import ClustersHealthCards from './ClustersHealth/ClustersHealthCards';
@@ -28,8 +28,7 @@ const SystemHealthDashboardPage = () => {
     const hasReadAccessForCluster = hasReadAccess('Cluster');
     const hasReadAccessForIntegration = hasReadAccess('Integration');
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isScannerV4Enabled = useIsScannerV4Enabled();
 
     const [pollingCountFaster, setPollingCountFaster] = useState(0);
     const [pollingCountSlower, setPollingCountSlower] = useState(0);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -66,9 +66,7 @@ export const imageDetailsQuery = gql`
 `;
 
 function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
-    return (
-        <Tooltip content="SBOM generation requires Scanner V4 to be enabled">{children}</Tooltip>
-    );
+    return <Tooltip content="SBOM generation requires Scanner V4">{children}</Tooltip>;
 }
 
 function ImagePage() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -27,8 +27,8 @@ import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import useURLPagination from 'hooks/useURLPagination';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import { getOverviewPagePath } from '../../utils/searchUtils';
@@ -72,7 +72,6 @@ function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
 }
 
 function ImagePage() {
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { imageId } = useParams();
     const { data, error } = useQuery<
         {
@@ -97,7 +96,7 @@ function ImagePage() {
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     const hasGenerateSBOMAbility = useHasGenerateSBOMAbility();
-    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isScannerV4Enabled = useIsScannerV4Enabled();
 
     const imageData = data && data.image;
     const imageName = imageData?.name;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -234,7 +234,7 @@ function ImageOverviewTable({
                                 title: 'Generate SBOM',
                                 isAriaDisabled: !isScannerV4Enabled,
                                 description: !isScannerV4Enabled
-                                    ? 'SBOM generation requires Scanner V4 to be enabled'
+                                    ? 'SBOM generation requires Scanner V4'
                                     : undefined,
                                 onClick: () => {},
                             });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
-import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Flex, Label } from '@patternfly/react-core';
 import { EyeIcon } from '@patternfly/react-icons';
 
@@ -17,6 +17,8 @@ import {
     getHiddenColumnCount,
     ManagedColumns,
 } from 'hooks/useManagedColumns';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
+import useHasGenerateSBOMAbility from '../../hooks/useHasGenerateSBOMAbility';
 import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../../types';
@@ -136,13 +138,13 @@ function ImageOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: ImageOverviewTableProps) {
+    const hasGenerateSBOMAbility = useHasGenerateSBOMAbility();
+    const isScannerV4Enabled = useIsScannerV4Enabled();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
+    const hasActionColumn = hasWriteAccessForWatchedImage || hasGenerateSBOMAbility;
     const colSpan =
-        5 +
-        (hasWriteAccessForWatchedImage ? 1 : 0) +
-        (showCveDetailFields ? 1 : 0) +
-        -hiddenColumnCount;
+        5 + (hasActionColumn ? 1 : 0) + (showCveDetailFields ? 1 : 0) + -hiddenColumnCount;
 
     return (
         <Table borders={false} variant="compact">
@@ -180,7 +182,7 @@ function ImageOverviewTable({
                     >
                         Scan time
                     </Th>
-                    {hasWriteAccessForWatchedImage && (
+                    {hasActionColumn && (
                         <Th>
                             <span className="pf-v5-screen-reader">Row actions</span>
                         </Th>
@@ -214,6 +216,29 @@ function ImageOverviewTable({
                         const isWatchedImage = watchStatus === 'WATCHED';
                         const watchImageMenuText = isWatchedImage ? 'Unwatch image' : 'Watch image';
                         const watchImageMenuAction = isWatchedImage ? onUnwatchImage : onWatchImage;
+
+                        const rowActions: IAction[] = [];
+
+                        if (hasWriteAccessForWatchedImage && name?.tag) {
+                            rowActions.push({
+                                title: watchImageMenuText,
+                                onClick: () =>
+                                    watchImageMenuAction(
+                                        `${name.registry}/${name.remote}:${name.tag}`
+                                    ),
+                            });
+                        }
+
+                        if (hasGenerateSBOMAbility) {
+                            rowActions.push({
+                                title: 'Generate SBOM',
+                                isAriaDisabled: !isScannerV4Enabled,
+                                description: !isScannerV4Enabled
+                                    ? 'SBOM generation requires Scanner V4 to be enabled'
+                                    : undefined,
+                                onClick: () => {},
+                            });
+                        }
 
                         return (
                             <Tbody
@@ -301,20 +326,12 @@ function ImageOverviewTable({
                                     >
                                         {scanTime ? <DateDistance date={scanTime} /> : 'unknown'}
                                     </Td>
-                                    {hasWriteAccessForWatchedImage && (
+                                    {hasActionColumn && (
                                         <Td isActionCell>
                                             {name?.tag && (
                                                 <ActionsColumn
                                                     popperProps={ACTION_COLUMN_POPPER_PROPS}
-                                                    items={[
-                                                        {
-                                                            title: watchImageMenuText,
-                                                            onClick: () =>
-                                                                watchImageMenuAction(
-                                                                    `${name.registry}/${name.remote}:${name.tag}`
-                                                                ),
-                                                        },
-                                                    ]}
+                                                    items={rowActions}
                                                 />
                                             )}
                                         </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -328,12 +328,10 @@ function ImageOverviewTable({
                                     </Td>
                                     {hasActionColumn && (
                                         <Td isActionCell>
-                                            {name?.tag && (
-                                                <ActionsColumn
-                                                    popperProps={ACTION_COLUMN_POPPER_PROPS}
-                                                    items={rowActions}
-                                                />
-                                            )}
+                                            <ActionsColumn
+                                                popperProps={ACTION_COLUMN_POPPER_PROPS}
+                                                items={rowActions}
+                                            />
                                         </Td>
                                     )}
                                 </Tr>

--- a/ui/apps/platform/src/hooks/useIsScannerV4Enabled.ts
+++ b/ui/apps/platform/src/hooks/useIsScannerV4Enabled.ts
@@ -1,0 +1,7 @@
+import useFeatureFlags from './useFeatureFlags';
+
+export default function useIsScannerV4Enabled() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    return isFeatureFlagEnabled('ROX_SCANNER_V4');
+}


### PR DESCRIPTION
### Description

As titled, adds the "Generate SBOM" menu item to images on the Workload CVE overview page.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit without the ROX_SBOM_GENERATION feature flag enabled, or without "READ_WRITE" access to "Image":
![image](https://github.com/user-attachments/assets/d7fbb7c1-f932-4483-a6e9-378bdd87503b)


Visit with both, but without Scanner V4 enabled. In this case, the menu option is disabled and a description tells why.
![image](https://github.com/user-attachments/assets/15070d24-bc89-4e2b-bb66-94096ea03f2d)

Visit with both and with Scanner V4 enabled.
![image](https://github.com/user-attachments/assets/05acc47d-fa61-46e7-b34d-adbab628cc5c)

