### PR TITLE
ROX-27390: Add Context to Workload CVEs to allow view customization

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
@@ -1,16 +1,17 @@
-import React, { Component, ElementType } from 'react';
+import React, { Component, ComponentProps, ComponentType, ElementType } from 'react';
 import Loader from 'Components/Loader';
 
-type Props = Record<string, never>;
 type State = {
     component: ElementType | null;
 };
 
-export default function asyncComponent(importComponent): ElementType {
-    class AsyncComponent extends Component<Props, State> {
+export default function asyncComponent<T extends ElementType>(
+    importComponent: () => Promise<{ default: T }>
+): ComponentType<ComponentProps<T>> {
+    class AsyncComponent extends Component<ComponentProps<T>, State> {
         isComponentMounted: boolean;
 
-        constructor(props) {
+        constructor(props: ComponentProps<T>) {
             super(props);
             this.state = {
                 component: null,

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -225,7 +225,15 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
             );
 
             return function WorkloadCvesPage() {
-                return <AsyncWorkloadCvesComponent />;
+                return (
+                    <AsyncWorkloadCvesComponent
+                        context={{
+                            pageTitle: 'Workload CVEs', // TODO Implement throughout in follow up
+                            baseSearchFilter: {}, // TODO Implement throughout in follow up
+                            createUrl: (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`, // TODO Implement throughout in follow up
+                        }}
+                    />
+                );
             };
         })(),
         path: vulnerabilitiesWorkloadCvesPath,

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -219,9 +219,15 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         path: vulnManagementPath,
     },
     'workload-cves': {
-        component: asyncComponent(
-            () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
-        ),
+        component: (() => {
+            const AsyncWorkloadCvesComponent = asyncComponent(
+                () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
+            );
+
+            return function WorkloadCvesPage() {
+                return <AsyncWorkloadCvesComponent />;
+            };
+        })(),
         path: vulnerabilitiesWorkloadCvesPath,
     },
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -85,6 +85,7 @@ import VulnerabilityStateTabs, {
     vulnStateTabContentId,
 } from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import DefaultFilterModal from '../components/DefaultFilterModal';
 import WorkloadCveFilterToolbar from '../components/WorkloadCveFilterToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
@@ -171,6 +172,7 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
+    const { pageTitle } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -371,13 +373,13 @@ function WorkloadCvesOverviewPage() {
 
     return (
         <>
-            <PageTitle title="Workload CVEs Overview" />
+            <PageTitle title={`${pageTitle} Overview`} />
             <PageSection
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-row pf-v5-u-align-items-center"
                 variant="light"
             >
                 <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                    <Title headingLevel="h1">Workload CVEs</Title>
+                    <Title headingLevel="h1">{pageTitle}</Title>
                     <FlexItem>
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { QuerySearchFilter } from '../types';
+
+export type WorkloadCveView = {
+    createUrl: (path: string) => string;
+    baseSearchFilter: QuerySearchFilter;
+    pageTitle: string;
+};
+
+/**
+ * The WorkloadCveViewContext provides dynamic values throughout the Workload CVE pages in order to support
+ * sections for both "Application/User Workloads" and a separate section for "Platform Workloads"
+ */
+export const WorkloadCveViewContext = createContext<WorkloadCveView | undefined>(undefined);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -19,6 +19,7 @@ import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCve/ImageCvePage';
 import NamespaceViewPage from './NamespaceView/NamespaceViewPage';
+import { WorkloadCveView, WorkloadCveViewContext } from './WorkloadCveViewContext';
 
 import './WorkloadCvesPage.css';
 
@@ -26,14 +27,18 @@ const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}
 const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCvesPath}/images/:imageId`;
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
-function WorkloadCvesPage() {
+export type WorkloadCvePageProps = {
+    context: WorkloadCveView;
+};
+
+function WorkloadCvesPage({ context }: WorkloadCvePageProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
     const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
     return (
-        <>
+        <WorkloadCveViewContext.Provider value={context}>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             {!isFeatureFlagEnabled('ROX_VULN_MGMT_2_GA') && (
                 <TechPreviewBanner
@@ -62,12 +67,12 @@ function WorkloadCvesPage() {
                 </Route>
                 <Route>
                     <PageSection variant="light">
-                        <PageTitle title="Workload CVEs - Not Found" />
+                        <PageTitle title={`${context.pageTitle} - Not Found`} />
                         <PageNotFound />
                     </PageSection>
                 </Route>
             </Switch>
-        </>
+        </WorkloadCveViewContext.Provider>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { WorkloadCveView, WorkloadCveViewContext } from '../WorkloadCveViewContext';
+
+export default function useWorkloadCveViewContext(): WorkloadCveView {
+    const value = useContext(WorkloadCveViewContext);
+
+    if (!value) {
+        throw new Error('A value must be provided to the WorkloadCveViewContext via a provider!');
+    }
+
+    return value;
+}


### PR DESCRIPTION
### Description

Adds a top level React.Context to the Workload CVE page in order to support dynamic values so that we can switch between "Application/User" workloads and "Platform" workloads.

At the moment this includes the following:
- A base search filter object used to set the default for `Platform component`
- A page title to swap out "Workload CVEs" with another value when viewing the "Platform view"
- A URL creation function to use when creating intra-section links (TBD on final implementation, but we will need _something_)

Context was used here to avoid excessive prop drilling.

ex) The base filter will be needed 3 levels deep:
```
WorkloadCvesPage -> ImagePage -> ImagePageVulnerabilities
WorkloadCvesPage -> ImagePage -> ImagePageResources
```
and URL construction will be needed 5 levels deep:
```
WorkloadCvesPage -> DeploymentPage -> DeploymentPageVulnerabilities -> DeploymentVulnerabilitiesTable -> DeploymentComponentVulnerabilitiesTable
```

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit Workload CVEs and verify that the dynamic `<h1>` is populated correctly:
![image](https://github.com/user-attachments/assets/6e495fb2-0586-455f-8d62-617696b12500)

