### PR TITLE
ROX-27393: Update Workload CVE pages to accept a base search filter

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -182,7 +182,7 @@ export_test_environment() {
     ci_export ROX_EPSS_SCORE "${ROX_EPSS_SCORE:-true}"
     ci_export ROX_SBOM_GENERATION "${ROX_SBOM_GENERATION:-true}"
     ci_export ROX_CLUSTERS_PAGE_MIGRATION_UI "${ROX_CLUSTERS_PAGE_MIGRATION_UI:-true}"
-    ci_export ROX_PLATFORM_CVE_SPLIT "${ROX_PLATFORM_CVE_SPLIT:-true}"
+    ci_export ROX_PLATFORM_CVE_SPLIT "${ROX_PLATFORM_CVE_SPLIT:-false}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -323,7 +323,7 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_SBOM_GENERATION'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_PLATFORM_CVE_SPLIT'
-    customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n        value: "false"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -16,9 +16,10 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
-import { getPaginationParams } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getDefaultWorkloadSortOption, getWorkloadSortFields } from '../../utils/sortUtils';
 import ImageResourceTable, { ImageResources, imageResourcesFragment } from './ImageResourceTable';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type DeploymentPageResourcesProps = {
     deploymentId: string;
@@ -36,6 +37,7 @@ const deploymentResourcesQuery = gql`
 `;
 
 function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageResourcesProps) {
+    const { baseSearchFilter } = useWorkloadCveViewContext();
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: getWorkloadSortFields('Image'),
@@ -51,7 +53,7 @@ function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageRes
     >(deploymentResourcesQuery, {
         variables: {
             id: deploymentId,
-            query: '',
+            query: getRequestQueryStringForSearchFilter(baseSearchFilter),
             pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -260,8 +260,8 @@ function DeploymentPageVulnerabilities({
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                             additionalContextFilter={{
-                                ...baseSearchFilter,
                                 'Deployment ID': deploymentId,
+                                ...baseSearchFilter,
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -70,6 +70,7 @@ import VulnerabilityStateTabs, {
     vulnStateTabContentId,
 } from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 const summaryQuery = gql`
     ${resourceCountByCveSeverityAndStatusFragment}
@@ -129,6 +130,8 @@ function DeploymentPageVulnerabilities({
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
+    const { baseSearchFilter } = useWorkloadCveViewContext();
+
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -148,7 +151,10 @@ function DeploymentPageVulnerabilities({
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
 
-    const query = getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState);
+    const query = getVulnStateScopedQueryString(
+        { ...baseSearchFilter, ...querySearchFilter },
+        currentVulnerabilityState
+    );
 
     const summaryRequest = useQuery<
         {
@@ -252,6 +258,10 @@ function DeploymentPageVulnerabilities({
                                 setSearchFilter(newFilter);
                                 setPage(1);
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
+                            }}
+                            additionalContextFilter={{
+                                ...baseSearchFilter,
+                                'Deployment ID': deploymentId,
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -16,12 +16,13 @@ import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
-import { getPaginationParams } from 'utils/searchUtils';
+import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getDefaultWorkloadSortOption, getWorkloadSortFields } from '../../utils/sortUtils';
 import DeploymentResourceTable, {
     DeploymentResources,
     deploymentResourcesFragment,
 } from './DeploymentResourceTable';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type ImagePageResourcesProps = {
     imageId: string;
@@ -39,6 +40,7 @@ const imageResourcesQuery = gql`
 `;
 
 function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
+    const { baseSearchFilter } = useWorkloadCveViewContext();
     const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: getWorkloadSortFields('Deployment'),
@@ -54,7 +56,7 @@ function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
     >(imageResourcesQuery, {
         variables: {
             id: imageId,
-            query: '',
+            query: getRequestQueryStringForSearchFilter(baseSearchFilter),
             pagination: getPaginationParams({ page, perPage, sortOption }),
         },
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -73,6 +73,7 @@ import ExceptionRequestModal, {
 } from '../../components/ExceptionRequestModal/ExceptionRequestModal';
 import CompletedExceptionRequestModal from '../../components/ExceptionRequestModal/CompletedExceptionRequestModal';
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
@@ -130,6 +131,8 @@ function ImagePageVulnerabilities({
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
+    const { baseSearchFilter } = useWorkloadCveViewContext();
+
     const currentVulnerabilityState = useVulnerabilityState();
     const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
 
@@ -163,7 +166,10 @@ function ImagePageVulnerabilities({
     >(imageVulnerabilitiesQuery, {
         variables: {
             id: imageId,
-            query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
+            query: getVulnStateScopedQueryString(
+                { ...baseSearchFilter, ...querySearchFilter },
+                currentVulnerabilityState
+            ),
             pagination: getPaginationParams({ page, perPage, sortOption }),
             statusesForExceptionCount: getStatusesForExceptionCount(currentVulnerabilityState),
         },
@@ -250,6 +256,10 @@ function ImagePageVulnerabilities({
                                 setSearchFilter(newFilter);
                                 setPage(1);
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
+                            }}
+                            additionalContextFilter={{
+                                ...baseSearchFilter,
+                                'Image SHA': imageId,
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -258,8 +258,8 @@ function ImagePageVulnerabilities({
                                 trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                             }}
                             additionalContextFilter={{
-                                ...baseSearchFilter,
                                 'Image SHA': imageId,
+                                ...baseSearchFilter,
                             }}
                         />
                     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -212,7 +212,7 @@ function ImageCvePage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { pageTitle } = useWorkloadCveViewContext();
+    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
@@ -223,6 +223,7 @@ function ImageCvePage() {
     const query = getVulnStateScopedQueryString(
         {
             ...querySearchFilter,
+            ...baseSearchFilter,
             CVE: [exactCveIdSearchRegex],
         },
         currentVulnerabilityState
@@ -277,7 +278,7 @@ function ImageCvePage() {
     });
 
     function getDeploymentSearchQuery(severity?: VulnerabilitySeverity) {
-        const filters = { ...querySearchFilter, CVE: [exactCveIdSearchRegex] };
+        const filters = { ...querySearchFilter, ...baseSearchFilter, CVE: [exactCveIdSearchRegex] };
         if (severity) {
             filters.SEVERITY = [severity];
         }
@@ -443,6 +444,10 @@ function ImageCvePage() {
                                     setSearchFilter(newFilter);
                                     setPage(1);
                                     trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
+                                }}
+                                additionalContextFilter={{
+                                    ...baseSearchFilter,
+                                    CVE: exactCveIdSearchRegex,
                                 }}
                             />
                         ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -446,7 +446,9 @@ function ImageCvePage() {
                                     trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                                 }}
                                 additionalContextFilter={{
-                                    CVE: exactCveIdSearchRegex,
+                                    // Only allow exact match for CVE ID using quotes, the autocomplete API does not
+                                    // support regex for exact matching
+                                    CVE: `"${cveId}"`,
                                     ...baseSearchFilter,
                                 }}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -222,9 +222,9 @@ function ImageCvePage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getVulnStateScopedQueryString(
         {
-            ...querySearchFilter,
-            ...baseSearchFilter,
             CVE: [exactCveIdSearchRegex],
+            ...baseSearchFilter,
+            ...querySearchFilter,
         },
         currentVulnerabilityState
     );
@@ -278,7 +278,7 @@ function ImageCvePage() {
     });
 
     function getDeploymentSearchQuery(severity?: VulnerabilitySeverity) {
-        const filters = { ...querySearchFilter, ...baseSearchFilter, CVE: [exactCveIdSearchRegex] };
+        const filters = { CVE: [exactCveIdSearchRegex], ...baseSearchFilter, ...querySearchFilter };
         if (severity) {
             filters.SEVERITY = [severity];
         }
@@ -446,8 +446,8 @@ function ImageCvePage() {
                                     trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                                 }}
                                 additionalContextFilter={{
-                                    ...baseSearchFilter,
                                     CVE: exactCveIdSearchRegex,
+                                    ...baseSearchFilter,
                                 }}
                             />
                         ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -108,9 +108,9 @@ function NamespaceViewPage() {
     const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter({
-        ...searchFilter,
-        ...defaultSearchFilters,
         ...baseSearchFilter,
+        ...defaultSearchFilters,
+        ...searchFilter,
     });
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -105,11 +105,12 @@ const pollInterval = 30000;
 function NamespaceViewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
-    const { pageTitle } = useWorkloadCveViewContext();
+    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter({
         ...searchFilter,
         ...defaultSearchFilters,
+        ...baseSearchFilter,
     });
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -196,14 +196,14 @@ function WorkloadCvesOverviewPage() {
     const workloadCvesScopedQueryString = isViewingWithCves
         ? getVulnStateScopedQueryString(
               {
-                  ...querySearchFilter,
                   ...baseSearchFilter,
+                  ...querySearchFilter,
               },
               currentVulnerabilityState
           )
         : getZeroCveScopedQueryString({
-              ...querySearchFilter,
               ...baseSearchFilter,
+              ...querySearchFilter,
           });
 
     const getDefaultSortOption = isViewingWithCves
@@ -347,8 +347,8 @@ function WorkloadCvesOverviewPage() {
             searchFilterConfig={searchFilterConfig}
             searchFilter={searchFilter}
             additionalContextFilter={{
-                ...baseSearchFilter,
                 'Image CVE Count': isViewingWithCves ? '>0' : '0',
+                ...baseSearchFilter,
             }}
             defaultFilters={localStorageValue.preferences.defaultFilters}
             onFilterChange={(newFilter, searchPayload) => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -172,7 +172,7 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { pageTitle } = useWorkloadCveViewContext();
+    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -194,8 +194,17 @@ function WorkloadCvesOverviewPage() {
     // the selected vulnerability state. If the user is viewing _without_ CVEs, we
     // need to scope the query to only show images/deployments with 0 CVEs.
     const workloadCvesScopedQueryString = isViewingWithCves
-        ? getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState)
-        : getZeroCveScopedQueryString(querySearchFilter);
+        ? getVulnStateScopedQueryString(
+              {
+                  ...querySearchFilter,
+                  ...baseSearchFilter,
+              },
+              currentVulnerabilityState
+          )
+        : getZeroCveScopedQueryString({
+              ...querySearchFilter,
+              ...baseSearchFilter,
+          });
 
     const getDefaultSortOption = isViewingWithCves
         ? getDefaultWorkloadSortOption
@@ -337,7 +346,10 @@ function WorkloadCvesOverviewPage() {
             className="pf-v5-u-py-md"
             searchFilterConfig={searchFilterConfig}
             searchFilter={searchFilter}
-            additionalContextFilter={{ 'Image CVE Count': isViewingWithCves ? '>0' : '0' }}
+            additionalContextFilter={{
+                ...baseSearchFilter,
+                'Image CVE Count': isViewingWithCves ? '>0' : '0',
+            }}
             defaultFilters={localStorageValue.preferences.defaultFilters}
             onFilterChange={(newFilter, searchPayload) => {
                 setSearchFilter(newFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { PageSection } from '@patternfly/react-core';
 
@@ -7,6 +7,7 @@ import PageTitle from 'Components/PageTitle';
 
 import { vulnerabilitiesWorkloadCvesPath, vulnerabilityNamespaceViewPath } from 'routePaths';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
@@ -21,29 +22,25 @@ const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}
 const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCvesPath}/images/:imageId`;
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
-const userWorkloadContext = {
-    pageTitle: 'Workload CVEs', // TODO Implement throughout in follow up
-    baseSearchFilter: {}, // TODO Implement throughout in follow up
-    createUrl: (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`, // TODO Implement throughout in follow up
-};
-
-// TODO Update these values for Platform View
-const platformWorkloadContext = {
-    pageTitle: 'Workload CVEs', // TODO Implement throughout in follow up
-    baseSearchFilter: {}, // TODO Implement throughout in follow up
-    createUrl: (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`, // TODO Implement throughout in follow up
-};
-
 export type WorkloadCvePageProps = {
     view: 'user-workload' | 'platform-workload';
 };
 
 function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
     const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
-    const context = view === 'user-workload' ? userWorkloadContext : platformWorkloadContext;
+    const context = useMemo(() => {
+        const pageTitle = 'Workload CVEs'; // TODO Implement throughout in follow up
+        const baseSearchFilter = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
+            ? { 'Platform Component': [String(view === 'platform-workload')] }
+            : {};
+        const createUrl = (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`; // TODO Implement throughout in follow up
+
+        return { pageTitle, baseSearchFilter, createUrl };
+    }, [view, isFeatureFlagEnabled]);
 
     return (
         <WorkloadCveViewContext.Provider value={context}>


### PR DESCRIPTION
### Description

Constructs a base search filter value to be used throughout queries in Workload CVE pages.

When the feature flag is off, this has no effect.

When the feature flag is on, `Platform component:true/false` will be passed to all queries in the Workload CVE section.

Note that this isn't _strictly_ required for all queries. e.g. The CVEs listed for an image will not change based on this parameter. The base search query was included in these queries just for the sake of consistency.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

With a top level context of `view="user-workload"`, results will be filtered to remove platform components. Screenshots below are of staging.

Image list:
![image](https://github.com/user-attachments/assets/1ece139c-e686-4676-8c4e-9462dec67cbe)

Deployment list:
![image](https://github.com/user-attachments/assets/101d1e6f-923a-4283-8725-dc146cd4eed6)

CVE Single page:
![image](https://github.com/user-attachments/assets/5e817955-49d9-4488-ab5c-966017be93d1)
![image](https://github.com/user-attachments/assets/21bca2a4-294b-4354-97b2-87ceab9d2fbc)


Namespace view:
![image](https://github.com/user-attachments/assets/3a216eb1-085f-4ed3-8e55-d06eee14e168)

Autocomplete results:
![image](https://github.com/user-attachments/assets/b88e9c26-4ea7-4297-aaea-4e3c43228f39)


With a manual override of `view="platform-workload"`, results will be inverted:

Image list:
![image](https://github.com/user-attachments/assets/216a2f80-848a-4e0a-bf89-ab20efdc5a51)

Deployment list:
![image](https://github.com/user-attachments/assets/71e53653-8fcd-4c9e-af13-d8b5ae68f806)


CVE Single page (same CVE as above, but only showing platform deployments):
![image](https://github.com/user-attachments/assets/06bafd54-aeb8-48cb-8423-0b233cce579a)
![image](https://github.com/user-attachments/assets/7000bad8-e842-42ef-8408-af674e4228d6)

Namespace view:
![image](https://github.com/user-attachments/assets/af9ee902-d4ee-41dd-81d7-f0bad2d4e834)

Autocomplete results:
![image](https://github.com/user-attachments/assets/e761f380-e9fc-4ab5-8a1d-9af6fcfa4197)


