### PR TITLE
chore: Improve Renovate behavior

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     // Clickable link https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
     // The following was used as example (we may want to check it if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
   ],
   "timezone": "Etc/UTC",
   "schedule": [
@@ -19,7 +19,7 @@
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
     // that.
-    "after 3am and before 7am"
+    "after 3am and before 7am",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,8 @@
     // The following was used as example (we may want to check it if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
+    "group:all",
   ],
   "timezone": "Etc/UTC",
   "schedule": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,13 @@
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
+  "tekton": {
+    "schedule": [
+      // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
+      // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
+      "after 3am and before 7am",
+    ],
+  },
   "dockerfile": {
     "includePaths": [
       // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks.
 
   // After making changes to this file, you can validate it by running something like this in the root of the repo:
-  // $ docker run --rm -it --entrypoint=/usr/local/bin/renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
+  // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
   // There are more validation options, see https://docs.renovatebot.com/config-validation/
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",


### PR DESCRIPTION
### Description

Please review this change per commits. I provided commit message in each.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No automated testing.

#### How I validated my change

Ran `renovate-config-validator` and it said all's ok.
