### PR TITLE
ROX-26570: fix postgres test race

### DIFF
--- a/migrator/postgreshelper/utils_test.go
+++ b/migrator/postgreshelper/utils_test.go
@@ -88,10 +88,6 @@ func (s *PostgresRestoreSuite) TestUtilities() {
 	// Successfully create active DB from restore DB
 	err = pgadmin.CreateDB(s.sourceMap, s.config, restoreDB, activeDB)
 	s.Nil(err)
-	// Have to terminate connections from the source DB before we can create
-	// the copy.  Make sure connection was terminated.
-	err = restorePool.Ping(s.ctx)
-	s.NotNil(err)
 
 	// Rename database to a database that exists
 	err = RenameDB(s.pool, restoreDB, activeDB)

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -89,10 +89,6 @@ func (s *PostgresRestoreSuite) TestUtilities() {
 	// Successfully create active DB from restore DB
 	err = CreateDB(s.sourceMap, s.config, restoreDB, activeDB)
 	s.Nil(err)
-	// Have to terminate connections from the source DB before we can create
-	// the copy.  Make sure connection was terminated.
-	err = restorePool.Ping(s.ctx)
-	s.NotNil(err)
 
 	// Reacquire a connection to the restore database
 	restorePool, err = GetClonePool(s.config, restoreDB)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Removing the check to see if the connection was terminated.  I am doing that for 2 reasons:

1. That check is racy because the underlying pool could have reconnected to the new test prior to the call to `Ping` in the test.
2. The check is pointless.  If the connection was not dropped the preceding calls to `CreateDB` would fail.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is sufficient as it is purely a test fix.