### PR TITLE
ROX-27414: Prevent deduping Node Index in Central

### DIFF
--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -114,18 +114,18 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	case *central.SensorEvent_ReprocessDeployment:
 		workerType = deploymentEventType
 	case *central.SensorEvent_NodeInventory:
-		// This will put both NodeInventory and Node events in the same worker queue,
+		// This will put all: NodeIndex, NodeInventory and Node events in the same worker queue,
 		// preventing events for the same Node ID to run concurrently.
 		workerType = nodeEventType
-		// Node and NodeInventory dedupe on Node ID. We use a different dedupe key for
-		// NodeInventory because the two should not dedupe between themselves.
+		// Node, NodeInventory and IndexReport dedupe on Node ID. We use a different dedupe key for
+		// IndexReport because the three should not dedupe between themselves.
 		msg.DedupeKey = fmt.Sprintf("NodeInventory:%s", msg.GetDedupeKey())
 	case *central.SensorEvent_IndexReport:
 		// This will put both NodeIndex and Node events in the same worker queue,
 		// preventing events for the same Node ID to run concurrently.
 		workerType = nodeEventType
-		// Node and NodeInventory dedupe on Node ID. We use a different dedupe key for
-		// NodeInventory because the two should not dedupe between themselves.
+		// Node, NodeInventory and IndexReport dedupe on Node ID. We use a different dedupe key for
+		// IndexReport because the three should not dedupe between themselves.
 		msg.DedupeKey = fmt.Sprintf("NodeIndex:%s", msg.GetDedupeKey())
 	default:
 		if event.GetResource() == nil {

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -120,6 +120,13 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 		// Node and NodeInventory dedupe on Node ID. We use a different dedupe key for
 		// NodeInventory because the two should not dedupe between themselves.
 		msg.DedupeKey = fmt.Sprintf("NodeInventory:%s", msg.GetDedupeKey())
+	case *central.SensorEvent_IndexReport:
+		// This will put both NodeIndex and Node events in the same worker queue,
+		// preventing events for the same Node ID to run concurrently.
+		workerType = nodeEventType
+		// Node and NodeInventory dedupe on Node ID. We use a different dedupe key for
+		// NodeInventory because the two should not dedupe between themselves.
+		msg.DedupeKey = fmt.Sprintf("NodeIndex:%s", msg.GetDedupeKey())
 	default:
 		if event.GetResource() == nil {
 			log.Errorf("Received event with unknown resource from cluster %s (%s). May be due to Sensor (%s) version mismatch with Central (%s)", s.cluster.GetName(), s.cluster.GetId(), s.sensorVersion, version.GetMainVersion())


### PR DESCRIPTION
## Description

### Condition

If Central receives NodeInventory and NodeIndex (IndexReport) messages in parallel for the same node...

### Observed behavior

...the message that arrives later will get deduped. 

### Why is this a problem?

This is bad for many reasons:
- No ACK can be sent back to Compliance and it will retry forever
- Switching from v2 to v4 node scanning without restarting Central may never work.


### Moreover

This change puts all Node, NodeInventory, and IndexReport into single worker queue. This shall prevent race condition if multiple events of those three kinds arrive very close to each other. The code in the pipelines is not bullet-proof regarding tight race conditions (that was a decision when working on Node scanning v2), because making it so, would require adding more complexity to it. Those situations can be prevented by using single worker for those type of messages, as it guarantees no parallelism among the messages handled by the same worker.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [ ] TODO: There are automated tests, but they do not cover this situation
- [x] One can verify that manually on a cluster where v2 and v4 node scanning runs in parallel - then both shall arrive to Central and Central shall drop one of them in the pipeline. If that change is not in place, there is a chance that the later message (usually v4 scan) will be deduped before being passed onto the respective pipieline.
