### PR TITLE
ROX-27415: Abandon UNSET action for NodeInventory and NodeIndex

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -314,9 +314,11 @@ func (c *sensorConnection) handleMessage(ctx context.Context, msg *central.MsgFr
 }
 
 func shallDedupe(msg *central.MsgFromSensor) bool {
-	// Special handling of node inventory and node indexes for Sensor version 4.6 and earlier
+	// Special handling of node inventory and node indexes for Sensor version 4.6 and earlier.
+	// NodeInventory and NodeIndex should never be deduped. Despite the packages/images to scan may be the same,
+	// the vulnerabilities database in scanner may get updated and new vulnerabilities may affect those packages.
 	ev := msg.GetEvent()
-	if ev.GetAction() == central.ResourceAction_UNSET_ACTION_RESOURCE {
+	if ev.GetAction() != central.ResourceAction_REMOVE_RESOURCE {
 		if ev.GetNodeInventory() != nil || ev.GetIndexReport() != nil {
 			return false
 		}

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -314,13 +314,14 @@ func (c *sensorConnection) handleMessage(ctx context.Context, msg *central.MsgFr
 }
 
 func shallDedupe(msg *central.MsgFromSensor) bool {
-	// Special handling of node inventory and node indexes for Sensor version 4.6 and earlier:
-	// they shall be treated similar as CREATE.
-	if msg.GetEvent().GetAction() == central.ResourceAction_UNSET_ACTION_RESOURCE {
-		return false
+	// Special handling of node inventory and node indexes for Sensor version 4.6 and earlier
+	ev := msg.GetEvent()
+	if ev.GetAction() == central.ResourceAction_UNSET_ACTION_RESOURCE {
+		if ev.GetNodeInventory() != nil || ev.GetIndexReport() != nil {
+			return false
+		}
 	}
-	// Only dedupe on non-creates
-	return msg.GetEvent().GetAction() != central.ResourceAction_CREATE_RESOURCE
+	return ev.GetAction() != central.ResourceAction_CREATE_RESOURCE
 }
 
 func (c *sensorConnection) processComplianceResponse(ctx context.Context, msg *central.ComplianceResponse) error {

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -70,8 +70,8 @@ func (p pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSen
 	if report == nil {
 		return errors.Errorf("unexpected resource type %T for index report", event.GetResource())
 	}
-	if event.GetAction() != central.ResourceAction_UNSET_ACTION_RESOURCE {
-		log.Errorf("index report from node %s has unsupported action: %q", event.GetNode().GetName(), event.GetAction())
+	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
+		log.Warn("Removal of node index is unsupported action")
 		return nil
 	}
 	log.Debugf("received node index report for node %s with %d packages from %d content sets",

--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -76,8 +76,8 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	nodeStr := fmt.Sprintf("(node name: %q, node id: %q)", ninv.GetNodeName(), ninv.GetNodeId())
 	log.Debugf("received inventory %s contains %d packages to scan from %d content sets", nodeStr,
 		len(ninv.GetComponents().GetRhelComponents()), len(ninv.GetComponents().GetRhelContentSets()))
-	if event.GetAction() != central.ResourceAction_UNSET_ACTION_RESOURCE {
-		log.Errorf("inventory %s has unsupported action: %q", nodeStr, event.GetAction())
+	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
+		log.Warn("Removal of node inventory is unsupported action")
 		return nil
 	}
 	ninv = ninv.CloneVT()

--- a/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
@@ -59,11 +59,30 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			wantErr: "unexpected resource type",
 		},
 		{
-			name: "when event action is not UNSET then ignore event",
+			name: "when event action is REMOVE_RESOURCE then ignore event",
 			setUp: func(t *testing.T, a *args, m *mocks) {
 				a.msg = createMsg("foobar")
-				a.msg.GetEvent().Action = central.ResourceAction_CREATE_RESOURCE
+				a.msg.GetEvent().Action = central.ResourceAction_REMOVE_RESOURCE
+				a.injector = &recordingInjector{}
 			},
+			wantInjectorContain: []*central.NodeInventoryACK{},
+		},
+		{
+			name: "when event action is CREATE_RESOURCE then do not ignore event",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				node := storage.Node{
+					Id: "test node id",
+				}
+				a.msg = createMsg(node.GetId())
+				a.msg.GetEvent().Action = central.ResourceAction_CREATE_RESOURCE
+				a.injector = &recordingInjector{}
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+					m.enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+					m.riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+				)
+			},
+			wantInjectorContain: []*central.NodeInventoryACK{{Action: central.NodeInventoryACK_ACK}},
 		},
 		{
 			name: "when event has inventory then enrich and upsert with risk",
@@ -144,9 +163,13 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			if err := p.Run(tt.args.ctx, tt.args.clusterID, tt.args.msg, tt.args.injector); (err != nil) != (tt.wantErr != "") {
 				assert.ErrorContainsf(t, err, tt.wantErr, "Run() error = %v, wantErr = %q", err, tt.wantErr)
 			}
-			if tt.wantInjectorContain != nil {
+			if tt.args.injector != nil {
 				inj := tt.args.injector.(*recordingInjector)
-				protoassert.SlicesEqual(t, tt.wantInjectorContain, inj.getSentACKs())
+				if len(tt.wantInjectorContain) == 0 {
+					assert.Len(t, inj.getSentACKs(), 0)
+				} else {
+					protoassert.SlicesEqual(t, tt.wantInjectorContain, inj.getSentACKs())
+				}
 			}
 		})
 	}

--- a/central/sensor/service/pipeline/utils.go
+++ b/central/sensor/service/pipeline/utils.go
@@ -17,5 +17,5 @@ func ActionToOperation(action central.ResourceAction) metrics.Op {
 	case central.ResourceAction_SYNC_RESOURCE:
 		return metrics.Sync
 	}
-	return 0
+	return metrics.Unset
 }

--- a/pkg/metrics/op_string.go
+++ b/pkg/metrics/op_string.go
@@ -36,11 +36,12 @@ func _() {
 	_ = x[UpsertAll-25]
 	_ = x[Walk-26]
 	_ = x[WalkByQuery-27]
+	_ = x[Unset-28]
 }
 
-const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetExternalFlowsForDeploymentGetFlowsForDeploymentGetByQueryGetGroupedGetProcessListeningOnPortListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchSyncUpdateUpdateManyUpsertUpsertAllWalkWalkByQuery"
+const _Op_name = "AddAddManyCountDedupeExistsGetGetAllGetManyGetExternalFlowsForDeploymentGetFlowsForDeploymentGetByQueryGetGroupedGetProcessListeningOnPortListPruneResetRenameRemoveRemoveManyRemoveFlowsByDeploymentSearchSyncUpdateUpdateManyUpsertUpsertAllWalkWalkByQueryUnset"
 
-var _Op_index = [...]uint8{0, 3, 10, 15, 21, 27, 30, 36, 43, 72, 93, 103, 113, 138, 142, 147, 152, 158, 164, 174, 197, 203, 207, 213, 223, 229, 238, 242, 253}
+var _Op_index = [...]uint16{0, 3, 10, 15, 21, 27, 30, 36, 43, 72, 93, 103, 113, 138, 142, 147, 152, 158, 164, 174, 197, 203, 207, 213, 223, 229, 238, 242, 253, 258}
 
 func (i Op) String() string {
 	if i < 0 || i >= Op(len(_Op_index)-1) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -49,4 +49,6 @@ const (
 
 	Walk
 	WalkByQuery
+
+	Unset
 )

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -209,8 +209,10 @@ func (c *nodeInventoryHandlerImpl) sendNodeInventory(toC chan<- *message.Expirin
 	case toC <- message.New(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
-				Id:     inventory.GetNodeId(),
-				Action: central.ResourceAction_UNSET_ACTION_RESOURCE, // There is no action required for NodeInventory as this is not a K8s resource
+				Id: inventory.GetNodeId(),
+				// ResourceAction_UNSET_ACTION_RESOURCE is the only one supported by Central 4.6 and older.
+				// This can be changed to CREATE or UPDATE for Sensor 4.8 or when Central 4.6 is out of support.
+				Action: central.ResourceAction_UNSET_ACTION_RESOURCE,
 				Resource: &central.SensorEvent_NodeInventory{
 					NodeInventory: inventory,
 				},
@@ -230,7 +232,9 @@ func (c *nodeInventoryHandlerImpl) sendNodeIndex(toC chan<- *message.ExpiringMes
 	case toC <- message.New(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
-				Id:     indexWrap.NodeID,
+				Id: indexWrap.NodeID,
+				// ResourceAction_UNSET_ACTION_RESOURCE is the only one supported by Central 4.6 and older.
+				// This can be changed to CREATE or UPDATE for Sensor 4.8 or when Central 4.6 is out of support.
 				Action: central.ResourceAction_UNSET_ACTION_RESOURCE,
 				Resource: &central.SensorEvent_IndexReport{
 					IndexReport: indexWrap.IndexReport,


### PR DESCRIPTION
### Description

For NodeInventories and NodeIndexes (NodeReports) sent from Sensor to Central, Central will no longer require the `ResourceAction_UNSET_ACTION_RESOURCE` to be used. Instead, it will accept all but `ResourceAction_REMOVE_RESOURCE`.

See ticket description for details about backwards-compatibility.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [x] Unit tests
- [x] Manually on cluster
    - [x] Looking at the metrics
    - [ ] ~Looking at the debug logs~ sorry, debug logs do not show that this change works, but the metrics do.


#### Central Metrics

This shows that:
- UNSET actions still work in Central
- UNSET action is no longer changed to CREATE  in metrics   
```
# HELP rox_central_resource_processed_count Number of elements received and processed
# TYPE rox_central_resource_processed_count counter
rox_central_resource_processed_count{Operation="Add",Resource="Alert"} 8
rox_central_resource_processed_count{Operation="Add",Resource="Deployment"} 7
rox_central_resource_processed_count{Operation="Add",Resource="Pod"} 24
rox_central_resource_processed_count{Operation="Add",Resource="ProcessIndicator"} 4676
rox_central_resource_processed_count{Operation="Remove",Resource="Alert"} 7
rox_central_resource_processed_count{Operation="Remove",Resource="Deployment"} 7
rox_central_resource_processed_count{Operation="Remove",Resource="Pod"} 26
rox_central_resource_processed_count{Operation="Sync",Resource="Alert"} 137
rox_central_resource_processed_count{Operation="Sync",Resource="Deployment"} 139
rox_central_resource_processed_count{Operation="Sync",Resource="ImageIntegration"} 16
rox_central_resource_processed_count{Operation="Sync",Resource="Namespace"} 71
rox_central_resource_processed_count{Operation="Sync",Resource="NetworkPolicy"} 17
rox_central_resource_processed_count{Operation="Sync",Resource="Node"} 5
rox_central_resource_processed_count{Operation="Sync",Resource="Pod"} 236
rox_central_resource_processed_count{Operation="Sync",Resource="Role"} 428
rox_central_resource_processed_count{Operation="Sync",Resource="RoleBinding"} 620
rox_central_resource_processed_count{Operation="Sync",Resource="Secret"} 663
rox_central_resource_processed_count{Operation="Sync",Resource="ServiceAccount"} 381
rox_central_resource_processed_count{Operation="Unset",Resource="ComplianceOperatorInfo"} 61
rox_central_resource_processed_count{Operation="Unset",Resource="DeploymentReprocess"} 138
rox_central_resource_processed_count{Operation="Unset",Resource="NodeInventory"} 16
rox_central_resource_processed_count{Operation="Unset",Resource="ProcessListeningOnPort"} 11
rox_central_resource_processed_count{Operation="Update",Resource="Alert"} 4
rox_central_resource_processed_count{Operation="Update",Resource="Deployment"} 54
rox_central_resource_processed_count{Operation="Update",Resource="Pod"} 76
```