### PR TITLE
ROX-27302: Disable one of DefaultPoliciesTest tests on AKS

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -472,6 +472,8 @@ class DefaultPoliciesTest extends BaseSpecification {
     }
 
     @Tag("BAT")
+    // ROX-27302 Test is failing for AKS platform since 2024-12-09 (K8S API update to v1.30)
+    @IgnoreIf({ Env.CI_JOB_NAME ==~ /^aks-.*/ })
     def "Verify that built-in services don't trigger unexpected alerts"() {
         expect:
         "Verify unexpected policies are not violated within the kube-system namespace"


### PR DESCRIPTION
### Description

This PR disabled `DefaultPoliciesTest` -> `Verify that built-in services don't trigger unexpected alerts` on `aks` platform.

The test has been constantly failing since `2024-12-09`. At that point, `aks` received an update to K8S API `v1.30`

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] disabled existing test conditionally

#### How I validated my change

I'll let CI validate it.

It is important to trigger tests on `aks`.
