### PR TITLE
ROX-24541: Enrich image to get sbom 

### DIFF
--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -61,10 +61,6 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteGRPCStyleError(w, codes.Unimplemented, errors.New("SBOM feature is not enabled"))
 		return
 	}
-<<<<<<< HEAD
-
-=======
->>>>>>> e87c06c130 (Fixed comments)
 	var params apiparams.SbomRequestBody
 	sbomGenMaxReqSizeBytes := env.SBOMGenerationMaxReqSizeBytes.IntegerSetting()
 	// timeout api after 10 minutes
@@ -79,12 +75,6 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	bytes, err := h.getSbom(ctx, params)
 	if err != nil {
 		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "generating SBOM"))
-
-		return
-	}
-
-	if len(bytes) == 0 {
-		httputil.WriteGRPCStyleError(w, codes.Internal, errors.New("SBOM not found for the image"))
 		return
 	}
 	if len(bytes) == 0 {
@@ -100,22 +90,7 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // enrichImage enriches the image with the given name and based on the given enrichment context
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
-	// forcedEnrichment is set to true when enrichImage forces an enrichment.
-	forceEnrichment := false
-	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
-	if err != nil {
-		return nil, forceEnrichment, err
-	}
-	// verify that image is scanned by scanner v4 if not force enrichment using scanner v4
-	scannedByV4 := h.scannedByScannerv4(img)
-=======
-func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, error, bool) {
-=======
-func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
->>>>>>> e87c06c130 (Fixed comments)
 
 	// forcedEnrichment is set to true when enrichImage forces an enrichment.
 	forceEnrichment := false
@@ -124,31 +99,15 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 		return nil, forceEnrichment, err
 	}
 	// verify that image is scanned by scanner v4 if not force enrichment using scanner v4
-<<<<<<< HEAD
-	scannedbyV4 := h.scannedByScannerv4(img)
->>>>>>> 53168d49c7 (Fixed comments)
-=======
 	scannedByV4 := h.scannedByScannerv4(img)
->>>>>>> e87c06c130 (Fixed comments)
 
 	if enrichmentCtx.FetchOpt != enricher.UseImageNamesRefetchCachedValues && !scannedByV4 {
 		// force scan by scanner v4
 		addForceToEnrichmentContext(&enrichmentCtx)
-<<<<<<< HEAD
-		enrichmentCtx.ScannerTypeHint = scannerTypes.ScannerV4
-		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
-		if err != nil {
-			return nil, forceEnrichment, err
-=======
 		forceEnrichment = true
 		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
 		if err != nil {
-<<<<<<< HEAD
-			return nil, err, forceEnrichment
->>>>>>> 53168d49c7 (Fixed comments)
-=======
 			return nil, forceEnrichment, err
->>>>>>> e87c06c130 (Fixed comments)
 		}
 	}
 
@@ -156,23 +115,6 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 	img.Id = utils.GetSHA(img)
 	if img.GetId() != "" {
 		if err := h.saveImage(img); err != nil {
-<<<<<<< HEAD
-<<<<<<< HEAD
-			return nil, forceEnrichment, err
-		}
-	}
-
-	return img, forceEnrichment, nil
-=======
-			return nil, err, forceEnrichment
-		}
-	}
-
-	return img, nil, forceEnrichment
->>>>>>> 53168d49c7 (Fixed comments)
-}
-
-=======
 			return nil, forceEnrichment, err
 		}
 	}
@@ -181,7 +123,6 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 }
 
 // getSbom generates an SBOM for the specified parameters
->>>>>>> e87c06c130 (Fixed comments)
 func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:        enricher.UseCachesIfPossible,
@@ -191,10 +132,6 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 
 	if params.Force {
 		addForceToEnrichmentContext(&enrichmentCtx)
-<<<<<<< HEAD
-		enrichmentCtx.ScannerTypeHint = scannerTypes.ScannerV4
-=======
->>>>>>> 53168d49c7 (Fixed comments)
 	}
 
 	if params.Cluster != "" {
@@ -205,15 +142,7 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 		}
 		enrichmentCtx.ClusterID = clusterID
 	}
-<<<<<<< HEAD
-<<<<<<< HEAD
 	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
-=======
-	img, err, forceEnrichment := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
->>>>>>> 53168d49c7 (Fixed comments)
-=======
-	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
->>>>>>> e87c06c130 (Fixed comments)
 	if err != nil {
 		return nil, err
 	}
@@ -227,40 +156,20 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 	if err != nil {
 		return nil, err
 	}
-<<<<<<< HEAD
-<<<<<<< HEAD
-
 	if !found && !params.Force && !alreadyForcedEnrichment {
 		// since index report for image does not exist force scan by scanner v4
 		addForceToEnrichmentContext(&enrichmentCtx)
-		enrichmentCtx.ScannerTypeHint = scannerTypes.ScannerV4
-=======
-	if !found && !params.Force && !forceEnrichment {
-=======
-	if !found && !params.Force && !alreadyForcedEnrichment {
->>>>>>> e87c06c130 (Fixed comments)
-		// since index report for image does not exist force scan by scanner v4
-		addForceToEnrichmentContext(&enrichmentCtx)
->>>>>>> 53168d49c7 (Fixed comments)
 		_, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
 		if err != nil {
 			return nil, err
 		}
-<<<<<<< HEAD
-=======
 		sbom, _, err = scannerV4.GetSBOM(img)
 
 		if err != nil {
 			return nil, err
 		}
 
->>>>>>> 53168d49c7 (Fixed comments)
 	}
-	sbom, _, err = scannerV4.GetSBOM(img)
-	if err != nil {
-		return nil, err
-	}
-
 	return sbom, nil
 }
 
@@ -279,14 +188,6 @@ func (h sbomHttpHandler) getScannerV4SBOMIntegration() (scannerTypes.SBOMer, err
 		}
 	}
 	return nil, errors.New("Scanner v4 integration not found")
-<<<<<<< HEAD
-}
-
-// scannedByScannerv4 checks if image is scanned by scanner v4
-func (h sbomHttpHandler) scannedByScannerv4(img *storage.Image) bool {
-	return img.GetScan().GetDataSource().GetId() == iiStore.DefaultScannerV4Integration.GetId()
-=======
->>>>>>> 53168d49c7 (Fixed comments)
 }
 
 // scannedByScannerv4 checks if image is scanned by scanner v4

