### PR TITLE
fix(deploy): fix name of Sensor Helm toggle var in script

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -727,7 +727,7 @@ function launch_sensor {
         helm_args+=(--set "allowNonstandardNamespace=true")
       fi
 
-      if [[ "$SENSOR_HELM_MANAGED" == "true" ]]; then
+      if [[ "$SENSOR_HELM_DEPLOY" == "true" ]]; then
         helm_args+=(--set "helmManaged=true")
       else
         helm_args+=(--set "helmManaged=false")


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The `deploy/common/k8sbased.sh` script uses two different env vars for Helm deploys:
* `SENSOR_HELM_DEPLOY`
* `SENSOR_HELM_MANAGED`

If the two have different values, it will lead to inconsistent configurations.

I discovered this issue when deploying in a local cluster with:
`./deploy/k8s/deploy-local.sh`
and then noticed that Sensor thinks it's not helm managed, even though it is:
`kubernetes/sensor: 2024/12/02 12:48:11.975656 sensor.go:100: Info: Install method: "MANAGER_TYPE_MANUAL"`



### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should be sufficient to test regressions.

I tested manually with a local deployment:
`./deploy/k8s/deploy-local.sh`
and now Sensor reports correctly that it is Helm-managed:
`kubernetes/sensor: 2024/12/02 17:28:17.210215 sensor.go:100: Info: Install method: "MANAGER_TYPE_HELM_CHART"`
