### PR TITLE
ROX-25270: Disable K8sRbacTest that fails for OSD on AWS

### DIFF
--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -20,8 +20,10 @@ import objects.K8sServiceAccount
 import objects.K8sSubject
 import services.RbacService
 import services.ServiceAccountService
+import util.Env
 import util.Helpers
 
+import spock.lang.IgnoreIf
 import spock.lang.Stepwise
 import spock.lang.Tag
 
@@ -60,6 +62,8 @@ class K8sRbacTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("COMPATIBILITY")
+    // ROX-25270 Test is failing for OSD on AWS
+    @IgnoreIf({ Env.CI_JOB_NAME ==~ /.*osd-aws.*/ })
     def "Verify scraped service accounts"() {
         given:
         List<K8sServiceAccount> orchestratorSAs = null


### PR DESCRIPTION
### Description

During the CI improvements meeting, we identified that this test is constantly failing for OSD on AWS.

This PR will disable this test until it is fixed.

**For reviewer**
- it is important that test is skipped for `osd-aws-qa-e2e-tests`
- but it runs for other `*-qa-e2e-tests`

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] disabled existing tests

#### How I validated my change

I will let the CI pipeline validate the changes.

It's important that the `osd-aws` test is triggered.
