### PR TITLE
chore: switch to NVD feeds

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -17,7 +17,7 @@ on:
         - nvd-api
         - nvd-feeds
         required: true
-        default: nvd-api
+        default: nvd-feeds
 
 jobs:
   parse-versions:


### PR DESCRIPTION
### Description

This Thanksgiving, NVD has been serving up 503s instead of turkey. Let's switch to the legacy JSON feeds so everyone can enjoy their holidays.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

I ran it manually earlier: https://github.com/stackrox/stackrox/actions/runs/12040515984
