### PR TITLE
ROX-25498: Allow specifying notifiers by name or ID in SecurityPolicy

### DIFF
--- a/config-controller/api/v1alpha1/policy_types_test.go
+++ b/config-controller/api/v1alpha1/policy_types_test.go
@@ -97,7 +97,10 @@ func TestToProtobuf(t *testing.T) {
 		MitreVectorsLocked: true,
 		IsDefault:          false,
 	}
-	protoPolicy := policyCRSpec.ToProtobuf()
+
+	mockNotifiers := make([]*storage.Notifier, 0)
+	protoPolicy, _ := policyCRSpec.ToProtobuf(mockNotifiers)
+
 	// Hack: Reset the source field for us to be able to compare
 	protoPolicy.Source = storage.PolicySource_IMPERATIVE
 	protoassert.Equal(t, expectedProto, protoPolicy, "proto message derived from custom resource not as expected")


### PR DESCRIPTION
### Description

A bare-bones implementation of searching the existing notifiers, to match a notifier specified by ID or name

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

TBD