### PR TITLE
ROX-26729: Disable SAC Verify Search test for searchImagesToken

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -395,7 +395,8 @@ class SACTest extends BaseSpecification {
         tokenName                | category     | numResults
         NOACCESSTOKEN            | "Cluster"    | 0
         "searchDeploymentsToken" | "Deployment" | 1
-        "searchImagesToken"      | "Image"      | 1
+        // ROX-26729 - it's failing ~5 times a week. Disabled for now.
+        // "searchImagesToken"      | "Image"      | 1
     }
 
     @Unroll


### PR DESCRIPTION
### Description

The test is failing `~5 times a week` since `2024-10-23`. This PR is disabling one of the test cases.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] disabled existing tests

#### How I validated my change

I'll let CI run and check that the disabled case is not executed anymore.
