### PR TITLE
ROX-27187: Add telemetry for UI initiated SBOM generation

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -169,9 +169,6 @@ function ImagePage() {
                                             <GenerateSbomModal
                                                 onClose={() => setSbomTargetImage(undefined)}
                                                 imageName={sbomTargetImage}
-                                                onGenerateSbom={() => {
-                                                    // TODO Implement analytics event
-                                                }}
                                             />
                                         )}
                                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -350,9 +350,6 @@ function ImageOverviewTable({
                 <GenerateSbomModal
                     onClose={() => setSbomTargetImage(undefined)}
                     imageName={sbomTargetImage}
-                    onGenerateSbom={() => {
-                        // TODO Implement analytics event
-                    }}
                 />
             )}
         </Table>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -13,19 +13,20 @@ import {
 import Raven from 'raven-js';
 
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useAnalytics, { IMAGE_SBOM_GENERATED } from 'hooks/useAnalytics';
 import useRestMutation from 'hooks/useRestMutation';
 import { generateAndSaveSbom } from 'services/ImageSbomService';
 
 export type GenerateSbomModalProps = {
     onClose: () => void;
-    onGenerateSbom: () => void;
     imageName: string;
 };
 
 function GenerateSbomModal(props: GenerateSbomModalProps) {
-    const { onClose, onGenerateSbom, imageName } = props;
+    const { analyticsTrack } = useAnalytics();
+    const { onClose, imageName } = props;
     const { mutate, isLoading, isSuccess, isError, error } = useRestMutation(generateAndSaveSbom, {
-        onSuccess: onGenerateSbom,
+        onSuccess: () => analyticsTrack(IMAGE_SBOM_GENERATED),
         onError: (err) => Raven.captureException(err),
     });
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -27,7 +27,7 @@ export const CIDR_BLOCK_FORM_OPENED = 'Network Graph: CIDR Block Form Opened';
 export const WATCH_IMAGE_MODAL_OPENED = 'Watch Image Modal Opened';
 export const WATCH_IMAGE_SUBMITTED = 'Watch Image Submitted';
 
-// workflow cves
+// workload cves
 export const WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED = 'Workload CVE Entity Context View';
 export const WORKLOAD_CVE_FILTER_APPLIED = 'Workload CVE Filter Applied';
 export const WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED = 'Workload CVE Default Filters Changed';
@@ -39,6 +39,7 @@ export const COLLECTION_CREATED = 'Collection Created';
 export const VULNERABILITY_REPORT_CREATED = 'Vulnerability Report Created';
 export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Download Generated';
 export const VULNERABILITY_REPORT_SENT_MANUALLY = 'Vulnerability Report Sent Manually';
+export const IMAGE_SBOM_GENERATED = 'Image SBOM Generated';
 
 // node and platform CVEs
 export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
@@ -242,6 +243,10 @@ export type AnalyticsEvent =
      * Tracks each time the user sends a vulnerability report manually.
      */
     | typeof VULNERABILITY_REPORT_SENT_MANUALLY
+    /**
+     * Tracks each time the user generates an SBOM for an image.
+     */
+    | typeof IMAGE_SBOM_GENERATED
     /**
      * Tracks each time the user snoozes a Node or Platform CVE via
      * Vulnerability Management 1.0


### PR DESCRIPTION
### Description

As titled.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Generate an SBOM and view the event payload being sent via the Network tab.
![image](https://github.com/user-attachments/assets/703d4f67-9fd5-4da4-8a13-7dc876e5cf75)

![image](https://github.com/user-attachments/assets/71b25ad7-ddff-40ce-b4c7-3d0bc76845a5)
