### PR TITLE
ROX-25945: CRS Support for Operator

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
@@ -18,10 +18,12 @@ Secured Cluster Configuration Summary:
 {{- end }}
 
 [<- if .FeatureFlags.ROX_CLUSTER_REGISTRATION_SECRETS >]
-{{- if ._rox.crs._enabled }}
+{{- if eq ._rox.env.installMethod "helm" }}
+  {{- if ._rox.crs._enabled }}
   Bootstrapping Method:                        Cluster Registration Secret (CRS)
-{{- else if ._rox.ca._cert }}
+  {{- else if ._rox.ca._cert }}
   Bootstrapping Method:                        Init Bundle
+  {{- end }}
 {{- end }}
 [<- end >]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -306,9 +306,12 @@ The following block checks for the validity of the provided init bundle. (`helm 
   {{- $_ = set $crs "_deserialized" $crsDeserialized -}}
   {{- $_ = set $crs "_caCert" $crsCA -}}
   {{- $_ = set $crs "_enabled" true -}}
+  {{- $_ = set $crs "_create" true -}}
 
   {{- $_ = set ._rox.ca "_cert" $crsCA -}}
   {{- $_ = set ._rox "createSecrets" false -}}
+{{- else if ._rox.crs.enabled -}}
+  {{- $_ = set $crs "_enabled" true -}}
 {{- end -}}
 [<- end >]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/cluster-registration-secret.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/cluster-registration-secret.yaml
@@ -1,4 +1,4 @@
-{{- if ._rox.crs._enabled }}
+{{- if ._rox.crs._create }}
 {{- $secret := ._rox.crs._secret -}}
 {{- $opaque := ._rox.crs._opaque -}}
 apiVersion: v1

--- a/operator/internal/securedcluster/values/translation/base-values.yaml
+++ b/operator/internal/securedcluster/values/translation/base-values.yaml
@@ -22,3 +22,5 @@ scannerV4:
       generate: false
     serviceTLS:
       generate: false
+crs:
+  enabled: true

--- a/operator/tests/common/crs-assert.yaml
+++ b/operator/tests/common/crs-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-registration-secret
+  annotations:
+    crs.platform.stackrox.io/name: testing-cluster

--- a/operator/tests/common/crs-fetch.yaml
+++ b/operator/tests/common/crs-fetch.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: retry-kubectl.sh exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify crs generate testing-cluster -p letmein --output - > crs.yaml
+- script: retry-kubectl.sh apply -n $NAMESPACE -f crs.yaml

--- a/operator/tests/securedcluster/sc-basic/007-assert-crs.yaml
+++ b/operator/tests/securedcluster/sc-basic/007-assert-crs.yaml
@@ -1,0 +1,1 @@
+../../common/crs-assert.yaml

--- a/operator/tests/securedcluster/sc-basic/007-assert-init-bundle.yaml
+++ b/operator/tests/securedcluster/sc-basic/007-assert-init-bundle.yaml
@@ -1,1 +1,0 @@
-../../common/init-bundle-assert.yaml

--- a/operator/tests/securedcluster/sc-basic/007-fetch-bundle.yaml
+++ b/operator/tests/securedcluster/sc-basic/007-fetch-bundle.yaml
@@ -1,1 +1,0 @@
-../../common/init-bundle-fetch.yaml

--- a/operator/tests/securedcluster/sc-basic/007-fetch-crs.yaml
+++ b/operator/tests/securedcluster/sc-basic/007-fetch-crs.yaml
@@ -1,0 +1,1 @@
+../../common/crs-fetch.yaml

--- a/pkg/crs/crs.go
+++ b/pkg/crs/crs.go
@@ -41,6 +41,10 @@ func DeserializeSecret(serializedCrs string) (*CRS, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "JSON unmarshalling CRS")
 	}
+	if len(deserializedCrs.CAs) == 0 {
+		return nil, errors.New("missing CA in CRS")
+	}
+
 	return &deserializedCrs, nil
 }
 


### PR DESCRIPTION
### Description

**IMPORTANT: Only review commits beginning with 2c951aef36e38116427f4654b63d0c764cd4efd7, the commits before that are hopefully soon to be found in master.**

Adds CRS support to the operator:

* The function `checkRequiredTLSSecrets` has been extended to be CRS-aware.
* For testing:
  - Modify the `sc-basic` test to use CRS instead of init-bundles.
  - (upgrader test needs to keep using init-bundles of course)

### User-facing documentation

- [x] CHANGELOG will be updated in a [different PR](https://github.com/stackrox/stackrox/pull/12713).
- [x] [Documentation ticket](https://issues.redhat.com/browse/ROX-26971) has been introduced to docs team.

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI and manual testing:

* set up OpenShift cluster, configure as current context.
* make -C operator install run

new shell:
* set up openshift cluster, configure as current context.
* NS=stackrox
* kubectl create ns $NS
* kubens $NS
* ./deploy/common/pull-secret.sh quay-ips quay.io | kubectl -n $NS apply -f -
* kubectl apply -f central-cr.yaml
  ```
  apiVersion: platform.stackrox.io/v1alpha1
  kind: Central
  metadata:
    name: stackrox-central-services
  spec:
    imagePullSecrets:
    - name: quay-ips
    central:
      exposure:
        route:
          enabled: true
      adminPasswordSecret:
        name: admin-pass
  ---
  apiVersion: v1
  kind: Secret
  metadata:
    name: admin-pass
  data:
    # letmein
    password: bGV0bWVpbg==

  ```
* export CENTRAL_ENDPOINT=https://$(kubectl get route central -o jsonpath='{.spec.host}')
* export ROX_ADMIN_PASSWORD=letmein
* rm -f crs.yaml; roxctl -e $CENTRAL_ENDPOINT central crs generate foo -o crs.yaml
* kubectl apply -f crs.yaml
* envsubst < operator/secured-cluster-cr.yml | kubectl apply -f -
  ```
  apiVersion: platform.stackrox.io/v1alpha1
  kind: SecuredCluster
  metadata:
    name: stackrox-secured-cluster-services
  spec:
    imagePullSecrets:
    - name: quay-ips
    centralEndpoint: "$CENTRAL_ENDPOINT"
    clusterName: foo
  ```

* Check all pods are happy.

