### PR TITLE
chore(CI): Disable failing UI test for Violations

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -274,7 +274,8 @@ describe('Violations', () => {
         );
     });
 
-    it('should show a resolved violation in the details page', () => {
+    // TODO(ROX-27198): The test is failing since 2024-11-27.
+    it.skip('should show a resolved violation in the details page', () => {
         visitViolations();
 
         // view "Resolved" violations


### PR DESCRIPTION
### Description

The test is constantly failing since: **2024-11-27**
Jira: https://issues.redhat.com/browse/ROX-27198

The first fail is with the following commit: https://github.com/stackrox/stackrox/commit/8ddf9e3be8eb56356444443874baffbdbb79ab01

Link to Prow: https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-ui-e2e-tests?buildId=1861949054968139776

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] removed UI e2e tests

#### How I validated my change

I'll let CI check it.