--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -26,12 +26,6 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-type sbomRequestBody struct {
-	Cluster   string `json:"cluster"`
-	ImageName string `json:"imageName"`
-	Force     bool   `json:"force"`
-}
-
 type sbomHttpHandler struct {
 	integration      integration.Set
 	enricher         enricher.ImageEnricher
@@ -67,7 +61,10 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteGRPCStyleError(w, codes.Unimplemented, errors.New("SBOM feature is not enabled"))
 		return
 	}
+<<<<<<< HEAD
 
+=======
+>>>>>>> e87c06c130 (Fixed comments)
 	var params apiparams.SbomRequestBody
 	sbomGenMaxReqSizeBytes := env.SBOMGenerationMaxReqSizeBytes.IntegerSetting()
 	// timeout api after 10 minutes
@@ -104,6 +101,7 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // enrichImage enriches the image with the given name and based on the given enrichment context
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
 	// forcedEnrichment is set to true when enrichImage forces an enrichment.
 	forceEnrichment := false
@@ -115,18 +113,25 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 	scannedByV4 := h.scannedByScannerv4(img)
 =======
 func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, error, bool) {
+=======
+func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
+>>>>>>> e87c06c130 (Fixed comments)
 
-	//this flag is set to true when enrichImage forces enrichment when image is not scanned by scanner v4
+	// forcedEnrichment is set to true when enrichImage forces an enrichment.
 	forceEnrichment := false
 	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
 	if err != nil {
-		return nil, err, forceEnrichment
+		return nil, forceEnrichment, err
 	}
 	// verify that image is scanned by scanner v4 if not force enrichment using scanner v4
+<<<<<<< HEAD
 	scannedbyV4 := h.scannedByScannerv4(img)
 >>>>>>> 53168d49c7 (Fixed comments)
+=======
+	scannedByV4 := h.scannedByScannerv4(img)
+>>>>>>> e87c06c130 (Fixed comments)
 
-	if enrichmentCtx.FetchOpt != enricher.UseImageNamesRefetchCachedValues && !scannedbyV4 {
+	if enrichmentCtx.FetchOpt != enricher.UseImageNamesRefetchCachedValues && !scannedByV4 {
 		// force scan by scanner v4
 		addForceToEnrichmentContext(&enrichmentCtx)
 <<<<<<< HEAD
@@ -138,8 +143,12 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 		forceEnrichment = true
 		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
 		if err != nil {
+<<<<<<< HEAD
 			return nil, err, forceEnrichment
 >>>>>>> 53168d49c7 (Fixed comments)
+=======
+			return nil, forceEnrichment, err
+>>>>>>> e87c06c130 (Fixed comments)
 		}
 	}
 
@@ -147,6 +156,7 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 	img.Id = utils.GetSHA(img)
 	if img.GetId() != "" {
 		if err := h.saveImage(img); err != nil {
+<<<<<<< HEAD
 <<<<<<< HEAD
 			return nil, forceEnrichment, err
 		}
@@ -162,6 +172,16 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 >>>>>>> 53168d49c7 (Fixed comments)
 }
 
+=======
+			return nil, forceEnrichment, err
+		}
+	}
+
+	return img, forceEnrichment, nil
+}
+
+// getSbom generates an SBOM for the specified parameters
+>>>>>>> e87c06c130 (Fixed comments)
 func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:        enricher.UseCachesIfPossible,
@@ -186,10 +206,14 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 		enrichmentCtx.ClusterID = clusterID
 	}
 <<<<<<< HEAD
+<<<<<<< HEAD
 	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
 =======
 	img, err, forceEnrichment := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
 >>>>>>> 53168d49c7 (Fixed comments)
+=======
+	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
+>>>>>>> e87c06c130 (Fixed comments)
 	if err != nil {
 		return nil, err
 	}
@@ -204,6 +228,7 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 		return nil, err
 	}
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 	if !found && !params.Force && !alreadyForcedEnrichment {
 		// since index report for image does not exist force scan by scanner v4
@@ -211,6 +236,9 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 		enrichmentCtx.ScannerTypeHint = scannerTypes.ScannerV4
 =======
 	if !found && !params.Force && !forceEnrichment {
+=======
+	if !found && !params.Force && !alreadyForcedEnrichment {
+>>>>>>> e87c06c130 (Fixed comments)
 		// since index report for image does not exist force scan by scanner v4
 		addForceToEnrichmentContext(&enrichmentCtx)
 >>>>>>> 53168d49c7 (Fixed comments)

--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -122,7 +122,6 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 	return img, forceEnrichment, nil
 }
 
-// getSbom generates an SBOM for the specified parameters
 func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:        enricher.UseCachesIfPossible,

--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 	clusterUtil "github.com/stackrox/rox/central/cluster/util"
+	iiStore "github.com/stackrox/rox/central/imageintegration/store"
+	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
@@ -17,6 +19,9 @@ import (
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/integration"
+	"github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/logging"
+	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stackrox/rox/pkg/zip"
 	"google.golang.org/grpc/codes"
 )
@@ -25,16 +30,18 @@ type sbomHttpHandler struct {
 	integration      integration.Set
 	enricher         enricher.ImageEnricher
 	clusterSACHelper sachelper.ClusterSacHelper
+	riskManager      manager.Manager
 }
 
 var _ http.Handler = (*sbomHttpHandler)(nil)
 
 // SBOMHandler returns a handler for get sbom http request
-func SBOMHandler(integration integration.Set, enricher enricher.ImageEnricher, clusterSACHelper sachelper.ClusterSacHelper) http.Handler {
+func SBOMHandler(integration integration.Set, enricher enricher.ImageEnricher, clusterSACHelper sachelper.ClusterSacHelper, riskManager manager.Manager) http.Handler {
 	return sbomHttpHandler{
 		integration:      integration,
 		enricher:         enricher,
 		clusterSACHelper: clusterSACHelper,
+		riskManager:      riskManager,
 	}
 
 }
@@ -70,6 +77,10 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "generating SBOM"))
 		return
 	}
+	if len(bytes) == 0 {
+		httputil.WriteGRPCStyleError(w, codes.Internal, errors.New("SBOM not found for the image"))
+		return
+	}
 
 	// Tell the browser this is a download.
 	w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=%s.%s", zip.GetSafeFilename(params.ImageName), "json"))
@@ -78,14 +89,49 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(bytes)
 }
 
