### PR TITLE
chore(ui): Delete unneeded padding in component subtables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -66,7 +66,6 @@ function DeploymentComponentVulnerabilitiesTable({
     const sortedComponentVulns = sortTableData(componentVulns, sortOption);
     return (
         <Table
-            className="pf-v5-u-p-md"
             style={{
                 border: '1px solid var(--pf-v5-c-table--BorderColor)',
             }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -53,7 +53,6 @@ function ImageComponentVulnerabilitiesTable({
     const sortedComponentVulns = sortTableData(componentVulns, sortOption);
     return (
         <Table
-            className="pf-v5-u-p-md"
             style={{
                 border: '1px solid var(--pf-v5-c-table--BorderColor)',
             }}


### PR DESCRIPTION
### Description

Found unusual `className="pf-v5-u-p-md"` prop while searching for something else.

### Problem

It has no effect on layout.

### Analysis

Even if it did, it seems superseded by `ExpandableRowContent` element that provides its layout.

### Solution

Delete it!

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4614730 - 4614730
        total -50 = 11562726 - 11562776
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/workload-cves click a vulnerability, and then expand an image row.

    * See same layout before and after change.
        ![ImageComponentVulnerabilitiesTable](https://github.com/user-attachments/assets/cf50e156-f19b-42fe-a10e-6d329e31cae1)

2. Click **Deployments** and then expand a deployment row.

    * See same layout before and after change.
![DeploymentComponentVulnerabilitiesTable pmg](https://github.com/user-attachments/assets/669259fe-6344-4a59-9dd7-767f05bc5305)
