### PR TITLE
ROX-26604: Add 'lineage' test images

### DIFF
--- a/qa-tests-backend/test-images/lineage/Dockerfile.jdk17.0.11
+++ b/qa-tests-backend/test-images/lineage/Dockerfile.jdk17.0.11
@@ -1,0 +1,12 @@
+# Pushed to: "quay.io/rhacs-eng/qa:lineage-jdk-17.0.11".
+
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.19
+
+USER root
+
+COPY --chown=root:root dummy.txt /dummy.txt
+
+USER jboss
+
+ENTRYPOINT [ "/bin/sh", "-c"]
+CMD [ "trap : TERM INT; sleep 9999999999d & wait" ]

--- a/qa-tests-backend/test-images/lineage/Dockerfile.jdk17.0.13
+++ b/qa-tests-backend/test-images/lineage/Dockerfile.jdk17.0.13
@@ -1,0 +1,14 @@
+# Pushed to: "quay.io/rhacs-eng/qa:lineage-jdk-17.0.13".
+
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.19
+
+USER root
+
+RUN microdnf -y install java-17-openjdk-headless-17.0.13.0.11-3.el8.x86_64
+
+COPY --chown=root:root dummy.txt /dummy.txt
+
+USER jboss
+
+ENTRYPOINT [ "/bin/sh", "-c"]
+CMD [ "trap : TERM INT; sleep 9999999999d & wait" ]

--- a/qa-tests-backend/test-images/lineage/README.md
+++ b/qa-tests-backend/test-images/lineage/README.md
@@ -1,0 +1,14 @@
+# Lineage Test Images
+The images produced by these Dockerfiles have common top and bottom layers, the middle layers differ.
+
+This scenario has caused past scanning issues, refer to ROX-26604 for more details.
+
+## Building
+
+```sh
+cd qa-tests-backend/test-images/lineage
+
+docker build -t quay.io/rhacs-eng/qa:lineage-jdk-17.0.11 -f Dockerfile.jdk17.0.11 .
+
+docker build -t quay.io/rhacs-eng/qa:lineage-jdk-17.0.13 -f Dockerfile.jdk17.0.13 .
+```

--- a/qa-tests-backend/test-images/lineage/dummy.txt
+++ b/qa-tests-backend/test-images/lineage/dummy.txt
@@ -1,0 +1,1 @@
+Dummy file added to multiple images to create a common image layer


### PR DESCRIPTION
### Description

Adds the Dockerfiles used to produce two test images used to validate the fix for ROX-26604.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

Tests added as part of https://github.com/stackrox/scanner/pull/1720

#### How I validated my change

Refer to https://github.com/stackrox/scanner/pull/1720