-func (h sbomHttpHandler) enrichImage(ctx context.Context, params apiparams.SbomRequestBody) (*storage.Image, error) {
+// enrichImage enriches the image with the given name and based on the given enrichment context
+func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
+
+	// forcedEnrichment is set to true when enrichImage forces an enrichment.
+	forceEnrichment := false
+	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
+	if err != nil {
+		return nil, forceEnrichment, err
+	}
+	// verify that image is scanned by scanner v4 if not force enrichment using scanner v4
+	scannedByV4 := h.scannedByScannerv4(img)
+
+	if enrichmentCtx.FetchOpt != enricher.UseImageNamesRefetchCachedValues && !scannedByV4 {
+		// force scan by scanner v4
+		addForceToEnrichmentContext(&enrichmentCtx)
+		forceEnrichment = true
+		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
+		if err != nil {
+			return nil, forceEnrichment, err
+		}
+	}
+
+	// Save the image
+	img.Id = utils.GetSHA(img)
+	if img.GetId() != "" {
+		if err := h.saveImage(img); err != nil {
+			return nil, forceEnrichment, err
+		}
+	}
+
+	return img, forceEnrichment, nil
+}
+
+// getSbom generates an SBOM for the specified parameters
+func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
-		FetchOpt:  enricher.UseCachesIfPossible,
-		Delegable: true,
+		FetchOpt:        enricher.UseCachesIfPossible,
+		Delegable:       true,
+		ScannerTypeHint: scannerTypes.ScannerV4,
 	}
 
 	if params.Force {
-		enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
+		addForceToEnrichmentContext(&enrichmentCtx)
 	}
 
 	if params.Cluster != "" {
@@ -96,39 +142,64 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, params apiparams.SbomR
 		}
 		enrichmentCtx.ClusterID = clusterID
 	}
-
-	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
+	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
 	if err != nil {
 		return nil, err
 	}
-	// TODO(ROX-24541): save the image to the database
-	return img, nil
+	// verify that index report exists. if not force image enrichment using scanner v4
+	scannerV4, err := h.getScannerV4SBOMIntegration()
+	if err != nil {
+		return nil, err
+	}
+	sbom, found, err := scannerV4.GetSBOM(img)
+
+	if err != nil {
+		return nil, err
+	}
+	if !found && !params.Force && !alreadyForcedEnrichment {
+		// since index report for image does not exist force scan by scanner v4
+		addForceToEnrichmentContext(&enrichmentCtx)
+		_, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
+		if err != nil {
+			return nil, err
+		}
+		sbom, _, err = scannerV4.GetSBOM(img)
+
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return sbom, nil
 }
 
-func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
-	// enrich image checks image metadata cache if fetchopt = UseCachesIfPossible otherwise fetches metdata from registry
-	// enrich image calls get scans on image which creates index report for image if it does not exsist
-	_, err := h.enrichImage(ctx, params)
-	if err != nil {
-		return nil, err
-	}
+func addForceToEnrichmentContext(enrichmentCtx *enricher.EnrichmentContext) {
+	enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
+}
 
