### PR TITLE
chore(ui): Switch to advanced filter bar for exception mgmt

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
@@ -2,7 +2,7 @@ import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     cancelAllCveExceptions,
-    typeAndSelectCustomSearchFilterValue,
+    typeAndEnterCustomSearchFilterValue,
     viewCvesByObservationState,
     visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
@@ -220,10 +220,10 @@ describe('Exception Management - Approved Deferrals Table', () => {
 
         cy.get('table tr:nth(1) td[data-label="Request name"] a').then((element) => {
             const requestName = element.text().trim();
-            typeAndSelectCustomSearchFilterValue('Request name', requestName);
+            typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
             cy.get('table tr:nth(1) td[data-label="Request name"] a').should('exist');
             cy.get(vulnSelectors.clearFiltersButton).click();
-            typeAndSelectCustomSearchFilterValue('Request name', 'BLAH');
+            typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', 'BLAH');
             cy.get('table tr:nth(1) td[data-label="Request name"] a').should('not.exist');
         });
     });
@@ -237,10 +237,10 @@ describe('Exception Management - Approved Deferrals Table', () => {
         approveRequest();
         visitApprovedDeferralsTab();
 
-        typeAndSelectCustomSearchFilterValue('Requester', 'ui_tests');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'ui_tests');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('exist');
         cy.get(vulnSelectors.clearFiltersButton).click();
-        typeAndSelectCustomSearchFilterValue('Requester', 'BLAH');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'BLAH');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
@@ -2,7 +2,7 @@ import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     cancelAllCveExceptions,
-    typeAndSelectCustomSearchFilterValue,
+    typeAndEnterCustomSearchFilterValue,
     viewCvesByObservationState,
     visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
@@ -199,9 +199,9 @@ describe('Exception Management - Approved False Positives Table', () => {
 
         cy.get('table tr:nth(1) td[data-label="Request name"] a').then((element) => {
             const requestName = element.text().trim();
-            typeAndSelectCustomSearchFilterValue('Request name', requestName);
+            typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
             cy.get(vulnSelectors.clearFiltersButton).click();
-            typeAndSelectCustomSearchFilterValue('Request name', 'BLAH');
+            typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', 'BLAH');
             cy.get('table tr:nth(1) td[data-label="Request name"] a').should('not.exist');
         });
     });
