### PR TITLE
ROX-27390: Add Context to Workload CVEs page for view customization

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -225,7 +225,7 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
             );
 
             return function WorkloadCvesPage() {
-                return <AsyncWorkloadCvesComponent />;
+                return <AsyncWorkloadCvesComponent view="user-workload" />;
             };
         })(),
         path: vulnerabilitiesWorkloadCvesPath,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -85,6 +85,7 @@ import VulnerabilityStateTabs, {
     vulnStateTabContentId,
 } from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import DefaultFilterModal from '../components/DefaultFilterModal';
 import WorkloadCveFilterToolbar from '../components/WorkloadCveFilterToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
@@ -171,6 +172,7 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
+    const { pageTitle } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -371,13 +373,13 @@ function WorkloadCvesOverviewPage() {
 
     return (
         <>
-            <PageTitle title="Workload CVEs Overview" />
+            <PageTitle title={`${pageTitle} Overview`} />
             <PageSection
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-row pf-v5-u-align-items-center"
                 variant="light"
             >
                 <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                    <Title headingLevel="h1">Workload CVEs</Title>
+                    <Title headingLevel="h1">{pageTitle}</Title>
                     <FlexItem>
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { QuerySearchFilter } from '../types';
+
+export type WorkloadCveView = {
+    createUrl: (path: string) => string;
+    baseSearchFilter: QuerySearchFilter;
+    pageTitle: string;
+};
+
+/**
+ * The WorkloadCveViewContext provides dynamic values throughout the Workload CVE pages in order to support
+ * sections for both "Application/User Workloads" and a separate section for "Platform Workloads"
+ */
+export const WorkloadCveViewContext = createContext<WorkloadCveView | undefined>(undefined);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -13,6 +13,7 @@ import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCve/ImageCvePage';
 import NamespaceViewPage from './NamespaceView/NamespaceViewPage';
+import { WorkloadCveViewContext } from './WorkloadCveViewContext';
 
 import './WorkloadCvesPage.css';
 
@@ -20,13 +21,32 @@ const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}
 const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCvesPath}/images/:imageId`;
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
-function WorkloadCvesPage() {
+const userWorkloadContext = {
+    pageTitle: 'Workload CVEs', // TODO Implement throughout in follow up
+    baseSearchFilter: {}, // TODO Implement throughout in follow up
+    createUrl: (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`, // TODO Implement throughout in follow up
+};
+
+// TODO Update these values for Platform View
+const platformWorkloadContext = {
+    pageTitle: 'Workload CVEs', // TODO Implement throughout in follow up
+    baseSearchFilter: {}, // TODO Implement throughout in follow up
+    createUrl: (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`, // TODO Implement throughout in follow up
+};
+
+export type WorkloadCvePageProps = {
+    view: 'user-workload' | 'platform-workload';
+};
+
+function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
     const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
+    const context = view === 'user-workload' ? userWorkloadContext : platformWorkloadContext;
+
     return (
-        <>
+        <WorkloadCveViewContext.Provider value={context}>
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Switch>
                 {hasReadAccessForNamespaces && (
@@ -48,12 +68,12 @@ function WorkloadCvesPage() {
                 </Route>
                 <Route>
                     <PageSection variant="light">
-                        <PageTitle title="Workload CVEs - Not Found" />
+                        <PageTitle title={`${context.pageTitle} - Not Found`} />
                         <PageNotFound />
                     </PageSection>
                 </Route>
             </Switch>
-        </>
+        </WorkloadCveViewContext.Provider>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { WorkloadCveView, WorkloadCveViewContext } from '../WorkloadCveViewContext';
+
+export default function useWorkloadCveViewContext(): WorkloadCveView {
+    const value = useContext(WorkloadCveViewContext);
+
+    if (!value) {
+        throw new Error('A value must be provided to the WorkloadCveViewContext via a provider!');
+    }
+
+    return value;
+}


### PR DESCRIPTION
### Description

Adds a React.Context at the top level of the WorkloadCvePage that will be used to customize values specific to either "User" workloads or "Platform" workloads.

This context will be provided at the route level and passed via props to the context provider.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Initial test - verify that the passed page title continues to display correctly to the WorkloadCvePage:
![image](https://github.com/user-attachments/assets/885974cd-081c-4845-807c-8a42a64f1747)