-	// get sbom from matcher
-	// for testing only
-	sbom := map[string]interface{}{
-		"SPDXID":      "SPDXRef-DOCUMENT",
-		"spdxVersion": "SPDX-2.3",
-		"creationInfo": map[string]interface{}{
-			"created": "2023-08-30T04:40:16Z",
-			"creators": []string{
-				"Organization: NA Org",
-				"Tool:  N/A - PoC",
-			},
-		},
+// getScannerV4SBOMIntegration returns the SBOM interface of scanner v4
+func (h sbomHttpHandler) getScannerV4SBOMIntegration() (scannerTypes.SBOMer, error) {
+	scanners := h.integration.ScannerSet()
+	for _, scanner := range scanners.GetAll() {
+		if scanner.GetScanner().Type() == scannerTypes.ScannerV4 {
+			if scannerv4, ok := scanner.GetScanner().(scannerTypes.SBOMer); ok {
+				return scannerv4, nil
+			}
+		}
 	}
-	sbomBytes, err := json.Marshal(sbom)
-	if err != nil {
-		return nil, err
+	return nil, errors.New("Scanner v4 integration not found")
+}
+
+// scannedByScannerv4 checks if image is scanned by scanner v4
+func (h sbomHttpHandler) scannedByScannerv4(img *storage.Image) bool {
+	return img.GetScan().GetDataSource().GetId() == iiStore.DefaultScannerV4Integration.GetId()
+}
+
+// saveImage saves the image to the scanner database
+func (h sbomHttpHandler) saveImage(img *storage.Image) error {
+	if err := h.riskManager.CalculateRiskAndUpsertImage(img); err != nil {
+		log.Errorw("Error upserting image", logging.ImageName(img.GetName().GetFullName()), logging.Err(err))
+		return err
 	}
-	return sbomBytes, nil
+	return nil
 }

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,14 +10,152 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/imageintegration"
+<<<<<<< HEAD
 	"github.com/stackrox/rox/pkg/apiparams"
+=======
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+>>>>>>> 660b15f188 (Add image enrichment to handler)
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	enricherMock "github.com/stackrox/rox/pkg/images/enricher/mocks"
+	"github.com/stackrox/rox/pkg/images/integration/mocks"
+	"github.com/stackrox/rox/pkg/registries/types"
+	scannerMocks "github.com/stackrox/rox/pkg/scanners/mocks"
+	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
+	scannerTypeMocks "github.com/stackrox/rox/pkg/scanners/types/mocks"
+	scannerv4Mocks "github.com/stackrox/rox/pkg/scannerv4/client/mocks"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/semaphore"
 )
+
+var _ scannerTypes.Scanner = (*fakeScanner)(nil)
+var _ scannerTypes.SBOMer = (*fakeScanner)(nil)
+
+type fakeScanner struct {
+	requestedScan bool
+	notMatch      bool
+}
+
+func (*fakeScanner) MaxConcurrentScanSemaphore() *semaphore.Weighted {
+	return semaphore.NewWeighted(1)
+}
+
+func (f *fakeScanner) GetSBOM(_ *storage.Image) ([]byte, error, bool) {
+	return []byte{}, nil, true
+}
+
+func (f *fakeScanner) GetScan(_ *storage.Image) (*storage.ImageScan, error) {
+	f.requestedScan = true
+	return &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{
+				Vulns: []*storage.EmbeddedVulnerability{
+					{
+						Cve: "CVE-2020-1234",
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (f *fakeScanner) Match(*storage.ImageName) bool {
+	return !f.notMatch
+}
+
+func (*fakeScanner) Test() error {
+	return nil
+}
+
+func (*fakeScanner) Type() string {
+	return scannerTypes.ScannerV4
+}
+
+func (*fakeScanner) Name() string {
+	return "name"
+}
+
+func (*fakeScanner) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
+	return &v1.VulnDefinitionsInfo{}, nil
+}
+
+var (
+	_ scannerTypes.ImageScannerWithDataSource = (*fakeRegistryScanner)(nil)
+	_ types.ImageRegistry                     = (*fakeRegistryScanner)(nil)
+)
+
+type fakeRegistryScanner struct {
+	scanner           *fakeScanner
+	requestedMetadata bool
+	notMatch          bool
+}
+
+type opts struct {
+	requestedScan     bool
+	requestedMetadata bool
+	notMatch          bool
+}
+
+func newFakeRegistryScanner(opts opts) *fakeRegistryScanner {
+	return &fakeRegistryScanner{
+		scanner: &fakeScanner{
+			requestedScan: opts.requestedScan,
+			notMatch:      opts.notMatch,
+		},
+		requestedMetadata: opts.requestedMetadata,
+		notMatch:          opts.notMatch,
+	}
+}
+
+func (f *fakeRegistryScanner) Metadata(*storage.Image) (*storage.ImageMetadata, error) {
+	f.requestedMetadata = true
+	return &storage.ImageMetadata{}, nil
+}
+
+func (f *fakeRegistryScanner) Config(_ context.Context) *types.Config {
+	return nil
+}
+
+func (f *fakeRegistryScanner) Match(*storage.ImageName) bool {
+	return !f.notMatch
+}
+
+func (*fakeRegistryScanner) Test() error {
+	return nil
+}
+
+func (*fakeRegistryScanner) Type() string {
+	return "type"
+}
+
+func (*fakeRegistryScanner) Name() string {
+	return "name"
+}
+
+func (*fakeRegistryScanner) HTTPClient() *http.Client {
+	return nil
+}
+
+func (f *fakeRegistryScanner) GetScanner() scannerTypes.Scanner {
+	return f.scanner
+}
+
+func (f *fakeRegistryScanner) DataSource() *storage.DataSource {
+	return &storage.DataSource{
+		Id:   "id",
+		Name: f.Name(),
+	}
+}
+
+func (f *fakeRegistryScanner) Source() *storage.ImageIntegration {
+	return &storage.ImageIntegration{
+		Id:   "id",
+		Name: f.Name(),
+	}
+}
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
 
@@ -25,7 +164,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/sbom", nil)
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -40,8 +179,27 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
+
+		// mockSbom returns sample sbom
+		sbom := map[string]interface{}{
+			"SPDXID":      "SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.3",
+			"creationInfo": map[string]interface{}{
+				"created": "2023-08-30T04:40:16Z",
+				"creators": []string{
+					"Organization: Uchiha Cortez",
+					"Tool: FOSSA v0.12.0",
+				},
+			},
+		}
+		sbomBytes, err := json.Marshal(sbom)
+		assert.NoError(t, err)
+
+		// initliaze mocks
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
+		mockSbom := scannerTypeMocks.NewMockSBOMer(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: false, ScanResult: enricher.ScanNotDone}, errors.New("Image enrichment failed")).AnyTimes()
+		mockSbom.EXPECT().GetSBOM(gomock.Any()).Return(sbomBytes, nil, true).AnyTimes()
 
 		reqBody := &apiparams.SbomRequestBody{
 			ImageName: "test-image",
@@ -52,7 +210,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(reqJson))
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), mockEnricher, nil)
+		handler := SBOMHandler(imageintegration.Set(), mockEnricher, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -67,19 +225,51 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
+
+		// mockSbom returns sample sbom
+		sbom := map[string]interface{}{
+			"SPDXID":      "SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.3",
+			"creationInfo": map[string]interface{}{
+				"created": "2023-08-30T04:40:16Z",
+				"creators": []string{
+					"Organization: Uchiha Cortez",
+					"Tool: FOSSA v0.12.0",
+				},
+			},
+		}
+		sbomBytes, err := json.Marshal(sbom)
+		assert.NoError(t, err)
+
+		// initliaze mocks
+		scannerSet := scannerMocks.NewMockSet(ctrl)
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
+		mockSbom := scannerv4Mocks.NewMockScanner(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil).AnyTimes()
 
+<<<<<<< HEAD
 		reqBody := &apiparams.SbomRequestBody{
 			ImageName: "test-image",
+=======
+		var _ scannerTypes.Scanner = (*fakeScanner)(nil)
+
+		mockSbom.EXPECT().GetSBOM(gomock.Any(), gomock.Any()).Return(sbomBytes, nil, true).AnyTimes()
+		set := mocks.NewMockSet(ctrl)
+		fsr := newFakeRegistryScanner(opts{})
+		scannerSet.EXPECT().GetAll().Return([]scannerTypes.ImageScannerWithDataSource{fsr}).AnyTimes()
+		set.EXPECT().ScannerSet().Return(scannerSet).AnyTimes()
+		reqBody := &sbomRequestBody{
+			ImageName: "quay.io/quay-qetest/nodejs-test-image:latest",
+>>>>>>> 660b15f188 (Add image enrichment to handler)
 			Force:     false,
 		}
+
 		reqJson, err := json.Marshal(reqBody)
 		assert.NoError(t, err)
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(reqJson))
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), mockEnricher, nil)
+		handler := SBOMHandler(set, mockEnricher, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -96,7 +286,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewBufferString(invalidJson))
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -111,7 +301,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/sbom", nil)
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -127,7 +317,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/sbom", nil)
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()
@@ -145,7 +335,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(largeRequestBody))
 		recorder := httptest.NewRecorder()
 
-		handler := SBOMHandler(imageintegration.Set(), nil, nil)
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
 		handler.ServeHTTP(recorder, req)
 
 		res := recorder.Result()

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -9,16 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/imageintegration"
-<<<<<<< HEAD
-<<<<<<< HEAD
 	"github.com/stackrox/rox/pkg/apiparams"
