### PR TITLE
ROX-27301: Rewrite Cypress test helper to remove use of `find`

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -227,16 +227,16 @@ export function selectSingleCveForException(exceptionType) {
             ? selectors.deferCveModal
             : selectors.markCveFalsePositiveModal;
 
-    return cy.get(selectors.firstTableRow).then(($row) => {
-        const cveName = $row.find('td[data-label="CVE"]').text();
-        cy.wrap($row).find(selectors.tableRowMenuToggle).click();
-        cy.get(selectors.menuOption(menuOption)).click();
-
-        cy.get('button:contains("CVE selections")').click();
-        // TODO - Update this code when modal form is completed
-        cy.get(`${modalSelector}:contains("${cveName}")`);
-        return Promise.resolve(cveName);
-    });
+    return cy
+        .get(`${selectors.firstTableRow} td[data-label="CVE"]`)
+        .then(($cell) => $cell.text())
+        .then((cveName) => {
+            cy.get(`${selectors.firstTableRow} ${selectors.tableRowMenuToggle}`).click();
+            cy.get(selectors.menuOption(menuOption)).click();
+            cy.get('button:contains("CVE selections")').click();
+            cy.get(`${modalSelector}:contains("${cveName}")`);
+            return Promise.resolve(cveName);
+        });
 }
 
 /**


### PR DESCRIPTION
### Description

Another attempt at fixing this CI flake. Two attempts have been merged and yet this issue persists. It has not been reproducible other than in a single digit percentage of CI runs.

This fix simply reworks the helper to not use the `cy.wrap().find()` call chain which is throwing the error, instead using `cy.get()` on the target element directly.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Local Cypress runs:
![image](https://github.com/user-attachments/assets/712dd52b-a9a0-4860-8d04-63ec9011f4ae)

Awaiting CI