### PR TITLE
chore(e2e): Update cypress 13.16.1 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -118,7 +118,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.17.0",
                 "@typescript-eslint/parser": "^8.17.0",
                 "axe-core": "^4.10.0",
-                "cypress": "^13.14.2",
+                "cypress": "^13.16.1",
                 "cypress-axe": "^1.5.0",
                 "eslint": "^9.16.0",
                 "eslint-import-resolver-typescript": "^3.6.3",
@@ -2568,10 +2568,11 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
-            "integrity": "sha1-ctfVQlI2okE709i7ZtAtncMWiWA= sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
+            "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -2579,16 +2580,16 @@
                 "combined-stream": "~1.0.6",
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "http-signature": "~1.3.6",
+                "form-data": "~4.0.0",
+                "http-signature": "~1.4.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "6.10.4",
+                "qs": "6.13.0",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "^4.1.3",
+                "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
             },
@@ -2597,32 +2598,31 @@
             }
         },
         "node_modules/@cypress/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y= sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 6"
             }
         },
-        "node_modules/@cypress/request/node_modules/qs": {
-            "version": "6.10.4",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-            "integrity": "sha1-ajADdVrdkcDsnqzcX4eLA05z+ec= sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+        "node_modules/@cypress/request/node_modules/tough-cookie": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "tldts": "^6.1.32"
             },
             "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=16"
             }
         },
         "node_modules/@cypress/xvfb": {
@@ -6182,10 +6182,11 @@
             "dev": true
         },
         "node_modules/asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY= sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -6193,8 +6194,9 @@
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8"
             }
@@ -6304,17 +6306,19 @@
         "node_modules/aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8= sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-            "dev": true
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/axe-core": {
             "version": "4.10.0",
@@ -6698,8 +6702,9 @@
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -7112,8 +7117,9 @@
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
+            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -8272,13 +8278,14 @@
             "integrity": "sha1-w0+CJqlLuxDDLMDXFK/flCKR/EE= sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
         },
         "node_modules/cypress": {
-            "version": "13.14.2",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
-            "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
+            "version": "13.16.1",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.1.tgz",
+            "integrity": "sha512-17FtCaz0cx7ssWYKXzGB0Vub8xHwpVPr+iPt2fHhLMDhVAPVrplD+rTQsZUsfb19LVBn5iwkEUFjQ1yVVJXsLA==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
-                "@cypress/request": "^3.0.1",
+                "@cypress/request": "^3.0.6",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
@@ -8289,6 +8296,7 @@
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.0",
                 "check-more-types": "^2.24.0",
+                "ci-info": "^4.0.0",
                 "cli-cursor": "^3.1.0",
                 "cli-table3": "~0.6.1",
                 "commander": "^6.2.1",
@@ -8303,7 +8311,6 @@
                 "figures": "^3.2.0",
                 "fs-extra": "^9.1.0",
                 "getos": "^3.2.1",
-                "is-ci": "^3.0.1",
                 "is-installed-globally": "~0.4.0",
                 "lazy-ass": "^1.6.0",
                 "listr2": "^3.8.3",
@@ -8318,6 +8325,7 @@
                 "semver": "^7.5.3",
                 "supports-color": "^8.1.1",
                 "tmp": "~0.2.3",
+                "tree-kill": "1.2.2",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -8339,6 +8347,22 @@
             "peerDependencies": {
                 "axe-core": "^3 || ^4",
                 "cypress": "^10 || ^11 || ^12 || ^13"
+            }
+        },
+        "node_modules/cypress/node_modules/ci-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/cypress/node_modules/execa": {
@@ -8992,8 +9016,9 @@
         "node_modules/dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -9590,8 +9615,9 @@
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -11039,8 +11065,9 @@
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo= sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
@@ -11080,11 +11107,12 @@
         "node_modules/extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
             "dev": true,
             "engines": [
                 "node >=0.6.0"
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -11483,8 +11511,9 @@
         "node_modules/forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "*"
             }
@@ -11917,8 +11946,9 @@
         "node_modules/getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -12512,14 +12542,15 @@
             "dev": true
         },
         "node_modules/http-signature": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-            "integrity": "sha1-y2+/34bRyXTzQ76U6H9/wShmLPk= sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