-=======
-	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/storage"
->>>>>>> 660b15f188 (Add image enrichment to handler)
-=======
-	"github.com/stackrox/rox/pkg/apiparams"
->>>>>>> e87c06c130 (Fixed comments)
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/enricher"
@@ -113,32 +104,15 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		scanner := scannerTypesMocks.NewMockScannerSBOMer(ctrl)
 		fsr := scannerTypesMocks.NewMockImageScannerWithDataSource(ctrl)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-		reqBody := &apiparams.SbomRequestBody{
-			ImageName: "test-image",
-=======
-		var _ scannerTypes.Scanner = (*fakeScanner)(nil)
-
-		mockSbom.EXPECT().GetSBOM(gomock.Any(), gomock.Any()).Return(sbomBytes, nil, true).AnyTimes()
-=======
->>>>>>> 53168d49c7 (Fixed comments)
-		set := mocks.NewMockSet(ctrl)
-		fsr := newFakeRegistryScanner(opts{})
-		scannerSet.EXPECT().GetAll().Return([]scannerTypes.ImageScannerWithDataSource{fsr}).AnyTimes()
-=======
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil).AnyTimes()
 		scanner.EXPECT().Type().Return(scannerTypes.ScannerV4).AnyTimes()
 		scanner.EXPECT().GetSBOM(gomock.Any()).DoAndReturn(getFakeSbom).AnyTimes()
->>>>>>> e87c06c130 (Fixed comments)
 		set.EXPECT().ScannerSet().Return(scannerSet).AnyTimes()
 		fsr.EXPECT().GetScanner().Return(scanner).AnyTimes()
 		scannerSet.EXPECT().GetAll().Return([]scannerTypes.ImageScannerWithDataSource{fsr}).AnyTimes()
 
 		reqBody := &apiparams.SbomRequestBody{
 			ImageName: "quay.io/quay-qetest/nodejs-test-image:latest",
->>>>>>> 660b15f188 (Add image enrichment to handler)
 			Force:     false,
 		}
 

--- a/central/main.go
+++ b/central/main.go
@@ -139,6 +139,7 @@ import (
 	"github.com/stackrox/rox/central/reprocessor"
 	collectionService "github.com/stackrox/rox/central/resourcecollection/service"
 	"github.com/stackrox/rox/central/risk/handlers/timeline"
+	riskManager "github.com/stackrox/rox/central/risk/manager"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/sachelper"
 	roleService "github.com/stackrox/rox/central/role/service"
@@ -750,7 +751,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		{
 			Route:         "/api/v1/images/sbom",
 			Authorizer:    user.With(permissions.Modify(resources.Image)),
-			ServerHandler: imageService.SBOMHandler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton())),
+			ServerHandler: imageService.SBOMHandler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton()), riskManager.Singleton()),
 			Compression:   true,
 		},
 		{

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -76,7 +76,7 @@ type EnrichmentContext struct {
 	Namespace string
 
 	Source *RequestSource
-
+	// ScannerTypeHint will ensure this scanner type is used when a scan is executed, does nothing if a scan is not executed.
 	ScannerTypeHint string
 }
 

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -76,6 +76,8 @@ type EnrichmentContext struct {
 	Namespace string
 
 	Source *RequestSource
+
+	ScannerTypeHint string
 }
 
 // FetchOnlyIfMetadataEmpty checks the fetch opts and return whether or not we can used a cached or saved

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -76,6 +76,7 @@ type EnrichmentContext struct {
 	Namespace string
 
 	Source *RequestSource
+
 	// ScannerTypeHint will ensure this scanner type is used when a scan is executed, does nothing if a scan is not executed.
 	ScannerTypeHint string
 }

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -238,6 +238,22 @@ func (e *enricherImpl) EnrichImage(ctx context.Context, enrichContext Enrichment
 
 	errorList := errorhelpers.NewErrorList("image enrichment")
 
+	//verify that there is an integration for  scanner specified in enrichContext
+	if enrichContext.ScannerTypeHint != "" {
+		scanners := e.integrations.ScannerSet()
+		found := false
+		for _, scanner := range scanners.GetAll() {
+			if scanner.GetScanner().Type() != enrichContext.ScannerTypeHint {
+				found = true
+				break
+			}
+		}
+		if !found {
+			errorList.AddError(errors.New("no image scanners are integrated"))
+			return EnrichmentResult{ImageUpdated: false, ScanResult: ScanNotDone}, errorList.ToError()
+		}
+	}
+
 	imageNoteSet := make(map[storage.Image_Note]struct{}, len(image.Notes))
 	for _, note := range image.Notes {
 		imageNoteSet[note] = struct{}{}

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -599,8 +599,7 @@ func (e *enricherImpl) enrichWithScan(ctx context.Context, enrichmentContext Enr
 			}
 		}
 		if !found {
-			errorList.AddError(errors.Errorf("no scanner integration found for scannerTypeHint %s", enrichmentContext.ScannerTypeHint))
-			return ScanNotDone, errorList.ToError()
+			return ScanNotDone, errors.Errorf("no scanner integration found for scannerTypeHint %q", enrichmentContext.ScannerTypeHint)
 		}
 	}
 
@@ -662,7 +661,6 @@ func (e *enricherImpl) enrichWithScan(ctx context.Context, enrichmentContext Enr
 			return result, nil
 		}
 	}