@@ -214,10 +214,10 @@ describe('Exception Management - Approved False Positives Table', () => {
         approveRequest();
         visitApprovedFalsePositivesTab();
 
-        typeAndSelectCustomSearchFilterValue('Requester', 'ui_tests');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'ui_tests');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('exist');
         cy.get(vulnSelectors.clearFiltersButton).click();
-        typeAndSelectCustomSearchFilterValue('Requester', 'BLAH');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'BLAH');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/deniedRequestsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/deniedRequestsTable.test.ts
@@ -2,7 +2,7 @@ import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     cancelAllCveExceptions,
-    typeAndSelectCustomSearchFilterValue,
+    typeAndEnterCustomSearchFilterValue,
 } from '../workloadCves/WorkloadCves.helpers';
 import {
     deferAndVisitRequestDetails,
@@ -215,7 +215,7 @@ describe('Exception Management - Denied Requests Table', () => {
 
         cy.get('table tr:nth(1) td[data-label="Request name"] a').then((element) => {
             const requestName = element.text().trim();
-            typeAndSelectCustomSearchFilterValue('Request name', requestName);
+            typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
             cy.get('table tr:nth(1) td[data-label="Request name"] a').should('exist');
         });
     });
@@ -229,10 +229,10 @@ describe('Exception Management - Denied Requests Table', () => {
         denyRequest();
         visitDeniedRequestsTab();
 
-        typeAndSelectCustomSearchFilterValue('Requester', 'ui_tests');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'ui_tests');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('exist');
         cy.get(vulnSelectors.clearFiltersButton).click();
-        typeAndSelectCustomSearchFilterValue('Requester', 'BLAH');
+        typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'BLAH');
         cy.get('table tr:nth(1) td[data-label="Request name"] a').should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/general.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/general.test.ts
@@ -3,7 +3,10 @@ import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../../helpers/title';
 import { visit } from '../../../helpers/visit';
-import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
+import {
+    cancelAllCveExceptions,
+    typeAndEnterCustomSearchFilterValue,
+} from '../workloadCves/WorkloadCves.helpers';
 import {
     approvedDeferralsPath,
     approvedFalsePositivesPath,
@@ -83,7 +86,6 @@ describe('Exception Management', () => {
     });
 
     it('should keep filters when navigating between tabs', () => {
-        const filterLabel = 'Filter by Request name';
         const filterText = 'AA-240101-1';
 
         cy.intercept({ method: 'POST', url: graphql('autocomplete') }).as('autocomplete');
@@ -91,12 +93,7 @@ describe('Exception Management', () => {
         visitPendingRequestsTab();
 
         // Add a filter
-        cy.get(`input[aria-label="${filterLabel}"]`).type(filterText);
-        cy.wait('@autocomplete');
-        cy.get(
-            `ul[role="listbox"][aria-label="${filterLabel}"] li button:contains("${filterText}")`
-        ).click();
-        cy.get('body').click('topLeft'); // closes the dropdown menu
+        typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', filterText);
 
         // The filter should be applied
         cy.get('div[aria-label="applied search filters"]').should('exist');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
@@ -7,7 +7,7 @@ import {
     verifyExceptionConfirmationDetails,
     verifySelectedCvesInModal,
     visitWorkloadCveOverview,
-    typeAndSelectCustomSearchFilterValue,
+    typeAndEnterCustomSearchFilterValue,
 } from '../workloadCves/WorkloadCves.helpers';
 import { visitPendingRequestsTab } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
@@ -249,7 +249,7 @@ describe('Exception Management Pending Requests Page', () => {
 
             cy.get('table td[data-label="Request name"] a').then((element) => {
                 const requestName = element.text().trim();
-                typeAndSelectCustomSearchFilterValue('Request name', requestName);
+                typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
                 cy.get('table td[data-label="Request name"] a').should('exist');
             });
         });
@@ -274,10 +274,10 @@ describe('Exception Management Pending Requests Page', () => {
 
             visitPendingRequestsTab();
 
-            typeAndSelectCustomSearchFilterValue('Requester', 'ui_tests');
+            typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'ui_tests');
             cy.get('table td[data-label="Request name"] a').should('exist');
             cy.get(vulnSelectors.clearFiltersButton).click();
-            typeAndSelectCustomSearchFilterValue('Requester', 'BLAH');
+            typeAndEnterCustomSearchFilterValue('Exception', 'Requester User Name', 'BLAH');
             cy.get('table td[data-label="Request name"] a').should('not.exist');
         });
     });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/vulnerabilityRequests.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/vulnerabilityRequests.ts
@@ -1,0 +1,17 @@
+import { CompoundSearchFilterAttribute } from '../types';
+
+export const RequestName: CompoundSearchFilterAttribute = {
+    displayName: 'Request Name',
+    filterChipLabel: 'Request Name',
+    searchTerm: 'Request Name',
+    inputType: 'autocomplete',
+};
+
+export const Requester: CompoundSearchFilterAttribute = {
+    displayName: 'Requester User Name',
+    filterChipLabel: 'Requester User Name',
+    searchTerm: 'Requester User Name',
+    inputType: 'autocomplete',
+};
+
+export const vulnerabilityRequestAttributes = [RequestName, Requester];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-    PageSection,
-    Pagination,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
+import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useURLPagination from 'hooks/useURLPagination';
@@ -15,7 +8,6 @@ import useURLSort from 'hooks/useURLSort';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
@@ -29,24 +21,11 @@ import {
     Requester,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-import FilterAutocompleteSelect from '../components/FilterAutocomplete';
 
-import {
-    SearchOption,
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-} from '../searchOptions';
 import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
-
-const searchOptions: SearchOption[] = [
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-];
+import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
+import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -118,44 +97,31 @@ function ApprovedDeferrals() {
     return (
         <PageSection>
             <PageTitle title="Exception Management - Approved Deferrals" />
-            <Toolbar>
-                <ToolbarContent>
-                    <FilterAutocompleteSelect
-                        searchFilter={searchFilter}
-                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
-                        searchOptions={searchOptions}
+            <AdvancedFiltersToolbar
+                searchFilterConfig={vulnRequestSearchFilterConfig}
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                includeCveSeverityFilters={false}
+                includeCveStatusFilters={false}
+            >
+                <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                    <Pagination
+                        toggleTemplate={({ firstIndex, lastIndex }) => (
+                            <span>
+                                <b>
+                                    {firstIndex} - {lastIndex}
+                                </b>{' '}
+                                of <b>many</b>
+                            </span>
+                        )}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        isCompact
                     />
-                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-                        <Pagination
-                            toggleTemplate={({ firstIndex, lastIndex }) => (
-                                <span>
-                                    <b>
-                                        {firstIndex} - {lastIndex}
-                                    </b>{' '}
-                                    of <b>many</b>
-                                </span>
-                            )}
-                            page={page}
-                            perPage={perPage}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
-                            isCompact
-                        />
-                    </ToolbarItem>
-                    <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
-                                return {
-                                    displayName: label,
-                                    searchFilterName: value,
-                                };
-                            })}
-                        />
-                    </ToolbarGroup>
-                </ToolbarContent>
-            </Toolbar>
+                </ToolbarItem>
+            </AdvancedFiltersToolbar>
             <Table borders={false}>
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-    PageSection,
-    Pagination,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
+import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useURLPagination from 'hooks/useURLPagination';
@@ -17,7 +10,6 @@ import useRestQuery from 'hooks/useRestQuery';
 import useURLSort from 'hooks/useURLSort';
 
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { SearchFilter } from 'types/search';
@@ -29,23 +21,10 @@ import {
     Requester,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-import FilterAutocompleteSelect from '../components/FilterAutocomplete';
-import {
-    SearchOption,
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-} from '../searchOptions';
 import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
-
-const searchOptions: SearchOption[] = [
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-];
+import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
+import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 
 const sortFields = ['Request Name', 'Requester User Name', 'Created Time', 'Image Registry Scope'];
 const defaultSortOption = {
@@ -111,44 +90,31 @@ function ApprovedFalsePositives() {
     return (
         <PageSection>
             <PageTitle title="Exception Management - Approved False Positives" />
-            <Toolbar>
-                <ToolbarContent>
-                    <FilterAutocompleteSelect
-                        searchFilter={searchFilter}
-                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
-                        searchOptions={searchOptions}
+            <AdvancedFiltersToolbar
+                searchFilterConfig={vulnRequestSearchFilterConfig}
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                includeCveSeverityFilters={false}
+                includeCveStatusFilters={false}
+            >
+                <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                    <Pagination
+                        toggleTemplate={({ firstIndex, lastIndex }) => (
+                            <span>
+                                <b>
+                                    {firstIndex} - {lastIndex}
+                                </b>{' '}
+                                of <b>many</b>
+                            </span>
+                        )}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        isCompact
                     />
-                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-                        <Pagination
-                            toggleTemplate={({ firstIndex, lastIndex }) => (
-                                <span>
-                                    <b>
-                                        {firstIndex} - {lastIndex}
-                                    </b>{' '}
-                                    of <b>many</b>
-                                </span>
-                            )}
-                            page={page}
-                            perPage={perPage}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
-                            isCompact
-                        />
-                    </ToolbarItem>
-                    <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
-                                return {
-                                    displayName: label,
-                                    searchFilterName: value,
-                                };
-                            })}
-                        />
-                    </ToolbarGroup>
-                </ToolbarContent>
-            </Toolbar>
+                </ToolbarItem>
+            </AdvancedFiltersToolbar>
             <Table borders={false}>
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-    PageSection,
-    Pagination,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
+import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useURLPagination from 'hooks/useURLPagination';
@@ -15,7 +8,6 @@ import useRestQuery from 'hooks/useRestQuery';
 import useURLSort from 'hooks/useURLSort';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
@@ -29,23 +21,10 @@ import {
     Requester,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-import FilterAutocompleteSelect from '../components/FilterAutocomplete';
-import {
-    SearchOption,
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-} from '../searchOptions';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
-
-const searchOptions: SearchOption[] = [
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-];
+import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
+import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -115,44 +94,31 @@ function DeniedRequests() {
     return (
         <PageSection>
             <PageTitle title="Exception Management - Denied Requests" />
-            <Toolbar>
-                <ToolbarContent>
-                    <FilterAutocompleteSelect
-                        searchFilter={searchFilter}
-                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
-                        searchOptions={searchOptions}
+            <AdvancedFiltersToolbar
+                searchFilterConfig={vulnRequestSearchFilterConfig}
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                includeCveSeverityFilters={false}
+                includeCveStatusFilters={false}
+            >
+                <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                    <Pagination
+                        toggleTemplate={({ firstIndex, lastIndex }) => (
+                            <span>
+                                <b>
+                                    {firstIndex} - {lastIndex}
+                                </b>{' '}
+                                of <b>many</b>
+                            </span>
+                        )}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        isCompact
                     />
-                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-                        <Pagination
-                            toggleTemplate={({ firstIndex, lastIndex }) => (
-                                <span>
-                                    <b>
-                                        {firstIndex} - {lastIndex}
-                                    </b>{' '}
-                                    of <b>many</b>
-                                </span>
-                            )}
-                            page={page}
-                            perPage={perPage}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
-                            isCompact
-                        />
-                    </ToolbarItem>
-                    <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
-                                return {
-                                    displayName: label,
-                                    searchFilterName: value,
-                                };
-                            })}
-                        />
-                    </ToolbarGroup>
-                </ToolbarContent>
-            </Toolbar>
+                </ToolbarItem>
+            </AdvancedFiltersToolbar>
             <Table borders={false}>
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-    PageSection,
-    Pagination,
-    Toolbar,
-    ToolbarContent,
-    ToolbarGroup,
-    ToolbarItem,
-} from '@patternfly/react-core';
+import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useURLPagination from 'hooks/useURLPagination';
@@ -14,7 +7,6 @@ import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import useURLSort from 'hooks/useURLSort';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
@@ -29,23 +21,10 @@ import {
     Requester,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-import FilterAutocompleteSelect from '../components/FilterAutocomplete';
-import {
-    SearchOption,
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-} from '../searchOptions';
+import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
-
-const searchOptions: SearchOption[] = [
-    REQUEST_NAME_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-];
+import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -116,44 +95,31 @@ function PendingApprovals() {
     return (
         <PageSection>
             <PageTitle title="Exception Management - Pending Requests" />
-            <Toolbar>
-                <ToolbarContent>
-                    <FilterAutocompleteSelect
-                        searchFilter={searchFilter}
-                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
-                        searchOptions={searchOptions}
+            <AdvancedFiltersToolbar
+                searchFilterConfig={vulnRequestSearchFilterConfig}
+                searchFilter={searchFilter}
+                onFilterChange={onFilterChange}
+                includeCveSeverityFilters={false}
+                includeCveStatusFilters={false}
+            >
+                <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                    <Pagination
+                        toggleTemplate={({ firstIndex, lastIndex }) => (
+                            <span>
+                                <b>
+                                    {firstIndex} - {lastIndex}
+                                </b>{' '}
+                                of <b>many</b>
+                            </span>
+                        )}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        isCompact
                     />
-                    <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-                        <Pagination
-                            toggleTemplate={({ firstIndex, lastIndex }) => (
-                                <span>
-                                    <b>
-                                        {firstIndex} - {lastIndex}
-                                    </b>{' '}
-                                    of <b>many</b>
-                                </span>
-                            )}
-                            page={page}
-                            perPage={perPage}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
-                            isCompact
-                        />
-                    </ToolbarItem>
-                    <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
-                                return {
-                                    displayName: label,
-                                    searchFilterName: value,
-                                };
-                            })}
-                        />
-                    </ToolbarGroup>
-                </ToolbarContent>
-            </Toolbar>
+                </ToolbarItem>
+            </AdvancedFiltersToolbar>
             <Table borders={false}>
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
@@ -1,0 +1,28 @@
+import { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
+import { Name as ImageName } from 'Components/CompoundSearchFilter/attributes/image';
+import { Name as ImageCveName } from 'Components/CompoundSearchFilter/attributes/imageCVE';
+import { vulnerabilityRequestAttributes } from 'Components/CompoundSearchFilter/attributes/vulnerabilityRequests';
+
+const imageSearchFilterConfig: CompoundSearchFilterEntity = {
+    displayName: 'Image',
+    searchCategory: 'IMAGES',
+    attributes: [ImageName],
+};
+
+const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
+    displayName: 'CVE',
+    searchCategory: 'IMAGE_VULNERABILITIES',
+    attributes: [ImageCveName],
+};
+
+const vulnerabilityRequestSearchFilterConfig: CompoundSearchFilterEntity = {
+    displayName: 'Exception',
+    searchCategory: 'VULN_REQUEST',
+    attributes: vulnerabilityRequestAttributes,
+};
+
+export const vulnRequestSearchFilterConfig = [
+    vulnerabilityRequestSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageSearchFilterConfig,
+];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Toolbar, ToolbarGroup, ToolbarContent } from '@patternfly/react-core';
 import { uniq } from 'lodash';
 
@@ -49,8 +49,7 @@ type AdvancedFiltersToolbarProps = {
     includeCveStatusFilters?: boolean;
     defaultSearchFilterEntity?: string;
     additionalContextFilter?: SearchFilter;
-    // TODO We need to be able to apply the autocomplete search context to the advanced filters component @see FilterAutocomplete.tsx
-    // autocompleteSearchContext?: unknown;
+    children?: ReactNode;
 };
 
 function AdvancedFiltersToolbar({
@@ -64,8 +63,7 @@ function AdvancedFiltersToolbar({
     includeCveStatusFilters = true,
     defaultSearchFilterEntity,
     additionalContextFilter,
-    // TODO We need to be able to apply the autocomplete search context to the advanced filters component
-    // autocompleteSearchContext,
+    children,
 }: AdvancedFiltersToolbarProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
         .concat({
@@ -152,6 +150,7 @@ function AdvancedFiltersToolbar({
                         )}
                     </ToolbarGroup>
                 )}
+                {children}
                 {getHasSearchApplied(searchFilter) && (
                     <ToolbarGroup aria-label="applied search filters" className="pf-v5-u-w-100">
                         <SearchFilterChips


### PR DESCRIPTION
### Description

Updates the Exception Management pages to use the new advanced filters bar and creating consistency with search on the rest of the VM pages.

Additionally this paves the way to:
- Delete the old search bar components
- Delete the ROX_ADVANCED_FILTERS feature flag and any dead code it creates

Note that this does not fix the following issues, some of which may require work on the BE as well:
1. Exception based searches do not return autocomplete results (error due to "VULN_REQUEST" not being implemented)
2. CVE and Image autocomplete requests do not seem to be able to scope to "Request State"
3. Substring search matches do not work, all search values must be a string prefix
4. Image name search does not work at all, search results are never filtered

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the tabs under Exception Management and test searching:
![image](https://github.com/user-attachments/assets/e54d0972-09e7-4458-81f8-c2283b223cea)
![image](https://github.com/user-attachments/assets/f6fc7449-1620-4636-8503-5a25b03d4514)
![image](https://github.com/user-attachments/assets/c22b8d94-a004-45a1-9470-32a0425ea170)
![image](https://github.com/user-attachments/assets/e6c80518-4824-47dd-99a7-d4852921c4e0)
![image](https://github.com/user-attachments/assets/ddcbe135-2a15-4d4d-a449-2212b054be45)



