### PR TITLE
ROX-27394: Sensor offline mode support in TLS issuer

### DIFF
--- a/pkg/concurrency/retry_ticker_test.go
+++ b/pkg/concurrency/retry_ticker_test.go
@@ -77,7 +77,7 @@ func TestRetryTickerCallsTickFunction(t *testing.T) {
 				schedulerSpy.On("afterFunc", backoff.Duration, mock.Anything).Return(nil).Once()
 			}
 
-			require.NoError(t, ticker.Start())
+			require.NoError(t, ticker.Start(context.Background()))
 
 			_, ok := doneErrSig.WaitWithTimeout(testTimeout)
 			require.True(t, ok, "timeout exceeded")
@@ -98,7 +98,7 @@ func TestRetryTickerStop(t *testing.T) {
 	})
 	defer ticker.Stop()
 
-	require.NoError(t, ticker.Start())
+	require.NoError(t, ticker.Start(context.Background()))
 	_, ok := firsTickErrSig.WaitWithTimeout(testTimeout)
 	require.True(t, ok, "timeout exceeded")
 	ticker.Stop()
@@ -116,7 +116,7 @@ func TestRetryTickerStopsOnNonRecoverableErrors(t *testing.T) {
 	})
 	defer ticker.Stop()
 
-	require.NoError(t, ticker.Start())
+	require.NoError(t, ticker.Start(context.Background()))
 	_, ok := firsTickErrSig.WaitWithTimeout(testTimeout)
 	require.True(t, ok, "timeout exceeded")
 
@@ -129,8 +129,8 @@ func TestRetryTickerStartWhileStarterFailure(t *testing.T) {
 	})
 	defer ticker.Stop()
 
-	require.NoError(t, ticker.Start())
-	assert.ErrorIs(t, ErrStartedTimer, ticker.Start())
+	require.NoError(t, ticker.Start(context.Background()))
+	assert.ErrorIs(t, ErrStartedTimer, ticker.Start(context.Background()))
 }
 
 func TestRetryTickerStartTwiceFailure(t *testing.T) {
@@ -139,9 +139,9 @@ func TestRetryTickerStartTwiceFailure(t *testing.T) {
 	})
 	defer ticker.Stop()
 
-	require.NoError(t, ticker.Start())
+	require.NoError(t, ticker.Start(context.Background()))
 	ticker.Stop()
