### PR TITLE
fix(scanner): Order vulns per package by severity

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -119,7 +120,7 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	}
 	return &v4.VulnerabilityReport{
 		Vulnerabilities:        vulnerabilities,
-		PackageVulnerabilities: toProtoV4PackageVulnerabilitiesMap(r.PackageVulnerabilities, r.Vulnerabilities),
+		PackageVulnerabilities: toProtoV4PackageVulnerabilitiesMap(r.PackageVulnerabilities, r.Vulnerabilities, vulnerabilities),
 		Contents:               contents,
 	}, nil
 }
@@ -292,7 +293,7 @@ func toProtoV4Environment(e *claircore.Environment) *v4.Environment {
 	}
 }
 
-func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string, ccVulnerabilities map[string]*claircore.Vulnerability) map[string]*v4.StringList {
+func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string, ccVulnerabilities map[string]*claircore.Vulnerability, vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerability) map[string]*v4.StringList {
 	if ccPkgVulnerabilities == nil {
 		return nil
 	}
@@ -307,8 +308,55 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 		pkgVulns[id] = &v4.StringList{
 			Values: filterRepeatedVulns(vulnIDs, ccVulnerabilities),
 		}
+		sortBySeverity(pkgVulns[id].GetValues(), vulnerabilities)
 	}
 	return pkgVulns
+}
+
+// baseScore returns the preferred CVSS base score found in the CVSS metrics, prioritizing V3 over V2.
+func baseScore(cvssMetrics []*v4.VulnerabilityReport_Vulnerability_CVSS) float32 {
+	var metric *v4.VulnerabilityReport_Vulnerability_CVSS
+	if len(cvssMetrics) == 0 {
+		return 0.0
+	}
+	metric = cvssMetrics[0] // first one is guaranteed to be the preferred
+	if v3 := metric.GetV3(); v3 != nil {
+		return v3.GetBaseScore()
+	} else if v2 := metric.GetV2(); v2 != nil {
+		return v2.GetBaseScore()
+	}
+	return 0.0
+}
+
+// sortBySeverity sorts the vulnerability IDs based on normalized severity and,
+// if equal, by the highest CVSS base score, decreasing.
+func sortBySeverity(ids []string, vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerability) {
+	sort.SliceStable(ids, func(i, j int) bool {
+		vulnI := vulnerabilities[ids[i]]
+		vulnJ := vulnerabilities[ids[j]]
+
+		// Handle nil vulnerabilities explicitly: nil is considered lower
+		if vulnI == nil && vulnJ == nil {
+			return false // keep the original order
+		}
+		if vulnI == nil {
+			return false // vulnJ non-nil, higher
+		}
+		if vulnJ == nil {
+			return true // vulnI non-nil, higher
+		}
+
+		// Compare by normalized severity (higher severity first).
+		if vulnI.GetNormalizedSeverity() != vulnJ.GetNormalizedSeverity() {
+			return vulnI.GetNormalizedSeverity() > vulnJ.GetNormalizedSeverity()
+		}
+
+		// If severities are equal, compare by the highest CVSS base score.
+		scoreI := baseScore(vulnI.GetCvssMetrics())
+		scoreJ := baseScore(vulnJ.GetCvssMetrics())
+
+		return scoreI > scoreJ
+	})
 }
 
 func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircore.Vulnerability, nvdVulns map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {


### PR DESCRIPTION
## Description

Sort vulnerability values per package by their severity, and scores on ties. The main goal is to reduce flapping of results in Central if multiple CVEs with the same name are returned for the same package, as Central will pick up the first one per package.

Motivation for this comes from the RHSA flapping issue observed in `4.6.0`. This is not a fix, but reduces the blast radius significantly as flapping will only occur if different severity exist in different images, or different packages in the same image, rather than every time a RHSA is associated with multilpe CVEs.

## User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Local Scanner Validation

```
podman run -e POSTGRESQL_USER=$(whoami) -e POSTGRESQL_DATABASE=scanner -e POSTGRESQL_PASSWORD=$(cat /proc/self/loginuid) -p 5432:5432 registry.redhat.io/rhel8/postgresql-13
```

Then update `database:`  entries (both Indexer and Matcher) at `scanner/config.yaml`:

```
  database:
    conn_string: "host=localhost database=scanner"
    password_file: "/proc/self/loginuid"
```

Then run scanner in combo mode:

```
cd scanner/
make bin/scanner
./bin/scanner --conf config.yaml
```

Now scanning the same image twice should give you scans in the same order:

```
quay=$(jq -r '.auths["quay.io"].auth' ~/.docker/config.json | base64 -d)
./bin/scannerctl scan --auth "$quay" --insecure-skip-tls-verify --indexer-address :8443 --matcher-address :8443 https://quay.io/rhacs-eng/qa:sandbox-nodejs-10 | tee ~/tmp/r.json
```

Now inspect results.

1. Look for "npm" (one of the affected packages in this image):
   ```
       {
        "id": "3300",
        "name": "npm",
        "version": "1:6.14.4-1.10.21.0.3.module+el8.2.0+7071+d2377ea3",
        "normalized_version": {
          "v": [
   ```
2. Look for all vulns affecting "3300":
   ```
       "3300": {
      "values": [
        "3915943",
        "3477022",
        "3667853",
        "3617625",
        "3409902",
        "3627924",
        "2905479",
        "2707628",
        "2674592",
        "3279205",
        "3960472",
        "3778667"
      ]
    },
   ```
3. Verify "3915943" has the highest severity:
   ```
   jq -r '.package_vulnerabilities["3300"].values[]' ~/tmp/r.json | \                                                                            [~/wt/main/github.com/stackrox/stackrox/scanner]
xargs -I {} jq -r --arg vuln_id {} '.vulnerabilities[$vuln_id] | [.name, .normalized_severity, .cvss_metrics]'
   ```

