### PR TITLE
fix(report): Remove scanConfig from runningReportConfigs on error

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -121,11 +121,7 @@ func (m *ManagerTestSuite) TestHandleReportRequest() {
 		now := protocompat.TimestampNow()
 		m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
 			Return(
-				[]*storage.ComplianceOperatorScanConfigurationV2{
-					{
-						Id: "scan-config-id",
-					},
-				}, nil,
+				[]*storage.ComplianceOperatorScanConfigurationV2{getTestScanConfig()}, nil,
 			)
 		m.pushScansAndResults(manager, getTestScanConfig(), now)
 
@@ -165,6 +161,85 @@ func (m *ManagerTestSuite) TestHandleReportRequest() {
 		}, 100*time.Millisecond, 10*time.Millisecond)
 
 		handleWaitGroup(m.T(), &wg, 500*time.Millisecond, "reports to be generated")
+	})
+
+}
+
+func (m *ManagerTestSuite) TestFailedReportWithWatcherRunningAndNoNotifiers() {
+	m.T().Setenv(env.ReportExecutionMaxConcurrency.EnvVar(), "1")
+	identity := mocks.NewMockIdentity(m.mockCtrl)
+	identity.EXPECT().UID().AnyTimes().Return("user-id")
+	identity.EXPECT().FullName().AnyTimes().Return("user-name")
+	identity.EXPECT().FriendlyName().AnyTimes().Return("user-friendly-name")
+	ctx := authn.ContextWithIdentity(context.Background(), identity, m.T())
+
+	// Set the timeouts to 1 and 2 seconds so the scan watchers timeout fast
+	m.T().Setenv(env.ComplianceScanWatcherTimeout.EnvVar(), "1s")
+	m.T().Setenv(env.ComplianceScanScheduleWatcherTimeout.EnvVar(), "2s")
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.reportGen)
+	manager.Start()
+	now := protocompat.TimestampNow()
+	scanConfig := getTestScanConfig()
+	scanConfig.Notifiers = nil
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{scanConfig}, nil)
+	m.pushScansAndResults(manager, scanConfig, now)
+
+	wg := concurrency.NewWaitGroup(1)
+	scans := getTestScansFromScanConfig(scanConfig, now)
+	scan := getTestScan(scans[0].GetId(), scans[0].GetClusterId(), now, true)
+	m.finishFirstScan(manager, scan, scanConfig)
+
+	// The rest of the scan should time out after 1s
+
+	m.scanConfigDataStore.EXPECT().GetScanConfigurationByName(gomock.Any(), gomock.Any()).Times(len(scans)-1).
+		Return(scanConfig, nil)
+	m.complianceIntegrationDataStore.EXPECT().GetComplianceIntegrationByCluster(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return([]*storage.ComplianceIntegration{
+			{
+				OperatorInstalled: true,
+				Version:           "v1.6.0",
+			},
+		}, nil)
+	m.Eventually(func() bool {
+		managerImp, ok := manager.(*managerImpl)
+		m.Require().True(ok)
+		return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
+			return len(managerImp.watchingScanConfigs) > 0
+		})
+	}, 100*time.Millisecond, 10*time.Millisecond)
+	gomock.InOrder(
+		// The first upsert happens when the download is requested
+		// The next upsert is the first scan handling
+		// The next three upsert are the next three scans timing out
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(4).Return(nil),
+		// We assert that the last upsert has the state as FAILURE
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).
+			Times(1).
+			DoAndReturn(func(_ any, snapshot *storage.ComplianceOperatorReportSnapshotV2) error {
+				assert.Equal(m.T(), storage.ComplianceOperatorReportStatus_FAILURE, snapshot.GetReportStatus().GetRunState())
+				wg.Add(-1)
+				return nil
+			}),
+	)
+	err := manager.SubmitReportRequest(ctx, scanConfig, storage.ComplianceOperatorReportStatus_DOWNLOAD)
+	m.Require().NoError(err)
+
+	managerImp, ok := manager.(*managerImpl)
+	m.Require().True(ok)
+	m.Eventually(func() bool {
+		return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
+			return len(managerImp.watchingScanConfigs) == 0
+		})
+	}, 10*time.Second, 10*time.Millisecond)
+
+	handleWaitGroup(m.T(), &wg, 10*time.Second, "report to fail")
+
+	// The runningReportConfigs should be empty at this point
+	concurrency.WithLock(&managerImp.mu, func() {
+		m.Assert().Len(managerImp.runningReportConfigs, 0)
 	})
 }
 
@@ -432,7 +507,7 @@ func (m *ManagerTestSuite) finishFirstScan(manager Manager, scan *storage.Compli
 	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).Times(2).
 		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
 	m.scanConfigDataStore.EXPECT().GetScanConfigurationByName(gomock.Any(), gomock.Any()).Times(1).
-		Return(getTestScanConfig(), nil)
+		Return(sc, nil)
 	err := manager.HandleScan(ctx, scan)
 	require.NoError(m.T(), err)
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

If there's an a running scan watcher that has on demand reports associated with it, we need to remove the scan config id on error. Otherwise we won't be able to request more on demand reports for that scan config without restarting central.

They way I reproduce this problem:

- Deploy ACS with LOGLEVEL=debug
- Create a scan schedule without notifiers
- Wait for the Scan to finish (checking central logs). Once it's finished if they are not notifiers configured they will be no snapshots created.
- Wait until CO send an extra update for the scan (after is finished). This will trigger an unnecessary scan watcher because no snapshots were created.
- Request a download.
- Observe the request for download is in the `Waiting` state.
- After a while the watcher should timeout but the request never transitions out of the `Waiting` state.
- This is because *on error* we are not removing the request from the `runningReportConfigs` map.

After the changes in this PR the request for download should transition to `Fail`.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Manually testing the scenario describe above.
- [x] Regression test added.
