### PR TITLE
ROX-27422: Replace CVSS score with CVSS for cluster in Platform CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -76,7 +76,7 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                     <Th sort={getSortParams(CLUSTER_CVE_STATUS_SORT_FIELD)}>CVE status</Th>
                     <Th sort={getSortParams(CVE_TYPE_SORT_FIELD)}>CVE type</Th>
-                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS score</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
                 </Tr>
             </Thead>
             <TbodyUnified
@@ -116,7 +116,7 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                                     <Td dataLabel="CVE type">
                                         {displayCveType(vulnerabilityType)}
                                     </Td>
-                                    <Td dataLabel="CVSS score">
+                                    <Td dataLabel="CVSS">
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
                                 </Tr>


### PR DESCRIPTION
### Description

Discussed with Mansur via chat.

Omit **score** although it is not strictly redundant with **Scoring System** in CVSS and EPSS.

### Problems

1. Vulnerabilities has table column headings:
    * **CVSS** as majority
    * **CVSS score** as minority of one (see Analysis)
2. To include **score** consistently would increase column width, especially:
    * NVD CVSS
    * Top CVSS

### Analysis

CVEsTable.tsx file renders **CVSS score** on cluster page.

* One side of coin:
    Because there are multiple CVEsTable.tsx file, fewer (only one) pages are affected than I first thought.
* Other side of coin:
    Google doc of PatternFly table column headings has only one occurrence.

Does not affect integration tests.

### Solution

Replace **CVSS score** with **CVSS**.

Thankfully the table does not have managed columns.

Lint rule reports inconsistent text of `dataLabel` prop and `Th` element!

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4614710 - 4614710
        total -12 = 11562368 - 11562380
            that is, 6 * 2 because length of space plus **score** in `Th` and `Td datalabel`
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/workload-cves

    * WorkloadCVEOverviewTable.tsx file renders **Top CVSS** column.
        ![WorkloadCVEOverviewTable_Top_CVSS](https://github.com/user-attachments/assets/39371d8b-a813-464f-99d8-13032bf41516)

2. Click a vulnerability.

    * AffectedImagesTable.tsx file renders **CVSS** column.
        ![AffectedImagesTable_CVSS](https://github.com/user-attachments/assets/5dfed001-b437-489f-9ed9-388ba1c63af0)

3. Visit /main/node-cves

    * NodeCves/Overview/CVEsTable.tsx file renders **Top CVSS** column.
        ![NodeCves_Overview_CVEsTable_Top_CVSS](https://github.com/user-attachments/assets/6f5233e0-cfbf-46a0-b4e8-39f095c17ef5)

4. Click a vulnerability.

    * AffectedNodesTable.tsx file renders **CVSS** column.
        ![AffectedNodesTable_CVSS](https://github.com/user-attachments/assets/fac5d8cd-f9ec-4c47-a9a0-182914a9029e)

5. Visit /main/platform-cves

    * PlatformCves/Overview/CVEsTable.tsx file renders **Top CVSS** column.
        ![NodeCves_Overview_CVEsTable_Top_CVSS](https://github.com/user-attachments/assets/1d89b1d2-1be0-44bf-8681-4c8a6f7ddf31)

6. Click **Clusters** and then click cluster.

    * PlatformCVEs/Cluster/CVEsTable.tsx file renders **CVSS score** column before change.
        ![PlatformCves_Cluster_CVEsTable_CVSS_score](https://github.com/user-attachments/assets/c283f13e-dbdf-4038-8506-17650c20e061)

    * PlatformCVEs/Cluster/CVEsTable.tsx file renders **CVSS** column after change.
        ![PlatformCves_Cluster_CVEsTable_CVSS](https://github.com/user-attachments/assets/c082c7d5-d2ee-44fc-aaf9-6b55abd86465)
