### PR TITLE
ROX-25576: Try fixing ReconciliationTest by increasing timeout

### DIFF
--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -137,7 +137,7 @@ class ReconciliationTest extends BaseSpecification {
             assert Services.getPods().findAll { it.deploymentId == busyboxDeployment.getDeploymentUid() }.size() == 1
 
             violations = getViolationsWithTimeout("testing123",
-                    "Secure Shell (ssh) Port Exposed", 30)
+                    "Secure Shell (ssh) Port Exposed", 90)
             assert violations.size() == 1
 
             NetworkPolicy policy = new NetworkPolicy("do-nothing")


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Alert showed up but after the test had failed. Increasing timeout should fix it.

Test failed at 13:37:40
```
    13:37:40 | ERROR | ReconciliationTest        | Helpers                   | An exception occurred in test
    org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:

    violations.size() == 1
    |          |      |
    []         0      false 
```

But alert showed up at 13:38:21

```
central_active=# select policy_name, deployment_name, time from alerts where policy_name = 'Secure Shell (ssh) Port Exposed';
           policy_name           | deployment_name |            time            
---------------------------------+-----------------+----------------------------
 Secure Shell (ssh) Port Exposed | testing123      | 2024-08-01 13:38:21.955239
(1 row) 
```

### User-facing documentation

- [X] CHANGELOG is not needed
- [X] documentation is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is enough