### PR TITLE
ROX-26868: Add SBOM generation modal

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.ts
@@ -98,4 +98,6 @@ export const selectors = {
 
     // Observed CVE mode selectors
     observedCveModeSelect: '*[aria-label="Observed CVE mode select"]',
+
+    generateSbomModal: '*[role="dialog"]:contains("Generate Software Bill of Materials (SBOM)")',
 };

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -28,7 +28,7 @@ describe('Workload CVE Image Single page', () => {
         }
     });
 
-    function visitFirstImage() {
+    function visitFirstImage(): Promise<string> {
         visitWorkloadCveOverview();
 
         selectEntityTab('Image');
@@ -39,7 +39,8 @@ describe('Workload CVE Image Single page', () => {
         return cy.get('tbody tr td[data-label="Image"] a').then(([$imageLink]) => {
             const imageName = $imageLink.innerText.replace('\n', '');
             cy.wrap($imageLink).click();
-            return cy.get('h1').contains(imageName);
+            cy.get('h1').contains(imageName);
+            return Promise.resolve(imageName);
         });
     }
 
@@ -345,11 +346,11 @@ describe('Workload CVE Image Single page', () => {
                 this.skip();
             }
 
-            visitFirstImage();
-
-            cy.get(sbomGenerationButtonSelector).should('not.have.attr', 'aria-disabled');
-
-            // TODO Add to implementation
+            visitFirstImage().then((imageFullName) => {
+                cy.get(sbomGenerationButtonSelector).click();
+                cy.get(selectors.generateSbomModal).contains(imageFullName);
+                // TODO Add to implementation
+            });
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -88,7 +88,7 @@ describe('Workload CVE overview page tests', () => {
             // Ensure that only the correct filter chip is present
             const filterChipGroupName = isAdvancedFiltersEnabled ? 'CVE severity' : 'Severity';
             cy.get(selectors.filterChipGroupItem(filterChipGroupName, 'Critical'));
-            cy.get(selectors.filterChipGroupItems).should('have.lengthOf', 1);
+            cy.get(selectors.filterChipGroupItems(filterChipGroupName)).should('have.lengthOf', 1);
 
             // TODO - See if there is a clean way to re-enable this to handle both cases where the
             // feature flag is not enabled and not enabled
@@ -158,11 +158,17 @@ describe('Workload CVE overview page tests', () => {
 
             visitWorkloadCveOverview();
             selectEntityTab('Image');
-            openTableRowActionMenu(selectors.firstTableRow);
 
-            cy.get(sbomGenerationButtonSelector).should('not.have.attr', 'aria-disabled');
+            cy.get(selectors.firstTableRow)
+                .find('td[data-label="Image"] a')
+                .then(($link) => {
+                    const imageFullName = $link.text();
+                    openTableRowActionMenu(selectors.firstTableRow);
 
-            // TODO Add to implementation
+                    cy.get(sbomGenerationButtonSelector).click();
+                    cy.get(selectors.generateSbomModal).contains(imageFullName);
+                    // TODO Add to implementation
+                });
         });
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
+
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+export type GenerateSbomModalProps = {
+    onClose: () => void;
+    onGenerateSbom: () => void;
+    imageFullName: string;
+};
+
+function GenerateSbomModal(props: GenerateSbomModalProps) {
+    const { onClose, onGenerateSbom, imageFullName } = props;
+
+    const isLoading = false;
+    const isSuccess = false;
+    const isError = false;
+    const error = undefined;
+
+    function onClickGenerateSbom() {
+        // TODO Implement API call
+        onGenerateSbom();
+    }
+
+    return (
+        <Modal
+            isOpen
+            onClose={onClose}
+            title="Generate Software Bill of Materials (SBOM)"
+            variant="medium"
+            actions={[
+                <Button
+                    key="generate-sbom-action"
+                    isLoading={isLoading}
+                    isDisabled={isLoading}
+                    onClick={onClickGenerateSbom}
+                >
+                    Generate SBOM
+                </Button>,
+                <Button key="close-modal" variant="link" onClick={onClose}>
+                    Cancel
+                </Button>,
+            ]}
+        >
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Text>
+                    Generate and download the Software Bill of Materials (SBOM) in SBDX 2.3 format.
+                    This file contains a detailed list of all components and dependencies included
+                    in the image.
+                </Text>
+                <Text>
+                    Selected image: <em>{imageFullName}</em>
+                </Text>
+                {isSuccess && (
+                    <Alert
+                        isInline
+                        component="p"
+                        variant="success"
+                        title="Software Bill of Materials (SBOM) generated successfully"
+                    />
+                )}
+                {isLoading && (
+                    <Alert
+                        isInline
+                        component="p"
+                        variant="info"
+                        title="Generating, please do not navigate away from this modal"
+                    />
+                )}
+                {isError && (
+                    <Alert
+                        isInline
+                        component="p"
+                        variant="danger"
+                        title="There was an error generating the Software Bill of Materials (SBOM)"
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
+            </Flex>
+        </Modal>
+    );
+}
+
+export default GenerateSbomModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
+import {
+    Alert,
+    Button,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    Modal,
+    Text,
+} from '@patternfly/react-core';
 
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -38,7 +48,7 @@ function GenerateSbomModal(props: GenerateSbomModalProps) {
                     Generate SBOM
                 </Button>,
                 <Button key="close-modal" variant="link" onClick={onClose}>
-                    Cancel
+                    Close
                 </Button>,
             ]}
         >
@@ -48,9 +58,12 @@ function GenerateSbomModal(props: GenerateSbomModalProps) {
                     This file contains a detailed list of all components and dependencies included
                     in the image.
                 </Text>
-                <Text>
-                    Selected image: <em>{imageFullName}</em>
-                </Text>
+                <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Selected image:</DescriptionListTerm>
+                        <DescriptionListDescription>{imageFullName}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
                 {isSuccess && (
                     <Alert
                         isInline


### PR DESCRIPTION
### Description

Adds the "Generate SBOM" modal and displays it via the Workload CVE Image list and Image single pages.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing



- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

View the Generate SBOM modal via the Workload CVE Image list menu item or the Image CVE single page button:
![image](https://github.com/user-attachments/assets/89d88b95-1f85-46b8-b8f2-4c4ec95e404a)
![image](https://github.com/user-attachments/assets/5cf19153-9a22-4dc2-a7a8-4a7f203d18e2)

The "Generate SBOM" button is not functional as this does not currently connect to an API request. Simulated API states below.

Loading:
![image](https://github.com/user-attachments/assets/0023bc2b-6694-4b52-be13-c701a0ca689e)
Success (this will trigger the native browser download):
![image](https://github.com/user-attachments/assets/db0b7d16-5cb5-4bba-a7a3-e07e1015d8a6)
Error:
![image](https://github.com/user-attachments/assets/4c71f639-a572-444c-b75b-b758a5db3111)

Open the modal via the Image single page:
![image](https://github.com/user-attachments/assets/2eec3fb6-5cb8-4703-ba25-dd0c81bcd0b5)


Verify a11y:
![image](https://github.com/user-attachments/assets/8637d4e9-c580-4cd8-8332-1bdeff72f00d)
