### PR TITLE
ROX-27343: Fix roxctl init-bundles list output time format

### DIFF
--- a/central/compliance/handlers/csv.go
+++ b/central/compliance/handlers/csv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/compliance/datastore"
@@ -161,7 +162,7 @@ func CSVHandler() http.HandlerFunc {
 		for _, d := range validResults {
 			controls := make(map[string]*v1.ComplianceControl)
 			standardName := d.GetRunMetadata().GetStandardId()
-			timestamp := protocompat.ConvertTimestampToCSVString(d.GetRunMetadata().GetFinishTimestamp())
+			timestamp := protocompat.ConvertTimestampToString(d.GetRunMetadata().GetFinishTimestamp(), time.RFC1123)
 			standard, ok, _ := standards.Standard(standardName)
 			if ok {
 				standardName = standard.GetMetadata().GetName()

--- a/pkg/protocompat/time.go
+++ b/pkg/protocompat/time.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const defaultTimeStringFormat = time.RFC3339Nano
+
 var (
 	// TimestampPtrType is a variable containing a nil pointer of Timestamp type
 	TimestampPtrType = reflect.TypeOf((*timestamppb.Timestamp)(nil))
@@ -36,15 +38,18 @@ func TimestampNow() *timestamppb.Timestamp {
 	return timestamppb.Now()
 }
 
-// ConvertTimestampToCSVString converts a proto timestamp to a string for display in a CSV report.
-func ConvertTimestampToCSVString(timestamp *timestamppb.Timestamp) string {
+// ConvertTimestampToString converts a proto timestamp to a string.
+func ConvertTimestampToString(timestamp *timestamppb.Timestamp, format string) string {
 	if timestamp == nil {
 		return "N/A"
 	}
 	if timestamp.CheckValid() != nil {
 		return "ERR"
 	}
-	return timestamp.AsTime().Format(time.RFC1123)
+	if format == "" {
+		format = defaultTimeStringFormat
+	}
+	return timestamp.AsTime().Format(format)
 }
 
 // ConvertTimestampToTimeOrNil converts a proto timestamp to a golang Time, defaulting to nil in case of error.

--- a/pkg/protocompat/time_test.go
+++ b/pkg/protocompat/time_test.go
@@ -25,23 +25,30 @@ func TestCompareTimestamps(t *testing.T) {
 	assert.Positive(t, CompareTimestamps(protoTS2, protoTS1))
 }
 
-func TestConvertTimestampToCSVString(t *testing.T) {
+func TestConvertTimestampToString(t *testing.T) {
 	var nilTS *timestamppb.Timestamp
-	nilStringRepresentation := ConvertTimestampToCSVString(nilTS)
+	nilStringRepresentation := ConvertTimestampToString(nilTS, time.RFC3339Nano)
 	assert.Equal(t, "N/A", nilStringRepresentation)
 
 	invalidTS := &timestamppb.Timestamp{
 		Seconds: -62234567890,
 	}
-	stringFromInvalid := ConvertTimestampToCSVString(invalidTS)
+	stringFromInvalid := ConvertTimestampToString(invalidTS, time.RFC3339Nano)
 	assert.Equal(t, "ERR", stringFromInvalid)
 
 	ts := &timestamppb.Timestamp{
 		Seconds: 2345678901,
 		Nanos:   123456789,
 	}
-	timeString := ConvertTimestampToCSVString(ts)
-	assert.Equal(t, "Sun, 01 May 2044 01:28:21 UTC", timeString)
+	timeString := ConvertTimestampToString(ts, time.RFC3339)
+	assert.Equal(t, "2044-05-01T01:28:21Z", timeString)
+
+	timeStringNoFormatProvided := ConvertTimestampToString(ts, "")
+	timeStringDefaultFormat := ConvertTimestampToString(ts, defaultTimeStringFormat)
+	assert.Equal(t, timeStringDefaultFormat, timeStringNoFormatProvided)
+
+	timeStringRFC1123 := ConvertTimestampToString(ts, time.RFC1123)
+	assert.Equal(t, "Sun, 01 May 2044 01:28:21 UTC", timeStringRFC1123)
 }
 
 func TestConvertTimestampToTimeOrError(t *testing.T) {

--- a/roxctl/central/crs/list.go
+++ b/roxctl/central/crs/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/protocompat"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
@@ -48,8 +49,8 @@ func listCRSs(cliEnvironment environment.Environment, timeout time.Duration, ret
 		}
 		fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\t%s\n",
 			name,
-			crsMeta.GetCreatedAt().AsTime().Format(time.RFC3339),
-			crsMeta.GetExpiresAt().AsTime().Format(time.RFC3339),
+			protocompat.ConvertTimestampToString(crsMeta.GetCreatedAt(), time.RFC3339),
+			protocompat.ConvertTimestampToString(crsMeta.GetExpiresAt(), time.RFC3339),
 			getPrettyUser(crsMeta.GetCreatedBy()),
 			crsMeta.GetId(),
 		)

--- a/roxctl/central/initbundles/list.go
+++ b/roxctl/central/initbundles/list.go
@@ -3,6 +3,7 @@ package initbundles
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"text/tabwriter"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/protocompat"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
@@ -29,8 +31,6 @@ func listInitBundles(cliEnvironment environment.Environment, timeout time.Durati
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)
 
-	tabWriter := tabwriter.NewWriter(cliEnvironment.InputOutput().Out(), 4, 8, 2, '\t', 0)
-
 	rsp, err := svc.GetInitBundles(ctx, &v1.Empty{})
 	if err != nil {
 		return errors.Wrap(err, "getting all init bundles")
@@ -38,6 +38,12 @@ func listInitBundles(cliEnvironment environment.Environment, timeout time.Durati
 
 	bundles := rsp.GetItems()
 	sort.Slice(bundles, func(i, j int) bool { return bundles[i].GetName() < bundles[j].GetName() })
+
+	return outputBundles(cliEnvironment.InputOutput().Out(), bundles)
+}
+
+func outputBundles(w io.Writer, bundles []*v1.InitBundleMeta) error {
+	tabWriter := tabwriter.NewWriter(w, 4, 8, 2, '\t', 0)
 
 	fmt.Fprintln(tabWriter, "Name\tCreated at\tExpires at\tCreated By\tID")
 	fmt.Fprintln(tabWriter, "====\t==========\t==========\t==========\t==")
@@ -49,12 +55,13 @@ func listInitBundles(cliEnvironment environment.Environment, timeout time.Durati
 		}
 		fmt.Fprintf(tabWriter, "%s\t%s\t%v\t%s\t%v\n",
 			name,
-			meta.GetCreatedAt(),
-			meta.GetExpiresAt(),
+			protocompat.ConvertTimestampToString(meta.GetCreatedAt(), time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(meta.GetExpiresAt(), time.RFC3339Nano),
 			getPrettyUser(meta.GetCreatedBy()),
 			meta.GetId(),
 		)
 	}
+
 	return errors.Wrap(tabWriter.Flush(), "flushing tabular output")
 }
 

--- a/roxctl/central/initbundles/list_test.go
+++ b/roxctl/central/initbundles/list_test.go
@@ -1,0 +1,111 @@
+package initbundles
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_outputBundles(t *testing.T) {
+	secondsCreatedAt := int64(2222222222)
+	secondsExpiresAt := int64(2345678901)
+	nanos := int32(123456789)
+
+	tests := map[string]struct {
+		bundles []*v1.InitBundleMeta
+		output  string
+	}{
+		"empty list": {
+			bundles: []*v1.InitBundleMeta{},
+			output: `Name	Created at	Expires at	Created By	ID
+====	==========	==========	==========	==
+`,
+		},
+		"time format is good": {
+			bundles: []*v1.InitBundleMeta{
+				{
+					Id:        "9887ccc2-20ce-44f9-b316-57f9f79f5e05",
+					Name:      "test",
+					CreatedAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsCreatedAt, nanos),
+					ExpiresAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsExpiresAt, nanos),
+				},
+			},
+			output: `Name	Created at			Expires at			Created By	ID
+====	==========			==========			==========	==
+test	2040-06-02T03:57:02.123456789Z	2044-05-01T01:28:21.123456789Z	(unknown)	9887ccc2-20ce-44f9-b316-57f9f79f5e05
+`,
+		},
+		"time format is good without nanos": {
+			bundles: []*v1.InitBundleMeta{
+				{
+					Id:        "9887ccc2-20ce-44f9-b316-57f9f79f5e05",
+					Name:      "test",
+					CreatedAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsCreatedAt, 0),
+					ExpiresAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsExpiresAt, 0),
+				},
+			},
+			output: `Name	Created at		Expires at		Created By	ID
+====	==========		==========		==========	==
+test	2040-06-02T03:57:02Z	2044-05-01T01:28:21Z	(unknown)	9887ccc2-20ce-44f9-b316-57f9f79f5e05
+`,
+		},
+		"nil Expires at": {
+			bundles: []*v1.InitBundleMeta{
+				{
+					Id:        "9887ccc2-20ce-44f9-b316-57f9f79f5e05",
+					Name:      "test",
+					CreatedAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsCreatedAt, nanos),
+				},
+			},
+			output: `Name	Created at			Expires at	Created By	ID
+====	==========			==========	==========	==
+test	2040-06-02T03:57:02.123456789Z	N/A		(unknown)	9887ccc2-20ce-44f9-b316-57f9f79f5e05
+`,
+		},
+		"nil Created at": {
+			bundles: []*v1.InitBundleMeta{
+				{
+					Id:        "9887ccc2-20ce-44f9-b316-57f9f79f5e05",
+					Name:      "test",
+					ExpiresAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsExpiresAt, nanos),
+				},
+			},
+			output: `Name	Created at	Expires at			Created By	ID
+====	==========	==========			==========	==
+test	N/A		2044-05-01T01:28:21.123456789Z	(unknown)	9887ccc2-20ce-44f9-b316-57f9f79f5e05
+`,
+		},
+		"full row": {
+			bundles: []*v1.InitBundleMeta{
+				{
+					Id:        "9887ccc2-20ce-44f9-b316-57f9f79f5e05",
+					Name:      "test",
+					CreatedAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsCreatedAt, nanos),
+					CreatedBy: &storage.User{
+						Id: "test-user",
+					},
+					ExpiresAt: protocompat.GetProtoTimestampFromSecondsAndNanos(secondsExpiresAt, 0),
+				},
+			},
+			output: `Name	Created at			Expires at		Created By	ID
+====	==========			==========		==========	==
+test	2040-06-02T03:57:02.123456789Z	2044-05-01T01:28:21Z	test-user	9887ccc2-20ce-44f9-b316-57f9f79f5e05
+`,
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var b bytes.Buffer
+			writer := io.Writer(&b)
+
+			assert.NoError(t, outputBundles(writer, tt.bundles))
+			assert.Equal(t, tt.output, b.String())
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR fixes the issue with time formatting in `central init-bundles list` table output.

Made changes:
- refactor `ConvertTimestampToCSVString` to be more generic `ConvertTimestampToString`
- use `time.RFC3339Nano` as default format (behaviour should be the same to older protobuf framework)
- tweak `roxctl/central/crs/list.go` - to use `ConvertTimestampToString` which should be a bit safer with `nil`
- added tests for tabular output to capture future regressions

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added regression tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Test only with added unit tests.

**EDIT:** I have built `roxctl` locally and tested it. It looks good.
