### PR TITLE
ci: increase ingress timeout for ocp-interop

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1068,6 +1068,7 @@ wait_for_api() {
         # OCP Interop tests are run on minimal instances and will take longer
         # Allow override with MAX_WAIT_SECONDS
         max_seconds=${MAX_WAIT_SECONDS:-600}
+        info "Waiting ${max_seconds}s (increased for openshift-ci provisioned clusters) for central api and $(( max_seconds * 6 )) for ingress..."
     fi
     max_ingress_seconds=$(( max_seconds * 6 ))
 


### PR DESCRIPTION
interop acs test times-out on OCP4.18 operator wait for route (for central to be ready)

Tests on this pr confirm passing without this condition applying the change. Verified also in openshift-ci, where the condition is true: https://github.com/openshift/release/pull/59206