### PR TITLE
ROX-26973: CRS Support in ACS UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement } from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+} from '@patternfly/react-core';
+
+import { ClusterRegistrationSecret } from 'services/ClustersService';
+
+export type ClusterRegistrationSecretDescriptionProps = {
+    clusterRegistrationSecret: ClusterRegistrationSecret;
+};
+
+function ClusterRegistrationSecretDescription({ clusterRegistrationSecret }: ClusterRegistrationSecretDescriptionProps): ReactElement {
+    return (
+        <DescriptionList
+            isCompact
+            isHorizontal
+            className="pf-v5-u-background-color-100 pf-v5-u-p-lg"
+        >
+            <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>{clusterRegistrationSecret.name}</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Created by</DescriptionListTerm>
+                <DescriptionListDescription>{clusterRegistrationSecret.createdBy.id}</DescriptionListDescription>
+            </DescriptionListGroup>
+            {clusterRegistrationSecret.createdBy.attributes.map((attribute) => {
+                return (
+                    <DescriptionListGroup key={attribute.key}>
+                        <DescriptionListTerm>{attribute.key}</DescriptionListTerm>
+                        <DescriptionListDescription>{attribute.value}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                );
+            })}
+            <DescriptionListGroup>
+                <DescriptionListTerm>Created at</DescriptionListTerm>
+                <DescriptionListDescription>{clusterRegistrationSecret.createdAt}</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Expires at</DescriptionListTerm>
+                <DescriptionListDescription>{clusterRegistrationSecret.expiresAt}</DescriptionListDescription>
+            </DescriptionListGroup>
+        </DescriptionList>
+    );
+}
+
+export default ClusterRegistrationSecretDescription;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -12,7 +12,9 @@ export type ClusterRegistrationSecretDescriptionProps = {
     clusterRegistrationSecret: ClusterRegistrationSecret;
 };
 
