### PR TITLE
fix(ui): Fix e2e test flake due to apollo cache misses

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/imageWithMultipleCves.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/imageWithMultipleCves.json
@@ -1,0 +1,30 @@
+{
+    "data": {
+        "image": {
+            "id": "sha256:abcxyz",
+            "name": {
+                "registry": "docker.io",
+                "remote": "cypress-test/image",
+                "tag": "v0.0.1",
+                "__typename": "ImageName"
+            },
+            "deploymentCount": 1,
+            "operatingSystem": "debian:8",
+            "metadata": {
+                "v1": {
+                    "created": "2020-09-15T22:35:00.560827473Z",
+                    "__typename": "V1Metadata"
+                },
+                "__typename": "ImageMetadata"
+            },
+            "dataSource": {
+                "name": "Stackrox Scanner",
+                "__typename": "DataSource"
+            },
+            "scanTime": "2024-12-02T13:51:19.876935617Z",
+            "scanNotes": ["OS_CVES_STALE"],
+            "notes": ["MISSING_SIGNATURE", "MISSING_SIGNATURE_VERIFICATION_DATA"],
+            "__typename": "Image"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
@@ -49,7 +49,7 @@
             "imageVulnerabilities": [
                 {
                     "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
-                    "cve": "CVE-2023-0464",
+                    "cve": "MOCK-2023-0464",
                     "summary": "This is a mocked CVE in a Cypress test",
                     "cvss": 7.5,
                     "scoreVersion": "V3",
@@ -80,7 +80,7 @@
                 },
                 {
                     "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
-                    "cve": "CVE-2023-5363",
+                    "cve": "MOCK-2023-5363",
                     "summary": "This is a mocked CVE in a Cypress test",
                     "cvss": 7.5,
                     "scoreVersion": "V3",

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -291,6 +291,14 @@ export function verifySelectedCvesInModal(cveNames) {
     });
 }
 
+/**
+ * Visits an image single page via the workload CVE overview page and mocks the responses for the image
+ * details and CVE list. We need to mock the CVE list to ensure that multiple CVEs are present for the image. We
+ * also need to mock the image details to ensure Apollo does not duplicate CVE requests due to mismatched
+ * image IDs.
+ *
+ * @returns {Cypress.Chainable} - The image name
+ */
 export function visitImageSinglePageWithMockedResponses() {
     const imageDetailsOpname = 'getImageDetails';
     const cveListOpname = 'getCVEsForImage';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -201,16 +201,18 @@ export function cancelAllCveExceptions() {
 
     cy.request({ url: '/v2/vulnerability-exceptions', auth }).as('vulnExceptions');
 
-    cy.get('@vulnExceptions').then((res) => {
-        res.body.exceptions.forEach(({ id, expired }) => {
-            if (!expired) {
-                cy.request({
-                    url: `/v2/vulnerability-exceptions/${id}/cancel`,
-                    auth,
-                    method: 'POST',
-                });
-            }
-        });
+    return cy.get('@vulnExceptions').then((res) => {
+        return Promise.all(
+            res.body.exceptions.map(({ id, expired, requester }) => {
+                return requester?.name === 'ui_tests' && !expired
+                    ? cy.request({
+                          url: `/v2/vulnerability-exceptions/${id}/cancel`,
+                          auth,
+                          method: 'POST',
+                      })
+                    : Promise.resolve();
+            })
+        );
     });
 }
 
@@ -227,11 +229,7 @@ export function selectSingleCveForException(exceptionType) {
 
     return cy.get(selectors.firstTableRow).then(($row) => {
         const cveName = $row.find('td[data-label="CVE"]').text();
-        cy.wrap($row)
-            .find(selectors.tableRowMenuToggle, { timeout: 10000 })
-            .should('exist')
-            .and('be.visible')
-            .click();
+        cy.wrap($row).find(selectors.tableRowMenuToggle).click();
         cy.get(selectors.menuOption(menuOption)).click();
 
         cy.get('button:contains("CVE selections")').click();
@@ -293,10 +291,17 @@ export function verifySelectedCvesInModal(cveNames) {
     });
 }
 
-export function visitAnyImageSinglePageWithMockedCves() {
+export function visitImageSinglePageWithMockedResponses() {
+    const imageDetailsOpname = 'getImageDetails';
     const cveListOpname = 'getCVEsForImage';
-    const routeMatcherMapForImageCves = getRouteMatcherMapForGraphQL([cveListOpname]);
+    const routeMatcherMapForImageCves = getRouteMatcherMapForGraphQL([
+        imageDetailsOpname,
+        cveListOpname,
+    ]);
     const staticResponseMapForImageCves = {
+        [imageDetailsOpname]: {
+            fixture: 'vulnerabilities/workloadCves/imageWithMultipleCves.json',
+        },
         [cveListOpname]: { fixture: 'vulnerabilities/workloadCves/multipleCvesForImage.json' },
     };
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -10,7 +10,7 @@ import {
     selectSingleCveForException,
     verifyExceptionConfirmationDetails,
     verifySelectedCvesInModal,
-    visitAnyImageSinglePageWithMockedCves,
+    visitImageSinglePageWithMockedResponses,
 } from './WorkloadCves.helpers';
 
 describe('Workload CVE Image page deferral and false positive flows', () => {
@@ -33,7 +33,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should defer a single CVE', () => {
-        visitAnyImageSinglePageWithMockedCves().then((image) => {
+        visitImageSinglePageWithMockedResponses().then((image) => {
             selectSingleCveForException('DEFERRAL').then((cveName) => {
                 verifySelectedCvesInModal([cveName]);
                 fillAndSubmitExceptionForm({
@@ -51,7 +51,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should defer multiple selected CVEs', () => {
-        visitAnyImageSinglePageWithMockedCves().then((image) => {
+        visitImageSinglePageWithMockedResponses().then((image) => {
             selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({
@@ -70,7 +70,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should mark a single CVE as false positive', () => {
-        visitAnyImageSinglePageWithMockedCves().then((image) => {
+        visitImageSinglePageWithMockedResponses().then((image) => {
             selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
                 verifySelectedCvesInModal([cveName]);
                 fillAndSubmitExceptionForm({ comment: 'Test comment' });
@@ -84,7 +84,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should mark multiple selected CVEs as false positive', () => {
-        visitAnyImageSinglePageWithMockedCves().then((image) => {
+        visitImageSinglePageWithMockedResponses().then((image) => {
             selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({


### PR DESCRIPTION
### Description

Days since apollo-client's normalized cache has caused* an obscure and time consuming issue that was difficult to track down: ~45~ **0**

This fixes a test flake in Workload CVE deferral flows where a table row element was not accessible when used with a chained `.find()` Cypress call. I believe the source of this issue is [this PR](https://github.com/stackrox/stackrox/pull/13231) that I merged less than a month ago. That PR mocks the CVE list response for an image for this test suite. This produces the familiar Cypress error:

```
Timed out retrying after 4000ms: `cy.find()` failed because the page updated as a result of 
this command, but you tried to continue the command chain. 
The subject is no longer attached to the DOM, and Cypress cannot requery 
the page after commands such as `cy.find()`.
```

The problem comes from the fact that the mocked cve list response has a different image **id** than the actual e2e response for image details. Due to the mismatch, apollo-client fetches the list of CVEs a second time when loading the page. I believe that the test failures are due to the `cy.get()` getting the element after the first request, and then using the `.find()` call after the second request when the element is no longer present in the DOM. This is timing related, and will only occur occasionally in CI (~7% of test runs last week).

The fix here mocks the response to the image details request as well in order to make sure that the `image.id` field in each request is the same. None of the mocked data is relevant to the e2e functionality under test.


_*I haven't been able to conclusively prove this yet, and have not been able to reproduce locally. The timing of the failures roughly coincides with the PR that introduced this issue and I was able to verify the change in behavior that could cause a test failure._

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Too many API calls using one mocked and one true API response:
![image](https://github.com/user-attachments/assets/a7f0e221-c87f-47e0-a085-b4d2a30059ff)


The expected number of API calls (2) after both responses are mocked:
![image](https://github.com/user-attachments/assets/7c7f43cc-4f6a-48ed-beec-750cee330083)
