### PR TITLE
ROX-27272: Pass props/context to Workload CVE page component

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
@@ -1,16 +1,17 @@
-import React, { Component, ElementType } from 'react';
+import React, { Component, ComponentProps, ComponentType, ElementType } from 'react';
 import Loader from 'Components/Loader';
 
-type Props = Record<string, never>;
 type State = {
     component: ElementType | null;
 };
 
-export default function asyncComponent(importComponent): ElementType {
-    class AsyncComponent extends Component<Props, State> {
+export default function asyncComponent<T extends ElementType>(
+    importComponent: () => Promise<{ default: T }>
+): ComponentType<ComponentProps<T>> {
+    class AsyncComponent extends Component<ComponentProps<T>, State> {
         isComponentMounted: boolean;
 
-        constructor(props) {
+        constructor(props: ComponentProps<T>) {
             super(props);
             this.state = {
                 component: null,

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -219,9 +219,15 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         path: vulnManagementPath,
     },
     'workload-cves': {
-        component: asyncComponent(
-            () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
-        ),
+        component: (() => {
+            const AsyncWorkloadCvesComponent = asyncComponent(
+                () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
+            );
+
+            return function WorkloadCvesPage() {
+                return <AsyncWorkloadCvesComponent />;
+            };
+        })(),
         path: vulnerabilitiesWorkloadCvesPath,
     },
 };


### PR DESCRIPTION
### Description

Adds the ability to pass props or wrap top level page components in preparation for the Workload CVE/Platform CVE split.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Smoke test of Workload CVE page and other app pages.

CI

