### PR TITLE
ROX-27186: Delete conditional code for classic dark theme

### DIFF
--- a/ui/apps/platform/public/index.html
+++ b/ui/apps/platform/public/index.html
@@ -17,7 +17,7 @@
     <title></title>
 </head>
 
-<body>
+<body class="theme-light">
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
     <!--

--- a/ui/apps/platform/src/Components/GroupedTabs.js
+++ b/ui/apps/platform/src/Components/GroupedTabs.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import upperFirst from 'lodash/upperFirst';
 
-import { useTheme } from 'Containers/ThemeProvider';
-
 const GroupedTab = ({ text, index, active, to }) => (
     <li
         className={`flex flex-grow items-center border-t border-base-400 ${
@@ -27,7 +25,6 @@ GroupedTab.propTypes = {
 };
 
 const GroupedTabs = ({ groups, tabs, activeTab }) => {
-    const { isDarkMode } = useTheme();
     const groupMapping = tabs.reduce((acc, curr) => {
         acc[curr.group] = [...(acc[curr.group] || []), curr];
         return acc;
@@ -41,10 +38,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
             return (
                 <li
                     data-testid="grouped-tab"
-                    className={`
-                        ${!isDarkMode ? 'bg-primary-100' : 'bg-base-0'} ${
-                            idx !== 0 ? 'ml-4' : ''
-                        } flex flex-col relative justify-end`}
+                    className={`${idx !== 0 ? 'ml-4' : ''} flex flex-col relative justify-end`}
                     key={group}
                 >
                     {showGroupTab && (
@@ -74,9 +68,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
         <div className="relative">
             <ul
                 data-testid="grouped-tabs"
-                className={` flex border-b border-base-400 px-4 text-sm ignore-react-onclickoutside ${
-                    !isDarkMode ? 'bg-primary-100' : 'bg-base-0'
-                }`}
+                className="flex border-b border-base-400 px-4 text-sm ignore-react-onclickoutside"
             >
                 {result}
             </ul>

--- a/ui/apps/platform/src/Components/PageHeader/PageHeader.js
+++ b/ui/apps/platform/src/Components/PageHeader/PageHeader.js
@@ -1,17 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { useTheme } from 'Containers/ThemeProvider';
 import SubHeader from 'Components/SubHeader';
 
 const PageHeader = ({ header, subHeader, classes, bgStyle, children }) => {
-    const { isDarkMode } = useTheme();
-
     return (
         <div
-            className={`flex h-18 px-4 w-full flex-shrink-0 z-10 border-b border-base-400 ${classes} ${
-                !isDarkMode ? 'bg-base-100' : 'bg-base-0'
-            }`}
+            className={`flex h-18 px-4 w-full flex-shrink-0 z-10 border-b border-base-400 ${classes} bg-base-100`}
             style={bgStyle}
             data-testid="page-header"
         >

--- a/ui/apps/platform/src/Components/animations/SidePanelAnimatedArea.tsx
+++ b/ui/apps/platform/src/Components/animations/SidePanelAnimatedArea.tsx
@@ -13,7 +13,6 @@ const transition = {
 
 export type SidePanelAnimatedAreaProps = {
     children: ReactNode;
-    isDarkMode: boolean;
     isOpen: boolean;
 };
 
@@ -28,13 +27,7 @@ export type SidePanelAnimatedAreaProps = {
  * A semi-transparent gray background color covers the main panel (underlay style).
  * The side panel opens from right to left.
  */
-function SidePanelAnimatedArea({
-    children,
-    isDarkMode,
-    isOpen,
-}: SidePanelAnimatedAreaProps): ReactElement {
-    const bgClassName = isDarkMode ? 'bg-base-0' : 'bg-base-100';
-
+function SidePanelAnimatedArea({ children, isOpen }: SidePanelAnimatedAreaProps): ReactElement {
     return (
         <AnimatePresence initial={false}>
             {isOpen && (
@@ -43,7 +36,7 @@ function SidePanelAnimatedArea({
                     style={{ backgroundColor: 'rgba(3, 3, 3, 0.62)' }}
                 >
                     <motion.div
-                        className={`${bgClassName} border-base-400 border-l h-full rounded-tl-lg shadow-sidepanel w-full lg:w-9/10`}
+                        className="bg-base-100 border-base-400 border-l h-full rounded-tl-lg shadow-sidepanel w-full lg:w-9/10"
                         initial="closed"
                         animate="open"
                         exit="closed"

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -1,16 +1,12 @@
 import React, { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
-import { useTheme } from 'Containers/ThemeProvider';
 import helm from 'images/helm.svg';
 
 function HelmIndicator(): ReactElement {
-    const { isDarkMode } = useTheme();
-    const darkModeStyle = isDarkMode ? 'bg-base-800 rounded-full' : '';
-
     return (
         <Tooltip content="This cluster is managed by Helm.">
-            <span className={`w-5 h-5 inline-block ${darkModeStyle}`}>
+            <span className="w-5 h-5 inline-block">
                 <img className="w-5 h-5" src={helm} alt="Managed by Helm" />
             </span>
         </Tooltip>

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -1,16 +1,12 @@
 import React, { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
-import { useTheme } from 'Containers/ThemeProvider';
 import operatorLogo from 'images/operator-logo.png';
 
 function OperatorIndicator(): ReactElement {
-    const { isDarkMode } = useTheme();
-    const darkModeStyle = isDarkMode ? 'bg-base-800 rounded-full' : '';
-
     return (
         <Tooltip content="This cluster is managed by a Kubernetes Operator.">
-            <span className={`w-5 h-5 inline-block ${darkModeStyle}`}>
+            <span className="w-5 h-5 inline-block">
                 <img
                     className="w-5 h-5"
                     src={operatorLogo}

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -11,7 +11,6 @@ import PageHeader from 'Components/PageHeader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { resourceTypes } from 'constants/entityTypes';
 import useCaseTypes from 'constants/useCaseTypes';
-import { useTheme } from 'Containers/ThemeProvider';
 import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
 import usePermissions from 'hooks/usePermissions';
 import {
@@ -67,11 +66,6 @@ function ComplianceDashboardPage(): ReactElement {
 
     const [isExporting, setIsExporting] = useState(false);
 
-    const { isDarkMode } = useTheme();
-    const darkModeClasses = `${
-        isDarkMode ? 'text-base-600 hover:bg-primary-200' : 'text-base-100 hover:bg-primary-800'
-    }`;
-
     const { runs, error, restartPolling, inProgressScanDetected, isCurrentScanIncomplete } =
         useComplianceRunStatuses(queriesToRefetchOnPollingComplete);
 
@@ -123,7 +117,7 @@ function ComplianceDashboardPage(): ReactElement {
                         <ComplianceDashboardTile entityType="DEPLOYMENT" />
                         {hasWriteAccessForCompliance && (
                             <ScanButton
-                                className={`flex items-center justify-center border-2 btn btn-base h-10 lg:min-w-32 xl:min-w-43 ${darkModeClasses}`}
+                                className={`flex items-center justify-center border-2 btn btn-base h-10 lg:min-w-32 xl:min-w-43`}
                                 text="Scan environment"
                                 textClass="hidden lg:block"
                                 textCondensed="Scan all"

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Page.js
@@ -9,7 +9,6 @@ import configMgmtPaginationContext, {
     SIDEPANEL_PAGINATION_PARAMS,
 } from 'Containers/configMgmtPaginationContext';
 import searchContext from 'Containers/searchContext';
-import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
 import useClickOutside from 'hooks/useClickOutside';
 import parseURL from 'utils/URLParser';
@@ -23,7 +22,6 @@ import Entity from '../Entity';
 const EntityPage = () => {
     const sidePanelRef = useRef(null);
     const [isExporting, setIsExporting] = useState(false);
-    const { isDarkMode } = useTheme();
     const location = useLocation();
     const history = useHistory();
     const match = useRouteMatch();
@@ -104,7 +102,7 @@ const EntityPage = () => {
                     </configMgmtPaginationContext.Provider>
                     <searchContext.Provider value={searchParams.sidePanel}>
                         <configMgmtPaginationContext.Provider value={SIDEPANEL_PAGINATION_PARAMS}>
-                            <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!entityId1}>
+                            <SidePanelAnimatedArea isOpen={!!entityId1}>
                                 <div ref={sidePanelRef}>
                                     <SidePanel
                                         contextEntityId={pageEntityId}

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
@@ -16,7 +16,6 @@ import configMgmtPaginationContext, {
 } from 'Containers/configMgmtPaginationContext';
 import searchContext from 'Containers/searchContext';
 import { searchParams } from 'constants/searchParams';
-import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
 import useClickOutside from 'hooks/useClickOutside';
 import entityLabels from 'messages/entity';
@@ -33,7 +32,6 @@ const ListPage = () => {
     const history = useHistory();
     const match = useRouteMatch();
     const [isExporting, setIsExporting] = useState(false);
-    const { isDarkMode } = useTheme();
 
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;
@@ -100,7 +98,7 @@ const ListPage = () => {
                 </configMgmtPaginationContext.Provider>
                 <searchContext.Provider value={searchParams.sidePanel}>
                     <configMgmtPaginationContext.Provider value={SIDEPANEL_PAGINATION_PARAMS}>
-                        <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!entityId1}>
+                        <SidePanelAnimatedArea isOpen={!!entityId1}>
                             <div ref={sidePanelRef}>
                                 <SidePanel
                                     entityType1={pageEntityListType}

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -44,7 +44,6 @@ import {
     deprecatedPoliciesBasePath,
     policiesBasePath,
 } from 'routePaths';
-import { useTheme } from 'Containers/ThemeProvider';
 
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
@@ -242,16 +241,10 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const hasWriteAccessForInviting = hasReadWriteAccess('Access');
     const showInviteModal = useSelector(selectors.inviteSelector);
 
-    const { isDarkMode } = useTheme();
-
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     return (
-        <div
-            className={`flex flex-col h-full w-full relative overflow-auto ${
-                isDarkMode ? 'bg-base-0' : 'bg-base-100'
-            }`}
-        >
+        <div className="flex flex-col h-full w-full relative overflow-auto 'bg-base-100">
             <ErrorBoundary>
                 <Switch>
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -244,7 +244,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     return (
-        <div className="flex flex-col h-full w-full relative overflow-auto 'bg-base-100">
+        <div className="flex flex-col h-full w-full relative overflow-auto bg-base-100">
             <ErrorBoundary>
                 <Switch>
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />

--- a/ui/apps/platform/src/Containers/MainPage/Header/ThemeToggleButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/ThemeToggleButton.tsx
@@ -1,3 +1,4 @@
+/*
 import React, { CSSProperties, ReactElement } from 'react';
 import { Moon, Sun } from 'react-feather';
 import { Button, Tooltip } from '@patternfly/react-core';
@@ -24,3 +25,4 @@ const ThemeToggleButton = (): ReactElement => {
 };
 
 export default ThemeToggleButton;
+*/

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -16,7 +16,6 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
-import { useTheme } from 'Containers/ThemeProvider';
 import useFetchNetworkPolicies from 'hooks/useFetchNetworkPolicies';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
@@ -36,8 +35,7 @@ const allNetworkPoliciesId = 'All network policies';
 function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
     const { networkPolicies, networkPolicyErrors, isLoading, error } =
         useFetchNetworkPolicies(policyIds);
-    const { isDarkMode } = useTheme();
-    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+    const [customDarkMode, setCustomDarkMode] = React.useState(false);
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
 import { DownloadIcon } from '@patternfly/react-icons';
 
-import { useTheme } from 'Containers/ThemeProvider';
 import useAnalytics, { DOWNLOAD_NETWORK_POLICIES } from 'hooks/useAnalytics';
 import useURLSearch from 'hooks/useURLSearch';
 import download from 'utils/download';
@@ -29,8 +28,7 @@ function NetworkPoliciesYAML({
     const { analyticsTrack } = useAnalytics();
     const { searchFilter } = useURLSearch();
 
-    const { isDarkMode } = useTheme();
-    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+    const [customDarkMode, setCustomDarkMode] = React.useState(false);
 
     function onToggleDarkMode() {
         setCustomDarkMode((prevValue) => !prevValue);

--- a/ui/apps/platform/src/Containers/ThemeProvider.js
+++ b/ui/apps/platform/src/Containers/ThemeProvider.js
@@ -1,3 +1,4 @@
+/*
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useMediaQuery } from 'react-responsive';
@@ -85,3 +86,4 @@ ThemeProvider.propTypes = {
 };
 
 export { ThemeProvider, useTheme };
+*/

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useContext } from 'react';
 
 import { defaultCountKeyMap as countKeyMap } from 'constants/workflowPages.constants';
-import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
 import {
     VulnerabilityManagementEntityType,
@@ -21,7 +20,6 @@ function RelatedEntitiesSideList({
     data,
     entityContext,
 }: RelatedEntitiesSideListProps): ReactNode {
-    const { isDarkMode } = useTheme();
     const workflowState = useContext(workflowStateContext);
     const { useCase } = workflowState;
     if (!useCase) {
@@ -61,11 +59,7 @@ function RelatedEntitiesSideList({
         return null;
     }
     return (
-        <div
-            className={`h-full relative border-base-100 border-l max-w-43 ${
-                !isDarkMode ? 'bg-primary-300' : 'bg-base-100'
-            }`}
-        >
+        <div className="h-full relative border-base-300 border-l max-w-43 bg-base-200">
             <div className="sticky top-0 py-4">
                 <h2 className="mb-3 p-2 rounded-l text-lg text-base-600 text-center font-700">
                     Related entities

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import { useTheme } from 'Containers/ThemeProvider';
 import TileLink from 'Components/TileLink';
 import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 
@@ -23,31 +22,16 @@ export type TileListProps = {
 };
 
 function TileList({ items, title }: TileListProps): ReactElement {
-    const { isDarkMode } = useTheme();
     return (
-        <div
-            className={`text-base-600 rounded border mx-2 my-3 ${
-                !isDarkMode
-                    ? 'bg-primary-200 border-primary-400'
-                    : 'bg-tertiary-200 border-tertiary-300'
-            }`}
-        >
-            <h3
-                className={`border-b text-base-600 text-center p-1 leading-normal font-700 ${
-                    !isDarkMode ? 'border-base-400' : 'border-tertiary-400'
-                }`}
-            >
+        <div className="text-base-600 rounded border mx-2 my-3 bg-primary-200 border-primary-400">
+            <h3 className="border-b text-base-600 text-center p-1 leading-normal font-700 border-base-400">
                 {title}
             </h3>
             <ul className="pb-2">
                 {items.map(({ count, entityType, url }) => (
                     <li className="p-2 pb-0" key={entityType}>
                         <TileLink
-                            colorClasses={` ${
-                                !isDarkMode
-                                    ? 'border-primary-400 hover:bg-primary-200 rounded'
-                                    : 'rounded bg-tertiary-200 border-tertiary-300 hover:bg-tertiary-100 hover:border-tertiary-400'
-                            }  `}
+                            colorClasses="border-primary-400 hover:bg-primary-200 rounded"
                             superText={count}
                             text={entityNounOrdinaryCase(count, entityType)}
                             url={url}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.js
@@ -8,7 +8,6 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import Loader from 'Components/Loader';
 import PageNotFound from 'Components/PageNotFound';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate/EmptyStateTemplate';
-import { useTheme } from 'Containers/ThemeProvider';
 import queryService from 'utils/queryService';
 
 import { LIST_PAGE_SIZE, defaultCountKeyMap } from 'constants/workflowPages.constants';
@@ -47,8 +46,6 @@ const WorkflowEntityPage = ({
     page,
     setRefreshTrigger,
 }) => {
-    const { isDarkMode } = useTheme();
-
     const enhancedQueryOptions =
         queryOptions && queryOptions.variables ? queryOptions : { variables: {} };
     let query = overviewQuery;
@@ -121,7 +118,7 @@ const WorkflowEntityPage = ({
             setRefreshTrigger={setRefreshTrigger}
         />
     ) : (
-        <div className={`flex w-full min-h-full ${isDarkMode ? 'bg-base-0' : 'bg-base-200'}`}>
+        <div className="flex w-full min-h-full bg-base-200">
             <div className="w-full min-h-full" id="capture-widgets">
                 <OverviewComponent
                     data={result}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.js
@@ -7,7 +7,6 @@ import PageHeader from 'Components/PageHeader';
 import EntitiesMenu from 'Components/workflow/EntitiesMenu';
 import ExportButton from 'Components/ExportButton';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
-import { useTheme } from 'Containers/ThemeProvider';
 import workflowStateContext from 'Containers/workflowStateContext';
 import entityTypes from 'constants/entityTypes';
 import parseURL from 'utils/URLParser';
@@ -26,7 +25,6 @@ import EntityTabs from './EntityTabs';
 
 const WorkflowEntityPageLayout = () => {
     const [isExporting, setIsExporting] = useState(false);
-    const { isDarkMode } = useTheme();
     const location = useLocation();
 
     const workflowState = parseURL(location);
@@ -134,7 +132,7 @@ const WorkflowEntityPageLayout = () => {
                         />
                     </div>
 
-                    <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!sidePanelEntityId}>
+                    <SidePanelAnimatedArea isOpen={!!sidePanelEntityId}>
                         <WorkflowSidePanel>
                             <EntityComponent
                                 entityId={sidePanelEntityId}

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -5,7 +5,6 @@ import { ChevronRight, ArrowLeft } from 'react-feather';
 import entityTypes from 'constants/entityTypes';
 import EntityIcon from 'Components/EntityIcon';
 import workflowStateContext from 'Containers/workflowStateContext';
-import { useTheme } from 'Containers/ThemeProvider';
 
 import EntityBreadCrumb, { WorkflowEntity } from './EntityBreadCrumb';
 
@@ -14,8 +13,6 @@ const Icon = (
 );
 
 const BackLink = ({ workflowState, enabled }) => {
-    const { isDarkMode } = useTheme();
-
     // if the link for this particular crumb is enabled, calculate the URL
     //   necessary to go back up the stack,
     //   and remove any existing sort and search on a sublist (fixes https://stack-rox.atlassian.net/browse/ROX-4449)
@@ -31,9 +28,7 @@ const BackLink = ({ workflowState, enabled }) => {
         </Link>
     ) : (
         <EntityIcon
-            className={`flex items-center justify-center border-r  px-4 mr-4 h-full w-16 ${
-                !isDarkMode ? 'border-base-300' : 'border-base-400'
-            }`}
+            className="flex items-center justify-center border-r  px-4 mr-4 h-full w-16 border-base-300"
             entityType={workflowState.getCurrentEntity().entityType}
         />
     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -28,7 +28,7 @@ const BackLink = ({ workflowState, enabled }) => {
         </Link>
     ) : (
         <EntityIcon
-            className="flex items-center justify-center border-r  px-4 mr-4 h-full w-16 border-base-300"
+            className="flex items-center justify-center border-r px-4 mr-4 h-full w-16 border-base-300"
             entityType={workflowState.getCurrentEntity().entityType}
         />
     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.js
@@ -4,7 +4,6 @@ import startCase from 'lodash/startCase';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
 import PageHeader from 'Components/PageHeader';
-import { useTheme } from 'Containers/ThemeProvider';
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import ExportButton from 'Components/ExportButton';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
@@ -27,7 +26,6 @@ const WorkflowListPageLayout = () => {
     const location = useLocation();
     const [isExporting, setIsExporting] = useState(false);
 
-    const { isDarkMode } = useTheme();
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;
     const pageState = new WorkflowState(
@@ -100,12 +98,7 @@ const WorkflowListPageLayout = () => {
                         </div>
                     </div>
                 </PageHeader>
-                <div
-                    className={`h-full relative z-0 min-h-0 ${
-                        !isDarkMode ? 'bg-base-100' : 'bg-base-0'
-                    }`}
-                    id="capture-list"
-                >
+                <div className="h-full relative z-0 min-h-0 bg-base-100" id="capture-list">
                     <ListComponent
                         entityListType={pageListType}
                         selectedRowId={selectedRow && selectedRow.entityId}
@@ -115,7 +108,7 @@ const WorkflowListPageLayout = () => {
                         refreshTrigger={refreshTrigger}
                         setRefreshTrigger={setRefreshTrigger}
                     />
-                    <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!sidePanelEntityId}>
+                    <SidePanelAnimatedArea isOpen={!!sidePanelEntityId}>
                         <WorkflowSidePanel>
                             <EntityComponent
                                 entityId={sidePanelEntityId}

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -19,7 +19,6 @@ import { configureMonacoYaml } from 'monaco-yaml';
 
 import ErrorBoundary from 'Components/PatternFly/ErrorBoundary/ErrorBoundary';
 import AppPage from 'Containers/AppPage';
-import { ThemeProvider } from 'Containers/ThemeProvider';
 import configureStore from 'store/configureStore';
 import installRaven from 'installRaven';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
@@ -73,11 +72,9 @@ root.render(
             */}
             {/* @ts-expect-error `connected-react-router does not support React 18 */}
             <ConnectedRouter history={history}>
-                <ThemeProvider>
-                    <ErrorBoundary>
-                        <AppPage />
-                    </ErrorBoundary>
-                </ThemeProvider>
+                <ErrorBoundary>
+                    <AppPage />
+                </ErrorBoundary>
             </ConnectedRouter>
         </ApolloProvider>
     </Provider>


### PR DESCRIPTION
### Description

### Problem

On one side of the coin, some classic colors are used only for dark theme that was turned off on 2023-06-10 in #6432

On other side of the coin, accessibility guidelines are easier to reinforce via rules with as much PatternFly as possible, and even then, rarely  `className` or `color` props and usually semantic color with `variant` prop:
* 1.4.1 Use of color
* 1.4.3 Contrast (Minimum)

### Analysis

Find in Files
* `useTheme()` has 18 results in 18 files.
* `isDarkMode` has 76 results in 22 files.
* `bg-base-0` has 7 results in 6 files before changes, but none after changes.
* `bg-primary-100` has 8 results in 7 files before changes, but 6 results in 6 files after changes.
* `bg-primary-300` has 3 results in 2 files before changes, but 2 results in 1 file after changes.

### Solution

1. Delete `isDarkMode` conditional rendering.
2. Delete `bg-primary-100` because it is stylistic variation on light background.

### Residue

1. Minimize unneeded classes for classic text and background color after we fix remaining accessibility issues for 1.4.1 guideline for use of color.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -22536 = 4615497 - 4638033 some code moved to another bundle
        total -2541 = 11553577 - 11556118
    * `ls -al build/static/js/*.js | wc`
        files 0 = 179 - 179
4. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/compliance

    * With `isDarkMode` before changes, see presence of `text-base-100` that is not used.
        ![ComplianceDashboardPage_with_isDarkMode](https://github.com/user-attachments/assets/52c25735-b03d-4ac6-a5f6-cc97e3e15e58)

    * Without `isDarkMode` after changes, see absence and the usual hover background.
        ![ComplianceDashboardPage_without_isDarkMode](https://github.com/user-attachments/assets/4b8e8822-4f55-48d4-90a7-250bec9aa646)

2. Visit /main/vulnerability-management/images and then click to open side panel.

    * With `isDarkMode` before changes, see **Related entities** area has blue background color.
        ![RelatedEntitiesSideList_with_isDarkMode](https://github.com/user-attachments/assets/9462cf9d-f204-4252-b88f-ed2baa93bbe8)

    * Without `isDarkMode` after changes, see **Related entities** area has same background color as rest of side panel content.
        ![RelatedEntitiesSideList_without_isDarkMode](https://github.com/user-attachments/assets/9d041999-6d69-4fdd-805c-23b86c1e5371)

    Remove `ThemeProvider` that dynamically sets `class` attribute of `body` element.

    * Without static `class="theme-light"` attribute before changes, see absence of match for some style rules.
        ![index_without_theme_class](https://github.com/user-attachments/assets/1ae539d0-38a5-40b4-9eab-34b6eda91411)

    * With static `class="theme-light"` attribute after changes, see absence of match for some style rules.
        ![index_with_theme_class](https://github.com/user-attachments/assets/42da6cfd-a473-4acd-b9d6-650cd81f8d81)

3. Visit /main/configmanagement/namespaces click to open side panel and then click to visit single page.

    * With `isDarkMode` before changes, see presence of line break in `class` attribute.
        ![GroupedTabs_with_isDarkMode](https://github.com/user-attachments/assets/19413fd2-2570-40db-8092-487464b1d59d)

    * Without `isDarkMode` after changes, see absence of line break in `class` attribute, but same style.
        ![GroupedTabs_without_isDarkMode](https://github.com/user-attachments/assets/c63deea0-fe3c-46a8-890f-8cca124b55c3)
