### PR TITLE
ROX-27268: Run local-sensor in CI with debug logs by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ sensor-integration-test: build-prep test-prep
 	set -eo pipefail ; \
 	rm -rf  $(GO_TEST_OUTPUT_PATH); \
 	for package in $(shell git ls-files ./sensor/tests | grep '_test.go' | xargs -n 1 dirname | uniq | sort | sed -e 's/sensor\/tests\///'); do \
-		CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -cover -coverprofile test-output/coverage.out -v ./sensor/tests/$$package \
+		CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 LOGLEVEL=debug GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -cover -coverprofile test-output/coverage.out -v ./sensor/tests/$$package \
 		| tee -a $(GO_TEST_OUTPUT_PATH); \
 	done \
 

--- a/tools/local-sensor/scripts/local-sensor.sh
+++ b/tools/local-sensor/scripts/local-sensor.sh
@@ -13,7 +13,6 @@ LOCAL_SENSOR_BIN=local-sensor
 EXEC=$OUTPUT_DIR/$LOCAL_SENSOR_BIN
 PROMETHEUS_ENDPOINT=http://localhost:9090
 ROX_METRICS_PORT=:9091
-LOGLEVEL="${LOGLEVEL:-debug}"
 PROMETHEUS_QUERY=rox_sensor_sensor_events
 PROMETHEUS_DUMP=$OUTPUT_DIR/sensor_events_dump.json
 
@@ -68,7 +67,6 @@ function print_header() {
   echo "RUN_GENERATE        = $RUN_GENERATE"
   echo "RUN_TEST            = $RUN_TEST"
   echo "VERBOSE             = $VERBOSE"
-  echo "LOGLEVEL            = $LOGLEVEL"
   echo "OUTPUT_DIR          = $OUTPUT_DIR"
   echo "K8S_EVENTS_FILE     = $K8S_EVENTS_FILE"
   echo "FAKE_WORKLOAD_FILE  = $FAKE_WORKLOAD_FILE"

--- a/tools/local-sensor/scripts/local-sensor.sh
+++ b/tools/local-sensor/scripts/local-sensor.sh
@@ -43,7 +43,6 @@ function generate_k8s_events() {
 function run_test() {
   [[ "$VERBOSE" == "false" ]] || echo "Running tests with: $K8S_EVENTS_FILE"
   export ROX_METRICS_PORT=$ROX_METRICS_PORT
-  export LOGLEVEL=$LOGLEVEL
   { time $EXEC -replay -replay-in="$K8S_EVENTS_FILE" -delay=0s -with-metrics -with-policies="$POLICIES_FILE" -central-out=/dev/null > "$OUTPUT_DIR"/test.log 2>&1 ; } > "$TIME_FILE" 2>&1 &
   TIME_PID=$!
   SENSOR_PID=$(pgrep -P $TIME_PID)

--- a/tools/local-sensor/scripts/local-sensor.sh
+++ b/tools/local-sensor/scripts/local-sensor.sh
@@ -13,6 +13,7 @@ LOCAL_SENSOR_BIN=local-sensor
 EXEC=$OUTPUT_DIR/$LOCAL_SENSOR_BIN
 PROMETHEUS_ENDPOINT=http://localhost:9090
 ROX_METRICS_PORT=:9091
+LOGLEVEL="${LOGLEVEL:-debug}"
 PROMETHEUS_QUERY=rox_sensor_sensor_events
 PROMETHEUS_DUMP=$OUTPUT_DIR/sensor_events_dump.json
 
@@ -43,6 +44,7 @@ function generate_k8s_events() {
 function run_test() {
   [[ "$VERBOSE" == "false" ]] || echo "Running tests with: $K8S_EVENTS_FILE"
   export ROX_METRICS_PORT=$ROX_METRICS_PORT
+  export LOGLEVEL=$LOGLEVEL
   { time $EXEC -replay -replay-in="$K8S_EVENTS_FILE" -delay=0s -with-metrics -with-policies="$POLICIES_FILE" -central-out=/dev/null > "$OUTPUT_DIR"/test.log 2>&1 ; } > "$TIME_FILE" 2>&1 &
   TIME_PID=$!
   SENSOR_PID=$(pgrep -P $TIME_PID)
@@ -66,6 +68,7 @@ function print_header() {
   echo "RUN_GENERATE        = $RUN_GENERATE"
   echo "RUN_TEST            = $RUN_TEST"
   echo "VERBOSE             = $VERBOSE"
+  echo "LOGLEVEL            = $LOGLEVEL"
   echo "OUTPUT_DIR          = $OUTPUT_DIR"
   echo "K8S_EVENTS_FILE     = $K8S_EVENTS_FILE"
   echo "FAKE_WORKLOAD_FILE  = $FAKE_WORKLOAD_FILE"


### PR DESCRIPTION
### Description

Local-sensor is used in Sensor integration tests in CI. It would be useful to make it print debug logs by default, so that an analysis of potential flakes is faster.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Nothing - running existing tests should be enough

#### How I validated my change

On CI:

- See [the logs from the run of ` gke-sensor-integration-tests` in CI](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/13533/pull-ci-stackrox-stackrox-master-gke-sensor-integration-tests/1866039770749079552)
    - [Direct link to the raw integration test output](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/13533/pull-ci-stackrox-stackrox-master-gke-sensor-integration-tests/1866039770749079552/artifacts/gke-sensor-integration-tests/stackrox-stackrox-e2e-test/build-log.txt)
