### PR TITLE
fix(scanner): Add pipefail to matrix steps

### DIFF
--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Create matrix
       id: output-matrix
       run: |
+        set -o pipefail
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "matrix<<$EOF" >> "$GITHUB_OUTPUT"
         .github/workflows/scripts/scanner-offline-bundle-matrix.sh | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -33,6 +33,7 @@ jobs:
     - name: Parse VULNERABILITY_BUNDLE_VERSION
       id: set-versions
       run: |
+        set -o pipefail
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "versions<<$EOF" >> "$GITHUB_OUTPUT"
         ./.github/workflows/scripts/scanner-get-released-tags.sh | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description

A step like this:

```
    - name: Create matrix
      id: output-matrix
      run: |
        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
        echo "matrix<<$EOF" >> "$GITHUB_OUTPUT"
        .github/workflows/scripts/scanner-offline-bundle-matrix.sh | tee -a "$GITHUB_OUTPUT"
        echo "$EOF" >> "$GITHUB_OUTPUT"
```

Does not fail even if `scanner-offline-bundle-matrix.sh` fails. I believe it's because GH actions' default bash flags does not contain `pipefail`, and `tee` is OK if stdin is empty. The matrix job will fail expecting a valid JSON, [see example](https://github.com/stackrox/stackrox/actions/runs/12272953984/job/34242763300).

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

Testing with `pr-update-scanner-vulns`.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Testing with `pr-update-scanner-vulns`.
