### PR TITLE
ROX-18278: Disable flaky Enforcement test

### DIFF
--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -16,6 +16,7 @@ import services.PolicyService
 import services.ProcessBaselineService
 import util.Timer
 
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -680,6 +681,8 @@ class Enforcement extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("PolicyEnforcement")
+    // ROX-18278 Test is flaky since 07/2023. (~2 failures / month)
+    @Ignore("ROX-18278")
     def "Test Alert and Kill Pod Enforcement - Baseline Process"() {
         // This test verifies enforcement of kill pod after triggering a policy violation of
         //  Unauthorized Process Execution


### PR DESCRIPTION
### Description

During the CI improvements meeting, we identified this test as flaky.

This PR is disabling it until it's fixed.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] disable existing tests

#### How I validated my change

I'll let the CI pipeline run and check if this test is skipped.
