### PR TITLE
ROX-22816: Fix issues with port bind in unit tests

### DIFF
--- a/central/scanner/handler_test.go
+++ b/central/scanner/handler_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
-	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stackrox/rox/pkg/testutils"
+	testutilsVersion "github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -28,7 +29,7 @@ type handlerTestSuite struct {
 func (s *handlerTestSuite) SetupTest() {
 	err := testutilsMTLS.LoadTestMTLSCerts(s.T())
 	s.Require().NoError(err)
-	testutils.SetExampleVersion(s.T())
+	testutilsVersion.SetExampleVersion(s.T())
 }
 
 func (s *handlerTestSuite) TestGenerateScannerHTTPHandler() {
@@ -41,12 +42,13 @@ func (s *handlerTestSuite) TestGenerateScannerHTTPHandler() {
 	s.Require().NoError(err)
 
 	resp, err := http.Post(server.URL, "application/json", bytes.NewReader(marshaledJSON))
+	defer testutils.SafeClientClose(resp)
 	s.Require().NoError(err)
 	s.Assert().Equal(http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	s.Require().NoError(err)
-	s.Assert().NotEmpty(body)
 
+	s.Assert().NotEmpty(body)
 	_, err = zip.NewReader(bytes.NewReader(body), int64(len(body)))
 	s.Assert().NoError(err)
 }

--- a/pkg/grpc/marshaler_test.go
+++ b/pkg/grpc/marshaler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -60,11 +61,11 @@ func (s *supressCveServiceTestErrorImpl) SuppressCVEs(_ context.Context, req *v1
 }
 
 func (a *MarshalerTest) TestDurationParsing() {
-
-	url := fmt.Sprintf("https://localhost:%d/v1/nodecves/suppress", testDefaultPort)
+	testPort := testutils.GetFreeTestPort()
+	url := fmt.Sprintf("https://localhost:%d/v1/nodecves/suppress", testPort)
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	api := newAPIForTest(a.T(), defaultConf())
+	api := newAPIForTest(a.T(), defaultConf(testPort))
 	grpcServiceHandler := &supressCveServiceTestErrorImpl{}
 	api.Register(grpcServiceHandler)
 	a.Require().NoError(api.Start().Wait())

--- a/pkg/grpc/server_ratelimit_test.go
+++ b/pkg/grpc/server_ratelimit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/grpc/ratelimit"
 	"github.com/stackrox/rox/pkg/grpc/routes"
+	"github.com/stackrox/rox/pkg/testutils"
 	"google.golang.org/grpc"
 )
 
@@ -78,7 +79,8 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 
 	for _, tt := range tests {
 		a.Run(tt.name, func() {
-			cfg := defaultConf()
+			testPort := testutils.GetFreeTestPort()
+			cfg := defaultConf(testPort)
 			if tt.hasLimiter {
 				cfg.RateLimiter = ratelimit.NewRateLimiter(tt.maxPerSec, 0)
 			}
@@ -100,10 +102,10 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 			a.T().Cleanup(func() { api.Stop() })
 			var urls []string
 			if tt.useHTTP {
-				urls = append(urls, fmt.Sprintf("https://localhost:%d/test", testDefaultPort))
+				urls = append(urls, fmt.Sprintf("https://localhost:%d/test", testPort))
 			}
 			if tt.useGRPC {
-				urls = append(urls, fmt.Sprintf("https://localhost:%d/v1/ping", testDefaultPort))
+				urls = append(urls, fmt.Sprintf("https://localhost:%d/v1/ping", testPort))
 			}
 
 			hitLimit := false
@@ -113,6 +115,7 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 				for _, url := range urls {
 					requestCount++
 					resp, err := http.Get(url)
+					testutils.SafeClientClose(resp)
 					a.Require().NoError(err)
 
 					if !tt.hasLimiter || tt.maxPerSec == 0 || requestCount <= tt.maxPerSec {
@@ -153,6 +156,7 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 			for _, url := range urls {
 				requestCount++
 				resp, err := http.Get(url)
+				testutils.SafeClientClose(resp)
 				a.Assert().NoError(err)
 				a.Assert().Equal(http.StatusOK, resp.StatusCode)
 			}

--- a/pkg/testutils/http.go
+++ b/pkg/testutils/http.go
@@ -1,0 +1,60 @@
+package testutils
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// Starting with 10000 up to 30000. Linux will usually use ports >30000 for clients.
+// By starting with 10000, we are trying to avoid port congestion in the upper port range.
+const minFreePortRange = 10000
+const maxFreePortRange = 30000
+
+var (
+	once        sync.Once
+	portCounter atomic.Uint64
+)
+
+// GetFreeTestPort returns next available free port. It panics if range of free ports is exhausted.
+func GetFreeTestPort() uint64 {
+	once.Do(func() {
+		portCounter.Store(minFreePortRange)
+	})
+
+	for {
+		freePort := portCounter.Add(1)
+		if freePort > maxFreePortRange {
+			panic("port number is out of range")
+		}
+
+		// If there is an error: net.Listen - will always return nil listener. (from code, no docs)
+		listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", freePort))
+		if err != nil {
+			continue
+		}
+		utils.IgnoreError(listener.Close)
+
+		// Ensure that port is free on IPv4 and IPv6.
+		listener, err = net.Listen("tcp6", fmt.Sprintf(":%d", freePort))
+		if err != nil {
+			continue
+		}
+		utils.IgnoreError(listener.Close)
+
+		return freePort
+	}
+}
+
+// SafeClientClose safely closes an open client connection.
+func SafeClientClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	utils.IgnoreError(resp.Body.Close)
+}

--- a/tests/http_to_https_test.go
+++ b/tests/http_to_https_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/require"
 )
@@ -15,6 +16,7 @@ func TestHttpToHttps(t *testing.T) {
 	url := "http://" + centralgrpc.RoxAPIEndpoint(t)
 
 	resp, err := http.Get(url)
+	defer testutils.SafeClientClose(resp)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }


### PR DESCRIPTION
### Description

**UPDATE - 2024-12-13**

- port range is changed from 10k to 30k - comment is provided in the code for more info
- all client closes should be safe
- check for free port is extended to check on IPv4 and IPv6 - we don't know from within the `GetFreePort` function how it will be used by the caller. To ensure we don't have a miss, we are checking on both IPv-s
- `getFreePort` from metrics tests is removed and replaced with implementation in `testutils.GetFreeTestPort`

**Original Description**

There are two problems that this PR is trying to address:
- we have extensive reusing of the same port across multiple tests
- we are not closing connections cleanly in our tests

After some investigation, the conclusion is that the `FIN_WAIT` state is piled because of the not properly closed connection on the client side. This should be improved with this PR.

Another problem that is not 100% clear is the `FIN_WAIT` state requires the server to be alive. It can be that it's hard to reproduce such a case manually, and it's happening with a big load during unit tests. To reduce high port reuse and potential collision, a new method has been added to this PR to get a free port. This should reduce port number "overload".

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

Local unit tests executed.

I also tested on a dedicated Linux machine, where I was able to reproduce and test the amount of `FIN_WAIT` states generated by the test run.

Here is a helpful article with some scripts on how to reproduce such a state: https://blog.cloudflare.com/this-is-strictly-a-violation-of-the-tcp-specification/
