### PR TITLE
chore(scanner): use nvd feeds

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')
-        NVD_BUNDLE_TYPE=${{ github.event.inputs.job || 'nvd-api' }}
+        NVD_BUNDLE_TYPE=${{ github.event.inputs.job || 'nvd-feeds' }}
         case "$NVD_BUNDLE_TYPE" in
             nvd-api)
                 nvd_file=nvd-api.zip


### PR DESCRIPTION
### Description

Followup of https://github.com/stackrox/stackrox/pull/13437. I thought that would do the trick, but I was wrong. Getting this in now to ensure people can enjoy the holiday.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

no