-function ClusterRegistrationSecretDescription({ clusterRegistrationSecret }: ClusterRegistrationSecretDescriptionProps): ReactElement {
+function ClusterRegistrationSecretDescription({
+    clusterRegistrationSecret,
+}: ClusterRegistrationSecretDescriptionProps): ReactElement {
     return (
         <DescriptionList
             isCompact
@@ -21,11 +23,15 @@ function ClusterRegistrationSecretDescription({ clusterRegistrationSecret }: Clu
         >
             <DescriptionListGroup>
                 <DescriptionListTerm>Name</DescriptionListTerm>
-                <DescriptionListDescription>{clusterRegistrationSecret.name}</DescriptionListDescription>
+                <DescriptionListDescription>
+                    {clusterRegistrationSecret.name}
+                </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>Created by</DescriptionListTerm>
-                <DescriptionListDescription>{clusterRegistrationSecret.createdBy.id}</DescriptionListDescription>
+                <DescriptionListDescription>
+                    {clusterRegistrationSecret.createdBy.id}
+                </DescriptionListDescription>
             </DescriptionListGroup>
             {clusterRegistrationSecret.createdBy.attributes.map((attribute) => {
                 return (
@@ -37,11 +43,15 @@ function ClusterRegistrationSecretDescription({ clusterRegistrationSecret }: Clu
             })}
             <DescriptionListGroup>
                 <DescriptionListTerm>Created at</DescriptionListTerm>
-                <DescriptionListDescription>{clusterRegistrationSecret.createdAt}</DescriptionListDescription>
+                <DescriptionListDescription>
+                    {clusterRegistrationSecret.createdAt}
+                </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>Expires at</DescriptionListTerm>
-                <DescriptionListDescription>{clusterRegistrationSecret.expiresAt}</DescriptionListDescription>
+                <DescriptionListDescription>
+                    {clusterRegistrationSecret.expiresAt}
+                </DescriptionListDescription>
             </DescriptionListGroup>
         </DescriptionList>
     );

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -7,29 +7,20 @@ import {
     Divider,
     Flex,
     Form,
-    FormGroup,
-    FormHelperText,
-    HelperText,
-    HelperTextItem,
     PageSection,
-    Radio,
     TextInput,
 } from '@patternfly/react-core';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
-import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import useAnalytics, { DOWNLOAD_CLUSTER_REGISTRATION_SECRET as DOWNLOAD_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
+import useAnalytics, { DOWNLOAD_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
 import { generateClusterRegistrationSecret } from 'services/ClustersService'; // ClusterRegistrationSecret
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import ClusterRegistrationSecretsHeader from './ClusterRegistrationSecretsHeader';
 
-import {
-    downloadClusterRegistrationSecret,
-} from './ClusterRegistrationSecretForm.utils';
+import { downloadClusterRegistrationSecret } from './ClusterRegistrationSecretForm.utils';
 
 export type ClusterRegistrationSecretFormValues = {
     name: string;
@@ -63,7 +54,6 @@ function ClusterRegistrationSecretForm(): ReactElement {
         isSubmitting,
         isValid,
         setFieldValue,
-        setValues,
         submitForm,
         touched,
         values,
@@ -87,7 +77,6 @@ function ClusterRegistrationSecretForm(): ReactElement {
         validateOnMount: true, // disable Next when Name is empty
         validationSchema,
     });
-    const { isOpen, onToggle } = useSelectToggle();
 
     function goBack() {
         history.goBack(); // to InputBundlesTable or NoClustersPage

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -1,0 +1,166 @@
+import React, { ReactElement, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+    ActionGroup,
+    Alert,
+    Button,
+    Divider,
+    Flex,
+    Form,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    PageSection,
+    Radio,
+    TextInput,
+} from '@patternfly/react-core';
+import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { useFormik } from 'formik';
+import * as yup from 'yup';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useAnalytics, { DOWNLOAD_CLUSTER_REGISTRATION_SECRET as DOWNLOAD_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
+import { generateClusterRegistrationSecret } from 'services/ClustersService'; // ClusterRegistrationSecret
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import ClusterRegistrationSecretsHeader from './ClusterRegistrationSecretsHeader';
+
+import {
+    downloadClusterRegistrationSecret,
+} from './ClusterRegistrationSecretForm.utils';
+
+export type ClusterRegistrationSecretFormValues = {
+    name: string;
+};
+
+export const initialValues: ClusterRegistrationSecretFormValues = {
+    name: '',
+};
+
+// https://github.com/stackrox/stackrox/blob/master/central/clusterinit/backend/validation.go#L11
+const nameValidatorRegExp = /^[a-zA-Z0-9._-]+$/;
+
+const validationSchema: yup.ObjectSchema<ClusterRegistrationSecretFormValues> = yup.object().shape({
+    name: yup
+        .string()
+        .trim()
+        .matches(
+            nameValidatorRegExp,
+            'Name can have only the following characters: letters, digits, period, underscore, hyphen (but no spaces)'
+        )
+        .required('Cluster registration secret name is required'),
+});
+
+function ClusterRegistrationSecretForm(): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+    const history = useHistory();
+    const [errorMessage, setErrorMessage] = useState('');
+    const {
+        errors,
+        handleBlur,
+        isSubmitting,
+        isValid,
+        setFieldValue,
+        setValues,
+        submitForm,
+        touched,
+        values,
+    } = useFormik({
+        initialValues,
+        onSubmit: (values, { setSubmitting }) => {
+            setSubmitting(true);
+            const { name } = values;
+            generateClusterRegistrationSecret({ name })
+                .then(({ response }) => {
+                    setErrorMessage('');
+                    downloadClusterRegistrationSecret(name, response); // TODO try catch?
+                    setSubmitting(false);
+                    goBack();
+                })
+                .catch((error) => {
+                    setErrorMessage(getAxiosErrorMessage(error));
+                    setSubmitting(false);
+                });
+        },
+        validateOnMount: true, // disable Next when Name is empty
+        validationSchema,
+    });
+    const { isOpen, onToggle } = useSelectToggle();
+
+    function goBack() {
+        history.goBack(); // to InputBundlesTable or NoClustersPage
+    }
+
+    // return setWhatever solves problem reported by typescript-eslint no-floating-promises
+
+    function onChangeTextInput(value, event) {
+        return setFieldValue(event.target.id, value);
+    }
+
+    return (
+        <>
+            <ClusterRegistrationSecretsHeader title="Create cluster registration secret" />
+            <Divider component="div" />
+            <PageSection variant="light">
+                <Flex direction={{ default: 'column' }}>
+                    <Form>
+                        <FormLabelGroup
+                            fieldId="name"
+                            label="Name"
+                            isRequired
+                            errors={errors}
+                            touched={touched}
+                        >
+                            <TextInput
+                                type="text"
+                                id="name"
+                                name="name"
+                                isRequired
+                                value={values.name}
+                                onBlur={handleBlur}
+                                onChange={(event, value) => onChangeTextInput(value, event)}
+                            />
+                        </FormLabelGroup>
+                    </Form>
+                    <Alert variant="info" isInline title="Download YAML file" component="p">
+                        <p>
+                            You can download the YAML file only once, when you create a cluster
+                            registration secret.
+                        </p>
+                        <p>Store the YAML file securely because it contains secrets.</p>
+                    </Alert>
+                    {errorMessage && (
+                        <Alert
+                            variant="danger"
+                            isInline
+                            title="Unable to create or download cluster registration secret"
+                            component="p"
+                        >
+                            {errorMessage}
+                        </Alert>
+                    )}
+                    <ActionGroup>
+                        <Button
+                            variant="primary"
+                            isDisabled={isSubmitting || !isValid}
+                            isLoading={isSubmitting}
+                            onClick={() => {
+                                analyticsTrack(DOWNLOAD_CLUSTER_REGISTRATION_SECRET);
+                                return submitForm();
+                            }}
+                        >
+                            Download
+                        </Button>
+                        <Button variant="link" isDisabled={isSubmitting} onClick={goBack}>
+                            Cancel
+                        </Button>
+                    </ActionGroup>
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default ClusterRegistrationSecretForm;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
     ActionGroup,
     Alert,
@@ -46,7 +46,7 @@ const validationSchema: yup.ObjectSchema<ClusterRegistrationSecretFormValues> = 
 
 function ClusterRegistrationSecretForm(): ReactElement {
     const { analyticsTrack } = useAnalytics();
-    const history = useHistory();
+    const navigate = useNavigate();
     const [errorMessage, setErrorMessage] = useState('');
     const {
         errors,
@@ -79,7 +79,7 @@ function ClusterRegistrationSecretForm(): ReactElement {
     });
 
     function goBack() {
-        history.goBack(); // to InputBundlesTable or NoClustersPage
+        navigate(-1); // to InputBundlesTable or NoClustersPage
     }
 
     // return setWhatever solves problem reported by typescript-eslint no-floating-promises

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.utils.ts
@@ -1,0 +1,18 @@
+import FileSaver from 'file-saver';
+
+import { GenerateClusterRegistrationSecretResponse } from 'services/ClustersService';
+
+export function downloadClusterRegistrationSecret(
+    name: string,
+    response: GenerateClusterRegistrationSecretResponse
+) {
+    const { crs } = response;
+    // TODO atob is deprecated
+    const decoded = typeof crs === 'string' ? atob(crs) : '';
+
+    const file = new Blob([decoded], {
+        type: 'application/x-yaml',
+    });
+
+    FileSaver.saveAs(file, `${name}-cluster-registration-secret.yaml`);
+}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -15,7 +15,10 @@ export type ClusterRegistrationSecretPageProps = {
     id: string;
 };
 
-function ClusterRegistrationSecretPage({ hasWriteAccessForClusterRegistrationSecrets, id }: ClusterRegistrationSecretPageProps): ReactElement {
+function ClusterRegistrationSecretPage({
+    hasWriteAccessForClusterRegistrationSecrets,
+    id,
+}: ClusterRegistrationSecretPageProps): ReactElement {
     const history = useHistory();
     const [isRevoking, setIsRevoking] = useState(false);
 
@@ -55,7 +58,10 @@ function ClusterRegistrationSecretPage({ hasWriteAccessForClusterRegistrationSec
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <ClusterRegistrationSecretsHeader headerActions={headerActions} title="Cluster registration secret" />
+            <ClusterRegistrationSecretsHeader
+                headerActions={headerActions}
+                title="Cluster registration secret"
+            />
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>
@@ -72,10 +78,12 @@ function ClusterRegistrationSecretPage({ hasWriteAccessForClusterRegistrationSec
                     </Alert>
                 ) : clusterRegistrationSecret ? (
                     <>
-                        <ClusterRegistrationSecretDescription clusterRegistrationSecret={clusterRegistrationSecret} />
+                        <ClusterRegistrationSecretDescription
+                            clusterRegistrationSecret={clusterRegistrationSecret}
+                        />
                         {isRevoking && (
                             <RevokeClusterRegistrationSecretModal
-                            clusterRegistrationSecret={clusterRegistrationSecret}
+                                clusterRegistrationSecret={clusterRegistrationSecret}
                                 onCloseModal={onCloseModal}
                             />
                         )}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
@@ -19,7 +19,7 @@ function ClusterRegistrationSecretPage({
     hasWriteAccessForClusterRegistrationSecrets,
     id,
 }: ClusterRegistrationSecretPageProps): ReactElement {
-    const history = useHistory();
+    const navigate = useNavigate();
     const [isRevoking, setIsRevoking] = useState(false);
 
     const {
@@ -39,7 +39,7 @@ function ClusterRegistrationSecretPage({
     function onCloseModal(wasRevoked: boolean) {
         setIsRevoking(false);
         if (wasRevoked) {
-            history.goBack(); // to table
+            navigate(-1); // to table
         }
     }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -1,0 +1,97 @@
+import React, { ReactElement, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
+
+import useRestQuery from 'hooks/useRestQuery';
+import { fetchClusterRegistrationSecrets } from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import ClusterRegistrationSecretDescription from './ClusterRegistrationSecretDescription';
+import ClusterRegistrationSecretsHeader from './ClusterRegistrationSecretsHeader';
+import RevokeClusterRegistrationSecretModal from './RevokeClusterRegistrationSecretModal';
+
+export type ClusterRegistrationSecretPageProps = {
+    hasWriteAccessForClusterRegistrationSecrets: boolean;
+    id: string;
+};
+
+function ClusterRegistrationSecretPage({ hasWriteAccessForClusterRegistrationSecrets, id }: ClusterRegistrationSecretPageProps): ReactElement {
+    const history = useHistory();
+    const [isRevoking, setIsRevoking] = useState(false);
+
+    const {
+        data: dataForFetch,
+        isLoading: isFetching,
+        error: errorForFetch,
+    } = useRestQuery(fetchClusterRegistrationSecrets);
+
+    const clusterRegistrationSecret = dataForFetch?.response?.items.find(
+        (clusterRegistrationSecretArg) => clusterRegistrationSecretArg.id === id
+    );
+
+    function onClickRevoke() {
+        setIsRevoking(true);
+    }
+
+    function onCloseModal(wasRevoked: boolean) {
+        setIsRevoking(false);
+        if (wasRevoked) {
+            history.goBack(); // to table
+        }
+    }
+
+    const headerActions =
+        hasWriteAccessForClusterRegistrationSecrets && clusterRegistrationSecret ? (
+            <Button
+                variant="danger"
+                isDisabled={isRevoking}
+                isLoading={isRevoking}
+                onClick={onClickRevoke}
+            >
+                Revoke cluster registration secret
+            </Button>
+        ) : null;
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <ClusterRegistrationSecretsHeader headerActions={headerActions} title="Cluster registration secret" />
+            <PageSection component="div">
+                {isFetching ? (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                ) : errorForFetch ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch cluster registration secrets"
+                        component="p"
+                        isInline
+                    >
+                        {getAxiosErrorMessage(errorForFetch)}
+                    </Alert>
+                ) : clusterRegistrationSecret ? (
+                    <>
+                        <ClusterRegistrationSecretDescription clusterRegistrationSecret={clusterRegistrationSecret} />
+                        {isRevoking && (
+                            <RevokeClusterRegistrationSecretModal
+                            clusterRegistrationSecret={clusterRegistrationSecret}
+                                onCloseModal={onCloseModal}
+                            />
+                        )}
+                    </>
+                ) : (
+                    <Alert
+                        variant="warning"
+                        title="Unable to find cluster registration secret"
+                        component="p"
+                        isInline
+                    />
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default ClusterRegistrationSecretPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement, ReactNode } from 'react';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Flex,
+    FlexItem,
+    PageSection,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import { clustersBasePath, clustersClusterRegistrationSecretsPath } from 'routePaths';
+
+export const titleClusterRegistrationSecrets = 'Cluster registration secrets';
+
+export type ClusterRegistrationSecretsHeaderProps = {
+    headerActions?: ReactNode | null;
+    title: string;
+};
+
+function ClusterRegistrationSecretsHeader({ headerActions, title }: ClusterRegistrationSecretsHeaderProps): ReactElement {
+    return (
+        <PageSection component="div" variant="light">
+            <PageTitle title={title} />
+            <Flex direction={{ default: 'column' }}>
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                    {title !== titleClusterRegistrationSecrets && (
+                        <BreadcrumbItemLink to={clustersClusterRegistrationSecretsPath}>
+                            {titleClusterRegistrationSecrets}
+                        </BreadcrumbItemLink>
+                    )}
+                    <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                </Breadcrumb>
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <Title headingLevel="h1">{title}</Title>
+                        <Text>
+                            Cluster registration secrets contain secrets for secured cluster services to
+                            establish initial trust with Central.
+                        </Text>
+                    </Flex>
+                    {headerActions && (
+                        <FlexItem align={{ default: 'alignRight' }}>{headerActions}</FlexItem>
+                    )}
+                </Flex>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default ClusterRegistrationSecretsHeader;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
@@ -20,7 +20,10 @@ export type ClusterRegistrationSecretsHeaderProps = {
     title: string;
 };
 
-function ClusterRegistrationSecretsHeader({ headerActions, title }: ClusterRegistrationSecretsHeaderProps): ReactElement {
+function ClusterRegistrationSecretsHeader({
+    headerActions,
+    title,
+}: ClusterRegistrationSecretsHeaderProps): ReactElement {
     return (
         <PageSection component="div" variant="light">
             <PageTitle title={title} />
@@ -41,8 +44,8 @@ function ClusterRegistrationSecretsHeader({ headerActions, title }: ClusterRegis
                     >
                         <Title headingLevel="h1">{title}</Title>
                         <Text>
-                            Cluster registration secrets contain secrets for secured cluster services to
-                            establish initial trust with Central.
+                            Cluster registration secrets contain secrets for secured cluster
+                            services to establish initial trust with Central.
                         </Text>
                     </Flex>
                     {headerActions && (

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -1,0 +1,91 @@
+import React, { ReactElement, useState } from 'react';
+import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useAnalytics, { CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED } from 'hooks/useAnalytics';
+import useRestQuery from 'hooks/useRestQuery';
+import { ClusterRegistrationSecret, fetchClusterRegistrationSecrets } from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { clustersClusterRegistrationSecretsPath } from 'routePaths';
+
+import ClusterRegistrationSecretsHeader, { titleClusterRegistrationSecrets } from './ClusterRegistrationSecretsHeader';
+import ClusterRegistrationSecretsTable from './ClusterRegistrationSecretsTable';
+import RevokeClusterRegistrationSecretModal from './RevokeClusterRegistrationSecretModal';
+
+export type ClusterRegistrationSecretsPageProps = {
+    hasWriteAccessForClusterRegistrationSecrets: boolean;
+};
+
+function ClusterRegistrationSecretsPage({ hasWriteAccessForClusterRegistrationSecrets }: ClusterRegistrationSecretsPageProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+    const [clusterRegistrationSecretToRevoke, setClusterRegistrationSecretToRevoke] = useState<ClusterRegistrationSecret | null>(null);
+    const headerActions = hasWriteAccessForClusterRegistrationSecrets ? (
+        <Button
+            variant="primary"
+            component={LinkShim}
+            href={`${clustersClusterRegistrationSecretsPath}?action=create`}
+            onClick={() => {
+                analyticsTrack({
+                    event: CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED,
+                    properties: { source: 'Cluster Registration Secrets' },
+                });
+            }}
+        >
+            Create cluster registration secret
+        </Button>
+    ) : null;
+
+    const {
+        data: dataForFetch,
+        error: errorForFetch,
+        isLoading: isFetching,
+        refetch,
+    } = useRestQuery(fetchClusterRegistrationSecrets);
+
+    function onCloseModal(wasRevoked: boolean) {
+        setClusterRegistrationSecretToRevoke(null);
+        if (wasRevoked) {
+            refetch();
+        }
+    }
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <ClusterRegistrationSecretsHeader headerActions={headerActions} title={titleClusterRegistrationSecrets} />
+            <PageSection component="div">
+                {isFetching ? (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                ) : errorForFetch ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch cluster cluster registration secrets"
+                        component="p"
+                        isInline
+                    >
+                        {getAxiosErrorMessage(errorForFetch)}
+                    </Alert>
+                ) : (
+                    <>
+                        <ClusterRegistrationSecretsTable
+                            hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets}
+                            clusterRegistrationSecrets={dataForFetch?.response?.items ?? []}
+                            setClusterRegistrationSecretToRevoke={setClusterRegistrationSecretToRevoke}
+                        />
+                        {clusterRegistrationSecretToRevoke && (
+                            <RevokeClusterRegistrationSecretModal
+                                clusterRegistrationSecret={clusterRegistrationSecretToRevoke}
+                                onCloseModal={onCloseModal}
+                            />
+                        )}
+                    </>
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default ClusterRegistrationSecretsPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -4,11 +4,16 @@ import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useAnalytics, { CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED } from 'hooks/useAnalytics';
 import useRestQuery from 'hooks/useRestQuery';
-import { ClusterRegistrationSecret, fetchClusterRegistrationSecrets } from 'services/ClustersService';
+import {
+    ClusterRegistrationSecret,
+    fetchClusterRegistrationSecrets,
+} from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersClusterRegistrationSecretsPath } from 'routePaths';
 
-import ClusterRegistrationSecretsHeader, { titleClusterRegistrationSecrets } from './ClusterRegistrationSecretsHeader';
+import ClusterRegistrationSecretsHeader, {
+    titleClusterRegistrationSecrets,
+} from './ClusterRegistrationSecretsHeader';
 import ClusterRegistrationSecretsTable from './ClusterRegistrationSecretsTable';
 import RevokeClusterRegistrationSecretModal from './RevokeClusterRegistrationSecretModal';
 
@@ -16,9 +21,12 @@ export type ClusterRegistrationSecretsPageProps = {
     hasWriteAccessForClusterRegistrationSecrets: boolean;
 };
 
-function ClusterRegistrationSecretsPage({ hasWriteAccessForClusterRegistrationSecrets }: ClusterRegistrationSecretsPageProps): ReactElement {
+function ClusterRegistrationSecretsPage({
+    hasWriteAccessForClusterRegistrationSecrets,
+}: ClusterRegistrationSecretsPageProps): ReactElement {
     const { analyticsTrack } = useAnalytics();
-    const [clusterRegistrationSecretToRevoke, setClusterRegistrationSecretToRevoke] = useState<ClusterRegistrationSecret | null>(null);
+    const [clusterRegistrationSecretToRevoke, setClusterRegistrationSecretToRevoke] =
+        useState<ClusterRegistrationSecret | null>(null);
     const headerActions = hasWriteAccessForClusterRegistrationSecrets ? (
         <Button
             variant="primary"
@@ -52,7 +60,10 @@ function ClusterRegistrationSecretsPage({ hasWriteAccessForClusterRegistrationSe
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <ClusterRegistrationSecretsHeader headerActions={headerActions} title={titleClusterRegistrationSecrets} />
+            <ClusterRegistrationSecretsHeader
+                headerActions={headerActions}
+                title={titleClusterRegistrationSecrets}
+            />
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>
@@ -70,9 +81,13 @@ function ClusterRegistrationSecretsPage({ hasWriteAccessForClusterRegistrationSe
                 ) : (
                     <>
                         <ClusterRegistrationSecretsTable
-                            hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets}
+                            hasWriteAccessForClusterRegistrationSecrets={
+                                hasWriteAccessForClusterRegistrationSecrets
+                            }
                             clusterRegistrationSecrets={dataForFetch?.response?.items ?? []}
-                            setClusterRegistrationSecretToRevoke={setClusterRegistrationSecretToRevoke}
+                            setClusterRegistrationSecretToRevoke={
+                                setClusterRegistrationSecretToRevoke
+                            }
                         />
                         {clusterRegistrationSecretToRevoke && (
                             <RevokeClusterRegistrationSecretModal

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
@@ -32,7 +32,12 @@ function ClusterRegistrationSecretsRoute(): ReactElement {
 
     if (id) {
         return (
-            <ClusterRegistrationSecretPage hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets} id={id} />
+            <ClusterRegistrationSecretPage
+                hasWriteAccessForClusterRegistrationSecrets={
+                    hasWriteAccessForClusterRegistrationSecrets
+                }
+                id={id}
+            />
         );
     }
 
@@ -40,7 +45,13 @@ function ClusterRegistrationSecretsRoute(): ReactElement {
         return <ClusterRegistrationSecretForm />;
     }
 
-    return <ClusterRegistrationSecretsPage hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets} />;
+    return (
+        <ClusterRegistrationSecretsPage
+            hasWriteAccessForClusterRegistrationSecrets={
+                hasWriteAccessForClusterRegistrationSecrets
+            }
+        />
+    );
 }
 
 export default ClusterRegistrationSecretsRoute;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
@@ -1,0 +1,46 @@
+import React, { ReactElement } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import qs from 'qs';
+
+import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release
+
+import ClusterRegistrationSecretForm from './ClusterRegistrationSecretForm';
+import ClusterRegistrationSecretPage from './ClusterRegistrationSecretPage';
+import ClusterRegistrationSecretsPage from './ClusterRegistrationSecretsPage';
+
+function hasCreateAction(search: string) {
+    const { action } = qs.parse(search, { ignoreQueryPrefix: true });
+    return action === 'create';
+}
+
+function ClusterRegistrationSecretsRoute(): ReactElement {
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
+    const hasWriteAccessForClusterRegistrationSecrets = hasAdminRole; // TODO after 4.4 release becomes redundant
+
+    const { search } = useLocation();
+    const { id } = useParams(); // see clustersClusterRegistrationSecretPathWithParam in routePaths.ts
+
+    /*
+    // TODO after 4.4 release
+    if (!hasAdminRole) {
+        return <NotFoundPage />; // factor out reusable component from Body.tsx file
+    }
+    */
+
+    const isCreateAction = hasWriteAccessForClusterRegistrationSecrets && hasCreateAction(search);
+
+    if (id) {
+        return (
+            <ClusterRegistrationSecretPage hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets} id={id} />
+        );
+    }
+
+    if (hasWriteAccessForClusterRegistrationSecrets && isCreateAction) {
+        return <ClusterRegistrationSecretForm />;
+    }
+
+    return <ClusterRegistrationSecretsPage hasWriteAccessForClusterRegistrationSecrets={hasWriteAccessForClusterRegistrationSecrets} />;
+}
+
+export default ClusterRegistrationSecretsRoute;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -1,0 +1,69 @@
+import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import { ClusterRegistrationSecret } from 'services/ClustersService';
+import { clustersClusterRegistrationSecretsPath } from 'routePaths';
+
+export type ClusterRegistrationSecretsTableProps = {
+    hasWriteAccessForClusterRegistrationSecrets: boolean;
+    clusterRegistrationSecrets: ClusterRegistrationSecret[];
+    setClusterRegistrationSecretToRevoke: (clusterRegistrationSecret: ClusterRegistrationSecret) => void;
+};
+
+function ClusterRegistrationSecretsTable({
+    hasWriteAccessForClusterRegistrationSecrets,
+    clusterRegistrationSecrets,
+    setClusterRegistrationSecretToRevoke,
+}: ClusterRegistrationSecretsTableProps): ReactElement {
+    return (
+        <Table variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>Name</Th>
+                    <Th>Created by</Th>
+                    <Th>Created at</Th>
+                    <Th>Expires at</Th>
+                    {hasWriteAccessForClusterRegistrationSecrets && (
+                        <Th>
+                            <span className="pf-v5-screen-reader">Row actions</span>
+                        </Th>
+                    )}
+                </Tr>
+            </Thead>
+            <Tbody>
+                {clusterRegistrationSecrets.map((clusterRegistrationSecret) => {
+                    const { createdAt, createdBy, expiresAt, id, name } = clusterRegistrationSecret;
+
+                    return (
+                        <Tr key={id}>
+                            <Td dataLabel="Name">
+                                <Link to={`${clustersClusterRegistrationSecretsPath}/${id}`}>{name}</Link>
+                            </Td>
+                            <Td dataLabel="Created by">{createdBy.id}</Td>
+                            <Td dataLabel="Created at">{createdAt}</Td>
+                            <Td dataLabel="Expires at">{expiresAt}</Td>
+                            {hasWriteAccessForClusterRegistrationSecrets && (
+                                <Td isActionCell>
+                                    <ActionsColumn
+                                        // menuAppendTo={() => document.body}
+                                        items={[
+                                            {
+                                                title: 'Revoke cluster registration secret',
+                                                onClick: () => {
+                                                    setClusterRegistrationSecretToRevoke(clusterRegistrationSecret);
+                                                },
+                                            },
+                                        ]}
+                                    />
+                                </Td>
+                            )}
+                        </Tr>
+                    );
+                })}
+            </Tbody>
+        </Table>
+    );
+}
+
+export default ClusterRegistrationSecretsTable;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -8,7 +8,9 @@ import { clustersClusterRegistrationSecretsPath } from 'routePaths';
 export type ClusterRegistrationSecretsTableProps = {
     hasWriteAccessForClusterRegistrationSecrets: boolean;
     clusterRegistrationSecrets: ClusterRegistrationSecret[];
-    setClusterRegistrationSecretToRevoke: (clusterRegistrationSecret: ClusterRegistrationSecret) => void;
+    setClusterRegistrationSecretToRevoke: (
+        clusterRegistrationSecret: ClusterRegistrationSecret
+    ) => void;
 };
 
 function ClusterRegistrationSecretsTable({
@@ -38,7 +40,9 @@ function ClusterRegistrationSecretsTable({
                     return (
                         <Tr key={id}>
                             <Td dataLabel="Name">
-                                <Link to={`${clustersClusterRegistrationSecretsPath}/${id}`}>{name}</Link>
+                                <Link to={`${clustersClusterRegistrationSecretsPath}/${id}`}>
+                                    {name}
+                                </Link>
                             </Td>
                             <Td dataLabel="Created by">{createdBy.id}</Td>
                             <Td dataLabel="Created at">{createdAt}</Td>
@@ -51,7 +55,9 @@ function ClusterRegistrationSecretsTable({
                                             {
                                                 title: 'Revoke cluster registration secret',
                                                 onClick: () => {
-                                                    setClusterRegistrationSecretToRevoke(clusterRegistrationSecret);
+                                                    setClusterRegistrationSecretToRevoke(
+                                                        clusterRegistrationSecret
+                                                    );
                                                 },
                                             },
                                         ]}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
@@ -1,0 +1,100 @@
+import React, { ReactElement, useState } from 'react';
+import {
+    Alert,
+    Button,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    List,
+    ListItem,
+    Modal,
+} from '@patternfly/react-core';
+
+import useAnalytics, { REVOKE_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
+import {
+    ClusterRegistrationSecret,
+    revokeClusterRegistrationSecrets,
+} from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+export type RevokeClusterRegistrationSecretModalProps = {
+    clusterRegistrationSecret: ClusterRegistrationSecret;
+    onCloseModal: (wasRevoked: boolean) => void;
+};
+
+function RevokeClusterRegistrationSecretModal({ clusterRegistrationSecret: clusterRegistrationSecret, onCloseModal }: RevokeClusterRegistrationSecretModalProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+    const [errorMessage, setErrorMessage] = useState('');
+    const [isRevokingClusterRegistrationSecret, setIsRevokingClusterRegistrationSecret] = useState(false);
+
+    function onRevokeClusterRegistrationSecret() {
+        setErrorMessage('');
+        setIsRevokingClusterRegistrationSecret(true);
+        revokeClusterRegistrationSecrets(
+            [clusterRegistrationSecret.id],
+        )
+            .then(({ crsRevocationErrors }) => {
+                if (crsRevocationErrors.length === 0) {
+                    onCloseModal(true);
+                }
+                analyticsTrack(REVOKE_CLUSTER_REGISTRATION_SECRET);
+            })
+            .catch((error) => {
+                setErrorMessage(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsRevokingClusterRegistrationSecret(false);
+            });
+    }
+
+    function onCancel() {
+        setErrorMessage('');
+        onCloseModal(false);
+    }
+
+    // showClose={false} to prevent clicking close while isRevokingClusterRegistrationSecret.
+    return (
+        <Modal
+            title="Revoke cluster registration secret"
+            variant="small"
+            isOpen
+            showClose={false}
+            actions={[
+                <Button
+                    key="Revoke cluster registration secret"
+                    variant='primary'
+                    onClick={onRevokeClusterRegistrationSecret}
+                    isDisabled={isRevokingClusterRegistrationSecret}
+                >
+                    Revoke cluster registration secret
+                </Button>,
+                <Button
+                    key="Cancel"
+                    variant="secondary"
+                    onClick={onCancel}
+                    isDisabled={isRevokingClusterRegistrationSecret}
+                >
+                    Cancel
+                </Button>,
+            ]}
+        >
+            <Flex direction={{ default: 'column' }}>
+                <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Name</DescriptionListTerm>
+                        <DescriptionListDescription>{clusterRegistrationSecret.name}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+                {errorMessage && (
+                    <Alert title="Revoke cluster registration secret failed" variant="danger" isInline component="p">
+                        {errorMessage}
+                    </Alert>
+                )}
+            </Flex>
+        </Modal>
+    );
+}
+
+export default RevokeClusterRegistrationSecretModal;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
@@ -7,8 +7,6 @@ import {
     DescriptionListGroup,
     DescriptionListTerm,
     Flex,
-    List,
-    ListItem,
     Modal,
 } from '@patternfly/react-core';
 
@@ -24,17 +22,19 @@ export type RevokeClusterRegistrationSecretModalProps = {
     onCloseModal: (wasRevoked: boolean) => void;
 };
 
-function RevokeClusterRegistrationSecretModal({ clusterRegistrationSecret: clusterRegistrationSecret, onCloseModal }: RevokeClusterRegistrationSecretModalProps): ReactElement {
+function RevokeClusterRegistrationSecretModal({
+    clusterRegistrationSecret,
+    onCloseModal,
+}: RevokeClusterRegistrationSecretModalProps): ReactElement {
     const { analyticsTrack } = useAnalytics();
     const [errorMessage, setErrorMessage] = useState('');
-    const [isRevokingClusterRegistrationSecret, setIsRevokingClusterRegistrationSecret] = useState(false);
+    const [isRevokingClusterRegistrationSecret, setIsRevokingClusterRegistrationSecret] =
+        useState(false);
 
     function onRevokeClusterRegistrationSecret() {
         setErrorMessage('');
         setIsRevokingClusterRegistrationSecret(true);
-        revokeClusterRegistrationSecrets(
-            [clusterRegistrationSecret.id],
-        )
+        revokeClusterRegistrationSecrets([clusterRegistrationSecret.id])
             .then(({ crsRevocationErrors }) => {
                 if (crsRevocationErrors.length === 0) {
                     onCloseModal(true);
@@ -64,7 +64,7 @@ function RevokeClusterRegistrationSecretModal({ clusterRegistrationSecret: clust
             actions={[
                 <Button
                     key="Revoke cluster registration secret"
-                    variant='primary'
+                    variant="primary"
                     onClick={onRevokeClusterRegistrationSecret}
                     isDisabled={isRevokingClusterRegistrationSecret}
                 >
@@ -84,11 +84,18 @@ function RevokeClusterRegistrationSecretModal({ clusterRegistrationSecret: clust
                 <DescriptionList isHorizontal>
                     <DescriptionListGroup>
                         <DescriptionListTerm>Name</DescriptionListTerm>
-                        <DescriptionListDescription>{clusterRegistrationSecret.name}</DescriptionListDescription>
+                        <DescriptionListDescription>
+                            {clusterRegistrationSecret.name}
+                        </DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>
                 {errorMessage && (
-                    <Alert title="Revoke cluster registration secret failed" variant="danger" isInline component="p">
+                    <Alert
+                        title="Revoke cluster registration secret failed"
+                        variant="danger"
+                        isInline
+                        component="p"
+                    >
                         {errorMessage}
                     </Alert>
                 )}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -15,7 +15,11 @@ import {
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
 import TabNav from 'Components/TabNav/TabNav';
-import { clustersBasePath, clustersClusterRegistrationSecretsPath, clustersSecureClusterCrsPath } from 'routePaths';
+import {
+    clustersBasePath,
+    clustersClusterRegistrationSecretsPath,
+    clustersSecureClusterCrsPath,
+} from 'routePaths';
 
 import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
 import SecureClusterUsingOperator from './SecureClusterUsingOperator';
@@ -55,7 +59,9 @@ function SecureClusterPage(): ReactElement {
                             </BreadcrumbItemLink>
                             <BreadcrumbItem isActive>{title}</BreadcrumbItem>
                         </Breadcrumb>
-                        <Title headingLevel="h1">Secure a cluster with a cluster registration secret</Title>
+                        <Title headingLevel="h1">
+                            Secure a cluster with a cluster registration secret
+                        </Title>
                     </Flex>
                     <FlexItem>
                         <TabNav

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -1,0 +1,84 @@
+import React, { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
+import qs from 'qs';
+import {
+    Alert,
+    Breadcrumb,
+    BreadcrumbItem,
+    Divider,
+    Flex,
+    FlexItem,
+    PageSection,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import TabNav from 'Components/TabNav/TabNav';
+import { clustersBasePath, clustersClusterRegistrationSecretsPath, clustersSecureClusterCrsPath } from 'routePaths';
+
+import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
+import SecureClusterUsingOperator from './SecureClusterUsingOperator';
+
+const title = 'Secure a cluster with a cluster registration secret';
+const headingLevel = 'h2';
+
+const tabHelmChart = 'Helm-chart';
+const titleOperator = 'Operator';
+const titleHelmChart = 'Helm chart';
+const tabLinks = [
+    {
+        href: `${clustersSecureClusterCrsPath}?tab=Operator`,
+        title: titleOperator,
+    },
+    {
+        href: `${clustersSecureClusterCrsPath}?tab=${tabHelmChart}`,
+        title: titleHelmChart,
+    },
+];
+
+function SecureClusterPage(): ReactElement {
+    const { search } = useLocation();
+    const { tab } = qs.parse(search, { ignoreQueryPrefix: true });
+    const isOperator = tab !== tabHelmChart;
+
+    return (
+        <>
+            <PageSection component="div" variant="light">
+                <PageTitle title="Secure a cluster" />
+                <Flex direction={{ default: 'column' }}>
+                    <Flex direction={{ default: 'column' }}>
+                        <Breadcrumb>
+                            <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                            <BreadcrumbItemLink to={clustersClusterRegistrationSecretsPath}>
+                                Cluster registration secrets
+                            </BreadcrumbItemLink>
+                            <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                        </Breadcrumb>
+                        <Title headingLevel="h1">Secure a cluster with a cluster registration secret</Title>
+                    </Flex>
+                    <FlexItem>
+                        <TabNav
+                            currentTabTitle={isOperator ? titleOperator : titleHelmChart}
+                            tabLinks={tabLinks}
+                        />
+                        <Divider component="div" />
+                    </FlexItem>
+                    {isOperator ? (
+                        <SecureClusterUsingOperator headingLevel={headingLevel} />
+                    ) : (
+                        <SecureClusterUsingHelmChart headingLevel={headingLevel} />
+                    )}
+                    <Alert
+                        variant="info"
+                        isInline
+                        title="You can use one cluster registration secret to secure at most one cluster."
+                        component="p"
+                    />
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default SecureClusterPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
@@ -11,10 +11,6 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
-import useMetadata from 'hooks/useMetadata';
-import { getVersionedDocs } from 'utils/versioning';
-
 const codeBlock = [
     'helm install -n stackrox --create-namespace \\',
     'stackrox-secured-cluster-services rhacs/secured-cluster-services \\',
@@ -32,7 +28,6 @@ export type SecureClusterUsingHelmChartProps = {
 function SecureClusterUsingHelmChart({
     headingLevel,
 }: SecureClusterUsingHelmChartProps): ReactElement {
-    const { version } = useMetadata();
     const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
     const [wasCopied, setWasCopied] = useState(false);
 
@@ -77,9 +72,7 @@ function SecureClusterUsingHelmChart({
                     </ClipboardCopy>
                 </ListItem>
                 <ListItem>
-                    <p>
-                        You must download the YAML file for a cluster registration secret.
-                    </p>
+                    <p>You must download the YAML file for a cluster registration secret.</p>
                 </ListItem>
                 <ListItem>
                     <p>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
@@ -1,0 +1,112 @@
+import React, { ReactElement, useState } from 'react';
+import {
+    ClipboardCopy,
+    ClipboardCopyButton,
+    CodeBlock,
+    CodeBlockAction,
+    CodeBlockCode,
+    Flex,
+    List,
+    ListItem,
+    Title,
+} from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
+
+const codeBlock = [
+    'helm install -n stackrox --create-namespace \\',
+    'stackrox-secured-cluster-services rhacs/secured-cluster-services \\',
+    '--set-file crs.file=<path/to/cluster-registration-secret.yaml> \\',
+    '--set clusterName=<name_of_the_secured_cluster> \\',
+    '--set centralEndpoint=<endpoint_of_central_service> \\',
+    '--set imagePullSecrets.username=<your redhat.com developer account username> \\',
+    '--set imagePullSecrets.password=<your redhat.com developer account password>',
+].join('\n');
+
+export type SecureClusterUsingHelmChartProps = {
+    headingLevel: 'h2' | 'h3';
+};
+
+function SecureClusterUsingHelmChart({
+    headingLevel,
+}: SecureClusterUsingHelmChartProps): ReactElement {
+    const { version } = useMetadata();
+    const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
+    const [wasCopied, setWasCopied] = useState(false);
+
+    function onClickCopy() {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#browser_compatibility
+        // Chrome 66 Edge 79 Firefox 63 Safari 13.1
+        navigator?.clipboard
+            ?.writeText(codeBlock)
+            .then(() => {
+                setWasCopied(true);
+            })
+            .catch(() => {
+                // TODO addToast(title, message)
+            });
+    }
+
+    const actions = (
+        <CodeBlockAction>
+            <ClipboardCopyButton
+                aria-label="Copy to clipboard"
+                id="ClipboardCopyButton"
+                onClick={onClickCopy}
+                textId="CodeBlockCode"
+                variant="plain"
+            >
+                {wasCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
+            </ClipboardCopyButton>
+        </CodeBlockAction>
+    );
+
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Title headingLevel={subHeadingLevel}>Prerequisites</Title>
+            <List component="ul">
+                <ListItem>
+                    <p>
+                        You must have previously added the Helm chart repository, or add it using
+                        the following command:
+                    </p>
+                    <ClipboardCopy>
+                        helm repo add rhacs https://mirror.openshift.com/pub/rhacs/charts/
+                    </ClipboardCopy>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must download the YAML file for a cluster registration secret.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must have access to the Red Hat Container Registry and a pull secret for
+                        authentication.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must have the address and the port number that you are exposing the
+                        Central service on.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <p>Run a command similar to the following:</p>
+                        <CodeBlock actions={actions}>
+                            <CodeBlockCode>{codeBlock}</CodeBlockCode>
+                        </CodeBlock>
+                    </Flex>
+                </ListItem>
+            </List>
+        </Flex>
+    );
+}
+
+export default SecureClusterUsingHelmChart;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -1,0 +1,81 @@
+import React, { ReactElement } from 'react';
+import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
+
+export type SecureClusterUsingOperatorProps = {
+    headingLevel: 'h2' | 'h3';
+};
+
+function SecureClusterUsingOperator({
+    headingLevel,
+}: SecureClusterUsingOperatorProps): ReactElement {
+    const { version } = useMetadata();
+    const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
+
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <p>
+                You can install secured cluster services on your clusters by using the{' '}
+                <strong>SecuredCluster</strong> custom resource.
+            </p>
+            <Title headingLevel={subHeadingLevel}>Prerequisites</Title>
+            <List component="ul">
+                <ListItem>
+                    <p>
+                        In the RHACS web portal, you have created a cluster registration secret and downloaded the
+                        YAML file for the cluster registration secret.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        In the Red Hat OpenShift Container Platform web console on the cluster that
+                        you are securing, you have installed the RHACS Operator.
+                    </p>
+                    <p>
+                        For Operator installation, create a new Red Hat OpenShift Container Platform
+                        project. <strong>rhacs-operator</strong> is a good name choice.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>Apply the cluster registration secret on the secured cluster. </p>
+                    <p>
+                        Perform one of the following tasks to apply the cluster registration secrets:
+                    </p>
+                    <List component="ul">
+                        <ListItem>
+                            <p>
+                                In the OpenShift Container Platform web console on the cluster that
+                                you are securing, in the top menu, click <strong>+</strong> to open
+                                the <strong>Import YAML</strong> page.
+                            </p>
+                            <p>
+                                You can drag the cluster registration secret file or copy and paste its contents
+                                into the editor, and then click <strong>Create</strong>.
+                            </p>
+                        </ListItem>
+                        <ListItem>
+                            <p>
+                                On the cluster that you are securing, using the Red Hat OpenShift
+                                CLI, run a command similar to the following:
+                            </p>
+                            <ClipboardCopy>
+                                oc create -f cluster-registration-secret.yaml -n stackrox
+                            </ClipboardCopy>
+                        </ListItem>
+                    </List>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        On the cluster that you are securing, install secured cluster services using
+                        the RHACS Operator.
+                    </p>
+                </ListItem>
+            </List>
+        </Flex>
+    );
+}
+
+export default SecureClusterUsingOperator;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -1,10 +1,6 @@
 import React, { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 
-import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
-import useMetadata from 'hooks/useMetadata';
-import { getVersionedDocs } from 'utils/versioning';
-
 export type SecureClusterUsingOperatorProps = {
     headingLevel: 'h2' | 'h3';
 };
@@ -12,7 +8,6 @@ export type SecureClusterUsingOperatorProps = {
 function SecureClusterUsingOperator({
     headingLevel,
 }: SecureClusterUsingOperatorProps): ReactElement {
-    const { version } = useMetadata();
     const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
 
     return (
@@ -25,8 +20,8 @@ function SecureClusterUsingOperator({
             <List component="ul">
                 <ListItem>
                     <p>
-                        In the RHACS web portal, you have created a cluster registration secret and downloaded the
-                        YAML file for the cluster registration secret.
+                        In the RHACS web portal, you have created a cluster registration secret and
+                        download the YAML file for the cluster registration secret.
                     </p>
                 </ListItem>
                 <ListItem>
@@ -42,7 +37,8 @@ function SecureClusterUsingOperator({
                 <ListItem>
                     <p>Apply the cluster registration secret on the secured cluster. </p>
                     <p>
-                        Perform one of the following tasks to apply the cluster registration secrets:
+                        Perform one of the following tasks to apply the cluster registration
+                        secrets:
                     </p>
                     <List component="ul">
                         <ListItem>
@@ -52,8 +48,9 @@ function SecureClusterUsingOperator({
                                 the <strong>Import YAML</strong> page.
                             </p>
                             <p>
-                                You can drag the cluster registration secret file or copy and paste its contents
-                                into the editor, and then click <strong>Create</strong>.
+                                You can drag the cluster registration secret file or copy and paste
+                                its contents into the editor, and then click <strong>Create</strong>
+                                .
                             </p>
                         </ListItem>
                         <ListItem>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -21,7 +21,7 @@ function SecureClusterUsingOperator({
                 <ListItem>
                     <p>
                         In the RHACS web portal, you have created a cluster registration secret and
-                        download the YAML file for the cluster registration secret.
+                        downloaded the YAML file for the cluster registration secret.
                     </p>
                 </ListItem>
                 <ListItem>

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -30,6 +30,7 @@ import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import useAnalytics, {
     LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
     SECURE_A_CLUSTER_LINK_CLICKED,
+    CRS_SECURE_A_CLUSTER_LINK_CLICKED,
 } from 'hooks/useAnalytics';
 import useAuthStatus from 'hooks/useAuthStatus';
 import useInterval from 'hooks/useInterval';
@@ -55,6 +56,7 @@ import {
     clustersDiscoveredClustersPath,
     clustersInitBundlesPath,
     clustersSecureClusterPath,
+    clustersSecureClusterCrsPath,
 } from 'routePaths';
 
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
@@ -163,6 +165,16 @@ function ClustersTablePanel({
                 });
             }}
             component={<Link to={clustersSecureClusterPath}>Init bundle installation methods</Link>}
+        />,
+        <DropdownItem
+            key="cluster-registration-secret"
+            onClick={() => {
+                analyticsTrack({
+                    event: CRS_SECURE_A_CLUSTER_LINK_CLICKED,
+                    properties: { source: 'Secure a Cluster Dropdown' },
+                });
+            }}
+            component={<Link to={clustersSecureClusterCrsPath}>Cluster registration secret installation methods</Link>}
         />,
         <DropdownItem
             key="legacy"

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -174,7 +174,11 @@ function ClustersTablePanel({
                     properties: { source: 'Secure a Cluster Dropdown' },
                 });
             }}
-            component={<Link to={clustersSecureClusterCrsPath}>Cluster registration secret installation methods</Link>}
+            component={
+                <Link to={clustersSecureClusterCrsPath}>
+                    Cluster registration secret installation methods
+                </Link>
+            }
         />,
         <DropdownItem
             key="legacy"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -21,7 +21,7 @@ import * as yup from 'yup';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import useAnalytics, { DOWNLOAD_INIT_BUNDLE } from 'hooks/useAnalytics';
+import useAnalytics, { DOWNLOAD_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
 import { generateClusterInitBundle } from 'services/ClustersService'; // ClusterInitBundle
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -230,7 +230,7 @@ function InitBundleForm(): ReactElement {
                             isDisabled={isSubmitting || !isValid}
                             isLoading={isSubmitting}
                             onClick={() => {
-                                analyticsTrack(DOWNLOAD_INIT_BUNDLE);
+                                analyticsTrack(DOWNLOAD_CLUSTER_REGISTRATION_SECRET);
                                 return submitForm();
                             }}
                         >

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -21,7 +21,7 @@ import * as yup from 'yup';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import useAnalytics, { DOWNLOAD_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
+import useAnalytics, { DOWNLOAD_INIT_BUNDLE } from 'hooks/useAnalytics';
 import { generateClusterInitBundle } from 'services/ClustersService'; // ClusterInitBundle
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -230,7 +230,7 @@ function InitBundleForm(): ReactElement {
                             isDisabled={isSubmitting || !isValid}
                             isLoading={isSubmitting}
                             onClick={() => {
-                                analyticsTrack(DOWNLOAD_CLUSTER_REGISTRATION_SECRET);
+                                analyticsTrack(DOWNLOAD_INIT_BUNDLE);
                                 return submitForm();
                             }}
                         >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
@@ -5,6 +5,7 @@ import usePermissions from 'hooks/usePermissions';
 
 import APITokensTile from './APITokensTile';
 import ClusterInitBundles from './ClusterInitBundlesTile';
+import ClusterRegistrationSecrets from './ClusterRegistrationSecretsTile';
 import IntegrationsSection from './IntegrationsSection';
 import MachineAccessTile from './MachineAccessTile';
 
@@ -22,6 +23,7 @@ function AuthenticationTokensSection(): ReactElement {
         <IntegrationsSection headerName="Authentication Tokens" id="token-integrations">
             <APITokensTile />
             {hasAdminRole && <ClusterInitBundles />}
+            {hasAdminRole && <ClusterRegistrationSecrets />}
             {hasReadAccessForAccess && <MachineAccessTile />}
         </IntegrationsSection>
     );

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ClusterRegistrationSecretsTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ClusterRegistrationSecretsTile.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+
+import { fetchClusterRegistrationSecrets } from 'services/ClustersService';
+import { clustersClusterRegistrationSecretsPath } from 'routePaths';
+
+import { clusterRegistrationSecretDescriptor as descriptor } from '../utils/integrationsList';
+import IntegrationTile from './IntegrationTile';
+
+const { image, label } = descriptor;
+
+function ClusterRegistrationSecretsTile(): ReactElement {
+    const [numIntegrations, setNumIntegrations] = useState(0);
+
+    useEffect(() => {
+        fetchClusterRegistrationSecrets()
+            .then(({ response: { items } }) => {
+                setNumIntegrations(items.length);
+            })
+            .catch(() => {});
+    }, []);
+
+    return (
+        <IntegrationTile
+            image={image}
+            label={label}
+            linkTo={clustersClusterRegistrationSecretsPath}
+            numIntegrations={numIntegrations}
+        />
+    );
+}
+
+export default ClusterRegistrationSecretsTile;

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -295,6 +295,13 @@ export const clusterInitBundleDescriptor: AuthProviderDescriptor = {
     type: 'clusterInitBundle',
 };
 
+export const clusterRegistrationSecretDescriptor: AuthProviderDescriptor = {
+    image: logo,
+    label: 'Cluster Registration Secret',
+    type: 'clusterRegistrationSecret',
+};
+
+
 export const machineAccessDescriptor: AuthProviderDescriptor = {
     image: logo,
     label: 'Machine access configuration',
@@ -304,6 +311,7 @@ export const machineAccessDescriptor: AuthProviderDescriptor = {
 const authenticationTokensDescriptors = [
     apiTokenDescriptor,
     clusterInitBundleDescriptor,
+    clusterRegistrationSecretDescriptor,
     machineAccessDescriptor,
 ];
 

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -301,7 +301,6 @@ export const clusterRegistrationSecretDescriptor: AuthProviderDescriptor = {
     type: 'clusterRegistrationSecret',
 };
 
-
 export const machineAccessDescriptor: AuthProviderDescriptor = {
     image: logo,
     label: 'Machine access configuration',

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -99,6 +99,7 @@ const originColumnDescriptor = {
 const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
     authProviders: {
         clusterInitBundle: [{ accessor: 'name', Header: 'Name' }],
+        clusterRegistrationSecret: [{ accessor: 'name', Header: 'Name' }],
         apitoken: [
             { accessor: 'name', Header: 'Name' },
             { accessor: 'role', Header: 'Role' },

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -127,7 +127,12 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     },
     // Cluster registration secrets must precede generic Clusters.
     'clusters/cluster-registration-secrets': {
-        component: asyncComponent(() => import('Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute')),
+        component: asyncComponent(
+            () =>
+                import(
+                    'Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute'
+                )
+        ),
         path: clustersClusterRegistrationSecretsPathWithParam,
     },
     // Cluster secure-a-cluster must precede generic Clusters.

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -13,8 +13,10 @@ import {
     clustersDelegatedScanningPath,
     clustersDiscoveredClustersPath,
     clustersInitBundlesPathWithParam,
+    clustersClusterRegistrationSecretsPathWithParam,
     clustersPathWithParam,
     clustersSecureClusterPath,
+    clustersSecureClusterCrsPath,
     collectionsPath,
     complianceEnhancedCoveragePath,
     complianceEnhancedSchedulesPath,
@@ -123,12 +125,24 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         component: asyncComponent(() => import('Containers/Clusters/InitBundles/InitBundlesRoute')),
         path: clustersInitBundlesPathWithParam,
     },
+    // Cluster registration secrets must precede generic Clusters.
+    'clusters/cluster-registration-secrets': {
+        component: asyncComponent(() => import('Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute')),
+        path: clustersClusterRegistrationSecretsPathWithParam,
+    },
     // Cluster secure-a-cluster must precede generic Clusters.
     'clusters/secure-a-cluster': {
         component: asyncComponent(
             () => import('Containers/Clusters/InitBundles/SecureClusterPage')
         ),
         path: clustersSecureClusterPath,
+    },
+    // Cluster secure-a-cluster-crs must precede generic Clusters.
+    'clusters/secure-a-cluster-crs': {
+        component: asyncComponent(
+            () => import('Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage')
+        ),
+        path: clustersSecureClusterCrsPath,
     },
     clusters: {
         component: asyncComponent(() => import('Containers/Clusters/ClustersPage')),

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -59,7 +59,8 @@ export const LEGACY_CLUSTER_DOWNLOAD_YAML = 'Legacy Cluster Download YAML';
 export const LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES = 'Legacy Cluster Download Helm Values';
 
 // cluster-registration-secrets
-export const CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED = 'Create Cluster Registration Secret Clicked';
+export const CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED =
+    'Create Cluster Registration Secret Clicked';
 export const DOWNLOAD_CLUSTER_REGISTRATION_SECRET = 'Download Cluster Registration Secret';
 export const REVOKE_CLUSTER_REGISTRATION_SECRET = 'Revoke Cluster Registration Secret';
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -52,10 +52,16 @@ export const PLATFORM_CVE_ENTITY_CONTEXT_VIEWED = 'Platform CVE Entity Context V
 export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
 export const SECURE_A_CLUSTER_LINK_CLICKED = 'Secure a Cluster Link Clicked';
 export const LEGACY_SECURE_A_CLUSTER_LINK_CLICKED = 'Legacy Secure a Cluster Link Clicked';
+export const CRS_SECURE_A_CLUSTER_LINK_CLICKED = 'CRS Secure a Cluster Link Clicked';
 export const DOWNLOAD_INIT_BUNDLE = 'Download Init Bundle';
 export const REVOKE_INIT_BUNDLE = 'Revoke Init Bundle';
 export const LEGACY_CLUSTER_DOWNLOAD_YAML = 'Legacy Cluster Download YAML';
 export const LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES = 'Legacy Cluster Download Helm Values';
+
+// cluster-registration-secrets
+export const CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED = 'Create Cluster Registration Secret Clicked';
+export const DOWNLOAD_CLUSTER_REGISTRATION_SECRET = 'Download Cluster Registration Secret';
+export const REVOKE_CLUSTER_REGISTRATION_SECRET = 'Revoke Cluster Registration Secret';
 
 // policy violations
 
@@ -290,10 +296,28 @@ export type AnalyticsEvent =
           };
       }
     /**
+     * Tracks each time the user clicks the "Create Cluster Registration Secrets" button
+     */
+    | {
+          event: typeof CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED;
+          properties: {
+              source: 'No Clusters' | 'Cluster Registration Secrets';
+          };
+      }
+    /**
      * Tracks each time the user clicks a link to visit the "Secure a Cluster" page
      */
     | {
           event: typeof SECURE_A_CLUSTER_LINK_CLICKED;
+          properties: {
+              source: 'No Clusters' | 'Secure a Cluster Dropdown';
+          };
+      }
+    /**
+     * Tracks each time the user clicks a link to visit the "CRS Secure a Cluster" page
+     */
+    | {
+          event: typeof CRS_SECURE_A_CLUSTER_LINK_CLICKED;
           properties: {
               source: 'No Clusters' | 'Secure a Cluster Dropdown';
           };
@@ -312,9 +336,17 @@ export type AnalyticsEvent =
      */
     | typeof DOWNLOAD_INIT_BUNDLE
     /**
+     * Tracks each time the user downloads a cluster registration secret
+     */
+    | typeof DOWNLOAD_CLUSTER_REGISTRATION_SECRET
+    /**
      * Tracks each time the user revokes an init bundle
      */
     | typeof REVOKE_INIT_BUNDLE
+    /**
+     * Tracks each time the user revokes cluster registration secret
+     */
+    | typeof REVOKE_CLUSTER_REGISTRATION_SECRET
     /**
      * Tracks each time the user downloads a cluster's YAML file and keys
      */

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -29,7 +29,11 @@ export const clustersDelegatedScanningPath = `${clustersBasePath}/delegated-imag
 export const clustersDiscoveredClustersPath = `${clustersBasePath}/discovered-clusters`;
 export const clustersInitBundlesPath = `${clustersBasePath}/init-bundles`;
 export const clustersInitBundlesPathWithParam = `${clustersInitBundlesPath}/:id?`;
+export const clustersClusterRegistrationSecretsPath = `${clustersBasePath}/cluster-registration-secrets`;
+export const clustersClusterRegistrationSecretsPathWithParam = `${clustersClusterRegistrationSecretsPath}/:id?`;
+
 export const clustersSecureClusterPath = `${clustersBasePath}/secure-a-cluster`;
+export const clustersSecureClusterCrsPath = `${clustersBasePath}/secure-a-cluster-crs`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
 export const complianceBasePath = `${mainPath}/compliance`;
@@ -147,8 +151,12 @@ export type RouteKey =
     | 'clusters/discovered-clusters'
     // Cluster init bundles must precede generic Clusters in Body and so here for consistency.
     | 'clusters/init-bundles'
+    // Cluster registration secrets must precede generic Clusters in Body and so here for consistency.
+    | 'clusters/cluster-registration-secrets'
     // Cluster secure-a-cluster must precede generic Clusters in Body and so here for consistency.
     | 'clusters/secure-a-cluster'
+    // Cluster secure-a-cluster-crs must precede generic Clusters in Body and so here for consistency.
+    | 'clusters/secure-a-cluster-crs'
     | 'clusters'
     | 'collections'
     | 'compliance'
@@ -206,8 +214,16 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'clusters/init-bundles': {
         resourceAccessRequirements: everyResource(['Administration', 'Integration']),
     },
+    // Cluster registration secrets must precede generic Clusters in Body and so here for consistency.
+    'clusters/cluster-registration-secrets': {
+        resourceAccessRequirements: everyResource(['Administration', 'Integration']),
+    },
     // Clusters secure-a-cluster must precede generic Clusters in Body and so here for consistency.
     'clusters/secure-a-cluster': {
+        resourceAccessRequirements: everyResource([]),
+    },
+    // Clusters secure-a-cluster-crs must precede generic Clusters in Body and so here for consistency.
+    'clusters/secure-a-cluster-crs': {
         resourceAccessRequirements: everyResource([]),
     },
     clusters: {

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -242,7 +242,9 @@ export function fetchClusterInitBundles(): Promise<{ response: { items: ClusterI
         });
 }
 
-export function fetchClusterRegistrationSecrets(): Promise<{ response: { items: ClusterRegistrationSecret[] } }> {
+export function fetchClusterRegistrationSecrets(): Promise<{
+    response: { items: ClusterRegistrationSecret[] };
+}> {
     return axios
         .get<{ items: ClusterRegistrationSecret[] }>(`${clusterInitUrl}/crs`)
         .then((response) => {
@@ -330,7 +332,7 @@ export function revokeClusterInitBundles(
 }
 
 export function revokeClusterRegistrationSecrets(
-    ids: string[],
+    ids: string[]
 ): Promise<ClusterRegistrationSecretRevokeResponse> {
     return axios
         .patch<ClusterRegistrationSecretRevokeResponse>(`${clusterInitUrl}/crs/revoke`, {

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -16,7 +16,7 @@ export type IntegrationType =
     | SignatureIntegrationType
     | CloudSourceIntegrationType;
 
-export type AuthProviderType = 'apitoken' | 'clusterInitBundle' | 'machineAccess';
+export type AuthProviderType = 'apitoken' | 'clusterInitBundle' | 'clusterRegistrationSecret' | 'machineAccess';
 
 // Investigate why the following occur in tableColumnDescriptor but not in integrationsList:
 /*

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -16,7 +16,11 @@ export type IntegrationType =
     | SignatureIntegrationType
     | CloudSourceIntegrationType;
 
-export type AuthProviderType = 'apitoken' | 'clusterInitBundle' | 'clusterRegistrationSecret' | 'machineAccess';
+export type AuthProviderType =
+    | 'apitoken'
+    | 'clusterInitBundle'
+    | 'clusterRegistrationSecret'
+    | 'machineAccess';
 
 // Investigate why the following occur in tableColumnDescriptor but not in integrationsList:
 /*


### PR DESCRIPTION
### Description

This is an attempt to implement basic support for Cluster registration secrets (CRS) in the UI by copying and modifying the implementation for init-bundles.

Notes:
* I did not copy over the code dealing with "impacted clusters", because revoking CRSs does not impact any cluster (a CRS is *only* used for establishing initial trust, they are not used after that and can be safely revoked).
* For CRS there is no distinction between "Operator format" (a Kubernetes manifest) and "Helm format" (which is YAML, but not a Kubernetes manifest).
* This PR cannot be merged in isolation, there are three PRs which need to be merged first: [backend CRS integration](https://github.com/stackrox/stackrox/pull/13239), [Helm chart integration](https://github.com/stackrox/stackrox/pull/12713) and finally [Operator integration](https://github.com/stackrox/stackrox/pull/13545).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation changes have been discussed elsewhere.

### Testing and quality

- [ ] the change is production ready: PR dependencies:
  - [ ] [backend CRS integration](https://github.com/stackrox/stackrox/pull/13239)
  - [ ] [Helm chart integration](https://github.com/stackrox/stackrox/pull/12713)
  - [ ] [Operator integration](https://github.com/stackrox/stackrox/pull/13545)
- [ ] CI results are inspected

#### Automated testing

Nothing.

#### How I validated my change

Trying out the CRS UI in the browser.