-	log.Infof("scanner type is %s", image.GetScan().GetDataSource().GetName())
 	return ScanNotDone, errorList.ToError()
 }
 

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -600,6 +600,7 @@ func (e *enricherImpl) enrichWithScan(ctx context.Context, enrichmentContext Enr
 		}
 		if !found {
 			errorList.AddError(errors.Errorf("no scanner integration found for scannerTypeHint %s", enrichmentContext.ScannerTypeHint))
+			return ScanNotDone, errorList.ToError()
 		}
 	}
 

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -29,10 +29,10 @@ import (
 const mockDigest = "registry/repository@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"
 
 var (
-	_ types.Scanner                  = (*Scannerv4)(nil)
-	_ types.ImageVulnerabilityGetter = (*Scannerv4)(nil)
-	_ types.NodeScanner              = (*Scannerv4)(nil)
-	_ types.SBOM                     = (*Scannerv4)(nil)
+	_ types.Scanner                  = (*scannerv4)(nil)
+	_ types.ImageVulnerabilityGetter = (*scannerv4)(nil)
+	_ types.NodeScanner              = (*scannerv4)(nil)
+	_ types.SBOMer                   = (*scannerv4)(nil)
 
 	log = logging.LoggerForModule()
 
@@ -56,7 +56,7 @@ func Creator(set registries.Set) (string, func(integration *storage.ImageIntegra
 	}
 }
 
-type Scannerv4 struct {
+type scannerv4 struct {
 	types.ScanSemaphore
 	types.NodeScanSemaphore
 
@@ -65,7 +65,7 @@ type Scannerv4 struct {
 	scannerClient    client.Scanner
 }
 
-func newScanner(integration *storage.ImageIntegration, activeRegistries registries.Set) (*Scannerv4, error) {
+func newScanner(integration *storage.ImageIntegration, activeRegistries registries.Set) (*scannerv4, error) {
 	conf := integration.GetScannerV4()
 	if conf == nil {
 		return nil, errors.New("scanner V4 configuration required")
@@ -92,12 +92,11 @@ func newScanner(integration *storage.ImageIntegration, activeRegistries registri
 		client.WithIndexerAddress(indexerEndpoint),
 		client.WithMatcherAddress(matcherEndpoint),
 	)
-
 	if err != nil {
 		return nil, err
 	}
 
-	scanner := &Scannerv4{
+	scanner := &scannerv4{
 		name:              integration.GetName(),
 		activeRegistries:  activeRegistries,
 		ScanSemaphore:     types.NewSemaphoreWithValue(numConcurrentScans),
@@ -108,20 +107,20 @@ func newScanner(integration *storage.ImageIntegration, activeRegistries registri
 	return scanner, nil
 }
 
-// GetSBOM
-func (s *Scannerv4) GetSBOM(image *storage.Image) ([]byte, error) {
+// GetSBOM returns sbom of an image as a byte array. It also returns a boolean indicating if the index report for the image was found.
+func (s *scannerv4) GetSBOM(image *storage.Image) ([]byte, error, bool) {
 
 	digest, err := pkgscanner.DigestFromImage(image)
 	if err != nil {
-		return nil, err
+		return nil, err, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
-	sbom, err := s.scannerClient.GetSBOM(ctx, digest)
-	return sbom, err
+	sbom, err, found := s.scannerClient.GetSBOM(ctx, digest)
+	return sbom, err, found
 }
 
-func (s *Scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {
+func (s *scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {
 	if image.GetMetadata() == nil {
 		return nil, nil
 	}
@@ -171,7 +170,7 @@ func (s *Scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {
 	return imageScan(image.GetMetadata(), vr), nil
 }
 
-func (s *Scannerv4) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
+func (s *scannerv4) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), metadataTimeout)
 	defer cancel()
 
@@ -190,25 +189,25 @@ func (s *Scannerv4) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
 	}, nil
 }
 
-func (s *Scannerv4) Match(image *storage.ImageName) bool {
+func (s *scannerv4) Match(image *storage.ImageName) bool {
 	return s.activeRegistries.Match(image)
 }
 
-func (s *Scannerv4) Name() string {
+func (s *scannerv4) Name() string {
 	return s.name
 }
 
-func (s *Scannerv4) Test() error {
+func (s *scannerv4) Test() error {
 	// TODO(ROX-20624): Dependent on the matcher/indexer test endpoints being avail.
 	log.Warn("ScannerV4 - Returning FAKE 'success' to Test")
 	return nil
 }
 
-func (s *Scannerv4) Type() string {
+func (s *scannerv4) Type() string {
 	return types.ScannerV4
 }
 
-func (s *Scannerv4) GetVulnerabilities(image *storage.Image, components *types.ScanComponents, _ []scannerv1.Note) (*storage.ImageScan, error) {
+func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.ScanComponents, _ []scannerv1.Note) (*storage.ImageScan, error) {
 	v4Contents := components.ScannerV4()
 
 	digest, err := pkgscanner.DigestFromImage(image)
@@ -237,7 +236,7 @@ func (s *Scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	return imageScan(image.GetMetadata(), vr), nil
 }
 
-func (s *Scannerv4) GetNodeVulnerabilityReport(node *storage.Node, indexReport *v4.IndexReport) (*v4.VulnerabilityReport, error) {
+func (s *scannerv4) GetNodeVulnerabilityReport(node *storage.Node, indexReport *v4.IndexReport) (*v4.VulnerabilityReport, error) {
 	nodeDigest, err := name.NewDigest(mockDigest)
 	if err != nil {
 		log.Errorf("Failed to parse digest from node %q: %v", node.GetName(), err)
@@ -254,7 +253,7 @@ func (s *Scannerv4) GetNodeVulnerabilityReport(node *storage.Node, indexReport *
 	return vr, nil
 }
 
-func (s *Scannerv4) GetNodeInventoryScan(node *storage.Node, inv *storage.NodeInventory, ir *v4.IndexReport) (*storage.NodeScan, error) {
+func (s *scannerv4) GetNodeInventoryScan(node *storage.Node, inv *storage.NodeInventory, ir *v4.IndexReport) (*storage.NodeScan, error) {
 	if ir == nil && inv != nil {
 		return nil, errors.New("Received Scanner v2 data for Scanner v4. Exiting.")
 	}
@@ -266,11 +265,11 @@ func (s *Scannerv4) GetNodeInventoryScan(node *storage.Node, inv *storage.NodeIn
 	return toNodeScan(vr, node.GetOsImage()), nil
 }
 
-func (s *Scannerv4) GetNodeScan(_ *storage.Node) (*storage.NodeScan, error) {
+func (s *scannerv4) GetNodeScan(_ *storage.Node) (*storage.NodeScan, error) {
 	return nil, errors.New("Not implemented for Scanner v4")
 }
 
-func (s *Scannerv4) TestNodeScanner() error {
+func (s *scannerv4) TestNodeScanner() error {
 	log.Warn("NodeScanner v4 - Returning FAKE 'success' to Test")
 	return nil
 }
@@ -282,7 +281,7 @@ func NodeScannerCreator() (string, func(integration *storage.NodeIntegration) (s
 	}
 }
 
-func newNodeScanner(integration *storage.NodeIntegration) (*Scannerv4, error) {
+func newNodeScanner(integration *storage.NodeIntegration) (*scannerv4, error) {
 	conf := integration.GetScannerv4()
 	if conf == nil {
 		return nil, errors.New("scanner v4 configuration required")
@@ -312,7 +311,7 @@ func newNodeScanner(integration *storage.NodeIntegration) (*Scannerv4, error) {
 		return nil, err
 	}
 
-	scanner := &Scannerv4{
+	scanner := &scannerv4{
 		name:              integration.GetName(),
 		activeRegistries:  nil,
 		ScanSemaphore:     types.NewSemaphoreWithValue(numConcurrentScans),

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -108,16 +108,15 @@ func newScanner(integration *storage.ImageIntegration, activeRegistries registri
 }
 
 // GetSBOM returns sbom of an image as a byte array. It also returns a boolean indicating if the index report for the image was found.
-func (s *scannerv4) GetSBOM(image *storage.Image) ([]byte, error, bool) {
-
+func (s *scannerv4) GetSBOM(image *storage.Image) ([]byte, bool, error) {
 	digest, err := pkgscanner.DigestFromImage(image)
 	if err != nil {
-		return nil, err, false
+		return nil, false, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
-	sbom, err, found := s.scannerClient.GetSBOM(ctx, digest)
-	return sbom, err, found
+	sbom, found, err := s.scannerClient.GetSBOM(ctx, digest)
+	return sbom, found, err
 }
 
 func (s *scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {

--- a/pkg/scanners/types/mocks/types.go
+++ b/pkg/scanners/types/mocks/types.go
@@ -145,6 +145,46 @@ func (mr *MockScannerMockRecorder) Type() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockScanner)(nil).Type))
 }
 
+// MockSBOMer is a mock of SBOMer interface.
+type MockSBOMer struct {
+	ctrl     *gomock.Controller
+	recorder *MockSBOMerMockRecorder
+	isgomock struct{}
+}
+
+// MockSBOMerMockRecorder is the mock recorder for MockSBOMer.
+type MockSBOMerMockRecorder struct {
+	mock *MockSBOMer
+}
+
+// NewMockSBOMer creates a new mock instance.
+func NewMockSBOMer(ctrl *gomock.Controller) *MockSBOMer {
+	mock := &MockSBOMer{ctrl: ctrl}
+	mock.recorder = &MockSBOMerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSBOMer) EXPECT() *MockSBOMerMockRecorder {
+	return m.recorder
+}
+
+// GetSBOM mocks base method.
+func (m *MockSBOMer) GetSBOM(image *storage.Image) ([]byte, error, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSBOM", image)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// GetSBOM indicates an expected call of GetSBOM.
+func (mr *MockSBOMerMockRecorder) GetSBOM(image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSBOM", reflect.TypeOf((*MockSBOMer)(nil).GetSBOM), image)
+}
+
 // MockImageScannerWithDataSource is a mock of ImageScannerWithDataSource interface.
 type MockImageScannerWithDataSource struct {
 	ctrl     *gomock.Controller

--- a/pkg/scanners/types/mocks/types.go
+++ b/pkg/scanners/types/mocks/types.go
@@ -170,12 +170,12 @@ func (m *MockSBOMer) EXPECT() *MockSBOMerMockRecorder {
 }
 
 // GetSBOM mocks base method.
-func (m *MockSBOMer) GetSBOM(image *storage.Image) ([]byte, error, bool) {
+func (m *MockSBOMer) GetSBOM(image *storage.Image) ([]byte, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSBOM", image)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	ret2, _ := ret[2].(bool)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 

--- a/pkg/scanners/types/mocks/types.go
+++ b/pkg/scanners/types/mocks/types.go
@@ -185,6 +185,146 @@ func (mr *MockSBOMerMockRecorder) GetSBOM(image any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSBOM", reflect.TypeOf((*MockSBOMer)(nil).GetSBOM), image)
 }
 
+// MockScannerSBOMer is a mock of ScannerSBOMer interface.
+type MockScannerSBOMer struct {
+	ctrl     *gomock.Controller
+	recorder *MockScannerSBOMerMockRecorder
+	isgomock struct{}
+}
+
+// MockScannerSBOMerMockRecorder is the mock recorder for MockScannerSBOMer.
+type MockScannerSBOMerMockRecorder struct {
+	mock *MockScannerSBOMer
+}
+
+// NewMockScannerSBOMer creates a new mock instance.
+func NewMockScannerSBOMer(ctrl *gomock.Controller) *MockScannerSBOMer {
+	mock := &MockScannerSBOMer{ctrl: ctrl}
+	mock.recorder = &MockScannerSBOMerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockScannerSBOMer) EXPECT() *MockScannerSBOMerMockRecorder {
+	return m.recorder
+}
+
+// GetSBOM mocks base method.
+func (m *MockScannerSBOMer) GetSBOM(image *storage.Image) ([]byte, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSBOM", image)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSBOM indicates an expected call of GetSBOM.
+func (mr *MockScannerSBOMerMockRecorder) GetSBOM(image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSBOM", reflect.TypeOf((*MockScannerSBOMer)(nil).GetSBOM), image)
+}
+
+// GetScan mocks base method.
+func (m *MockScannerSBOMer) GetScan(image *storage.Image) (*storage.ImageScan, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScan", image)
+	ret0, _ := ret[0].(*storage.ImageScan)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScan indicates an expected call of GetScan.
+func (mr *MockScannerSBOMerMockRecorder) GetScan(image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScan", reflect.TypeOf((*MockScannerSBOMer)(nil).GetScan), image)
+}
+
+// GetVulnDefinitionsInfo mocks base method.
+func (m *MockScannerSBOMer) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVulnDefinitionsInfo")
+	ret0, _ := ret[0].(*v1.VulnDefinitionsInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVulnDefinitionsInfo indicates an expected call of GetVulnDefinitionsInfo.
+func (mr *MockScannerSBOMerMockRecorder) GetVulnDefinitionsInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVulnDefinitionsInfo", reflect.TypeOf((*MockScannerSBOMer)(nil).GetVulnDefinitionsInfo))
+}
+
+// Match mocks base method.
+func (m *MockScannerSBOMer) Match(image *storage.ImageName) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Match", image)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Match indicates an expected call of Match.
+func (mr *MockScannerSBOMerMockRecorder) Match(image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Match", reflect.TypeOf((*MockScannerSBOMer)(nil).Match), image)
+}
+
+// MaxConcurrentScanSemaphore mocks base method.
+func (m *MockScannerSBOMer) MaxConcurrentScanSemaphore() *semaphore.Weighted {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxConcurrentScanSemaphore")
+	ret0, _ := ret[0].(*semaphore.Weighted)
+	return ret0
+}
+
+// MaxConcurrentScanSemaphore indicates an expected call of MaxConcurrentScanSemaphore.
+func (mr *MockScannerSBOMerMockRecorder) MaxConcurrentScanSemaphore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxConcurrentScanSemaphore", reflect.TypeOf((*MockScannerSBOMer)(nil).MaxConcurrentScanSemaphore))
+}
+
+// Name mocks base method.
+func (m *MockScannerSBOMer) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockScannerSBOMerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockScannerSBOMer)(nil).Name))
+}
+
+// Test mocks base method.
+func (m *MockScannerSBOMer) Test() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Test")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Test indicates an expected call of Test.
+func (mr *MockScannerSBOMerMockRecorder) Test() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Test", reflect.TypeOf((*MockScannerSBOMer)(nil).Test))
+}
+
+// Type mocks base method.
+func (m *MockScannerSBOMer) Type() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Type indicates an expected call of Type.
+func (mr *MockScannerSBOMerMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockScannerSBOMer)(nil).Type))
+}
+
 // MockImageScannerWithDataSource is a mock of ImageScannerWithDataSource interface.
 type MockImageScannerWithDataSource struct {
 	ctrl     *gomock.Controller

--- a/pkg/scanners/types/types.go
+++ b/pkg/scanners/types/types.go
@@ -38,6 +38,15 @@ type SBOMer interface {
 	GetSBOM(image *storage.Image) ([]byte, bool, error)
 }
 
+// ScannerSBOMer represents a Scanner with SBOM generation capabilities. This
+// was initially created for mock generation to simplify tests.
+//
+//go:generate mockgen-wrapper
+type ScannerSBOMer interface {
+	Scanner
+	SBOMer
+}
+
 // ImageScannerWithDataSource provides a GetScanner to retrieve the underlying Scanner and
 // a DataSource function to describe which integration formed the interface.
 //

--- a/pkg/scanners/types/types.go
+++ b/pkg/scanners/types/types.go
@@ -33,9 +33,9 @@ type Scanner interface {
 }
 
 // SBOM is the interface that contains the StackRox SBOM methods
-type SBOM interface {
-	//GetSBOM to get sbom for an image
-	GetSBOM(image *storage.Image) ([]byte, error)
+type SBOMer interface {
+	// GetSBOM to get sbom for an image
+	GetSBOM(image *storage.Image) ([]byte, error, bool)
 }
 
 // ImageScannerWithDataSource provides a GetScanner to retrieve the underlying Scanner and

--- a/pkg/scanners/types/types.go
+++ b/pkg/scanners/types/types.go
@@ -35,7 +35,7 @@ type Scanner interface {
 // SBOM is the interface that contains the StackRox SBOM methods
 type SBOMer interface {
 	// GetSBOM to get sbom for an image
-	GetSBOM(image *storage.Image) ([]byte, error, bool)
+	GetSBOM(image *storage.Image) ([]byte, bool, error)
 }
 
 // ImageScannerWithDataSource provides a GetScanner to retrieve the underlying Scanner and

--- a/pkg/scanners/types/types.go
+++ b/pkg/scanners/types/types.go
@@ -32,6 +32,12 @@ type Scanner interface {
 	GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error)
 }
 
+// SBOM is the interface that contains the StackRox SBOM methods
+type SBOM interface {
+	//GetSBOM to get sbom for an image
+	GetSBOM(image *storage.Image) ([]byte, error)
+}
+
 // ImageScannerWithDataSource provides a GetScanner to retrieve the underlying Scanner and
 // a DataSource function to describe which integration formed the interface.
 //

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -54,7 +54,7 @@ type Scanner interface {
 	GetMatcherMetadata(context.Context) (*v4.Metadata, error)
 
 	// GetSBOM to get sbom for an image
-	GetSBOM(ctx context.Context, ref name.Digest) ([]byte, error, bool)
+	GetSBOM(ctx context.Context, ref name.Digest) ([]byte, bool, error)
 
 	// Close cleans up any resources used by the implementation.
 	Close() error
@@ -181,15 +181,15 @@ func createGRPCConn(ctx context.Context, o connOptions) (*grpc.ClientConn, error
 }
 
 // GetSBOM verifies that index report exists and calls matcher to return sbom for an image
-func (c *gRPCScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, error, bool) {
+func (c *gRPCScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, bool, error) {
 	// verify index report exists for the image
 	hashId := getImageManifestID(ref)
 	_, found, err := c.GetImageIndex(ctx, hashId)
 	if err != nil {
-		return nil, err, false
+		return nil, false, err
 	}
 	if !found {
-		return nil, nil, false
+		return nil, false, nil
 	}
 
 	// for testing only
@@ -199,16 +199,16 @@ func (c *gRPCScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, err
 		"creationInfo": map[string]interface{}{
 			"created": "2023-08-30T04:40:16Z",
 			"creators": []string{
-				"Organization: Uchiha Cortez",
+				"Organization: Xyz",
 				"Tool: FOSSA v0.12.0",
 			},
 		},
 	}
 	sbomBytes, err := json.Marshal(sbom)
 	if err != nil {
-		return nil, err, false
+		return nil, false, err
 	}
-	return sbomBytes, nil, true
+	return sbomBytes, true, nil
 }
 
 // GetImageIndex calls the Indexer's gRPC endpoint GetIndexReport.

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -104,6 +104,22 @@ func (mr *MockScannerMockRecorder) GetOrCreateImageIndex(ctx, ref, auth, opt any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateImageIndex", reflect.TypeOf((*MockScanner)(nil).GetOrCreateImageIndex), ctx, ref, auth, opt)
 }
 
+// GetSBOM mocks base method.
+func (m *MockScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, error, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSBOM", ctx, ref)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// GetSBOM indicates an expected call of GetSBOM.
+func (mr *MockScannerMockRecorder) GetSBOM(ctx, ref any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSBOM", reflect.TypeOf((*MockScanner)(nil).GetSBOM), ctx, ref)
+}
+
 // GetVulnerabilities mocks base method.
 func (m *MockScanner) GetVulnerabilities(ctx context.Context, ref name.Digest, contents *v4.Contents) (*v4.VulnerabilityReport, error) {
 	m.ctrl.T.Helper()

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -105,12 +105,12 @@ func (mr *MockScannerMockRecorder) GetOrCreateImageIndex(ctx, ref, auth, opt any
 }
 
 // GetSBOM mocks base method.
-func (m *MockScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, error, bool) {
+func (m *MockScanner) GetSBOM(ctx context.Context, ref name.Digest) ([]byte, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSBOM", ctx, ref)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	ret2, _ := ret[2].(bool)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 


### PR DESCRIPTION
This PR adds image enrichment in get sbom method in http handler to generate index report and image metadata.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Tested this change manually by calling sbom http endpoint 
![Screenshot 2024-12-20 at 2 32 15 PM](https://github.com/user-attachments/assets/36690622-69c8-4a8f-a357-52d0ee383a53)
![Screenshot 2024-12-20 at 2 38 49 PM](https://github.com/user-attachments/assets/b7e43bc2-8d6b-4e2c-ae00-df66e081dc77)

