### PR TITLE
ROX-26945: increase backup test timeouts

### DIFF
--- a/central/externalbackups/plugins/gcs/gcs.go
+++ b/central/externalbackups/plugins/gcs/gcs.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	timeout          = 5 * time.Second
 	backupMaxTimeout = 4 * time.Hour
+	testMaxTimeout   = 9 * time.Second
 
 	backupPrefix = "stackrox-backup"
 	timeFormat   = "2006-01-02-15-04-05"
@@ -83,11 +83,8 @@ func newGCS(integration *storage.ExternalBackup) (*gcs, error) {
 	}, nil
 }
 
-func (s *gcs) send(client *googleStorage.Client, duration time.Duration, objectPath string, reader io.Reader) error {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-	defer cancel()
-
-	bucketHandle := client.Bucket(s.bucket)
+func (s *gcs) send(ctx context.Context, objectPath string, reader io.Reader) error {
+	bucketHandle := s.client.Bucket(s.bucket)
 	wc := bucketHandle.Object(objectPath).NewWriter(ctx)
 	if _, err := io.Copy(wc, reader); err != nil {
 		if err := wc.Close(); err != nil {
@@ -101,11 +98,8 @@ func (s *gcs) send(client *googleStorage.Client, duration time.Duration, objectP
 	return nil
 }
 
-func (s *gcs) delete(client *googleStorage.Client, objectPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	bucketHandle := client.Bucket(s.bucket)
+func (s *gcs) delete(ctx context.Context, objectPath string) error {
+	bucketHandle := s.client.Bucket(s.bucket)
 	err := bucketHandle.Object(objectPath).Delete(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "deleting object: %s", objectPath)
@@ -113,10 +107,8 @@ func (s *gcs) delete(client *googleStorage.Client, objectPath string) error {
 	return nil
 }
 
-func (s *gcs) pruneBackupsIfNecessary(client *googleStorage.Client) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	bucketHandle := client.Bucket(s.bucket)
+func (s *gcs) pruneBackupsIfNecessary(ctx context.Context) error {
+	bucketHandle := s.client.Bucket(s.bucket)
 	objectIterator := bucketHandle.Objects(ctx, &googleStorage.Query{
 		Prefix: s.objectPrefix,
 	})
@@ -150,7 +142,7 @@ func (s *gcs) pruneBackupsIfNecessary(client *googleStorage.Client) error {
 	numBackupsToRemove := len(currentBackups) - s.backupsToKeep
 	for _, attrToRemove := range currentBackups[:numBackupsToRemove] {
 		log.Infof("Pruning old backup %s", attrToRemove.Name)
-		if err := s.delete(client, attrToRemove.Name); err != nil {
+		if err := s.delete(ctx, attrToRemove.Name); err != nil {
 			errorList.AddError(s.createError(
 				fmt.Sprintf("deleting object %q from bucket %q", attrToRemove.Name, s.bucket), err),
 			)
@@ -173,26 +165,31 @@ func (s *gcs) Backup(reader io.ReadCloser) error {
 			log.Errorf("Error closing reader: %v", err)
 		}
 	}()
+	ctx, cancel := context.WithTimeout(context.Background(), backupMaxTimeout)
+	defer cancel()
 
 	key := fmt.Sprintf("%s-%s.zip", backupPrefix, formattedTime())
 	formattedKey := s.prefixKey(key)
 
 	log.Infof("Starting GCS Backup for file %v", formattedKey)
-	if err := s.send(s.client, backupMaxTimeout, formattedKey, reader); err != nil {
+	if err := s.send(ctx, formattedKey, reader); err != nil {
 		return s.createError(fmt.Sprintf("creating backup in bucket %q with key %q", s.bucket, formattedKey), err)
 	}
 	log.Info("Successfully backed up to GCS")
-	return s.pruneBackupsIfNecessary(s.client)
+	return s.pruneBackupsIfNecessary(ctx)
 }
 
 func (s *gcs) Test() error {
+	ctx, cancel := context.WithTimeout(context.Background(), testMaxTimeout)
+	defer cancel()
+
 	formattedKey := s.prefixKey(fmt.Sprintf("%s-test-%s", backupPrefix, formattedTime()))
 	reader := strings.NewReader("This is a test of the StackRox integration with this bucket")
-	if err := s.send(s.client, timeout, formattedKey, reader); err != nil {
+	if err := s.send(ctx, formattedKey, reader); err != nil {
 		return s.createError(fmt.Sprintf("creating test object %q in bucket %q", formattedKey, s.bucket), err)
 	}
 
-	if err := s.delete(s.client, formattedKey); err != nil {
+	if err := s.delete(ctx, formattedKey); err != nil {
 		return s.createError(fmt.Sprintf("deleting test object %q from bucket %q",
 			formattedKey, s.bucket), err)
 	}

--- a/central/externalbackups/plugins/gcs/gcs.go
+++ b/central/externalbackups/plugins/gcs/gcs.go
@@ -26,7 +26,8 @@ import (
 
 const (
 	backupMaxTimeout = 4 * time.Hour
-	testMaxTimeout   = 9 * time.Second
+	// Keep test timeout smaller than the UI timeout (see apps/platform/src/services/instance.js#7).
+	testMaxTimeout = 9 * time.Second
 
 	backupPrefix = "stackrox-backup"
 	timeFormat   = "2006-01-02-15-04-05"

--- a/central/externalbackups/plugins/s3/s3.go
+++ b/central/externalbackups/plugins/s3/s3.go
@@ -29,7 +29,8 @@ import (
 
 const (
 	backupMaxTimeout = 4 * time.Hour
-	testMaxTimeout   = 9 * time.Second
+	// Keep test timeout smaller than the UI timeout (see apps/platform/src/services/instance.js#7).
+	testMaxTimeout = 9 * time.Second
 )
 
 var log = logging.LoggerForModule(option.EnableAdministrationEvents())

--- a/central/externalbackups/plugins/s3/s3.go
+++ b/central/externalbackups/plugins/s3/s3.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	backupMaxTimeout = 4 * time.Hour
-	testMaxTimeout   = 5 * time.Second
+	testMaxTimeout   = 9 * time.Second
 )
 
 var log = logging.LoggerForModule(option.EnableAdministrationEvents())

--- a/central/externalbackups/plugins/s3compatible/s3compatible.go
+++ b/central/externalbackups/plugins/s3compatible/s3compatible.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	backupMaxTimeout               = 4 * time.Hour
+	backupMaxTimeout = 4 * time.Hour
+	// Keep test timeout smaller than the UI timeout (see apps/platform/src/services/instance.js#7).
 	testMaxTimeout                 = 9 * time.Second
 	initialConfigurationMaxTimeout = 5 * time.Minute
 	formatKey                      = "backup_2006-01-02T15:04:05.zip"

--- a/central/externalbackups/plugins/s3compatible/s3compatible.go
+++ b/central/externalbackups/plugins/s3compatible/s3compatible.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	backupMaxTimeout               = 4 * time.Hour
-	testMaxTimeout                 = 5 * time.Second
+	testMaxTimeout                 = 9 * time.Second
 	initialConfigurationMaxTimeout = 5 * time.Minute
 	formatKey                      = "backup_2006-01-02T15:04:05.zip"
 )


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In ROX-26945 we observed a test flake where we hit the timeout.

```
GCS backup: creating test object "153cdf82-0569-4df0-9359-cb2eb7bf5b22/stackrox-backup-test-2024-11-11-02-45-35"
in bucket "stackrox-ci-qa-backup-tests": closing GCS writer: context deadline exceeded
```

This PR increases the test timeout from 5 to 9 seconds, which will hopefully make such flakes less likely. Note that we should stay under the 10 second timeout that is enforced by the UI.

I also refactored the contexts to pass them down from a higher level function.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
