### PR TITLE
ROX-27233: Log reason for not showing a NetworkGraph entity

### DIFF
--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -289,7 +289,7 @@ func (d IPNetwork) String() string {
 	return ipNet.String()
 }
 
-// IPNetworkFromCIDR converts a CIDR string string to an `IPNetwork`. In case of invalid string, an invalid IPNetwork is returned.
+// IPNetworkFromCIDR converts a CIDR string to an `IPNetwork`. In case of invalid string, an invalid IPNetwork is returned.
 func IPNetworkFromCIDR(cidr string) IPNetwork {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {

--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -279,7 +279,7 @@ func (d IPNetwork) Contains(ip IPAddress) bool {
 // String returns the IPNetwork in string form.
 func (d IPNetwork) String() string {
 	if !d.IsValid() {
-		return "no IP data"
+		return ""
 	}
 
 	ipNet := &net.IPNet{

--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -279,7 +279,7 @@ func (d IPNetwork) Contains(ip IPAddress) bool {
 // String returns the IPNetwork in string form.
 func (d IPNetwork) String() string {
 	if !d.IsValid() {
-		return ""
+		return "no IP data"
 	}
 
 	ipNet := &net.IPNet{

--- a/pkg/net/endpoint.go
+++ b/pkg/net/endpoint.go
@@ -16,6 +16,13 @@ const (
 	ICMP
 )
 
+var (
+	// ExternalIPv4Addr is the "canonical" external address sent by collector when the precise IPv4 address is not needed.
+	ExternalIPv4Addr = ParseIP("255.255.255.255")
+	// ExternalIPv6Addr is the "canonical" external address sent by collector when the precise IPv6 address is not needed.
+	ExternalIPv6Addr = ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+)
+
 // String represents a string representation of this L4 protocol.
 func (p L4Proto) String() string {
 	switch p {
@@ -83,4 +90,9 @@ func (e NumericEndpoint) IsValid() bool {
 // String returns a string representation of this numeric endpoint.
 func (e NumericEndpoint) String() string {
 	return fmt.Sprintf("%s (%s)", e.IPAndPort, e.L4Proto)
+}
+
+// IsConsideredExternal checks whether the given numeric endpoint is considered as external IP by collector.
+func (e NumericEndpoint) IsConsideredExternal() bool {
+	return e.IPAndPort.Address == ExternalIPv4Addr || e.IPAndPort.Address == ExternalIPv6Addr
 }

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -569,10 +569,11 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 
 	container, ok := m.clusterEntities.LookupByContainerID(conn.containerID)
 	if !ok {
-		// There is an incoming connection to a container that we do not know.
+		// There is an incoming connection to a container that Sensor does not recognize.
 		// 90% of the cases that container is Sensor itself before being restarted.
-		err := m.handleContainerNotFound(conn, status, enrichedConnections)
-		log.Debugf("Enrichment failed: %v", err)
+		if err := m.handleContainerNotFound(conn, status, enrichedConnections); err != nil {
+			log.Debugf("Enrichment failed: %v", err)
+		}
 		return
 	}
 	netGraphFailReason = multierror.Append(netGraphFailReason, errors.New("ContainerID lookup successful"))

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -51,10 +51,6 @@ const (
 )
 
 var (
-	// these are "canonical" external addresses sent by collector when we don't care about the precise IP address.
-	externalIPv4Addr = net.ParseIP("255.255.255.255")
-	externalIPv6Addr = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-
 	emptyProcessInfo = processInfo{}
 	tickerTime       = time.Second * 30
 )
@@ -551,7 +547,7 @@ func logReasonForAggregatingNetGraphFlow(conn *connection, contNs, contName, ent
 		reasonStr = failReason.Error()
 	}
 	// No need to produce complex chain of reasons, if there is one simple explanation
-	if strings.HasPrefix(conn.remote.IPAndPort.String(), "255.255.255.255") {
+	if conn.remote.IsConsideredExternal() {
 		reasonStr = "Collector did not report the IP address to Sensor - the remote part is the Internet"
 	}
 	if conn.incoming {
@@ -585,7 +581,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 	var isInternet = false
 
 	// Check if the remote address represents the de-facto INTERNET entity.
-	if conn.remote.IPAndPort.Address == externalIPv4Addr || conn.remote.IPAndPort.Address == externalIPv6Addr {
+	if conn.remote.IsConsideredExternal() {
 		isFresh = false
 		isInternet = true
 		netGraphFailReason = multierror.Append(netGraphFailReason,

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -604,7 +604,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 
 		if extSrc == nil {
 			netGraphFailReason = multierror.Append(netGraphFailReason,
-				fmt.Errorf("lookup by network in externalSrcsStore failed for network %s", conn.remote.IPAndPort.IPNetwork.String()))
+				fmt.Errorf("lookup by network in externalSrcsStore failed for network %+v", conn.remote.IPAndPort))
 			entityType := networkgraph.InternetEntity()
 			isExternal, err := conn.IsExternal()
 			if err != nil {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -652,6 +652,8 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			}
 		}
 	} else {
+		failReasons = multierror.Append(failReasons,
+			fmt.Errorf("got %d lookup results for endpoint %s", len(lookupResults), conn.remote.String()))
 		if !status.used {
 			flowMetrics.NetworkEntityFlowCounter.With(metricDirection).Inc()
 		}
@@ -694,7 +696,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			}
 		}
 	}
-	return errors.New("end of function")
+	return nil
 }
 
 func (m *networkFlowManager) enrichContainerEndpoint(ep *containerEndpoint, status *connStatus, enrichedEndpoints map[containerEndpointIndicator]timestamp.MicroTS) {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -541,13 +541,13 @@ func formatMultiErrorOneline(errs []error) string {
 
 func logReasonForAggregatingNetGraphFlow(conn *connection, contNs, contName, entitiesName string, port uint16, failReason *multierror.Error) {
 	reasonStr := ""
-	// No need to produce complex chain of reasons, if there is one simple explanation
-	if strings.HasPrefix(conn.remote.IPAndPort.String(), "255.255.255.255") {
-		reasonStr = "Collector did not report the IP address to Sensor"
-	}
 	if failReason != nil {
 		failReason.ErrorFormat = formatMultiErrorOneline
 		reasonStr = failReason.Error()
+	}
+	// No need to produce complex chain of reasons, if there is one simple explanation
+	if strings.HasPrefix(conn.remote.IPAndPort.String(), "255.255.255.255") {
+		reasonStr = "Collector did not report the IP address to Sensor - the remote part is the Internet"
 	}
 	if conn.incoming {
 		// Keep internal wording even if central lacks `NetworkGraphInternalEntitiesSupported` capability.

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -661,7 +661,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		if conn.incoming {
 			// Only report incoming connections from outside the cluster. These are already taken care of by the
 			// corresponding outgoing connection from the other end.
-			return multierror.Append(failReasons, fmt.Errorf("connection is incoming (we handle only outgoing to avoid duplicates)"))
+			return nil // returning reasons here would flood the logs
 		}
 	}
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -582,7 +582,8 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 	if conn.remote.IPAndPort.Address == externalIPv4Addr || conn.remote.IPAndPort.Address == externalIPv6Addr {
 		isFresh = false
 		isInternet = true
-		netGraphFailReason = multierror.Append(netGraphFailReason, errors.New("remote part is the Internet"))
+		netGraphFailReason = multierror.Append(netGraphFailReason,
+			errors.New("Remote part of the connection is the Internet"))
 	} else {
 		// Otherwise, check if the remote entity is actually a cluster entity.
 		lookupResults = m.clusterEntities.LookupByEndpoint(conn.remote)
@@ -641,13 +642,14 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 					entityType = networkgraph.DiscoveredExternalEntity(net.IPNetworkFromNetworkPeerID(conn.remote.IPAndPort))
 				} else {
 					netGraphFailReason = multierror.Append(netGraphFailReason,
-						errors.New("central lacks capability to display discovered external entities"))
+						errors.New("Central lacks capability to display discovered external entities"))
 				}
 			} else if centralcaps.Has(centralsensor.NetworkGraphInternalEntitiesSupported) {
 				// Central without the capability would crash the UI if we make it display "Internal Entities".
 				entityType = networkgraph.InternalEntities()
+			} else {
 				netGraphFailReason = multierror.Append(netGraphFailReason,
-					errors.New("central lacks capability to display internal entities in the UI"))
+					errors.New("Central lacks capability to display 'Internal Entities' in the UI"))
 			}
 
 			// Fake a lookup result. This shows "External Entities" or "Internal Entities" in the network graph

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
@@ -18,10 +23,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
 	mocksManager "github.com/stackrox/rox/sensor/common/networkflow/manager/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"go.uber.org/mock/gomock"
 )
 
 var (
@@ -394,7 +395,7 @@ func (s *NetworkFlowManagerTestSuite) TestEnrichConnection() {
 			tCase.expectEntityLookupContainer.runIfSet()
 			tCase.expectEntityLookupEndpoint.runIfSet()
 			tCase.expectExternalLookup.runIfSet()
-			m.enrichConnection(tCase.connPair.conn, tCase.connPair.status, tCase.enrichedConnections)
+			_ = m.enrichConnection(tCase.connPair.conn, tCase.connPair.status, tCase.enrichedConnections)
 			s.Assert().Equal(tCase.expectedStatus.used, tCase.connPair.status.used)
 			s.Assert().Equal(tCase.expectedStatus.rotten, tCase.connPair.status.rotten)
 			if tCase.expectedIndicator != nil {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -394,7 +394,7 @@ func (s *NetworkFlowManagerTestSuite) TestEnrichConnection() {
 			tCase.expectEntityLookupContainer.runIfSet()
 			tCase.expectEntityLookupEndpoint.runIfSet()
 			tCase.expectExternalLookup.runIfSet()
-			_ = m.enrichConnection(tCase.connPair.conn, tCase.connPair.status, tCase.enrichedConnections)
+			m.enrichConnection(tCase.connPair.conn, tCase.connPair.status, tCase.enrichedConnections)
 			s.Assert().Equal(tCase.expectedStatus.used, tCase.connPair.status.used)
 			s.Assert().Equal(tCase.expectedStatus.rotten, tCase.connPair.status.rotten)
 			if tCase.expectedIndicator != nil {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -5,11 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"go.uber.org/mock/gomock"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
@@ -23,6 +18,10 @@ import (
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
 	mocksManager "github.com/stackrox/rox/sensor/common/networkflow/manager/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 )
 
 var (

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -111,7 +111,7 @@ func (c *connectionPair) incoming() *connectionPair {
 }
 
 func (c *connectionPair) external() *connectionPair {
-	c.conn.remote.IPAndPort.Address = externalIPv4Addr
+	c.conn.remote.IPAndPort.Address = net.ExternalIPv4Addr
 	return c
 }
 


### PR DESCRIPTION
### Description

This PR refactors part of the code but does not change the behavior.

⚠️ ⚠️⚠️All of the description below applies when the logging in Sensor is set to debug mode!

When Sensor made the decision to show something on the network graph as internal- or external entities, we produced  log lines that were roughly like this:

```
Debug: Marking incoming connection to container kube-system/fluentbit-gke from 10.68.153.85:2021 as 'Internal Entities' in the network graph.

Debug: Marking outgoing connection from container gmp-system/prometheus to 10.68.153.85:10250 as 'Internal Entities' in the network graph.

Debug: Marking outgoing connection from container kube-system/konnectivity-agent-metrics-collector to 255.255.255.255:443 as 'External Entities' in the network graph.
```

The point was to help the customers who are oriented on details to confirm that Sensor did not miss the connection and maybe show few details (container name and IP). However, this information was not helpful for us when debugging the WHY of such decision.

With this PR, I wanted to introduce a very simple change that could help us in finding the WHY of every single log line like in the example at the top. After this PR, the respective log would look as follows:

```
Debug: Marking incoming connection to container kube-system/fluentbit-gke from 10.68.153.85:2021 as 'Internal Entities' in the network graph: (1) ContainerID Lookup Successful, (2) Lookup In ClusterEntitiesStore Failed For Endpoint 10.68.153.85 (Tcp), (3) Lookup By Network In ExternalSrcsStore Failed For Network 10.68.153.85.

Debug: Marking outgoing connection from container gmp-system/prometheus to 10.68.153.85:10250 as 'Internal Entities' in the network graph: (1) ContainerID Lookup Successful, (2) Lookup In ClusterEntitiesStore Failed For Endpoint 10.68.153.85:10250 (Tcp), (3) Lookup By Network In ExternalSrcsStore Failed For Network 10.68.153.85:10250.

Debug: Marking outgoing connection from container kube-system/konnectivity-agent-metrics-collector to 255.255.255.255:443 as 'External Entities' in the network graph: Collector did not report the IP address to Sensor - the remote part is the Internet.
``` 

Note how much easier is now to answer such questions like:
- Why there is this arrow to External Entities on the Graph?
    - Answer (log line 3): because Collector filtered the IP address claiming that the remote is truly an external entity.
- Why there are so many connections to Internal Entities?
    - Answer (log line 1,2): Because the <IP:PORT> has not been added to the cluster entities store or it has been deleted from it recently.  You may try an experimental setting `ROX_ALLOW_HOST_NETWORK_POD_IPS_IN_ENTITIES_STORE ` (See https://github.com/stackrox/stackrox/pull/13340/files#diff-6afc97fcdff18b02b1dba01e62fecf916203356e7c4df9cd44ce0500db8c430bR27)  to see if it helps.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Did nothing new here - existing tests are sufficient to confirm that nothing was broken.
There are no test for log lines here - that would be an overkill (but feel free to convince otherwise).

#### How I validated my change

Deployed to a cluster, enabled debug logging and looked at the logs produced - excerpts pasted in this PR description.