-	require.ErrorIs(t, ErrStoppedTimer, ticker.Start())
+	require.ErrorIs(t, ErrStoppedTimer, ticker.Start(context.Background()))
 }
 
 func newRetryTicker(t *testing.T, doFunc tickFunc) *retryTickerImpl {

--- a/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/localscanner_tls_issuer.go
@@ -36,7 +36,6 @@ func NewLocalScannerTLSIssuer(
 		getCertificateRefresherFn:    newCertificatesRefresher,
 		getServiceCertificatesRepoFn: localscanner.NewServiceCertificatesRepo,
 		msgToCentralC:                make(chan *message.ExpiringMessage),
-		stopSig:                      concurrency.NewErrorSignal(),
 		newMsgFromSensorFn:           newLocalScannerMsgFromSensor,
 		responseReceived:             concurrency.NewSignal(),
 		requiredCentralCapability:    nil,

--- a/sensor/kubernetes/certrefresh/localscanner_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/localscanner_tls_issuer_test.go
@@ -59,7 +59,6 @@ func newLocalScannerTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *local
 		certRefreshBackoff:           certRefreshBackoff,
 		getCertificateRefresherFn:    fixture.componentGetter.getCertificateRefresher,
 		getServiceCertificatesRepoFn: fixture.componentGetter.getServiceCertificatesRepo,
-		stopSig:                      concurrency.NewErrorSignal(),
 		msgToCentralC:                make(chan *message.ExpiringMessage),
 		newMsgFromSensorFn:           newLocalScannerMsgFromSensor,
 		responseReceived:             concurrency.NewSignal(),
@@ -75,7 +74,7 @@ func (f *localScannerTLSIssuerFixture) assertMockExpectations(t *testing.T) {
 
 // mockForStart setups the mocks for the happy path of Start
 func (f *localScannerTLSIssuerFixture) mockForStart(conf mockForStartConfig) {
-	f.certRefresher.On("Start").Once().Return(conf.refresherStartErr)
+	f.certRefresher.On("Start", mock.Anything).Once().Return(conf.refresherStartErr)
 
 	f.repo.On("GetServiceCertificates", mock.Anything).Once().
 		Return((*storage.TypedServiceCertificateSet)(nil), conf.getCertsErr)

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -36,7 +36,6 @@ func NewSecuredClusterTLSIssuer(
 		getCertificateRefresherFn:    newCertificatesRefresher,
 		getServiceCertificatesRepoFn: securedcluster.NewServiceCertificatesRepo,
 		msgToCentralC:                make(chan *message.ExpiringMessage),
-		stopSig:                      concurrency.NewErrorSignal(),
 		newMsgFromSensorFn:           newSecuredClusterMsgFromSensor,
 		responseReceived:             concurrency.NewSignal(),
 		requiredCentralCapability: func() *centralsensor.CentralCapability {

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -67,7 +67,6 @@ func newSecuredClusterTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *sec
 		certRefreshBackoff:           certRefreshBackoff,
 		getCertificateRefresherFn:    fixture.componentGetter.getCertificateRefresher,
 		getServiceCertificatesRepoFn: fixture.componentGetter.getServiceCertificatesRepo,
-		stopSig:                      concurrency.NewErrorSignal(),
 		msgToCentralC:                make(chan *message.ExpiringMessage),
 		newMsgFromSensorFn:           newSecuredClusterMsgFromSensor,
 		responseReceived:             concurrency.NewSignal(),
@@ -87,7 +86,7 @@ func (f *securedClusterTLSIssuerFixture) assertMockExpectations(t *testing.T) {
 
 // mockForStart setups the mocks for the happy path of Start
 func (f *securedClusterTLSIssuerFixture) mockForStart(conf mockForStartConfig) {
-	f.certRefresher.On("Start").Once().Return(conf.refresherStartErr)
+	f.certRefresher.On("Start", mock.Anything).Once().Return(conf.refresherStartErr)
 
 	f.repo.On("GetServiceCertificates", mock.Anything).Once().
 		Return((*storage.TypedServiceCertificateSet)(nil), conf.getCertsErr)

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -71,7 +71,10 @@ func newSecuredClusterTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *sec
 		msgToCentralC:                make(chan *message.ExpiringMessage),
 		newMsgFromSensorFn:           newSecuredClusterMsgFromSensor,
 		responseReceived:             concurrency.NewSignal(),
-		requiredCentralCapability:    nil,
+		requiredCentralCapability: func() *centralsensor.CentralCapability {
+			centralCap := centralsensor.CentralCapability(centralsensor.SecuredClusterCertificatesReissue)
+			return &centralCap
+		}(),
 	}
 
 	return fixture
@@ -118,7 +121,23 @@ func (f *securedClusterTLSIssuerFixture) respondRequest(
 	}
 }
 
-func TestSecuredClusterTLSIssuerStartStopSuccess(t *testing.T) {
+func TestSecuredClusterTLSIssuerTests(t *testing.T) {
+	suite.Run(t, new(securedClusterTLSIssuerTests))
+}
+
+type securedClusterTLSIssuerTests struct {
+	suite.Suite
+}
+
+func (s *securedClusterTLSIssuerTests) SetupTest() {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+}
+
+func (s *securedClusterTLSIssuerTests) TearDownTest() {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+}
+
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerStartStopSuccess() {
 	testCases := map[string]struct {
 		getCertsErr error
 	}{
@@ -128,35 +147,47 @@ func TestSecuredClusterTLSIssuerStartStopSuccess(t *testing.T) {
 		"missing secret":      {getCertsErr: k8sErrors.NewNotFound(schema.GroupResource{Group: "Core", Resource: "Secret"}, "scanner-db-slim-tls")},
 	}
 	for tcName, tc := range testCases {
-		t.Run(tcName, func(t *testing.T) {
+		s.Run(tcName, func() {
 			fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 			fixture.mockForStart(mockForStartConfig{getCertsErr: tc.getCertsErr})
 			fixture.certRefresher.On("Stop").Once()
 
 			startErr := fixture.tlsIssuer.Start()
 			fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
-			assert.NotNil(t, fixture.tlsIssuer.certRefresher)
+			assert.NotNil(s.T(), fixture.tlsIssuer.certRefresher)
 			fixture.tlsIssuer.Stop(nil)
 
-			assert.NoError(t, startErr)
-			assert.Nil(t, fixture.tlsIssuer.certRefresher)
-			fixture.assertMockExpectations(t)
+			assert.NoError(s.T(), startErr)
+			assert.Nil(s.T(), fixture.tlsIssuer.certRefresher)
+			fixture.assertMockExpectations(s.T())
 		})
 	}
 }
 
-func TestSecuredClusterTLSIssuerRefresherFailureStartFailure(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerStartFailure() {
 	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	fixture.mockForStart(mockForStartConfig{refresherStartErr: errForced})
 
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	startErr := fixture.tlsIssuer.Start()
 
-	require.Error(t, startErr)
-	fixture.assertMockExpectations(t)
+	require.Error(s.T(), startErr)
+	fixture.assertMockExpectations(s.T())
 }
 
-func TestSecuredClusterTLSIssuerStartAlreadyStarted(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerDoesNotStartWhenCentralLacksReissueCapability() {
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.mockForStart(mockForStartConfig{})
+
+	startErr := fixture.tlsIssuer.Start()
+	assert.NoError(s.T(), startErr)
+
+	centralcaps.Set([]centralsensor.CentralCapability{})
+	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	require.Nil(s.T(), fixture.tlsIssuer.certRefresher)
+}
+
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerStartAlreadyStarted() {
 	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	fixture.mockForStart(mockForStartConfig{})
 
@@ -164,12 +195,12 @@ func TestSecuredClusterTLSIssuerStartAlreadyStarted(t *testing.T) {
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	secondStartErr := fixture.tlsIssuer.Start()
 
-	require.NoError(t, startErr)
-	require.NoError(t, secondStartErr)
-	fixture.assertMockExpectations(t)
+	require.NoError(s.T(), startErr)
+	require.NoError(s.T(), secondStartErr)
+	fixture.assertMockExpectations(s.T())
 }
 
-func TestSecuredClusterTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure() {
 	testCases := map[string]struct {
 		k8sClientConfig fakeK8sClientConfig
 	}{
@@ -177,19 +208,19 @@ func TestSecuredClusterTLSIssuerFetchSensorDeploymentOwnerRefErrorStartFailure(t
 		"sensor pod missing":         {k8sClientConfig: fakeK8sClientConfig{skipSensorPod: true}},
 	}
 	for tcName, tc := range testCases {
-		t.Run(tcName, func(t *testing.T) {
+		s.Run(tcName, func() {
 			fixture := newSecuredClusterTLSIssuerFixture(tc.k8sClientConfig)
 
 			fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 			startErr := fixture.tlsIssuer.Start()
 
-			require.Error(t, startErr)
-			fixture.assertMockExpectations(t)
+			require.Error(s.T(), startErr)
+			fixture.assertMockExpectations(s.T())
 		})
 	}
 }
 
-func TestSecuredClusterTLSIssuerProcessMessageKnownMessage(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessageKnownMessage() {
 	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	expectedResponse := &central.IssueSecuredClusterCertsResponse{
 		RequestId: uuid.NewDummy().String(),
@@ -203,79 +234,71 @@ func TestSecuredClusterTLSIssuerProcessMessageKnownMessage(t *testing.T) {
 	fixture.tlsIssuer.ongoingRequestID = expectedResponse.RequestId
 	fixture.tlsIssuer.requestOngoing.Store(true)
 
-	assert.NoError(t, fixture.tlsIssuer.ProcessMessage(msg))
-	assert.Eventually(t, func() bool {
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
+	assert.Eventually(s.T(), func() bool {
 		return fixture.tlsIssuer.responseReceived.IsDone()
 	}, 2*time.Second, 100*time.Millisecond)
 }
 
-func TestSecuredClusterTLSIssuerProcessMessageUnknownMessage(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessageUnknownMessage() {
 	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	msg := &central.MsgToSensor{
 		Msg: &central.MsgToSensor_ReprocessDeployments{},
 	}
 
-	assert.NoError(t, fixture.tlsIssuer.ProcessMessage(msg))
-	assert.Never(t, func() bool {
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
+	assert.Never(s.T(), func() bool {
 		return fixture.tlsIssuer.responseReceived.IsDone()
 	}, 200*time.Millisecond, 50*time.Millisecond)
 }
 
-func TestSecuredClusterTLSIssuerRequestCancellation(t *testing.T) {
-	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
-	defer func() {
-		centralcaps.Set([]centralsensor.CentralCapability{})
-	}()
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerRequestCancellation() {
 	f := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
 
 	certs, requestErr := f.tlsIssuer.requestCertificates(ctx)
-	assert.Nil(t, certs)
-	assert.Equal(t, context.Canceled, requestErr)
+	assert.Nil(s.T(), certs)
+	assert.Equal(s.T(), context.Canceled, requestErr)
 }
 
-func TestSecuredClusterTLSIssuerRequestSuccess(t *testing.T) {
-	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
-	defer func() {
-		centralcaps.Set([]centralsensor.CentralCapability{})
-	}()
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerRequestSuccess() {
 	f := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	go f.respondRequest(ctx, t, nil)
+	go f.respondRequest(ctx, s.T(), nil)
 
 	response, err := f.tlsIssuer.requestCertificates(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, f.interceptedRequestID.Load(), response.RequestId)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), f.interceptedRequestID.Load(), response.RequestId)
 	oldRequestId := response.RequestId
 
 	// Check that a second call also works
-	go f.respondRequest(ctx, t, nil)
+	go f.respondRequest(ctx, s.T(), nil)
 
 	response, err = f.tlsIssuer.requestCertificates(ctx)
-	assert.NoError(t, err)
-	assert.Equal(t, f.interceptedRequestID.Load(), response.RequestId)
-	assert.NotEqual(t, oldRequestId, response.RequestId)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), f.interceptedRequestID.Load(), response.RequestId)
+	assert.NotEqual(s.T(), oldRequestId, response.RequestId)
 }
 
-func TestSecuredClusterTLSIssuerResponsesWithUnknownIDAreIgnored(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerResponsesWithUnknownIDAreIgnored() {
 	f := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	response := &central.IssueSecuredClusterCertsResponse{RequestId: "UNKNOWN"}
 	// Request with different request ID should be ignored.
-	go f.respondRequest(ctx, t, response)
+	go f.respondRequest(ctx, s.T(), response)
 
 	certs, requestErr := f.tlsIssuer.requestCertificates(ctx)
-	assert.Nil(t, certs)
-	assert.Equal(t, context.DeadlineExceeded, requestErr)
+	assert.Nil(s.T(), certs)
+	assert.Equal(s.T(), context.DeadlineExceeded, requestErr)
 }
 
-func TestSecuredClusterCertificateRequesterNoReplyFromCentral(t *testing.T) {
+func (s *securedClusterTLSIssuerTests) TestSecuredClusterCertificateRequesterNoReplyFromCentral() {
 	f := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -283,29 +306,29 @@ func TestSecuredClusterCertificateRequesterNoReplyFromCentral(t *testing.T) {
 	certs, requestErr := f.tlsIssuer.requestCertificates(ctx)
 
 	// No response was set using `f.respondRequest`, which simulates not receiving a reply from Central
-	assert.Nil(t, certs)
-	assert.Equal(t, context.DeadlineExceeded, requestErr)
+	assert.Nil(s.T(), certs)
+	assert.Equal(s.T(), context.DeadlineExceeded, requestErr)
 }
 
 func TestSecuredClusterTLSIssuerIntegrationTests(t *testing.T) {
-	suite.Run(t, new(securedClusterTLSIssueIntegrationTests))
+	suite.Run(t, new(securedClusterTLSIssuerIntegrationTests))
 }
 
-type securedClusterTLSIssueIntegrationTests struct {
+type securedClusterTLSIssuerIntegrationTests struct {
 	suite.Suite
 }
 
-func (s *securedClusterTLSIssueIntegrationTests) SetupTest() {
+func (s *securedClusterTLSIssuerIntegrationTests) SetupTest() {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
 	err := testutilsMTLS.LoadTestMTLSCerts(s.T())
 	s.Require().NoError(err)
 }
 
-func (s *securedClusterTLSIssueIntegrationTests) TestSuccessfulRefresh() {
-	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
-	defer func() {
-		centralcaps.Set([]centralsensor.CentralCapability{})
-	}()
+func (s *securedClusterTLSIssuerIntegrationTests) TearDownTest() {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+}
 
+func (s *securedClusterTLSIssuerIntegrationTests) TestSuccessfulRefresh() {
 	testCases := map[string]struct {
 		k8sClientConfig    fakeK8sClientConfig
 		numFailedResponses int
@@ -376,12 +399,63 @@ func (s *securedClusterTLSIssueIntegrationTests) TestSuccessfulRefresh() {
 	}
 }
 
-func (s *securedClusterTLSIssueIntegrationTests) TestUnexpectedOwnerStop() {
-	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
-	defer func() {
-		centralcaps.Set([]centralsensor.CentralCapability{})
-	}()
+func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes() {
+	testTimeout := 2 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
 
+	secretsCerts := getAllSecuredClusterCertificates(s.T())
+
+	k8sClient := getFakeK8sClient(fakeK8sClientConfig{})
+	tlsIssuer := newSecuredClusterTLSIssuer(s.T(), k8sClient, sensorNamespace, sensorPodName)
+	tlsIssuer.certRefreshBackoff = wait.Backoff{
+		Duration: time.Millisecond,
+	}
+
+	s.Require().NoError(tlsIssuer.Start())
+	tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	defer tlsIssuer.Stop(nil)
+	s.Require().NotNil(tlsIssuer.certRefresher)
+	s.Require().False(tlsIssuer.certRefresher.Stopped())
+
+	request := s.waitForRequest(ctx, tlsIssuer)
+	response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
+	err = tlsIssuer.ProcessMessage(response)
+	s.Require().NoError(err)
+
+	tlsIssuer.Notify(common.SensorComponentEventOfflineMode)
+	s.Require().Nil(tlsIssuer.certRefresher)
+
+	tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NotNil(tlsIssuer.certRefresher)
+
+	request = s.waitForRequest(ctx, tlsIssuer)
+	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
+	err = tlsIssuer.ProcessMessage(response)
+	s.Require().NoError(err)
+
+	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
+
+	tlsIssuer.Notify(common.SensorComponentEventOfflineMode)
+	s.Require().Nil(tlsIssuer.certRefresher)
+
+	// Delete all secrets to force a refresh when Sensor goes back online
+	deleteAllSecrets(ctx, s.T(), k8sClient, sensorNamespace)
+
+	tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NotNil(tlsIssuer.certRefresher)
+
+	request = s.waitForRequest(ctx, tlsIssuer)
+	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
+	err = tlsIssuer.ProcessMessage(response)
+	s.Require().NoError(err)
+
+	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
+}
+
+func (s *securedClusterTLSIssuerIntegrationTests) TestUnexpectedOwnerStop() {
 	testCases := map[string]struct {
 		secretNames []string
 	}{
@@ -434,7 +508,7 @@ func getAllSecuredClusterCertificates(t require.TestingT) map[string]*mtls.Issue
 	}
 }
 
-func (s *securedClusterTLSIssueIntegrationTests) waitForRequest(ctx context.Context, tlsIssuer common.SensorComponent) *central.IssueSecuredClusterCertsRequest {
+func (s *securedClusterTLSIssuerIntegrationTests) waitForRequest(ctx context.Context, tlsIssuer common.SensorComponent) *central.IssueSecuredClusterCertsRequest {
 	var request *message.ExpiringMessage
 	select {
 	case request = <-tlsIssuer.ResponsesC():

--- a/sensor/kubernetes/certrefresh/tls_issuer_common.go
+++ b/sensor/kubernetes/certrefresh/tls_issuer_common.go
@@ -68,6 +68,7 @@ type tlsIssuerImpl struct {
 	started                      atomic.Bool
 	online                       atomic.Bool
 	cancelRefresher              context.CancelFunc
+	activateLock                 sync.Mutex
 }
 
 // Start starts the Sensor component and launches a certificate refresher that:
@@ -81,6 +82,9 @@ func (i *tlsIssuerImpl) Start() error {
 }
 
 func (i *tlsIssuerImpl) activate() error {
+	i.activateLock.Lock()
+	defer i.activateLock.Unlock()
+
 	if !i.started.Load() {
 		return nil
 	}
@@ -126,6 +130,9 @@ func (i *tlsIssuerImpl) Stop(_ error) {
 }
 
 func (i *tlsIssuerImpl) deactivate() {
+	i.activateLock.Lock()
+	defer i.activateLock.Unlock()
+
 	i.cancelRefresher()
 	if i.certRefresher != nil {
 		i.certRefresher.Stop()

--- a/sensor/kubernetes/certrefresh/tls_issuer_common.go
+++ b/sensor/kubernetes/certrefresh/tls_issuer_common.go
@@ -145,7 +145,9 @@ func (i *tlsIssuerImpl) Notify(e common.SensorComponentEvent) {
 			return
 		}
 		i.online = true
-		i.activate()
+		if err := i.activate(); err != nil {
+			log.Warnf("Failed to activate %s TLS issuer: %v", i.componentName, err)
+		}
 	case common.SensorComponentEventOfflineMode:
 		i.online = false
 		i.deactivate()

--- a/sensor/kubernetes/certrefresh/tls_issuer_common_test.go
+++ b/sensor/kubernetes/certrefresh/tls_issuer_common_test.go
@@ -119,8 +119,8 @@ type certificateRefresherMock struct {
 	stopped bool
 }
 
-func (m *certificateRefresherMock) Start() error {
-	args := m.Called()
+func (m *certificateRefresherMock) Start(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 

--- a/sensor/kubernetes/certrefresh/tls_issuer_common_test.go
+++ b/sensor/kubernetes/certrefresh/tls_issuer_common_test.go
@@ -169,7 +169,7 @@ func verifySecrets(ctx context.Context, t require.TestingT,
 	require.True(t, ok)
 	pollTimeout := time.Until(ctxDeadline)
 	var secrets *v1.SecretList
-	ok = concurrency.PollWithTimeout(func() bool {
+	require.Eventually(t, func() bool {
 		var err error
 		secrets, err = k8sClient.CoreV1().Secrets(sensorNamespace).List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
@@ -182,8 +182,7 @@ func verifySecrets(ctx context.Context, t require.TestingT,
 			}
 		}
 		return allSecretsHaveData && len(secrets.Items) == len(secretsCerts)
-	}, 10*time.Millisecond, pollTimeout)
-	require.True(t, ok, "expected exactly %d secrets with non-empty data available in the k8s API", len(secretsCerts))
+	}, pollTimeout, 10*time.Millisecond, "expected exactly %d secrets with non-empty data available in the k8s API", len(secretsCerts))
 
 	for _, secret := range secrets.Items {
 		expectedCert, exists := secretsCerts[secret.GetName()]
@@ -194,6 +193,26 @@ func verifySecrets(ctx context.Context, t require.TestingT,
 		require.Equal(t, expectedCert.CertPEM, secret.Data[mtls.ServiceCertFileName])
 		require.Equal(t, expectedCert.KeyPEM, secret.Data[mtls.ServiceKeyFileName])
 	}
+}
+
+func deleteAllSecrets(ctx context.Context, t require.TestingT,
+	k8sClient kubernetes.Interface, sensorNamespace string) {
+	secrets, err := k8sClient.CoreV1().Secrets(sensorNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "failed to list secrets")
+
+	for _, secret := range secrets.Items {
+		err := k8sClient.CoreV1().Secrets(sensorNamespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
+		require.NoError(t, err, "failed to delete secret %q", secret.Name)
+	}
+
+	ctxDeadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	pollTimeout := time.Until(ctxDeadline)
+	require.Eventually(t, func() bool {
+		updatedSecrets, err := k8sClient.CoreV1().Secrets(sensorNamespace).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err, "failed to list secrets")
+		return len(updatedSecrets.Items) == 0
+	}, pollTimeout, 10*time.Millisecond, "expected 0 secrets in the %q namespace", sensorNamespace)
 }
 
 func getCertificate(t require.TestingT, serviceType storage.ServiceType) *mtls.IssuedCert {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds explicit handling for Sensor offline mode in the TLS issuer components. As these components cannot do anything useful in offline mode, the certificate refresh logic is now only active when Sensor is online.
(note: the TLS issuer was already resilient to Sensor being offline due to its retry mechanism)

Main changes:
* start the certificate refresher only when the component is both started *and* online
* changed behavior of Start / Stop so that they can be called in the wrong order (e.g. calling Start several times in a row is now fine)
* Perform the Central capability check when Sensor enters online mode
* integration tests that cycle through online and offline modes
* unit test for Central capability check
* some testing code clean-up

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual smoke test that shows that the Secured Cluster cert refresher works:
```bash
# Disable CRS to trigger a cert refresh on startup (otherwise the CRS logic retrieves the certs)
ROX_DEPLOY_SENSOR_WITH_CRS=false SENSOR_HELM_MANAGED=true ./deploy/k8s/deploy-local.sh

# Wait for sensor to be in Ready state

❯ kubectl -n stackrox get secret | grep tls-
tls-cert-scanner-v4-db                                    Opaque               3      5m31s
tls-cert-sensor                                           Opaque               3      5m31s
tls-cert-collector                                        Opaque               3      5m30s
tls-cert-admission-control                                Opaque               3      5m30s
tls-cert-scanner                                          Opaque               3      5m29s
tls-cert-scanner-db                                       Opaque               3      5m29s
tls-cert-scanner-v4-indexer                               Opaque               3      5m29s 
```

Sensor logs:
```
kubernetes/certrefresh: 2025/02/20 15:59:19.365620 tls_issuer_common.go:139: Info: Component runs now in Online mode
...
kubernetes/certrefresh: 2025/02/20 15:59:21.641724 cert_refresher.go:110: Warn: secured cluster not found (this is expected on a new deployment), will refresh certificates immediately: 7 errors occurred:
	* secrets "tls-cert-scanner-db" not found
	* secrets "tls-cert-scanner-v4-indexer" not found
	* secrets "tls-cert-scanner-v4-db" not found
	* secrets "tls-cert-sensor" not found
	* secrets "tls-cert-collector" not found
	* secrets "tls-cert-admission-control" not found
	* secrets "tls-cert-scanner" not found

kubernetes/certrefresh: 2025/02/20 15:59:24.442826 cert_refresher.go:85: Info: successfully refreshed secured cluster for: SENSOR_SERVICE, COLLECTOR_SERVICE, ADMISSION_CONTROL_SERVICE, SCANNER_V4_DB_SERVICE, SCANNER_DB_SERVICE, SCANNER_SERVICE, SCANNER_V4_INDEXER_SERVICE
kubernetes/certrefresh: 2025/02/20 15:59:24.442884 cert_refresher.go:46: Info: secured cluster scheduled to be refreshed in 3604h37m14.557118633s
```