### PR TITLE
ROX-27344: Add test to verify consistent image CVE counts

### DIFF
--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -46,6 +46,11 @@ export function sortByTableHeader(headerName: string) {
     return queryTableSortHeader(headerName).click();
 }
 
+export function changePerPageOption(amount: number) {
+    cy.get('button').contains(new RegExp('\\d+ - \\d+ of \\d+')).click();
+    cy.get('button[role="menuitem"]').contains(`${amount} per page`).click();
+}
+
 export function paginateNext() {
     return cy.get('button[aria-label="Go to next page"]').click();
 }


### PR DESCRIPTION
### Description

This adds test cases to cover the scenario of a customer issue where the CVE count on the Image Detail page fluctuated when applying sorts and pagination. This was observed on a screenshare call but we have not been able to reproduce locally.

This test runs a variety of similar scenarios in order to attempt to catch this in many CI runs. (Additionally, it doesn't hurt to have more coverage here.)

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