-                "sshpk": "^1.14.1"
+                "sshpk": "^1.18.0"
             },
             "engines": {
                 "node": ">=0.10"
@@ -12922,18 +12953,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-ci": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-            "integrity": "sha1-227L7RvWWcQ9rA9FZh52dBA9GGc= sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-            "dev": true,
-            "dependencies": {
-                "ci-info": "^3.2.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
-        },
         "node_modules/is-core-module": {
             "version": "2.15.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
@@ -13293,8 +13312,9 @@
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
@@ -13376,8 +13396,9 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.0.0",
@@ -14296,8 +14317,9 @@
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
+            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/jsdom": {
             "version": "20.0.3",
@@ -14496,11 +14518,12 @@
         "node_modules/jsprim": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
-            "integrity": "sha1-d8oj281BNc02SADSL/gsIYWAPU0= sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+            "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
             "dev": true,
             "engines": [
                 "node >=0.6.0"
             ],
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -20970,10 +20993,11 @@
             "dev": true
         },
         "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha1-V4CC2S1P5hKxMAdJblQ/oPvL5MU= sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -21901,6 +21925,26 @@
                 "node": "*"
             }
         },
+        "node_modules/tldts": {
+            "version": "6.1.65",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.65.tgz",
+            "integrity": "sha512-xU9gLTfAGsADQ2PcWee6Hg8RFAv0DnjMGVJmDnUmI8a9+nYmapMQix4afwrdaCtT+AqP4MaxEzu7cCrYmBPbzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.65"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.65",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.65.tgz",
+            "integrity": "sha512-Uq5t0N0Oj4nQSbU8wFN1YYENvMthvwU13MQrMJRspYCGLSAZjAfoBOJki5IQpnBM/WFskxxC/gIOTwaedmHaSg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tmp": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -21995,6 +22039,16 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
             }
         },
         "node_modules/tryer": {
@@ -22118,8 +22172,9 @@
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -22130,8 +22185,9 @@
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true
+            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+            "dev": true,
+            "license": "Unlicense"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -22559,25 +22615,17 @@
         "node_modules/verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
             "dev": true,
             "engines": [
                 "node >=0.6.0"
             ],
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
             }
-        },
-        "node_modules/verror/node_modules/extsprintf": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
-            "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
-            "dev": true,
-            "engines": [
-                "node >=0.6.0"
-            ]
         },
         "node_modules/victory-area": {
             "version": "36.9.2",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -141,7 +141,7 @@
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "@typescript-eslint/parser": "^8.17.0",
         "axe-core": "^4.10.0",
-        "cypress": "^13.14.2",
+        "cypress": "^13.16.1",
         "cypress-axe": "^1.5.0",
         "eslint": "^9.16.0",
         "eslint-import-resolver-typescript": "^3.6.3",


### PR DESCRIPTION
### Description

Cypress has either minor or patch update about every other week.

This is our first update during 4.7 effort.

https://docs.cypress.io/app/references/changelog#13-16-0

* Fixed an issue where some JS assets were not properly getting sourcemaps included with the vite dev server if they had a cache busting query parameter in the URL. Fixed some scenarios to ensure that the sourcemaps that were included by the vite dev server were inlined.

https://docs.cypress.io/app/references/changelog#13-15-2

* Fixed an issue where the Cypress runner could hang in `after` or `afterEach` hooks that run Cypress commands after a page load timeout error occurs.

* Updated `mobx` from 5.15.4 to 6.13.5 and `mobx-react` from 6.1.8 to 9.1.1.
* Updated `@cypress/request` from 3.0.4 to 3.0.6.

https://docs.cypress.io/app/references/changelog#13-15-1

* Fixed an issue where Firefox was incorrectly mutating the state of click events on checkboxes after Firefox version 129 and up.
* Updated `simple-git` from 3.16.0 to 3.25.0.

https://docs.cypress.io/app/references/changelog#13-15-0

* Update `@cypress/request` from 3.0.1 to 3.0.4.
* Updated `express` from 4.19.2 to 4.21.0.
    This removes the CVE-2024-43796, CVE-2024-45590, and CVE-2024-43800 vulnerabilities being reported in security scans.
* Update `launch-editor` from 2.8.0 to 2.9.1.
* Updated `loader-utils` from 1.4.0 to 1.4.2.
    This removes the CVE-2022-37601 vulnerability being reported in security scans.
* Updated `send` from 0.17.1 to 0.19.0.
    This removes the CVE-2024-43799 vulnerability being reported in security scans.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

In ui/apps/platform folder:
* For contribution: `npm install` to update package-lock.json file according to changes in package.json file.
* For team: `npm ci` to delete and recreate ui/apps/platform/node_modules folder.

#### Integration testing

1. `npm run cypress-open` in ui/apps/platform
    * E2E testing
    * Component testing